### PR TITLE
Update rayon dependencies to avoid duplicate crossbeam dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.1"
 wat = "1.0.2"
 libc = "0.2.60"
-rayon = "1.1"
+rayon = "1.2.1"
 wasm-webidl-bindings = "0.6"
 
 [dev-dependencies]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -35,7 +35,7 @@ serde = { "version" = "1.0.94", features = ["derive"] }
 pretty_env_logger = "0.3.0"
 wasmtime-wast = { path = "../wast" }
 wasmtime-wasi = { path = "../wasi" }
-rayon = "1.1"
+rayon = "1.2.1"
 file-per-thread-logger = "0.1.1"
 wat = "1.0"
 

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -18,7 +18,7 @@ cranelift-wasm = { version = "0.50.0", features = ["enable-serde"] }
 wasmparser = "0.39.2"
 lightbeam = { path = "../lightbeam", optional = true }
 indexmap = "1.0.2"
-rayon = "1.2"
+rayon = "1.2.1"
 thiserror = "1.0.4"
 directories = "2.0.1"
 sha2 = "0.8.0"


### PR DESCRIPTION
rayon 1.2.1 avoids introducing two different versions of crossbeam
crates into the dependency tree (one through rayon, the other through
rayon-core).