### PR TITLE
Disable some tests for crates in their manifest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
     - run: cargo fetch
 
     # Build and test all features except for lightbeam
-    - run: cargo test --features test_programs --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py -- --nocapture
+    - run: cargo test --features test_programs --all --exclude lightbeam -- --nocapture
       env:
         RUST_BACKTRACE: 1
         RUSTFLAGS: "-D warnings"
@@ -294,7 +294,7 @@ jobs:
     - run: $CENTOS cargo build --release --manifest-path crates/api/Cargo.toml
       shell: bash
     # Test what we just built
-    - run: $CENTOS cargo test --features test_programs --release --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py --exclude wasmtime --exclude wasmtime-fuzzing
+    - run: $CENTOS cargo test --features test_programs --release --all --exclude lightbeam --exclude wasmtime --exclude wasmtime-fuzzing
       shell: bash
       env:
         RUST_BACKTRACE: 1

--- a/crates/misc/py/Cargo.toml
+++ b/crates/misc/py/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [lib]
 name = "_wasmtime"
 crate-type = ["cdylib"]
+test = false
 
 [dependencies]
 wasmtime = { path = "../../api" }

--- a/crates/wasi-c/Cargo.toml
+++ b/crates/wasi-c/Cargo.toml
@@ -28,3 +28,7 @@ bindgen = "0.51.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[lib]
+test = false
+doctest = false


### PR DESCRIPTION
Instead of passing `--exclude` in CI disable them in the manifest so
`--all` can work with fewer flags locally as well.