### PR TITLE
Use clap instead of docopt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ wasmtime-wast = { path = "wasmtime-wast" }
 wasmtime-wasi = { path = "wasmtime-wasi" }
 wasmtime-wasi-c = { path = "wasmtime-wasi-c", optional = true }
 wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
-docopt = "1.0.1"
-serde = { "version" = "1.0.94", features = ["derive"] }
+clap = { version = "2.33.0", features = ["color"] }
 faerie = "0.11.0"
 failure = "0.1"
 target-lexicon = { version = "0.8.1", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 use wasmtime_jit::CompilationStrategy;
 
-pub fn pick_compilation_strategy(cranelift: bool, lightbeam: bool) -> CompilationStrategy {
+pub fn pick_compilation_strategy(compiler: Option<&str>) -> CompilationStrategy {
     // Decide how to compile.
-    match (lightbeam, cranelift) {
+    match compiler {
         #[cfg(feature = "lightbeam")]
-        (true, false) => CompilationStrategy::Lightbeam,
+        Some("lightbeam") => CompilationStrategy::Lightbeam,
         #[cfg(not(feature = "lightbeam"))]
-        (true, false) => panic!("--lightbeam given, but Lightbeam support is not enabled"),
-        (false, true) => CompilationStrategy::Cranelift,
-        (false, false) => CompilationStrategy::Auto,
-        (true, true) => panic!("Can't enable --cranelift and --lightbeam at the same time"),
+        Some("lightbeam") => panic!("--lightbeam given, but Lightbeam support is not enabled"),
+        Some("cranelift") => CompilationStrategy::Cranelift,
+        Some(name) => panic!("Unknown compiler: {}", name),
+        None => CompilationStrategy::Auto,
     }
 }
 

--- a/wasmtime-api/Cargo.toml
+++ b/wasmtime-api/Cargo.toml
@@ -36,8 +36,7 @@ core = ["hashbrown/nightly", "cranelift-codegen/core", "cranelift-wasm/core", "w
 [dev-dependencies]
 # for wasmtime.rs
 wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
-docopt = "1.0.1"
-serde = { "version" = "1.0.94", features = ["derive"] }
+clap = { version = "2.33.0", features = ["color"] }
 pretty_env_logger = "0.3.0"
 wasmtime-wast = { path="../wasmtime-wast" }
 wasmtime-wasi = { path="../wasmtime-wasi" }


### PR DESCRIPTION
The CLI has changed a little bit:
- `-O` (big O) is used for `--optimize`; wasm2obj uses `-o` as output
- There are `-C`, `--compiler` instead of `--cranelift` and `--lightbeam`
- All options taking multiple values are required to be specified one by one, e.q. `--preload a --preload b` according to warning [in the docs](https://docs.rs/clap/2.33.0/clap/struct.Arg.html#method.multiple). Other idea is to use delimiter (hm, it looks good... I need to check the behaviour)
- We will need to get rid of `--create-cache-config`. If we want to tell the clap this option can't be used with any other, we need manually set conflicts in CLI (which is error prone) or create subcommands, so usage will become uncomfortable (`wasmtime run ...`). I suggest creating a new binary, let's say `wasmtime-utils`, with the `--create-cache-config` option.

cc @sunfishcode 