### PR TITLE
Remove usage of `CompilationStrategy` from `Config` 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,7 +207,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2019-08-15
+        toolchain: nightly-2020-01-06
     - uses: ./.github/actions/binary-compatible-builds
     - run: mkdir crates/misc/py/wheelhouse
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ dependencies = [
 name = "wasmtime-environ"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "base64 0.11.0",
  "bincode",
  "cranelift-codegen",
@@ -2115,6 +2116,7 @@ dependencies = [
 name = "wasmtime-obj"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "faerie",
  "more-asserts",
  "wasmtime-environ",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,6 +2055,7 @@ dependencies = [
  "env_logger 0.7.1",
  "libfuzzer-sys",
  "log",
+ "wasmtime",
  "wasmtime-fuzzing",
  "wasmtime-jit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,8 @@ members = [
 lightbeam = [
     "wasmtime-environ/lightbeam",
     "wasmtime-jit/lightbeam",
-    "wasmtime-wast/lightbeam"
+    "wasmtime-wast/lightbeam",
+    "wasmtime/lightbeam",
 ]
 wasi-c = ["wasmtime-wasi-c"]
 test_programs = ["test-programs/test_programs"]

--- a/build.rs
+++ b/build.rs
@@ -149,7 +149,7 @@ fn write_testsuite_tests(
     writeln!(out, "fn r#{}() -> anyhow::Result<()> {{", &testname)?;
     writeln!(
         out,
-        "crate::run_wast(r#\"{}\"#, crate::CompilationStrategy::{})",
+        "crate::run_wast(r#\"{}\"#, crate::Strategy::{})",
         path.display(),
         strategy
     )?;

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -36,3 +36,9 @@ wat = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+# Enables experimental support for the lightbeam codegen backend, an alternative
+# to cranelift. Requires Nightly Rust currently, and this is not enabled by
+# default.
+lightbeam = ["wasmtime-jit/lightbeam"]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::externals::*;
 pub use crate::instance::Instance;
 pub use crate::module::Module;
 pub use crate::r#ref::{AnyRef, HostInfo, HostRef};
-pub use crate::runtime::{Config, Engine, Store};
+pub use crate::runtime::{Config, Engine, Store, Strategy};
 pub use crate::trap::{FrameInfo, Trap, TrapInfo};
 pub use crate::types::*;
 pub use crate::values::*;

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 cranelift-codegen = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-entity = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-wasm = { version = "0.52.0", features = ["enable-serde"] }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -32,14 +32,15 @@ fn host_isa() -> Box<dyn isa::TargetIsa> {
 /// Performs initial validation, and returns early if the Wasm is invalid.
 ///
 /// You can control which compiler is used via passing a `CompilationStrategy`.
-pub fn instantiate(wasm: &[u8], compilation_strategy: CompilationStrategy) {
+pub fn instantiate(wasm: &[u8], strategy: Strategy) {
     if wasmparser::validate(wasm, None).is_err() {
         return;
     }
 
     let mut config = Config::new();
-    config.strategy(compilation_strategy);
-
+    config
+        .strategy(strategy)
+        .expect("failed to enable lightbeam");
     let engine = Engine::new(&config);
     let store = HostRef::new(Store::new(&engine));
 

--- a/crates/fuzzing/tests/regressions.rs
+++ b/crates/fuzzing/tests/regressions.rs
@@ -5,10 +5,11 @@
 //! use the Wasm binary by including it via
 //! `include_bytes!("./regressions/some-descriptive-name.wasm")`.
 
+use wasmtime::Strategy;
 use wasmtime_fuzzing::oracles;
 
 #[test]
 fn instantiate_empty_module() {
     let data = wat::parse_str(include_str!("./regressions/empty.wat")).unwrap();
-    oracles::instantiate(&data, wasmtime_jit::CompilationStrategy::Auto);
+    oracles::instantiate(&data, Strategy::Auto);
 }

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 wasmtime-environ = { path = "../environ" }
 faerie = "0.13.0"
 more-asserts = "0.2.1"

--- a/crates/obj/src/data_segment.rs
+++ b/crates/obj/src/data_segment.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use faerie::{Artifact, Decl};
 use wasmtime_environ::DataInitializer;
 
@@ -6,10 +7,9 @@ pub fn declare_data_segment(
     obj: &mut Artifact,
     _data_initaliazer: &DataInitializer,
     index: usize,
-) -> Result<(), String> {
+) -> Result<()> {
     let name = format!("_memory_{}", index);
-    obj.declare(name, Decl::data())
-        .map_err(|err| format!("{}", err))?;
+    obj.declare(name, Decl::data())?;
     Ok(())
 }
 
@@ -18,9 +18,8 @@ pub fn emit_data_segment(
     obj: &mut Artifact,
     data_initaliazer: &DataInitializer,
     index: usize,
-) -> Result<(), String> {
+) -> Result<()> {
     let name = format!("_memory_{}", index);
-    obj.define(name, Vec::from(data_initaliazer.data))
-        .map_err(|err| format!("{}", err))?;
+    obj.define(name, Vec::from(data_initaliazer.data))?;
     Ok(())
 }

--- a/crates/obj/src/module.rs
+++ b/crates/obj/src/module.rs
@@ -2,6 +2,7 @@ use crate::context::layout_vmcontext;
 use crate::data_segment::{declare_data_segment, emit_data_segment};
 use crate::function::{declare_functions, emit_functions};
 use crate::table::{declare_table, emit_table};
+use anyhow::Result;
 use faerie::{Artifact, Decl, Link};
 use wasmtime_environ::isa::TargetFrontendConfig;
 use wasmtime_environ::{Compilation, DataInitializer, Module, Relocations};
@@ -10,18 +11,16 @@ fn emit_vmcontext_init(
     obj: &mut Artifact,
     module: &Module,
     target_config: &TargetFrontendConfig,
-) -> Result<(), String> {
+) -> Result<()> {
     let (data, table_relocs) = layout_vmcontext(module, target_config);
-    obj.declare_with("_vmcontext_init", Decl::data().global(), data.to_vec())
-        .map_err(|err| format!("{}", err))?;
+    obj.declare_with("_vmcontext_init", Decl::data().global(), data.to_vec())?;
     for reloc in table_relocs.iter() {
         let target_name = format!("_table_{}", reloc.index);
         obj.link(Link {
             from: "_vmcontext_init",
             to: &target_name,
             at: reloc.offset as u64,
-        })
-        .map_err(|err| format!("{}", err))?;
+        })?;
     }
     Ok(())
 }
@@ -35,7 +34,7 @@ pub fn emit_module(
     relocations: &Relocations,
     data_initializers: &[DataInitializer],
     target_config: &TargetFrontendConfig,
-) -> Result<(), String> {
+) -> Result<()> {
     declare_functions(obj, module, relocations)?;
 
     for (i, initializer) in data_initializers.iter().enumerate() {

--- a/crates/obj/src/table.rs
+++ b/crates/obj/src/table.rs
@@ -1,18 +1,17 @@
+use anyhow::Result;
 use faerie::{Artifact, Decl};
 
 /// Declares data segment symbol
-pub fn declare_table(obj: &mut Artifact, index: usize) -> Result<(), String> {
+pub fn declare_table(obj: &mut Artifact, index: usize) -> Result<()> {
     let name = format!("_table_{}", index);
-    obj.declare(name, Decl::data())
-        .map_err(|err| format!("{}", err))?;
+    obj.declare(name, Decl::data())?;
     Ok(())
 }
 
 /// Emit segment data and initialization location
-pub fn emit_table(obj: &mut Artifact, index: usize) -> Result<(), String> {
+pub fn emit_table(obj: &mut Artifact, index: usize) -> Result<()> {
     let name = format!("_table_{}", index);
     // FIXME: We need to initialize table using function symbols
-    obj.define(name, Vec::new())
-        .map_err(|err| format!("{}", err))?;
+    obj.define(name, Vec::new())?;
     Ok(())
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = "0.7.1"
 log = "0.4.8"
 wasmtime-fuzzing = { path = "../crates/fuzzing", features = ["env_logger"] }
 wasmtime-jit = { path = "../crates/jit" }
+wasmtime = { path = "../crates/api" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/fuzz/fuzz_targets/instantiate.rs
+++ b/fuzz/fuzz_targets/instantiate.rs
@@ -1,12 +1,9 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use wasmtime::Strategy;
 use wasmtime_fuzzing::{oracles, with_log_wasm_test_case};
-use wasmtime_jit::CompilationStrategy;
 
 fuzz_target!(|data: &[u8]| {
-    with_log_wasm_test_case!(data, |data| oracles::instantiate(
-        data,
-        CompilationStrategy::Auto
-    ));
+    with_log_wasm_test_case!(data, |data| oracles::instantiate(data, Strategy::Auto,));
 });

--- a/fuzz/fuzz_targets/instantiate_translated.rs
+++ b/fuzz/fuzz_targets/instantiate_translated.rs
@@ -1,8 +1,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use wasmtime_fuzzing::{generators, oracles, with_log_wasm_test_case};
 use wasmtime::Strategy;
+use wasmtime_fuzzing::{generators, oracles, with_log_wasm_test_case};
 
 fuzz_target!(|data: generators::WasmOptTtf| {
     with_log_wasm_test_case!(&data.wasm, |wasm| oracles::instantiate(

--- a/fuzz/fuzz_targets/instantiate_translated.rs
+++ b/fuzz/fuzz_targets/instantiate_translated.rs
@@ -2,11 +2,11 @@
 
 use libfuzzer_sys::fuzz_target;
 use wasmtime_fuzzing::{generators, oracles, with_log_wasm_test_case};
-use wasmtime_jit::CompilationStrategy;
+use wasmtime::Strategy;
 
 fuzz_target!(|data: generators::WasmOptTtf| {
     with_log_wasm_test_case!(&data.wasm, |wasm| oracles::instantiate(
         wasm,
-        CompilationStrategy::Auto
+        Strategy::Auto,
     ));
 });

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -257,11 +257,11 @@ fn main() -> Result<()> {
     }
 
     // Decide how to compile.
-    let strategy = pick_compilation_strategy(args.flag_cranelift, args.flag_lightbeam);
-
-    config
-        .flags(settings::Flags::new(flag_builder))
-        .strategy(strategy);
+    config.strategy(pick_compilation_strategy(
+        args.flag_cranelift,
+        args.flag_lightbeam,
+    )?)?;
+    config.flags(settings::Flags::new(flag_builder));
     let engine = Engine::new(&config);
     let store = HostRef::new(Store::new(&engine));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,13 @@
-use wasmtime_jit::CompilationStrategy;
+use anyhow::{bail, Result};
+use wasmtime::Strategy;
 
-pub fn pick_compilation_strategy(cranelift: bool, lightbeam: bool) -> CompilationStrategy {
-    // Decide how to compile.
-    match (lightbeam, cranelift) {
-        #[cfg(feature = "lightbeam")]
-        (true, false) => CompilationStrategy::Lightbeam,
-        #[cfg(not(feature = "lightbeam"))]
-        (true, false) => panic!("--lightbeam given, but Lightbeam support is not enabled"),
-        (false, true) => CompilationStrategy::Cranelift,
-        (false, false) => CompilationStrategy::Auto,
-        (true, true) => panic!("Can't enable --cranelift and --lightbeam at the same time"),
-    }
+pub fn pick_compilation_strategy(cranelift: bool, lightbeam: bool) -> Result<Strategy> {
+    Ok(match (lightbeam, cranelift) {
+        (true, false) => Strategy::Lightbeam,
+        (false, true) => Strategy::Cranelift,
+        (false, false) => Strategy::Auto,
+        (true, true) => bail!("Can't enable --cranelift and --lightbeam at the same time"),
+    })
 }
 
 pub fn init_file_per_thread_logger(prefix: &'static str) {

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -1,8 +1,7 @@
 use std::path::Path;
-use wasmtime::{Config, Engine, HostRef, Store};
+use wasmtime::{Config, Engine, HostRef, Store, Strategy};
 use wasmtime_environ::settings;
 use wasmtime_environ::settings::Configurable;
-use wasmtime_jit::CompilationStrategy;
 use wasmtime_wast::WastContext;
 
 include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
@@ -10,7 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
 // Each of the tests included from `wast_testsuite_tests` will call this
 // function which actually executes the `wast` test suite given the `strategy`
 // to compile it.
-fn run_wast(wast: &str, strategy: CompilationStrategy) -> anyhow::Result<()> {
+fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
     let wast = Path::new(wast);
 
     let mut flag_builder = settings::builder();
@@ -21,7 +20,7 @@ fn run_wast(wast: &str, strategy: CompilationStrategy) -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_simd(wast.iter().any(|s| s == "simd"))
         .wasm_multi_value(wast.iter().any(|s| s == "multi-value"))
-        .strategy(strategy)
+        .strategy(strategy)?
         .flags(settings::Flags::new(flag_builder));
     let store = HostRef::new(Store::new(&Engine::new(&cfg)));
     let mut wast_context = WastContext::new(store);


### PR DESCRIPTION
This commit removes the public API usage of the internal
`CompilationStrategy` enumeration from the `Config` type in the
`wasmtime` crate. To do this the `enum` was copied locally into the
crate and renamed `Strategy`. The high-level description of this change
is:

* The `Config::strategy` method now takes a locally-defined `Strategy`
  enumeration instead of an internal type.

* The contents of `Strategy` are always the same, not relying on Cargo
  features to indicate which variants are present. This avoids
  unnecessary downstream `#[cfg]`.

* A `lightbeam` feature was added to the `wasmtime` crate itself to
  lightbeam compilation support.

* The `Config::strategy` method is now fallible. It returns a runtime
  error if support for the selected strategy wasn't compiled in.

* The `Strategy` enum is listed as `#[non_exhaustive]` so we can safely
  add variants over time to it.

This reduces the public crate dependencies of the `wasmtime` crate
itself, removing the need to reach into internal crates even more!

cc #708

> **Note**: This is based on https://github.com/bytecodealliance/wasmtime/pull/763 currently and the first commit doesn't need to be reviewed here. Additionally the change to `Config::strategy` being fallible had a bit more fallout than intended, but overall pushed the usage of `anyhow` and `?` into more places so felt somewhat appropriate to be here. That ended up cascading in a number of otherwise-unrelated changes though.
