### PR TITLE
Handle same-named imports with different signatures

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -56,7 +56,7 @@ impl Extern {
         }
     }
 
-    pub(crate) fn get_wasmtime_export(&mut self) -> wasmtime_runtime::Export {
+    pub(crate) fn get_wasmtime_export(&self) -> wasmtime_runtime::Export {
         match self {
             Extern::Func(f) => f.borrow().wasmtime_export().clone(),
             Extern::Global(g) => g.borrow().wasmtime_export().clone(),

--- a/crates/api/tests/import-indexes.rs
+++ b/crates/api/tests/import-indexes.rs
@@ -1,0 +1,68 @@
+use std::rc::Rc;
+use wasmtime::*;
+
+#[test]
+fn same_import_names_still_distinct() -> anyhow::Result<()> {
+    const WAT: &str = r#"
+(module
+  (import "" "" (func $a (result i32)))
+  (import "" "" (func $b (result f32)))
+  (func (export "foo") (result i32)
+    call $a
+    call $b
+    i32.trunc_f32_u
+    i32.add)
+)
+    "#;
+
+    struct Ret1;
+
+    impl Callable for Ret1 {
+        fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), Trap> {
+            assert!(params.is_empty());
+            assert_eq!(results.len(), 1);
+            results[0] = 1i32.into();
+            Ok(())
+        }
+    }
+
+    struct Ret2;
+
+    impl Callable for Ret2 {
+        fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), Trap> {
+            assert!(params.is_empty());
+            assert_eq!(results.len(), 1);
+            results[0] = 2.0f32.into();
+            Ok(())
+        }
+    }
+
+    let store = Store::default();
+    let wasm = wat::parse_str(WAT)?;
+    let module = Module::new(&store, &wasm)?;
+
+    let imports = [
+        HostRef::new(Func::new(
+            &store,
+            FuncType::new(Box::new([]), Box::new([ValType::I32])),
+            Rc::new(Ret1),
+        ))
+        .into(),
+        HostRef::new(Func::new(
+            &store,
+            FuncType::new(Box::new([]), Box::new([ValType::F32])),
+            Rc::new(Ret2),
+        ))
+        .into(),
+    ];
+    let instance = Instance::new(&store, &module, &imports)?;
+
+    let func = instance.find_export_by_name("foo").unwrap().func().unwrap();
+    let results = func.borrow().call(&[])?;
+    assert_eq!(results.len(), 1);
+    match results[0] {
+        Val::I32(n) => assert_eq!(n, 3),
+        _ => panic!("unexpected type of return"),
+    }
+    Ok(())
+}

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -136,17 +136,18 @@ pub struct Module {
     /// Unprocessed signatures exactly as provided by `declare_signature()`.
     pub signatures: PrimaryMap<SignatureIndex, ir::Signature>,
 
-    /// Names of imported functions.
-    pub imported_funcs: PrimaryMap<FuncIndex, (String, String)>,
+    /// Names of imported functions, as well as the index of the import that
+    /// performed this import.
+    pub imported_funcs: PrimaryMap<FuncIndex, (String, String, u32)>,
 
     /// Names of imported tables.
-    pub imported_tables: PrimaryMap<TableIndex, (String, String)>,
+    pub imported_tables: PrimaryMap<TableIndex, (String, String, u32)>,
 
     /// Names of imported memories.
-    pub imported_memories: PrimaryMap<MemoryIndex, (String, String)>,
+    pub imported_memories: PrimaryMap<MemoryIndex, (String, String, u32)>,
 
     /// Names of imported globals.
-    pub imported_globals: PrimaryMap<GlobalIndex, (String, String)>,
+    pub imported_globals: PrimaryMap<GlobalIndex, (String, String, u32)>,
 
     /// Types of functions, imported and local.
     pub functions: PrimaryMap<FuncIndex, SignatureIndex>,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -55,6 +55,7 @@ impl<'data> ModuleTranslation<'data> {
 pub struct ModuleEnvironment<'data> {
     /// The result to be filled in.
     result: ModuleTranslation<'data>,
+    imports: u32,
 }
 
 impl<'data> ModuleEnvironment<'data> {
@@ -69,6 +70,7 @@ impl<'data> ModuleEnvironment<'data> {
                 tunables,
                 module_translation: None,
             },
+            imports: 0,
         }
     }
 
@@ -123,10 +125,12 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         );
         self.result.module.functions.push(sig_index);
 
-        self.result
-            .module
-            .imported_funcs
-            .push((String::from(module), String::from(field)));
+        self.result.module.imported_funcs.push((
+            String::from(module),
+            String::from(field),
+            self.imports,
+        ));
+        self.imports += 1;
         Ok(())
     }
 
@@ -139,10 +143,12 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         let plan = TablePlan::for_table(table, &self.result.tunables);
         self.result.module.table_plans.push(plan);
 
-        self.result
-            .module
-            .imported_tables
-            .push((String::from(module), String::from(field)));
+        self.result.module.imported_tables.push((
+            String::from(module),
+            String::from(field),
+            self.imports,
+        ));
+        self.imports += 1;
         Ok(())
     }
 
@@ -160,10 +166,12 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         let plan = MemoryPlan::for_memory(memory, &self.result.tunables);
         self.result.module.memory_plans.push(plan);
 
-        self.result
-            .module
-            .imported_memories
-            .push((String::from(module), String::from(field)));
+        self.result.module.imported_memories.push((
+            String::from(module),
+            String::from(field),
+            self.imports,
+        ));
+        self.imports += 1;
         Ok(())
     }
 
@@ -180,10 +188,12 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         );
         self.result.module.globals.push(global);
 
-        self.result
-            .module
-            .imported_globals
-            .push((String::from(module), String::from(field)));
+        self.result.module.imported_globals.push((
+            String::from(module),
+            String::from(field),
+            self.imports,
+        ));
+        self.imports += 1;
         Ok(())
     }
 

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -30,8 +30,8 @@ pub fn link_module(
     let mut dependencies = HashSet::new();
 
     let mut function_imports = PrimaryMap::with_capacity(module.imported_funcs.len());
-    for (index, (ref module_name, ref field)) in module.imported_funcs.iter() {
-        match resolver.resolve(module_name, field) {
+    for (index, (module_name, field, import_idx)) in module.imported_funcs.iter() {
+        match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
                 Export::Function {
                     address,
@@ -71,8 +71,8 @@ pub fn link_module(
     }
 
     let mut table_imports = PrimaryMap::with_capacity(module.imported_tables.len());
-    for (index, (ref module_name, ref field)) in module.imported_tables.iter() {
-        match resolver.resolve(module_name, field) {
+    for (index, (module_name, field, import_idx)) in module.imported_tables.iter() {
+        match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
                 Export::Table {
                     definition,
@@ -110,8 +110,8 @@ pub fn link_module(
     }
 
     let mut memory_imports = PrimaryMap::with_capacity(module.imported_memories.len());
-    for (index, (ref module_name, ref field)) in module.imported_memories.iter() {
-        match resolver.resolve(module_name, field) {
+    for (index, (module_name, field, import_idx)) in module.imported_memories.iter() {
+        match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
                 Export::Memory {
                     definition,
@@ -163,8 +163,8 @@ pub fn link_module(
     }
 
     let mut global_imports = PrimaryMap::with_capacity(module.imported_globals.len());
-    for (index, (ref module_name, ref field)) in module.imported_globals.iter() {
-        match resolver.resolve(module_name, field) {
+    for (index, (module_name, field, import_idx)) in module.imported_globals.iter() {
+        match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
                 Export::Table { .. } | Export::Memory { .. } | Export::Function { .. } => {
                     return Err(LinkError(format!(

--- a/crates/jit/src/namespace.rs
+++ b/crates/jit/src/namespace.rs
@@ -36,7 +36,7 @@ impl Namespace {
 }
 
 impl Resolver for Namespace {
-    fn resolve(&mut self, name: &str, field: &str) -> Option<Export> {
+    fn resolve(&mut self, _idx: u32, name: &str, field: &str) -> Option<Export> {
         if let Some(instance) = self.names.get_mut(name) {
             instance.lookup(field)
         } else {

--- a/crates/jit/src/resolver.rs
+++ b/crates/jit/src/resolver.rs
@@ -5,15 +5,22 @@ use wasmtime_runtime::Export;
 
 /// Import resolver connects imports with available exported values.
 pub trait Resolver {
-    /// Resolve the given module/field combo.
-    fn resolve(&mut self, module: &str, field: &str) -> Option<Export>;
+    /// Resolves an import a WebAssembly module to an export it's hooked up to.
+    ///
+    /// The `index` provided is the index of the import in the wasm module
+    /// that's being resolved. For example 1 means that it's the second import
+    /// listed in the wasm module.
+    ///
+    /// The `module` and `field` arguments provided are the module/field names
+    /// listed on the import itself.
+    fn resolve(&mut self, index: u32, module: &str, field: &str) -> Option<Export>;
 }
 
 /// `Resolver` implementation that always resolves to `None`.
 pub struct NullResolver {}
 
 impl Resolver for NullResolver {
-    fn resolve(&mut self, _module: &str, _field: &str) -> Option<Export> {
+    fn resolve(&mut self, _idx: u32, _module: &str, _field: &str) -> Option<Export> {
         None
     }
 }


### PR DESCRIPTION
This commit fixes the `wasmtime::Instance` instantiation API when
imports have the same name but might be imported under different types.
This is handled in the API by listing imports as a list instead of as a
name map, but they were interpreted as a name map under the hood causing
collisions.

This commit now keeps track of the index used to define each import, and
the index is passed through in the `Resolver`. Existing implementaitons
of `Resolver` all ignore this, but the API now uses it exclusivley to
match up `Extern` definitions to imports.