### PR TITLE
Replace global-exports mechanism with caller-vmctx mechanism

### DIFF
--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -26,8 +26,7 @@ fuzz_target!(|data: &[u8]| {
     let isa = isa_builder.finish(settings::Flags::new(flag_builder));
     let mut compiler = Compiler::new(isa);
     let mut resolver = NullResolver {};
-    let global_exports = Rc::new(RefCell::new(HashMap::new()));
-    let _compiled = match CompiledModule::new(&mut compiler, data, &mut resolver, global_exports, false) {
+    let _compiled = match CompiledModule::new(&mut compiler, data, &mut resolver, false) {
         Ok(x) => x,
         Err(_) => return,
     };

--- a/misc/wasmtime-py/src/import.rs
+++ b/misc/wasmtime-py/src/import.rs
@@ -91,11 +91,14 @@ fn make_trampoline(
     let pointer_type = isa.pointer_type();
     let mut stub_sig = ir::Signature::new(isa.frontend_config().default_call_conv);
 
-    // Add the `vmctx` parameter.
+    // Add the callee `vmctx` parameter.
     stub_sig.params.push(ir::AbiParam::special(
         pointer_type,
         ir::ArgumentPurpose::VMContext,
     ));
+
+    // Add the caller `vmctx` parameter.
+    stub_sig.params.push(ir::AbiParam::new(pointer_type));
 
     // Add the `call_id` parameter.
     stub_sig.params.push(ir::AbiParam::new(types::I32));
@@ -208,6 +211,7 @@ fn get_signature_from_py_annotation(
         pointer_type,
         ir::ArgumentPurpose::VMContext,
     ));
+    params.push(ir::AbiParam::new(pointer_type));
     let mut returns = None;
     for (name, value) in annot.iter() {
         let ty = parse_annotation_type(&value.to_string());

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -294,7 +294,6 @@ fn rmain() -> Result<(), Error> {
     );
 
     // Make wasi available by default.
-    let global_exports = store.borrow().global_exports().clone();
     let preopen_dirs = compute_preopen_dirs(&args.flag_dir, &args.flag_mapdir);
     let argv = compute_argv(&args.arg_file, &args.arg_arg);
     let environ = compute_environ(&args.flag_env);
@@ -302,14 +301,14 @@ fn rmain() -> Result<(), Error> {
     let wasi = if args.flag_wasi_c {
         #[cfg(feature = "wasi-c")]
         {
-            instantiate_wasi_c("", global_exports.clone(), &preopen_dirs, &argv, &environ)?
+            instantiate_wasi_c("", &preopen_dirs, &argv, &environ)?
         }
         #[cfg(not(feature = "wasi-c"))]
         {
             bail!("wasi-c feature not enabled at build time")
         }
     } else {
-        instantiate_wasi("", global_exports.clone(), &preopen_dirs, &argv, &environ)?
+        instantiate_wasi("", &preopen_dirs, &argv, &environ)?
     };
 
     module_registry.insert(

--- a/wasmtime-api/src/runtime.rs
+++ b/wasmtime-api/src/runtime.rs
@@ -1,6 +1,4 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use crate::context::{create_compiler, Context};
 use crate::r#ref::HostRef;
@@ -83,7 +81,6 @@ impl Engine {
 pub struct Store {
     engine: HostRef<Engine>,
     context: Context,
-    global_exports: Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>>,
     signature_cache: HashMap<wasmtime_runtime::VMSharedSignatureIndex, ir::Signature>,
 }
 
@@ -95,7 +92,6 @@ impl Store {
         Store {
             engine,
             context: Context::create(flags, features, debug_info),
-            global_exports: Rc::new(RefCell::new(HashMap::new())),
             signature_cache: HashMap::new(),
         }
     }
@@ -106,13 +102,6 @@ impl Store {
 
     pub(crate) fn context(&mut self) -> &mut Context {
         &mut self.context
-    }
-
-    // Specific to wasmtime: hack to pass memory around to wasi
-    pub fn global_exports(
-        &self,
-    ) -> &Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>> {
-        &self.global_exports
     }
 
     pub(crate) fn register_cranelift_signature(

--- a/wasmtime-api/src/trampoline/create_handle.rs
+++ b/wasmtime-api/src/trampoline/create_handle.rs
@@ -8,8 +8,8 @@ use wasmtime_environ::Module;
 use wasmtime_runtime::{Imports, InstanceHandle, VMFunctionBody};
 
 use std::any::Any;
-use std::cell::{RefCell, RefMut};
-use std::collections::{HashMap, HashSet};
+use std::cell::RefMut;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use crate::runtime::Store;
@@ -20,9 +20,6 @@ pub(crate) fn create_handle(
     finished_functions: PrimaryMap<DefinedFuncIndex, *const VMFunctionBody>,
     state: Box<dyn Any>,
 ) -> Result<InstanceHandle, Error> {
-    let global_exports: Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>> =
-        Rc::new(RefCell::new(HashMap::new()));
-
     let imports = Imports::new(
         HashSet::new(),
         PrimaryMap::new(),
@@ -47,7 +44,6 @@ pub(crate) fn create_handle(
 
     Ok(InstanceHandle::new(
         Rc::new(module),
-        global_exports,
         finished_functions.into_boxed_slice(),
         imports,
         &data_initializers,

--- a/wasmtime-api/src/trampoline/func.rs
+++ b/wasmtime-api/src/trampoline/func.rs
@@ -85,11 +85,14 @@ fn make_trampoline(
     let pointer_type = isa.pointer_type();
     let mut stub_sig = ir::Signature::new(isa.frontend_config().default_call_conv);
 
-    // Add the `vmctx` parameter.
+    // Add the callee `vmctx` parameter.
     stub_sig.params.push(ir::AbiParam::special(
         pointer_type,
         ir::ArgumentPurpose::VMContext,
     ));
+
+    // Add the caller `vmctx` parameter.
+    stub_sig.params.push(ir::AbiParam::new(pointer_type));
 
     // Add the `call_id` parameter.
     stub_sig.params.push(ir::AbiParam::new(types::I32));

--- a/wasmtime-api/src/types.rs
+++ b/wasmtime-api/src/types.rs
@@ -150,7 +150,13 @@ impl FuncType {
                 .iter()
                 .map(|p| AbiParam::new(p.get_cranelift_type()))
                 .collect::<Vec<_>>();
-            params.insert(0, AbiParam::special(types::I64, ArgumentPurpose::VMContext));
+            let ptr_ty = match HOST.pointer_width().unwrap() {
+                target_lexicon::PointerWidth::U16 => panic!("16-bit pointers not supported"),
+                target_lexicon::PointerWidth::U32 => types::I32,
+                target_lexicon::PointerWidth::U64 => types::I64,
+            };
+            params.insert(0, AbiParam::special(ptr_ty, ArgumentPurpose::VMContext));
+            params.insert(1, AbiParam::new(ptr_ty));
 
             Signature {
                 params,

--- a/wasmtime-environ/src/cranelift.rs
+++ b/wasmtime-environ/src/cranelift.rs
@@ -237,6 +237,7 @@ impl crate::compilation::Compiler for Cranelift {
                         let mut reloc_sink = RelocSink::new(func_index);
                         let mut trap_sink = TrapSink::new();
                         let mut stackmap_sink = binemit::NullStackmapSink {};
+                        println!("func {}", context.func.display(isa));
                         context
                             .compile_and_emit(
                                 isa,

--- a/wasmtime-environ/src/module_environ.rs
+++ b/wasmtime-environ/src/module_environ.rs
@@ -358,11 +358,13 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
 
 /// Add environment-specific function parameters.
 pub fn translate_signature(mut sig: ir::Signature, pointer_type: ir::Type) -> ir::Signature {
-    // Prepend the vmctx argument.
+    // Prepend the callee vmctx argument.
     sig.params.insert(
         0,
         AbiParam::special(pointer_type, ArgumentPurpose::VMContext),
     );
+    // Prepend the caller vmctx argument.
+    sig.params.insert(1, AbiParam::new(pointer_type));
     sig
 }
 

--- a/wasmtime-jit/src/action.rs
+++ b/wasmtime-jit/src/action.rs
@@ -186,10 +186,15 @@ pub fn invoke(
     // Make all JIT code produced thus far executable.
     compiler.publish_compiled_code();
 
+    // There is no caller vmctx since we're invoking a wasm function from
+    // outside of any module.
+    let caller_vmctx = ptr::null_mut();
+
     // Call the trampoline.
     if let Err(message) = unsafe {
         wasmtime_call_trampoline(
             callee_vmctx,
+            caller_vmctx,
             exec_code_buf,
             values_vec.as_mut_ptr() as *mut u8,
         )

--- a/wasmtime-runtime/signalhandlers/Trampolines.cpp
+++ b/wasmtime-runtime/signalhandlers/Trampolines.cpp
@@ -3,7 +3,9 @@
 #include "SignalHandlers.hpp"
 
 extern "C"
-int WasmtimeCallTrampoline(void *vmctx, void (*body)(void*, void*), void *args) {
+int WasmtimeCallTrampoline(void *callee_vmctx, void *caller_vmctx,
+                           void (*body)(void*, void*, void*), void *args)
+{
   jmp_buf buf;
   void *volatile prev;
   if (setjmp(buf) != 0) {
@@ -11,13 +13,15 @@ int WasmtimeCallTrampoline(void *vmctx, void (*body)(void*, void*), void *args) 
     return 0;
   }
   prev = EnterScope(&buf);
-  body(vmctx, args);
+  body(callee_vmctx, caller_vmctx, args);
   LeaveScope(prev);
   return 1;
 }
 
 extern "C"
-int WasmtimeCall(void *vmctx, void (*body)(void*)) {
+int WasmtimeCall(void *callee_vmctx, void *caller_vmctx,
+                 void (*body)(void*, void*))
+{
   jmp_buf buf;
   void *volatile prev;
   if (setjmp(buf) != 0) {
@@ -25,7 +29,7 @@ int WasmtimeCall(void *vmctx, void (*body)(void*)) {
     return 0;
   }
   prev = EnterScope(&buf);
-  body(vmctx);
+  body(callee_vmctx, caller_vmctx);
   LeaveScope(prev);
   return 1;
 }

--- a/wasmtime-runtime/src/instance.rs
+++ b/wasmtime-runtime/src/instance.rs
@@ -456,8 +456,12 @@ impl Instance {
             }
         };
 
+        // There is no caller vmctx since we're invoking a wasm function from
+        // outside of any module.
+        let caller_vmctx = ptr::null_mut();
+
         // Make the call.
-        unsafe { wasmtime_call(callee_vmctx, callee_address) }
+        unsafe { wasmtime_call(callee_vmctx, caller_vmctx, callee_address) }
             .map_err(InstantiationError::StartTrap)
     }
 

--- a/wasmtime-runtime/src/vmcontext.rs
+++ b/wasmtime-runtime/src/vmcontext.rs
@@ -564,8 +564,8 @@ impl VMContext {
         self.instance().host_state()
     }
 
-    /// Lookup an export in the global exports namespace.
-    pub unsafe fn lookup_global_export(&mut self, field: &str) -> Option<crate::export::Export> {
-        self.instance().lookup_global_export(field)
+    /// Lookup an export.
+    pub unsafe fn lookup(&mut self, field: &str) -> Option<crate::export::Export> {
+        self.instance().lookup(field)
     }
 }

--- a/wasmtime-wasi-c/src/instantiate.rs
+++ b/wasmtime-wasi-c/src/instantiate.rs
@@ -6,8 +6,6 @@ use cranelift_codegen::ir::types;
 use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::DefinedFuncIndex;
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::ffi::CString;
 use std::fs::File;
 use std::mem;
@@ -27,7 +25,6 @@ pub(crate) struct WASIState {
 /// Return an instance implementing the "wasi" interface.
 pub fn instantiate_wasi_c(
     prefix: &str,
-    global_exports: Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>>,
     preopened_dirs: &[(String, File)],
     argv: &[String],
     environ: &[(String, String)],
@@ -163,7 +160,6 @@ pub fn instantiate_wasi_c(
 
     InstanceHandle::new(
         Rc::new(module),
-        global_exports,
         finished_functions.into_boxed_slice(),
         imports,
         &data_initializers,

--- a/wasmtime-wasi-c/src/translate.rs
+++ b/wasmtime-wasi-c/src/translate.rs
@@ -10,12 +10,12 @@ use wasmtime_runtime::{Export, VMContext};
 /// This is unsafe due to trusting the contents of vmctx. The pointer result
 /// is bounds and alignment checked.
 unsafe fn decode_ptr(
-    vmctx: &mut VMContext,
+    fixme: &mut VMContext,
     ptr: wasm32::uintptr_t,
     len: usize,
     align: usize,
 ) -> Result<*mut u8, host::__wasi_errno_t> {
-    match vmctx.lookup_global_export("memory") {
+    match fixme.lookup("memory") {
         Some(Export::Memory {
             definition,
             vmctx: _,

--- a/wasmtime-wasi/src/instantiate.rs
+++ b/wasmtime-wasi/src/instantiate.rs
@@ -3,8 +3,6 @@ use cranelift_codegen::ir::types;
 use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::DefinedFuncIndex;
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fs::File;
 use std::rc::Rc;
 use target_lexicon::HOST;
@@ -15,7 +13,6 @@ use wasmtime_runtime::{Imports, InstanceHandle, InstantiationError, VMFunctionBo
 /// Return an instance implementing the "wasi" interface.
 pub fn instantiate_wasi(
     prefix: &str,
-    global_exports: Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>>,
     preopened_dirs: &[(String, File)],
     argv: &[String],
     environ: &[(String, String)],
@@ -127,7 +124,6 @@ pub fn instantiate_wasi(
 
     InstanceHandle::new(
         Rc::new(module),
-        global_exports,
         finished_functions.into_boxed_slice(),
         imports,
         &data_initializers,

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -83,9 +83,9 @@ fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&mut WasiCtx, wasm32::__wasi_er
     }
 }
 
-fn get_memory(vmctx: &mut VMContext) -> Result<&mut [u8], wasm32::__wasi_errno_t> {
+fn get_memory(fixme: &mut VMContext) -> Result<&mut [u8], wasm32::__wasi_errno_t> {
     unsafe {
-        match vmctx.lookup_global_export("memory") {
+        match fixme.lookup("memory") {
             Some(Export::Memory {
                 definition,
                 vmctx: _,

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -74,18 +74,21 @@ impl AbiRet for () {
     }
 }
 
-fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&mut WasiCtx, wasm32::__wasi_errno_t> {
+fn get_wasi_ctx(callee_vmctx: &mut VMContext) -> Result<&mut WasiCtx, wasm32::__wasi_errno_t> {
     unsafe {
-        vmctx.host_state().downcast_mut::<WasiCtx>().ok_or_else(|| {
-            println!("!!! no host state named WasiCtx available");
-            wasm32::__WASI_EINVAL
-        })
+        callee_vmctx
+            .host_state()
+            .downcast_mut::<WasiCtx>()
+            .ok_or_else(|| {
+                println!("!!! no host state named WasiCtx available");
+                wasm32::__WASI_EINVAL
+            })
     }
 }
 
-fn get_memory(fixme: &mut VMContext) -> Result<&mut [u8], wasm32::__wasi_errno_t> {
+fn get_memory(caller_vmctx: &mut VMContext) -> Result<&mut [u8], wasm32::__wasi_errno_t> {
     unsafe {
-        match fixme.lookup("memory") {
+        match caller_vmctx.lookup("memory") {
             Some(Export::Memory {
                 definition,
                 vmctx: _,
@@ -118,7 +121,11 @@ macro_rules! ok_or_errno {
 }
 
 macro_rules! syscalls {
-    ($(pub unsafe extern "C" fn $name:ident($ctx:ident: *mut VMContext $(, $arg:ident: $ty:ty)*,) -> $ret:ty {
+    ($(pub unsafe extern "C" fn $name:ident(
+        $callee_ctx:ident: *mut VMContext,
+        $caller_ctx:ident: *mut VMContext
+        $(, $arg:ident: $ty:ty)*,
+    ) -> $ret:ty {
         $($body:tt)*
     })*) => ($(
         pub mod $name {
@@ -142,19 +149,25 @@ macro_rules! syscalls {
             /// a compiler bug which prvents that from being cast to a `usize`.
             pub static SHIM: unsafe extern "C" fn(
                 *mut VMContext,
+                *mut VMContext,
                 $(<$ty as AbiParam>::Abi),*
             ) -> <$ret as AbiRet>::Abi = shim;
 
             unsafe extern "C" fn shim(
-                $ctx: *mut VMContext,
+                $callee_ctx: *mut VMContext,
+                $caller_ctx: *mut VMContext,
                 $($arg: <$ty as AbiParam>::Abi,)*
             ) -> <$ret as AbiRet>::Abi {
-                let r = super::$name($ctx, $(<$ty as AbiParam>::convert($arg),)*);
+                let r = super::$name($callee_ctx, $caller_ctx, $(<$ty as AbiParam>::convert($arg),)*);
                 <$ret as AbiRet>::convert(r)
             }
         }
 
-        pub unsafe extern "C" fn $name($ctx: *mut VMContext, $($arg: $ty,)*) -> $ret {
+        pub unsafe extern "C" fn $name(
+            $callee_ctx: *mut VMContext,
+            $caller_ctx: *mut VMContext,
+            $($arg: $ty,)*
+        ) -> $ret {
             $($body)*
         }
     )*)
@@ -162,7 +175,8 @@ macro_rules! syscalls {
 
 syscalls! {
     pub unsafe extern "C" fn args_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         argv: wasm32::uintptr_t,
         argv_buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
@@ -171,13 +185,14 @@ syscalls! {
             argv,
             argv_buf,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::args_get(wasi_ctx, memory, argv, argv_buf)
     }
 
     pub unsafe extern "C" fn args_sizes_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         argc: wasm32::uintptr_t,
         argv_buf_size: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
@@ -186,13 +201,14 @@ syscalls! {
             argc,
             argv_buf_size,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::args_sizes_get(wasi_ctx, memory, argc, argv_buf_size)
     }
 
     pub unsafe extern "C" fn clock_res_get(
-        vmctx: *mut VMContext,
+        _callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         clock_id: wasm32::__wasi_clockid_t,
         resolution: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
@@ -201,12 +217,13 @@ syscalls! {
             clock_id,
             resolution,
         );
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::clock_res_get(memory, clock_id, resolution)
     }
 
     pub unsafe extern "C" fn clock_time_get(
-        vmctx: *mut VMContext,
+        _callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         clock_id: wasm32::__wasi_clockid_t,
         precision: wasm32::__wasi_timestamp_t,
         time: wasm32::uintptr_t,
@@ -217,12 +234,13 @@ syscalls! {
             precision,
             time,
         );
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::clock_time_get(memory, clock_id, precision, time)
     }
 
     pub unsafe extern "C" fn environ_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         environ: wasm32::uintptr_t,
         environ_buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
@@ -231,13 +249,14 @@ syscalls! {
             environ,
             environ_buf,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::environ_get(wasi_ctx, memory, environ, environ_buf)
     }
 
     pub unsafe extern "C" fn environ_sizes_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         environ_count: wasm32::uintptr_t,
         environ_buf_size: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
@@ -246,54 +265,59 @@ syscalls! {
             environ_count,
             environ_buf_size,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::environ_sizes_get(wasi_ctx, memory, environ_count, environ_buf_size)
     }
 
     pub unsafe extern "C" fn fd_prestat_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_prestat_get(fd={:?}, buf={:#x?})", fd, buf);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_prestat_get(wasi_ctx, memory, fd, buf)
     }
 
     pub unsafe extern "C" fn fd_prestat_dir_name(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_prestat_dir_name(fd={:?}, path={:#x?}, path_len={})", fd, path, path_len);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_prestat_dir_name(wasi_ctx, memory, fd, path, path_len)
     }
 
     pub unsafe extern "C" fn fd_close(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_close(fd={:?})", fd);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_close(wasi_ctx, fd)
     }
 
     pub unsafe extern "C" fn fd_datasync(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_datasync(fd={:?})", fd);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_datasync(wasi_ctx, fd)
     }
 
     pub unsafe extern "C" fn fd_pread(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         iovs: wasm32::uintptr_t,
         iovs_len: wasm32::size_t,
@@ -308,8 +332,8 @@ syscalls! {
             offset,
             nread
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_pread(
             wasi_ctx,
             memory,
@@ -322,7 +346,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_pwrite(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         iovs: wasm32::uintptr_t,
         iovs_len: wasm32::size_t,
@@ -337,8 +362,8 @@ syscalls! {
             offset,
             nwritten
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_pwrite(
             wasi_ctx,
             memory,
@@ -351,7 +376,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_read(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         iovs: wasm32::uintptr_t,
         iovs_len: wasm32::size_t,
@@ -364,23 +390,25 @@ syscalls! {
             iovs_len,
             nread
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_read(wasi_ctx, memory, fd, iovs, iovs_len, nread)
     }
 
     pub unsafe extern "C" fn fd_renumber(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         from: wasm32::__wasi_fd_t,
         to: wasm32::__wasi_fd_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_renumber(from={:?}, to={:?})", from, to);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_renumber(wasi_ctx, from, to)
     }
 
     pub unsafe extern "C" fn fd_seek(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         offset: wasm32::__wasi_filedelta_t,
         whence: wasm32::__wasi_whence_t,
@@ -393,35 +421,38 @@ syscalls! {
             wasm32::whence_to_str(whence),
             newoffset
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_seek(wasi_ctx, memory, fd, offset, whence, newoffset)
     }
 
     pub unsafe extern "C" fn fd_tell(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         newoffset: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_tell(fd={:?}, newoffset={:#x?})", fd, newoffset);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_tell(wasi_ctx, memory, fd, newoffset)
     }
 
     pub unsafe extern "C" fn fd_fdstat_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_fdstat_get(fd={:?}, buf={:#x?})", fd, buf);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_fdstat_get(wasi_ctx, memory, fd, buf)
     }
 
     pub unsafe extern "C" fn fd_fdstat_set_flags(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         flags: wasm32::__wasi_fdflags_t,
     ) -> wasm32::__wasi_errno_t {
@@ -430,12 +461,13 @@ syscalls! {
             fd,
             flags
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_fdstat_set_flags(wasi_ctx, fd, flags)
     }
 
     pub unsafe extern "C" fn fd_fdstat_set_rights(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         fs_rights_base: wasm32::__wasi_rights_t,
         fs_rights_inheriting: wasm32::__wasi_rights_t,
@@ -446,7 +478,7 @@ syscalls! {
             fs_rights_base,
             fs_rights_inheriting
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_fdstat_set_rights(
             wasi_ctx,
             fd,
@@ -456,16 +488,18 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_sync(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_sync(fd={:?})", fd);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_sync(wasi_ctx, fd)
     }
 
     pub unsafe extern "C" fn fd_write(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         iovs: wasm32::uintptr_t,
         iovs_len: wasm32::size_t,
@@ -478,13 +512,14 @@ syscalls! {
             iovs_len,
             nwritten
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_write(wasi_ctx, memory, fd, iovs, iovs_len, nwritten)
     }
 
     pub unsafe extern "C" fn fd_advise(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         offset: wasm32::__wasi_filesize_t,
         len: wasm32::__wasi_filesize_t,
@@ -497,23 +532,25 @@ syscalls! {
             len,
             advice
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_advise(wasi_ctx,  fd, offset, len, advice)
     }
 
     pub unsafe extern "C" fn fd_allocate(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         offset: wasm32::__wasi_filesize_t,
         len: wasm32::__wasi_filesize_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_allocate(fd={:?}, offset={}, len={})", fd, offset, len);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_allocate(wasi_ctx, fd, offset, len)
     }
 
     pub unsafe extern "C" fn path_create_directory(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -524,13 +561,14 @@ syscalls! {
             path,
             path_len,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_create_directory(wasi_ctx, memory, fd, path, path_len)
     }
 
     pub unsafe extern "C" fn path_link(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd0: wasm32::__wasi_fd_t,
         flags0: wasm32::__wasi_lookupflags_t,
         path0: wasm32::uintptr_t,
@@ -549,8 +587,8 @@ syscalls! {
             path1,
             path_len1
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_link(
             wasi_ctx,
             memory,
@@ -567,7 +605,8 @@ syscalls! {
     // TODO: When multi-value happens, switch to that instead of passing
     // the `fd` by reference?
     pub unsafe extern "C" fn path_open(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         dirfd: wasm32::__wasi_fd_t,
         dirflags: wasm32::__wasi_lookupflags_t,
         path: wasm32::uintptr_t,
@@ -590,8 +629,8 @@ syscalls! {
             fs_flags,
             fd
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_open(
             wasi_ctx,
             memory,
@@ -608,7 +647,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_readdir(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
         buf_len: wasm32::size_t,
@@ -623,8 +663,8 @@ syscalls! {
             cookie,
             buf_used,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_readdir(
             wasi_ctx,
             memory,
@@ -637,7 +677,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn path_readlink(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -654,8 +695,8 @@ syscalls! {
             buf_len,
             buf_used,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_readlink(
             wasi_ctx,
             memory,
@@ -669,7 +710,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn path_rename(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd0: wasm32::__wasi_fd_t,
         path0: wasm32::uintptr_t,
         path_len0: wasm32::size_t,
@@ -686,8 +728,8 @@ syscalls! {
             path1,
             path_len1,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_rename(
             wasi_ctx,
             memory,
@@ -701,18 +743,20 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_filestat_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_filestat_get(fd={:?}, buf={:#x?})", fd, buf);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::fd_filestat_get(wasi_ctx, memory, fd, buf)
     }
 
     pub unsafe extern "C" fn fd_filestat_set_times(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         st_atim: wasm32::__wasi_timestamp_t,
         st_mtim: wasm32::__wasi_timestamp_t,
@@ -724,12 +768,13 @@ syscalls! {
             st_atim, st_mtim,
             fstflags
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_filestat_set_times(wasi_ctx, fd, st_atim, st_mtim, fstflags)
     }
 
     pub unsafe extern "C" fn fd_filestat_set_size(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        _caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         size: wasm32::__wasi_filesize_t,
     ) -> wasm32::__wasi_errno_t {
@@ -738,12 +783,13 @@ syscalls! {
             fd,
             size
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
         hostcalls::fd_filestat_set_size(wasi_ctx, fd, size)
     }
 
     pub unsafe extern "C" fn path_filestat_get(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         flags: wasm32::__wasi_lookupflags_t,
         path: wasm32::uintptr_t,
@@ -758,13 +804,14 @@ syscalls! {
             path_len,
             buf
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_filestat_get(wasi_ctx, memory, fd, flags, path, path_len, buf)
     }
 
     pub unsafe extern "C" fn path_filestat_set_times(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         flags: wasm32::__wasi_lookupflags_t,
         path: wasm32::uintptr_t,
@@ -782,8 +829,8 @@ syscalls! {
             st_atim, st_mtim,
             fstflags
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_filestat_set_times(
             wasi_ctx,
             memory,
@@ -798,7 +845,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn path_symlink(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         path0: wasm32::uintptr_t,
         path_len0: wasm32::size_t,
         fd: wasm32::__wasi_fd_t,
@@ -813,8 +861,8 @@ syscalls! {
             path1,
             path_len1
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_symlink(
             wasi_ctx,
             memory,
@@ -827,7 +875,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn path_unlink_file(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -838,13 +887,14 @@ syscalls! {
             path,
             path_len
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_unlink_file(wasi_ctx, memory, fd, path, path_len)
     }
 
     pub unsafe extern "C" fn path_remove_directory(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -855,13 +905,14 @@ syscalls! {
             path,
             path_len
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::path_remove_directory(wasi_ctx, memory, fd, path, path_len)
     }
 
     pub unsafe extern "C" fn poll_oneoff(
-        vmctx: *mut VMContext,
+        _callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         in_: wasm32::uintptr_t,
         out: wasm32::uintptr_t,
         nsubscriptions: wasm32::size_t,
@@ -874,42 +925,45 @@ syscalls! {
             nsubscriptions,
             nevents,
         );
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::poll_oneoff(memory, in_, out, nsubscriptions, nevents)
     }
 
-    pub unsafe extern "C" fn proc_exit(_vmctx: *mut VMContext, rval: u32,) -> () {
+    pub unsafe extern "C" fn proc_exit(_callee_vmctx: *mut VMContext, _caller_vmctx: *mut VMContext, rval: u32,) -> () {
         trace!("proc_exit(rval={:?})", rval);
         hostcalls::proc_exit(rval)
     }
 
     pub unsafe extern "C" fn proc_raise(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         sig: wasm32::__wasi_signal_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("proc_raise(sig={:?})", sig);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::proc_raise(wasi_ctx, memory, sig)
     }
 
     pub unsafe extern "C" fn random_get(
-        vmctx: *mut VMContext,
+        _callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         buf: wasm32::uintptr_t,
         buf_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("random_get(buf={:#x?}, buf_len={:?})", buf, buf_len);
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::random_get(memory, buf, buf_len)
     }
 
-    pub unsafe extern "C" fn sched_yield(_vmctx: *mut VMContext,) -> wasm32::__wasi_errno_t {
+    pub unsafe extern "C" fn sched_yield(_caller_vmctx: *mut VMContext, _callee_vmctx: *mut VMContext,) -> wasm32::__wasi_errno_t {
         trace!("sched_yield(void)");
         hostcalls::sched_yield()
     }
 
     pub unsafe extern "C" fn sock_recv(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         sock: wasm32::__wasi_fd_t,
         ri_data: wasm32::uintptr_t,
         ri_data_len: wasm32::size_t,
@@ -923,8 +977,8 @@ syscalls! {
             ri_data, ri_data_len, ri_flags,
             ro_datalen, ro_flags
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::sock_recv(
             wasi_ctx,
             memory,
@@ -938,7 +992,8 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn sock_send(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         sock: wasm32::__wasi_fd_t,
         si_data: wasm32::uintptr_t,
         si_data_len: wasm32::size_t,
@@ -950,8 +1005,8 @@ syscalls! {
             sock,
             si_data, si_data_len, si_flags, so_datalen,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::sock_send(
             wasi_ctx,
             memory,
@@ -964,13 +1019,14 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn sock_shutdown(
-        vmctx: *mut VMContext,
+        callee_vmctx: *mut VMContext,
+        caller_vmctx: *mut VMContext,
         sock: wasm32::__wasi_fd_t,
         how: wasm32::__wasi_sdflags_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("sock_shutdown(sock={:?}, how={:?})", sock, how);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
+        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *callee_vmctx));
+        let memory = ok_or_errno!(get_memory(&mut *caller_vmctx));
         hostcalls::sock_shutdown(wasi_ctx, memory, sock, how)
     }
 }

--- a/wasmtime-wast/src/spectest.rs
+++ b/wasmtime-wast/src/spectest.rs
@@ -2,8 +2,6 @@ use cranelift_codegen::ir::types;
 use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, Global, GlobalInit, Memory, Table, TableElementType};
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 use target_lexicon::HOST;
 use wasmtime_environ::{translate_signature, Export, MemoryPlan, Module, TablePlan};
@@ -218,7 +216,6 @@ pub fn instantiate_spectest() -> Result<InstanceHandle, InstantiationError> {
 
     InstanceHandle::new(
         Rc::new(module),
-        Rc::new(RefCell::new(HashMap::new())),
         finished_functions.into_boxed_slice(),
         imports,
         &data_initializers,


### PR DESCRIPTION
This is a work-in-progress PR to replace the temporary global-exports mechanism with a system that passes the caller vmctx as part of the wasm calling convention.

cc @steveeJ 