### PR TITLE
Correctly read from a possibly misaligned pointer

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -36,7 +36,7 @@ impl<'a> Iterator for ReadDir<'a> {
 
             // Read the data
             let dirent_ptr = self.buf.as_ptr() as *const wasi_unstable::Dirent;
-            let dirent = *dirent_ptr;
+            let dirent = dirent_ptr.read_unaligned();
             let name_ptr = dirent_ptr.offset(1) as *const u8;
             // NOTE Linux syscall returns a NULL-terminated name, but WASI doesn't
             let namelen = dirent.d_namlen as usize;

--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -1077,12 +1077,12 @@ impl Dirent {
 
         let sys_dirent = raw.as_mut_ptr() as *mut wasi::__wasi_dirent_t;
         unsafe {
-            *sys_dirent = wasi::__wasi_dirent_t {
+            sys_dirent.write_unaligned(wasi::__wasi_dirent_t {
                 d_namlen: namlen.try_into()?,
                 d_ino: self.ino,
                 d_next: self.cookie,
                 d_type: self.ftype.to_wasi(),
-            };
+            });
         }
 
         let sys_name = unsafe { sys_dirent.offset(1) as *mut u8 };


### PR DESCRIPTION
This was reported in #513. `read_unaligned` is definitely the most ergonomic solution but clippy still marks this as an error, see https://github.com/rust-lang/rust-clippy/issues/2881 for more details.

I also fixed a potentially misaligned write in the implementation of `fd_readdir`.

I can't ask for reviewers, so cc @kubkon @sunfishcode @peterhuene