### PR TITLE
[dotnet] Root bindings so the delegate in FunctionBinding is not GCed

### DIFF
--- a/crates/misc/dotnet/src/Instance.cs
+++ b/crates/misc/dotnet/src/Instance.cs
@@ -17,8 +17,10 @@ namespace Wasmtime
             Host = host;
             Module = module;
 
-            var bindings = host.GetImportBindings(module);
-            var handles = bindings.Select(b => b.Bind(module.Store, host)).ToList();
+            //Save the bindings to root the objects.
+            //Otherwise the GC may collect the delegates from ExternFunction for example.
+            _bindings = host.GetImportBindings(module);
+            var handles = _bindings.Select(b => b.Bind(module.Store, host)).ToList();
 
             unsafe
             {
@@ -141,5 +143,6 @@ namespace Wasmtime
         private Interop.wasm_extern_vec_t _externs;
         private Dictionary<string, ExternFunction> _functions;
         private Dictionary<string, ExternGlobal> _globals;
+        private List<Bindings.Binding> _bindings;
     }
 }


### PR DESCRIPTION
Currently `Instance` does not root the `Binding` objects. This allows them to be garbage collected. In the case of `FunctionBinding`, this means its delegate can also be garbage collected. When the WASM runtime calls the reverse P/invoke stub, the CLR notices that the underlying delegate has been garbage collected and exits the process.