### PR TITLE
Deny warnings in the CI by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,7 @@ jobs:
     - run: cargo test --features test_programs --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py -- --nocapture
       env:
         RUST_BACKTRACE: 1
+        RUSTFLAGS: "-D warnings"
 
     # Build and test lightbeam if we're using the nightly toolchain. Note that
     # Lightbeam tests fail right now, but we don't want to block on that.

--- a/crates/test-programs/wasi-tests/src/bin/dangling_fd.rs
+++ b/crates/test-programs/wasi-tests/src/bin/dangling_fd.rs
@@ -5,27 +5,6 @@ use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, cleanup_file, create_dir, create_file};
 use wasi_tests::wasi_wrappers::wasi_path_open;
 
-unsafe fn create_or_open(
-    dir_fd: wasi_unstable::Fd,
-    name: &str,
-    flags: wasi_unstable::OFlags,
-) -> wasi_unstable::Fd {
-    let mut file_fd = wasi_unstable::Fd::max_value() - 1;
-    let mut status = wasi_path_open(dir_fd, 0, name, flags, 0, 0, 0, &mut file_fd);
-    assert_eq!(
-        status,
-        wasi_unstable::raw::__WASI_ESUCCESS,
-        "opening '{}'",
-        name
-    );
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi_unstable::Fd,
-        "file descriptor range check",
-    );
-    file_fd
-}
-
 unsafe fn test_dangling_fd(dir_fd: wasi_unstable::Fd) {
     // Create a file, open it, delete it without closing the handle,
     // and then try creating it again
@@ -48,7 +27,7 @@ unsafe fn test_dangling_fd(dir_fd: wasi_unstable::Fd) {
     // Now, repeat the same process but for a directory
     create_dir(dir_fd, "subdir");
     let mut subdir_fd = wasi_unstable::Fd::max_value() - 1;
-    let mut status = wasi_path_open(
+    status = wasi_path_open(
         dir_fd,
         0,
         "subdir",

--- a/crates/test-programs/wasi-tests/src/bin/path_link.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_link.rs
@@ -13,7 +13,7 @@ unsafe fn create_or_open(
     flags: wasi_unstable::OFlags,
 ) -> wasi_unstable::Fd {
     let mut file_fd = wasi_unstable::Fd::max_value() - 1;
-    let mut status = wasi_path_open(dir_fd, 0, name, flags, 0, 0, 0, &mut file_fd);
+    let status = wasi_path_open(dir_fd, 0, name, flags, 0, 0, 0, &mut file_fd);
     assert_eq!(
         status,
         wasi_unstable::raw::__WASI_ESUCCESS,
@@ -30,7 +30,7 @@ unsafe fn create_or_open(
 
 unsafe fn open_link(dir_fd: wasi_unstable::Fd, name: &str) -> wasi_unstable::Fd {
     let mut file_fd = wasi_unstable::Fd::max_value() - 1;
-    let mut status = wasi_path_open(dir_fd, 0, name, 0, 0, 0, 0, &mut file_fd);
+    let status = wasi_path_open(dir_fd, 0, name, 0, 0, 0, 0, &mut file_fd);
     assert_eq!(
         status,
         wasi_unstable::raw::__WASI_ESUCCESS,
@@ -135,7 +135,7 @@ unsafe fn test_path_link(dir_fd: wasi_unstable::Fd) {
 
     // Create a link to a directory
     create_dir(dir_fd, "subdir");
-    let subdir_fd = create_or_open(dir_fd, "subdir", wasi_unstable::O_DIRECTORY);
+    create_or_open(dir_fd, "subdir", wasi_unstable::O_DIRECTORY);
     assert_eq!(
         wasi_path_link(dir_fd, 0, "subdir", dir_fd, "link"),
         Err(wasi_unstable::EPERM),

--- a/crates/test-programs/wasi-tests/src/bin/stdio.rs
+++ b/crates/test-programs/wasi-tests/src/bin/stdio.rs
@@ -1,6 +1,4 @@
-use libc;
 use std::mem::MaybeUninit;
-use std::{env, process};
 use wasi::wasi_unstable;
 use wasi_tests::wasi_wrappers::wasi_fd_fdstat_get;
 


### PR DESCRIPTION
This commit passes `-D warnings` flag to `rustc` in the Test stage
of the CI in order to deny warnings on _all_ tested platforms.

Addresses #614.

cc @marmistrz