### PR TITLE
Fix .NET interop issue for Windows release builds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -328,7 +328,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        build: [linux-debug, linux-release, macos-debug, macos-release, windows-debug, windows-release]
+        include:
+          - build: linux-debug
+            os: ubuntu-latest
+            config: debug
+          - build: linux-release
+            os: ubuntu-latest
+            config: release
+          - build: macos-debug
+            os: macos-latest
+            config: debug
+          - build: macos-release
+            os: macos-latest
+            config: release
+          - build: windows-debug
+            os: windows-latest
+            config: debug
+          - build: windows-release
+            os: windows-latest
+            config: release
     steps:
     - uses: actions/checkout@v1
       with:
@@ -339,12 +358,14 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.0.101'
-    - run: |
+    - name: Test
+      run: |
         cd crates/misc/dotnet/tests
-        dotnet test
-    - run: |
+        dotnet test -c ${{ matrix.config }}
+    - name: Create package
+      run: |
         cd crates/misc/dotnet/src
-        dotnet pack
+        dotnet pack -c ${{ matrix.config }}
       if: matrix.os == 'macos-latest' # Currently the pack target only supports macOS
 
   # Consumes all published artifacts from all the previous build steps, creates

--- a/crates/api/src/wasm.rs
+++ b/crates/api/src/wasm.rs
@@ -56,7 +56,7 @@ macro_rules! declare_vec {
 
             #[allow(dead_code)]
             fn as_slice(&self) -> &[$elem_ty] {
-                unsafe { slice::from_raw_parts(self.data as *const $elem_ty, self.size) }
+                unsafe { slice::from_raw_parts(self.data, self.size) }
             }
         }
 
@@ -122,8 +122,8 @@ macro_rules! declare_vec {
             }
 
             #[allow(dead_code)]
-            fn as_slice(&self) -> &[$elem_ty] {
-                unsafe { slice::from_raw_parts(self.data as *const $elem_ty, self.size) }
+            fn as_slice(&self) -> &[*mut $elem_ty] {
+                unsafe { slice::from_raw_parts(self.data, self.size) }
             }
         }
 

--- a/crates/misc/dotnet/src/ValueKind.cs
+++ b/crates/misc/dotnet/src/ValueKind.cs
@@ -5,7 +5,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents the possible kinds of WebAssembly values.
     /// </summary>
-    public enum ValueKind
+    public enum ValueKind : byte
     {
         /// <summary>
         /// The value is a 32-bit integer.


### PR DESCRIPTION
For Windows release builds, the `wasm_valtype_kind` C API return value
is being returned as a single byte.

The .NET interop signature for this function was expecting an
integer-sized return, resulting in three extra bytes being used on
Windows.

The fix is to limit the corresponding C# enum to a byte representation,
which will properly mask the return value from `wasm_valtype_kind`.

CI has also been updated to test both debug and release configurations
(previously it was only testing debug, hence why this was missed).

Also fixed a cast bug in the `declare_vec!` macro in the C API when the
element types were pointers to values.  The `as_slice` implementation
was incorrectly casting away a level of pointer indirection, resulting
in corrupted data when accessing the slice's elements.