### PR TITLE
[WIP] first updates to introduce sockets

### DIFF
--- a/crates/wasi-c/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/crates/wasi-c/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -210,6 +210,7 @@ typedef uint64_t __wasi_rights_t;
 #define __WASI_RIGHT_PATH_UNLINK_FILE        (0x0000000004000000)
 #define __WASI_RIGHT_POLL_FD_READWRITE       (0x0000000008000000)
 #define __WASI_RIGHT_SOCK_SHUTDOWN           (0x0000000010000000)
+#define __WASI_RIGHT_SOCK_CONNECT            (0x0000000020000000)
 
 typedef uint16_t __wasi_roflags_t;
 #define __WASI_SOCK_RECV_DATA_TRUNCATED (0x0001)

--- a/crates/wasi-c/sandboxed-system-primitives/src/rights.h
+++ b/crates/wasi-c/sandboxed-system-primitives/src/rights.h
@@ -28,7 +28,8 @@
    __WASI_RIGHT_FD_FILESTAT_SET_SIZE |                                     \
    __WASI_RIGHT_PATH_SYMLINK | __WASI_RIGHT_PATH_UNLINK_FILE |             \
    __WASI_RIGHT_PATH_REMOVE_DIRECTORY |                                    \
-   __WASI_RIGHT_POLL_FD_READWRITE | __WASI_RIGHT_SOCK_SHUTDOWN)
+   __WASI_RIGHT_POLL_FD_READWRITE | __WASI_RIGHT_SOCK_SHUTDOWN |           \
+   __WASI_RIGHT_SOCK_CONNECT)
 
 // Block and character device interaction is outside the scope of
 // CloudABI. Simply allow everything.
@@ -70,7 +71,8 @@
 #define RIGHTS_SOCKET_BASE                                     \
   (__WASI_RIGHT_FD_READ | __WASI_RIGHT_FD_FDSTAT_SET_FLAGS |   \
    __WASI_RIGHT_FD_WRITE | __WASI_RIGHT_FD_FILESTAT_GET |      \
-   __WASI_RIGHT_POLL_FD_READWRITE | __WASI_RIGHT_SOCK_SHUTDOWN)
+   __WASI_RIGHT_POLL_FD_READWRITE | __WASI_RIGHT_SOCK_SHUTDOWN | \
+   __WASI_RIGHT_SOCK_CONNECT)
 #define RIGHTS_SOCKET_INHERITING RIGHTS_ALL
 
 // Operations that apply to TTYs.

--- a/crates/wasi-c/src/wasm32.rs
+++ b/crates/wasi-c/src/wasm32.rs
@@ -1404,6 +1404,7 @@ pub const __WASI_RIGHT_PATH_REMOVE_DIRECTORY: __wasi_rights_t = 33554432;
 pub const __WASI_RIGHT_PATH_UNLINK_FILE: __wasi_rights_t = 67108864;
 pub const __WASI_RIGHT_POLL_FD_READWRITE: __wasi_rights_t = 134217728;
 pub const __WASI_RIGHT_SOCK_SHUTDOWN: __wasi_rights_t = 268435456;
+pub const __WASI_RIGHT_SOCK_CONNECT: __wasi_rights_t = 536870912;
 pub const __WASI_SOCK_RECV_DATA_TRUNCATED: __wasi_roflags_t = 1;
 pub const __WASI_SHUT_RD: __wasi_sdflags_t = 1;
 pub const __WASI_SHUT_WR: __wasi_sdflags_t = 2;

--- a/crates/wasi-common/src/hostcalls/sock.rs
+++ b/crates/wasi-common/src/hostcalls/sock.rs
@@ -4,6 +4,8 @@
 use crate::ctx::WasiCtx;
 use crate::{wasi, wasi32};
 use wasi_common_cbindgen::wasi_common_cbindgen;
+use std::net::ToSocketAddrs;
+use std::net::TcpStream;
 
 #[wasi_common_cbindgen]
 pub unsafe fn sock_recv(
@@ -40,4 +42,26 @@ pub unsafe fn sock_shutdown(
     how: wasi::__wasi_sdflags_t,
 ) -> wasi::__wasi_errno_t {
     unimplemented!("sock_shutdown")
+}
+
+hostcalls! {
+    pub unsafe fn sock_connect(
+        wasi_ctx: &WasiCtx,
+        memory: &mut [u8],
+        sock: wasi::__wasi_fd_t,
+        addr_ptr: wasi32::uintptr_t,
+        addr_len: wasi32::size_t,
+    ) -> wasi::__wasi_errno_t;
+
+    pub unsafe fn sock_socket(
+        wasi_ctx: &mut WasiCtx,
+        memory: &mut [u8],
+        sock_domain: i32,
+        // socket type
+        // DGRAM 5
+        // STREAM 6
+        sock_type: wasi::__wasi_filetype_t,
+        sock_protocol: i32,
+        fd_out_ptr: wasi32::uintptr_t,
+    ) -> wasi::__wasi_errno_t;
 }

--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -363,6 +363,8 @@ pub(crate) unsafe fn fd_write(
         .as_descriptor_mut(wasi::__WASI_RIGHT_FD_WRITE, 0)?
     {
         Descriptor::OsFile(file) => file.write_vectored(&iovs)?,
+        Descriptor::Socket(_) => return Err(Error::EBADF),
+        Descriptor::SocketFd(_) => return Err(Error::EBADF),
         Descriptor::Stdin => return Err(Error::EBADF),
         Descriptor::Stdout => {
             // lock for the duration of the scope

--- a/crates/wasi-common/src/hostcalls_impl/mod.rs
+++ b/crates/wasi-common/src/hostcalls_impl/mod.rs
@@ -1,7 +1,9 @@
 mod fs;
 mod fs_helpers;
 mod misc;
+mod sock;
 
 pub(crate) use self::fs::*;
 pub(crate) use self::fs_helpers::PathGet;
 pub(crate) use self::misc::*;
+pub(crate) use self::sock::*;

--- a/crates/wasi-common/src/hostcalls_impl/sock.rs
+++ b/crates/wasi-common/src/hostcalls_impl/sock.rs
@@ -1,0 +1,51 @@
+#![allow(non_camel_case_types)]
+use crate::ctx::WasiCtx;
+use crate::memory::*;
+use crate::helpers::*;
+use crate::{wasi, wasi32, Result};
+use crate::sys::hostcalls_impl;
+use crate::fdentry::{SocketDetails, FdEntry};
+use log::trace;
+
+pub(crate) fn sock_connect(
+    wasi_ctx: &WasiCtx,
+    memory: &mut [u8],
+    sock: wasi::__wasi_fd_t,
+    addr_ptr: wasi32::uintptr_t,
+    addr_len: wasi32::size_t,
+) -> Result<()> {
+    let addr = dec_slice_of_u8(memory, addr_ptr, addr_len).and_then(path_from_slice)?;
+    let fd = hostcalls_impl::sock_connect(addr)?;
+    Ok(())
+}
+
+pub(crate) fn sock_socket(
+    wasi_ctx: &mut WasiCtx,
+    memory: &mut [u8],
+    sock_domain: i32,
+    sock_type: wasi::__wasi_filetype_t,
+    sock_protocol: i32,
+    fd_out_ptr: wasi32::uintptr_t,
+) -> Result<()> {
+    trace!(
+        "sock_socket(sock_domain={:?}, sock_type={:?}, sock_protocol={:?}, fd_out_ptr={:#x?})",
+        sock_domain,
+        sock_type,
+        sock_protocol,
+        fd_out_ptr,
+    );
+
+    // pre-encode fd_out_ptr to -1 in case of error in creating a socket
+    enc_fd_byref(memory, fd_out_ptr, wasi::__wasi_fd_t::max_value())?;
+
+
+    let details = SocketDetails {
+        socket_domain: sock_domain,
+        socket_type: sock_type,
+        socket_protocol: sock_protocol,
+    };
+    let fe = FdEntry::from_socket_details(details)?;
+    let sock_fd = wasi_ctx.insert_fd_entry(fe)?;
+
+    enc_fd_byref(memory, fd_out_ptr, sock_fd)
+}

--- a/crates/wasi-common/src/sys/unix/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/unix/fdentry_impl.rs
@@ -24,6 +24,9 @@ impl AsRawFd for Descriptor {
     fn as_raw_fd(&self) -> RawFd {
         match self {
             Self::OsFile(file) => file.as_raw_fd(),
+            Self::Socket(s) => s.as_raw_fd(),
+            // TODO: set errno
+            Self::SocketFd(s) => unimplemented!(),
             Self::Stdin => io::stdin().as_raw_fd(),
             Self::Stdout => io::stdout().as_raw_fd(),
             Self::Stderr => io::stderr().as_raw_fd(),
@@ -52,6 +55,14 @@ pub(crate) unsafe fn determine_type_and_access_rights<Fd: AsRawFd>(
     }
 
     Ok((file_type, rights_base, rights_inheriting))
+}
+
+pub(crate) unsafe fn determine_type_and_access_rights_for_socket() -> Result<(
+    wasi::__wasi_filetype_t,
+    wasi::__wasi_rights_t,
+    wasi::__wasi_rights_t,
+)> {
+    unimplemented!()
 }
 
 /// This function is unsafe because it operates on a raw file descriptor.

--- a/crates/wasi-common/src/sys/unix/hostcalls_impl/mod.rs
+++ b/crates/wasi-common/src/sys/unix/hostcalls_impl/mod.rs
@@ -3,6 +3,8 @@
 mod fs;
 pub(crate) mod fs_helpers;
 mod misc;
+mod sock;
 
 pub(crate) use self::fs::*;
 pub(crate) use self::misc::*;
+pub(crate) use self::sock::*;

--- a/crates/wasi-common/src/sys/unix/hostcalls_impl/sock.rs
+++ b/crates/wasi-common/src/sys/unix/hostcalls_impl/sock.rs
@@ -1,0 +1,8 @@
+#![allow(non_camel_case_types)]
+use crate::Result;
+use std::net::{TcpStream, ToSocketAddrs};
+
+pub(crate) fn sock_connect(addr: impl ToSocketAddrs) -> Result<TcpStream> {
+    TcpStream::connect(addr)
+        .map_err(Into::into) // some number just to compile
+}

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -38,8 +38,8 @@ pub(crate) const RIGHTS_ALL: __wasi_rights_t = __WASI_RIGHT_FD_DATASYNC
     | __WASI_RIGHT_PATH_UNLINK_FILE
     | __WASI_RIGHT_PATH_REMOVE_DIRECTORY
     | __WASI_RIGHT_POLL_FD_READWRITE
-    | __WASI_RIGHT_SOCK_SHUTDOWN
-    | __WASI_RIGHT_SOCK_CONNECT;
+    | __WASI_RIGHT_SOCK_SHUTDOWN;
+//    | __WASI_RIGHT_SOCK_CONNECT;
 
 // Block and character device interaction is outside the scope of
 // WASI. Simply allow everything.
@@ -96,8 +96,8 @@ pub(crate) const RIGHTS_SOCKET_BASE: __wasi_rights_t = __WASI_RIGHT_FD_READ
     | __WASI_RIGHT_FD_WRITE
     | __WASI_RIGHT_FD_FILESTAT_GET
     | __WASI_RIGHT_POLL_FD_READWRITE
-    | __WASI_RIGHT_SOCK_SHUTDOWN
-    | __WASI_RIGHT_SOCK_CONNECT;
+    | __WASI_RIGHT_SOCK_SHUTDOWN;
+//    | __WASI_RIGHT_SOCK_CONNECT;
 pub(crate) const RIGHTS_SOCKET_INHERITING: __wasi_rights_t = RIGHTS_ALL;
 
 // Operations that apply to TTYs.

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -38,7 +38,8 @@ pub(crate) const RIGHTS_ALL: __wasi_rights_t = __WASI_RIGHT_FD_DATASYNC
     | __WASI_RIGHT_PATH_UNLINK_FILE
     | __WASI_RIGHT_PATH_REMOVE_DIRECTORY
     | __WASI_RIGHT_POLL_FD_READWRITE
-    | __WASI_RIGHT_SOCK_SHUTDOWN;
+    | __WASI_RIGHT_SOCK_SHUTDOWN
+    | __WASI_RIGHT_SOCK_CONNECT;
 
 // Block and character device interaction is outside the scope of
 // WASI. Simply allow everything.
@@ -95,7 +96,8 @@ pub(crate) const RIGHTS_SOCKET_BASE: __wasi_rights_t = __WASI_RIGHT_FD_READ
     | __WASI_RIGHT_FD_WRITE
     | __WASI_RIGHT_FD_FILESTAT_GET
     | __WASI_RIGHT_POLL_FD_READWRITE
-    | __WASI_RIGHT_SOCK_SHUTDOWN;
+    | __WASI_RIGHT_SOCK_SHUTDOWN
+    | __WASI_RIGHT_SOCK_CONNECT;
 pub(crate) const RIGHTS_SOCKET_INHERITING: __wasi_rights_t = RIGHTS_ALL;
 
 // Operations that apply to TTYs.

--- a/crates/wasi-common/wasi-misc-tests/Cargo.toml
+++ b/crates/wasi-common/wasi-misc-tests/Cargo.toml
@@ -10,3 +10,6 @@ publish = false
 libc = "0.2.65"
 wasi = "0.7.0"
 more-asserts = "0.2.1"
+
+[patch.crates-io.wasi]
+path = "../../../../rust-wasi"

--- a/crates/wasi-common/wasi-misc-tests/src/bin/sock_socket.rs
+++ b/crates/wasi-common/wasi-misc-tests/src/bin/sock_socket.rs
@@ -1,0 +1,15 @@
+use wasi::wasi_unstable;
+
+fn test_sock_socket() {
+    let mut sock_fd = wasi_unstable::Fd::max_value() - 1;
+    let mut rights = 0;
+    println!("before the call");
+    let res = unsafe {
+        wasi_unstable::raw::__wasi_sock_socket(1, 1, 1, &mut sock_fd, &mut rights)
+    };
+    println!("the result is {:?}", res);
+}
+
+fn main() {
+    test_sock_socket();
+}


### PR DESCRIPTION
Reopening of https://github.com/CraneStation/wasi-common/pull/139

It's an attempt to implement two first networking methods:
- `sock_socket`, which creates a file descriptor and stores some information like domain, type, protocol
- `sock_connect`, which opens connection using fd obtained in `sock_socket`
