### PR TITLE
Build python 3.8 wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
 
   # Builds a Python wheel (package) for Windows/Mac/Linux. Note that we're
   # careful to create binary-compatible releases here to old releases of
-  # Windows/Mac/Linux. This will also build wheels for Python 3.6 and 3.7.
+  # Windows/Mac/Linux. This will also build wheels for Python 3.6, 3.7 and 3.8.
   wheels:
     name: Python Wheel
     runs-on: ${{ matrix.os }}
@@ -178,7 +178,29 @@ jobs:
         architecture: x64
       if: matrix.os != 'ubuntu-latest'
     - name: Build Python 3.7
-      run: $CENTOS sh ci/setup_centos6_python37.sh
+      run: $CENTOS sh ci/setup_centos6_python3.sh 3.7.3
+      if: matrix.os == 'ubuntu-latest'
+    - run: $CENTOS pip3 install setuptools wheel==0.31.1 setuptools-rust auditwheel
+      shell: bash
+    - run: (cd crates/misc/py && $CENTOS $python setup.py bdist_wheel)
+      shell: bash
+
+    # Clear the build directory between building different wheels for different
+    # Python versions to ensure that we don't package dynamic libraries twice by
+    # accident.
+    - run: $CENTOS rm -rf crates/misc/py/build
+      shell: bash
+
+    # Set up Python 3.8 (and build it on Linux), reinstall dependencies, then
+    # rebuild our wheels
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.8'
+        architecture: x64
+      if: matrix.os != 'ubuntu-latest'
+    - name: Build Python 3.8
+      run: $CENTOS sh ci/setup_centos6_python3.sh 3.8.0
       if: matrix.os == 'ubuntu-latest'
     - run: $CENTOS pip3 install setuptools wheel==0.31.1 setuptools-rust auditwheel
       shell: bash

--- a/ci/setup_centos6_python3.sh
+++ b/ci/setup_centos6_python3.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+VERSION=${1:-3.7.3}
+
 # Python 3.6 stands in our way -- nuking it
 yum erase -y rh-python36
 rm -rf /opt/rh/rh-python36
@@ -22,11 +24,11 @@ rm -rf openssl-OpenSSL_1_1_1c
 # Fixing libssl.so.1.1: cannot open shared object file
 echo "/usr/local/lib64" >> /etc/ld.so.conf && ldconfig
 
-curl -O -L https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
-tar xzf Python-3.7.3.tgz
-cd Python-3.7.3
+curl -O -L https://www.python.org/ftp/python/${VERSION}/Python-${VERSION}.tgz
+tar xzf Python-${VERSION}.tgz
+cd Python-${VERSION}
 ./configure
 make -sj4
 make install
 cd ..
-rm -rf Python-3.7.3
+rm -rf Python-${VERSION}


### PR DESCRIPTION
I updated the setup script for python 3.7 and 3.8 installation, and added an extra step for generating 3.8 wheels. [Here][0] is an example build from this PR, and I checked the artifacts to see if the wheels have valid names (and are also valid wheels)

[0]: https://github.com/bytecodealliance/wasmtime/runs/323859831#step:13:1 