### PR TITLE
Move the `wasi-tests` crate to the main workspace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,11 +115,9 @@ jobs:
           - build: beta
             os: ubuntu-latest
             rust: beta
-          # FIXME need to wait for rust-lang/rust#67065 to get into nightlies,
-          # and then this can be updated to `nightly` again.
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2019-12-03
+            rust: nightly
           - build: macos
             os: macos-latest
             rust: stable
@@ -186,7 +184,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2019-08-15
+        toolchain: nightly
     - uses: ./.github/actions/binary-compatible-builds
     - run: mkdir crates/misc/py/wheelhouse
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.7.0",
 ]
 
 [[package]]
@@ -1866,6 +1866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
 name = "wasi-common"
 version = "0.7.0"
 dependencies = [
@@ -1894,6 +1900,16 @@ dependencies = [
  "quote",
  "syn",
  "trybuild",
+]
+
+[[package]]
+name = "wasi-tests"
+version = "0.7.0"
+dependencies = [
+ "libc",
+ "more-asserts",
+ "wasi 0.7.0",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
   "crates/fuzzing",
   "crates/misc/rust",
   "crates/misc/py",
+  "crates/test-programs/wasi-tests",
 ]
 
 [features]

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -11,8 +11,3 @@ libc = "0.2.65"
 wasi = "0.9.0"
 wasi-old = { version = "0.7.0", package = "wasi" }
 more-asserts = "0.2.1"
-
-# This crate is built with the wasm32-wasi target, so it's separate
-# from the main Wasmtime build, so use this directive to exclude it
-# from the parent directory's workspace.
-[workspace]

--- a/crates/test-programs/wasi-tests/src/bin/fd_filestat_set.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_filestat_set.rs
@@ -12,7 +12,8 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
         wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
         0,
         0,
-    ).expect("failed to create file");
+    )
+    .expect("failed to create file");
     assert_gt!(
         file_fd,
         libc::STDERR_FILENO as wasi::Fd,
@@ -36,21 +37,12 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
     let old_atim = stat.atim;
     let new_mtim = stat.mtim - 100;
     assert!(
-        wasi::fd_filestat_set_times(
-            file_fd,
-            new_mtim,
-            new_mtim,
-            wasi::FSTFLAGS_MTIM,
-        )
-        .is_ok(),
+        wasi::fd_filestat_set_times(file_fd, new_mtim, new_mtim, wasi::FSTFLAGS_MTIM,).is_ok(),
         "fd_filestat_set_times"
     );
 
     let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 3");
-    assert_eq!(
-        stat.size, 100,
-        "file size should remain unchanged at 100"
-    );
+    assert_eq!(stat.size, 100, "file size should remain unchanged at 100");
     assert_eq!(stat.mtim, new_mtim, "mtim should change");
     assert_eq!(stat.atim, old_atim, "atim should not change");
 

--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -48,12 +48,10 @@ impl<'a> Iterator for ReadDir<'a> {
     }
 }
 
-unsafe fn exec_fd_readdir(
-    fd: wasi::Fd,
-    cookie: wasi::Dircookie,
-) -> Vec<DirEntry> {
+unsafe fn exec_fd_readdir(fd: wasi::Fd, cookie: wasi::Dircookie) -> Vec<DirEntry> {
     let mut buf: [u8; BUF_LEN] = [0; BUF_LEN];
-    let bufused = wasi::fd_readdir(fd, buf.as_mut_ptr(), BUF_LEN, cookie).expect("failed fd_readdir");
+    let bufused =
+        wasi::fd_readdir(fd, buf.as_mut_ptr(), BUF_LEN, cookie).expect("failed fd_readdir");
 
     let sl = slice::from_raw_parts(buf.as_ptr(), min(BUF_LEN, bufused));
     let dirs: Vec<_> = ReadDir::from_slice(sl).collect();
@@ -72,22 +70,14 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
     // the first entry should be `.`
     let dir = dirs.next().expect("first entry is None");
     assert_eq!(dir.name, ".", "first name");
-    assert_eq!(
-        dir.dirent.d_type,
-        wasi::FILETYPE_DIRECTORY,
-        "first type"
-    );
+    assert_eq!(dir.dirent.d_type, wasi::FILETYPE_DIRECTORY, "first type");
     assert_eq!(dir.dirent.d_ino, stat.ino);
     assert_eq!(dir.dirent.d_namlen, 1);
 
     // the second entry should be `..`
     let dir = dirs.next().expect("second entry is None");
     assert_eq!(dir.name, "..", "second name");
-    assert_eq!(
-        dir.dirent.d_type,
-        wasi::FILETYPE_DIRECTORY,
-        "second type"
-    );
+    assert_eq!(dir.dirent.d_type, wasi::FILETYPE_DIRECTORY, "second type");
 
     assert!(
         dirs.next().is_none(),
@@ -103,7 +93,8 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
         0,
         0,
-    ).expect("failed to create file");
+    )
+    .expect("failed to create file");
     assert_gt!(
         file_fd,
         libc::STDERR_FILENO as wasi::Fd,

--- a/crates/test-programs/wasi-tests/src/lib.rs
+++ b/crates/test-programs/wasi-tests/src/lib.rs
@@ -1,9 +1,6 @@
 pub mod utils;
 pub mod wasi_wrappers;
 
-use libc;
-use std::ffi::CString;
-use std::io;
 use wasi_old::wasi_unstable;
 
 /// Opens a fresh file descriptor for `path` where `path` should be a preopened
@@ -11,20 +8,27 @@ use wasi_old::wasi_unstable;
 /// `wasi_snapshot_preview1`. This is getting phased out and will likely be
 /// deleted soon.
 pub fn open_scratch_directory(path: &str) -> Result<wasi_unstable::Fd, String> {
-    // Open the scratch directory.
-    let dir_fd: wasi_unstable::Fd = unsafe {
-        let cstr = CString::new(path.as_bytes()).unwrap();
-        libc::open(cstr.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY)
-    } as wasi_unstable::Fd;
+    unsafe {
+        for i in 3.. {
+            let stat = match wasi_unstable::fd_prestat_get(i) {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            if stat.pr_type != wasi::PREOPENTYPE_DIR {
+                continue;
+            }
+            let mut dst = Vec::with_capacity(stat.u.dir.pr_name_len);
+            if wasi::fd_prestat_dir_name(i, dst.as_mut_ptr(), dst.capacity()).is_err() {
+                continue;
+            }
+            dst.set_len(stat.u.dir.pr_name_len);
+            if dst == path.as_bytes() {
+                return Ok(wasi::path_open(i, 0, ".", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+                    .expect("failed to open dir"));
+            }
+        }
 
-    if (dir_fd as std::os::raw::c_int) < 0 {
-        Err(format!(
-            "error opening scratch directory '{}': {}",
-            path,
-            io::Error::last_os_error()
-        ))
-    } else {
-        Ok(dir_fd)
+        Err(format!("failed to find scratch dir"))
     }
 }
 


### PR DESCRIPTION
The previous comment indicated that this was necessary to separate the
build directories but that's already happening due to the usage of
`--target-dir`, so there's no need for `wasi-tests` to live in a
separate part of the workspace.