### PR TITLE
Implement `__wasi_fd_fdstat_get` for Windows.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
@@ -35,7 +35,8 @@ unsafe fn test_path_filestat(dir_fd: wasi_unstable::Fd) {
             | wasi_unstable::RIGHT_FD_WRITE
             | wasi_unstable::RIGHT_PATH_FILESTAT_GET,
         0,
-        0,
+        // Pass some flags for later retrieval
+        wasi_unstable::FDFLAG_APPEND | wasi_unstable::FDFLAG_SYNC,
         &mut file_fd,
     );
     assert_eq!(
@@ -61,6 +62,11 @@ unsafe fn test_path_filestat(dir_fd: wasi_unstable::Fd) {
         fdstat.fs_rights_inheriting & wasi_unstable::RIGHT_PATH_FILESTAT_GET,
         0,
         "files shouldn't have rights for path_* syscalls even if manually given",
+    );
+    assert_ne!(
+        fdstat.fs_flags & (wasi_unstable::FDFLAG_APPEND | wasi_unstable::FDFLAG_SYNC),
+        0,
+        "file should have the same flags used to create the file"
     );
 
     // Check file size

--- a/crates/wasi-common/src/old/snapshot_0/sys/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/mod.rs
@@ -12,7 +12,6 @@ cfg_if! {
     } else if #[cfg(windows)] {
         mod windows;
         pub(crate) use self::windows::*;
-        pub use self::windows::preopen_dir;
 
         pub(crate) fn errno_from_host(err: i32) -> wasi::__wasi_errno_t {
             host_impl::errno_from_win(winx::winerror::WinError::from_u32(err as u32))

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
@@ -53,13 +53,13 @@ pub(crate) unsafe fn determine_type_and_access_rights<Handle: AsRawHandle>(
     wasi::__wasi_rights_t,
     wasi::__wasi_rights_t,
 )> {
-    use winx::file::{get_file_access_mode, AccessMode};
+    use winx::file::{query_access_information, AccessMode};
 
     let (file_type, mut rights_base, rights_inheriting) = determine_type_rights(handle)?;
 
     match file_type {
         wasi::__WASI_FILETYPE_DIRECTORY | wasi::__WASI_FILETYPE_REGULAR_FILE => {
-            let mode = get_file_access_mode(handle.as_raw_handle())?;
+            let mode = query_access_information(handle.as_raw_handle())?;
             if mode.contains(AccessMode::FILE_GENERIC_READ) {
                 rights_base |= wasi::__WASI_RIGHTS_FD_READ;
             }

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs.rs
@@ -56,7 +56,7 @@ pub(crate) fn fd_pwrite(file: &File, buf: &[u8], offset: wasi::__wasi_filesize_t
 
 pub(crate) fn fd_fdstat_get(fd: &File) -> Result<wasi::__wasi_fdflags_t> {
     use winx::file::AccessMode;
-    unsafe { winx::file::get_file_access_mode(fd.as_raw_handle()) }
+    unsafe { winx::file::query_access_information(fd.as_raw_handle()) }
         .map(host_impl::fdflags_from_win)
         .map_err(Into::into)
 }

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/mod.rs
@@ -4,29 +4,11 @@ pub(crate) mod hostcalls_impl;
 
 use crate::old::snapshot_0::Result;
 use std::fs::{File, OpenOptions};
-use std::path::Path;
 
 pub(crate) fn dev_null() -> Result<File> {
     OpenOptions::new()
         .read(true)
         .write(true)
         .open("NUL")
-        .map_err(Into::into)
-}
-
-pub fn preopen_dir<P: AsRef<Path>>(path: P) -> Result<File> {
-    use std::fs::OpenOptions;
-    use std::os::windows::fs::OpenOptionsExt;
-    use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
-
-    // To open a directory using CreateFile, specify the
-    // FILE_FLAG_BACKUP_SEMANTICS flag as part of dwFileFlags...
-    // cf. https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-createfile2
-    OpenOptions::new()
-        .create(false)
-        .write(true)
-        .read(true)
-        .attributes(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(path)
         .map_err(Into::into)
 }

--- a/crates/wasi-common/src/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/windows/fdentry_impl.rs
@@ -53,13 +53,13 @@ pub(crate) unsafe fn determine_type_and_access_rights<Handle: AsRawHandle>(
     wasi::__wasi_rights_t,
     wasi::__wasi_rights_t,
 )> {
-    use winx::file::{get_file_access_mode, AccessMode};
+    use winx::file::{query_access_information, AccessMode};
 
     let (file_type, mut rights_base, rights_inheriting) = determine_type_rights(handle)?;
 
     match file_type {
         wasi::__WASI_FILETYPE_DIRECTORY | wasi::__WASI_FILETYPE_REGULAR_FILE => {
-            let mode = get_file_access_mode(handle.as_raw_handle())?;
+            let mode = query_access_information(handle.as_raw_handle())?;
             if mode.contains(AccessMode::FILE_GENERIC_READ) {
                 rights_base |= wasi::__WASI_RIGHTS_FD_READ;
             }

--- a/crates/wasi-common/src/sys/windows/host_impl.rs
+++ b/crates/wasi-common/src/sys/windows/host_impl.rs
@@ -1,13 +1,7 @@
 //! WASI host types specific to Windows host.
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(unused)]
 use crate::{wasi, Error, Result};
 use std::ffi::OsStr;
-use std::fs::OpenOptions;
 use std::os::windows::ffi::OsStrExt;
-use std::os::windows::fs::OpenOptionsExt;
-use winx::file::{AccessMode, Attributes, CreationDisposition, Flags};
 
 pub(crate) fn errno_from_win(error: winx::winerror::WinError) -> wasi::__wasi_errno_t {
     // TODO: implement error mapping between Windows and WASI
@@ -37,64 +31,6 @@ pub(crate) fn errno_from_win(error: winx::winerror::WinError) -> wasi::__wasi_er
         ERROR_DIRECTORY => wasi::__WASI_ERRNO_NOTDIR,
         ERROR_ALREADY_EXISTS => wasi::__WASI_ERRNO_EXIST,
         _ => wasi::__WASI_ERRNO_NOTSUP,
-    }
-}
-
-pub(crate) fn fdflags_from_win(mode: AccessMode) -> wasi::__wasi_fdflags_t {
-    let mut fdflags = 0;
-    // TODO verify this!
-    if mode.contains(AccessMode::FILE_APPEND_DATA) {
-        fdflags |= wasi::__WASI_FDFLAGS_APPEND;
-    }
-    if mode.contains(AccessMode::SYNCHRONIZE) {
-        fdflags |= wasi::__WASI_FDFLAGS_DSYNC;
-        fdflags |= wasi::__WASI_FDFLAGS_RSYNC;
-        fdflags |= wasi::__WASI_FDFLAGS_SYNC;
-    }
-    // The NONBLOCK equivalent is FILE_FLAG_OVERLAPPED
-    // but it seems winapi doesn't provide a mechanism
-    // for checking whether the handle supports async IO.
-    // On the contrary, I've found some dicsussion online
-    // which suggests that on Windows all handles should
-    // generally be assumed to be opened with async support
-    // and then the program should fallback should that **not**
-    // be the case at the time of the operation.
-    // TODO: this requires further investigation
-    fdflags
-}
-
-pub(crate) fn win_from_fdflags(fdflags: wasi::__wasi_fdflags_t) -> (AccessMode, Flags) {
-    let mut access_mode = AccessMode::empty();
-    let mut flags = Flags::empty();
-
-    // TODO verify this!
-    if fdflags & wasi::__WASI_FDFLAGS_NONBLOCK != 0 {
-        flags.insert(Flags::FILE_FLAG_OVERLAPPED);
-    }
-    if fdflags & wasi::__WASI_FDFLAGS_APPEND != 0 {
-        access_mode.insert(AccessMode::FILE_APPEND_DATA);
-    }
-    if fdflags & wasi::__WASI_FDFLAGS_DSYNC != 0
-        || fdflags & wasi::__WASI_FDFLAGS_RSYNC != 0
-        || fdflags & wasi::__WASI_FDFLAGS_SYNC != 0
-    {
-        access_mode.insert(AccessMode::SYNCHRONIZE);
-    }
-
-    (access_mode, flags)
-}
-
-pub(crate) fn win_from_oflags(oflags: wasi::__wasi_oflags_t) -> CreationDisposition {
-    if oflags & wasi::__WASI_OFLAGS_CREAT != 0 {
-        if oflags & wasi::__WASI_OFLAGS_EXCL != 0 {
-            CreationDisposition::CREATE_NEW
-        } else {
-            CreationDisposition::CREATE_ALWAYS
-        }
-    } else if oflags & wasi::__WASI_OFLAGS_TRUNC != 0 {
-        CreationDisposition::TRUNCATE_EXISTING
-    } else {
-        CreationDisposition::OPEN_EXISTING
     }
 }
 

--- a/crates/wasi-common/winx/src/lib.rs
+++ b/crates/wasi-common/winx/src/lib.rs
@@ -22,6 +22,7 @@
 #![cfg(windows)]
 
 pub mod file;
+mod ntdll;
 pub mod time;
 pub mod winerror;
 

--- a/crates/wasi-common/winx/src/ntdll.rs
+++ b/crates/wasi-common/winx/src/ntdll.rs
@@ -1,0 +1,65 @@
+//! Module for importing functions from ntdll.dll.
+//! The winapi crate does not expose these Windows API functions.
+
+#![allow(nonstandard_style)]
+
+use std::ffi::c_void;
+use std::os::raw::c_ulong;
+use std::os::windows::prelude::RawHandle;
+use winapi::shared::ntdef::NTSTATUS;
+use winapi::um::winnt::ACCESS_MASK;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) enum FILE_INFORMATION_CLASS {
+    FileAccessInformation = 8,
+    FileModeInformation = 16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) union IO_STATUS_BLOCK_u {
+    pub Status: NTSTATUS,
+    pub Pointer: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) struct IO_STATUS_BLOCK {
+    pub u: IO_STATUS_BLOCK_u,
+    pub Information: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub(crate) struct FILE_ACCESS_INFORMATION {
+    pub AccessFlags: ACCESS_MASK,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub(crate) struct FILE_MODE_INFORMATION {
+    pub Mode: c_ulong,
+}
+
+impl Default for IO_STATUS_BLOCK {
+    #[inline]
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[link(name = "ntdll")]
+extern "C" {
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntqueryinformationfile
+    pub(crate) fn NtQueryInformationFile(
+        FileHandle: RawHandle,
+        IoStatusBlock: *mut IO_STATUS_BLOCK,
+        FileInformation: *mut c_void,
+        Length: c_ulong,
+        FileInformationClass: FILE_INFORMATION_CLASS,
+    ) -> NTSTATUS;
+
+    // https://docs.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-rtlntstatustodoserror
+    pub(crate) fn RtlNtStatusToDosError(status: NTSTATUS) -> c_ulong;
+}


### PR DESCRIPTION
This PRfully implements `__wasi_fd_fdstat_get` on Windows so that
the descriptor flags can be determined.

It does this by calling into `NtQueryInformationFile` (safe to call from
user mode) to get the open mode and access of the underlying OS handle.

`NtQueryInformationFile` isn't included in the `winapi` crate, so it is
manually being linked against.

This PR also fixes several bugs on Windows:

* Ignore `__WASI_FDFLAG_NONBLOCK` by not setting `FILE_FLAG_OVERLAPPED`
   on file handles (the POSIX behavior for `O_NONBLOCK` on files).
* Use `FILE_FLAG_WRITE_THROUGH` for the `__WASI_FDFLAG_?SYNC` flags.
* `__WASI_FDFLAG_APPEND` should disallow `FILE_WRITE_DATA` access to
  force append-only on write operations.
* Use `GENERIC_READ` and `GENERIC_WRITE` access flags.  The
  latter is required when opening a file for truncation.
