### PR TITLE
Fast-forward snapshot_0 to match wasi-common upstream

### DIFF
--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/mod.rs
@@ -22,23 +22,10 @@ pub(crate) mod fdentry_impl {
 }
 
 pub(crate) mod host_impl {
-    use super::super::host_impl::dirent_filetype_from_host;
     use crate::old::snapshot_0::{wasi, Result};
     use std::convert::TryFrom;
 
     pub(crate) const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_SYNC;
-
-    pub(crate) fn dirent_from_host(
-        host_entry: &nix::libc::dirent,
-    ) -> Result<wasi::__wasi_dirent_t> {
-        let mut entry = unsafe { std::mem::zeroed::<wasi::__wasi_dirent_t>() };
-        let d_type = dirent_filetype_from_host(host_entry)?;
-        entry.d_ino = host_entry.d_ino;
-        entry.d_next = host_entry.d_seekoff;
-        entry.d_namlen = u32::from(host_entry.d_namlen);
-        entry.d_type = d_type;
-        Ok(entry)
-    }
 
     pub(crate) fn stdev_from_nix(dev: nix::libc::dev_t) -> Result<wasi::__wasi_device_t> {
         wasi::__wasi_device_t::try_from(dev).map_err(Into::into)

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/oshandle.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/oshandle.rs
@@ -1,33 +1,29 @@
+use super::super::dir::Dir;
 use std::fs;
-use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::os::unix::prelude::{AsRawFd, RawFd};
 use std::sync::Mutex;
 
 #[derive(Debug)]
-pub(crate) struct DirStream {
-    pub(crate) file: ManuallyDrop<fs::File>,
-    pub(crate) dir_ptr: *mut libc::DIR,
-}
-
-impl Drop for DirStream {
-    fn drop(&mut self) {
-        unsafe { libc::closedir(self.dir_ptr) };
-    }
-}
-
-#[derive(Debug)]
 pub(crate) struct OsHandle {
     pub(crate) file: fs::File,
-    pub(crate) dir_stream: Option<Mutex<DirStream>>,
+    // In case that this `OsHandle` actually refers to a directory,
+    // when the client makes a `fd_readdir` syscall on this descriptor,
+    // we will need to cache the `libc::DIR` pointer manually in order
+    // to be able to seek on it later. While on Linux, this is handled
+    // by the OS, BSD Unixes require the client to do this caching.
+    //
+    // This comes directly from the BSD man pages on `readdir`:
+    //   > Values returned by telldir() are good only for the lifetime
+    //   > of the DIR pointer, dirp, from which they are derived.
+    //   > If the directory is closed and then reopened, prior values
+    //   > returned by telldir() will no longer be valid.
+    pub(crate) dir: Option<Mutex<Dir>>,
 }
 
 impl From<fs::File> for OsHandle {
     fn from(file: fs::File) -> Self {
-        Self {
-            file,
-            dir_stream: None,
-        }
+        Self { file, dir: None }
     }
 }
 

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/dir.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/dir.rs
@@ -1,16 +1,15 @@
 // Based on src/dir.rs from nix
-#![allow(unused)] // temporarily, until BSD catches up with this change
 use crate::old::snapshot_0::hostcalls_impl::FileType;
 use libc;
-use nix::{errno::Errno, Error, Result};
+use nix::{Error, Result};
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::{ffi, ptr};
 
 #[cfg(target_os = "linux")]
-use libc::{dirent64 as dirent, readdir64_r as readdir_r};
+use libc::dirent64 as dirent;
 
-#[cfg(not(target_os = "linux"))]
-use libc::{dirent, readdir_r};
+#[cfg(not(target_os = "linux",))]
+use libc::dirent;
 
 /// An open directory.
 ///
@@ -26,7 +25,7 @@ use libc::{dirent, readdir_r};
 ///    * returns entries' names as a `CStr` (no allocation or conversion beyond whatever libc
 ///      does).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct Dir(ptr::NonNull<libc::DIR>);
+pub(crate) struct Dir(pub(crate) ptr::NonNull<libc::DIR>);
 
 impl Dir {
     /// Converts from a descriptor-based object, closing the descriptor on success or failure.
@@ -90,53 +89,12 @@ impl Drop for Dir {
     }
 }
 
-pub(crate) struct IntoIter(Dir);
-impl Iterator for IntoIter {
-    type Item = Result<Entry>;
-    fn next(&mut self) -> Option<Self::Item> {
-        unsafe {
-            // Note: POSIX specifies that portable applications should dynamically allocate a
-            // buffer with room for a `d_name` field of size `pathconf(..., _PC_NAME_MAX)` plus 1
-            // for the NUL byte. It doesn't look like the std library does this; it just uses
-            // fixed-sized buffers (and libc's dirent seems to be sized so this is appropriate).
-            // Probably fine here too then.
-            //
-            // See `impl Iterator for ReadDir` [1] for more details.
-            // [1] https://github.com/rust-lang/rust/blob/master/src/libstd/sys/unix/fs.rs
-            let mut ent = std::mem::MaybeUninit::<dirent>::uninit();
-            let mut result = ptr::null_mut();
-            if let Err(e) = Errno::result(readdir_r(
-                (self.0).0.as_ptr(),
-                ent.as_mut_ptr(),
-                &mut result,
-            )) {
-                return Some(Err(e));
-            }
-            if result.is_null() {
-                None
-            } else {
-                assert_eq!(result, ent.as_mut_ptr(), "readdir_r specification violated");
-                Some(Ok(Entry(ent.assume_init())))
-            }
-        }
-    }
-}
-
-impl IntoIterator for Dir {
-    type IntoIter = IntoIter;
-    type Item = Result<Entry>;
-
-    fn into_iter(self) -> IntoIter {
-        IntoIter(self)
-    }
-}
-
 /// A directory entry, similar to `std::fs::DirEntry`.
 ///
 /// Note that unlike the std version, this may represent the `.` or `..` entries.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 #[repr(transparent)]
-pub(crate) struct Entry(dirent);
+pub(crate) struct Entry(pub(crate) dirent);
 
 pub(crate) type Type = FileType;
 

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs.rs
@@ -7,7 +7,7 @@ use crate::old::snapshot_0::helpers::systemtime_to_timestamp;
 use crate::old::snapshot_0::hostcalls_impl::{
     fd_filestat_set_times_impl, Dirent, FileType, PathGet,
 };
-use crate::old::snapshot_0::sys::fdentry_impl::{determine_type_rights, OsHandle};
+use crate::old::snapshot_0::sys::fdentry_impl::determine_type_rights;
 use crate::old::snapshot_0::sys::host_impl::{self, path_from_host};
 use crate::old::snapshot_0::sys::hostcalls_impl::fs_helpers::PathGetExt;
 use crate::old::snapshot_0::{wasi, Error, Result};
@@ -18,7 +18,7 @@ use std::io::{self, Seek, SeekFrom};
 use std::os::windows::fs::{FileExt, OpenOptionsExt};
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle};
 use std::path::{Path, PathBuf};
-use winx::file::{AccessMode, Flags};
+use winx::file::{AccessMode, CreationDisposition, FileModeInformation, Flags};
 
 fn read_at(mut file: &File, buf: &mut [u8], offset: u64) -> io::Result<usize> {
     // get current cursor position
@@ -55,10 +55,29 @@ pub(crate) fn fd_pwrite(file: &File, buf: &[u8], offset: wasi::__wasi_filesize_t
 }
 
 pub(crate) fn fd_fdstat_get(fd: &File) -> Result<wasi::__wasi_fdflags_t> {
-    use winx::file::AccessMode;
-    unsafe { winx::file::query_access_information(fd.as_raw_handle()) }
-        .map(host_impl::fdflags_from_win)
-        .map_err(Into::into)
+    let mut fdflags = 0;
+
+    let handle = unsafe { fd.as_raw_handle() };
+
+    let access_mode = winx::file::query_access_information(handle)?;
+    let mode = winx::file::query_mode_information(handle)?;
+
+    // Append without write implies append-only (__WASI_FDFLAGS_APPEND)
+    if access_mode.contains(AccessMode::FILE_APPEND_DATA)
+        && !access_mode.contains(AccessMode::FILE_WRITE_DATA)
+    {
+        fdflags |= wasi::__WASI_FDFLAGS_APPEND;
+    }
+
+    if mode.contains(FileModeInformation::FILE_WRITE_THROUGH) {
+        // Only report __WASI_FDFLAGS_SYNC
+        // This is technically the only one of the O_?SYNC flags Windows supports.
+        fdflags |= wasi::__WASI_FDFLAGS_SYNC;
+    }
+
+    // Files do not support the `__WASI_FDFLAGS_NONBLOCK` flag
+
+    Ok(fdflags)
 }
 
 pub(crate) fn fd_fdstat_set_flags(fd: &File, fdflags: wasi::__wasi_fdflags_t) -> Result<()> {
@@ -102,35 +121,22 @@ pub(crate) fn path_open(
 ) -> Result<File> {
     use winx::file::{AccessMode, CreationDisposition, Flags};
 
-    let mut access_mode = AccessMode::READ_CONTROL;
-    if read {
-        access_mode.insert(AccessMode::FILE_GENERIC_READ);
-    }
-    if write {
-        access_mode.insert(AccessMode::FILE_GENERIC_WRITE);
-    }
-
-    let mut flags = Flags::FILE_FLAG_BACKUP_SEMANTICS;
-
     // convert open flags
+    // note: the calls to `write(true)` are to bypass an internal OpenOption check
+    // the write flag will ultimately be ignored when `access_mode` is called below.
     let mut opts = OpenOptions::new();
-    match host_impl::win_from_oflags(oflags) {
+    match creation_disposition_from_oflags(oflags) {
         CreationDisposition::CREATE_ALWAYS => {
-            opts.create(true).append(true);
+            opts.create(true).write(true);
         }
         CreationDisposition::CREATE_NEW => {
             opts.create_new(true).write(true);
         }
         CreationDisposition::TRUNCATE_EXISTING => {
-            opts.truncate(true);
+            opts.truncate(true).write(true);
         }
         _ => {}
     }
-
-    // convert file descriptor flags
-    let (add_access_mode, add_flags) = host_impl::win_from_fdflags(fdflags);
-    access_mode.insert(add_access_mode);
-    flags.insert(add_flags);
 
     let path = resolved.concatenate()?;
 
@@ -164,10 +170,69 @@ pub(crate) fn path_open(
         },
     }
 
-    opts.access_mode(access_mode.bits())
-        .custom_flags(flags.bits())
+    opts.access_mode(file_access_mode_from_fdflags(fdflags, read, write).bits())
+        .custom_flags(file_flags_from_fdflags(fdflags).bits())
         .open(&path)
         .map_err(Into::into)
+}
+
+fn creation_disposition_from_oflags(oflags: wasi::__wasi_oflags_t) -> CreationDisposition {
+    if oflags & wasi::__WASI_OFLAGS_CREAT != 0 {
+        if oflags & wasi::__WASI_OFLAGS_EXCL != 0 {
+            CreationDisposition::CREATE_NEW
+        } else {
+            CreationDisposition::CREATE_ALWAYS
+        }
+    } else if oflags & wasi::__WASI_OFLAGS_TRUNC != 0 {
+        CreationDisposition::TRUNCATE_EXISTING
+    } else {
+        CreationDisposition::OPEN_EXISTING
+    }
+}
+
+fn file_access_mode_from_fdflags(
+    fdflags: wasi::__wasi_fdflags_t,
+    read: bool,
+    write: bool,
+) -> AccessMode {
+    let mut access_mode = AccessMode::READ_CONTROL;
+
+    if read {
+        access_mode.insert(AccessMode::GENERIC_READ);
+    }
+
+    if write {
+        access_mode.insert(AccessMode::GENERIC_WRITE);
+    }
+
+    // For append, grant the handle FILE_APPEND_DATA access but *not* FILE_WRITE_DATA.
+    // This makes the handle "append only".
+    // Changes to the file pointer will be ignored (like POSIX's O_APPEND behavior).
+    if fdflags & wasi::__WASI_FDFLAGS_APPEND != 0 {
+        access_mode.insert(AccessMode::FILE_APPEND_DATA);
+        access_mode.remove(AccessMode::FILE_WRITE_DATA);
+    }
+
+    access_mode
+}
+
+fn file_flags_from_fdflags(fdflags: wasi::__wasi_fdflags_t) -> Flags {
+    // Enable backup semantics so directories can be opened as files
+    let mut flags = Flags::FILE_FLAG_BACKUP_SEMANTICS;
+
+    // Note: __WASI_FDFLAGS_NONBLOCK is purposely being ignored for files
+    // While Windows does inherently support a non-blocking mode on files, the WASI API will
+    // treat I/O operations on files as synchronous. WASI might have an async-io API in the future.
+
+    // Technically, Windows only supports __WASI_FDFLAGS_SYNC, but treat all the flags as the same.
+    if fdflags & wasi::__WASI_FDFLAGS_DSYNC != 0
+        || fdflags & wasi::__WASI_FDFLAGS_RSYNC != 0
+        || fdflags & wasi::__WASI_FDFLAGS_SYNC != 0
+    {
+        flags.insert(Flags::FILE_FLAG_WRITE_THROUGH);
+    }
+
+    flags
 }
 
 fn dirent_from_path<P: AsRef<Path>>(
@@ -220,7 +285,7 @@ fn dirent_from_path<P: AsRef<Path>>(
 // .        gets cookie = 1
 // ..       gets cookie = 2
 // other entries, in order they were returned by FindNextFileW get subsequent integers as their cookies
-pub(crate) fn fd_readdir_impl(
+pub(crate) fn fd_readdir(
     fd: &File,
     cookie: wasi::__wasi_dircookie_t,
 ) -> Result<impl Iterator<Item = Result<Dirent>>> {
@@ -257,30 +322,6 @@ pub(crate) fn fd_readdir_impl(
     //
     // See https://github.com/WebAssembly/WASI/issues/61 for more details.
     Ok(iter.skip(cookie))
-}
-
-// This should actually be common code with Linux
-pub(crate) fn fd_readdir(
-    os_handle: &mut OsHandle,
-    mut host_buf: &mut [u8],
-    cookie: wasi::__wasi_dircookie_t,
-) -> Result<usize> {
-    let iter = fd_readdir_impl(os_handle, cookie)?;
-    let mut used = 0;
-    for dirent in iter {
-        let dirent_raw = dirent?.to_wasi_raw()?;
-        let offset = dirent_raw.len();
-        if host_buf.len() < offset {
-            break;
-        } else {
-            host_buf[0..offset].copy_from_slice(&dirent_raw);
-            used += offset;
-            host_buf = &mut host_buf[offset..];
-        }
-    }
-
-    trace!("     | *buf_used={:?}", used);
-    Ok(used)
 }
 
 pub(crate) fn path_readlink(resolved: PathGet, buf: &mut [u8]) -> Result<usize> {


### PR DESCRIPTION
While we are waiting for the Rust toolchain to use the new ABI, I thought it might be useful to sync `snapshot_0` with the latest code in `wasi-common` "upstream". This mainly includes the latest refactoring effort to unify the machinery for `fd_readdir` between Linux, Windows and BSD.

__NB__ this PR builds on #631, so let's merge #631 before we merge this one.