### PR TITLE
Fix wast error line numbers; previously off by one

### DIFF
--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -152,7 +152,7 @@ impl WastContext {
         };
         let context = |sp: wast::Span| {
             let (line, col) = sp.linecol_in(wast);
-            format!("for directive on {}:{}:{}", filename, line, col)
+            format!("for directive on {}:{}:{}", filename, line + 1, col)
         };
 
         let buf = wast::parser::ParseBuffer::new(wast).map_err(adjust_wast)?;


### PR DESCRIPTION
@alexcrichton, I noticed that the `wast` library [returns 0-based line numbers][wast]; this is fine, but in order to get 1-based line numbers from wasmtime's `wast` binary I believe we need to add 1 where `lineco_in` is called. (I was expecting 1-based line numbers and assume most other users expect the same). What do you think?

[wast]: https://github.com/bytecodealliance/wat/blob/7b3c6dacaece54554cf06b615067feda3fac59f5/crates/wast/src/ast/token.rs#L18