### PR TITLE
Add missing import to wasmtime-rust macro

### DIFF
--- a/crates/misc/rust/src/lib.rs
+++ b/crates/misc/rust/src/lib.rs
@@ -7,6 +7,7 @@ pub mod __rt {
     pub use wasmtime_api;
     pub use wasmtime_interface_types;
     pub use wasmtime_jit;
+    pub use wasmtime_wasi;
 
     use std::convert::{TryFrom, TryInto};
     use wasmtime_interface_types::Value;


### PR DESCRIPTION
This commit does two things: 1) it fixes `wasmtime_rust::wasmtime` proc macro by
adding the missing import to the `__rt` module, and fixing the scoping inside
the macro itself; and 2) it augments the `wasmtime_rust::wasmtime` proc macro with
custom error messages in case the implementor forgets the `self` argument in the
trait methods.