### PR TITLE
Bump crate versions to 0.8.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "lightbeam"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1876,7 +1876,7 @@ checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common-cbindgen"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "docopt",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "docopt",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "faerie",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64 0.11.0",
  "bincode",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fuzz"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arbitrary",
  "env_logger 0.7.1",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-interface-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "walrus",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "faerie",
  "more-asserts",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-py"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "pyo3",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cc",
  "indexmap",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust-macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-c"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bindgen 0.51.1",
  "cmake",
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags",
  "cvt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Command-line interface for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "High-level API to expose the Wasmtime runtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-debug"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Debug utils for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-environ"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Standalone environment support for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/interface-types/Cargo.toml
+++ b/crates/interface-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-interface-types"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Support for wasm interface types with wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT-style execution for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightbeam"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Lightbeam Project Developers"]
 description = "An optimising one-pass streaming compiler for WebAssembly"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/misc/py/Cargo.toml
+++ b/crates/misc/py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-py"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Python extension for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Rust extension for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/misc/rust/macro/Cargo.toml
+++ b/crates/misc/rust/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust-macro"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Macro support crate for wasmtime-rust"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-obj"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Native object file output for WebAsssembly code in Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-runtime"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-programs"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 readme = "README.md"
 edition = "2018"

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-tests"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 readme = "README.md"
 edition = "2018"

--- a/crates/wasi-c/Cargo.toml
+++ b/crates/wasi-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-c"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/wasi-common-cbindgen/Cargo.toml
+++ b/crates/wasi-common/wasi-common-cbindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common-cbindgen"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jakub Konka <kubkon@jakubkonka.com>"]
 description = "Interface generator utilities used by wasi-common"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/wig/Cargo.toml
+++ b/crates/wasi-common/wig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wig"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dan Gohman <sunfish@mozilla.com>"]
 description = "WebAssembly Interface Generator"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/winx/Cargo.toml
+++ b/crates/wasi-common/winx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winx"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jakub Konka <kubkon@jakubkonka.com>"]
 description = "Windows API helper library"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wast"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 description = "wast testing support for wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-fuzz"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
Bumping the crate versions to 0.8.0 to match what is currently published.