### PR TITLE
Move command function invocation out of wasmtime-instance.

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -472,37 +472,6 @@ impl Instance {
     fn invoke_start_function(&mut self) -> Result<(), InstantiationError> {
         if let Some(start_index) = self.module.start_func {
             self.invoke_function(start_index)
-        } else if let Some(start_export) = self.module.exports.get("_start") {
-            // As a compatibility measure, if the module doesn't have a start
-            // function but does have a _start function exported, call that.
-            match *start_export {
-                wasmtime_environ::Export::Function(func_index) => {
-                    let sig = &self.module.signatures[self.module.functions[func_index]];
-                    // No wasm params or returns; just the vmctx param.
-                    if sig.params.len() == 1 && sig.returns.is_empty() {
-                        self.invoke_function(func_index)
-                    } else {
-                        Ok(())
-                    }
-                }
-                _ => Ok(()),
-            }
-        } else if let Some(main_export) = self.module.exports.get("main") {
-            // As a further compatibility measure, if the module doesn't have a
-            // start function or a _start function exported, but does have a main
-            // function exported, call that.
-            match *main_export {
-                wasmtime_environ::Export::Function(func_index) => {
-                    let sig = &self.module.signatures[self.module.functions[func_index]];
-                    // No wasm params or returns; just the vmctx param.
-                    if sig.params.len() == 1 && sig.returns.is_empty() {
-                        self.invoke_function(func_index)
-                    } else {
-                        Ok(())
-                    }
-                }
-                _ => Ok(()),
-            }
         } else {
             Ok(())
         }

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -366,12 +366,27 @@ fn handle_module(
     args: &Args,
     path: &Path,
 ) -> Result<()> {
-    let (instance, _module, data) = instantiate_module(store, module_registry, path)?;
+    let (instance, module, data) = instantiate_module(store, module_registry, path)?;
 
     // If a function to invoke was given, invoke it.
     if let Some(f) = &args.flag_invoke {
         let data = ModuleData::new(&data)?;
         invoke_export(instance, &data, f, args)?;
+    } else if module
+        .borrow()
+        .exports()
+        .iter()
+        .find(|export| export.name().as_str().is_empty())
+        .is_some()
+    {
+        // Launch the default command export.
+        let data = ModuleData::new(&data)?;
+        invoke_export(instance, &data, "", args)?;
+    } else {
+        // If the module doesn't have a default command export, launch the
+        // _start function if one is present, as a compatibility measure.
+        let data = ModuleData::new(&data)?;
+        invoke_export(instance, &data, "_start", args)?;
     }
 
     Ok(())


### PR DESCRIPTION
Previously, "_start" was run as part of module instantiation, which
meant it was always run, even for wasm modules that weren't being
loaded as commands. Now, just invoke it from the wasmtime driver,
which for now is the only place that runs wasm modules as actual
commands.

Also, stop recognizing the old "main" entry point, which tools have
stopped using a while ago, and switch to start recognizing the ""
entrypoint.