### PR TITLE
Fix feature-gating of test-programs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
     - run: cargo fetch
 
     # Build and test all features except for lightbeam
-    - run: cargo test --features test-programs --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py -- --nocapture
+    - run: cargo test --features test_programs --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py -- --nocapture
       env:
         RUST_BACKTRACE: 1
 
@@ -219,7 +219,7 @@ jobs:
     - run: $CENTOS cargo build --release --manifest-path crates/api/Cargo.toml
       shell: bash
     # Test what we just built
-    - run: $CENTOS cargo test --features test-programs --release --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py --exclude wasmtime
+    - run: $CENTOS cargo test --features test_programs --release --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py --exclude wasmtime
       shell: bash
       env:
         RUST_BACKTRACE: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,13 @@ wat = "1.0.2"
 libc = "0.2.60"
 rayon = "1.1"
 wasm-webidl-bindings = "0.6"
+
+[dev-dependencies]
 more-asserts = "0.2.1"
 # This feature requires the wasm32-wasi target be installed. It enables
 # wasm32-wasi integration tests. To enable, run
 # `cargo test --features test-programs`.
-test-programs = { path = "crates/test-programs", optional = true }
+test-programs = { path = "crates/test-programs" }
 
 [build-dependencies]
 anyhow = "1.0.19"
@@ -63,6 +65,7 @@ lightbeam = [
     "wasmtime-wast/lightbeam"
 ]
 wasi-c = ["wasmtime-wasi-c"]
+test_programs = ["test-programs/test_programs"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -23,3 +23,6 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.2"
+
+[features]
+test_programs = []

--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -4,11 +4,11 @@
 //! to automatically run the files in parallel.
 
 fn main() {
-    #[cfg(features = "test-programs")]
+    #[cfg(feature = "test_programs")]
     wasi_tests::build_and_generate_tests()
 }
 
-#[cfg(features = "test-programs")]
+#[cfg(feature = "test_programs")]
 mod wasi_tests {
     use std::env;
     use std::fs::{read_dir, DirEntry, File};
@@ -16,7 +16,7 @@ mod wasi_tests {
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
 
-    fn build_and_generate_tests() {
+    pub(super) fn build_and_generate_tests() {
         // Validate if any of test sources are present and if they changed
         // This should always work since there is no submodule to init anymore
         let bin_tests = std::fs::read_dir("wasi-tests/src/bin").unwrap();

--- a/crates/test-programs/tests/wasm_tests/main.rs
+++ b/crates/test-programs/tests/wasm_tests/main.rs
@@ -1,4 +1,4 @@
-#![cfg(features = "test-programs")]
+#![cfg(feature = "test_programs")]
 mod runtime;
 mod utils;
 

--- a/crates/wasi-common/README.md
+++ b/crates/wasi-common/README.md
@@ -60,10 +60,10 @@ rustup target add wasm32-wasi
 [rustup]: https://rustup.rs
 
 Now, you should be able to run the integration testsuite by running `cargo test` on the
-`test-programs` package:
+`test-programs` package with `test_programs` feature enabled:
 
 ```
-cargo test --package test-programs
+cargo test --features test_programs --package test-programs
 ```
 
 ## Third-Party Code


### PR DESCRIPTION
This commit fixes bugs in enabling feature-gating of `test-programs`
which was introduced in #600. It turns out, #600 accidentally
disabled `test-programs` from ever running, and this commit fixes
that.