### PR TITLE
Fail CI if the lock file needs an update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,7 +155,7 @@ jobs:
     # tests
     - run: rustup target add wasm32-wasi
 
-    - run: cargo fetch
+    - run: cargo fetch --locked
 
     # Build and test all features except for lightbeam
     - run: cargo test --features test_programs --all --exclude lightbeam -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
+ "wig",
 ]
 
 [[package]]


### PR DESCRIPTION
This uses `--locked` on CI to ensure that if the lock file needs
changing it's reflected in the PR instead of letting CI accidentally and
silently update the lock file for us.