### PR TITLE
wasi-common/yanix: fix FreeBSD support

### DIFF
--- a/crates/jit/src/function_table.rs
+++ b/crates/jit/src/function_table.rs
@@ -109,14 +109,14 @@ impl Drop for FunctionTable {
 /// Represents a runtime function table.
 ///
 /// This is used to register JIT code with the operating system to enable stack walking and unwinding.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(unix)]
 pub(crate) struct FunctionTable {
     functions: Vec<u32>,
     relocs: Vec<FunctionTableReloc>,
     published: Option<Vec<usize>>,
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(unix)]
 impl FunctionTable {
     /// Creates a new function table.
     pub fn new() -> Self {
@@ -191,7 +191,7 @@ impl FunctionTable {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(unix)]
 impl Drop for FunctionTable {
     fn drop(&mut self) {
         extern "C" {

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -34,7 +34,7 @@ use wasmtime_environ::wasm::{
 use wasmtime_environ::{DataInitializer, Module, TableElements, VMOffsets};
 
 cfg_if::cfg_if! {
-    if #[cfg(any(target_os = "linux", target_os = "macos"))] {
+    if #[cfg(unix)] {
         pub type SignalHandler = dyn Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool;
 
         impl InstanceHandle {

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -30,7 +30,7 @@ extern "C" {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(any(target_os = "linux", target_os = "macos"))] {
+    if #[cfg(unix)] {
         #[no_mangle]
         pub unsafe extern "C" fn HandleTrap(
             pc: *mut u8,

--- a/crates/wasi-common/yanix/src/sys/bsd/dir.rs
+++ b/crates/wasi-common/yanix/src/sys/bsd/dir.rs
@@ -42,6 +42,12 @@ pub(crate) fn iter_impl(dir: &Dir) -> Option<Result<EntryImpl>> {
 }
 
 impl EntryExt for Entry {
+    #[cfg(target_os = "freebsd")]
+    fn ino(&self) -> u64 {
+        self.0.d_fileno.into()
+    }
+
+    #[cfg(not(target_os = "freebsd"))]
     fn ino(&self) -> u64 {
         self.0.d_ino.into()
     }


### PR DESCRIPTION
- there is no `O_DSYNC`, [define that to zero](https://reviews.freebsd.org/D19407#inline-118670), same with `O_RSYNC`
  - can't have another top level `cfg` for `not(…)` in the bitflags because https://github.com/bitflags/bitflags/issues/137 but `cfg_if` is better anyway (platforms only listed once)
- `d_fileno` for inode