### PR TITLE
[wasmtime-api] Wrap Trap to be Sync+Send; Trap in Instance::new()

### DIFF
--- a/crates/api/examples/hello.rs
+++ b/crates/api/examples/hello.rs
@@ -7,7 +7,7 @@ use wasmtime::*;
 struct HelloCallback;
 
 impl Callable for HelloCallback {
-    fn call(&self, _params: &[Val], _results: &mut [Val]) -> Result<(), HostRef<Trap>> {
+    fn call(&self, _params: &[Val], _results: &mut [Val]) -> Result<(), Trap> {
         println!("Calling back...");
         println!("> Hello World!");
         Ok(())

--- a/crates/api/examples/multi.rs
+++ b/crates/api/examples/multi.rs
@@ -7,7 +7,7 @@ use wasmtime::*;
 struct Callback;
 
 impl Callable for Callback {
-    fn call(&self, args: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
+    fn call(&self, args: &[Val], results: &mut [Val]) -> Result<(), Trap> {
         println!("Calling back...");
         println!("> {} {}", args[0].unwrap_i32(), args[1].unwrap_i64());
 

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -147,7 +147,7 @@ impl Func {
         self.r#type.results().len()
     }
 
-    pub fn call(&self, params: &[Val]) -> Result<Box<[Val]>, HostRef<Trap>> {
+    pub fn call(&self, params: &[Val]) -> Result<Box<[Val]>, Trap> {
         let mut results = vec![Val::null(); self.result_arity()];
         self.callable.call(params, &mut results)?;
         Ok(results.into_boxed_slice())

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -28,6 +28,6 @@ pub use crate::instance::Instance;
 pub use crate::module::Module;
 pub use crate::r#ref::{AnyRef, HostInfo, HostRef};
 pub use crate::runtime::{Config, Engine, Store};
-pub use crate::trap::Trap;
+pub use crate::trap::{FrameInfo, Trap, TrapInfo};
 pub use crate::types::*;
 pub use crate::values::*;

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -96,6 +96,7 @@ unsafe extern "C" fn stub_fn(vmctx: *mut VMContext, call_id: u32, values_vec: *m
             0
         }
         Err(trap) => {
+            let trap = trap.trap_info_unchecked();
             record_api_trap(trap);
             1
         }

--- a/crates/api/src/trampoline/trap.rs
+++ b/crates/api/src/trampoline/trap.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 
 use crate::r#ref::HostRef;
-use crate::Trap;
+use crate::TrapInfo;
 use wasmtime_environ::ir::{SourceLoc, TrapCode};
 use wasmtime_environ::TrapInformation;
 use wasmtime_jit::trampoline::binemit;
@@ -10,10 +10,10 @@ use wasmtime_jit::trampoline::binemit;
 pub const API_TRAP_CODE: TrapCode = TrapCode::User(13);
 
 thread_local! {
-    static RECORDED_API_TRAP: Cell<Option<HostRef<Trap>>> = Cell::new(None);
+    static RECORDED_API_TRAP: Cell<Option<HostRef<TrapInfo>>> = Cell::new(None);
 }
 
-pub fn record_api_trap(trap: HostRef<Trap>) {
+pub fn record_api_trap(trap: HostRef<TrapInfo>) {
     RECORDED_API_TRAP.with(|data| {
         let trap = Cell::new(Some(trap));
         data.swap(&trap);
@@ -24,7 +24,7 @@ pub fn record_api_trap(trap: HostRef<Trap>) {
     });
 }
 
-pub fn take_api_trap() -> Option<HostRef<Trap>> {
+pub fn take_api_trap() -> Option<HostRef<TrapInfo>> {
     RECORDED_API_TRAP.with(|data| data.take())
 }
 

--- a/crates/api/src/trap.rs
+++ b/crates/api/src/trap.rs
@@ -1,4 +1,76 @@
+use crate::instance::Instance;
+use crate::r#ref::HostRef;
+use std::fmt;
+use std::sync::{Arc, Mutex};
 use thiserror::Error;
+
+#[derive(Debug)]
+pub struct FrameInfo;
+
+impl FrameInfo {
+    pub fn instance(&self) -> *const Instance {
+        unimplemented!("FrameInfo::instance");
+    }
+
+    pub fn func_index() -> usize {
+        unimplemented!("FrameInfo::func_index");
+    }
+
+    pub fn func_offset() -> usize {
+        unimplemented!("FrameInfo::func_offset");
+    }
+
+    pub fn module_offset() -> usize {
+        unimplemented!("FrameInfo::module_offset");
+    }
+}
+
+#[derive(Debug)]
+pub struct TrapInfo {
+    message: String,
+    trace: Vec<FrameInfo>,
+}
+
+impl TrapInfo {
+    pub fn new<I: Into<String>>(message: I) -> Self {
+        Self {
+            message: message.into(),
+            trace: vec![],
+        }
+    }
+
+    /// Returns a reference the `message` stored in `Trap`.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn origin(&self) -> Option<&FrameInfo> {
+        self.trace.first()
+    }
+
+    pub fn trace(&self) -> &[FrameInfo] {
+        &self.trace
+    }
+}
+
+/// A struct to hold unsafe TrapInfo host reference, designed
+/// to be Send-able. The only access for it provided via the
+/// Trap::trap_info_unchecked() method.
+struct UnsafeTrapInfo(HostRef<TrapInfo>);
+
+impl UnsafeTrapInfo {
+    fn trap_info(&self) -> HostRef<TrapInfo> {
+        self.0.clone()
+    }
+}
+
+unsafe impl Send for UnsafeTrapInfo {}
+
+impl fmt::Debug for UnsafeTrapInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "UnsafeTrapInfo")
+    }
+}
 
 /// A struct representing an aborted instruction execution, with a message
 /// indicating the cause.
@@ -6,6 +78,11 @@ use thiserror::Error;
 #[error("Wasm trap: {message}")]
 pub struct Trap {
     message: String,
+    info: Arc<Mutex<UnsafeTrapInfo>>,
+}
+
+fn _assert_trap_is_sync_and_send(t: &Trap) -> (&dyn Sync, &dyn Send) {
+    (t, t)
 }
 
 impl Trap {
@@ -15,20 +92,26 @@ impl Trap {
     /// let trap = wasmtime::Trap::new("unexpected error");
     /// assert_eq!("unexpected error", trap.message());
     /// ```
-    pub fn new<I: Into<String>>(message: I) -> Trap {
-        Self {
-            message: message.into(),
-        }
-    }
-
-    /// Create a `Trap` without defining a message for the trap. Mostly useful
-    /// for prototypes and tests.
-    pub fn fake() -> Trap {
-        Self::new("TODO trap")
+    pub fn new<I: Into<String>>(message: I) -> Self {
+        Trap::from(HostRef::new(TrapInfo::new(message)))
     }
 
     /// Returns a reference the `message` stored in `Trap`.
     pub fn message(&self) -> &str {
         &self.message
+    }
+
+    /// Returns inner TrapInfo assotiated with the Trap.
+    /// The method is unsafe: obtained TrapInfo is not thread safe.
+    pub(crate) unsafe fn trap_info_unchecked(&self) -> HostRef<TrapInfo> {
+        self.info.lock().unwrap().trap_info()
+    }
+}
+
+impl From<HostRef<TrapInfo>> for Trap {
+    fn from(trap_info: HostRef<TrapInfo>) -> Self {
+        let message = trap_info.borrow().message().to_string();
+        let info = Arc::new(Mutex::new(UnsafeTrapInfo(trap_info)));
+        Trap { message, info }
     }
 }

--- a/crates/api/tests/import_calling_export.rs
+++ b/crates/api/tests/import_calling_export.rs
@@ -20,7 +20,7 @@ fn test_import_calling_export() {
     }
 
     impl Callable for Callback {
-        fn call(&self, _params: &[Val], _results: &mut [Val]) -> Result<(), HostRef<Trap>> {
+        fn call(&self, _params: &[Val], _results: &mut [Val]) -> Result<(), Trap> {
             self.other
                 .borrow()
                 .as_ref()

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -7,8 +7,8 @@ fn test_trap_return() -> Result<(), String> {
     struct HelloCallback;
 
     impl Callable for HelloCallback {
-        fn call(&self, _params: &[Val], _results: &mut [Val]) -> Result<(), HostRef<Trap>> {
-            Err(HostRef::new(Trap::new("test 123")))
+        fn call(&self, _params: &[Val], _results: &mut [Val]) -> Result<(), Trap> {
+            Err(Trap::new("test 123"))
         }
     }
 
@@ -32,7 +32,7 @@ fn test_trap_return() -> Result<(), String> {
 
     let imports = vec![hello_func.into()];
     let instance = Instance::new(&store, &module, imports.as_slice())
-        .map_err(|e| format!("failed to instantiate module: {}", e))?;
+        .map_err(|e| format!("failed to instantiate module: {:?}", e))?;
     let run_func = instance.exports()[0]
         .func()
         .expect("expected function export");
@@ -43,7 +43,7 @@ fn test_trap_return() -> Result<(), String> {
         .err()
         .expect("error calling function");
 
-    assert_eq!(e.borrow().message(), "test 123");
+    assert_eq!(e.message(), "test 123");
 
     Ok(())
 }

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -10,7 +10,7 @@ use wasmtime::{
 pub fn dummy_imports(
     store: &HostRef<Store>,
     import_tys: &[ImportType],
-) -> Result<Vec<Extern>, HostRef<Trap>> {
+) -> Result<Vec<Extern>, Trap> {
     let mut imports = Vec::with_capacity(import_tys.len());
     for imp in import_tys {
         imports.push(match imp.ty() {
@@ -45,7 +45,7 @@ impl DummyFunc {
 }
 
 impl Callable for DummyFunc {
-    fn call(&self, _params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
+    fn call(&self, _params: &[Val], results: &mut [Val]) -> Result<(), Trap> {
         for (ret_ty, result) in self.0.results().iter().zip(results) {
             *result = dummy_value(ret_ty)?;
         }
@@ -55,38 +55,38 @@ impl Callable for DummyFunc {
 }
 
 /// Construct a dummy value for the given value type.
-pub fn dummy_value(val_ty: &ValType) -> Result<Val, HostRef<Trap>> {
+pub fn dummy_value(val_ty: &ValType) -> Result<Val, Trap> {
     Ok(match val_ty {
         ValType::I32 => Val::I32(0),
         ValType::I64 => Val::I64(0),
         ValType::F32 => Val::F32(0),
         ValType::F64 => Val::F64(0),
         ValType::V128 => {
-            return Err(HostRef::new(Trap::new(
+            return Err(Trap::new(
                 "dummy_value: unsupported function return type: v128".to_string(),
-            )))
+            ))
         }
         ValType::AnyRef => {
-            return Err(HostRef::new(Trap::new(
+            return Err(Trap::new(
                 "dummy_value: unsupported function return type: anyref".to_string(),
-            )))
+            ))
         }
         ValType::FuncRef => {
-            return Err(HostRef::new(Trap::new(
+            return Err(Trap::new(
                 "dummy_value: unsupported function return type: funcref".to_string(),
-            )))
+            ))
         }
     })
 }
 
 /// Construct a dummy global for the given global type.
-pub fn dummy_global(store: &HostRef<Store>, ty: GlobalType) -> Result<Global, HostRef<Trap>> {
+pub fn dummy_global(store: &HostRef<Store>, ty: GlobalType) -> Result<Global, Trap> {
     let val = dummy_value(ty.content())?;
     Ok(Global::new(store, ty, val))
 }
 
 /// Construct a dummy table for the given table type.
-pub fn dummy_table(store: &HostRef<Store>, ty: TableType) -> Result<Table, HostRef<Trap>> {
+pub fn dummy_table(store: &HostRef<Store>, ty: TableType) -> Result<Table, Trap> {
     let init_val = dummy_value(&ty.element())?;
     Ok(Table::new(store, ty, init_val))
 }

--- a/crates/misc/py/src/function.rs
+++ b/crates/misc/py/src/function.rs
@@ -82,7 +82,7 @@ impl wasmtime::Callable for WrappedFn {
         &self,
         params: &[wasmtime::Val],
         returns: &mut [wasmtime::Val],
-    ) -> Result<(), wasmtime::HostRef<wasmtime::Trap>> {
+    ) -> Result<(), wasmtime::Trap> {
         let gil = Python::acquire_gil();
         let py = gil.python();
 

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -91,7 +91,7 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         .borrow()
         .call(&[])
     {
-        bail!("trapped: {:?}", trap.borrow());
+        bail!("trapped: {:?}", trap);
     }
 
     Ok(())

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -9,9 +9,9 @@ struct MyCall<F>(F);
 
 impl<F> Callable for MyCall<F>
 where
-    F: Fn(&[Val], &mut [Val]) -> Result<(), HostRef<Trap>>,
+    F: Fn(&[Val], &mut [Val]) -> Result<(), Trap>,
 {
-    fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
+    fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), Trap> {
         (self.0)(params, results)
     }
 }
@@ -19,7 +19,7 @@ where
 fn wrap(
     store: &HostRef<Store>,
     ty: FuncType,
-    callable: impl Fn(&[Val], &mut [Val]) -> Result<(), HostRef<Trap>> + 'static,
+    callable: impl Fn(&[Val], &mut [Val]) -> Result<(), Trap> + 'static,
 ) -> Func {
     Func::new(store, ty, Rc::new(MyCall(callable)))
 }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -36,7 +36,7 @@ pub struct WastContext {
 
 enum Outcome<T = Vec<Val>> {
     Ok(T),
-    Trap(HostRef<Trap>),
+    Trap(Trap),
 }
 
 impl WastContext {
@@ -101,7 +101,7 @@ impl WastContext {
                     .filter_map(|e| e.downcast_ref::<InstantiationError>())
                     .next();
                 if let Some(InstantiationError::StartTrap(msg)) = err {
-                    return Ok(Outcome::Trap(HostRef::new(Trap::new(msg.clone()))));
+                    return Ok(Outcome::Trap(Trap::new(msg.clone())));
                 }
                 return Err(e);
             }
@@ -139,7 +139,7 @@ impl WastContext {
     fn module(&mut self, instance_name: Option<&str>, module: &[u8]) -> Result<()> {
         let instance = match self.instantiate(module)? {
             Outcome::Ok(i) => i,
-            Outcome::Trap(e) => bail!("instantiation failed with: {}", e.borrow().message()),
+            Outcome::Trap(e) => bail!("instantiation failed with: {}", e.message()),
         };
         if let Some(name) = instance_name {
             self.instances.insert(name.to_string(), instance.clone());
@@ -241,7 +241,6 @@ impl WastContext {
                         }
                     }
                     Outcome::Trap(t) => {
-                        let t = t.borrow();
                         bail!("{}\nunexpected trap: {}", context(span), t.message())
                     }
                 },
@@ -254,7 +253,6 @@ impl WastContext {
                         bail!("{}\nexpected trap, got {:?}", context(span), values)
                     }
                     Outcome::Trap(t) => {
-                        let t = t.borrow();
                         if t.message().contains(message) {
                             continue;
                         }
@@ -283,7 +281,6 @@ impl WastContext {
                         bail!("{}\nexpected trap, got {:?}", context(span), values)
                     }
                     Outcome::Trap(t) => {
-                        let t = t.borrow();
                         if t.message().contains(message) {
                             continue;
                         }
@@ -315,7 +312,6 @@ impl WastContext {
                             }
                         }
                         Outcome::Trap(t) => {
-                            let t = t.borrow();
                             bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
@@ -340,7 +336,6 @@ impl WastContext {
                             }
                         }
                         Outcome::Trap(t) => {
-                            let t = t.borrow();
                             bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
@@ -365,7 +360,6 @@ impl WastContext {
                             }
                         }
                         Outcome::Trap(t) => {
-                            let t = t.borrow();
                             bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
@@ -390,7 +384,6 @@ impl WastContext {
                             }
                         }
                         Outcome::Trap(t) => {
-                            let t = t.borrow();
                             bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
@@ -415,7 +408,6 @@ impl WastContext {
                             }
                         }
                         Outcome::Trap(t) => {
-                            let t = t.borrow();
                             bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
@@ -440,7 +432,6 @@ impl WastContext {
                             }
                         }
                         Outcome::Trap(t) => {
-                            let t = t.borrow();
                             bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -349,7 +349,10 @@ fn instantiate_module(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let instance = HostRef::new(Instance::new(store, &module, &imports)?);
+    let instance = HostRef::new(match Instance::new(store, &module, &imports) {
+        Ok(instance) => instance,
+        Err(trap) => bail!("Failed to instantiate {:?}: {:?}", path, trap),
+    });
 
     Ok((instance, module, data))
 }


### PR DESCRIPTION
Currently, the Instance::new() fails with generic Error. Though, it is expected that it might fails with the `Trap`, which can be raised at the start function, custom or not.

This PR also attempts to define full interface for `Frame` and `Trap`, which will carry information about stack trace.