### PR TITLE
Remove need for `HostRef<Engine>`

### DIFF
--- a/crates/api/examples/gcd.rs
+++ b/crates/api/examples/gcd.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
     let wasm = wat::parse_str(WAT)?;
 
     // Instantiate engine and store.
-    let engine = HostRef::new(Engine::default());
+    let engine = Engine::default();
     let store = HostRef::new(Store::new(&engine));
 
     // Load a module.

--- a/crates/api/examples/hello.rs
+++ b/crates/api/examples/hello.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
     // Configure the initial compilation environment, creating more global
     // structures such as an `Engine` and a `Store`.
     println!("Initializing...");
-    let engine = HostRef::new(Engine::default());
+    let engine = Engine::default();
     let store = HostRef::new(Store::new(&engine));
 
     // Next upload the `*.wasm` binary file, which in this case we're going to

--- a/crates/api/examples/memory.rs
+++ b/crates/api/examples/memory.rs
@@ -62,7 +62,7 @@ macro_rules! call {
 fn main() -> Result<(), Error> {
     // Initialize.
     println!("Initializing...");
-    let engine = HostRef::new(Engine::default());
+    let engine = Engine::default();
     let store = HostRef::new(Store::new(&engine));
 
     // Load binary.

--- a/crates/api/examples/multi.rs
+++ b/crates/api/examples/multi.rs
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
         multi_value: true,
         ..Default::default()
     });
-    let engine = HostRef::new(Engine::new(&cfg));
+    let engine = Engine::new(&cfg);
     let store = HostRef::new(Store::new(&engine));
 
     // Load binary.

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -43,7 +43,7 @@ use wasmtime_runtime::Export;
 /// "#)?;
 ///
 /// // Initialise environment and our module.
-/// let engine = HostRef::new(wasmtime::Engine::default());
+/// let engine = wasmtime::Engine::default();
 /// let store = HostRef::new(wasmtime::Store::new(&engine));
 /// let module = HostRef::new(wasmtime::Module::new(&store, &binary)?);
 ///

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -204,7 +204,7 @@ impl Module {
         }
     }
     pub fn validate(store: &HostRef<Store>, binary: &[u8]) -> Result<()> {
-        let features = store.borrow().engine().borrow().config.features.clone();
+        let features = store.borrow().engine().config.features.clone();
         let config = ValidatingParserConfig {
             operator_config: OperatorValidatorConfig {
                 enable_threads: features.threads,

--- a/crates/api/src/wasm.rs
+++ b/crates/api/src/wasm.rs
@@ -778,7 +778,7 @@ pub unsafe extern "C" fn wasm_store_delete(store: *mut wasm_store_t) {
 pub unsafe extern "C" fn wasm_store_new(engine: *mut wasm_engine_t) -> *mut wasm_store_t {
     let engine = &(*engine).engine;
     let store = Box::new(wasm_store_t {
-        store: HostRef::new(Store::new(&engine)),
+        store: HostRef::new(Store::new(&engine.borrow())),
     });
     Box::into_raw(store)
 }

--- a/crates/api/tests/import_calling_export.rs
+++ b/crates/api/tests/import_calling_export.rs
@@ -32,7 +32,7 @@ fn test_import_calling_export() {
         }
     }
 
-    let engine = HostRef::new(Engine::default());
+    let engine = Engine::default();
     let store = HostRef::new(Store::new(&engine));
     let wasm = wat::parse_str(WAT).unwrap();
     let module = HostRef::new(Module::new(&store, &wasm).expect("failed to create module"));

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -12,7 +12,7 @@ fn test_trap_return() -> Result<(), String> {
         }
     }
 
-    let engine = HostRef::new(Engine::default());
+    let engine = Engine::default();
     let store = HostRef::new(Store::new(&engine));
     let binary = parse_str(
         r#"

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -40,7 +40,7 @@ pub fn instantiate(wasm: &[u8], compilation_strategy: CompilationStrategy) {
     let mut config = Config::new();
     config.strategy(compilation_strategy);
 
-    let engine = HostRef::new(Engine::new(&config));
+    let engine = Engine::new(&config);
     let store = HostRef::new(Store::new(&engine));
 
     let module =
@@ -89,7 +89,7 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
     use crate::generators::api::ApiCall;
 
     let mut config: Option<Config> = None;
-    let mut engine: Option<HostRef<Engine>> = None;
+    let mut engine: Option<Engine> = None;
     let mut store: Option<HostRef<Store>> = None;
     let mut modules: HashMap<usize, HostRef<Module>> = Default::default();
     let mut instances: HashMap<usize, HostRef<Instance>> = Default::default();
@@ -107,7 +107,7 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
 
             ApiCall::EngineNew => {
                 assert!(engine.is_none());
-                engine = Some(HostRef::new(Engine::new(config.as_ref().unwrap())));
+                engine = Some(Engine::new(config.as_ref().unwrap()));
             }
 
             ApiCall::StoreNew => {

--- a/crates/misc/py/src/lib.rs
+++ b/crates/misc/py/src/lib.rs
@@ -92,7 +92,7 @@ pub fn instantiate(
         ..Default::default()
     });
 
-    let engine = wasmtime::HostRef::new(wasmtime::Engine::new(&config));
+    let engine = wasmtime::Engine::new(&config);
     let store = wasmtime::HostRef::new(wasmtime::Store::new(&engine));
 
     let module = wasmtime::HostRef::new(wasmtime::Module::new(&store, wasm_data).map_err(err2py)?);

--- a/crates/misc/rust/macro/src/lib.rs
+++ b/crates/misc/rust/macro/src/lib.rs
@@ -56,7 +56,7 @@ fn generate_load(item: &syn::ItemTrait) -> syn::Result<TokenStream> {
                 multi_value: true,
                 ..Default::default()
             });
-            let engine = HostRef::new(Engine::new(&config));
+            let engine = Engine::new(&config);
             let store = HostRef::new(Store::new(&engine));
             let global_exports = store.borrow().global_exports().clone();
 

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -15,7 +15,7 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
 
     let mut config = Config::new();
     config.flags(settings::Flags::new(flag_builder));
-    let engine = HostRef::new(Engine::new(&config));
+    let engine = Engine::new(&config);
     let store = HostRef::new(Store::new(&engine));
 
     let global_exports = store.borrow().global_exports().clone();

--- a/docs/embed-rust.md
+++ b/docs/embed-rust.md
@@ -38,7 +38,7 @@ It is time to add code to the `src/main.rs`. First, the engine and storage need 
 ```rust
 use wasmtime::*;
 
-let engine = HostRef::new(Engine::default());
+let engine = Engine::default();
 let store = HostRef::new(Store::new(&engine));
 ```
 
@@ -87,7 +87,7 @@ use std::fs::read;
 use wasmtime::*;
 
 fn main() {
-    let engine = HostRef::new(Engine::default());
+    let engine = Engine::default();
     let store = HostRef::new(Store::new(&engine));
 
     let wasm = read("hello.wasm").expect("wasm file");

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -266,7 +266,7 @@ fn main() -> Result<()> {
         .flags(settings::Flags::new(flag_builder))
         .debug_info(debug_info)
         .strategy(strategy);
-    let engine = HostRef::new(Engine::new(&config));
+    let engine = Engine::new(&config);
     let store = HostRef::new(Store::new(&engine));
 
     let mut module_registry = HashMap::new();

--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -154,7 +154,7 @@ fn main() {
     cfg.strategy(strategy)
         .flags(settings::Flags::new(flag_builder))
         .features(features);
-    let store = HostRef::new(Store::new(&HostRef::new(Engine::new(&cfg))));
+    let store = HostRef::new(Store::new(&Engine::new(&cfg)));
     let mut wast_context = WastContext::new(store);
 
     wast_context

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -27,7 +27,7 @@ fn run_wast(wast: &str, strategy: CompilationStrategy) -> anyhow::Result<()> {
     cfg.strategy(strategy)
         .flags(settings::Flags::new(flag_builder))
         .features(features);
-    let store = HostRef::new(Store::new(&HostRef::new(Engine::new(&cfg))));
+    let store = HostRef::new(Store::new(&Engine::new(&cfg)));
     let mut wast_context = WastContext::new(store);
     wast_context.register_spectest()?;
     wast_context.run_file(wast)?;


### PR DESCRIPTION
This commit removes the need to use `HostRef<Engine>` in the Rust API.
Usage is retained in the C API in one location, but otherwise `Engine`
can always be used directly.

This is the first step of progress on #708 for the `Engine` type.
Changes here include:

* `Engine` is now `Clone`, and is documented as being cheap. It's not
  intended that cloning an engine creates a deep copy.
* `Engine` is now both `Send` and `Sync`, and asserted to be so.
* Usage of `Engine` in APIs no longer requires or uses `HostRef`.