### PR TITLE
Add initial impl of path_link on Windows

### DIFF
--- a/crates/wasi-common/build.rs
+++ b/crates/wasi-common/build.rs
@@ -178,7 +178,6 @@ mod wasm_tests {
                         "symlink_loop" => true,
                         "truncation_rights" => true,
                         "poll_oneoff" => true,
-                        "path_link" => true,
                         _ => false,
                     }
                 } else {

--- a/crates/wasi-common/src/sys/windows/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/sys/windows/hostcalls_impl/fs.rs
@@ -88,7 +88,10 @@ pub(crate) fn path_create_directory(resolved: PathGet) -> Result<()> {
 }
 
 pub(crate) fn path_link(resolved_old: PathGet, resolved_new: PathGet) -> Result<()> {
-    unimplemented!("path_link")
+    use std::fs;
+    let old_path = resolved_old.concatenate()?;
+    let new_path = resolved_new.concatenate()?;
+    fs::hard_link(old_path, new_path).map_err(Into::into)
 }
 
 pub(crate) fn path_open(


### PR DESCRIPTION
This commit adds initial implementation of `path_link` syscall on
Windows, and enables the `path_link` test case on Windows.