### PR TITLE
Store v128 as `u128` in `wasmtime` crate

### DIFF
--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -37,7 +37,7 @@ pub enum Val {
     FuncRef(HostRef<Func>),
 
     /// A 128-bit number
-    V128([u8; 16]),
+    V128(u128),
 }
 
 macro_rules! accessors {
@@ -110,7 +110,7 @@ impl Val {
         (F32(f32) f32 unwrap_f32 f32::from_bits(*e))
         (F64(f64) f64 unwrap_f64 f64::from_bits(*e))
         (FuncRef(&HostRef<Func>) funcref unwrap_funcref e)
-        (V128(&[u8; 16]) v128 unwrap_v128 e)
+        (V128(u128) v128 unwrap_v128 *e)
     }
 
     /// Attempt to access the underlying value of this `Val`, returning
@@ -188,7 +188,7 @@ impl From<RuntimeValue> for Val {
             RuntimeValue::I64(i) => Val::I64(i),
             RuntimeValue::F32(u) => Val::F32(u),
             RuntimeValue::F64(u) => Val::F64(u),
-            RuntimeValue::V128(u) => Val::V128(u),
+            RuntimeValue::V128(u) => Val::V128(u128::from_le_bytes(u)),
         }
     }
 }

--- a/crates/interface-types/src/lib.rs
+++ b/crates/interface-types/src/lib.rs
@@ -157,7 +157,7 @@ impl ModuleData {
                     wasmtime::Val::I64(i) => RuntimeValue::I64(i),
                     wasmtime::Val::F32(i) => RuntimeValue::F32(i),
                     wasmtime::Val::F64(i) => RuntimeValue::F64(i),
-                    wasmtime::Val::V128(i) => RuntimeValue::V128(i),
+                    wasmtime::Val::V128(i) => RuntimeValue::V128(i.to_le_bytes()),
                     _ => panic!("unsupported value {:?}", v),
                 })
                 .collect::<Vec<RuntimeValue>>(),


### PR DESCRIPTION
As [suggested], this seems like a better and more ergonomic idea than
using `[u8; 16]`!

[suggested]: https://github.com/bytecodealliance/wasmtime/commit/3d69e04659a9dade78fa80a76e69e3f1b9d1af07#r36326017