### PR TITLE
Fix wasi-common-cbindgen missing no_mangle attr

### DIFF
--- a/crates/wasi-common/wasi-common-cbindgen/src/lib.rs
+++ b/crates/wasi-common/wasi-common-cbindgen/src/lib.rs
@@ -141,6 +141,7 @@ pub fn wasi_common_cbindgen_old(attr: TokenStream, function: TokenStream) -> Tok
     let result = quote! {
         #function
 
+        #[no_mangle]
         #vis unsafe extern "C" fn #c_fn_ident(
             #(
                 #arg_ident: #arg_type,


### PR DESCRIPTION
`#[no_mangle]` must have been accidentally left out when creating `snapshot_0` of `wasi-common`. This commit fixes this.