### PR TITLE
Go back to testing true nightlies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,11 +136,9 @@ jobs:
           - build: beta
             os: ubuntu-latest
             rust: beta
-          # FIXME need to wait for rust-lang/rust#67065 to get into nightlies,
-          # and then this can be updated to `nightly` again.
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2019-12-03
+            rust: nightly
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
Now that all the wasi fixes are upstream in nightlies I think we're good
to go to test the `nightly` channel again.