### PR TITLE
Run our fuzz targets on our corpora in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,30 @@ jobs:
         name: doc-api
         path: target/doc
 
+  # Download our libFuzzer corpus and make sure that we can still handle all the
+  # inputs.
+  fuzz_corpora:
+    name: Fuzz Corpora
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/checkout@v1
+      with:
+        repository: bytecodealliance/wasmtime-libfuzzer-corpus
+        path: ./wasmtime/fuzz/corpus
+        ref: refs/heads/master
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly
+    - run: cargo install cargo-fuzz
+    - run: cargo fetch
+      working-directory: ./fuzz
+    # NB: the `-runs=0` means that libFuzzer won't generate new inputs, only run
+    # the seeds from the corpus.
+    - run: cargo fuzz run compile -- -runs=0
+    - run: cargo fuzz run instantiate -- -runs=0
+    - run: cargo fuzz run instantiate_translated -- -runs=0
+
   # Perform all tests (debug mode) for `wasmtime`. This runs stable/beta/nightly
   # channels of Rust as well as macOS/Linux/Windows.
   test:

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,52 @@
+# `cargo fuzz` Targets for Wasmtime
+
+This crate defines various [libFuzzer](https://www.llvm.org/docs/LibFuzzer.html)
+fuzzing targets for Wasmtime, which can be run via [`cargo
+fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html).
+
+These fuzz targets just glue together pre-defined test case generators with
+oracles and pass libFuzzer-provided inputs to them. The test case generators and
+oracles themselves are independent from the fuzzing engine that is driving the
+fuzzing process and are defined in `wasmtime/crates/fuzzing`.
+
+## Example
+
+To start fuzzing run the following command, where `$MY_FUZZ_TARGET` is one of
+the [available fuzz targets](#available-fuzz-targets):
+
+```shell
+cargo fuzz run $MY_FUZZ_TARGET
+```
+
+## Available Fuzz Targets
+
+At the time of writing, we have the following fuzz targets:
+
+* `compile`: Attempt to compile libFuzzer's raw input bytes with Wasmtime.
+* `instantiate`: Attempt to compile and instantiate libFuzzer's raw input bytes
+  with Wasmtime.
+* `instantiate_translated`: Pass libFuzzer's input bytes to `wasm-opt -ttf` to
+  generate a random, valid Wasm module, and then attempt to instantiate it.
+
+The canonical list of fuzz targets is the `.rs` files in the `fuzz_targets`
+directory:
+
+```shell
+ls wasmtime/fuzz/fuzz_targets/
+```
+
+## Corpora
+
+While you *can* start from scratch, libFuzzer will work better if it is given a
+[corpus](https://www.llvm.org/docs/LibFuzzer.html#corpus) of seed inputs to kick
+start the fuzzing process. We maintain a corpus for each of these fuzz targets
+in [a dedicated repo on
+github](https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus).
+
+You can use our corpora by cloning it and placing it at `wasmtime/fuzz/corpus`:
+
+```shell
+git clone \
+    https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus.git \
+    wasmtime/fuzz/corpus
+```


### PR DESCRIPTION
This doesn't have libFuzzer generate new inputs in CI, only verifies that we can still successfully process our existing seed inputs in each of our targets' corpora.

Part of https://github.com/bytecodealliance/wasmtime/issues/611

------------------

This may take a few force pushes to get the CI config just right 😅