### PR TITLE
Squash improper_ctypes warnings on nightly

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,5 +1,6 @@
 //! Wasmtime embed API. Based on wasm-c-api.
 
+#![allow(improper_ctypes)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod callable;

--- a/crates/misc/py/src/lib.rs
+++ b/crates/misc/py/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(improper_ctypes)]
+
 use crate::import::into_instance_from_obj;
 use crate::instance::Instance;
 use crate::memory::Memory;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,5 +1,6 @@
 //! Runtime library support for Wasmtime.
 
+#![allow(improper_ctypes)]
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(improper_ctypes)]
+
 extern crate alloc;
 
 mod instantiate;

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -1,3 +1,5 @@
+#![allow(improper_ctypes)]
+
 use alloc::rc::Rc;
 use core::cell::RefCell;
 use cranelift_codegen::ir::types;


### PR DESCRIPTION
Lots more warnings are showing up on nightly compilers due to a recent
change. I've opened rust-lang/rust#66373 on the compiler side for this
as well.