### PR TITLE
Reduce number of crates needed for `Config` usage

### DIFF
--- a/crates/api/src/context.rs
+++ b/crates/api/src/context.rs
@@ -1,8 +1,8 @@
+use crate::Config;
 use alloc::rc::Rc;
 use core::cell::{RefCell, RefMut};
 use core::hash::{Hash, Hasher};
-use cranelift_codegen::settings;
-use wasmtime_jit::{CompilationStrategy, Compiler, Features};
+use wasmtime_jit::{Compiler, Features};
 
 #[derive(Clone)]
 pub struct Context {
@@ -12,21 +12,19 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(compiler: Compiler, features: Features, debug_info: bool) -> Context {
-        Context {
-            compiler: Rc::new(RefCell::new(compiler)),
-            features,
-            debug_info,
-        }
+    pub fn new(config: &Config) -> Context {
+        let isa_builder =
+            cranelift_native::builder().expect("host machine is not a supported target");
+        let isa = isa_builder.finish(config.flags.clone());
+        Context::new_with_compiler(config, Compiler::new(isa, config.strategy))
     }
 
-    pub fn create(
-        flags: settings::Flags,
-        features: Features,
-        debug_info: bool,
-        strategy: CompilationStrategy,
-    ) -> Context {
-        Context::new(create_compiler(flags, strategy), features, debug_info)
+    pub fn new_with_compiler(config: &Config, compiler: Compiler) -> Context {
+        Context {
+            compiler: Rc::new(RefCell::new(compiler)),
+            features: config.features.clone(),
+            debug_info: config.debug_info,
+        }
     }
 
     pub(crate) fn debug_info(&self) -> bool {
@@ -53,14 +51,4 @@ impl PartialEq for Context {
     fn eq(&self, other: &Context) -> bool {
         Rc::ptr_eq(&self.compiler, &other.compiler)
     }
-}
-
-pub(crate) fn create_compiler(flags: settings::Flags, strategy: CompilationStrategy) -> Compiler {
-    let isa = {
-        let isa_builder =
-            cranelift_native::builder().expect("host machine is not a supported target");
-        isa_builder.finish(flags)
-    };
-
-    Compiler::new(isa, strategy)
 }

--- a/crates/api/tests/import_calling_export.rs
+++ b/crates/api/tests/import_calling_export.rs
@@ -24,7 +24,7 @@ fn test_import_calling_export() {
         }
     }
 
-    let engine = HostRef::new(Engine::new(Config::default()));
+    let engine = HostRef::new(Engine::default());
     let store = HostRef::new(Store::new(&engine));
     let module = HostRef::new(
         Module::new(

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -15,8 +15,6 @@ test = false
 doctest = false
 
 [dependencies]
-cranelift-codegen = "0.50.0"
-cranelift-native = "0.50.0"
 wasmtime-interface-types = { path = "../../interface-types" }
 wasmtime-jit = { path = "../../jit" }
 wasmtime-rust-macro = { path = "./macro" }

--- a/crates/misc/rust/macro/src/lib.rs
+++ b/crates/misc/rust/macro/src/lib.rs
@@ -51,17 +51,12 @@ fn generate_load(item: &syn::ItemTrait) -> syn::Result<TokenStream> {
             use #root::wasmtime_api::{HostRef, Config, Extern, Engine, Store, Instance, Module};
             use #root::anyhow::{bail, format_err};
 
-            let config = {
-                let flag_builder = #root::cranelift_codegen::settings::builder();
-                let flags = #root::cranelift_codegen::settings::Flags::new(flag_builder);
-                let features = #root::wasmtime_jit::Features {
-                    multi_value: true,
-                    ..Default::default()
-                };
-                let strategy = #root::wasmtime_jit::CompilationStrategy::Auto;
-                Config::new(flags, features, false, strategy)
-            };
-            let engine = HostRef::new(Engine::new(config));
+            let mut config = Config::new();
+            config.features(#root::wasmtime_jit::Features {
+                multi_value: true,
+                ..Default::default()
+            });
+            let engine = HostRef::new(Engine::new(&config));
             let store = HostRef::new(Store::new(&engine));
             let global_exports = store.borrow().global_exports().clone();
 

--- a/crates/misc/rust/src/lib.rs
+++ b/crates/misc/rust/src/lib.rs
@@ -4,8 +4,6 @@ pub use wasmtime_rust_macro::wasmtime;
 #[doc(hidden)]
 pub mod __rt {
     pub use anyhow;
-    pub use cranelift_codegen;
-    pub use cranelift_native;
     pub use wasmtime_api;
     pub use wasmtime_interface_types;
     pub use wasmtime_jit;

--- a/crates/wasi-common/tests/wasm_tests/runtime.rs
+++ b/crates/wasi-common/tests/wasm_tests/runtime.rs
@@ -3,7 +3,6 @@ use cranelift_codegen::settings::{self, Configurable};
 use std::fs::File;
 use std::{collections::HashMap, path::Path};
 use wasmtime_api::{Config, Engine, HostRef, Instance, Module, Store};
-use wasmtime_jit::{CompilationStrategy, Features};
 
 pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> anyhow::Result<()> {
     // Prepare runtime
@@ -14,13 +13,9 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         .enable("avoid_div_traps")
         .context("error while enabling proper division trap")?;
 
-    let config = Config::new(
-        settings::Flags::new(flag_builder),
-        Features::default(),
-        false,
-        CompilationStrategy::Auto,
-    );
-    let engine = HostRef::new(Engine::new(config));
+    let mut config = Config::new();
+    config.flags(settings::Flags::new(flag_builder));
+    let engine = HostRef::new(Engine::new(&config));
     let store = HostRef::new(Store::new(&engine));
 
     let mut module_registry = HashMap::new();

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -267,13 +267,13 @@ fn main() -> Result<()> {
     // Decide how to compile.
     let strategy = pick_compilation_strategy(args.flag_cranelift, args.flag_lightbeam);
 
-    let config = Config::new(
-        settings::Flags::new(flag_builder),
-        features,
-        debug_info,
-        strategy,
-    );
-    let engine = HostRef::new(Engine::new(config));
+    let mut config = Config::new();
+    config
+        .features(features)
+        .flags(settings::Flags::new(flag_builder))
+        .debug_info(debug_info)
+        .strategy(strategy);
+    let engine = HostRef::new(Engine::new(&config));
     let store = HostRef::new(Store::new(&engine));
 
     let mut module_registry = HashMap::new();


### PR DESCRIPTION
This commit is an attempt to reduce the number of crates necessary to
link to when using `wasmtime::Config` in "default mode" or with only one
or two tweaks. The change moves to a builder-style pattern for `Config`
to only require importing crates as necessary if you configure a
particular setting. This then also propagates that change to `Context`
as well by taking a `Config` instead of requiring that all arguments are
passed alone.