### PR TITLE
Remove HostRef from API

### DIFF
--- a/crates/api/examples/gcd.rs
+++ b/crates/api/examples/gcd.rs
@@ -42,11 +42,10 @@ fn main() -> Result<()> {
     let store = HostRef::new(Store::new(&engine));
 
     // Load a module.
-    let module = HostRef::new(Module::new(&store, &wasm)?);
+    let module = Module::new(&store, &wasm)?;
 
     // Find index of the `gcd` export.
     let gcd_index = module
-        .borrow()
         .exports()
         .iter()
         .enumerate()

--- a/crates/api/examples/gcd.rs
+++ b/crates/api/examples/gcd.rs
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
 
     // Instantiate engine and store.
     let engine = HostRef::new(Engine::default());
-    let store = HostRef::new(Store::new(&engine));
+    let mut store = Store::new(&engine);
 
     // Load a module.
     let module = Module::new(&store, &wasm)?;
@@ -54,12 +54,12 @@ fn main() -> Result<()> {
         .0;
 
     // Instantiate the module.
-    let instance = Instance::new(&store, &module, &[])?;
+    let instance = Instance::new(&mut store, &module, &[])?;
 
     // Invoke `gcd` export
     let gcd = instance.exports()[gcd_index].func().expect("gcd");
     let result = gcd
-        .borrow()
+        .borrow_mut()
         .call(&[Val::from(6i32), Val::from(27i32)])
         .map_err(|e| format_err!("call error: {:?}", e))?;
 

--- a/crates/api/examples/hello.rs
+++ b/crates/api/examples/hello.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
 
     // Compiler the `*.wasm` binary into an in-memory instance of a `Module`.
     println!("Compiling module...");
-    let module = HostRef::new(Module::new(&store, &binary).context("> Error compiling module!")?);
+    let module = Module::new(&store, &binary).context("> Error compiling module!")?;
 
     // Here we handle the imports of the module, which in this case is our
     // `HelloCallback` type and its associated implementation of `Callback.

--- a/crates/api/examples/memory.rs
+++ b/crates/api/examples/memory.rs
@@ -87,7 +87,7 @@ fn main() -> Result<(), Error> {
 
     // Compile.
     println!("Compiling module...");
-    let module = HostRef::new(Module::new(&store, &binary).context("> Error compiling module!")?);
+    let module = Module::new(&store, &binary).context("> Error compiling module!")?;
 
     // Instantiate.
     println!("Instantiating module...");

--- a/crates/api/examples/memory.rs
+++ b/crates/api/examples/memory.rs
@@ -33,7 +33,7 @@ macro_rules! check {
 
 macro_rules! check_ok {
   ($func:expr, $($p:expr),*) => {
-    if let Err(_) = $func.borrow().call(&[$($p.into()),*]) {
+    if let Err(_) = $func.borrow_mut().call(&[$($p.into()),*]) {
       bail!("> Error on result, expected return");
     }
   }
@@ -41,7 +41,7 @@ macro_rules! check_ok {
 
 macro_rules! check_trap {
   ($func:expr, $($p:expr),*) => {
-    if let Ok(_) = $func.borrow().call(&[$($p.into()),*]) {
+    if let Ok(_) = $func.borrow_mut().call(&[$($p.into()),*]) {
       bail!("> Error on result, expected trap");
     }
   }
@@ -49,7 +49,7 @@ macro_rules! check_trap {
 
 macro_rules! call {
   ($func:expr, $($p:expr),*) => {
-    match $func.borrow().call(&[$($p.into()),*]) {
+    match $func.borrow_mut().call(&[$($p.into()),*]) {
       Ok(result) => {
         let result: i32 = result[0].unwrap_i32();
         result
@@ -63,7 +63,7 @@ fn main() -> Result<(), Error> {
     // Initialize.
     println!("Initializing...");
     let engine = HostRef::new(Engine::default());
-    let store = HostRef::new(Store::new(&engine));
+    let mut store = Store::new(&engine);
 
     // Load binary.
     println!("Loading binary...");
@@ -87,11 +87,11 @@ fn main() -> Result<(), Error> {
 
     // Compile.
     println!("Compiling module...");
-    let module = Module::new(&store, &binary).context("> Error compiling module!")?;
+    let module = Module::new(&mut store, &binary).context("> Error compiling module!")?;
 
     // Instantiate.
     println!("Instantiating module...");
-    let instance = Instance::new(&store, &module, &[]).context("> Error instantiating module!")?;
+    let instance = Instance::new(&mut store, &module, &[]).context("> Error instantiating module!")?;
 
     // Extract export.
     println!("Extracting export...");

--- a/crates/api/examples/multi.rs
+++ b/crates/api/examples/multi.rs
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
 
     // Compile.
     println!("Compiling module...");
-    let module = HostRef::new(Module::new(&store, &binary).context("Error compiling module!")?);
+    let module = Module::new(&store, &binary).context("Error compiling module!")?;
 
     // Create external print functions.
     println!("Creating callback...");

--- a/crates/api/examples/multi.rs
+++ b/crates/api/examples/multi.rs
@@ -46,7 +46,7 @@ fn main() -> Result<()> {
     // Initialize.
     println!("Initializing...");
     let engine = HostRef::new(Engine::default());
-    let store = HostRef::new(Store::new(&engine));
+    let mut store = Store::new(&engine);
 
     // Load binary.
     println!("Loading binary...");
@@ -62,12 +62,12 @@ fn main() -> Result<()> {
         Box::new([ValType::I32, ValType::I64]),
         Box::new([ValType::I64, ValType::I32]),
     );
-    let callback_func = HostRef::new(Func::new(&store, callback_type, Rc::new(Callback)));
+    let callback_func = HostRef::new(Func::new(&mut store, callback_type, Rc::new(Callback)));
 
     // Instantiate.
     println!("Instantiating module...");
     let imports = vec![callback_func.into()];
-    let instance = Instance::new(&store, &module, imports.as_slice())
+    let instance = Instance::new(&mut store, &module, imports.as_slice())
         .context("Error instantiating module!")?;
 
     // Extract exports.
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
     println!("Calling export \"g\"...");
     let args = vec![Val::I32(1), Val::I64(3)];
     let results = g
-        .borrow()
+        .borrow_mut()
         .call(&args)
         .map_err(|e| format_err!("> Error calling g! {:?}", e))?;
 
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
         Val::I64(9),
     ];
     let results = round_trip_many
-        .borrow()
+        .borrow_mut()
         .call(&args)
         .map_err(|e| format_err!("> Error calling round_trip_many! {:?}", e))?;
 

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -14,7 +14,7 @@ pub trait Callable {
 }
 
 pub(crate) trait WrappedCallable {
-    fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>>;
+    fn call(&mut self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>>;
     fn signature(&self) -> &ir::Signature {
         match self.wasmtime_export() {
             Export::Function { signature, .. } => signature,
@@ -42,7 +42,7 @@ impl WasmtimeFn {
 }
 
 impl WrappedCallable for WasmtimeFn {
-    fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
+    fn call(&mut self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
         use std::cmp::max;
         use std::{mem, ptr};
 
@@ -131,7 +131,7 @@ impl NativeCallable {
         store: &mut Store,
     ) -> Self {
         let (instance, export) =
-            generate_func_export(ft, &mut callable, store).expect("generated func");
+            generate_func_export(ft, &callable, store).expect("generated func");
         NativeCallable {
             callable,
             instance,
@@ -141,7 +141,7 @@ impl NativeCallable {
 }
 
 impl WrappedCallable for NativeCallable {
-    fn call(&self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
+    fn call(&mut self, params: &[Val], results: &mut [Val]) -> Result<(), HostRef<Trap>> {
         self.callable.call(params, results)
     }
     fn wasmtime_handle(&self) -> &InstanceHandle {

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -26,13 +26,13 @@ pub(crate) trait WrappedCallable {
 }
 
 pub(crate) struct WasmtimeFn {
-    store: HostRef<Store>,
+    store: Store,
     instance: InstanceHandle,
     export: Export,
 }
 
 impl WasmtimeFn {
-    pub fn new(store: &HostRef<Store>, instance: InstanceHandle, export: Export) -> WasmtimeFn {
+    pub fn new(store: &Store, instance: InstanceHandle, export: Export) -> WasmtimeFn {
         WasmtimeFn {
             store: store.clone(),
             instance,
@@ -76,7 +76,6 @@ impl WrappedCallable for WasmtimeFn {
         // Get the trampoline to call for this function.
         let exec_code_buf = self
             .store
-            .borrow_mut()
             .context()
             .compiler()
             .get_published_trampoline(body, &signature, value_size)
@@ -129,10 +128,10 @@ impl NativeCallable {
     pub(crate) fn new(
         callable: Rc<dyn Callable + 'static>,
         ft: &FuncType,
-        store: &HostRef<Store>,
+        store: &mut Store,
     ) -> Self {
         let (instance, export) =
-            generate_func_export(ft, &callable, store).expect("generated func");
+            generate_func_export(ft, &mut callable, store).expect("generated func");
         NativeCallable {
             callable,
             instance,

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -66,7 +66,7 @@ impl Extern {
     }
 
     pub(crate) fn from_wasmtime_export(
-        store: &HostRef<Store>,
+        store: &Store,
         instance_handle: InstanceHandle,
         export: wasmtime_runtime::Export,
     ) -> Extern {
@@ -112,19 +112,19 @@ impl From<HostRef<Table>> for Extern {
 }
 
 pub struct Func {
-    _store: HostRef<Store>,
+    _store: Store,
     callable: Rc<dyn WrappedCallable + 'static>,
     r#type: FuncType,
 }
 
 impl Func {
-    pub fn new(store: &HostRef<Store>, ty: FuncType, callable: Rc<dyn Callable + 'static>) -> Self {
-        let callable = Rc::new(NativeCallable::new(callable, &ty, &store));
+    pub fn new(store: &mut Store, ty: FuncType, callable: Rc<dyn Callable + 'static>) -> Self {
+        let callable = Rc::new(NativeCallable::new(callable, &ty, &mut store));
         Func::from_wrapped(store, ty, callable)
     }
 
     fn from_wrapped(
-        store: &HostRef<Store>,
+        store: &Store,
         r#type: FuncType,
         callable: Rc<dyn WrappedCallable + 'static>,
     ) -> Func {
@@ -159,7 +159,7 @@ impl Func {
 
     pub(crate) fn from_wasmtime_function(
         export: wasmtime_runtime::Export,
-        store: &HostRef<Store>,
+        store: &Store,
         instance_handle: InstanceHandle,
     ) -> Self {
         let ty = if let wasmtime_runtime::Export::Function { signature, .. } = &export {
@@ -179,7 +179,7 @@ impl fmt::Debug for Func {
 }
 
 pub struct Global {
-    _store: HostRef<Store>,
+    _store: Store,
     r#type: GlobalType,
     wasmtime_export: wasmtime_runtime::Export,
     #[allow(dead_code)]
@@ -187,7 +187,7 @@ pub struct Global {
 }
 
 impl Global {
-    pub fn new(store: &HostRef<Store>, r#type: GlobalType, val: Val) -> Global {
+    pub fn new(store: &Store, r#type: GlobalType, val: Val) -> Global {
         let (wasmtime_export, wasmtime_state) =
             generate_global_export(&r#type, val).expect("generated global");
         Global {
@@ -248,7 +248,7 @@ impl Global {
 
     pub(crate) fn from_wasmtime_global(
         export: wasmtime_runtime::Export,
-        store: &HostRef<Store>,
+        store: &Store,
     ) -> Global {
         let global = if let wasmtime_runtime::Export::Global { ref global, .. } = export {
             global
@@ -266,7 +266,7 @@ impl Global {
 }
 
 pub struct Table {
-    store: HostRef<Store>,
+    store: Store,
     r#type: TableType,
     wasmtime_handle: InstanceHandle,
     wasmtime_export: wasmtime_runtime::Export,
@@ -274,7 +274,7 @@ pub struct Table {
 
 fn get_table_item(
     handle: &InstanceHandle,
-    store: &HostRef<Store>,
+    store: &Store,
     table_index: wasm::DefinedTableIndex,
     item_index: u32,
 ) -> Val {
@@ -287,7 +287,7 @@ fn get_table_item(
 
 fn set_table_item(
     handle: &mut InstanceHandle,
-    store: &HostRef<Store>,
+    store: &Store,
     table_index: wasm::DefinedTableIndex,
     item_index: u32,
     val: Val,
@@ -302,7 +302,7 @@ fn set_table_item(
 }
 
 impl Table {
-    pub fn new(store: &HostRef<Store>, r#type: TableType, init: Val) -> Table {
+    pub fn new(store: &Store, r#type: TableType, init: Val) -> Table {
         match r#type.element() {
             ValType::FuncRef => (),
             _ => panic!("table is not for funcref"),
@@ -387,7 +387,7 @@ impl Table {
 
     pub(crate) fn from_wasmtime_table(
         export: wasmtime_runtime::Export,
-        store: &HostRef<Store>,
+        store: &Store,
         instance_handle: wasmtime_runtime::InstanceHandle,
     ) -> Table {
         let table = if let wasmtime_runtime::Export::Table { ref table, .. } = export {
@@ -406,14 +406,14 @@ impl Table {
 }
 
 pub struct Memory {
-    _store: HostRef<Store>,
+    _store: Store,
     r#type: MemoryType,
     wasmtime_handle: InstanceHandle,
     wasmtime_export: wasmtime_runtime::Export,
 }
 
 impl Memory {
-    pub fn new(store: &HostRef<Store>, r#type: MemoryType) -> Memory {
+    pub fn new(store: &Store, r#type: MemoryType) -> Memory {
         let (wasmtime_handle, wasmtime_export) =
             generate_memory_export(&r#type).expect("generated memory");
         Memory {
@@ -471,7 +471,7 @@ impl Memory {
 
     pub(crate) fn from_wasmtime_memory(
         export: wasmtime_runtime::Export,
-        store: &HostRef<Store>,
+        store: &Store,
         instance_handle: wasmtime_runtime::InstanceHandle,
     ) -> Memory {
         let memory = if let wasmtime_runtime::Export::Memory { ref memory, .. } = export {

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -1,7 +1,6 @@
 use crate::context::Context;
 use crate::externals::Extern;
 use crate::module::Module;
-use crate::r#ref::HostRef;
 use crate::runtime::Store;
 use crate::trampoline::take_api_trap;
 use crate::types::{ExportType, ExternType};

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -65,12 +65,12 @@ pub struct Instance {
 
 impl Instance {
     pub fn new(
-        store: &HostRef<Store>,
+        store: &mut Store,
         module: &Module,
         externs: &[Extern],
     ) -> Result<Instance> {
-        let context = store.borrow_mut().context().clone();
-        let exports = store.borrow_mut().global_exports().clone();
+        let context = store.context().clone();
+        let exports = store.global_exports().clone();
         let imports = module
             .imports()
             .iter()
@@ -123,7 +123,7 @@ impl Instance {
         Some(&self.exports()[i])
     }
 
-    pub fn from_handle(store: &HostRef<Store>, instance_handle: InstanceHandle) -> Instance {
+    pub fn from_handle(store: &mut Store, instance_handle: InstanceHandle) -> Instance {
         let contexts = HashSet::new();
 
         let mut exports = Vec::new();
@@ -135,7 +135,7 @@ impl Instance {
                 // HACK ensure all handles, instantiated outside Store, present in
                 // the store's SignatureRegistry, e.g. WASI instances that are
                 // imported into this store using the from_handle() method.
-                let _ = store.borrow_mut().register_wasmtime_signature(signature);
+                let _ = store.register_wasmtime_signature(signature);
             }
             let extern_type = ExternType::from_wasmtime_export(&export);
             exports_types.push(ExportType::new(name, extern_type));

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -55,7 +55,7 @@ pub fn instantiate_in_context(
 pub struct Instance {
     instance_handle: InstanceHandle,
 
-    module: HostRef<Module>,
+    module: Module,
 
     // We need to keep CodeMemory alive.
     contexts: HashSet<Context>,
@@ -66,29 +66,27 @@ pub struct Instance {
 impl Instance {
     pub fn new(
         store: &HostRef<Store>,
-        module: &HostRef<Module>,
+        module: &Module,
         externs: &[Extern],
     ) -> Result<Instance> {
         let context = store.borrow_mut().context().clone();
         let exports = store.borrow_mut().global_exports().clone();
         let imports = module
-            .borrow()
             .imports()
             .iter()
             .zip(externs.iter())
             .map(|(i, e)| (i.module().to_string(), i.name().to_string(), e.clone()))
             .collect::<Vec<_>>();
         let (mut instance_handle, contexts) = instantiate_in_context(
-            module.borrow().binary().expect("binary"),
+            &module.binary().expect("binary"),
             imports,
             context,
             exports,
         )?;
 
         let exports = {
-            let module = module.borrow();
             let mut exports = Vec::with_capacity(module.exports().len());
-            for export in module.exports() {
+            for export in &*module.exports() {
                 let name = export.name().to_string();
                 let export = instance_handle.lookup(&name).expect("export");
                 exports.push(Extern::from_wasmtime_export(
@@ -111,14 +109,13 @@ impl Instance {
         &self.exports
     }
 
-    pub fn module(&self) -> &HostRef<Module> {
+    pub fn module(&self) -> &Module {
         &self.module
     }
 
     pub fn find_export_by_name(&self, name: &str) -> Option<&Extern> {
         let (i, _) = self
             .module
-            .borrow()
             .exports()
             .iter()
             .enumerate()
@@ -149,10 +146,10 @@ impl Instance {
             ));
         }
 
-        let module = HostRef::new(Module::from_exports(
+        let module = Module::from_exports(
             store,
             exports_types.into_boxed_slice(),
-        ));
+        );
 
         Instance {
             instance_handle,

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -230,7 +230,6 @@ pub(crate) enum ModuleCodeSource {
     Unknown,
 }
 
-#[derive(Clone)]
 struct ModuleInner {
     store: HostRef<Store>,
     source: ModuleCodeSource,

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -9,6 +9,7 @@ use wasmparser::{
     validate, ExternalKind, ImportSectionEntryType, ModuleReader, OperatorValidatorConfig,
     SectionCode, ValidatingParserConfig,
 };
+use std::cell::Ref;
 
 fn into_memory_type(mt: wasmparser::MemoryType) -> MemoryType {
     assert!(!mt.shared);
@@ -163,44 +164,35 @@ fn read_imports_and_exports(binary: &[u8]) -> Result<(Box<[ImportType]>, Box<[Ex
     Ok((imports.into_boxed_slice(), exports.into_boxed_slice()))
 }
 
-#[derive(Clone)]
-pub(crate) enum ModuleCodeSource {
-    Binary(Box<[u8]>),
-    Unknown,
-}
-
+/// A Module wraps around some WASM source and manages its imports and exports.
 #[derive(Clone)]
 pub struct Module {
-    store: HostRef<Store>,
-    source: ModuleCodeSource,
-    imports: Box<[ImportType]>,
-    exports: Box<[ExportType]>,
+    inner: HostRef<ModuleInner>
 }
-
 impl Module {
     /// Validate and decode the raw wasm data in `binary` and create a new
     /// `Module` in the given `store`.
+    #[inline]
     pub fn new(store: &HostRef<Store>, binary: &[u8]) -> Result<Module> {
-        Self::validate(store, binary)?;
-        Self::new_unchecked(store, binary)
+        Ok(Self {
+            inner: HostRef::new(ModuleInner::new(store, binary)?),
+        })
     }
     /// Similar to `new`, but does not perform any validation. Only use this
     /// on modules which are known to have been validated already!
+    #[inline]
     pub fn new_unchecked(store: &HostRef<Store>, binary: &[u8]) -> Result<Module> {
-        let (imports, exports) = read_imports_and_exports(binary)?;
-        Ok(Module {
-            store: store.clone(),
-            source: ModuleCodeSource::Binary(binary.into()),
-            imports,
-            exports,
+        Ok(Self {
+            inner: HostRef::new(ModuleInner::new_unchecked(store, binary)?),
         })
     }
-    pub(crate) fn binary(&self) -> Option<&[u8]> {
-        match &self.source {
-            ModuleCodeSource::Binary(b) => Some(b),
-            _ => None,
+    pub fn from_exports(store: &HostRef<Store>, exports: Box<[ExportType]>) -> Self {
+        Self {
+            inner: HostRef::new(ModuleInner::from_exports(store, exports)),
         }
     }
+
+    /// Ensure that a given WASM store has valid syntax and semantics.
     pub fn validate(_store: &HostRef<Store>, binary: &[u8]) -> Result<()> {
         let config = ValidatingParserConfig {
             operator_config: OperatorValidatorConfig {
@@ -213,18 +205,73 @@ impl Module {
         };
         validate(binary, Some(config)).map_err(Error::new)
     }
-    pub fn imports(&self) -> &[ImportType] {
-        &self.imports
+
+    pub(crate) fn binary(&self) -> Option<Ref<[u8]>> {
+        self.inner.borrow().binary().map(|_| {
+            // note that the variable that's passed to this closure
+            // cannot be used as the binary that's returned with the ref,
+            // otherwise the mapped borrow lives to long.
+            // one borrow is needed to check if it's binary,
+            // another borrow is needed to return to the user.
+            Ref::map(self.inner.borrow(), |i: &ModuleInner| -> &[u8] { &i.binary().unwrap() })
+        })
     }
-    pub fn exports(&self) -> &[ExportType] {
-        &self.exports
+    pub fn imports(&self) -> Ref<[ImportType]> {
+        Ref::map(self.inner.borrow(), |i| -> &[ImportType] { &i.imports() })
     }
-    pub fn from_exports(store: &HostRef<Store>, exports: Box<[ExportType]>) -> Self {
-        Module {
+    pub fn exports(&self) -> Ref<[ExportType]> {
+        Ref::map(self.inner.borrow(), |i| -> &[ExportType] { &i.exports() })
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum ModuleCodeSource {
+    Binary(Box<[u8]>),
+    Unknown,
+}
+
+#[derive(Clone)]
+struct ModuleInner {
+    store: HostRef<Store>,
+    source: ModuleCodeSource,
+    pub(crate) imports: Box<[ImportType]>,
+    pub(crate) exports: Box<[ExportType]>,
+}
+
+impl ModuleInner {
+    /// See documentation on ModuleInner.
+    fn new(store: &HostRef<Store>, binary: &[u8]) -> Result<Self> {
+        Module::validate(store, binary)?;
+        Self::new_unchecked(store, binary)
+    }
+    /// See documentation on ModuleInner.
+    fn new_unchecked(store: &HostRef<Store>, binary: &[u8]) -> Result<Self> {
+        let (imports, exports) = read_imports_and_exports(binary)?;
+        Ok(ModuleInner {
+            store: store.clone(),
+            source: ModuleCodeSource::Binary(binary.into()),
+            imports,
+            exports,
+        })
+    }
+    fn from_exports(store: &HostRef<Store>, exports: Box<[ExportType]>) -> Self {
+        ModuleInner {
             store: store.clone(),
             source: ModuleCodeSource::Unknown,
             imports: Box::new([]),
             exports,
         }
+    }
+    pub(crate) fn binary(&self) -> Option<&[u8]> {
+        match &self.source {
+            ModuleCodeSource::Binary(b) => Some(b),
+            _ => None,
+        }
+    }
+    pub fn imports(&self) -> &[ImportType] {
+        &self.imports
+    }
+    pub fn exports(&self) -> &[ExportType] {
+        &self.exports
     }
 }

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -137,7 +137,7 @@ impl Store {
         &mut self,
         signature: &ir::Signature,
     ) -> wasmtime_runtime::VMSharedSignatureIndex {
-        self.inner.borrow().register_wasmtime_signature(signature)
+        self.inner.borrow_mut().register_wasmtime_signature(signature)
     }
 
     pub(crate) fn lookup_wasmtime_signature(

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -3,7 +3,7 @@
 use crate::runtime::Store;
 use anyhow::Result;
 use std::any::Any;
-use std::cell::{RefCell, RefMut};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use wasmtime_environ::entity::PrimaryMap;
@@ -31,7 +31,7 @@ pub(crate) fn create_handle(
 
     // Compute indices into the shared signature table.
     let signatures = signature_registry
-        .and_then(|mut signature_registry| {
+        .and_then(|signature_registry| {
             Some(
                 module
                     .signatures

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -13,7 +13,7 @@ use wasmtime_runtime::{Imports, InstanceHandle, VMFunctionBody};
 
 pub(crate) fn create_handle(
     module: Module,
-    signature_registry: Option<RefMut<Store>>,
+    signature_registry: Option<&mut Store>,
     finished_functions: PrimaryMap<DefinedFuncIndex, *const VMFunctionBody>,
     state: Box<dyn Any>,
 ) -> Result<InstanceHandle> {

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -231,7 +231,7 @@ fn make_trampoline(
 pub fn create_handle_with_function(
     ft: &FuncType,
     func: &Rc<dyn Callable + 'static>,
-    store: &HostRef<Store>,
+    store: &mut Store,
 ) -> Result<InstanceHandle> {
     let sig = ft.get_wasmtime_signature().clone();
 
@@ -267,7 +267,7 @@ pub fn create_handle_with_function(
 
     create_handle(
         module,
-        Some(store.borrow_mut()),
+        Some(&mut store),
         finished_functions,
         Box::new(trampoline_state),
     )

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -2,7 +2,6 @@
 
 use super::create_handle::create_handle;
 use super::trap::{record_api_trap, TrapSink, API_TRAP_CODE};
-use crate::r#ref::HostRef;
 use crate::{Callable, FuncType, Store, Val};
 use anyhow::Result;
 use std::cmp;
@@ -267,7 +266,7 @@ pub fn create_handle_with_function(
 
     create_handle(
         module,
-        Some(&mut store),
+        Some(store),
         finished_functions,
         Box::new(trampoline_state),
     )

--- a/crates/api/src/trampoline/mod.rs
+++ b/crates/api/src/trampoline/mod.rs
@@ -12,7 +12,6 @@ use self::global::create_global;
 use self::memory::create_handle_with_memory;
 use self::table::create_handle_with_table;
 use super::{Callable, FuncType, GlobalType, MemoryType, Store, TableType, Val};
-use crate::r#ref::HostRef;
 use anyhow::Result;
 use std::rc::Rc;
 
@@ -24,7 +23,7 @@ pub fn generate_func_export(
     func: &Rc<dyn Callable + 'static>,
     store: &mut Store,
 ) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
-    let mut instance = create_handle_with_function(ft, func, &mut store)?;
+    let mut instance = create_handle_with_function(ft, func, store)?;
     let export = instance.lookup("trampoline").expect("trampoline export");
     Ok((instance, export))
 }

--- a/crates/api/src/trampoline/mod.rs
+++ b/crates/api/src/trampoline/mod.rs
@@ -22,9 +22,9 @@ pub use self::trap::take_api_trap;
 pub fn generate_func_export(
     ft: &FuncType,
     func: &Rc<dyn Callable + 'static>,
-    store: &HostRef<Store>,
+    store: &mut Store,
 ) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
-    let mut instance = create_handle_with_function(ft, func, store)?;
+    let mut instance = create_handle_with_function(ft, func, &mut store)?;
     let export = instance.lookup("trampoline").expect("trampoline export");
     Ok((instance, export))
 }

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -232,7 +232,6 @@ pub(crate) fn from_checked_anyfunc(
         return Val::AnyRef(AnyRef::Null);
     }
     let signature = store
-        .borrow()
         .lookup_wasmtime_signature(item.type_index)
         .expect("signature")
         .clone();

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -195,7 +195,7 @@ impl From<RuntimeValue> for Val {
 
 pub(crate) fn into_checked_anyfunc(
     val: Val,
-    store: &HostRef<Store>,
+    store: &mut Store,
 ) -> wasmtime_runtime::VMCallerCheckedAnyfunc {
     match val {
         Val::AnyRef(AnyRef::Null) => wasmtime_runtime::VMCallerCheckedAnyfunc {
@@ -213,7 +213,7 @@ pub(crate) fn into_checked_anyfunc(
                 } => (*vmctx, *address, signature),
                 _ => panic!("expected function export"),
             };
-            let type_index = store.borrow_mut().register_wasmtime_signature(signature);
+            let type_index = store.register_wasmtime_signature(signature);
             wasmtime_runtime::VMCallerCheckedAnyfunc {
                 func_ptr,
                 type_index,
@@ -226,7 +226,7 @@ pub(crate) fn into_checked_anyfunc(
 
 pub(crate) fn from_checked_anyfunc(
     item: &wasmtime_runtime::VMCallerCheckedAnyfunc,
-    store: &HostRef<Store>,
+    store: &Store,
 ) -> Val {
     if item.type_index == wasmtime_runtime::VMSharedSignatureIndex::default() {
         return Val::AnyRef(AnyRef::Null);

--- a/crates/api/src/wasm.rs
+++ b/crates/api/src/wasm.rs
@@ -327,7 +327,7 @@ pub struct wasm_foreign_t {
 #[repr(C)]
 #[derive(Clone)]
 pub struct wasm_module_t {
-    module: HostRef<Module>,
+    module: Module,
     imports: Vec<wasm_importtype_t>,
     exports: Vec<wasm_exporttype_t>,
 }
@@ -748,7 +748,7 @@ pub unsafe extern "C" fn wasm_module_new(
         })
         .collect::<Vec<_>>();
     let module = Box::new(wasm_module_t {
-        module: HostRef::new(module),
+        module,
         imports,
         exports,
     });

--- a/crates/api/tests/import_calling_export.rs
+++ b/crates/api/tests/import_calling_export.rs
@@ -35,7 +35,7 @@ fn test_import_calling_export() {
     let engine = HostRef::new(Engine::default());
     let store = HostRef::new(Store::new(&engine));
     let wasm = wat::parse_str(WAT).unwrap();
-    let module = HostRef::new(Module::new(&store, &wasm).expect("failed to create module"));
+    let module = Module::new(&store, &wasm).expect("failed to create module");
 
     let callback = Rc::new(Callback {
         other: RefCell::new(None),

--- a/crates/api/tests/import_calling_export.rs
+++ b/crates/api/tests/import_calling_export.rs
@@ -25,7 +25,7 @@ fn test_import_calling_export() {
                 .borrow()
                 .as_ref()
                 .expect("expected a function ref")
-                .borrow()
+                .borrow_mut()
                 .call(&[])
                 .expect("expected function not to trap");
             Ok(())
@@ -33,7 +33,7 @@ fn test_import_calling_export() {
     }
 
     let engine = HostRef::new(Engine::default());
-    let store = HostRef::new(Store::new(&engine));
+    let mut store = Store::new(&engine);
     let wasm = wat::parse_str(WAT).unwrap();
     let module = Module::new(&store, &wasm).expect("failed to create module");
 
@@ -42,14 +42,14 @@ fn test_import_calling_export() {
     });
 
     let callback_func = HostRef::new(Func::new(
-        &store,
+        &mut store,
         FuncType::new(Box::new([]), Box::new([])),
         callback.clone(),
     ));
 
     let imports = vec![callback_func.into()];
     let instance = HostRef::new(
-        Instance::new(&store, &module, imports.as_slice()).expect("failed to instantiate module"),
+        Instance::new(&mut store, &module, imports.as_slice()).expect("failed to instantiate module"),
     );
 
     let exports = Ref::map(instance.borrow(), |instance| instance.exports());
@@ -67,7 +67,7 @@ fn test_import_calling_export() {
     );
 
     run_func
-        .borrow()
+        .borrow_mut()
         .call(&[])
         .expect("expected function not to trap");
 }

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -24,9 +24,7 @@ fn test_trap_return() -> Result<(), String> {
     )
     .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
 
-    let module = HostRef::new(
-        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?,
-    );
+    let module = Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?;
     let hello_type = FuncType::new(Box::new([]), Box::new([]));
     let hello_func = HostRef::new(Func::new(&store, hello_type, Rc::new(HelloCallback)));
 

--- a/crates/interface-types/src/lib.rs
+++ b/crates/interface-types/src/lib.rs
@@ -148,7 +148,7 @@ impl ModuleData {
             .into_iter()
             .map(|rv| rv.into())
             .collect::<Vec<_>>();
-        let wasm_results = match f.borrow().call(&wasm_args) {
+        let wasm_results = match f.borrow_mut().call(&wasm_args) {
             Ok(values) => values
                 .to_vec()
                 .into_iter()
@@ -335,7 +335,7 @@ impl TranslateContext for InstanceTranslateContext {
             .ok_or_else(|| format_err!("`{}` is not a (alloc) function", alloc_func_name))?
             .clone();
         let alloc_args = vec![wasmtime::Val::I32(len)];
-        let results = match alloc.borrow().call(&alloc_args) {
+        let results = match alloc.borrow_mut().call(&alloc_args) {
             Ok(values) => values,
             Err(trap) => bail!("trapped: {:?}", trap),
         };

--- a/crates/wasi/src/instantiate.rs
+++ b/crates/wasi/src/instantiate.rs
@@ -14,14 +14,14 @@ use wasmtime_runtime::{Imports, InstanceHandle, InstantiationError, VMFunctionBo
 
 /// Creates `wasmtime::Instance` object implementing the "wasi" interface.
 pub fn create_wasi_instance(
-    store: &wasmtime::HostRef<wasmtime::Store>,
+    store: &mut wasmtime::Store,
     preopened_dirs: &[(String, File)],
     argv: &[String],
     environ: &[(String, String)],
 ) -> Result<wasmtime::Instance, InstantiationError> {
-    let global_exports = store.borrow().global_exports().clone();
+    let global_exports = store.global_exports().clone();
     let wasi = instantiate_wasi(global_exports, preopened_dirs, argv, environ)?;
-    let instance = wasmtime::Instance::from_handle(&store, wasi);
+    let instance = wasmtime::Instance::from_handle(store, wasi);
     Ok(instance)
 }
 

--- a/crates/wasi/src/old/snapshot_0/instantiate.rs
+++ b/crates/wasi/src/old/snapshot_0/instantiate.rs
@@ -14,14 +14,14 @@ use wasmtime_runtime::{Imports, InstanceHandle, InstantiationError, VMFunctionBo
 
 /// Creates `wasmtime::Instance` object implementing the "wasi" interface.
 pub fn create_wasi_instance(
-    store: &wasmtime::HostRef<wasmtime::Store>,
+    store: &mut wasmtime::Store,
     preopened_dirs: &[(String, File)],
     argv: &[String],
     environ: &[(String, String)],
 ) -> Result<wasmtime::Instance, InstantiationError> {
-    let global_exports = store.borrow().global_exports().clone();
+    let global_exports = store.global_exports().clone();
     let wasi = instantiate_wasi(global_exports, preopened_dirs, argv, environ)?;
-    let instance = wasmtime::Instance::from_handle(&store, wasi);
+    let instance = wasmtime::Instance::from_handle(store, wasi);
     Ok(instance)
 }
 

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -329,15 +329,14 @@ fn instantiate_module(
     store: &HostRef<Store>,
     module_registry: &HashMap<String, HostRef<Instance>>,
     path: &Path,
-) -> Result<(HostRef<Instance>, HostRef<Module>, Vec<u8>)> {
+) -> Result<(HostRef<Instance>, Module, Vec<u8>)> {
     // Read the wasm module binary either as `*.wat` or a raw binary
     let data = wat::parse_file(path.to_path_buf())?;
 
-    let module = HostRef::new(Module::new(store, &data)?);
+    let module = Module::new(store, &data)?;
 
     // Resolve import using module_registry.
     let imports = module
-        .borrow()
         .imports()
         .iter()
         .map(|i| {
@@ -377,7 +376,6 @@ fn handle_module(
         let data = ModuleData::new(&data)?;
         invoke_export(instance, &data, f, args)?;
     } else if module
-        .borrow()
         .exports()
         .iter()
         .find(|export| export.name().is_empty())


### PR DESCRIPTION
Unfinished prototyping and attempting to implement #682.

I've decided to start with Module as a testing ground for figuring out how we can begin to hide Hostref from the users. Once we have something we're happy with for Module it should be relatively simple to follow suit for the rest of the API until we can eventually make HostRef private.

How Module relays back information from the ModuleInner it contains is kind of gross; I'm not sure whether we'd want to come up with some clever Deref implementation or some sort of macro or what.


To the best of my knowledge, I believe this is a complete list of everything that needs to be done to make HostRef private.
If there's anything I'm missing, please let me know.

Structs which need to become HostRef wrappers around their Inner counterparts:
- [X] Module
- [ ] Instance
- [x] Store
- [ ] Engine
- [ ] Func
- [ ] Global
- [ ] Table
- [ ] Memory
- [ ] Trap

Misc.
- [ ] HostObject trait for allowing configuration of HostRefs contained in wrapper structs