### PR TITLE
Remove usage of `Features` from `wasmtime::Config` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,6 @@ dependencies = [
  "wasmtime",
  "wasmtime-environ",
  "wasmtime-interface-types",
- "wasmtime-jit",
  "wasmtime-runtime",
  "wasmtime-wasi",
 ]
@@ -2160,7 +2159,6 @@ dependencies = [
  "anyhow",
  "wasmtime",
  "wasmtime-interface-types",
- "wasmtime-jit",
  "wasmtime-rust-macro",
  "wasmtime-wasi",
 ]

--- a/crates/api/examples/multi.rs
+++ b/crates/api/examples/multi.rs
@@ -45,12 +45,7 @@ const WAT: &str = r#"
 fn main() -> Result<()> {
     // Initialize.
     println!("Initializing...");
-    let mut cfg = Config::new();
-    cfg.features(wasmtime_jit::Features {
-        multi_value: true,
-        ..Default::default()
-    });
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(Config::new().wasm_multi_value(true));
     let store = HostRef::new(Store::new(&engine));
 
     // Load binary.

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -59,16 +59,102 @@ impl Config {
         self
     }
 
-    /// Indicates which WebAssembly features are enabled for this compilation
-    /// session.
+    /// Configures whether the WebAssembly threads proposal will be enabled for
+    /// compilation.
     ///
-    /// By default only stable features are enabled by default (and none are
-    /// fully stabilized yet at this time). If you're loading wasm modules
-    /// which may use non-MVP features you'll want to be sure to call this
-    /// method and enable the appropriate feature in the [`Features`]
-    /// structure.
-    pub fn features(&mut self, features: Features) -> &mut Self {
-        self.features = features;
+    /// The [WebAssembly threads proposal][threads] is not currently fully
+    /// standardized and is undergoing development. Additionally the support in
+    /// wasmtime itself is still being worked on. Support for this feature can
+    /// be enabled through this method for appropriate wasm modules.
+    ///
+    /// This feature gates items such as shared memories and atomic
+    /// instructions.
+    ///
+    /// This is `false` by default.
+    ///
+    /// [threads]: https://github.com/webassembly/threads
+    pub fn wasm_threads(&mut self, enable: bool) -> &mut Self {
+        self.features.threads = enable;
+        self
+    }
+
+    /// Configures whether the WebAssembly reference types proposal will be
+    /// enabled for compilation.
+    ///
+    /// The [WebAssembly reference types proposal][proposal] is not currently
+    /// fully standardized and is undergoing development. Additionally the
+    /// support in wasmtime itself is still being worked on. Support for this
+    /// feature can be enabled through this method for appropriate wasm
+    /// modules.
+    ///
+    /// This feature gates items such as the `anyref` type and multiple tables
+    /// being in a module.
+    ///
+    /// This is `false` by default.
+    ///
+    /// [proposal]: https://github.com/webassembly/reference-types
+    pub fn wasm_reference_types(&mut self, enable: bool) -> &mut Self {
+        self.features.reference_types = enable;
+        self
+    }
+
+    /// Configures whether the WebAssembly SIMD proposal will be
+    /// enabled for compilation.
+    ///
+    /// The [WebAssembly SIMD proposal][proposal] is not currently
+    /// fully standardized and is undergoing development. Additionally the
+    /// support in wasmtime itself is still being worked on. Support for this
+    /// feature can be enabled through this method for appropriate wasm
+    /// modules.
+    ///
+    /// This feature gates items such as the `v128` type and all of its
+    /// operators being in a module.
+    ///
+    /// This is `false` by default.
+    ///
+    /// [proposal]: https://github.com/webassembly/simd
+    pub fn wasm_simd(&mut self, enable: bool) -> &mut Self {
+        self.features.simd = enable;
+        self
+    }
+
+    /// Configures whether the WebAssembly bulk memory operations proposal will
+    /// be enabled for compilation.
+    ///
+    /// The [WebAssembly bulk memory operations proposal][proposal] is not
+    /// currently fully standardized and is undergoing development.
+    /// Additionally the support in wasmtime itself is still being worked on.
+    /// Support for this feature can be enabled through this method for
+    /// appropriate wasm modules.
+    ///
+    /// This feature gates items such as the `memory.copy` instruction, passive
+    /// data/table segments, etc, being in a module.
+    ///
+    /// This is `false` by default.
+    ///
+    /// [proposal]: https://github.com/webassembly/bulk-memory-operations
+    pub fn wasm_bulk_memory(&mut self, enable: bool) -> &mut Self {
+        self.features.bulk_memory = enable;
+        self
+    }
+
+    /// Configures whether the WebAssembly multi-value proposal will
+    /// be enabled for compilation.
+    ///
+    /// The [WebAssembly multi-value proposal][proposal] is not
+    /// currently fully standardized and is undergoing development.
+    /// Additionally the support in wasmtime itself is still being worked on.
+    /// Support for this feature can be enabled through this method for
+    /// appropriate wasm modules.
+    ///
+    /// This feature gates functions and blocks returning multiple values in a
+    /// module, for example.
+    ///
+    /// This is `false` by default.
+    ///
+    /// [proposal]: https://github.com/webassembly/multi-value
+    pub fn wasm_multi_value(&mut self, enable: bool) -> &mut Self {
+        self.features.multi_value = enable;
         self
     }
 

--- a/crates/misc/py/Cargo.toml
+++ b/crates/misc/py/Cargo.toml
@@ -19,7 +19,6 @@ test = false
 wasmtime = { path = "../../api" }
 wasmtime-environ = { path = "../../environ" }
 wasmtime-interface-types = { path = "../../interface-types" }
-wasmtime-jit = { path = "../../jit" }
 wasmtime-runtime = { path = "../../runtime" }
 wasmtime-wasi = { path = "../../wasi" }
 target-lexicon = { version = "0.9.0", default-features = false }

--- a/crates/misc/py/src/lib.rs
+++ b/crates/misc/py/src/lib.rs
@@ -10,7 +10,6 @@ use pyo3::types::{PyAny, PyBytes, PyDict, PySet};
 use pyo3::wrap_pyfunction;
 use std::rc::Rc;
 use wasmtime_interface_types::ModuleData;
-use wasmtime_jit::Features;
 
 mod function;
 mod instance;
@@ -86,13 +85,7 @@ pub fn instantiate(
 ) -> PyResult<Py<InstantiateResultObject>> {
     let wasm_data = buffer_source.as_bytes();
 
-    let mut config = wasmtime::Config::new();
-    config.features(Features {
-        multi_value: true,
-        ..Default::default()
-    });
-
-    let engine = wasmtime::Engine::new(&config);
+    let engine = wasmtime::Engine::new(&wasmtime::Config::new().wasm_multi_value(true));
     let store = wasmtime::HostRef::new(wasmtime::Store::new(&engine));
 
     let module = wasmtime::HostRef::new(wasmtime::Module::new(&store, wasm_data).map_err(err2py)?);

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 
 [dependencies]
 wasmtime-interface-types = { path = "../../interface-types" }
-wasmtime-jit = { path = "../../jit" }
 wasmtime-rust-macro = { path = "./macro" }
 wasmtime-wasi = { path = "../../wasi" }
 wasmtime = { path = "../../api" }

--- a/crates/misc/rust/macro/src/lib.rs
+++ b/crates/misc/rust/macro/src/lib.rs
@@ -51,12 +51,7 @@ fn generate_load(item: &syn::ItemTrait) -> syn::Result<TokenStream> {
             use #root::wasmtime::{HostRef, Config, Extern, Engine, Store, Instance, Module};
             use #root::anyhow::{bail, format_err};
 
-            let mut config = Config::new();
-            config.features(#root::wasmtime_jit::Features {
-                multi_value: true,
-                ..Default::default()
-            });
-            let engine = Engine::new(&config);
+            let engine = Engine::new(Config::new().wasm_multi_value(true));
             let store = HostRef::new(Store::new(&engine));
             let global_exports = store.borrow().global_exports().clone();
 

--- a/crates/misc/rust/src/lib.rs
+++ b/crates/misc/rust/src/lib.rs
@@ -6,7 +6,6 @@ pub mod __rt {
     pub use anyhow;
     pub use wasmtime;
     pub use wasmtime_interface_types;
-    pub use wasmtime_jit;
     pub use wasmtime_wasi;
 
     use std::convert::{TryFrom, TryInto};

--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -32,7 +32,6 @@ use wasmtime_cli::pick_compilation_strategy;
 use wasmtime_environ::settings;
 use wasmtime_environ::settings::Configurable;
 use wasmtime_environ::{cache_create_new_config, cache_init};
-use wasmtime_jit::Features;
 use wasmtime_wast::WastContext;
 
 const USAGE: &str = "
@@ -125,8 +124,8 @@ fn main() {
         process::exit(1);
     }
 
+    let mut cfg = Config::new();
     let mut flag_builder = settings::builder();
-    let mut features: Features = Default::default();
 
     // There are two possible traps for division, and this way
     // we get the proper one if code traps.
@@ -145,15 +144,13 @@ fn main() {
     // Enable SIMD if requested
     if args.flag_enable_simd {
         flag_builder.enable("enable_simd").unwrap();
-        features.simd = true;
+        cfg.wasm_simd(true);
     }
 
     // Decide how to compile.
     let strategy = pick_compilation_strategy(args.flag_cranelift, args.flag_lightbeam);
-    let mut cfg = Config::new();
     cfg.strategy(strategy)
-        .flags(settings::Flags::new(flag_builder))
-        .features(features);
+        .flags(settings::Flags::new(flag_builder));
     let store = HostRef::new(Store::new(&Engine::new(&cfg)));
     let mut wast_context = WastContext::new(store);
 


### PR DESCRIPTION
Instead expose a number of boolean accessors which doesn't require users
to construct a foreign `Features` type and allows us to decouple the API
of the `wasmtime` crate from the underlying implementation detail.

cc #708 