### PR TITLE
Re-enable some missing WASI tests on Windows

### DIFF
--- a/crates/wasi-common/build.rs
+++ b/crates/wasi-common/build.rs
@@ -177,8 +177,6 @@ mod wasm_tests {
                         "dangling_symlink" => true,
                         "symlink_loop" => true,
                         "truncation_rights" => true,
-                        "path_rename_trailing_slashes" => true,
-                        "fd_readdir" => true,
                         "poll_oneoff" => true,
                         _ => false,
                     }


### PR DESCRIPTION
For some weird reason (probably when migrating the codebase from
`wasi-common` repo to `wasmtime`), these did not get enabled for the
Windows platform.