### PR TITLE
Simplify examples: avoid unnecessary HostRef wrap/unwrap

### DIFF
--- a/crates/api/examples/gcd.rs
+++ b/crates/api/examples/gcd.rs
@@ -58,7 +58,7 @@ fn main() -> Result<()> {
     let instance = Instance::new(&store, &module, &[])?;
 
     // Invoke `gcd` export
-    let gcd = instance.exports()[gcd_index].func().expect("gcd").clone();
+    let gcd = instance.exports()[gcd_index].func().expect("gcd");
     let result = gcd
         .borrow()
         .call(&[Val::from(6i32), Val::from(27i32)])

--- a/crates/api/examples/gcd.rs
+++ b/crates/api/examples/gcd.rs
@@ -55,13 +55,10 @@ fn main() -> Result<()> {
         .0;
 
     // Instantiate the module.
-    let instance = HostRef::new(Instance::new(&store, &module, &[])?);
+    let instance = Instance::new(&store, &module, &[])?;
 
     // Invoke `gcd` export
-    let gcd = instance.borrow().exports()[gcd_index]
-        .func()
-        .expect("gcd")
-        .clone();
+    let gcd = instance.exports()[gcd_index].func().expect("gcd").clone();
     let result = gcd
         .borrow()
         .call(&[Val::from(6i32), Val::from(27i32)])

--- a/crates/api/examples/hello.rs
+++ b/crates/api/examples/hello.rs
@@ -1,7 +1,6 @@
 //! Translation of hello example
 
 use anyhow::{ensure, format_err, Context as _, Result};
-use std::cell::Ref;
 use std::rc::Rc;
 use wasmtime::*;
 
@@ -49,14 +48,12 @@ fn main() -> Result<()> {
     // Note that this is where the wasm `start` function, if any, would run.
     println!("Instantiating module...");
     let imports = vec![hello_func.into()];
-    let instance = HostRef::new(
-        Instance::new(&store, &module, imports.as_slice())
-            .context("> Error instantiating module!")?,
-    );
+    let instance = Instance::new(&store, &module, imports.as_slice())
+        .context("> Error instantiating module!")?;
 
     // Next we poke around a bit to extract the `run` function from the module.
     println!("Extracting export...");
-    let exports = Ref::map(instance.borrow(), |instance| instance.exports());
+    let exports = instance.exports();
     ensure!(!exports.is_empty(), "> Error accessing exports!");
     let run_func = exports[0].func().context("> Error accessing exports!")?;
 

--- a/crates/api/examples/memory.rs
+++ b/crates/api/examples/memory.rs
@@ -1,7 +1,6 @@
 //! Translation of the memory example
 
 use anyhow::{bail, ensure, Context as _, Error};
-use std::cell::Ref;
 use wasmtime::*;
 
 fn get_export_memory(exports: &[Extern], i: usize) -> Result<HostRef<Memory>, Error> {
@@ -92,12 +91,11 @@ fn main() -> Result<(), Error> {
 
     // Instantiate.
     println!("Instantiating module...");
-    let instance =
-        HostRef::new(Instance::new(&store, &module, &[]).context("> Error instantiating module!")?);
+    let instance = Instance::new(&store, &module, &[]).context("> Error instantiating module!")?;
 
     // Extract export.
     println!("Extracting export...");
-    let exports = Ref::map(instance.borrow(), |instance| instance.exports());
+    let exports = instance.exports();
     ensure!(!exports.is_empty(), "> Error accessing exports!");
     let memory = get_export_memory(&exports, 0)?;
     let size_func = get_export_func(&exports, 1)?;

--- a/crates/api/examples/multi.rs
+++ b/crates/api/examples/multi.rs
@@ -1,7 +1,6 @@
 //! Translation of multi example
 
 use anyhow::{ensure, format_err, Context as _, Result};
-use std::cell::Ref;
 use std::rc::Rc;
 use wasmtime::*;
 
@@ -68,14 +67,12 @@ fn main() -> Result<()> {
     // Instantiate.
     println!("Instantiating module...");
     let imports = vec![callback_func.into()];
-    let instance = HostRef::new(
-        Instance::new(&store, &module, imports.as_slice())
-            .context("Error instantiating module!")?,
-    );
+    let instance = Instance::new(&store, &module, imports.as_slice())
+        .context("Error instantiating module!")?;
 
     // Extract exports.
     println!("Extracting export...");
-    let exports = Ref::map(instance.borrow(), |instance| instance.exports());
+    let exports = instance.exports();
     ensure!(!exports.is_empty(), "Error accessing exports!");
     let g = exports[0].func().context("> Error accessing export $g!")?;
     let round_trip_many = exports[1]


### PR DESCRIPTION
Several of the examples wrap the Instance in a HostRef, only to
immediately borrow it again to get the exports,and then never touch it
again. Simplify this by owning the Instance directly. This makes the
logic of the examples a little easier to follow.