### PR TITLE
Update the `*.wast` runner to use the `wasmtime` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
+ "wig",
 ]
 
 [[package]]
@@ -2213,9 +2214,7 @@ name = "wasmtime-wast"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "target-lexicon",
- "wasmtime-environ",
- "wasmtime-jit",
+ "wasmtime",
  "wasmtime-runtime",
  "wast 4.0.0",
 ]

--- a/crates/api/examples/multi.rs
+++ b/crates/api/examples/multi.rs
@@ -45,7 +45,12 @@ const WAT: &str = r#"
 fn main() -> Result<()> {
     // Initialize.
     println!("Initializing...");
-    let engine = HostRef::new(Engine::default());
+    let mut cfg = Config::new();
+    cfg.features(wasmtime_jit::Features {
+        multi_value: true,
+        ..Default::default()
+    });
+    let engine = HostRef::new(Engine::new(&cfg));
     let store = HostRef::new(Store::new(&engine));
 
     // Load binary.

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -181,6 +181,7 @@ impl WrappedCallable for WasmtimeFn {
                     ir::types::I64 => Val::I64(ptr::read(ptr as *const i64)),
                     ir::types::F32 => Val::F32(ptr::read(ptr as *const u32)),
                     ir::types::F64 => Val::F64(ptr::read(ptr as *const u64)),
+                    ir::types::I8X16 => Val::V128(ptr::read(ptr as *const [u8; 16])),
                     other => panic!("unsupported value type {:?}", other),
                 }
             }

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -121,7 +121,7 @@ impl WasmtimeFn {
 impl WrappedCallable for WasmtimeFn {
     fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
         use std::cmp::max;
-        use std::{mem, ptr};
+        use std::mem;
 
         let (vmctx, body, signature) = match self.wasmtime_export() {
             Export::Function {
@@ -132,21 +132,14 @@ impl WrappedCallable for WasmtimeFn {
             _ => panic!("unexpected export type in Callable"),
         };
 
-        let value_size = mem::size_of::<u64>();
-        let mut values_vec: Vec<u64> = vec![0; max(params.len(), results.len())];
+        let value_size = mem::size_of::<u128>();
+        let mut values_vec = vec![0; max(params.len(), results.len())];
 
         // Store the argument values into `values_vec`.
         for (index, arg) in params.iter().enumerate() {
             unsafe {
                 let ptr = values_vec.as_mut_ptr().add(index);
-
-                match arg {
-                    Val::I32(x) => ptr::write(ptr as *mut i32, *x),
-                    Val::I64(x) => ptr::write(ptr as *mut i64, *x),
-                    Val::F32(x) => ptr::write(ptr as *mut u32, *x),
-                    Val::F64(x) => ptr::write(ptr as *mut u64, *x),
-                    _ => unimplemented!("WasmtimeFn arg"),
-                }
+                arg.write_value_to(ptr);
             }
         }
 
@@ -176,14 +169,7 @@ impl WrappedCallable for WasmtimeFn {
             unsafe {
                 let ptr = values_vec.as_ptr().add(index);
 
-                results[index] = match abi_param.value_type {
-                    ir::types::I32 => Val::I32(ptr::read(ptr as *const i32)),
-                    ir::types::I64 => Val::I64(ptr::read(ptr as *const i64)),
-                    ir::types::F32 => Val::F32(ptr::read(ptr as *const u32)),
-                    ir::types::F64 => Val::F64(ptr::read(ptr as *const u64)),
-                    ir::types::I8X16 => Val::V128(ptr::read(ptr as *const [u8; 16])),
-                    other => panic!("unsupported value type {:?}", other),
-                }
+                results[index] = Val::read_value_from(ptr, abi_param.value_type);
             }
         }
 

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -201,14 +201,15 @@ impl Module {
             _ => None,
         }
     }
-    pub fn validate(_store: &HostRef<Store>, binary: &[u8]) -> Result<()> {
+    pub fn validate(store: &HostRef<Store>, binary: &[u8]) -> Result<()> {
+        let features = store.borrow().engine().borrow().config.features.clone();
         let config = ValidatingParserConfig {
             operator_config: OperatorValidatorConfig {
-                enable_threads: false,
-                enable_reference_types: false,
-                enable_bulk_memory: false,
-                enable_simd: false,
-                enable_multi_value: true,
+                enable_threads: features.threads,
+                enable_reference_types: features.reference_types,
+                enable_bulk_memory: features.bulk_memory,
+                enable_simd: features.simd,
+                enable_multi_value: features.multi_value,
             },
         };
         validate(binary, Some(config)).map_err(Error::new)

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -94,7 +94,7 @@ impl Default for Config {
 
 #[derive(Default)]
 pub struct Engine {
-    config: Config,
+    pub(crate) config: Config,
 }
 
 impl Engine {

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -89,7 +89,7 @@ impl Val {
             Val::I64(i) => ptr::write(p as *mut i64, *i),
             Val::F32(u) => ptr::write(p as *mut u32, *u),
             Val::F64(u) => ptr::write(p as *mut u64, *u),
-            Val::V128(b) => ptr::write(p as *mut [u8; 16], *b),
+            Val::V128(b) => ptr::write(p as *mut u128, *b),
             _ => unimplemented!("Val::write_value_to"),
         }
     }
@@ -100,7 +100,7 @@ impl Val {
             ir::types::I64 => Val::I64(ptr::read(p as *const i64)),
             ir::types::F32 => Val::F32(ptr::read(p as *const u32)),
             ir::types::F64 => Val::F64(ptr::read(p as *const u64)),
-            ir::types::I8X16 => Val::V128(ptr::read(p as *const [u8; 16])),
+            ir::types::I8X16 => Val::V128(ptr::read(p as *const u128)),
             _ => unimplemented!("Val::read_value_from"),
         }
     }

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -83,22 +83,24 @@ impl Val {
         }
     }
 
-    pub(crate) unsafe fn write_value_to(&self, p: *mut i64) {
+    pub(crate) unsafe fn write_value_to(&self, p: *mut i128) {
         match self {
             Val::I32(i) => ptr::write(p as *mut i32, *i),
             Val::I64(i) => ptr::write(p as *mut i64, *i),
             Val::F32(u) => ptr::write(p as *mut u32, *u),
             Val::F64(u) => ptr::write(p as *mut u64, *u),
+            Val::V128(b) => ptr::write(p as *mut [u8; 16], *b),
             _ => unimplemented!("Val::write_value_to"),
         }
     }
 
-    pub(crate) unsafe fn read_value_from(p: *const i64, ty: ir::Type) -> Val {
+    pub(crate) unsafe fn read_value_from(p: *const i128, ty: ir::Type) -> Val {
         match ty {
             ir::types::I32 => Val::I32(ptr::read(p as *const i32)),
             ir::types::I64 => Val::I64(ptr::read(p as *const i64)),
             ir::types::F32 => Val::F32(ptr::read(p as *const u32)),
             ir::types::F64 => Val::F64(ptr::read(p as *const u64)),
+            ir::types::I8X16 => Val::V128(ptr::read(p as *const [u8; 16])),
             _ => unimplemented!("Val::read_value_from"),
         }
     }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -11,12 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-jit = { path = "../jit" }
-wasmtime-runtime = { path = "../runtime" }
-wasmtime-environ = { path = "../environ" }
-wast = "4.0.0"
 anyhow = "1.0.19"
-target-lexicon = "0.9.0"
+wasmtime = { path = "../api" }
+wasmtime-runtime = { path = "../runtime" }
+wast = "4.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -1,26 +1,24 @@
 use crate::spectest::instantiate_spectest;
-use anyhow::{bail, Context as _, Result};
+use anyhow::{anyhow, bail, Context as _, Result};
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::path::Path;
 use std::str;
-use wasmtime_jit::{
-    ActionError, ActionOutcome, Compiler, Context, Features, InstanceHandle, InstantiationError,
-    RuntimeValue, SetupError,
-};
+use wasmtime::*;
 
 /// Translate from a `script::Value` to a `RuntimeValue`.
-fn runtime_value(v: &wast::Expression<'_>) -> RuntimeValue {
+fn runtime_value(v: &wast::Expression<'_>) -> Val {
     use wast::Instruction::*;
 
     if v.instrs.len() != 1 {
         panic!("too many instructions in {:?}", v);
     }
     match &v.instrs[0] {
-        I32Const(x) => RuntimeValue::I32(*x),
-        I64Const(x) => RuntimeValue::I64(*x),
-        F32Const(x) => RuntimeValue::F32(x.bits),
-        F64Const(x) => RuntimeValue::F64(x.bits),
-        V128Const(x) => RuntimeValue::V128(x.to_le_bytes()),
+        I32Const(x) => Val::I32(*x),
+        I64Const(x) => Val::I64(*x),
+        F32Const(x) => Val::F32(x.bits),
+        F64Const(x) => Val::F64(x.bits),
+        V128Const(x) => Val::V128(x.to_le_bytes()),
         other => panic!("couldn't convert {:?} to a runtime value", other),
     }
 }
@@ -30,85 +28,128 @@ fn runtime_value(v: &wast::Expression<'_>) -> RuntimeValue {
 pub struct WastContext {
     /// Wast files have a concept of a "current" module, which is the most
     /// recently defined.
-    current: Option<InstanceHandle>,
+    current: Option<HostRef<Instance>>,
 
-    context: Context,
+    instances: HashMap<String, HostRef<Instance>>,
+    store: HostRef<Store>,
+    spectest: Option<HashMap<&'static str, Extern>>,
+}
+
+enum Outcome<T = Vec<Val>> {
+    Ok(T),
+    Trap(HostRef<Trap>),
 }
 
 impl WastContext {
     /// Construct a new instance of `WastContext`.
-    pub fn new(compiler: Box<Compiler>) -> Self {
+    pub fn new(store: HostRef<Store>) -> Self {
         Self {
             current: None,
-            context: Context::new(compiler),
+            store,
+            spectest: None,
+            instances: HashMap::new(),
         }
     }
 
-    /// Construct a new instance with the given features using the current `Context`
-    pub fn with_features(self, features: Features) -> Self {
-        Self {
-            context: self.context.with_features(features),
-            ..self
+    fn get_instance(&self, instance_name: Option<&str>) -> Result<HostRef<Instance>> {
+        match instance_name {
+            Some(name) => self
+                .instances
+                .get(name)
+                .cloned()
+                .ok_or_else(|| anyhow!("failed to find instance named `{}`", name)),
+            None => self
+                .current
+                .clone()
+                .ok_or_else(|| anyhow!("no previous instance found")),
         }
     }
 
-    fn get_instance(&mut self, instance_name: Option<&str>) -> Result<&mut InstanceHandle> {
-        let instance = if let Some(instance_name) = instance_name {
-            self.context
-                .get_instance(instance_name)
-                .context("failed to fetch instance")?
-        } else {
-            self.current
-                .as_mut()
-                .ok_or_else(|| anyhow::format_err!("no current instance"))?
+    fn instantiate(&self, module: &[u8]) -> Result<Outcome<HostRef<Instance>>> {
+        let module = HostRef::new(Module::new(&self.store, module)?);
+        let mut imports = Vec::new();
+        for import in module.borrow().imports() {
+            if import.module() == "spectest" {
+                let spectest = self
+                    .spectest
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("spectest module isn't instantiated"))?;
+                let export = spectest.get(import.name()).ok_or_else(|| {
+                    anyhow!("unknown import `spectest::{}`", import.name())
+                })?;
+                imports.push(export.clone());
+                continue;
+            }
+
+            let instance = self
+                .instances
+                .get(import.module())
+                .ok_or_else(|| anyhow!("no module named `{}`", import.module()))?;
+            let export = instance
+                .borrow()
+                .find_export_by_name(import.name())
+                .ok_or_else(|| anyhow!("unknown import `{}::{}`", import.name(), import.module()))?
+                .clone();
+            imports.push(export);
+        }
+        let instance = match Instance::new(&self.store, &module, &imports) {
+            Ok(i) => i,
+            // FIXME(#683) shouldn't have to reach into runtime crate
+            Err(e) => {
+                use wasmtime_runtime::InstantiationError;
+                let err = e.chain().filter_map(|e| e.downcast_ref::<InstantiationError>()).next();
+                if let Some(InstantiationError::StartTrap(msg)) = err {
+                    return Ok(Outcome::Trap(HostRef::new(Trap::new(msg.clone()))));
+                }
+                return Err(e)
+            }
         };
-
-        Ok(instance)
+        Ok(Outcome::Ok(HostRef::new(instance)))
     }
 
     /// Register "spectest" which is used by the spec testsuite.
     pub fn register_spectest(&mut self) -> Result<()> {
-        let instance = instantiate_spectest()?;
-        self.context.name_instance("spectest".to_owned(), instance);
+        self.spectest = Some(instantiate_spectest(&self.store));
         Ok(())
     }
 
     /// Perform the action portion of a command.
-    fn perform_execute(&mut self, exec: wast::WastExecute<'_>) -> Result<ActionOutcome> {
+    fn perform_execute(&mut self, exec: wast::WastExecute<'_>) -> Result<Outcome> {
         match exec {
             wast::WastExecute::Invoke(invoke) => self.perform_invoke(invoke),
             wast::WastExecute::Module(mut module) => {
                 let binary = module.encode()?;
-                let result = self.context.instantiate_module(None, &binary);
-                match result {
-                    Ok(_) => Ok(ActionOutcome::Returned { values: Vec::new() }),
-                    Err(ActionError::Setup(SetupError::Instantiate(
-                        InstantiationError::StartTrap(message),
-                    ))) => Ok(ActionOutcome::Trapped { message }),
-                    Err(e) => Err(e.into()),
-                }
+                let result = self.instantiate(&binary)?;
+                Ok(match result {
+                    Outcome::Ok(_) => Outcome::Ok(Vec::new()),
+                    Outcome::Trap(e) => Outcome::Trap(e),
+                })
             }
             wast::WastExecute::Get { module, global } => self.get(module.map(|s| s.name()), global),
         }
     }
 
-    fn perform_invoke(&mut self, exec: wast::WastInvoke<'_>) -> Result<ActionOutcome> {
+    fn perform_invoke(&mut self, exec: wast::WastInvoke<'_>) -> Result<Outcome> {
         self.invoke(exec.module.map(|i| i.name()), exec.name, &exec.args)
     }
 
     /// Define a module and register it.
     fn module(&mut self, instance_name: Option<&str>, module: &[u8]) -> Result<()> {
-        let index = self
-            .context
-            .instantiate_module(instance_name.map(|s| s.to_string()), module)?;
-        self.current = Some(index);
+        let instance = match self.instantiate(module)? {
+            Outcome::Ok(i) => i,
+            Outcome::Trap(e) => bail!("instantiation failed with: {}", e.borrow().message()),
+        };
+        if let Some(name) = instance_name {
+            self.instances.insert(name.to_string(), instance.clone());
+        }
+        self.current = Some(instance);
         Ok(())
     }
 
     /// Register an instance to make it available for performing actions.
     fn register(&mut self, name: Option<&str>, as_name: &str) -> Result<()> {
         let instance = self.get_instance(name)?.clone();
-        self.context.name_instance(as_name.to_string(), instance);
+        self.instances.insert(as_name.to_string(), instance);
         Ok(())
     }
 
@@ -118,26 +159,35 @@ impl WastContext {
         instance_name: Option<&str>,
         field: &str,
         args: &[wast::Expression],
-    ) -> Result<ActionOutcome> {
-        let value_args = args.iter().map(runtime_value).collect::<Vec<_>>();
-        let mut instance = self.get_instance(instance_name)?.clone();
-        let result = self
-            .context
-            .invoke(&mut instance, field, &value_args)
-            .with_context(|| format!("failed to invoke `{}`", field))?;
-        Ok(result)
+    ) -> Result<Outcome> {
+        let values = args.iter().map(runtime_value).collect::<Vec<_>>();
+        let instance = self.get_instance(instance_name.as_ref().map(|x| &**x))?;
+        let instance = instance.borrow();
+        let export = instance
+            .find_export_by_name(field)
+            .ok_or_else(|| anyhow!("no global named `{}`", field))?;
+        let func = match export {
+            Extern::Func(f) => f.borrow(),
+            _ => bail!("export of `{}` wasn't a global", field),
+        };
+        Ok(match func.call(&values) {
+            Ok(result) => Outcome::Ok(result.into()),
+            Err(e) => Outcome::Trap(e),
+        })
     }
 
     /// Get the value of an exported global from an instance.
-    fn get(&mut self, instance_name: Option<&str>, field: &str) -> Result<ActionOutcome> {
-        let instance = self
-            .get_instance(instance_name.as_ref().map(|x| &**x))?
-            .clone();
-        let result = self
-            .context
-            .get(&instance, field)
-            .with_context(|| format!("failed to get field `{}`", field))?;
-        Ok(result)
+    fn get(&mut self, instance_name: Option<&str>, field: &str) -> Result<Outcome> {
+        let instance = self.get_instance(instance_name.as_ref().map(|x| &**x))?;
+        let instance = instance.borrow();
+        let export = instance
+            .find_export_by_name(field)
+            .ok_or_else(|| anyhow!("no global named `{}`", field))?;
+        let global = match export {
+            Extern::Global(g) => g.borrow(),
+            _ => bail!("export of `{}` wasn't a global", field),
+        };
+        Ok(Outcome::Ok(vec![global.get()]))
     }
 
     /// Run a wast script from a byte buffer.
@@ -179,16 +229,17 @@ impl WastContext {
                     exec,
                     results,
                 } => match self.perform_execute(exec).with_context(|| context(span))? {
-                    ActionOutcome::Returned { values } => {
+                    Outcome::Ok(values) => {
                         for (v, e) in values.iter().zip(results.iter().map(runtime_value)) {
-                            if *v == e {
+                            if values_equal(v, &e) {
                                 continue;
                             }
-                            bail!("{}\nexpected {}, got {}", context(span), e, v)
+                            bail!("{}\nexpected {:?}, got {:?}", context(span), e, v)
                         }
                     }
-                    ActionOutcome::Trapped { message } => {
-                        bail!("{}\nunexpected trap: {}", context(span), message)
+                    Outcome::Trap(t) => {
+                        let t = t.borrow();
+                        bail!("{}\nunexpected trap: {}", context(span), t.message())
                     }
                 },
                 AssertTrap {
@@ -196,13 +247,12 @@ impl WastContext {
                     exec,
                     message,
                 } => match self.perform_execute(exec).with_context(|| context(span))? {
-                    ActionOutcome::Returned { values } => {
+                    Outcome::Ok(values) => {
                         bail!("{}\nexpected trap, got {:?}", context(span), values)
                     }
-                    ActionOutcome::Trapped {
-                        message: trap_message,
-                    } => {
-                        if trap_message.contains(message) {
+                    Outcome::Trap(t) => {
+                        let t = t.borrow();
+                        if t.message().contains(message) {
                             continue;
                         }
                         if cfg!(feature = "lightbeam") {
@@ -217,7 +267,7 @@ impl WastContext {
                             "{}\nexpected {}, got {}",
                             context(span),
                             message,
-                            trap_message
+                            t.message(),
                         )
                     }
                 },
@@ -226,202 +276,169 @@ impl WastContext {
                     call,
                     message,
                 } => match self.perform_invoke(call).with_context(|| context(span))? {
-                    ActionOutcome::Returned { values } => {
+                    Outcome::Ok(values) => {
                         bail!("{}\nexpected trap, got {:?}", context(span), values)
                     }
-                    ActionOutcome::Trapped {
-                        message: trap_message,
-                    } => {
-                        if trap_message.contains(message) {
+                    Outcome::Trap(t) => {
+                        let t = t.borrow();
+                        if t.message().contains(message) {
                             continue;
                         }
                         bail!(
                             "{}\nexpected exhaustion with {}, got {}",
                             context(span),
                             message,
-                            trap_message
+                            t.message(),
                         )
                     }
                 },
                 AssertReturnCanonicalNan { span, invoke } => {
                     match self.perform_invoke(invoke).with_context(|| context(span))? {
-                        ActionOutcome::Returned { values } => {
+                        Outcome::Ok(values) => {
                             for v in values.iter() {
                                 match v {
-                                    RuntimeValue::I32(_) | RuntimeValue::I64(_) => {
-                                        bail!("{}\nunexpected integer in NaN test", context(span))
-                                    }
-                                    RuntimeValue::V128(_) => {
-                                        bail!("{}\nunexpected vector in NaN test", context(span))
-                                    }
-                                    RuntimeValue::F32(x) => {
+                                    Val::F32(x) => {
                                         if !is_canonical_f32_nan(x) {
                                             bail!("{}\nexpected canonical NaN", context(span))
                                         }
                                     }
-                                    RuntimeValue::F64(x) => {
+                                    Val::F64(x) => {
                                         if !is_canonical_f64_nan(x) {
                                             bail!("{}\nexpected canonical NaN", context(span))
                                         }
                                     }
+                                    other => panic!("expected float, got {:?}", other),
                                 };
                             }
                         }
-                        ActionOutcome::Trapped { message } => {
-                            bail!("{}\nunexpected trap: {}", context(span), message)
+                        Outcome::Trap(t) => {
+                            let t = t.borrow();
+                            bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
                 }
                 AssertReturnCanonicalNanF32x4 { span, invoke } => {
                     match self.perform_invoke(invoke).with_context(|| context(span))? {
-                        ActionOutcome::Returned { values } => {
+                        Outcome::Ok(values) => {
                             for v in values.iter() {
-                                match v {
-                                    RuntimeValue::I32(_) | RuntimeValue::I64(_) => {
-                                        bail!("{}\nunexpected integer in NaN test", context(span))
-                                    }
-                                    RuntimeValue::F32(_) | RuntimeValue::F64(_) => bail!(
-                                        "{}\nunexpected scalar float in vector NaN test",
-                                        context(span)
-                                    ),
-                                    RuntimeValue::V128(x) => {
-                                        for l in 0..4 {
-                                            if !is_canonical_f32_nan(&extract_lane_as_u32(x, l)?) {
-                                                bail!(
-                                                    "{}\nexpected f32x4 canonical NaN in lane {}",
-                                                    context(span),
-                                                    l
-                                                )
-                                            }
-                                        }
-                                    }
+                                let val = match v {
+                                    Val::V128(x) => x,
+                                    other => panic!("expected v128, got {:?}", other),
                                 };
+                                for l in 0..4 {
+                                    if !is_canonical_f32_nan(&extract_lane_as_u32(val, l)?) {
+                                        bail!(
+                                            "{}\nexpected f32x4 canonical NaN in lane {}",
+                                            context(span),
+                                            l
+                                        )
+                                    }
+                                }
                             }
                         }
-                        ActionOutcome::Trapped { message } => {
-                            bail!("{}\nunexpected trap: {}", context(span), message)
+                        Outcome::Trap(t) => {
+                            let t = t.borrow();
+                            bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
                 }
                 AssertReturnCanonicalNanF64x2 { span, invoke } => {
                     match self.perform_invoke(invoke).with_context(|| context(span))? {
-                        ActionOutcome::Returned { values } => {
+                        Outcome::Ok(values) => {
                             for v in values.iter() {
-                                match v {
-                                    RuntimeValue::I32(_) | RuntimeValue::I64(_) => {
-                                        bail!("{}\nunexpected integer in NaN test", context(span))
-                                    }
-                                    RuntimeValue::F32(_) | RuntimeValue::F64(_) => bail!(
-                                        "{}\nunexpected scalar float in vector NaN test",
-                                        context(span)
-                                    ),
-                                    RuntimeValue::V128(x) => {
-                                        for l in 0..2 {
-                                            if !is_canonical_f64_nan(&extract_lane_as_u64(x, l)?) {
-                                                bail!(
-                                                    "{}\nexpected f64x2 canonical NaN in lane {}",
-                                                    context(span),
-                                                    l
-                                                )
-                                            }
-                                        }
-                                    }
+                                let val = match v {
+                                    Val::V128(x) => x,
+                                    other => panic!("expected v128, got {:?}", other),
                                 };
+                                for l in 0..2 {
+                                    if !is_canonical_f64_nan(&extract_lane_as_u64(val, l)?) {
+                                        bail!(
+                                            "{}\nexpected f64x2 canonical NaN in lane {}",
+                                            context(span),
+                                            l
+                                        )
+                                    }
+                                }
                             }
                         }
-                        ActionOutcome::Trapped { message } => {
-                            bail!("{}\nunexpected trap: {}", context(span), message)
+                        Outcome::Trap(t) => {
+                            let t = t.borrow();
+                            bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
                 }
                 AssertReturnArithmeticNan { span, invoke } => {
                     match self.perform_invoke(invoke).with_context(|| context(span))? {
-                        ActionOutcome::Returned { values } => {
+                        Outcome::Ok(values) => {
                             for v in values.iter() {
                                 match v {
-                                    RuntimeValue::I32(_) | RuntimeValue::I64(_) => {
-                                        bail!("{}\nunexpected integer in NaN test", context(span))
-                                    }
-                                    RuntimeValue::V128(_) => {
-                                        bail!("{}\nunexpected vector in NaN test", context(span))
-                                    }
-                                    RuntimeValue::F32(x) => {
+                                    Val::F32(x) => {
                                         if !is_arithmetic_f32_nan(x) {
                                             bail!("{}\nexpected arithmetic NaN", context(span))
                                         }
                                     }
-                                    RuntimeValue::F64(x) => {
+                                    Val::F64(x) => {
                                         if !is_arithmetic_f64_nan(x) {
                                             bail!("{}\nexpected arithmetic NaN", context(span))
                                         }
                                     }
+                                    other => panic!("expected float, got {:?}", other),
                                 };
                             }
                         }
-                        ActionOutcome::Trapped { message } => {
-                            bail!("{}\nunexpected trap: {}", context(span), message)
+                        Outcome::Trap(t) => {
+                            let t = t.borrow();
+                            bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
                 }
                 AssertReturnArithmeticNanF32x4 { span, invoke } => {
                     match self.perform_invoke(invoke).with_context(|| context(span))? {
-                        ActionOutcome::Returned { values } => {
+                        Outcome::Ok(values) => {
                             for v in values.iter() {
-                                match v {
-                                    RuntimeValue::I32(_) | RuntimeValue::I64(_) => {
-                                        bail!("{}\nunexpected integer in NaN test", context(span))
-                                    }
-                                    RuntimeValue::F32(_) | RuntimeValue::F64(_) => bail!(
-                                        "{}\nunexpected scalar float in vector NaN test",
-                                        context(span)
-                                    ),
-                                    RuntimeValue::V128(x) => {
-                                        for l in 0..4 {
-                                            if !is_arithmetic_f32_nan(&extract_lane_as_u32(x, l)?) {
-                                                bail!(
-                                                    "{}\nexpected f32x4 arithmetic NaN in lane {}",
-                                                    context(span),
-                                                    l
-                                                )
-                                            }
-                                        }
-                                    }
+                                let val = match v {
+                                    Val::V128(x) => x,
+                                    other => panic!("expected v128, got {:?}", other),
                                 };
+                                for l in 0..4 {
+                                    if !is_arithmetic_f32_nan(&extract_lane_as_u32(val, l)?) {
+                                        bail!(
+                                            "{}\nexpected f32x4 arithmetic NaN in lane {}",
+                                            context(span),
+                                            l
+                                        )
+                                    }
+                                }
                             }
                         }
-                        ActionOutcome::Trapped { message } => {
-                            bail!("{}\nunexpected trap: {}", context(span), message)
+                        Outcome::Trap(t) => {
+                            let t = t.borrow();
+                            bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
                 }
                 AssertReturnArithmeticNanF64x2 { span, invoke } => {
                     match self.perform_invoke(invoke).with_context(|| context(span))? {
-                        ActionOutcome::Returned { values } => {
+                        Outcome::Ok(values) => {
                             for v in values.iter() {
-                                match v {
-                                    RuntimeValue::I32(_) | RuntimeValue::I64(_) => {
-                                        bail!("{}\nunexpected integer in NaN test", context(span))
-                                    }
-                                    RuntimeValue::F32(_) | RuntimeValue::F64(_) => bail!(
-                                        "{}\nunexpected scalar float in vector NaN test",
-                                        context(span)
-                                    ),
-                                    RuntimeValue::V128(x) => {
-                                        for l in 0..2 {
-                                            if !is_arithmetic_f64_nan(&extract_lane_as_u64(x, l)?) {
-                                                bail!(
-                                                    "{}\nexpected f64x2 arithmetic NaN in lane {}",
-                                                    context(span),
-                                                    l
-                                                )
-                                            }
-                                        }
-                                    }
+                                let val = match v {
+                                    Val::V128(x) => x,
+                                    other => panic!("expected v128, got {:?}", other),
                                 };
+                                for l in 0..2 {
+                                    if !is_arithmetic_f64_nan(&extract_lane_as_u64(val, l)?) {
+                                        bail!(
+                                            "{}\nexpected f64x2 arithmetic NaN in lane {}",
+                                            context(span),
+                                            l
+                                        )
+                                    }
+                                }
                             }
                         }
-                        ActionOutcome::Trapped { message } => {
-                            bail!("{}\nunexpected trap: {}", context(span), message)
+                        Outcome::Trap(t) => {
+                            let t = t.borrow();
+                            bail!("{}\nunexpected trap: {}", context(span), t.message())
                         }
                     }
                 }
@@ -534,4 +551,15 @@ fn is_arithmetic_f32_nan(bits: &u32) -> bool {
 
 fn is_arithmetic_f64_nan(bits: &u64) -> bool {
     return (bits & 0x0008000000000000) == 0x0008000000000000;
+}
+
+fn values_equal(v1: &Val, v2: &Val) -> bool {
+    match (v1, v2) {
+        (Val::I32(a), Val::I32(b)) => a == b,
+        (Val::I64(a), Val::I64(b)) => a == b,
+        (Val::F32(a), Val::F32(b)) => a == b,
+        (Val::F64(a), Val::F64(b)) => a == b,
+        (Val::V128(a), Val::V128(b)) => a == b,
+        _ => panic!("don't know how to compare {:?} and {:?} yet", v1, v2),
+    }
 }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -74,9 +74,9 @@ impl WastContext {
                     .spectest
                     .as_ref()
                     .ok_or_else(|| anyhow!("spectest module isn't instantiated"))?;
-                let export = spectest.get(import.name()).ok_or_else(|| {
-                    anyhow!("unknown import `spectest::{}`", import.name())
-                })?;
+                let export = spectest
+                    .get(import.name())
+                    .ok_or_else(|| anyhow!("unknown import `spectest::{}`", import.name()))?;
                 imports.push(export.clone());
                 continue;
             }
@@ -97,11 +97,14 @@ impl WastContext {
             // FIXME(#683) shouldn't have to reach into runtime crate
             Err(e) => {
                 use wasmtime_runtime::InstantiationError;
-                let err = e.chain().filter_map(|e| e.downcast_ref::<InstantiationError>()).next();
+                let err = e
+                    .chain()
+                    .filter_map(|e| e.downcast_ref::<InstantiationError>())
+                    .next();
                 if let Some(InstantiationError::StartTrap(msg)) = err {
                     return Ok(Outcome::Trap(HostRef::new(Trap::new(msg.clone()))));
                 }
-                return Err(e)
+                return Err(e);
             }
         };
         Ok(Outcome::Ok(HostRef::new(instance)))

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -558,6 +558,8 @@ fn values_equal(v1: &Val, v2: &Val) -> Result<bool> {
     Ok(match (v1, v2) {
         (Val::I32(a), Val::I32(b)) => a == b,
         (Val::I64(a), Val::I64(b)) => a == b,
+        // Note that these float comparisons are comparing bits, not float
+        // values, so we're testing for bit-for-bit equivalence
         (Val::F32(a), Val::F32(b)) => a == b,
         (Val::F64(a), Val::F64(b)) => a == b,
         (Val::V128(a), Val::V128(b)) => a == b,

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -46,7 +46,6 @@ use wasmtime_wasi::create_wasi_instance;
 use wasmtime_wasi::old::snapshot_0::create_wasi_instance as create_wasi_instance_snapshot_0;
 #[cfg(feature = "wasi-c")]
 use wasmtime_wasi_c::instantiate_wasi_c;
-use wasmtime_wast::instantiate_spectest;
 
 const USAGE: &str = "
 Wasm runner.
@@ -274,12 +273,6 @@ fn main() -> Result<()> {
     let store = HostRef::new(Store::new(&engine));
 
     let mut module_registry = HashMap::new();
-
-    // Make spectest available by default.
-    module_registry.insert(
-        "spectest".to_owned(),
-        HostRef::new(Instance::from_handle(&store, instantiate_spectest()?)),
-    );
 
     // Make wasi available by default.
     let preopen_dirs = compute_preopen_dirs(&args.flag_dir, &args.flag_mapdir);

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use wasmtime::{Config, Engine, HostRef, Store};
-use wasmtime_environ::settings::Configurable;
 use wasmtime_environ::settings;
+use wasmtime_environ::settings::Configurable;
 use wasmtime_jit::{CompilationStrategy, Features};
 use wasmtime_wast::WastContext;
 

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
+use wasmtime::{Config, Engine, HostRef, Store};
 use wasmtime_environ::settings::Configurable;
-use wasmtime_environ::{isa, settings};
-use wasmtime_jit::{native, CompilationStrategy, Compiler, Features};
+use wasmtime_environ::settings;
+use wasmtime_jit::{CompilationStrategy, Features};
 use wasmtime_wast::WastContext;
 
 include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
@@ -11,26 +12,24 @@ include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
 // to compile it.
 fn run_wast(wast: &str, strategy: CompilationStrategy) -> anyhow::Result<()> {
     let wast = Path::new(wast);
-    let isa = native_isa();
-    let compiler = Compiler::new(isa, strategy);
     let features = Features {
         simd: wast.iter().any(|s| s == "simd"),
         multi_value: wast.iter().any(|s| s == "multi-value"),
         ..Default::default()
     };
-    let mut wast_context = WastContext::new(Box::new(compiler)).with_features(features);
-    wast_context.register_spectest()?;
-    wast_context.run_file(wast)?;
-    Ok(())
-}
 
-fn native_isa() -> Box<dyn isa::TargetIsa> {
     let mut flag_builder = settings::builder();
     flag_builder.enable("enable_verifier").unwrap();
     flag_builder.enable("avoid_div_traps").unwrap();
     flag_builder.enable("enable_simd").unwrap();
 
-    let isa_builder = native::builder();
-
-    isa_builder.finish(settings::Flags::new(flag_builder))
+    let mut cfg = Config::new();
+    cfg.strategy(strategy)
+        .flags(settings::Flags::new(flag_builder))
+        .features(features);
+    let store = HostRef::new(Store::new(&HostRef::new(Engine::new(&cfg))));
+    let mut wast_context = WastContext::new(store);
+    wast_context.register_spectest()?;
+    wast_context.run_file(wast)?;
+    Ok(())
 }


### PR DESCRIPTION
This commit migrates the `wasmtime-wast` crate, which executes `*.wast`
test suites, to use the `wasmtime` crate exclusively instead of the raw
support provided by the `wasmtime-*` family of crates.

The primary motivation for this change is to use `*.wast` test to test
the support for interface types, but interface types is only being added
in the `wasmtime` crate for now rather than all throughout the core
crates. This means that without this transition it's much more difficult
to write tests for wasm interface types!

A secondary motivation for this is that it's testing the support we
provide to users through the `wasmtime` crate, since that's the
expectation of what most users would use rather than the raw
`wasmtime-*` crates.