### PR TITLE
Make `invoke` public.

### DIFF
--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -35,7 +35,7 @@ mod target_tunables;
 pub mod native;
 pub mod trampoline;
 
-pub use crate::action::{ActionError, ActionOutcome, RuntimeValue};
+pub use crate::action::{invoke, ActionError, ActionOutcome, RuntimeValue};
 pub use crate::code_memory::CodeMemory;
 pub use crate::compiler::{CompilationStrategy, Compiler};
 pub use crate::context::{Context, ContextError, Features, UnknownInstance};


### PR DESCRIPTION
It seems that `Context` is the primary way of interaction with the API despite its description of being just "a convenient context". It seems, however, that it doesn't support instantiating instances with a custom `Resolver`. FWIW, my use case is to resolve functions from some host module even though they don't exist there trapping if they actually called.

It is pretty easy to workaround by avoiding the using context, with one little caveat: invoking an exported function is not possible without using the `Context`.

This simple PR just publishes this function.