### PR TITLE
[lightbeam] remove some panic, expect and unimplemented from microwasm.rs

### DIFF
--- a/crates/environ/src/lightbeam.rs
+++ b/crates/environ/src/lightbeam.rs
@@ -54,13 +54,13 @@ impl crate::compilation::Compiler for Lightbeam {
                 i.as_u32(),
                 &wasmparser::FunctionBody::new(0, function_body.data),
             )
-            .expect("Failed to translate function. TODO: Stop this from panicking");
+            .map_err(|e| CompileError::Codegen(format!("Failed to translate function: {}", e)))?;
             relocations.push(reloc_sink.func_relocs);
         }
 
         let code_section = codegen_session
             .into_translated_code_section()
-            .expect("Failed to generate output code. TODO: Stop this from panicking");
+            .map_err(|e| CompileError::Codegen(format!("Failed to generate output code: {}", e)))?;
 
         // TODO pass jump table offsets to Compilation::from_buffer() when they
         // are implemented in lightbeam -- using empty set of offsets for now.

--- a/crates/lightbeam/src/error.rs
+++ b/crates/lightbeam/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
 
     #[error("Input error: {0}")]
     Input(String),
+
+    #[error("Microwasm error: {0}")]
+    Microwasm(String),
 }
 
 impl From<BinaryReaderError> for Error {


### PR DESCRIPTION
Hi,

I was doing some fuzzing on lightbeam and triggered some bugs. 
Those bugs are mainly related to usage of `panic!`, `expect` and `unimplemented!`.

Related bugs:
- https://github.com/bytecodealliance/wasmtime/issues/655
- https://github.com/bytecodealliance/wasmtime/issues/654
- https://github.com/bytecodealliance/wasmtime/issues/653

If `lightbeam` is called as a 3rd library by `wasmtime` or another program, calling those macros will make the entire processus to crash without properly handling any Errors and without a concrete information for the user.

In this pull request, i've also modify other part of the code not reached by the bugs but that can caused panics as well.