### PR TITLE
use setuptools_scm for python version management

### DIFF
--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -60,6 +60,7 @@ const exec = s => {
 exec('yum install -y centos-release-scl cmake xz epel-release');
 exec('yum install -y rh-python36 patchelf unzip');
 exec('yum install -y devtoolset-8-gcc devtoolset-8-binutils devtoolset-8-gcc-c++');
+exec('yum install -y git');
 
 // Delete `libstdc++.so` to force gcc to link against `libstdc++.a` instead.
 // This is a hack and not the right way to do this, but it ends up doing the

--- a/crates/misc/py/setup.py
+++ b/crates/misc/py/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
 setup(name='wasmtime',
-      version="0.0.1",
       classifiers=[
             "Development Status :: 1 - Planning",
             "Intended Audience :: Developers",
@@ -14,5 +13,7 @@ setup(name='wasmtime',
       ],
       packages=['wasmtime'],
       package_dir={'wasmtime': 'python/wasmtime'},
+      use_scm_version = {"root": "../../..", "relative_to": __file__},
+      setup_requires=['setuptools_scm'],
       rust_extensions=[RustExtension('wasmtime.lib_wasmtime', 'Cargo.toml',  binding=Binding.PyO3)],
       zip_safe=False)

--- a/crates/misc/py/setup.py
+++ b/crates/misc/py/setup.py
@@ -1,6 +1,13 @@
 from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
+
+def no_tag_default_to_dev(version):
+    if version.exact:
+        return version.format_with("{tag}")
+    return "dev"
+
+
 setup(name='wasmtime',
       classifiers=[
             "Development Status :: 1 - Planning",
@@ -13,7 +20,12 @@ setup(name='wasmtime',
       ],
       packages=['wasmtime'],
       package_dir={'wasmtime': 'python/wasmtime'},
-      use_scm_version = {"root": "../../..", "relative_to": __file__},
+      use_scm_version = {
+          "root": "../../..",
+          "relative_to": __file__,
+          "version_scheme": no_tag_default_to_dev,
+          "local_scheme": lambda _: "",
+      },
       setup_requires=['setuptools_scm'],
       rust_extensions=[RustExtension('wasmtime.lib_wasmtime', 'Cargo.toml',  binding=Binding.PyO3)],
       zip_safe=False)

--- a/crates/misc/py/setup.py
+++ b/crates/misc/py/setup.py
@@ -5,7 +5,7 @@ from setuptools_rust import Binding, RustExtension
 def no_tag_default_to_dev(version):
     if version.exact:
         return version.format_with("{tag}")
-    return "dev"
+    return "0.0.1"
 
 
 setup(name='wasmtime',


### PR DESCRIPTION
Hello,

I noticed https://pypi.org/project/wasmtime/ is still stuck in 0.2, and releases [like 0.8.0](https://github.com/bytecodealliance/wasmtime/releases/tag/v0.8.0) still generate version `0.0.1` for the Python wheels.

This PR uses [setuptools_scm](https://github.com/pypa/setuptools_scm) to read version information from the git tags, so the right version will be picked up (and no manual update is needed in setup.py).

TODO: check what happens with the `dev` tag...