### PR TITLE
Trace the syscall return values

### DIFF
--- a/crates/wasi-common/src/macros.rs
+++ b/crates/wasi-common/src/macros.rs
@@ -6,6 +6,7 @@ macro_rules! hostcalls {
                     Ok(()) => wasi::__WASI_ERRNO_SUCCESS,
                     Err(e) => e.as_wasi_errno(),
                 };
+                log::trace!("{} -> {}", stringify!($name), ret);
 
                 ret
             }
@@ -22,6 +23,7 @@ macro_rules! hostcalls_old {
                     Ok(()) => wasi::__WASI_ERRNO_SUCCESS,
                     Err(e) => e.as_wasi_errno(),
                 };
+                log::trace!("{} -> {}", stringify!($name), ret);
 
                 ret
             }


### PR DESCRIPTION
That's useful while debugging. I'm wondering if it's better to print the error code or the original error struct.