### PR TITLE
[wasmtime-api] Collect and wrap cranelift dependencies

### DIFF
--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -1,10 +1,10 @@
+use crate::data_structures::ir;
 use crate::r#ref::HostRef;
 use crate::runtime::Store;
 use crate::trampoline::generate_func_export;
 use crate::trap::Trap;
 use crate::types::FuncType;
 use crate::values::Val;
-use cranelift_codegen::ir;
 use std::rc::Rc;
 use wasmtime_jit::InstanceHandle;
 use wasmtime_runtime::Export;

--- a/crates/api/src/context.rs
+++ b/crates/api/src/context.rs
@@ -1,3 +1,4 @@
+use crate::data_structures::native_isa_builder;
 use crate::Config;
 use std::cell::{RefCell, RefMut};
 use std::hash::{Hash, Hasher};
@@ -13,8 +14,7 @@ pub struct Context {
 
 impl Context {
     pub fn new(config: &Config) -> Context {
-        let isa_builder =
-            cranelift_native::builder().expect("host machine is not a supported target");
+        let isa_builder = native_isa_builder();
         let isa = isa_builder.finish(config.flags.clone());
         Context::new_with_compiler(config, Compiler::new(isa, config.strategy))
     }

--- a/crates/api/src/data_structures.rs
+++ b/crates/api/src/data_structures.rs
@@ -1,0 +1,74 @@
+pub(crate) mod ir {
+    pub(crate) use cranelift_codegen::ir::{
+        types, AbiParam, ArgumentPurpose, ExternalName, Function, InstBuilder, MemFlags, Signature,
+        StackSlotData, StackSlotKind, TrapCode, Type,
+    };
+}
+
+pub(crate) mod settings {
+    pub(crate) use cranelift_codegen::settings::{builder, Flags};
+}
+
+pub(crate) use cranelift_codegen::isa::{CallConv, TargetIsa};
+pub(crate) use cranelift_codegen::Context;
+pub(crate) use cranelift_entity::{EntityRef, PrimaryMap};
+
+pub(crate) mod wasm {
+    pub(crate) use cranelift_wasm::{
+        DefinedFuncIndex, DefinedTableIndex, FuncIndex, Global, GlobalInit, Memory, Table,
+        TableElementType,
+    };
+}
+
+pub(crate) mod binemit {
+    pub(crate) use cranelift_codegen::binemit::{NullStackmapSink, NullTrapSink};
+
+    pub use cranelift_codegen::{binemit, ir};
+
+    /// We don't expect trampoline compilation to produce any relocations, so
+    /// this `RelocSink` just asserts that it doesn't recieve any.
+    pub(crate) struct TrampolineRelocSink {}
+
+    impl binemit::RelocSink for TrampolineRelocSink {
+        fn reloc_ebb(
+            &mut self,
+            _offset: binemit::CodeOffset,
+            _reloc: binemit::Reloc,
+            _ebb_offset: binemit::CodeOffset,
+        ) {
+            panic!("trampoline compilation should not produce ebb relocs");
+        }
+        fn reloc_external(
+            &mut self,
+            _offset: binemit::CodeOffset,
+            _reloc: binemit::Reloc,
+            _name: &ir::ExternalName,
+            _addend: binemit::Addend,
+        ) {
+            panic!("trampoline compilation should not produce external symbol relocs");
+        }
+        fn reloc_constant(
+            &mut self,
+            _code_offset: binemit::CodeOffset,
+            _reloc: binemit::Reloc,
+            _constant_offset: ir::ConstantOffset,
+        ) {
+            panic!("trampoline compilation should not produce constant relocs");
+        }
+        fn reloc_jt(
+            &mut self,
+            _offset: binemit::CodeOffset,
+            _reloc: binemit::Reloc,
+            _jt: ir::JumpTable,
+        ) {
+            panic!("trampoline compilation should not produce jump table relocs");
+        }
+    }
+}
+
+pub(crate) use cranelift_codegen::print_errors::pretty_error;
+pub(crate) use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+
+pub(crate) fn native_isa_builder() -> cranelift_codegen::isa::Builder {
+    cranelift_native::builder().expect("host machine is not a supported target")
+}

--- a/crates/api/src/data_structures.rs
+++ b/crates/api/src/data_structures.rs
@@ -1,16 +1,12 @@
 pub(crate) mod ir {
-    pub(crate) use cranelift_codegen::ir::{
-        types, AbiParam, ArgumentPurpose, ExternalName, Function, InstBuilder, MemFlags, Signature,
-        StackSlotData, StackSlotKind, TrapCode, Type,
-    };
+    pub(crate) use cranelift_codegen::ir::{types, AbiParam, ArgumentPurpose, Signature, Type};
 }
 
 pub(crate) mod settings {
     pub(crate) use cranelift_codegen::settings::{builder, Flags};
 }
 
-pub(crate) use cranelift_codegen::isa::{CallConv, TargetIsa};
-pub(crate) use cranelift_codegen::Context;
+pub(crate) use cranelift_codegen::isa::CallConv;
 pub(crate) use cranelift_entity::{EntityRef, PrimaryMap};
 
 pub(crate) mod wasm {
@@ -20,55 +16,11 @@ pub(crate) mod wasm {
     };
 }
 
-pub(crate) mod binemit {
-    pub(crate) use cranelift_codegen::binemit::{NullStackmapSink, NullTrapSink};
-
-    pub use cranelift_codegen::{binemit, ir};
-
-    /// We don't expect trampoline compilation to produce any relocations, so
-    /// this `RelocSink` just asserts that it doesn't recieve any.
-    pub(crate) struct TrampolineRelocSink {}
-
-    impl binemit::RelocSink for TrampolineRelocSink {
-        fn reloc_ebb(
-            &mut self,
-            _offset: binemit::CodeOffset,
-            _reloc: binemit::Reloc,
-            _ebb_offset: binemit::CodeOffset,
-        ) {
-            panic!("trampoline compilation should not produce ebb relocs");
-        }
-        fn reloc_external(
-            &mut self,
-            _offset: binemit::CodeOffset,
-            _reloc: binemit::Reloc,
-            _name: &ir::ExternalName,
-            _addend: binemit::Addend,
-        ) {
-            panic!("trampoline compilation should not produce external symbol relocs");
-        }
-        fn reloc_constant(
-            &mut self,
-            _code_offset: binemit::CodeOffset,
-            _reloc: binemit::Reloc,
-            _constant_offset: ir::ConstantOffset,
-        ) {
-            panic!("trampoline compilation should not produce constant relocs");
-        }
-        fn reloc_jt(
-            &mut self,
-            _offset: binemit::CodeOffset,
-            _reloc: binemit::Reloc,
-            _jt: ir::JumpTable,
-        ) {
-            panic!("trampoline compilation should not produce jump table relocs");
-        }
-    }
-}
-
-pub(crate) use cranelift_codegen::print_errors::pretty_error;
-pub(crate) use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-
 pub(crate) fn native_isa_builder() -> cranelift_codegen::isa::Builder {
     cranelift_native::builder().expect("host machine is not a supported target")
+}
+
+pub(crate) fn native_isa_call_conv() -> CallConv {
+    use target_lexicon::HOST;
+    CallConv::triple_default(&HOST)
 }

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -1,4 +1,5 @@
 use crate::callable::{Callable, NativeCallable, WasmtimeFn, WrappedCallable};
+use crate::data_structures::wasm;
 use crate::r#ref::{AnyRef, HostRef};
 use crate::runtime::Store;
 use crate::trampoline::{generate_global_export, generate_memory_export, generate_table_export};
@@ -274,7 +275,7 @@ pub struct Table {
 fn get_table_item(
     handle: &InstanceHandle,
     store: &HostRef<Store>,
-    table_index: cranelift_wasm::DefinedTableIndex,
+    table_index: wasm::DefinedTableIndex,
     item_index: u32,
 ) -> Val {
     if let Some(item) = handle.table_get(table_index, item_index) {
@@ -287,7 +288,7 @@ fn get_table_item(
 fn set_table_item(
     handle: &mut InstanceHandle,
     store: &HostRef<Store>,
-    table_index: cranelift_wasm::DefinedTableIndex,
+    table_index: wasm::DefinedTableIndex,
     item_index: u32,
     val: Val,
 ) -> bool {
@@ -335,7 +336,7 @@ impl Table {
         &self.r#type
     }
 
-    fn wasmtime_table_index(&self) -> cranelift_wasm::DefinedTableIndex {
+    fn wasmtime_table_index(&self) -> wasm::DefinedTableIndex {
         match self.wasmtime_export {
             wasmtime_runtime::Export::Table { definition, .. } => {
                 self.wasmtime_handle.table_index(unsafe { &*definition })

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -163,7 +163,7 @@ impl Func {
         instance_handle: InstanceHandle,
     ) -> Self {
         let ty = if let wasmtime_runtime::Export::Function { signature, .. } = &export {
-            FuncType::from_cranelift_signature(signature.clone())
+            FuncType::from_wasmtime_signature(signature.clone())
         } else {
             panic!("expected function export")
         };
@@ -255,7 +255,7 @@ impl Global {
         } else {
             panic!("wasmtime export is not memory")
         };
-        let ty = GlobalType::from_cranelift_global(&global);
+        let ty = GlobalType::from_wasmtime_global(&global);
         Global {
             _store: store.clone(),
             r#type: ty,
@@ -395,7 +395,7 @@ impl Table {
         } else {
             panic!("wasmtime export is not table")
         };
-        let ty = TableType::from_cranelift_table(&table.table);
+        let ty = TableType::from_wasmtime_table(&table.table);
         Table {
             store: store.clone(),
             r#type: ty,
@@ -479,7 +479,7 @@ impl Memory {
         } else {
             panic!("wasmtime export is not memory")
         };
-        let ty = MemoryType::from_cranelift_memory(&memory.memory);
+        let ty = MemoryType::from_wasmtime_memory(&memory.memory);
         Memory {
             _store: store.clone(),
             r#type: ty,

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -132,7 +132,7 @@ impl Instance {
                 // HACK ensure all handles, instantiated outside Store, present in
                 // the store's SignatureRegistry, e.g. WASI instances that are
                 // imported into this store using the from_handle() method.
-                let _ = store.borrow_mut().register_cranelift_signature(signature);
+                let _ = store.borrow_mut().register_wasmtime_signature(signature);
             }
             let extern_type = ExternType::from_wasmtime_export(&export);
             exports_types.push(ExportType::new(Name::new(name), extern_type));

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod callable;
 mod context;
+mod data_structures;
 mod externals;
 mod instance;
 mod module;

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -139,7 +139,7 @@ impl Store {
         &self.global_exports
     }
 
-    pub(crate) fn register_cranelift_signature(
+    pub(crate) fn register_wasmtime_signature(
         &mut self,
         signature: &ir::Signature,
     ) -> wasmtime_runtime::VMSharedSignatureIndex {
@@ -154,7 +154,7 @@ impl Store {
         index
     }
 
-    pub(crate) fn lookup_cranelift_signature(
+    pub(crate) fn lookup_wasmtime_signature(
         &self,
         type_index: wasmtime_runtime::VMSharedSignatureIndex,
     ) -> Option<&ir::Signature> {

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::context::Context;
+use crate::data_structures::{ir, settings};
 use crate::r#ref::HostRef;
-use cranelift_codegen::{ir, settings};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -36,7 +36,7 @@ pub(crate) fn create_handle(
                 module
                     .signatures
                     .values()
-                    .map(|sig| signature_registry.register_cranelift_signature(sig))
+                    .map(|sig| signature_registry.register_wasmtime_signature(sig))
                     .collect::<PrimaryMap<_, _>>(),
             )
         })

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -1,9 +1,9 @@
 //! Support for a calling of an imported function.
 
+use crate::data_structures::wasm::DefinedFuncIndex;
+use crate::data_structures::PrimaryMap;
 use crate::runtime::Store;
 use anyhow::Result;
-use cranelift_entity::PrimaryMap;
-use cranelift_wasm::DefinedFuncIndex;
 use std::any::Any;
 use std::cell::{RefCell, RefMut};
 use std::collections::{HashMap, HashSet};

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -198,7 +198,7 @@ pub fn create_handle_with_function(
     func: &Rc<dyn Callable + 'static>,
     store: &HostRef<Store>,
 ) -> Result<InstanceHandle> {
-    let sig = ft.get_cranelift_signature().clone();
+    let sig = ft.get_wasmtime_signature().clone();
 
     let isa = {
         let isa_builder = native_isa_builder();

--- a/crates/api/src/trampoline/global.rs
+++ b/crates/api/src/trampoline/global.rs
@@ -1,7 +1,7 @@
 use super::create_handle::create_handle;
+use crate::data_structures::{wasm, PrimaryMap};
 use crate::{GlobalType, Mutability, Val};
 use anyhow::Result;
-use cranelift_entity::PrimaryMap;
 use wasmtime_environ::Module;
 use wasmtime_runtime::{InstanceHandle, VMGlobalDefinition};
 
@@ -23,13 +23,13 @@ pub fn create_global(gt: &GlobalType, val: Val) -> Result<(wasmtime_runtime::Exp
         }
     }
 
-    let global = cranelift_wasm::Global {
+    let global = wasm::Global {
         ty: gt.content().get_cranelift_type(),
         mutability: match gt.mutability() {
             Mutability::Const => false,
             Mutability::Var => true,
         },
-        initializer: cranelift_wasm::GlobalInit::Import, // TODO is it right?
+        initializer: wasm::GlobalInit::Import, // TODO is it right?
     };
     let mut handle =
         create_handle(Module::new(), None, PrimaryMap::new(), Box::new(())).expect("handle");

--- a/crates/api/src/trampoline/global.rs
+++ b/crates/api/src/trampoline/global.rs
@@ -24,7 +24,7 @@ pub fn create_global(gt: &GlobalType, val: Val) -> Result<(wasmtime_runtime::Exp
     }
 
     let global = wasm::Global {
-        ty: gt.content().get_cranelift_type(),
+        ty: gt.content().get_wasmtime_type(),
         mutability: match gt.mutability() {
             Mutability::Const => false,
             Mutability::Var => true,

--- a/crates/api/src/trampoline/memory.rs
+++ b/crates/api/src/trampoline/memory.rs
@@ -1,7 +1,7 @@
 use super::create_handle::create_handle;
+use crate::data_structures::{wasm, PrimaryMap};
 use crate::MemoryType;
 use anyhow::Result;
-use cranelift_entity::PrimaryMap;
 use wasmtime_environ::Module;
 use wasmtime_runtime::InstanceHandle;
 
@@ -10,7 +10,7 @@ use wasmtime_runtime::InstanceHandle;
 pub fn create_handle_with_memory(memory: &MemoryType) -> Result<InstanceHandle> {
     let mut module = Module::new();
 
-    let memory = cranelift_wasm::Memory {
+    let memory = wasm::Memory {
         minimum: memory.limits().min(),
         maximum: if memory.limits().max() == std::u32::MAX {
             None

--- a/crates/api/src/trampoline/table.rs
+++ b/crates/api/src/trampoline/table.rs
@@ -1,15 +1,14 @@
 use super::create_handle::create_handle;
+use crate::data_structures::{wasm, PrimaryMap};
 use crate::{TableType, ValType};
 use anyhow::Result;
-use cranelift_entity::PrimaryMap;
-use cranelift_wasm::TableElementType;
 use wasmtime_environ::Module;
 use wasmtime_runtime::InstanceHandle;
 
 pub fn create_handle_with_table(table: &TableType) -> Result<InstanceHandle> {
     let mut module = Module::new();
 
-    let table = cranelift_wasm::Table {
+    let table = wasm::Table {
         minimum: table.limits().min(),
         maximum: if table.limits().max() == std::u32::MAX {
             None
@@ -17,8 +16,8 @@ pub fn create_handle_with_table(table: &TableType) -> Result<InstanceHandle> {
             Some(table.limits().max())
         },
         ty: match table.element() {
-            ValType::FuncRef => TableElementType::Func,
-            _ => TableElementType::Val(table.element().get_cranelift_type()),
+            ValType::FuncRef => wasm::TableElementType::Func,
+            _ => wasm::TableElementType::Val(table.element().get_cranelift_type()),
         },
     };
     let tunable = Default::default();

--- a/crates/api/src/trampoline/table.rs
+++ b/crates/api/src/trampoline/table.rs
@@ -17,7 +17,7 @@ pub fn create_handle_with_table(table: &TableType) -> Result<InstanceHandle> {
         },
         ty: match table.element() {
             ValType::FuncRef => wasm::TableElementType::Func,
-            _ => wasm::TableElementType::Val(table.element().get_cranelift_type()),
+            _ => wasm::TableElementType::Val(table.element().get_wasmtime_type()),
         },
     };
     let tunable = Default::default();

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -156,10 +156,9 @@ pub struct FuncType {
 
 impl FuncType {
     pub fn new(params: Box<[ValType]>, results: Box<[ValType]>) -> FuncType {
-        use crate::data_structures::ir::*;
-        use crate::data_structures::CallConv;
-        use target_lexicon::HOST;
-        let call_conv = CallConv::triple_default(&HOST);
+        use crate::data_structures::ir::{types, AbiParam, ArgumentPurpose, Signature};
+        use crate::data_structures::native_isa_call_conv;
+        let call_conv = native_isa_call_conv();
         let signature: Signature = {
             let mut params = params
                 .iter()

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -1,4 +1,4 @@
-use cranelift_codegen::ir;
+use crate::data_structures::{ir, wasm};
 
 // Type Representations
 
@@ -156,8 +156,8 @@ pub struct FuncType {
 
 impl FuncType {
     pub fn new(params: Box<[ValType]>, results: Box<[ValType]>) -> FuncType {
-        use cranelift_codegen::ir::*;
-        use cranelift_codegen::isa::CallConv;
+        use crate::data_structures::ir::*;
+        use crate::data_structures::CallConv;
         use target_lexicon::HOST;
         let call_conv = CallConv::triple_default(&HOST);
         let signature: Signature = {
@@ -236,7 +236,7 @@ impl GlobalType {
         self.mutability
     }
 
-    pub(crate) fn from_cranelift_global(global: &cranelift_wasm::Global) -> GlobalType {
+    pub(crate) fn from_cranelift_global(global: &wasm::Global) -> GlobalType {
         let ty = ValType::from_cranelift_type(global.ty);
         let mutability = if global.mutability {
             Mutability::Var
@@ -266,8 +266,8 @@ impl TableType {
         &self.limits
     }
 
-    pub(crate) fn from_cranelift_table(table: &cranelift_wasm::Table) -> TableType {
-        assert!(if let cranelift_wasm::TableElementType::Func = table.ty {
+    pub(crate) fn from_cranelift_table(table: &wasm::Table) -> TableType {
+        assert!(if let wasm::TableElementType::Func = table.ty {
             true
         } else {
             false
@@ -293,7 +293,7 @@ impl MemoryType {
         &self.limits
     }
 
-    pub(crate) fn from_cranelift_memory(memory: &cranelift_wasm::Memory) -> MemoryType {
+    pub(crate) fn from_cranelift_memory(memory: &wasm::Memory) -> MemoryType {
         MemoryType::new(Limits::new(
             memory.minimum,
             memory.maximum.unwrap_or(::std::u32::MAX),

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -65,25 +65,25 @@ impl ValType {
         }
     }
 
-    pub(crate) fn get_cranelift_type(&self) -> ir::Type {
+    pub(crate) fn get_wasmtime_type(&self) -> ir::Type {
         match self {
             ValType::I32 => ir::types::I32,
             ValType::I64 => ir::types::I64,
             ValType::F32 => ir::types::F32,
             ValType::F64 => ir::types::F64,
             ValType::V128 => ir::types::I8X16,
-            _ => unimplemented!("get_cranelift_type other"),
+            _ => unimplemented!("get_wasmtime_type other"),
         }
     }
 
-    pub(crate) fn from_cranelift_type(ty: ir::Type) -> ValType {
+    pub(crate) fn from_wasmtime_type(ty: ir::Type) -> ValType {
         match ty {
             ir::types::I32 => ValType::I32,
             ir::types::I64 => ValType::I64,
             ir::types::F32 => ValType::F32,
             ir::types::F64 => ValType::F64,
             ir::types::I8X16 => ValType::V128,
-            _ => unimplemented!("from_cranelift_type other"),
+            _ => unimplemented!("from_wasmtime_type other"),
         }
     }
 }
@@ -126,25 +126,25 @@ impl ExternType {
     pub(crate) fn from_wasmtime_export(export: &wasmtime_runtime::Export) -> Self {
         match export {
             wasmtime_runtime::Export::Function { signature, .. } => {
-                ExternType::ExternFunc(FuncType::from_cranelift_signature(signature.clone()))
+                ExternType::ExternFunc(FuncType::from_wasmtime_signature(signature.clone()))
             }
             wasmtime_runtime::Export::Memory { memory, .. } => {
-                ExternType::ExternMemory(MemoryType::from_cranelift_memory(&memory.memory))
+                ExternType::ExternMemory(MemoryType::from_wasmtime_memory(&memory.memory))
             }
             wasmtime_runtime::Export::Global { global, .. } => {
-                ExternType::ExternGlobal(GlobalType::from_cranelift_global(&global))
+                ExternType::ExternGlobal(GlobalType::from_wasmtime_global(&global))
             }
             wasmtime_runtime::Export::Table { table, .. } => {
-                ExternType::ExternTable(TableType::from_cranelift_table(&table.table))
+                ExternType::ExternTable(TableType::from_wasmtime_table(&table.table))
             }
         }
     }
 }
 
 // Function Types
-fn from_cranelift_abiparam(param: &ir::AbiParam) -> ValType {
+fn from_wasmtime_abiparam(param: &ir::AbiParam) -> ValType {
     assert_eq!(param.purpose, ir::ArgumentPurpose::Normal);
-    ValType::from_cranelift_type(param.value_type)
+    ValType::from_wasmtime_type(param.value_type)
 }
 
 #[derive(Debug, Clone)]
@@ -163,11 +163,11 @@ impl FuncType {
         let signature: Signature = {
             let mut params = params
                 .iter()
-                .map(|p| AbiParam::new(p.get_cranelift_type()))
+                .map(|p| AbiParam::new(p.get_wasmtime_type()))
                 .collect::<Vec<_>>();
             let returns = results
                 .iter()
-                .map(|p| AbiParam::new(p.get_cranelift_type()))
+                .map(|p| AbiParam::new(p.get_wasmtime_type()))
                 .collect::<Vec<_>>();
             params.insert(0, AbiParam::special(types::I64, ArgumentPurpose::VMContext));
 
@@ -190,21 +190,21 @@ impl FuncType {
         &self.results
     }
 
-    pub(crate) fn get_cranelift_signature(&self) -> &ir::Signature {
+    pub(crate) fn get_wasmtime_signature(&self) -> &ir::Signature {
         &self.signature
     }
 
-    pub(crate) fn from_cranelift_signature(signature: ir::Signature) -> FuncType {
+    pub(crate) fn from_wasmtime_signature(signature: ir::Signature) -> FuncType {
         let params = signature
             .params
             .iter()
             .filter(|p| p.purpose == ir::ArgumentPurpose::Normal)
-            .map(|p| from_cranelift_abiparam(p))
+            .map(|p| from_wasmtime_abiparam(p))
             .collect::<Vec<_>>();
         let results = signature
             .returns
             .iter()
-            .map(|p| from_cranelift_abiparam(p))
+            .map(|p| from_wasmtime_abiparam(p))
             .collect::<Vec<_>>();
         FuncType {
             params: params.into_boxed_slice(),
@@ -236,8 +236,8 @@ impl GlobalType {
         self.mutability
     }
 
-    pub(crate) fn from_cranelift_global(global: &wasm::Global) -> GlobalType {
-        let ty = ValType::from_cranelift_type(global.ty);
+    pub(crate) fn from_wasmtime_global(global: &wasm::Global) -> GlobalType {
+        let ty = ValType::from_wasmtime_type(global.ty);
         let mutability = if global.mutability {
             Mutability::Var
         } else {
@@ -266,7 +266,7 @@ impl TableType {
         &self.limits
     }
 
-    pub(crate) fn from_cranelift_table(table: &wasm::Table) -> TableType {
+    pub(crate) fn from_wasmtime_table(table: &wasm::Table) -> TableType {
         assert!(if let wasm::TableElementType::Func = table.ty {
             true
         } else {
@@ -293,7 +293,7 @@ impl MemoryType {
         &self.limits
     }
 
-    pub(crate) fn from_cranelift_memory(memory: &wasm::Memory) -> MemoryType {
+    pub(crate) fn from_wasmtime_memory(memory: &wasm::Memory) -> MemoryType {
         MemoryType::new(Limits::new(
             memory.minimum,
             memory.maximum.unwrap_or(::std::u32::MAX),

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -228,7 +228,7 @@ pub(crate) fn into_checked_anyfunc(
                 } => (*vmctx, *address, signature),
                 _ => panic!("expected function export"),
             };
-            let type_index = store.borrow_mut().register_cranelift_signature(signature);
+            let type_index = store.borrow_mut().register_wasmtime_signature(signature);
             wasmtime_runtime::VMCallerCheckedAnyfunc {
                 func_ptr,
                 type_index,
@@ -248,7 +248,7 @@ pub(crate) fn from_checked_anyfunc(
     }
     let signature = store
         .borrow()
-        .lookup_cranelift_signature(item.type_index)
+        .lookup_wasmtime_signature(item.type_index)
         .expect("signature")
         .clone();
     let instance_handle = unsafe { wasmtime_runtime::InstanceHandle::from_vmctx(item.vmctx) };

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -1,8 +1,8 @@
+use crate::data_structures::ir;
 use crate::externals::Func;
 use crate::r#ref::{AnyRef, HostRef};
 use crate::runtime::Store;
 use crate::types::ValType;
-use cranelift_codegen::ir;
 use std::ptr;
 use wasmtime_jit::RuntimeValue;
 


### PR DESCRIPTION
The embedding api crates heavily depend on cranelift data structures. This patch collects all such dependency into single module. There is no easy way to maintain this invariant, so I'm wondering if we can do the same at wasmtime-{jit, runtime, environ} levels too.