### PR TITLE
Use nested paths for use declarations

### DIFF
--- a/src/bin/wasm2obj.rs
+++ b/src/bin/wasm2obj.rs
@@ -29,7 +29,10 @@
     )
 )]
 
-use cranelift_codegen::{isa, settings, settings::Configurable};
+use cranelift_codegen::{
+    isa,
+    settings::{self, Configurable},
+};
 use cranelift_entity::EntityRef;
 use cranelift_wasm::DefinedMemoryIndex;
 use docopt::Docopt;
@@ -39,8 +42,8 @@ use std::{
     error::Error,
     fmt::format,
     path::{Path, PathBuf},
-    process, str,
-    str::FromStr,
+    process,
+    str::{self, FromStr},
 };
 use target_lexicon::Triple;
 use wasmtime_cli::pick_compilation_strategy;

--- a/src/bin/wasm2obj.rs
+++ b/src/bin/wasm2obj.rs
@@ -29,18 +29,19 @@
     )
 )]
 
-use cranelift_codegen::settings::Configurable;
-use cranelift_codegen::{isa, settings};
+use cranelift_codegen::{isa, settings, settings::Configurable};
 use cranelift_entity::EntityRef;
 use cranelift_wasm::DefinedMemoryIndex;
 use docopt::Docopt;
 use faerie::Artifact;
 use serde::Deserialize;
-use std::error::Error;
-use std::fmt::format;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use std::{process, str};
+use std::{
+    error::Error,
+    fmt::format,
+    path::{Path, PathBuf},
+    process, str,
+    str::FromStr,
+};
 use target_lexicon::Triple;
 use wasmtime_cli::pick_compilation_strategy;
 use wasmtime_debug::{emit_debugsections, read_debuginfo};

--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -25,14 +25,12 @@
     )
 )]
 
-use cranelift_codegen::settings;
-use cranelift_codegen::settings::Configurable;
+use cranelift_codegen::{settings, settings::Configurable};
 use cranelift_native;
 use docopt::Docopt;
 use pretty_env_logger;
 use serde::Deserialize;
-use std::path::Path;
-use std::process;
+use std::{path::Path, process};
 use wasmtime_cli::pick_compilation_strategy;
 use wasmtime_environ::{cache_create_new_config, cache_init};
 use wasmtime_jit::{Compiler, Features};

--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -25,7 +25,7 @@
     )
 )]
 
-use cranelift_codegen::{settings, settings::Configurable};
+use cranelift_codegen::settings::{self, Configurable};
 use cranelift_native;
 use docopt::Docopt;
 use pretty_env_logger;


### PR DESCRIPTION
This commit follows up on Commit 0753b1206b79254b9c71d82ccfcbd2ddb9c00fc2 ("Use nested paths for use declaration") and uses nested paths for cranelift_codegen, and some of the standard library use declarations in `wasm2obj.rs` and `wast.rs`.