### PR TITLE
Update WASI API C header file path

### DIFF
--- a/docs/WASI-documents.md
+++ b/docs/WASI-documents.md
@@ -7,7 +7,7 @@ For more detail on what WASI is, see [the overview](WASI-overview.md).
 
 For specifics on the API, see the [API documentation](https://github.com/bytecodealliance/wasmtime/blob/master/docs/WASI-api.md).
 Additionally, a C header file describing the WASI API is
-[here](https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/core.h).
+[here](https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/api.h).
 
 The WASI libc repository is [wasi-libc](https://github.com/CraneStation/wasi-libc/).
 


### PR DESCRIPTION
Hi!
The [previous link][1] was 404ing. From CraneStation/wasi-libc@446cb3f I assume the new link is [this][2].

[1]: https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/core.h
[2]: https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/api.h