### PR TITLE
Fix AppVerifier check regarding invalid call to VirtualFree.

### DIFF
--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -255,8 +255,8 @@ impl Drop for Mmap {
             use winapi::ctypes::c_void;
             use winapi::um::memoryapi::VirtualFree;
             use winapi::um::winnt::MEM_RELEASE;
-            let r = unsafe { VirtualFree(self.ptr as *mut c_void, self.len, MEM_RELEASE) };
-            assert_eq!(r, 0);
+            let r = unsafe { VirtualFree(self.ptr as *mut c_void, 0, MEM_RELEASE) };
+            assert_ne!(r, 0);
         }
     }
 }


### PR DESCRIPTION
Calls to `VirtualFree` that pass `MEM_RELEASE` must specify a size of 0
as the OS will be freeing the original range for the given base address.

The calls to free `MMap` memory on Windows were silently failing because
of an incorrect assertion (on Windows, `VirtualFree` returns non-zero
for success).

This was caught via AppVerifier while investigating a heap overrun issue
on a different PR.