### PR TITLE
Pin an older nightly to fix wasi tests

### DIFF
--- a/.github/actions/install-rust/main.js
+++ b/.github/actions/install-rust/main.js
@@ -1,17 +1,13 @@
 const child_process = require('child_process');
 const toolchain = process.env.INPUT_TOOLCHAIN;
 
-for (var i = 0, keys = Object.keys(process.env), ii = keys.length; i < ii; i++) {
-  console.log(keys[i] + '=' + process.env[keys[i]]);
-}
-
 if (process.platform === 'darwin') {
   child_process.execSync(`curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=none --profile=minimal`);
   const bindir = `${process.env.HOME}/.cargo/bin`;
   console.log(`::add-path::${bindir}`);
   process.env.PATH = `${process.env.PATH}:${bindir}`;
-  child_process.execFileSync('rustup', ['set', 'profile', 'minimal']);
 }
 
+child_process.execFileSync('rustup', ['set', 'profile', 'minimal']);
 child_process.execFileSync('rustup', ['update', toolchain, '--no-self-update']);
 child_process.execFileSync('rustup', ['default', toolchain]);

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,9 +102,11 @@ jobs:
           - build: beta
             os: ubuntu-latest
             rust: beta
+          # FIXME need to wait for rust-lang/rust#67065 to get into nightlies,
+          # and then this can be updated to `nightly` again.
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2019-12-03
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
Rust's recent update to libstd of the wasm32-wasi target turned out to
be buggy with respect to fetching the process arguments, so we'll need
to wait on a fix there before we can run these tests with nightly again.