### PR TITLE
Fix rights check for fd_pread and fd_pwrite

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/file_pread_pwrite.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_pread_pwrite.rs
@@ -14,7 +14,7 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
         0,
         "file",
         wasi_unstable::O_CREAT,
-        wasi_unstable::RIGHT_FD_READ | wasi_unstable::RIGHT_FD_WRITE,
+        wasi_unstable::RIGHT_FD_READ | wasi_unstable::RIGHT_FD_SEEK | wasi_unstable::RIGHT_FD_WRITE,
         0,
         0,
         &mut file_fd,

--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -61,7 +61,7 @@ pub(crate) unsafe fn fd_pread(
 
     let fd = wasi_ctx
         .get_fd_entry(fd)?
-        .as_descriptor(wasi::__WASI_RIGHT_FD_READ, 0)?
+        .as_descriptor(wasi::__WASI_RIGHT_FD_READ | wasi::__WASI_RIGHT_FD_SEEK, 0)?
         .as_file()?;
 
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
@@ -110,7 +110,7 @@ pub(crate) unsafe fn fd_pwrite(
 
     let fd = wasi_ctx
         .get_fd_entry(fd)?
-        .as_descriptor(wasi::__WASI_RIGHT_FD_WRITE, 0)?
+        .as_descriptor(wasi::__WASI_RIGHT_FD_WRITE | wasi::__WASI_RIGHT_FD_SEEK, 0)?
         .as_file()?;
     let iovs = dec_ciovec_slice(memory, iovs_ptr, iovs_len)?;
 


### PR DESCRIPTION
This commit fixes rights check for `fd_pread` and `fd_pwrite` to be
conformant with the WASI spec. In the spec, it is clearly stated that
the right to invoke `__wasi_fd_pread()` requires a combination of
`__WASI_RIGHT_FD_READ` with `__WASI_RIGHT_FD_SEEK`, and similarly for
`__wasi_fd_pwrite()` the combination is `__WASI_RIGHT_FD_WRITE` with
`__WASI_RIGHT_FD_SEEK`. Relevant link to the spec: [__wasi_rights_t].

[__wasi_rights_t]: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs/wasi_unstable_preview1.md#__wasi_rights_t-uint64_t-bitfield