### PR TITLE
Update dependabot for only security updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,4 +7,4 @@ update_configs:
     version_requirement_updates: "auto"
     allowed_updates:
     - match:
-        update_type: "all"
+        update_type: "security"


### PR DESCRIPTION
This'll hopefully help reduce the noise of dependabot PRs, but still
notify us to very important ones!