### PR TITLE
Make `Module::new` perform validation.

### DIFF
--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -187,7 +187,7 @@ impl Module {
     /// Validate and decode the raw wasm data in `binary` and create a new
     /// `Module` in the given `store`.
     pub fn new(store: &HostRef<Store>, binary: &[u8]) -> Result<Module> {
-        Self::validate(&store.borrow(), binary)?;
+        Self::validate(store, binary)?;
         Self::new_unchecked(store, binary)
     }
     /// Similar to `new`, but does not perform any validation. Only use this
@@ -207,7 +207,7 @@ impl Module {
             _ => None,
         }
     }
-    pub fn validate(_store: &Store, binary: &[u8]) -> Result<()> {
+    pub fn validate(_store: &HostRef<Store>, binary: &[u8]) -> Result<()> {
         validate(binary, None).map_err(|e| Error::new(e))
     }
     pub fn imports(&self) -> &[ImportType] {

--- a/crates/api/src/wasm.rs
+++ b/crates/api/src/wasm.rs
@@ -722,6 +722,8 @@ impl wasm_name_t {
     }
 }
 
+/// Note that this function does not perform validation on the wasm
+/// binary. To perform validation, use `wasm_module_validate`.
 #[no_mangle]
 pub unsafe extern "C" fn wasm_module_new(
     store: *mut wasm_store_t,
@@ -729,7 +731,7 @@ pub unsafe extern "C" fn wasm_module_new(
 ) -> *mut wasm_module_t {
     let binary = (*binary).as_slice();
     let store = &(*store).store;
-    let module = Module::new(store, binary).expect("module");
+    let module = Module::new_unchecked(store, binary).expect("module");
     let imports = module
         .imports()
         .iter()
@@ -754,6 +756,16 @@ pub unsafe extern "C" fn wasm_module_new(
         exports,
     });
     Box::into_raw(module)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasm_module_validate(
+    store: *mut wasm_store_t,
+    binary: *const wasm_byte_vec_t,
+) -> bool {
+    let binary = (*binary).as_slice();
+    let store = &(*store).store;
+    Module::validate(&store.borrow(), binary).is_ok()
 }
 
 #[no_mangle]

--- a/crates/api/src/wasm.rs
+++ b/crates/api/src/wasm.rs
@@ -765,7 +765,7 @@ pub unsafe extern "C" fn wasm_module_validate(
 ) -> bool {
     let binary = (*binary).as_slice();
     let store = &(*store).store;
-    Module::validate(&store.borrow(), binary).is_ok()
+    Module::validate(store, binary).is_ok()
 }
 
 #[no_mangle]


### PR DESCRIPTION
As noticed in #602, `Module::new` did not perform validation, which
turns out to be error-prone in practice. Rename it to
`Module::new_unchecked`, and add a new `Module::new` which does
perform validation.

Preserve wasm-c-api's `wasm_module_new`'s behavior by using
`Module::new_unchecked`, and implement `wasm_module_validate`.