### PR TITLE
Support fd_fdstat_get and fd_renumber on stdin/stdout/stderr

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/stdio.rs
+++ b/crates/test-programs/wasi-tests/src/bin/stdio.rs
@@ -1,0 +1,31 @@
+use libc;
+use std::mem::MaybeUninit;
+use std::{env, process};
+use wasi::wasi_unstable;
+use wasi_tests::wasi_wrappers::wasi_fd_fdstat_get;
+
+unsafe fn test_stdio() {
+    for fd in &[
+        wasi_unstable::STDIN_FD,
+        wasi_unstable::STDOUT_FD,
+        wasi_unstable::STDERR_FD,
+    ] {
+        let mut fdstat: wasi_unstable::FdStat = MaybeUninit::zeroed().assume_init();
+        let status = wasi_fd_fdstat_get(*fd, &mut fdstat);
+        assert_eq!(
+            status,
+            wasi_unstable::raw::__WASI_ESUCCESS,
+            "fd_fdstat_get on stdio"
+        );
+
+        assert!(
+            wasi_unstable::fd_renumber(*fd, *fd + 100).is_ok(),
+            "renumbering stdio",
+        );
+    }
+}
+
+fn main() {
+    // Run the tests.
+    unsafe { test_stdio() }
+}

--- a/crates/wasi-common/src/fdentry.rs
+++ b/crates/wasi-common/src/fdentry.rs
@@ -26,37 +26,6 @@ impl Descriptor {
             _ => Err(Error::EBADF),
         }
     }
-
-    pub(crate) fn is_file(&self) -> bool {
-        match self {
-            Self::OsFile(_) => true,
-            _ => false,
-        }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn is_stdin(&self) -> bool {
-        match self {
-            Self::Stdin => true,
-            _ => false,
-        }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn is_stdout(&self) -> bool {
-        match self {
-            Self::Stdout => true,
-            _ => false,
-        }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn is_stderr(&self) -> bool {
-        match self {
-            Self::Stderr => true,
-            _ => false,
-        }
-    }
 }
 
 /// An abstraction struct serving as a wrapper for a host `Descriptor` object which requires
@@ -88,10 +57,6 @@ impl FdEntry {
                 preopen_path: None,
             },
         )
-    }
-
-    pub(crate) fn duplicate(file: &fs::File) -> Result<Self> {
-        Self::from(file.try_clone()?)
     }
 
     pub(crate) fn duplicate_stdin() -> Result<Self> {

--- a/crates/wasi-common/src/fdentry.rs
+++ b/crates/wasi-common/src/fdentry.rs
@@ -3,7 +3,9 @@ use crate::sys::fdentry_impl::{
     descriptor_as_oshandle, determine_type_and_access_rights, OsHandle,
 };
 use crate::{wasi, Error, Result};
+use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::{fs, io};
 
@@ -35,7 +37,7 @@ impl Descriptor {
     }
 
     /// Return an `OsHandle`, which may be a stream or socket file descriptor.
-    pub(crate) fn as_os_handle(&self) -> ManuallyDrop<OsHandle> {
+    pub(crate) fn as_os_handle<'descriptor>(&'descriptor self) -> OsHandleRef<'descriptor> {
         descriptor_as_oshandle(self)
     }
 }
@@ -159,5 +161,37 @@ impl FdEntry {
         } else {
             Ok(())
         }
+    }
+}
+
+/// This allows an `OsHandle` to be temporarily borrowed from a
+/// `Descriptor`. The `Descriptor` continues to own the resource,
+/// and `OsHandleRef`'s lifetime parameter ensures that it doesn't
+/// outlive the `Descriptor`.
+pub(crate) struct OsHandleRef<'descriptor> {
+    handle: ManuallyDrop<OsHandle>,
+    _ref: PhantomData<&'descriptor Descriptor>,
+}
+
+impl<'descriptor> OsHandleRef<'descriptor> {
+    pub fn new(handle: ManuallyDrop<OsHandle>) -> Self {
+        OsHandleRef {
+            handle,
+            _ref: PhantomData,
+        }
+    }
+}
+
+impl<'descriptor> Deref for OsHandleRef<'descriptor> {
+    type Target = fs::File;
+
+    fn deref(&self) -> &Self::Target {
+        &self.handle
+    }
+}
+
+impl<'descriptor> DerefMut for OsHandleRef<'descriptor> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.handle
     }
 }

--- a/crates/wasi-common/src/fdentry.rs
+++ b/crates/wasi-common/src/fdentry.rs
@@ -174,7 +174,7 @@ pub(crate) struct OsHandleRef<'descriptor> {
 }
 
 impl<'descriptor> OsHandleRef<'descriptor> {
-    pub fn new(handle: ManuallyDrop<OsHandle>) -> Self {
+    pub(crate) fn new(handle: ManuallyDrop<OsHandle>) -> Self {
         OsHandleRef {
             handle,
             _ref: PhantomData,

--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -1015,7 +1015,7 @@ pub(crate) unsafe fn fd_readdir(
     let file = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_READDIR, 0)?
-        .as_actual_file()?;
+        .as_actual_file_mut()?;
     let mut host_buf = dec_slice_of_mut_u8(memory, buf, buf_len)?;
 
     trace!("     | (buf,buf_len)={:?}", host_buf);

--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -36,7 +36,7 @@ pub(crate) unsafe fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasi::__wasi_fd_t) -> R
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_DATASYNC, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     fd.sync_data().map_err(Into::into)
 }
@@ -62,7 +62,7 @@ pub(crate) unsafe fn fd_pread(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_READ | wasi::__WASI_RIGHTS_FD_SEEK, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
 
@@ -114,7 +114,7 @@ pub(crate) unsafe fn fd_pwrite(
             wasi::__WASI_RIGHTS_FD_WRITE | wasi::__WASI_RIGHTS_FD_SEEK,
             0,
         )?
-        .as_file()?;
+        .as_actual_file()?;
     let iovs = dec_ciovec_slice(memory, iovs_ptr, iovs_len)?;
 
     if offset > i64::max_value() as u64 {
@@ -227,7 +227,7 @@ pub(crate) unsafe fn fd_seek(
     let fd = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(rights, 0)?
-        .as_file_mut()?;
+        .as_actual_file_mut()?;
 
     let pos = match whence {
         wasi::__WASI_WHENCE_CUR => SeekFrom::Current(offset),
@@ -253,7 +253,7 @@ pub(crate) unsafe fn fd_tell(
     let fd = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_TELL, 0)?
-        .as_file_mut()?;
+        .as_actual_file_mut()?;
 
     let host_offset = fd.seek(SeekFrom::Current(0))?;
 
@@ -271,9 +271,9 @@ pub(crate) unsafe fn fd_fdstat_get(
     trace!("fd_fdstat_get(fd={:?}, fdstat_ptr={:#x?})", fd, fdstat_ptr);
 
     let mut fdstat = dec_fdstat_byref(memory, fdstat_ptr)?;
-    let wasi_fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
+    let host_fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file();
 
-    let fs_flags = hostcalls_impl::fd_fdstat_get(wasi_fd)?;
+    let fs_flags = hostcalls_impl::fd_fdstat_get(&host_fd)?;
 
     let fe = wasi_ctx.get_fd_entry(fd)?;
     fdstat.fs_filetype = fe.file_type;
@@ -293,9 +293,9 @@ pub(crate) unsafe fn fd_fdstat_set_flags(
 ) -> Result<()> {
     trace!("fd_fdstat_set_flags(fd={:?}, fdflags={:#x?})", fd, fdflags);
 
-    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
+    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file();
 
-    hostcalls_impl::fd_fdstat_set_flags(fd, fdflags)
+    hostcalls_impl::fd_fdstat_set_flags(&fd, fdflags)
 }
 
 pub(crate) unsafe fn fd_fdstat_set_rights(
@@ -329,7 +329,7 @@ pub(crate) unsafe fn fd_sync(wasi_ctx: &WasiCtx, fd: wasi::__wasi_fd_t) -> Resul
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_SYNC, 0)?
-        .as_file()?;
+        .as_actual_file()?;
     fd.sync_all().map_err(Into::into)
 }
 
@@ -393,7 +393,7 @@ pub(crate) unsafe fn fd_advise(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_ADVISE, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     hostcalls_impl::fd_advise(fd, advice, offset, len)
 }
@@ -409,7 +409,7 @@ pub(crate) unsafe fn fd_allocate(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_ALLOCATE, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     let metadata = fd.metadata()?;
 
@@ -672,7 +672,10 @@ pub(crate) unsafe fn fd_filestat_get(
         filestat_ptr
     );
 
-    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
+    let fd = wasi_ctx
+        .get_fd_entry(fd)?
+        .as_descriptor(0, 0)?
+        .as_actual_file()?;
 
     let host_filestat = hostcalls_impl::fd_filestat_get_impl(fd)?;
 
@@ -699,7 +702,7 @@ pub(crate) unsafe fn fd_filestat_set_times(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_FILESTAT_SET_TIMES, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     fd_filestat_set_times_impl(fd, st_atim, st_mtim, fst_flags)
 }
@@ -750,7 +753,7 @@ pub(crate) unsafe fn fd_filestat_set_size(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_FILESTAT_SET_SIZE, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     // This check will be unnecessary when rust-lang/rust#63326 is fixed
     if st_size > i64::max_value() as u64 {
@@ -1012,7 +1015,7 @@ pub(crate) unsafe fn fd_readdir(
     let file = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_READDIR, 0)?
-        .as_file_mut()?;
+        .as_actual_file()?;
     let mut host_buf = dec_slice_of_mut_u8(memory, buf, buf_len)?;
 
     trace!("     | (buf,buf_len)={:?}", host_buf);

--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -36,7 +36,7 @@ pub(crate) unsafe fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasi::__wasi_fd_t) -> R
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_DATASYNC, 0)?
-        .as_actual_file()?;
+        .as_file()?;
 
     fd.sync_data().map_err(Into::into)
 }
@@ -62,7 +62,7 @@ pub(crate) unsafe fn fd_pread(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_READ | wasi::__WASI_RIGHTS_FD_SEEK, 0)?
-        .as_actual_file()?;
+        .as_file()?;
 
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
 
@@ -114,7 +114,7 @@ pub(crate) unsafe fn fd_pwrite(
             wasi::__WASI_RIGHTS_FD_WRITE | wasi::__WASI_RIGHTS_FD_SEEK,
             0,
         )?
-        .as_actual_file()?;
+        .as_file()?;
     let iovs = dec_ciovec_slice(memory, iovs_ptr, iovs_len)?;
 
     if offset > i64::max_value() as u64 {
@@ -161,7 +161,7 @@ pub(crate) unsafe fn fd_read(
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_READ, 0)?
     {
-        Descriptor::OsFile(file) => file.read_vectored(&mut iovs),
+        Descriptor::OsHandle(file) => file.read_vectored(&mut iovs),
         Descriptor::Stdin => io::stdin().lock().read_vectored(&mut iovs),
         _ => return Err(Error::EBADF),
     };
@@ -227,7 +227,7 @@ pub(crate) unsafe fn fd_seek(
     let fd = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(rights, 0)?
-        .as_actual_file_mut()?;
+        .as_file_mut()?;
 
     let pos = match whence {
         wasi::__WASI_WHENCE_CUR => SeekFrom::Current(offset),
@@ -253,7 +253,7 @@ pub(crate) unsafe fn fd_tell(
     let fd = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_TELL, 0)?
-        .as_actual_file_mut()?;
+        .as_file_mut()?;
 
     let host_offset = fd.seek(SeekFrom::Current(0))?;
 
@@ -271,7 +271,10 @@ pub(crate) unsafe fn fd_fdstat_get(
     trace!("fd_fdstat_get(fd={:?}, fdstat_ptr={:#x?})", fd, fdstat_ptr);
 
     let mut fdstat = dec_fdstat_byref(memory, fdstat_ptr)?;
-    let host_fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file();
+    let host_fd = wasi_ctx
+        .get_fd_entry(fd)?
+        .as_descriptor(0, 0)?
+        .as_os_handle();
 
     let fs_flags = hostcalls_impl::fd_fdstat_get(&host_fd)?;
 
@@ -293,7 +296,10 @@ pub(crate) unsafe fn fd_fdstat_set_flags(
 ) -> Result<()> {
     trace!("fd_fdstat_set_flags(fd={:?}, fdflags={:#x?})", fd, fdflags);
 
-    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file();
+    let fd = wasi_ctx
+        .get_fd_entry(fd)?
+        .as_descriptor(0, 0)?
+        .as_os_handle();
 
     hostcalls_impl::fd_fdstat_set_flags(&fd, fdflags)
 }
@@ -329,7 +335,7 @@ pub(crate) unsafe fn fd_sync(wasi_ctx: &WasiCtx, fd: wasi::__wasi_fd_t) -> Resul
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_SYNC, 0)?
-        .as_actual_file()?;
+        .as_file()?;
     fd.sync_all().map_err(Into::into)
 }
 
@@ -357,7 +363,7 @@ pub(crate) unsafe fn fd_write(
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_WRITE, 0)?
     {
-        Descriptor::OsFile(file) => file.write_vectored(&iovs)?,
+        Descriptor::OsHandle(file) => file.write_vectored(&iovs)?,
         Descriptor::Stdin => return Err(Error::EBADF),
         Descriptor::Stdout => {
             // lock for the duration of the scope
@@ -393,7 +399,7 @@ pub(crate) unsafe fn fd_advise(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_ADVISE, 0)?
-        .as_actual_file()?;
+        .as_file()?;
 
     hostcalls_impl::fd_advise(fd, advice, offset, len)
 }
@@ -409,7 +415,7 @@ pub(crate) unsafe fn fd_allocate(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_ALLOCATE, 0)?
-        .as_actual_file()?;
+        .as_file()?;
 
     let metadata = fd.metadata()?;
 
@@ -672,10 +678,7 @@ pub(crate) unsafe fn fd_filestat_get(
         filestat_ptr
     );
 
-    let fd = wasi_ctx
-        .get_fd_entry(fd)?
-        .as_descriptor(0, 0)?
-        .as_actual_file()?;
+    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
 
     let host_filestat = hostcalls_impl::fd_filestat_get_impl(fd)?;
 
@@ -702,7 +705,7 @@ pub(crate) unsafe fn fd_filestat_set_times(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_FILESTAT_SET_TIMES, 0)?
-        .as_actual_file()?;
+        .as_file()?;
 
     fd_filestat_set_times_impl(fd, st_atim, st_mtim, fst_flags)
 }
@@ -753,7 +756,7 @@ pub(crate) unsafe fn fd_filestat_set_size(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_FILESTAT_SET_SIZE, 0)?
-        .as_actual_file()?;
+        .as_file()?;
 
     // This check will be unnecessary when rust-lang/rust#63326 is fixed
     if st_size > i64::max_value() as u64 {
@@ -1015,7 +1018,7 @@ pub(crate) unsafe fn fd_readdir(
     let file = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_READDIR, 0)?
-        .as_actual_file_mut()?;
+        .as_file_mut()?;
     let mut host_buf = dec_slice_of_mut_u8(memory, buf, buf_len)?;
 
     trace!("     | (buf,buf_len)={:?}", host_buf);

--- a/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
@@ -46,7 +46,7 @@ pub(crate) fn path_get(
 
     let dirfd = fe
         .as_descriptor(rights_base, rights_inheriting)?
-        .as_file()?
+        .as_actual_file()?
         .try_clone()?;
 
     // Stack of directory file descriptors. Index 0 always corresponds with the directory provided

--- a/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
@@ -46,7 +46,7 @@ pub(crate) fn path_get(
 
     let dirfd = fe
         .as_descriptor(rights_base, rights_inheriting)?
-        .as_actual_file()?
+        .as_file()?
         .try_clone()?;
 
     // Stack of directory file descriptors. Index 0 always corresponds with the directory provided

--- a/crates/wasi-common/src/old/snapshot_0/fdentry.rs
+++ b/crates/wasi-common/src/old/snapshot_0/fdentry.rs
@@ -1,6 +1,6 @@
 use crate::old::snapshot_0::sys::dev_null;
 use crate::old::snapshot_0::sys::fdentry_impl::{
-    descriptor_as_osfile, determine_type_and_access_rights, OsFile,
+    descriptor_as_oshandle, determine_type_and_access_rights, OsHandle,
 };
 use crate::old::snapshot_0::{wasi, Error, Result};
 use std::mem::ManuallyDrop;
@@ -9,33 +9,34 @@ use std::{fs, io};
 
 #[derive(Debug)]
 pub(crate) enum Descriptor {
-    OsFile(OsFile),
+    OsHandle(OsHandle),
     Stdin,
     Stdout,
     Stderr,
 }
 
 impl Descriptor {
-    /// Return a reference to the actual `OsFile`, allowing operations which
-    /// require an actual file and not just a stream or socket file descriptor.
-    pub(crate) fn as_actual_file(&self) -> Result<&OsFile> {
+    /// Return a reference to the `OsHandle` treating it as an actual file/dir, and
+    /// allowing operations which require an actual file and not just a stream or
+    /// socket file descriptor.
+    pub(crate) fn as_file(&self) -> Result<&OsHandle> {
         match self {
-            Self::OsFile(file) => Ok(file),
+            Self::OsHandle(file) => Ok(file),
             _ => Err(Error::EBADF),
         }
     }
 
-    /// Like `as_actual_file`, but return a mutable reference.
-    pub(crate) fn as_actual_file_mut(&mut self) -> Result<&mut OsFile> {
+    /// Like `as_file`, but return a mutable reference.
+    pub(crate) fn as_file_mut(&mut self) -> Result<&mut OsHandle> {
         match self {
-            Self::OsFile(file) => Ok(file),
+            Self::OsHandle(file) => Ok(file),
             _ => Err(Error::EBADF),
         }
     }
 
-    /// Return an `OsFile`, which may be a stream or socket file descriptor.
-    pub(crate) fn as_file(&self) -> ManuallyDrop<OsFile> {
-        descriptor_as_osfile(self)
+    /// Return an `OsHandle`, which may be a stream or socket file descriptor.
+    pub(crate) fn as_os_handle(&self) -> ManuallyDrop<OsHandle> {
+        descriptor_as_oshandle(self)
     }
 }
 
@@ -62,7 +63,7 @@ impl FdEntry {
         unsafe { determine_type_and_access_rights(&file) }.map(
             |(file_type, rights_base, rights_inheriting)| Self {
                 file_type,
-                descriptor: Descriptor::OsFile(OsFile::from(file)),
+                descriptor: Descriptor::OsHandle(OsHandle::from(file)),
                 rights_base,
                 rights_inheriting,
                 preopen_path: None,

--- a/crates/wasi-common/src/old/snapshot_0/fdentry.rs
+++ b/crates/wasi-common/src/old/snapshot_0/fdentry.rs
@@ -26,37 +26,6 @@ impl Descriptor {
             _ => Err(Error::EBADF),
         }
     }
-
-    pub(crate) fn is_file(&self) -> bool {
-        match self {
-            Self::OsFile(_) => true,
-            _ => false,
-        }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn is_stdin(&self) -> bool {
-        match self {
-            Self::Stdin => true,
-            _ => false,
-        }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn is_stdout(&self) -> bool {
-        match self {
-            Self::Stdout => true,
-            _ => false,
-        }
-    }
-
-    #[allow(unused)]
-    pub(crate) fn is_stderr(&self) -> bool {
-        match self {
-            Self::Stderr => true,
-            _ => false,
-        }
-    }
 }
 
 /// An abstraction struct serving as a wrapper for a host `Descriptor` object which requires
@@ -88,10 +57,6 @@ impl FdEntry {
                 preopen_path: None,
             },
         )
-    }
-
-    pub(crate) fn duplicate(file: &fs::File) -> Result<Self> {
-        Self::from(file.try_clone()?)
     }
 
     pub(crate) fn duplicate_stdin() -> Result<Self> {

--- a/crates/wasi-common/src/old/snapshot_0/fdentry.rs
+++ b/crates/wasi-common/src/old/snapshot_0/fdentry.rs
@@ -1,6 +1,9 @@
 use crate::old::snapshot_0::sys::dev_null;
-use crate::old::snapshot_0::sys::fdentry_impl::{determine_type_and_access_rights, OsFile};
+use crate::old::snapshot_0::sys::fdentry_impl::{
+    descriptor_as_osfile, determine_type_and_access_rights, OsFile,
+};
 use crate::old::snapshot_0::{wasi, Error, Result};
+use std::mem::ManuallyDrop;
 use std::path::PathBuf;
 use std::{fs, io};
 
@@ -13,18 +16,26 @@ pub(crate) enum Descriptor {
 }
 
 impl Descriptor {
-    pub(crate) fn as_file(&self) -> Result<&OsFile> {
+    /// Return a reference to the actual `OsFile`, allowing operations which
+    /// require an actual file and not just a stream or socket file descriptor.
+    pub(crate) fn as_actual_file(&self) -> Result<&OsFile> {
         match self {
             Self::OsFile(file) => Ok(file),
             _ => Err(Error::EBADF),
         }
     }
 
-    pub(crate) fn as_file_mut(&mut self) -> Result<&mut OsFile> {
+    /// Like `as_actual_file`, but return a mutable reference.
+    pub(crate) fn as_actual_file_mut(&mut self) -> Result<&mut OsFile> {
         match self {
             Self::OsFile(file) => Ok(file),
             _ => Err(Error::EBADF),
         }
+    }
+
+    /// Return an `OsFile`, which may be a stream or socket file descriptor.
+    pub(crate) fn as_file(&self) -> ManuallyDrop<OsFile> {
+        descriptor_as_osfile(self)
     }
 }
 

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs.rs
@@ -36,7 +36,7 @@ pub(crate) unsafe fn fd_datasync(wasi_ctx: &WasiCtx, fd: wasi::__wasi_fd_t) -> R
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_DATASYNC, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     fd.sync_data().map_err(Into::into)
 }
@@ -62,7 +62,7 @@ pub(crate) unsafe fn fd_pread(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_READ | wasi::__WASI_RIGHTS_FD_SEEK, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     let iovs = dec_iovec_slice(memory, iovs_ptr, iovs_len)?;
 
@@ -114,7 +114,7 @@ pub(crate) unsafe fn fd_pwrite(
             wasi::__WASI_RIGHTS_FD_WRITE | wasi::__WASI_RIGHTS_FD_SEEK,
             0,
         )?
-        .as_file()?;
+        .as_actual_file()?;
     let iovs = dec_ciovec_slice(memory, iovs_ptr, iovs_len)?;
 
     if offset > i64::max_value() as u64 {
@@ -227,7 +227,7 @@ pub(crate) unsafe fn fd_seek(
     let fd = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(rights, 0)?
-        .as_file_mut()?;
+        .as_actual_file_mut()?;
 
     let pos = match whence {
         wasi::__WASI_WHENCE_CUR => SeekFrom::Current(offset),
@@ -253,7 +253,7 @@ pub(crate) unsafe fn fd_tell(
     let fd = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_TELL, 0)?
-        .as_file_mut()?;
+        .as_actual_file_mut()?;
 
     let host_offset = fd.seek(SeekFrom::Current(0))?;
 
@@ -271,9 +271,9 @@ pub(crate) unsafe fn fd_fdstat_get(
     trace!("fd_fdstat_get(fd={:?}, fdstat_ptr={:#x?})", fd, fdstat_ptr);
 
     let mut fdstat = dec_fdstat_byref(memory, fdstat_ptr)?;
-    let wasi_fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
+    let host_fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file();
 
-    let fs_flags = hostcalls_impl::fd_fdstat_get(wasi_fd)?;
+    let fs_flags = hostcalls_impl::fd_fdstat_get(&host_fd)?;
 
     let fe = wasi_ctx.get_fd_entry(fd)?;
     fdstat.fs_filetype = fe.file_type;
@@ -293,9 +293,9 @@ pub(crate) unsafe fn fd_fdstat_set_flags(
 ) -> Result<()> {
     trace!("fd_fdstat_set_flags(fd={:?}, fdflags={:#x?})", fd, fdflags);
 
-    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
+    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file();
 
-    hostcalls_impl::fd_fdstat_set_flags(fd, fdflags)
+    hostcalls_impl::fd_fdstat_set_flags(&fd, fdflags)
 }
 
 pub(crate) unsafe fn fd_fdstat_set_rights(
@@ -329,7 +329,7 @@ pub(crate) unsafe fn fd_sync(wasi_ctx: &WasiCtx, fd: wasi::__wasi_fd_t) -> Resul
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_SYNC, 0)?
-        .as_file()?;
+        .as_actual_file()?;
     fd.sync_all().map_err(Into::into)
 }
 
@@ -393,7 +393,7 @@ pub(crate) unsafe fn fd_advise(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_ADVISE, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     hostcalls_impl::fd_advise(fd, advice, offset, len)
 }
@@ -409,7 +409,7 @@ pub(crate) unsafe fn fd_allocate(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_ALLOCATE, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     let metadata = fd.metadata()?;
 
@@ -593,7 +593,7 @@ pub(crate) unsafe fn fd_readdir(
     let file = wasi_ctx
         .get_fd_entry_mut(fd)?
         .as_descriptor_mut(wasi::__WASI_RIGHTS_FD_READDIR, 0)?
-        .as_file_mut()?;
+        .as_actual_file_mut()?;
     let host_buf = dec_slice_of_mut_u8(memory, buf, buf_len)?;
 
     trace!("     | (buf,buf_len)={:?}", host_buf);
@@ -707,7 +707,10 @@ pub(crate) unsafe fn fd_filestat_get(
         filestat_ptr
     );
 
-    let fd = wasi_ctx.get_fd_entry(fd)?.as_descriptor(0, 0)?.as_file()?;
+    let fd = wasi_ctx
+        .get_fd_entry(fd)?
+        .as_descriptor(0, 0)?
+        .as_actual_file()?;
 
     let host_filestat = hostcalls_impl::fd_filestat_get_impl(fd)?;
 
@@ -734,7 +737,7 @@ pub(crate) unsafe fn fd_filestat_set_times(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_FILESTAT_SET_TIMES, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     fd_filestat_set_times_impl(fd, st_atim, st_mtim, fst_flags)
 }
@@ -785,7 +788,7 @@ pub(crate) unsafe fn fd_filestat_set_size(
     let fd = wasi_ctx
         .get_fd_entry(fd)?
         .as_descriptor(wasi::__WASI_RIGHTS_FD_FILESTAT_SET_SIZE, 0)?
-        .as_file()?;
+        .as_actual_file()?;
 
     // This check will be unnecessary when rust-lang/rust#63326 is fixed
     if st_size > i64::max_value() as u64 {

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs_helpers.rs
@@ -46,7 +46,7 @@ pub(crate) fn path_get(
 
     let dirfd = fe
         .as_descriptor(rights_base, rights_inheriting)?
-        .as_file()?
+        .as_actual_file()?
         .try_clone()?;
 
     // Stack of directory file descriptors. Index 0 always corresponds with the directory provided

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs_helpers.rs
@@ -46,7 +46,7 @@ pub(crate) fn path_get(
 
     let dirfd = fe
         .as_descriptor(rights_base, rights_inheriting)?
-        .as_actual_file()?
+        .as_file()?
         .try_clone()?;
 
     // Stack of directory file descriptors. Index 0 always corresponds with the directory provided

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod filetime;
 pub(crate) mod hostcalls_impl;
-pub(crate) mod osfile;
+pub(crate) mod oshandle;
 
 pub(crate) mod fdentry_impl {
     use crate::old::snapshot_0::{sys::host_impl, Result};

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/oshandle.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/oshandle.rs
@@ -17,12 +17,12 @@ impl Drop for DirStream {
 }
 
 #[derive(Debug)]
-pub(crate) struct OsFile {
+pub(crate) struct OsHandle {
     pub(crate) file: fs::File,
     pub(crate) dir_stream: Option<Mutex<DirStream>>,
 }
 
-impl From<fs::File> for OsFile {
+impl From<fs::File> for OsHandle {
     fn from(file: fs::File) -> Self {
         Self {
             file,
@@ -31,13 +31,13 @@ impl From<fs::File> for OsFile {
     }
 }
 
-impl AsRawFd for OsFile {
+impl AsRawFd for OsHandle {
     fn as_raw_fd(&self) -> RawFd {
         self.file.as_raw_fd()
     }
 }
 
-impl Deref for OsFile {
+impl Deref for OsHandle {
     type Target = fs::File;
 
     fn deref(&self) -> &Self::Target {
@@ -45,7 +45,7 @@ impl Deref for OsFile {
     }
 }
 
-impl DerefMut for OsFile {
+impl DerefMut for OsHandle {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.file
     }

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/fdentry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/fdentry_impl.rs
@@ -7,7 +7,7 @@ use std::os::unix::prelude::{AsRawFd, FileTypeExt, FromRawFd, RawFd};
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
-        pub(crate) use super::linux::osfile::*;
+        pub(crate) use super::linux::oshandle::*;
         pub(crate) use super::linux::fdentry_impl::*;
     } else if #[cfg(any(
             target_os = "macos",
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
             target_os = "ios",
             target_os = "dragonfly"
     ))] {
-        pub(crate) use super::bsd::osfile::*;
+        pub(crate) use super::bsd::oshandle::*;
         pub(crate) use super::bsd::fdentry_impl::*;
     }
 }
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
 impl AsRawFd for Descriptor {
     fn as_raw_fd(&self) -> RawFd {
         match self {
-            Self::OsFile(file) => file.as_raw_fd(),
+            Self::OsHandle(file) => file.as_raw_fd(),
             Self::Stdin => io::stdin().as_raw_fd(),
             Self::Stdout => io::stdout().as_raw_fd(),
             Self::Stderr => io::stderr().as_raw_fd(),
@@ -33,8 +33,10 @@ impl AsRawFd for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
-    ManuallyDrop::new(OsFile::from(unsafe { File::from_raw_fd(desc.as_raw_fd()) }))
+pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
+    ManuallyDrop::new(OsHandle::from(unsafe {
+        File::from_raw_fd(desc.as_raw_fd())
+    }))
 }
 
 /// This function is unsafe because it operates on a raw file descriptor.

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/fdentry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/fdentry_impl.rs
@@ -1,6 +1,8 @@
 use crate::old::snapshot_0::fdentry::Descriptor;
 use crate::old::snapshot_0::{wasi, Error, Result};
+use std::fs::File;
 use std::io;
+use std::mem::ManuallyDrop;
 use std::os::unix::prelude::{AsRawFd, FileTypeExt, FromRawFd, RawFd};
 
 cfg_if::cfg_if! {
@@ -29,6 +31,10 @@ impl AsRawFd for Descriptor {
             Self::Stderr => io::stderr().as_raw_fd(),
         }
     }
+}
+
+pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
+    ManuallyDrop::new(OsFile::from(unsafe { File::from_raw_fd(desc.as_raw_fd()) }))
 }
 
 /// This function is unsafe because it operates on a raw file descriptor.

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/fdentry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/fdentry_impl.rs
@@ -1,4 +1,4 @@
-use crate::old::snapshot_0::fdentry::Descriptor;
+use crate::old::snapshot_0::fdentry::{Descriptor, OsHandleRef};
 use crate::old::snapshot_0::{wasi, Error, Result};
 use std::fs::File;
 use std::io;
@@ -33,10 +33,12 @@ impl AsRawFd for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
-    ManuallyDrop::new(OsHandle::from(unsafe {
+pub(crate) fn descriptor_as_oshandle<'lifetime>(
+    desc: &'lifetime Descriptor,
+) -> OsHandleRef<'lifetime> {
+    OsHandleRef::new(ManuallyDrop::new(OsHandle::from(unsafe {
         File::from_raw_fd(desc.as_raw_fd())
-    }))
+    })))
 }
 
 /// This function is unsafe because it operates on a raw file descriptor.

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/hostcalls_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/hostcalls_impl.rs
@@ -1,5 +1,5 @@
 use super::super::dir::{Dir, Entry, SeekLoc};
-use super::osfile::OsFile;
+use super::oshandle::OsHandle;
 use crate::old::snapshot_0::hostcalls_impl::{Dirent, PathGet};
 use crate::old::snapshot_0::sys::host_impl;
 use crate::old::snapshot_0::sys::unix::str_to_cstring;
@@ -115,11 +115,11 @@ pub(crate) fn fd_readdir_impl(
 // This should actually be common code with Windows,
 // but there's BSD stuff remaining
 pub(crate) fn fd_readdir(
-    os_file: &mut OsFile,
+    os_handle: &mut OsHandle,
     mut host_buf: &mut [u8],
     cookie: wasi::__wasi_dircookie_t,
 ) -> Result<usize> {
-    let iter = fd_readdir_impl(os_file, cookie)?;
+    let iter = fd_readdir_impl(os_handle, cookie)?;
     let mut used = 0;
     for dirent in iter {
         let dirent_raw = dirent?.to_wasi_raw()?;

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod filetime;
 pub(crate) mod hostcalls_impl;
-pub(crate) mod osfile;
+pub(crate) mod oshandle;
 
 pub(crate) mod fdentry_impl {
     use crate::old::snapshot_0::{sys::host_impl, Result};

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/oshandle.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/oshandle.rs
@@ -3,21 +3,21 @@ use std::ops::{Deref, DerefMut};
 use std::os::unix::prelude::{AsRawFd, RawFd};
 
 #[derive(Debug)]
-pub(crate) struct OsFile(fs::File);
+pub(crate) struct OsHandle(fs::File);
 
-impl From<fs::File> for OsFile {
+impl From<fs::File> for OsHandle {
     fn from(file: fs::File) -> Self {
         Self(file)
     }
 }
 
-impl AsRawFd for OsFile {
+impl AsRawFd for OsHandle {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }
 }
 
-impl Deref for OsFile {
+impl Deref for OsHandle {
     type Target = fs::File;
 
     fn deref(&self) -> &Self::Target {
@@ -25,7 +25,7 @@ impl Deref for OsFile {
     }
 }
 
-impl DerefMut for OsFile {
+impl DerefMut for OsHandle {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
@@ -7,21 +7,21 @@ use std::ops::{Deref, DerefMut};
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle, RawHandle};
 
 #[derive(Debug)]
-pub(crate) struct OsFile(File);
+pub(crate) struct OsHandle(File);
 
-impl From<File> for OsFile {
+impl From<File> for OsHandle {
     fn from(file: File) -> Self {
         Self(file)
     }
 }
 
-impl AsRawHandle for OsFile {
+impl AsRawHandle for OsHandle {
     fn as_raw_handle(&self) -> RawHandle {
         self.0.as_raw_handle()
     }
 }
 
-impl Deref for OsFile {
+impl Deref for OsHandle {
     type Target = File;
 
     fn deref(&self) -> &Self::Target {
@@ -29,7 +29,7 @@ impl Deref for OsFile {
     }
 }
 
-impl DerefMut for OsFile {
+impl DerefMut for OsHandle {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -38,7 +38,7 @@ impl DerefMut for OsFile {
 impl AsRawHandle for Descriptor {
     fn as_raw_handle(&self) -> RawHandle {
         match self {
-            Self::OsFile(file) => file.as_raw_handle(),
+            Self::OsHandle(file) => file.as_raw_handle(),
             Self::Stdin => io::stdin().as_raw_handle(),
             Self::Stdout => io::stdout().as_raw_handle(),
             Self::Stderr => io::stderr().as_raw_handle(),
@@ -46,8 +46,8 @@ impl AsRawHandle for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
-    ManuallyDrop::new(OsFile::from(unsafe {
+pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
+    ManuallyDrop::new(OsHandle::from(unsafe {
         File::from_raw_handle(desc.as_raw_handle())
     }))
 }

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
@@ -2,6 +2,7 @@ use crate::old::snapshot_0::fdentry::Descriptor;
 use crate::old::snapshot_0::{wasi, Error, Result};
 use std::fs::File;
 use std::io;
+use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle, RawHandle};
 
@@ -43,6 +44,12 @@ impl AsRawHandle for Descriptor {
             Self::Stderr => io::stderr().as_raw_handle(),
         }
     }
+}
+
+pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
+    ManuallyDrop::new(OsFile::from(unsafe {
+        File::from_raw_handle(desc.as_raw_handle())
+    }))
 }
 
 /// This function is unsafe because it operates on a raw file handle.

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/fdentry_impl.rs
@@ -1,4 +1,4 @@
-use crate::old::snapshot_0::fdentry::Descriptor;
+use crate::old::snapshot_0::fdentry::{Descriptor, OsHandleRef};
 use crate::old::snapshot_0::{wasi, Error, Result};
 use std::fs::File;
 use std::io;
@@ -46,10 +46,12 @@ impl AsRawHandle for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
-    ManuallyDrop::new(OsHandle::from(unsafe {
+pub(crate) fn descriptor_as_oshandle<'lifetime>(
+    desc: &'lifetime Descriptor,
+) -> OsHandleRef<'lifetime> {
+    OsHandleRef::new(ManuallyDrop::new(OsHandle::from(unsafe {
         File::from_raw_handle(desc.as_raw_handle())
-    }))
+    })))
 }
 
 /// This function is unsafe because it operates on a raw file handle.

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs.rs
@@ -7,7 +7,7 @@ use crate::old::snapshot_0::helpers::systemtime_to_timestamp;
 use crate::old::snapshot_0::hostcalls_impl::{
     fd_filestat_set_times_impl, Dirent, FileType, PathGet,
 };
-use crate::old::snapshot_0::sys::fdentry_impl::{determine_type_rights, OsFile};
+use crate::old::snapshot_0::sys::fdentry_impl::{determine_type_rights, OsHandle};
 use crate::old::snapshot_0::sys::host_impl::{self, path_from_host};
 use crate::old::snapshot_0::sys::hostcalls_impl::fs_helpers::PathGetExt;
 use crate::old::snapshot_0::{wasi, Error, Result};
@@ -261,11 +261,11 @@ pub(crate) fn fd_readdir_impl(
 
 // This should actually be common code with Linux
 pub(crate) fn fd_readdir(
-    os_file: &mut OsFile,
+    os_handle: &mut OsHandle,
     mut host_buf: &mut [u8],
     cookie: wasi::__wasi_dircookie_t,
 ) -> Result<usize> {
-    let iter = fd_readdir_impl(os_file, cookie)?;
+    let iter = fd_readdir_impl(os_handle, cookie)?;
     let mut used = 0;
     for dirent in iter {
         let dirent_raw = dirent?.to_wasi_raw()?;

--- a/crates/wasi-common/src/sys/unix/bsd/mod.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod filetime;
 pub(crate) mod hostcalls_impl;
-pub(crate) mod osfile;
+pub(crate) mod oshandle;
 
 pub(crate) mod fdentry_impl {
     use crate::{sys::host_impl, Result};

--- a/crates/wasi-common/src/sys/unix/bsd/oshandle.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/oshandle.rs
@@ -5,9 +5,9 @@ use std::os::unix::prelude::{AsRawFd, RawFd};
 use std::sync::Mutex;
 
 #[derive(Debug)]
-pub(crate) struct OsFile {
+pub(crate) struct OsHandle {
     pub(crate) file: fs::File,
-    // In case that this `OsFile` actually refers to a directory,
+    // In case that this `OsHandle` actually refers to a directory,
     // when the client makes a `fd_readdir` syscall on this descriptor,
     // we will need to cache the `libc::DIR` pointer manually in order
     // to be able to seek on it later. While on Linux, this is handled
@@ -21,19 +21,19 @@ pub(crate) struct OsFile {
     pub(crate) dir: Option<Mutex<Dir>>,
 }
 
-impl From<fs::File> for OsFile {
+impl From<fs::File> for OsHandle {
     fn from(file: fs::File) -> Self {
         Self { file, dir: None }
     }
 }
 
-impl AsRawFd for OsFile {
+impl AsRawFd for OsHandle {
     fn as_raw_fd(&self) -> RawFd {
         self.file.as_raw_fd()
     }
 }
 
-impl Deref for OsFile {
+impl Deref for OsHandle {
     type Target = fs::File;
 
     fn deref(&self) -> &Self::Target {
@@ -41,7 +41,7 @@ impl Deref for OsFile {
     }
 }
 
-impl DerefMut for OsFile {
+impl DerefMut for OsHandle {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.file
     }

--- a/crates/wasi-common/src/sys/unix/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/unix/fdentry_impl.rs
@@ -7,7 +7,7 @@ use std::os::unix::prelude::{AsRawFd, FileTypeExt, FromRawFd, RawFd};
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
-        pub(crate) use super::linux::osfile::*;
+        pub(crate) use super::linux::oshandle::*;
         pub(crate) use super::linux::fdentry_impl::*;
     } else if #[cfg(any(
             target_os = "macos",
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
             target_os = "ios",
             target_os = "dragonfly"
     ))] {
-        pub(crate) use super::bsd::osfile::*;
+        pub(crate) use super::bsd::oshandle::*;
         pub(crate) use super::bsd::fdentry_impl::*;
     }
 }
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
 impl AsRawFd for Descriptor {
     fn as_raw_fd(&self) -> RawFd {
         match self {
-            Self::OsFile(file) => file.as_raw_fd(),
+            Self::OsHandle(file) => file.as_raw_fd(),
             Self::Stdin => io::stdin().as_raw_fd(),
             Self::Stdout => io::stdout().as_raw_fd(),
             Self::Stderr => io::stderr().as_raw_fd(),
@@ -33,8 +33,10 @@ impl AsRawFd for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
-    ManuallyDrop::new(OsFile::from(unsafe { File::from_raw_fd(desc.as_raw_fd()) }))
+pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
+    ManuallyDrop::new(OsHandle::from(unsafe {
+        File::from_raw_fd(desc.as_raw_fd())
+    }))
 }
 
 /// This function is unsafe because it operates on a raw file descriptor.

--- a/crates/wasi-common/src/sys/unix/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/unix/fdentry_impl.rs
@@ -1,6 +1,8 @@
 use crate::fdentry::Descriptor;
 use crate::{wasi, Error, Result};
+use std::fs::File;
 use std::io;
+use std::mem::ManuallyDrop;
 use std::os::unix::prelude::{AsRawFd, FileTypeExt, FromRawFd, RawFd};
 
 cfg_if::cfg_if! {
@@ -29,6 +31,10 @@ impl AsRawFd for Descriptor {
             Self::Stderr => io::stderr().as_raw_fd(),
         }
     }
+}
+
+pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
+    ManuallyDrop::new(OsFile::from(unsafe { File::from_raw_fd(desc.as_raw_fd()) }))
 }
 
 /// This function is unsafe because it operates on a raw file descriptor.

--- a/crates/wasi-common/src/sys/unix/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/unix/fdentry_impl.rs
@@ -1,4 +1,4 @@
-use crate::fdentry::Descriptor;
+use crate::fdentry::{Descriptor, OsHandleRef};
 use crate::{wasi, Error, Result};
 use std::fs::File;
 use std::io;
@@ -33,10 +33,12 @@ impl AsRawFd for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
-    ManuallyDrop::new(OsHandle::from(unsafe {
+pub(crate) fn descriptor_as_oshandle<'lifetime>(
+    desc: &'lifetime Descriptor,
+) -> OsHandleRef<'lifetime> {
+    OsHandleRef::new(ManuallyDrop::new(OsHandle::from(unsafe {
         File::from_raw_fd(desc.as_raw_fd())
-    }))
+    })))
 }
 
 /// This function is unsafe because it operates on a raw file descriptor.

--- a/crates/wasi-common/src/sys/unix/linux/mod.rs
+++ b/crates/wasi-common/src/sys/unix/linux/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod filetime;
 pub(crate) mod hostcalls_impl;
-pub(crate) mod osfile;
+pub(crate) mod oshandle;
 
 pub(crate) mod fdentry_impl {
     use crate::{sys::host_impl, Result};

--- a/crates/wasi-common/src/sys/unix/linux/oshandle.rs
+++ b/crates/wasi-common/src/sys/unix/linux/oshandle.rs
@@ -3,21 +3,21 @@ use std::ops::{Deref, DerefMut};
 use std::os::unix::prelude::{AsRawFd, RawFd};
 
 #[derive(Debug)]
-pub(crate) struct OsFile(fs::File);
+pub(crate) struct OsHandle(fs::File);
 
-impl From<fs::File> for OsFile {
+impl From<fs::File> for OsHandle {
     fn from(file: fs::File) -> Self {
         Self(file)
     }
 }
 
-impl AsRawFd for OsFile {
+impl AsRawFd for OsHandle {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }
 }
 
-impl Deref for OsFile {
+impl Deref for OsHandle {
     type Target = fs::File;
 
     fn deref(&self) -> &Self::Target {
@@ -25,7 +25,7 @@ impl Deref for OsFile {
     }
 }
 
-impl DerefMut for OsFile {
+impl DerefMut for OsHandle {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/crates/wasi-common/src/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/windows/fdentry_impl.rs
@@ -7,21 +7,21 @@ use std::ops::{Deref, DerefMut};
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle, RawHandle};
 
 #[derive(Debug)]
-pub(crate) struct OsFile(File);
+pub(crate) struct OsHandle(File);
 
-impl From<File> for OsFile {
+impl From<File> for OsHandle {
     fn from(file: File) -> Self {
         Self(file)
     }
 }
 
-impl AsRawHandle for OsFile {
+impl AsRawHandle for OsHandle {
     fn as_raw_handle(&self) -> RawHandle {
         self.0.as_raw_handle()
     }
 }
 
-impl Deref for OsFile {
+impl Deref for OsHandle {
     type Target = File;
 
     fn deref(&self) -> &Self::Target {
@@ -29,7 +29,7 @@ impl Deref for OsFile {
     }
 }
 
-impl DerefMut for OsFile {
+impl DerefMut for OsHandle {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -38,7 +38,7 @@ impl DerefMut for OsFile {
 impl AsRawHandle for Descriptor {
     fn as_raw_handle(&self) -> RawHandle {
         match self {
-            Self::OsFile(file) => file.as_raw_handle(),
+            Self::OsHandle(file) => file.as_raw_handle(),
             Self::Stdin => io::stdin().as_raw_handle(),
             Self::Stdout => io::stdout().as_raw_handle(),
             Self::Stderr => io::stderr().as_raw_handle(),
@@ -46,8 +46,8 @@ impl AsRawHandle for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
-    ManuallyDrop::new(OsFile::from(unsafe {
+pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
+    ManuallyDrop::new(OsHandle::from(unsafe {
         File::from_raw_handle(desc.as_raw_handle())
     }))
 }

--- a/crates/wasi-common/src/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/windows/fdentry_impl.rs
@@ -1,4 +1,4 @@
-use crate::fdentry::Descriptor;
+use crate::fdentry::{Descriptor, OsHandleRef};
 use crate::{wasi, Error, Result};
 use std::fs::File;
 use std::io;
@@ -46,10 +46,12 @@ impl AsRawHandle for Descriptor {
     }
 }
 
-pub(crate) fn descriptor_as_oshandle(desc: &Descriptor) -> ManuallyDrop<OsHandle> {
-    ManuallyDrop::new(OsHandle::from(unsafe {
+pub(crate) fn descriptor_as_oshandle<'lifetime>(
+    desc: &'lifetime Descriptor,
+) -> OsHandleRef<'lifetime> {
+    OsHandleRef::new(ManuallyDrop::new(OsHandle::from(unsafe {
         File::from_raw_handle(desc.as_raw_handle())
-    }))
+    })))
 }
 
 /// This function is unsafe because it operates on a raw file handle.

--- a/crates/wasi-common/src/sys/windows/fdentry_impl.rs
+++ b/crates/wasi-common/src/sys/windows/fdentry_impl.rs
@@ -2,6 +2,7 @@ use crate::fdentry::Descriptor;
 use crate::{wasi, Error, Result};
 use std::fs::File;
 use std::io;
+use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle, RawHandle};
 
@@ -43,6 +44,12 @@ impl AsRawHandle for Descriptor {
             Self::Stderr => io::stderr().as_raw_handle(),
         }
     }
+}
+
+pub(crate) fn descriptor_as_osfile(desc: &Descriptor) -> ManuallyDrop<OsFile> {
+    ManuallyDrop::new(OsFile::from(unsafe {
+        File::from_raw_handle(desc.as_raw_handle())
+    }))
 }
 
 /// This function is unsafe because it operates on a raw file handle.

--- a/crates/wasi-common/src/sys/windows/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/sys/windows/hostcalls_impl/fs.rs
@@ -5,7 +5,7 @@ use crate::ctx::WasiCtx;
 use crate::fdentry::FdEntry;
 use crate::helpers::systemtime_to_timestamp;
 use crate::hostcalls_impl::{fd_filestat_set_times_impl, Dirent, FileType, PathGet};
-use crate::sys::fdentry_impl::{determine_type_rights, OsFile};
+use crate::sys::fdentry_impl::determine_type_rights;
 use crate::sys::host_impl::{self, path_from_host};
 use crate::sys::hostcalls_impl::fs_helpers::PathGetExt;
 use crate::{wasi, Error, Result};


### PR DESCRIPTION
fd_fdstat_get was unintentionally failing on stdin etc., because the implementation uses a Rust `File` and the descriptor for `Stdin` etc. doesn't hold a `File`. This adds a way to obtain a `File` hold the stdin etc. file descriptors, so that we can do `fd_fdstat_get` and potentially additional operations in the future.

Also, support renumbering stdin/stdout/stderr. Applications may use this to open files and renumber them into the stdin/stdout/stderr number slots.