### PR TITLE
Fix compilation error in instantiate.rs

### DIFF
--- a/crates/wasi/src/old/snapshot_0/instantiate.rs
+++ b/crates/wasi/src/old/snapshot_0/instantiate.rs
@@ -1,3 +1,4 @@
+extern crate alloc;
 use super::syscalls;
 use alloc::rc::Rc;
 use core::cell::RefCell;


### PR DESCRIPTION
Currently, the following compilation error is generated:
```console
Compiling wasmtime-wasi v0.7.0 (/work/wasm/wasmtime/crates/wasi)
error[E0433]: failed to resolve: use of undeclared type or module `alloc`
 --> crates/wasi/src/old/snapshot_0/instantiate.rs:2:5
  |
2 | use alloc::rc::Rc;
  |     ^^^^^ use of undeclared type or module `alloc`
```
This commit adds an external crate dependency to the alloc crate which
allows for a successful build.