### PR TITLE
Remove unneded prefix argument from `instantiate_wasi`.

### DIFF
--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -53,7 +53,6 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         Instance::from_handle(
             &store,
             wasmtime_wasi::instantiate_wasi_with_context(
-                "",
                 global_exports.clone(),
                 builder.build().context("failed to build wasi context")?,
             )

--- a/crates/wasi/src/instantiate.rs
+++ b/crates/wasi/src/instantiate.rs
@@ -21,7 +21,7 @@ pub fn create_wasi_instance(
     environ: &[(String, String)],
 ) -> Result<api::Instance, InstantiationError> {
     let global_exports = store.borrow().global_exports().clone();
-    let wasi = instantiate_wasi("", global_exports, preopened_dirs, argv, environ)?;
+    let wasi = instantiate_wasi(global_exports, preopened_dirs, argv, environ)?;
     let instance = api::Instance::from_handle(&store, wasi);
     Ok(instance)
 }

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -293,7 +293,7 @@ fn main() -> Result<()> {
         #[cfg(feature = "wasi-c")]
         {
             let global_exports = store.borrow().global_exports().clone();
-            let handle = instantiate_wasi_c("", global_exports, &preopen_dirs, &argv, &environ)?;
+            let handle = instantiate_wasi_c(global_exports, &preopen_dirs, &argv, &environ)?;
             Instance::from_handle(&store, handle)
         }
         #[cfg(not(feature = "wasi-c"))]


### PR DESCRIPTION
This was an artifact of an earlier backwards-compatibility mechanism
which is no longer needed.