### PR TITLE
Remove unused std::result import

### DIFF
--- a/crates/debug/src/write_debuginfo.rs
+++ b/crates/debug/src/write_debuginfo.rs
@@ -2,7 +2,6 @@ use faerie::artifact::{Decl, SectionKind};
 use faerie::*;
 use gimli::write::{Address, Dwarf, EndianVec, Result, Sections, Writer};
 use gimli::{RunTimeEndian, SectionId};
-use std::result;
 
 #[derive(Clone)]
 struct DebugReloc {


### PR DESCRIPTION
Currently, the following warning is generated when building:
```console
warning: unused import: `std::result`
 --> crates/debug/src/write_debuginfo.rs:5:5
  |
5 | use std::result;
  |     ^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```
This commit removes this unused import.