### PR TITLE
Fix build errors on nightly

### DIFF
--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod fdentry_impl {
 pub(crate) mod host_impl {
     use super::super::host_impl::dirent_filetype_from_host;
     use crate::old::snapshot_0::{wasi, Result};
+    use std::convert::TryFrom;
 
     pub(crate) const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_SYNC;
 
@@ -37,5 +38,13 @@ pub(crate) mod host_impl {
         entry.d_namlen = u32::from(host_entry.d_namlen);
         entry.d_type = d_type;
         Ok(entry)
+    }
+
+    pub(crate) fn stdev_from_nix(dev: nix::libc::dev_t) -> Result<wasi::__wasi_device_t> {
+        wasi::__wasi_device_t::try_from(dev).map_err(Into::into)
+    }
+
+    pub(crate) fn stino_from_nix(ino: nix::libc::ino_t) -> Result<wasi::__wasi_inode_t> {
+        wasi::__wasi_device_t::try_from(ino).map_err(Into::into)
     }
 }

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/host_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/host_impl.rs
@@ -188,7 +188,6 @@ pub(crate) fn filetype_from_nix(sflags: nix::sys::stat::SFlag) -> FileType {
 pub(crate) fn filestat_from_nix(
     filestat: nix::sys::stat::FileStat,
 ) -> Result<wasi::__wasi_filestat_t> {
-    use std::convert::TryFrom;
     fn filestat_to_timestamp(secs: u64, nsecs: u64) -> Result<wasi::__wasi_timestamp_t> {
         secs.checked_mul(1_000_000_000)
             .and_then(|sec_nsec| sec_nsec.checked_add(nsecs))
@@ -196,8 +195,8 @@ pub(crate) fn filestat_from_nix(
     }
 
     let filetype = nix::sys::stat::SFlag::from_bits_truncate(filestat.st_mode);
-    let dev = wasi::__wasi_device_t::try_from(filestat.st_dev)?;
-    let ino = wasi::__wasi_inode_t::try_from(filestat.st_ino)?;
+    let dev = stdev_from_nix(filestat.st_dev)?;
+    let ino = stino_from_nix(filestat.st_ino)?;
     let atim = filestat_to_timestamp(filestat.st_atime as u64, filestat.st_atime_nsec as u64)?;
     let ctim = filestat_to_timestamp(filestat.st_ctime as u64, filestat.st_ctime_nsec as u64)?;
     let mtim = filestat_to_timestamp(filestat.st_mtime as u64, filestat.st_mtime_nsec as u64)?;

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/mod.rs
@@ -29,5 +29,15 @@ pub(crate) mod fdentry_impl {
 }
 
 pub(crate) mod host_impl {
+    use crate::old::snapshot_0::{wasi, Result};
+
     pub(crate) const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_RSYNC;
+
+    pub(crate) fn stdev_from_nix(dev: nix::libc::dev_t) -> Result<wasi::__wasi_device_t> {
+        Ok(wasi::__wasi_device_t::from(dev))
+    }
+
+    pub(crate) fn stino_from_nix(ino: nix::libc::ino_t) -> Result<wasi::__wasi_inode_t> {
+        Ok(wasi::__wasi_device_t::from(ino))
+    }
 }

--- a/crates/wasi-common/src/sys/unix/bsd/mod.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/mod.rs
@@ -22,5 +22,16 @@ pub(crate) mod fdentry_impl {
 }
 
 pub(crate) mod host_impl {
+    use crate::{wasi, Result};
+    use std::convert::TryFrom;
+
     pub(crate) const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_SYNC;
+
+    pub(crate) fn stdev_from_nix(dev: nix::libc::dev_t) -> Result<wasi::__wasi_device_t> {
+        wasi::__wasi_device_t::try_from(dev).map_err(Into::into)
+    }
+
+    pub(crate) fn stino_from_nix(ino: nix::libc::ino_t) -> Result<wasi::__wasi_inode_t> {
+        wasi::__wasi_device_t::try_from(ino).map_err(Into::into)
+    }
 }

--- a/crates/wasi-common/src/sys/unix/host_impl.rs
+++ b/crates/wasi-common/src/sys/unix/host_impl.rs
@@ -188,7 +188,6 @@ pub(crate) fn filetype_from_nix(sflags: nix::sys::stat::SFlag) -> FileType {
 pub(crate) fn filestat_from_nix(
     filestat: nix::sys::stat::FileStat,
 ) -> Result<wasi::__wasi_filestat_t> {
-    use std::convert::TryFrom;
     fn filestat_to_timestamp(secs: u64, nsecs: u64) -> Result<wasi::__wasi_timestamp_t> {
         secs.checked_mul(1_000_000_000)
             .and_then(|sec_nsec| sec_nsec.checked_add(nsecs))
@@ -196,8 +195,8 @@ pub(crate) fn filestat_from_nix(
     }
 
     let filetype = nix::sys::stat::SFlag::from_bits_truncate(filestat.st_mode);
-    let dev = wasi::__wasi_device_t::try_from(filestat.st_dev)?;
-    let ino = wasi::__wasi_inode_t::try_from(filestat.st_ino)?;
+    let dev = stdev_from_nix(filestat.st_dev)?;
+    let ino = stino_from_nix(filestat.st_ino)?;
     let atim = filestat_to_timestamp(filestat.st_atime as u64, filestat.st_atime_nsec as u64)?;
     let ctim = filestat_to_timestamp(filestat.st_ctime as u64, filestat.st_ctime_nsec as u64)?;
     let mtim = filestat_to_timestamp(filestat.st_mtime as u64, filestat.st_mtime_nsec as u64)?;

--- a/crates/wasi-common/src/sys/unix/linux/mod.rs
+++ b/crates/wasi-common/src/sys/unix/linux/mod.rs
@@ -29,5 +29,15 @@ pub(crate) mod fdentry_impl {
 }
 
 pub(crate) mod host_impl {
+    use crate::{wasi, Result};
+
     pub(crate) const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_RSYNC;
+
+    pub(crate) fn stdev_from_nix(dev: nix::libc::dev_t) -> Result<wasi::__wasi_device_t> {
+        Ok(wasi::__wasi_device_t::from(dev))
+    }
+
+    pub(crate) fn stino_from_nix(ino: nix::libc::ino_t) -> Result<wasi::__wasi_inode_t> {
+        Ok(wasi::__wasi_device_t::from(ino))
+    }
 }


### PR DESCRIPTION
Workaround for a regression in upstream rust-lang/rust.

Builds on #634, closes #633.