### PR TITLE
[lightbeam] replace asserts by Errors in module.rs / translate_only

### DIFF
--- a/crates/lightbeam/src/module.rs
+++ b/crates/lightbeam/src/module.rs
@@ -565,14 +565,16 @@ pub fn translate_only(data: &[u8]) -> Result<TranslatedModule, Error> {
 
         if mem.len() > 1 {
             return Err(Error::Input(
-                "Multiple memory sections not yet unimplemented".to_string(),
+                "Multiple memory sections not yet implemented".to_string(),
             ));
         }
 
         if !mem.is_empty() {
             let mem = mem[0];
             if Some(mem.limits.initial) != mem.limits.maximum {
-                return Err(Error::Input("Memory limits not matching".to_string()));
+                return Err(Error::Input(
+                    "Custom memory limits not supported in lightbeam".to_string(),
+                ));
             }
             output.memory = Some(mem);
         }
@@ -645,7 +647,9 @@ pub fn translate_only(data: &[u8]) -> Result<TranslatedModule, Error> {
     }
 
     if !reader.eof() {
-        return Err(Error::Input("Module not transate completely".to_string()));
+        return Err(Error::Input(
+            "Unexpected data found after the end of the module".to_string(),
+        ));
     }
 
     Ok(output)

--- a/crates/lightbeam/src/module.rs
+++ b/crates/lightbeam/src/module.rs
@@ -7,7 +7,7 @@ use cranelift_codegen::{
     isa,
 };
 use memoffset::offset_of;
-use more_asserts::assert_le;
+
 use std::{convert::TryInto, mem};
 use thiserror::Error;
 use wasmparser::{FuncType, MemoryType, ModuleReader, SectionCode, Type};
@@ -563,15 +563,17 @@ pub fn translate_only(data: &[u8]) -> Result<TranslatedModule, Error> {
         let memories = section.get_memory_section_reader()?;
         let mem = translate_sections::memory(memories)?;
 
-        assert_le!(
-            mem.len(),
-            1,
-            "Multiple memory sections not yet unimplemented"
-        );
+        if mem.len() > 1 {
+            return Err(Error::Input(
+                "Multiple memory sections not yet unimplemented".to_string(),
+            ));
+        }
 
         if !mem.is_empty() {
             let mem = mem[0];
-            assert_eq!(Some(mem.limits.initial), mem.limits.maximum);
+            if Some(mem.limits.initial) != mem.limits.maximum {
+                return Err(Error::Input("Memory limits not matching".to_string()));
+            }
             output.memory = Some(mem);
         }
 
@@ -642,7 +644,9 @@ pub fn translate_only(data: &[u8]) -> Result<TranslatedModule, Error> {
         translate_sections::data(data)?;
     }
 
-    assert!(reader.eof());
+    if !reader.eof() {
+        return Err(Error::Input("Module not transate completely".to_string()));
+    }
 
     Ok(output)
 }


### PR DESCRIPTION
Just a simple PR to replace some asserts by Errors, i have not modify the code logic.

I notice that `translate_only` is translating wasm module linearly. In short that means that if the import section is after the table function you will get an Error. 
I think this function should be rewrite to translate all the sections whatever their order inside the module. 