### PR TITLE
Run cargo format to avoid test-all.sh failure

### DIFF
--- a/crates/lightbeam/src/microwasm.rs
+++ b/crates/lightbeam/src/microwasm.rs
@@ -1179,12 +1179,8 @@ where
                 sig!((ty) -> (ty))
             }
 
-            WasmOperator::GetGlobal { global_index } => {
-                sig!(() -> (self.module.global_type(*global_index).to_microwasm_type()))
-            }
-            WasmOperator::SetGlobal { global_index } => {
-                sig!((self.module.global_type(*global_index).to_microwasm_type()) -> ())
-            }
+            WasmOperator::GetGlobal { global_index } => sig!(() -> (self.module.global_type(*global_index).to_microwasm_type())),
+            WasmOperator::SetGlobal { global_index } => sig!((self.module.global_type(*global_index).to_microwasm_type()) -> ()),
 
             WasmOperator::F32Load { .. } => sig!((I32) -> (F32)),
             WasmOperator::F64Load { .. } => sig!((I32) -> (F64)),
@@ -1263,12 +1259,8 @@ where
             | WasmOperator::F64Le
             | WasmOperator::F64Ge => sig!((F64, F64) -> (I32)),
 
-            WasmOperator::I32Clz | WasmOperator::I32Ctz | WasmOperator::I32Popcnt => {
-                sig!((I32) -> (I32))
-            }
-            WasmOperator::I64Clz | WasmOperator::I64Ctz | WasmOperator::I64Popcnt => {
-                sig!((I64) -> (I64))
-            }
+            WasmOperator::I32Clz | WasmOperator::I32Ctz | WasmOperator::I32Popcnt => sig!((I32) -> (I32)),
+            WasmOperator::I64Clz | WasmOperator::I64Ctz | WasmOperator::I64Popcnt => sig!((I64) -> (I64)),
 
             WasmOperator::I32Add
             | WasmOperator::I32Sub


### PR DESCRIPTION
When running `scripts/test-all.sh`, the script failed due to a formatting diff. This change is the result of running `cargo fmt --all`.