### PR TITLE
Refactor the `types.rs` types and structures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,6 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         build: [stable, beta, nightly, windows, macos]
         include:
@@ -165,7 +164,6 @@ jobs:
     name: Python Wheel
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
@@ -262,7 +260,6 @@ jobs:
     name: Build wasmtime
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:

--- a/crates/api/examples/memory.rs
+++ b/crates/api/examples/memory.rs
@@ -151,7 +151,7 @@ fn main() -> Result<(), Error> {
     // Create stand-alone memory.
     // TODO(wasm+): Once Wasm allows multiple memories, turn this into import.
     println!("Creating stand-alone memory...");
-    let memorytype = MemoryType::new(Limits::new(5, 5));
+    let memorytype = MemoryType::new(Limits::new(5, Some(5)));
     let mut memory2 = Memory::new(&store, memorytype);
     check!(memory2.size(), 5u32);
     check!(memory2.grow(1), false);

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -49,10 +49,10 @@ impl Extern {
 
     pub fn r#type(&self) -> ExternType {
         match self {
-            Extern::Func(ft) => ExternType::ExternFunc(ft.borrow().r#type().clone()),
-            Extern::Memory(ft) => ExternType::ExternMemory(ft.borrow().r#type().clone()),
-            Extern::Table(tt) => ExternType::ExternTable(tt.borrow().r#type().clone()),
-            Extern::Global(gt) => ExternType::ExternGlobal(gt.borrow().r#type().clone()),
+            Extern::Func(ft) => ExternType::Func(ft.borrow().r#type().clone()),
+            Extern::Memory(ft) => ExternType::Memory(ft.borrow().r#type().clone()),
+            Extern::Table(tt) => ExternType::Table(tt.borrow().r#type().clone()),
+            Extern::Global(gt) => ExternType::Global(gt.borrow().r#type().clone()),
         }
     }
 

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -4,7 +4,7 @@ use crate::module::Module;
 use crate::r#ref::HostRef;
 use crate::runtime::Store;
 use crate::trampoline::take_api_trap;
-use crate::types::{ExportType, ExternType, Name};
+use crate::types::{ExportType, ExternType};
 use anyhow::Result;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -122,7 +122,7 @@ impl Instance {
             .exports()
             .iter()
             .enumerate()
-            .find(|(_, e)| e.name().as_str() == name)?;
+            .find(|(_, e)| e.name() == name)?;
         Some(&self.exports()[i])
     }
 
@@ -141,7 +141,7 @@ impl Instance {
                 let _ = store.borrow_mut().register_wasmtime_signature(signature);
             }
             let extern_type = ExternType::from_wasmtime_export(&export);
-            exports_types.push(ExportType::new(Name::new(name), extern_type));
+            exports_types.push(ExportType::new(name, extern_type));
             exports.push(Extern::from_wasmtime_export(
                 store,
                 instance_handle.clone(),

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,4 +1,10 @@
-//! Wasmtime embed API. Based on wasm-c-api.
+//! Wasmtime's embedding API
+//!
+//! This crate contains a high-level API used to interact with WebAssembly
+//! modules. The API here is intended to mirror the proposed [WebAssembly C
+//! API](https://github.com/WebAssembly/wasm-c-api), with small extensions here
+//! and there to implement Rust idioms. This crate also defines the actual C API
+//! itself for consumption from other languages.
 
 #![allow(improper_ctypes)]
 

--- a/crates/api/src/trampoline/memory.rs
+++ b/crates/api/src/trampoline/memory.rs
@@ -12,11 +12,7 @@ pub fn create_handle_with_memory(memory: &MemoryType) -> Result<InstanceHandle> 
 
     let memory = wasm::Memory {
         minimum: memory.limits().min(),
-        maximum: if memory.limits().max() == std::u32::MAX {
-            None
-        } else {
-            Some(memory.limits().max())
-        },
+        maximum: memory.limits().max(),
         shared: false, // TODO
     };
     let tunable = Default::default();

--- a/crates/api/src/trampoline/table.rs
+++ b/crates/api/src/trampoline/table.rs
@@ -10,11 +10,7 @@ pub fn create_handle_with_table(table: &TableType) -> Result<InstanceHandle> {
 
     let table = wasm::Table {
         minimum: table.limits().min(),
-        maximum: if table.limits().max() == std::u32::MAX {
-            None
-        } else {
-            Some(table.limits().max())
-        },
+        maximum: table.limits().max(),
         ty: match table.element() {
             ValType::FuncRef => wasm::TableElementType::Func,
             _ => wasm::TableElementType::Val(table.element().get_wasmtime_type()),

--- a/crates/api/src/wasm.rs
+++ b/crates/api/src/wasm.rs
@@ -7,8 +7,8 @@
 
 use super::{
     AnyRef, Callable, Engine, ExportType, Extern, ExternType, Func, FuncType, Global, GlobalType,
-    HostInfo, HostRef, ImportType, Instance, Limits, Memory, MemoryType, Module, Name, Store,
-    Table, TableType, Trap, Val, ValType,
+    HostInfo, HostRef, ImportType, Instance, Limits, Memory, MemoryType, Module, Store, Table,
+    TableType, Trap, Val, ValType,
 };
 use std::rc::Rc;
 use std::{mem, ptr, slice};
@@ -714,11 +714,8 @@ pub unsafe extern "C" fn wasm_module_delete(module: *mut wasm_module_t) {
 }
 
 impl wasm_name_t {
-    fn from_name(name: &Name) -> wasm_name_t {
-        let s = name.to_string();
-        let mut buffer = Vec::new();
-        buffer.extend_from_slice(s.as_bytes());
-        buffer.into()
+    fn from_name(name: &str) -> wasm_name_t {
+        name.to_string().into_bytes().into()
     }
 }
 
@@ -977,7 +974,7 @@ pub unsafe extern "C" fn wasm_importtype_type(
     it: *const wasm_importtype_t,
 ) -> *const wasm_externtype_t {
     let ty = Box::new(wasm_externtype_t {
-        ty: (*it).ty.r#type().clone(),
+        ty: (*it).ty.ty().clone(),
         cache: wasm_externtype_t_type_cache::Empty,
     });
     Box::into_raw(ty)
@@ -1004,7 +1001,7 @@ pub unsafe extern "C" fn wasm_exporttype_type(
     if (*et).type_cache.is_none() {
         let et = (et as *mut wasm_exporttype_t).as_mut().unwrap();
         et.type_cache = Some(wasm_externtype_t {
-            ty: (*et).ty.r#type().clone(),
+            ty: (*et).ty.ty().clone(),
             cache: wasm_externtype_t_type_cache::Empty,
         });
     }
@@ -1018,10 +1015,10 @@ pub unsafe extern "C" fn wasm_exporttype_vec_delete(et: *mut wasm_exporttype_vec
 
 fn from_externtype(ty: &ExternType) -> wasm_externkind_t {
     match ty {
-        ExternType::ExternFunc(_) => 0,
-        ExternType::ExternGlobal(_) => 1,
-        ExternType::ExternTable(_) => 2,
-        ExternType::ExternMemory(_) => 3,
+        ExternType::Func(_) => 0,
+        ExternType::Global(_) => 1,
+        ExternType::Table(_) => 2,
+        ExternType::Memory(_) => 3,
     }
 }
 
@@ -1044,7 +1041,7 @@ pub unsafe extern "C" fn wasm_externtype_as_functype_const(
     et: *const wasm_externtype_t,
 ) -> *const wasm_functype_t {
     if let wasm_externtype_t_type_cache::Empty = (*et).cache {
-        let functype = (*et).ty.func().clone();
+        let functype = (*et).ty.unwrap_func().clone();
         let f = wasm_functype_t {
             functype,
             params_cache: None,
@@ -1064,7 +1061,7 @@ pub unsafe extern "C" fn wasm_externtype_as_globaltype_const(
     et: *const wasm_externtype_t,
 ) -> *const wasm_globaltype_t {
     if let wasm_externtype_t_type_cache::Empty = (*et).cache {
-        let globaltype = (*et).ty.global().clone();
+        let globaltype = (*et).ty.unwrap_global().clone();
         let g = wasm_globaltype_t {
             globaltype,
             content_cache: None,
@@ -1083,7 +1080,7 @@ pub unsafe extern "C" fn wasm_externtype_as_tabletype_const(
     et: *const wasm_externtype_t,
 ) -> *const wasm_tabletype_t {
     if let wasm_externtype_t_type_cache::Empty = (*et).cache {
-        let tabletype = (*et).ty.table().clone();
+        let tabletype = (*et).ty.unwrap_table().clone();
         let t = wasm_tabletype_t {
             tabletype,
             element_cache: None,
@@ -1103,7 +1100,7 @@ pub unsafe extern "C" fn wasm_externtype_as_memorytype_const(
     et: *const wasm_externtype_t,
 ) -> *const wasm_memorytype_t {
     if let wasm_externtype_t_type_cache::Empty = (*et).cache {
-        let memorytype = (*et).ty.memory().clone();
+        let memorytype = (*et).ty.unwrap_memory().clone();
         let m = wasm_memorytype_t {
             memorytype,
             limits_cache: None,
@@ -1210,7 +1207,7 @@ pub unsafe extern "C" fn wasm_memorytype_limits(
         let limits = (*mt).memorytype.limits();
         mt.limits_cache = Some(wasm_limits_t {
             min: limits.min(),
-            max: limits.max(),
+            max: limits.max().unwrap_or(u32::max_value()),
         });
     }
     (*mt).limits_cache.as_ref().unwrap()
@@ -1270,7 +1267,7 @@ pub unsafe extern "C" fn wasm_tabletype_limits(
         let limits = (*tt).tabletype.limits();
         tt.limits_cache = Some(wasm_limits_t {
             min: limits.min(),
-            max: limits.max(),
+            max: limits.max().unwrap_or(u32::max_value()),
         });
     }
     (*tt).limits_cache.as_ref().unwrap()
@@ -1469,7 +1466,12 @@ pub unsafe extern "C" fn wasm_memorytype_delete(mt: *mut wasm_memorytype_t) {
 pub unsafe extern "C" fn wasm_memorytype_new(
     limits: *const wasm_limits_t,
 ) -> *mut wasm_memorytype_t {
-    let limits = Limits::new((*limits).min, (*limits).max);
+    let max = if (*limits).max == u32::max_value() {
+        None
+    } else {
+        Some((*limits).max)
+    };
+    let limits = Limits::new((*limits).min, max);
     let mt = Box::new(wasm_memorytype_t {
         memorytype: MemoryType::new(limits),
         limits_cache: None,
@@ -1615,7 +1617,12 @@ pub unsafe extern "C" fn wasm_tabletype_new(
     limits: *const wasm_limits_t,
 ) -> *mut wasm_tabletype_t {
     let ty = Box::from_raw(ty).ty;
-    let limits = Limits::new((*limits).min, (*limits).max);
+    let max = if (*limits).max == u32::max_value() {
+        None
+    } else {
+        Some((*limits).max)
+    };
+    let limits = Limits::new((*limits).min, max);
     let tt = Box::new(wasm_tabletype_t {
         tabletype: TableType::new(ty, limits),
         element_cache: None,

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -13,17 +13,17 @@ pub fn dummy_imports(
 ) -> Result<Vec<Extern>, HostRef<Trap>> {
     let mut imports = Vec::with_capacity(import_tys.len());
     for imp in import_tys {
-        imports.push(match imp.r#type() {
-            ExternType::ExternFunc(func_ty) => {
+        imports.push(match imp.ty() {
+            ExternType::Func(func_ty) => {
                 Extern::Func(HostRef::new(DummyFunc::new(&store, func_ty.clone())))
             }
-            ExternType::ExternGlobal(global_ty) => {
+            ExternType::Global(global_ty) => {
                 Extern::Global(HostRef::new(dummy_global(&store, global_ty.clone())?))
             }
-            ExternType::ExternTable(table_ty) => {
+            ExternType::Table(table_ty) => {
                 Extern::Table(HostRef::new(dummy_table(&store, table_ty.clone())?))
             }
-            ExternType::ExternMemory(mem_ty) => {
+            ExternType::Memory(mem_ty) => {
                 Extern::Memory(HostRef::new(dummy_memory(&store, mem_ty.clone())))
             }
         });

--- a/crates/misc/py/src/instance.rs
+++ b/crates/misc/py/src/instance.rs
@@ -22,8 +22,8 @@ impl Instance {
         let exports = PyDict::new(py);
         let module = self.instance.borrow().module().clone();
         for (i, e) in module.borrow().exports().iter().enumerate() {
-            match e.r#type() {
-                wasmtime::ExternType::ExternFunc(ft) => {
+            match e.ty() {
+                wasmtime::ExternType::Func(ft) => {
                     let mut args_types = Vec::new();
                     for ty in ft.params().iter() {
                         args_types.push(ty.clone());
@@ -39,7 +39,7 @@ impl Instance {
                     )?;
                     exports.set_item(e.name().to_string(), f)?;
                 }
-                wasmtime::ExternType::ExternMemory(_) => {
+                wasmtime::ExternType::Memory(_) => {
                     let f = Py::new(
                         py,
                         Memory {

--- a/crates/misc/py/src/lib.rs
+++ b/crates/misc/py/src/lib.rs
@@ -122,10 +122,7 @@ pub fn instantiate(
                 .1
                 .find_export_by_name(i.name())
                 .ok_or_else(|| {
-                    PyErr::new::<Exception, _>(format!(
-                        "wasi export {} is not found",
-                        i.name(),
-                    ))
+                    PyErr::new::<Exception, _>(format!("wasi export {} is not found", i.name(),))
                 })?;
             imports.push(e.clone());
         } else {

--- a/crates/misc/py/src/lib.rs
+++ b/crates/misc/py/src/lib.rs
@@ -111,20 +111,20 @@ pub fn instantiate(
 
     let mut imports: Vec<wasmtime::Extern> = Vec::new();
     for i in module.borrow().imports() {
-        let module_name = i.module().as_str();
+        let module_name = i.module();
         if let Some(m) = import_obj.get_item(module_name) {
-            let e = find_export_in(m, &store, i.name().as_str())?;
+            let e = find_export_in(m, &store, i.name())?;
             imports.push(e);
         } else if wasi.is_some() && module_name == wasi.as_ref().unwrap().0 {
             let e = wasi
                 .as_ref()
                 .unwrap()
                 .1
-                .find_export_by_name(i.name().as_str())
+                .find_export_by_name(i.name())
                 .ok_or_else(|| {
                     PyErr::new::<Exception, _>(format!(
                         "wasi export {} is not found",
-                        i.name().as_str()
+                        i.name(),
                     ))
                 })?;
             imports.push(e.clone());

--- a/crates/misc/rust/macro/src/lib.rs
+++ b/crates/misc/rust/macro/src/lib.rs
@@ -69,13 +69,13 @@ fn generate_load(item: &syn::ItemTrait) -> syn::Result<TokenStream> {
                 let wasi_instance = #root::wasmtime_wasi::create_wasi_instance(&store, &[], &[], &[])
                     .map_err(|e| format_err!("wasm instantiation error: {:?}", e))?;
                 for i in module.borrow().imports().iter() {
-                    if i.module().as_str() != module_name {
-                        bail!("unknown import module {}", i.module().as_str());
+                    if i.module() != module_name {
+                        bail!("unknown import module {}", i.module());
                     }
-                    if let Some(export) = wasi_instance.find_export_by_name(i.name().as_str()) {
+                    if let Some(export) = wasi_instance.find_export_by_name(i.name()) {
                         imports.push(export.clone());
                     } else {
-                        bail!("unknown import {}:{}", i.module().as_str(), i.name().as_str())
+                        bail!("unknown import {}:{}", i.module(), i.name())
                     }
                 }
             }

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -68,9 +68,9 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         .imports()
         .iter()
         .map(|i| {
-            let module_name = i.module().as_str();
+            let module_name = i.module();
             if let Some(instance) = module_registry.get(module_name) {
-                let field_name = i.name().as_str();
+                let field_name = i.name();
                 if let Some(export) = instance.find_export_by_name(field_name) {
                     Ok(export.clone())
                 } else {

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -341,9 +341,9 @@ fn instantiate_module(
         .imports()
         .iter()
         .map(|i| {
-            let module_name = i.module().as_str();
+            let module_name = i.module();
             if let Some(instance) = module_registry.get(module_name) {
-                let field_name = i.name().as_str();
+                let field_name = i.name();
                 if let Some(export) = instance.borrow().find_export_by_name(field_name) {
                     Ok(export.clone())
                 } else {
@@ -380,7 +380,7 @@ fn handle_module(
         .borrow()
         .exports()
         .iter()
-        .find(|export| export.name().as_str().is_empty())
+        .find(|export| export.name().is_empty())
         .is_some()
     {
         // Launch the default command export.


### PR DESCRIPTION
A few changes applied along the way:

* Documentation added to most methods and types.
* Limits are now stored with the maximum as optional rather than a
  sentinel u32 value for `None`.
* The `Name` type was removed in favor of just using a bare `String`.
* The `Extern` prefix in the varaints of `ExternType` has been removed
  since it was redundant.
* Accessors of `ExternType` variants no longer panic, and unwrapping
  versions were added with "unwrap" in the name.
* Fields and methods named `r#type` were renamed to `ty` to avoid
  requiring a raw identifier to use them.