### PR TITLE
Use embedded API in the wasmtime-rust

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -255,7 +255,7 @@ impl Global {
         } else {
             panic!("wasmtime export is not memory")
         };
-        let ty = GlobalType::from_cranelift_global(global.clone());
+        let ty = GlobalType::from_cranelift_global(&global);
         Global {
             _store: store.clone(),
             r#type: ty,
@@ -395,7 +395,7 @@ impl Table {
         } else {
             panic!("wasmtime export is not table")
         };
-        let ty = TableType::from_cranelift_table(table.table.clone());
+        let ty = TableType::from_cranelift_table(&table.table);
         Table {
             store: store.clone(),
             r#type: ty,
@@ -479,7 +479,7 @@ impl Memory {
         } else {
             panic!("wasmtime export is not memory")
         };
-        let ty = MemoryType::from_cranelift_memory(memory.memory.clone());
+        let ty = MemoryType::from_cranelift_memory(&memory.memory);
         Memory {
             _store: store.clone(),
             r#type: ty,

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -1,7 +1,7 @@
-use crate::context::{create_compiler, Context};
+use crate::context::Context;
 use crate::r#ref::HostRef;
 use crate::HashMap;
-use alloc::{boxed::Box, rc::Rc, string::String};
+use alloc::{rc::Rc, string::String};
 use core::cell::RefCell;
 use cranelift_codegen::{ir, settings};
 use wasmtime_jit::{CompilationStrategy, Features};
@@ -80,11 +80,6 @@ impl Engine {
 
     pub(crate) fn config(&self) -> &Config {
         &self.config
-    }
-
-    pub fn create_wasmtime_context(&self) -> wasmtime_jit::Context {
-        let flags = self.config.flags().clone();
-        wasmtime_jit::Context::new(Box::new(create_compiler(flags, self.config.strategy())))
     }
 }
 

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -180,6 +180,34 @@ impl Into<AnyRef> for Val {
     }
 }
 
+impl From<RuntimeValue> for Val {
+    fn from(rv: RuntimeValue) -> Self {
+        match rv {
+            RuntimeValue::I32(i) => Val::I32(i),
+            RuntimeValue::I64(i) => Val::I64(i),
+            RuntimeValue::F32(u) => Val::F32(u),
+            RuntimeValue::F64(u) => Val::F64(u),
+            x => {
+                panic!("unsupported {:?}", x);
+            }
+        }
+    }
+}
+
+impl Into<RuntimeValue> for Val {
+    fn into(self) -> RuntimeValue {
+        match self {
+            Val::I32(i) => RuntimeValue::I32(i),
+            Val::I64(i) => RuntimeValue::I64(i),
+            Val::F32(u) => RuntimeValue::F32(u),
+            Val::F64(u) => RuntimeValue::F64(u),
+            x => {
+                panic!("unsupported {:?}", x);
+            }
+        }
+    }
+}
+
 pub(crate) fn into_checked_anyfunc(
     val: Val,
     store: &HostRef<Store>,

--- a/crates/interface-types/Cargo.toml
+++ b/crates/interface-types/Cargo.toml
@@ -16,6 +16,7 @@ cranelift-codegen = { version = "0.50.0", default-features = false }
 walrus = "0.13"
 wasmparser = { version = "0.39.2", default-features = false }
 wasm-webidl-bindings = "0.6"
+wasmtime = { path = '../api' }
 wasmtime-jit = { path = '../jit', default-features = false }
 wasmtime-runtime = { path = '../runtime', default-features = false }
 wasmtime-wasi = { path = '../wasi' }

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -21,6 +21,7 @@ wasmtime-interface-types = { path = "../../interface-types" }
 wasmtime-jit = { path = "../../jit" }
 wasmtime-rust-macro = { path = "./macro" }
 wasmtime-wasi = { path = "../../wasi" }
+wasmtime = { path = "../../api" }
 anyhow = "1.0.19"
 
 [badges]

--- a/crates/misc/rust/src/lib.rs
+++ b/crates/misc/rust/src/lib.rs
@@ -6,6 +6,7 @@ pub mod __rt {
     pub use anyhow;
     pub use cranelift_codegen;
     pub use cranelift_native;
+    pub use wasmtime_api;
     pub use wasmtime_interface_types;
     pub use wasmtime_jit;
 

--- a/crates/wasi-common/tests/wasm_tests/runtime.rs
+++ b/crates/wasi-common/tests/wasm_tests/runtime.rs
@@ -73,11 +73,11 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         .imports()
         .iter()
         .map(|i| {
-            let module_name = i.module().to_string();
-            if let Some((instance, map)) = module_registry.get(&module_name) {
-                let field_name = i.name().to_string();
-                if let Some(export_index) = map.get(&field_name) {
-                    Ok(instance.exports()[*export_index].clone())
+            let module_name = i.module().as_str();
+            if let Some(instance) = module_registry.get(module_name) {
+                let field_name = i.name().as_str();
+                if let Some(export) = instance.find_export_by_name(field_name) {
+                    Ok(export.clone())
                 } else {
                     bail!(
                         "import {} was not found in module {}",


### PR DESCRIPTION
* Adds wasmtime_interface_types::ModuleData::invoke_export -- similar to invoke() but using wasmtime_api
* Changes macro to use wasmtime_api::Instance instead of cx.instantiate_module
* Adjustment to wasmtime-cli