### PR TITLE
Remove a few more explicit `alloc::` and `core::`.

### DIFF
--- a/crates/debug/src/write_debuginfo.rs
+++ b/crates/debug/src/write_debuginfo.rs
@@ -2,7 +2,6 @@ use faerie::artifact::{Decl, SectionKind};
 use faerie::*;
 use gimli::write::{Address, Dwarf, EndianVec, Result, Sections, Writer};
 use gimli::{RunTimeEndian, SectionId};
-use std::result;
 
 #[derive(Clone)]
 struct DebugReloc {

--- a/crates/wasi/src/old/snapshot_0/instantiate.rs
+++ b/crates/wasi/src/old/snapshot_0/instantiate.rs
@@ -1,12 +1,12 @@
 use super::syscalls;
-use alloc::rc::Rc;
-use core::cell::RefCell;
 use cranelift_codegen::ir::types;
 use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::DefinedFuncIndex;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
+use std::rc::Rc;
 use target_lexicon::HOST;
 use wasi_common::old::snapshot_0::{WasiCtx, WasiCtxBuilder};
 use wasmtime_api as api;


### PR DESCRIPTION
These were accidently re-introduced by
d645902620bf172b8d4ee6afe70fe8eee4f6fdc0 after
39e57e3e9ac9c15bef45eb77a2544a7c0b76501a landed.