### PR TITLE
Start to update the `wasi` crate in wasi tests

### DIFF
--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -30,6 +30,7 @@ mod wasi_tests {
                 println!("cargo:rerun-if-changed={}", test_file_path);
             }
         }
+        println!("cargo:rerun-if-changed=wasi-tests/Cargo.toml");
         // Build tests to OUT_DIR (target/*/build/wasi-common-*/out/wasm32-wasi/release/*.wasm)
         let out_dir = PathBuf::from(
             env::var("OUT_DIR").expect("The OUT_DIR environment variable must be set"),

--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -31,6 +31,7 @@ mod wasi_tests {
             }
         }
         println!("cargo:rerun-if-changed=wasi-tests/Cargo.toml");
+        println!("cargo:rerun-if-changed=wasi-tests/src/lib.rs");
         // Build tests to OUT_DIR (target/*/build/wasi-common-*/out/wasm32-wasi/release/*.wasm)
         let out_dir = PathBuf::from(
             env::var("OUT_DIR").expect("The OUT_DIR environment variable must be set"),

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -81,21 +81,21 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         .imports()
         .iter()
         .map(|i| {
-            let instance = if i.module().as_str() == "wasi_unstable" {
+            let instance = if i.module() == "wasi_unstable" {
                 &snapshot0
-            } else if i.module().as_str() == "wasi_snapshot_preview1" {
+            } else if i.module() == "wasi_snapshot_preview1" {
                 &snapshot1
             } else {
-                bail!("import module {} was not found", i.module().as_str())
+                bail!("import module {} was not found", i.module())
             };
-            let field_name = i.name().as_str();
+            let field_name = i.name();
             if let Some(export) = instance.find_export_by_name(field_name) {
                 Ok(export.clone())
             } else {
                 bail!(
                     "import {} was not found in module {}",
                     field_name,
-                    i.module().as_str(),
+                    i.module(),
                 )
             }
         })

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -33,7 +33,7 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
 
     // Create our wasi context with pretty standard arguments/inheritance/etc.
     // Additionally register andy preopened directories if we have them.
-    let mut builder = wasi_common::old::snapshot_0::WasiCtxBuilder::new()
+    let mut builder = wasi_common::WasiCtxBuilder::new()
         .arg(bin_name)
         .arg(".")
         .inherit_stdio();
@@ -50,6 +50,29 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
 
     // The current stable Rust toolchain uses the old `wasi_unstable` ABI,
     // aka `snapshot_0`.
+    module_registry.insert(
+        "wasi_snapshot_preview1".to_owned(),
+        Instance::from_handle(
+            &store,
+            wasmtime_wasi::instantiate_wasi_with_context(
+                global_exports.clone(),
+                builder.build().context("failed to build wasi context")?,
+            )
+            .context("failed to instantiate wasi")?,
+        ),
+    );
+
+    // ... and then do the same as above but for the old snapshot of wasi, since
+    // a few tests still test that
+    let mut builder = wasi_common::old::snapshot_0::WasiCtxBuilder::new()
+        .arg(bin_name)
+        .arg(".")
+        .inherit_stdio();
+    for (dir, file) in get_preopens(workspace)? {
+        builder = builder.preopened_dir(file, dir);
+    }
+    let (reader, _writer) = os_pipe::pipe()?;
+    builder = builder.stdin(reader_to_file(reader));
     module_registry.insert(
         "wasi_unstable".to_owned(),
         Instance::from_handle(

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context};
 use std::fs::File;
-use std::{collections::HashMap, path::Path};
+use std::path::Path;
 use wasmtime::{Config, Engine, HostRef, Instance, Module, Store};
 use wasmtime_environ::settings::{self, Configurable};
 
@@ -18,7 +18,6 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
     let engine = HostRef::new(Engine::new(&config));
     let store = HostRef::new(Store::new(&engine));
 
-    let mut module_registry = HashMap::new();
     let global_exports = store.borrow().global_exports().clone();
     let get_preopens = |workspace: Option<&Path>| -> anyhow::Result<Vec<_>> {
         if let Some(workspace) = workspace {
@@ -47,19 +46,13 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
     // stdin is closed which causes tests to fail.
     let (reader, _writer) = os_pipe::pipe()?;
     builder = builder.stdin(reader_to_file(reader));
-
-    // The current stable Rust toolchain uses the old `wasi_unstable` ABI,
-    // aka `snapshot_0`.
-    module_registry.insert(
-        "wasi_snapshot_preview1".to_owned(),
-        Instance::from_handle(
-            &store,
-            wasmtime_wasi::instantiate_wasi_with_context(
-                global_exports.clone(),
-                builder.build().context("failed to build wasi context")?,
-            )
-            .context("failed to instantiate wasi")?,
-        ),
+    let snapshot1 = Instance::from_handle(
+        &store,
+        wasmtime_wasi::instantiate_wasi_with_context(
+            global_exports.clone(),
+            builder.build().context("failed to build wasi context")?,
+        )
+        .context("failed to instantiate wasi")?,
     );
 
     // ... and then do the same as above but for the old snapshot of wasi, since
@@ -73,16 +66,13 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
     }
     let (reader, _writer) = os_pipe::pipe()?;
     builder = builder.stdin(reader_to_file(reader));
-    module_registry.insert(
-        "wasi_unstable".to_owned(),
-        Instance::from_handle(
-            &store,
-            wasmtime_wasi::old::snapshot_0::instantiate_wasi_with_context(
-                global_exports.clone(),
-                builder.build().context("failed to build wasi context")?,
-            )
-            .context("failed to instantiate wasi")?,
-        ),
+    let snapshot0 = Instance::from_handle(
+        &store,
+        wasmtime_wasi::old::snapshot_0::instantiate_wasi_with_context(
+            global_exports.clone(),
+            builder.build().context("failed to build wasi context")?,
+        )
+        .context("failed to instantiate wasi")?,
     );
 
     let module = HostRef::new(Module::new(&store, &data).context("failed to create wasm module")?);
@@ -91,20 +81,22 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         .imports()
         .iter()
         .map(|i| {
-            let module_name = i.module();
-            if let Some(instance) = module_registry.get(module_name) {
-                let field_name = i.name();
-                if let Some(export) = instance.find_export_by_name(field_name) {
-                    Ok(export.clone())
-                } else {
-                    bail!(
-                        "import {} was not found in module {}",
-                        field_name,
-                        module_name
-                    )
-                }
+            let instance = if i.module().as_str() == "wasi_unstable" {
+                &snapshot0
+            } else if i.module().as_str() == "wasi_snapshot_preview1" {
+                &snapshot1
             } else {
-                bail!("import module {} was not found", module_name)
+                bail!("import module {} was not found", i.module().as_str())
+            };
+            let field_name = i.name().as_str();
+            if let Some(export) = instance.find_export_by_name(field_name) {
+                Ok(export.clone())
+            } else {
+                bail!(
+                    "import {} was not found in module {}",
+                    field_name,
+                    i.module().as_str(),
+                )
             }
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 
 [dependencies]
 libc = "0.2.65"
-wasi = "0.7.0"
+wasi = "0.9.0"
+wasi-old = { version = "0.7.0", package = "wasi" }
 more-asserts = "0.2.1"
 
 # This crate is built with the wasm32-wasi target, so it's separate

--- a/crates/test-programs/wasi-tests/src/bin/big_random_buf.rs
+++ b/crates/test-programs/wasi-tests/src/bin/big_random_buf.rs
@@ -1,12 +1,9 @@
-use wasi_old::wasi_unstable;
-
 fn test_big_random_buf() {
     let mut buf = Vec::new();
     buf.resize(1024, 0);
-    assert!(
-        wasi_unstable::random_get(&mut buf).is_ok(),
-        "calling get_random on a large buffer"
-    );
+    unsafe {
+        wasi::random_get(buf.as_mut_ptr(), 1024).expect("failed to call random_get");
+    }
     // Chances are pretty good that at least *one* byte will be non-zero in
     // any meaningful random function producing 1024 u8 values.
     assert!(buf.iter().any(|x| *x != 0), "random_get returned all zeros");

--- a/crates/test-programs/wasi-tests/src/bin/big_random_buf.rs
+++ b/crates/test-programs/wasi-tests/src/bin/big_random_buf.rs
@@ -1,4 +1,4 @@
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 
 fn test_big_random_buf() {
     let mut buf = Vec::new();

--- a/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
+++ b/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
@@ -1,5 +1,5 @@
 use more_asserts::assert_le;
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::wasi_wrappers::wasi_clock_time_get;
 
 unsafe fn test_clock_time_get() {

--- a/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
+++ b/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
@@ -4,13 +4,12 @@ unsafe fn test_clock_time_get() {
     // Test that clock_time_get succeeds. Even in environments where it's not
     // desirable to expose high-precision timers, it should still succeed.
     // clock_res_get is where information about precision can be provided.
-    wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 1)
-        .expect("precision 1 should work");
+    wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 1).expect("precision 1 should work");
 
-    let first_time = wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0)
-        .expect("precision 0 should work");
+    let first_time =
+        wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).expect("precision 0 should work");
 
-    let time = wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).unwrap();
+    let time = wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).expect("re-fetch time should work");
     assert_le!(first_time, time, "CLOCK_MONOTONIC should be monotonic");
 }
 

--- a/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
+++ b/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
@@ -1,33 +1,16 @@
 use more_asserts::assert_le;
-use wasi_old::wasi_unstable;
-use wasi_tests::wasi_wrappers::wasi_clock_time_get;
 
 unsafe fn test_clock_time_get() {
     // Test that clock_time_get succeeds. Even in environments where it's not
     // desirable to expose high-precision timers, it should still succeed.
     // clock_res_get is where information about precision can be provided.
-    let mut time: wasi_unstable::Timestamp = 0;
-    let status = wasi_clock_time_get(wasi_unstable::CLOCK_MONOTONIC, 1, &mut time);
-    assert_eq!(
-        status,
-        wasi_unstable::raw::__WASI_ESUCCESS,
-        "clock_time_get with a precision of 1"
-    );
+    wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 1)
+        .expect("precision 1 should work");
 
-    let status = wasi_clock_time_get(wasi_unstable::CLOCK_MONOTONIC, 0, &mut time);
-    assert_eq!(
-        status,
-        wasi_unstable::raw::__WASI_ESUCCESS,
-        "clock_time_get with a precision of 0"
-    );
-    let first_time = time;
+    let first_time = wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0)
+        .expect("precision 0 should work");
 
-    let status = wasi_clock_time_get(wasi_unstable::CLOCK_MONOTONIC, 0, &mut time);
-    assert_eq!(
-        status,
-        wasi_unstable::raw::__WASI_ESUCCESS,
-        "clock_time_get with a precision of 0"
-    );
+    let time = wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).unwrap();
     assert_le!(first_time, time, "CLOCK_MONOTONIC should be monotonic");
 }
 

--- a/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
+++ b/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
@@ -1,60 +1,46 @@
-use libc;
 use more_asserts::assert_gt;
-use std::{env, mem, process};
-use wasi_old::wasi_unstable;
-use wasi_tests::open_scratch_directory;
-use wasi_tests::wasi_wrappers::wasi_fd_fdstat_get;
+use std::{env, process};
+use wasi_tests::open_scratch_directory_new;
 
-unsafe fn test_close_preopen(dir_fd: wasi_unstable::Fd) {
-    let pre_fd: wasi_unstable::Fd = (libc::STDERR_FILENO + 1) as wasi_unstable::Fd;
+unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
+    let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
 
     assert_gt!(dir_fd, pre_fd, "dir_fd number");
 
     // Try to close a preopened directory handle.
     assert_eq!(
-        wasi_unstable::fd_close(pre_fd),
-        Err(wasi_unstable::ENOTSUP),
+        wasi::fd_close(pre_fd).unwrap_err().raw_error(),
+        wasi::ERRNO_NOTSUP,
         "closing a preopened file descriptor",
     );
 
     // Try to renumber over a preopened directory handle.
     assert_eq!(
-        wasi_unstable::fd_renumber(dir_fd, pre_fd),
-        Err(wasi_unstable::ENOTSUP),
+        wasi::fd_renumber(dir_fd, pre_fd).unwrap_err().raw_error(),
+        wasi::ERRNO_NOTSUP,
         "renumbering over a preopened file descriptor",
     );
 
     // Ensure that dir_fd is still open.
-    let mut dir_fdstat: wasi_unstable::FdStat = mem::zeroed();
-    let mut status = wasi_fd_fdstat_get(dir_fd, &mut dir_fdstat);
-    assert_eq!(
-        status,
-        wasi_unstable::raw::__WASI_ESUCCESS,
-        "calling fd_fdstat on the scratch directory"
-    );
+    let dir_fdstat = wasi::fd_fdstat_get(dir_fd).expect("failed fd_fdstat_get");
     assert_eq!(
         dir_fdstat.fs_filetype,
-        wasi_unstable::FILETYPE_DIRECTORY,
+        wasi::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
 
     // Try to renumber a preopened directory handle.
     assert_eq!(
-        wasi_unstable::fd_renumber(pre_fd, dir_fd),
-        Err(wasi_unstable::ENOTSUP),
+        wasi::fd_renumber(pre_fd, dir_fd).unwrap_err().raw_error(),
+        wasi::ERRNO_NOTSUP,
         "renumbering over a preopened file descriptor",
     );
 
     // Ensure that dir_fd is still open.
-    status = wasi_fd_fdstat_get(dir_fd, &mut dir_fdstat);
-    assert_eq!(
-        status,
-        wasi_unstable::raw::__WASI_ESUCCESS,
-        "calling fd_fdstat on the scratch directory"
-    );
+    let dir_fdstat = wasi::fd_fdstat_get(dir_fd).expect("failed fd_fdstat_get");
     assert_eq!(
         dir_fdstat.fs_filetype,
-        wasi_unstable::FILETYPE_DIRECTORY,
+        wasi::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
 }
@@ -70,7 +56,7 @@ fn main() {
     };
 
     // Open scratch directory
-    let dir_fd = match open_scratch_directory(&arg) {
+    let dir_fd = match open_scratch_directory_new(&arg) {
         Ok(dir_fd) => dir_fd,
         Err(err) => {
             eprintln!("{}", err);

--- a/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
+++ b/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, mem, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::wasi_wrappers::wasi_fd_fdstat_get;
 

--- a/crates/test-programs/wasi-tests/src/bin/dangling_fd.rs
+++ b/crates/test-programs/wasi-tests/src/bin/dangling_fd.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, cleanup_file, create_dir, create_file};
 use wasi_tests::wasi_wrappers::wasi_path_open;

--- a/crates/test-programs/wasi-tests/src/bin/dangling_symlink.rs
+++ b/crates/test-programs/wasi-tests/src/bin/dangling_symlink.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::cleanup_file;
 use wasi_tests::wasi_wrappers::{wasi_path_open, wasi_path_symlink};

--- a/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
+++ b/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, mem, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, close_fd, create_dir};
 use wasi_tests::wasi_wrappers::{wasi_fd_fdstat_get, wasi_fd_seek, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/fd_advise.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_advise.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::{wasi_fd_advise, wasi_fd_filestat_get, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/fd_filestat_set.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_filestat_set.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{cmp::min, env, mem, process, slice, str};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_fd_readdir, wasi_path_open};
 

--- a/crates/test-programs/wasi-tests/src/bin/file_allocate.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_allocate.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/file_pread_pwrite.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_pread_pwrite.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::{wasi_fd_pread, wasi_fd_pwrite, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/file_seek_tell.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_seek_tell.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::{wasi_fd_seek, wasi_fd_tell, wasi_fd_write, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/file_unbuffered_write.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_unbuffered_write.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd, create_file};
 use wasi_tests::wasi_wrappers::{wasi_fd_read, wasi_fd_write, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
+++ b/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{close_fd, create_dir, create_file};
 use wasi_tests::wasi_wrappers::{

--- a/crates/test-programs/wasi-tests/src/bin/isatty.rs
+++ b/crates/test-programs/wasi-tests/src/bin/isatty.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::wasi_path_open;

--- a/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
+++ b/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd, create_dir, create_file};
 use wasi_tests::wasi_wrappers::{wasi_path_open, wasi_path_remove_directory, wasi_path_symlink};

--- a/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::{

--- a/crates/test-programs/wasi-tests/src/bin/path_link.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_link.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, cleanup_file, create_dir, create_file};
 use wasi_tests::wasi_wrappers::{

--- a/crates/test-programs/wasi-tests/src/bin/path_open_create_existing.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_create_existing.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd};
 use wasi_tests::wasi_wrappers::wasi_path_open;

--- a/crates/test-programs/wasi-tests/src/bin/path_open_dirfd_not_dir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_dirfd_not_dir.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::close_fd;
 use wasi_tests::wasi_wrappers::wasi_path_open;

--- a/crates/test-programs/wasi-tests/src/bin/path_rename.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_rename.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, cleanup_file, close_fd, create_dir, create_file};
 use wasi_tests::wasi_wrappers::{wasi_path_open, wasi_path_rename};

--- a/crates/test-programs/wasi-tests/src/bin/path_rename_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_rename_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, cleanup_file, create_dir, create_file};
 use wasi_tests::wasi_wrappers::wasi_path_rename;

--- a/crates/test-programs/wasi-tests/src/bin/path_symlink_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_symlink_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, cleanup_file, create_dir, create_file};
 use wasi_tests::wasi_wrappers::wasi_path_symlink;

--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff.rs
@@ -1,6 +1,6 @@
 use more_asserts::assert_gt;
 use std::{env, mem::MaybeUninit, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::{
     open_scratch_directory,
     utils::{cleanup_file, close_fd},

--- a/crates/test-programs/wasi-tests/src/bin/readlink.rs
+++ b/crates/test-programs/wasi-tests/src/bin/readlink.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, create_file};
 use wasi_tests::wasi_wrappers::{wasi_path_readlink, wasi_path_symlink};

--- a/crates/test-programs/wasi-tests/src/bin/readlink_no_buffer.rs
+++ b/crates/test-programs/wasi-tests/src/bin/readlink_no_buffer.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::cleanup_file;
 use wasi_tests::wasi_wrappers::{wasi_path_readlink, wasi_path_symlink};

--- a/crates/test-programs/wasi-tests/src/bin/remove_directory_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/remove_directory_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, create_dir, create_file};
 use wasi_tests::wasi_wrappers::wasi_path_remove_directory;

--- a/crates/test-programs/wasi-tests/src/bin/remove_nonempty_directory.rs
+++ b/crates/test-programs/wasi-tests/src/bin/remove_nonempty_directory.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, create_dir};
 use wasi_tests::wasi_wrappers::wasi_path_remove_directory;

--- a/crates/test-programs/wasi-tests/src/bin/renumber.rs
+++ b/crates/test-programs/wasi-tests/src/bin/renumber.rs
@@ -1,7 +1,7 @@
 use libc;
 use more_asserts::assert_gt;
 use std::{env, mem, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::close_fd;
 use wasi_tests::wasi_wrappers::{wasi_fd_fdstat_get, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/sched_yield.rs
+++ b/crates/test-programs/wasi-tests/src/bin/sched_yield.rs
@@ -1,4 +1,4 @@
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 
 fn test_sched_yield() {
     assert!(wasi_unstable::sched_yield().is_ok(), "sched_yield");

--- a/crates/test-programs/wasi-tests/src/bin/stdio.rs
+++ b/crates/test-programs/wasi-tests/src/bin/stdio.rs
@@ -1,5 +1,5 @@
 use std::mem::MaybeUninit;
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::wasi_wrappers::wasi_fd_fdstat_get;
 
 unsafe fn test_stdio() {

--- a/crates/test-programs/wasi-tests/src/bin/symlink_loop.rs
+++ b/crates/test-programs/wasi-tests/src/bin/symlink_loop.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::cleanup_file;
 use wasi_tests::wasi_wrappers::{wasi_path_open, wasi_path_symlink};

--- a/crates/test-programs/wasi-tests/src/bin/truncation_rights.rs
+++ b/crates/test-programs/wasi-tests/src/bin/truncation_rights.rs
@@ -1,5 +1,5 @@
 use std::{env, mem, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_file, close_fd, create_file};
 use wasi_tests::wasi_wrappers::{wasi_fd_fdstat_get, wasi_path_open};

--- a/crates/test-programs/wasi-tests/src/bin/unlink_file_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/unlink_file_trailing_slashes.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 use wasi_tests::open_scratch_directory;
 use wasi_tests::utils::{cleanup_dir, create_dir, create_file};
 use wasi_tests::wasi_wrappers::wasi_path_unlink_file;

--- a/crates/test-programs/wasi-tests/src/lib.rs
+++ b/crates/test-programs/wasi-tests/src/lib.rs
@@ -6,6 +6,10 @@ use std::ffi::CString;
 use std::io;
 use wasi_old::wasi_unstable;
 
+/// Opens a fresh file descriptor for `path` where `path` should be a preopened
+/// directory. This is intended to be used with `wasi_unstable`, not with
+/// `wasi_snapshot_preview1`. This is getting phased out and will likely be
+/// deleted soon.
 pub fn open_scratch_directory(path: &str) -> Result<wasi_unstable::Fd, String> {
     // Open the scratch directory.
     let dir_fd: wasi_unstable::Fd = unsafe {
@@ -24,6 +28,11 @@ pub fn open_scratch_directory(path: &str) -> Result<wasi_unstable::Fd, String> {
     }
 }
 
+/// Same as `open_scratch_directory` above, except uses `wasi_snapshot_preview1`
+/// APIs instead of `wasi_unstable` ones.
+///
+/// This is intended to replace `open_scratch_directory` once all the tests are
+/// updated.
 pub fn open_scratch_directory_new(path: &str) -> Result<wasi::Fd, String> {
     unsafe {
         for i in 3.. {

--- a/crates/test-programs/wasi-tests/src/lib.rs
+++ b/crates/test-programs/wasi-tests/src/lib.rs
@@ -23,3 +23,28 @@ pub fn open_scratch_directory(path: &str) -> Result<wasi_unstable::Fd, String> {
         Ok(dir_fd)
     }
 }
+
+pub fn open_scratch_directory_new(path: &str) -> Result<wasi::Fd, String> {
+    unsafe {
+        for i in 3.. {
+            let stat = match wasi::fd_prestat_get(i) {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            if stat.pr_type != wasi::PREOPENTYPE_DIR {
+                continue;
+            }
+            let mut dst = Vec::with_capacity(stat.u.dir.pr_name_len);
+            if wasi::fd_prestat_dir_name(i, dst.as_mut_ptr(), dst.capacity()).is_err() {
+                continue;
+            }
+            dst.set_len(stat.u.dir.pr_name_len);
+            if dst == path.as_bytes() {
+                return Ok(wasi::path_open(i, 0, ".", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+                    .expect("failed to open dir"));
+            }
+        }
+
+        Err(format!("failed to find scratch dir"))
+    }
+}

--- a/crates/test-programs/wasi-tests/src/lib.rs
+++ b/crates/test-programs/wasi-tests/src/lib.rs
@@ -4,7 +4,7 @@ pub mod wasi_wrappers;
 use libc;
 use std::ffi::CString;
 use std::io;
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 
 pub fn open_scratch_directory(path: &str) -> Result<wasi_unstable::Fd, String> {
     // Open the scratch directory.

--- a/crates/test-programs/wasi-tests/src/utils.rs
+++ b/crates/test-programs/wasi-tests/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::wasi_wrappers::*;
 use more_asserts::assert_gt;
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 
 pub unsafe fn create_dir(dir_fd: wasi_unstable::Fd, dir_name: &str) {
     assert!(

--- a/crates/test-programs/wasi-tests/src/wasi_wrappers.rs
+++ b/crates/test-programs/wasi-tests/src/wasi_wrappers.rs
@@ -6,7 +6,7 @@
 //! interfaces so that we can test whether they are stored to. In the future,
 //! WASI should switch to multi-value and eliminate out parameters altogether.
 
-use wasi::wasi_unstable;
+use wasi_old::wasi_unstable;
 
 pub unsafe fn wasi_path_create_directory(
     dir_fd: wasi_unstable::Fd,


### PR DESCRIPTION
This commit starts an update where all the `wasi-tests/src/bin/*.rs` programs are updated to the newest snapshot of the wasi API, rather tan using the old snapshot 0.

Not all tests are updated, and there's a few changes here:

* The test harness instantiates both snapshots of the wasi API now
* Both 0.7.0 and 0.9.0 are available to tests. The 0.7.0 version is now known as `wasi_old` and the 0.9.0 version is now known as just normal `wasi`. 
* A few tests have been updated to use `wasi` rather than `wasi_old`
* The `open_scratch_directory` function had to get a duplicate which uses the most recent snapshot's file descriptors. 

The purpose of this PR is to start us down the road of updating these tests, allowing the update to happen in parallel for each test. Also to get some early feedback!