### PR TITLE
Publish Python packages on pypi on every git tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [master, deploy-python-wheel-to-pypi]
     tags-ignore: [dev]
   pull_request:
     branches: [master]
@@ -408,7 +408,7 @@ jobs:
   # github releases and/or tags for pushes.
   publish:
     name: Publish
-    needs: [doc_book, doc_api, wheels, build]
+    needs: [doc_book, doc_api, wheels, build, wheels]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -493,6 +493,25 @@ jobs:
         name: tarballs
         path: dist
 
+    # The action 'pypa/gh-action-pypi-publish' will try to upload all files in the
+    # dist/ folder. This folder also contains non-package files, and therefore the
+    # action fails.
+    #
+    # To prevent the action from failing all .whl files are copied into a new
+    # directory.
+    - run: |
+        mkdir -p tmp/whl
+        find dist/ -name '*.whl' -type f -exec cp '{}' tmp/whl -v \;
+
+    - name: Publish Python wheels on Pypi
+      uses: pypa/gh-action-pypi-publish@master
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        packages_dir: tmp/whl
+        repository_url: https://test.pypi.org/legacy/
+
     # ... and if this was an actual push (tag or `master`) then we publish a
     # new release. This'll automatically publish a tag release or update `dev`
     # with this `sha`
@@ -503,3 +522,4 @@ jobs:
         files: "dist/*"
         name: ${{ steps.tagname.outputs.val }}
         token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, deploy-python-wheel-to-pypi]
+    branches: [master]
     tags-ignore: [dev]
   pull_request:
     branches: [master]
@@ -510,7 +510,6 @@ jobs:
         user: __token__
         password: ${{ secrets.pypi_password }}
         packages_dir: tmp/whl
-        repository_url: https://test.pypi.org/legacy/
 
     # ... and if this was an actual push (tag or `master`) then we publish a
     # new release. This'll automatically publish a tag release or update `dev`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -408,7 +408,7 @@ jobs:
   # github releases and/or tags for pushes.
   publish:
     name: Publish
-    needs: [doc_book, doc_api, wheels, build, wheels]
+    needs: [doc_book, doc_api, wheels, build]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -504,7 +504,7 @@ jobs:
         find dist/ -name '*.whl' -type f -exec cp '{}' tmp/whl -v \;
 
     - name: Publish Python wheels on Pypi
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.0.0a0
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       with:
         user: __token__


### PR DESCRIPTION
This commit adds support for publishing the wasmtime Python packages to the Python Package Index (pypi) on every release.

This PR consists of 2 commits. Most work is done in 1f51bed001498c2cfa01cd0b7a5a8527fe2f6483.
In order to test my changes I had to introduce things which I undid it the last commit 970313b1cb8eb583b681b54cd07601055e26fe61

1) Publish the package to the [pypi test index](https://test.pypi.org/).
2) Make the CI  job run on my feature branch.

You can see the logs of the CI job in [here](https://github.com/orangetux/wasmtime/commit/cc1a86a2fe041dd22acf15a88fc4cdd69ac2fab2/checks?check_suite_id=386094253).

**Note** The CI job requires an access token in order to upload the packages to pypi. The token can be obtained in the settings menu of the package. See the screenshot:

![Screenshot_2020-01-06_14-50-16](https://user-images.githubusercontent.com/1565144/71822064-2b6bce80-3094-11ea-990b-ef4bf157cddf.png)

This token must be added to Github as a secret by the name **pypi_password** as is shown in the screenshot.
![Screenshot_2020-01-06_14-53-26](https://user-images.githubusercontent.com/1565144/71822158-7554b480-3094-11ea-84b3-9fe3b7fc2cf9.png)

Fixes: #312 