### PR TITLE
Use getrandom for random_get, disable default rand features

### DIFF
--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -44,7 +44,7 @@ errno = "0.2.4"
 tempfile = "3"
 target-lexicon = { version = "0.9.0", default-features = false }
 pretty_env_logger = "0.3.0"
-rand = { version = "0.7.0", features = ["small_rng"] }
+rand = { version = "0.7.0", default-features = false, features = ["small_rng"] }
 cranelift-codegen = { version = "0.50.0", features = ["enable-serde", "all-arch"] }
 filetime = "0.2.7"
 

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -15,7 +15,7 @@ wasi-common-cbindgen = { path = "wasi-common-cbindgen" }
 anyhow = "1.0"
 thiserror = "1.0"
 libc = "0.2"
-rand = "0.7"
+getrandom = "0.1"
 cfg-if = "0.1.9"
 log = "0.4"
 filetime = "0.2.7"

--- a/crates/wasi-common/src/hostcalls_impl/misc.rs
+++ b/crates/wasi-common/src/hostcalls_impl/misc.rs
@@ -4,7 +4,7 @@ use crate::fdentry::Descriptor;
 use crate::memory::*;
 use crate::sys::hostcalls_impl;
 use crate::{wasi, wasi32, Error, Result};
-use log::{trace, error};
+use log::{error, trace};
 use std::convert::TryFrom;
 
 pub(crate) fn args_get(

--- a/crates/wasi-common/src/hostcalls_impl/misc.rs
+++ b/crates/wasi-common/src/hostcalls_impl/misc.rs
@@ -4,7 +4,7 @@ use crate::fdentry::Descriptor;
 use crate::memory::*;
 use crate::sys::hostcalls_impl;
 use crate::{wasi, wasi32, Error, Result};
-use log::trace;
+use log::{trace, error};
 use std::convert::TryFrom;
 
 pub(crate) fn args_get(
@@ -132,15 +132,14 @@ pub(crate) fn random_get(
     buf_ptr: wasi32::uintptr_t,
     buf_len: wasi32::size_t,
 ) -> Result<()> {
-    use rand::{thread_rng, RngCore};
-
     trace!("random_get(buf_ptr={:#x?}, buf_len={:?})", buf_ptr, buf_len);
 
     let buf = dec_slice_of_mut_u8(memory, buf_ptr, buf_len)?;
 
-    thread_rng().fill_bytes(buf);
-
-    Ok(())
+    getrandom(buf).map_err(|err| {
+        error!("getrandom failure: {:?}", err);
+        Error::EIO
+    })
 }
 
 pub(crate) fn clock_res_get(

--- a/crates/wasi-common/src/hostcalls_impl/misc.rs
+++ b/crates/wasi-common/src/hostcalls_impl/misc.rs
@@ -136,7 +136,7 @@ pub(crate) fn random_get(
 
     let buf = dec_slice_of_mut_u8(memory, buf_ptr, buf_len)?;
 
-    getrandom(buf).map_err(|err| {
+    getrandom::getrandom(buf).map_err(|err| {
         error!("getrandom failure: {:?}", err);
         Error::EIO
     })

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/misc.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/misc.rs
@@ -132,15 +132,14 @@ pub(crate) fn random_get(
     buf_ptr: wasi32::uintptr_t,
     buf_len: wasi32::size_t,
 ) -> Result<()> {
-    use rand::{thread_rng, RngCore};
-
     trace!("random_get(buf_ptr={:#x?}, buf_len={:?})", buf_ptr, buf_len);
 
     let buf = dec_slice_of_mut_u8(memory, buf_ptr, buf_len)?;
 
-    thread_rng().fill_bytes(buf);
-
-    Ok(())
+    getrandom(buf).map_err(|err| {
+        error!("getrandom failure: {:?}", err);
+        Error::EIO
+    })
 }
 
 pub(crate) fn clock_res_get(

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/misc.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/misc.rs
@@ -4,7 +4,7 @@ use crate::old::snapshot_0::fdentry::Descriptor;
 use crate::old::snapshot_0::memory::*;
 use crate::old::snapshot_0::sys::hostcalls_impl;
 use crate::old::snapshot_0::{wasi, wasi32, Error, Result};
-use log::trace;
+use log::{error, trace};
 use std::convert::TryFrom;
 
 pub(crate) fn args_get(

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/misc.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/misc.rs
@@ -136,7 +136,7 @@ pub(crate) fn random_get(
 
     let buf = dec_slice_of_mut_u8(memory, buf_ptr, buf_len)?;
 
-    getrandom(buf).map_err(|err| {
+    getrandom::getrandom(buf).map_err(|err| {
         error!("getrandom failure: {:?}", err);
         Error::EIO
     })


### PR DESCRIPTION
`random_get` should draw host OS entropy directly, instead of using user-space PRNG via `ThreadRng`. Relevant issue: wasmerio/wasmer#909

Additionally `rand`'s default features are disabled for `environ` crate, since they are not needed.