### PR TITLE
Fix the path_filestat test on Linux

### DIFF
--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/filetime.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/filetime.rs
@@ -36,7 +36,7 @@ pub(crate) fn utimensat(
     static INVALID: AtomicBool = AtomicBool::new(false);
     if !INVALID.load(Relaxed) {
         let p = CString::new(path.as_bytes())?;
-        let times = [to_timespec(&atime), to_timespec(&mtime)];
+        let times = [to_timespec(&atime)?, to_timespec(&mtime)?];
         let rc = unsafe {
             libc::syscall(
                 libc::SYS_utimensat,

--- a/crates/wasi-common/src/sys/unix/linux/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/linux/filetime.rs
@@ -36,7 +36,7 @@ pub(crate) fn utimensat(
     static INVALID: AtomicBool = AtomicBool::new(false);
     if !INVALID.load(Relaxed) {
         let p = CString::new(path.as_bytes())?;
-        let times = [to_timespec(&atime), to_timespec(&mtime)];
+        let times = [to_timespec(&atime)?, to_timespec(&mtime)?];
         let rc = unsafe {
             libc::syscall(
                 libc::SYS_utimensat,


### PR DESCRIPTION
Only very recently in #700 did we actually start running wasi tests
again (they weren't running by accident). Just before that landed we
also landed #688 which had some refactorings. Unfortunately #688 had a
minor issue in it which wasn't caught because tests weren't run. This
means that the bug in #688 slipped in and is now being caught by #700
now that both are landed on master.

This commit fixes the small issue introduced and should get our CI green
again!