### PR TITLE
Ensure `Trap` is returned for start function traps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,7 +2216,6 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wasmtime-runtime",
  "wast 4.0.0",
 ]
 

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -10,8 +10,8 @@ use anyhow::{Error, Result};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
-use wasmtime_jit::{instantiate, Resolver};
-use wasmtime_runtime::{Export, InstanceHandle};
+use wasmtime_jit::{instantiate, Resolver, SetupError};
+use wasmtime_runtime::{Export, InstanceHandle, InstantiationError};
 
 struct SimpleResolver {
     imports: Vec<(String, String, Extern)>,
@@ -46,6 +46,8 @@ pub fn instantiate_in_context(
     .map_err(|e| -> Error {
         if let Some(trap) = take_api_trap() {
             Trap::from(trap).into()
+        } else if let SetupError::Instantiate(InstantiationError::StartTrap(msg)) = e {
+            Trap::new(msg).into()
         } else {
             e.into()
         }

--- a/crates/api/src/trap.rs
+++ b/crates/api/src/trap.rs
@@ -74,7 +74,7 @@ impl fmt::Debug for UnsafeTrapInfo {
 
 /// A struct representing an aborted instruction execution, with a message
 /// indicating the cause.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[error("Wasm trap: {message}")]
 pub struct Trap {
     message: String,

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../api" }
-wasmtime-runtime = { path = "../runtime" }
 wast = "4.0.0"
 
 [badges]

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -94,12 +94,9 @@ impl WastContext {
         let instance = match Instance::new(&self.store, &module, &imports) {
             Ok(i) => i,
             Err(e) => {
-                let err = e
-                    .chain()
-                    .filter_map(|e| e.downcast_ref::<Trap>())
-                    .next();
+                let err = e.chain().filter_map(|e| e.downcast_ref::<Trap>()).next();
                 if let Some(trap) = err {
-                    return Ok(Outcome::Trap(trap.clone()))
+                    return Ok(Outcome::Trap(trap.clone()));
                 }
                 return Err(e);
             }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -93,15 +93,13 @@ impl WastContext {
         }
         let instance = match Instance::new(&self.store, &module, &imports) {
             Ok(i) => i,
-            // FIXME(#683) shouldn't have to reach into runtime crate
             Err(e) => {
-                use wasmtime_runtime::InstantiationError;
                 let err = e
                     .chain()
-                    .filter_map(|e| e.downcast_ref::<InstantiationError>())
+                    .filter_map(|e| e.downcast_ref::<Trap>())
                     .next();
-                if let Some(InstantiationError::StartTrap(msg)) = err {
-                    return Ok(Outcome::Trap(Trap::new(msg.clone())));
+                if let Some(trap) = err {
+                    return Ok(Outcome::Trap(trap.clone()))
                 }
                 return Err(e);
             }


### PR DESCRIPTION
Handle another case of errors coming out of instantiation, resolve a
FIXME, and remove an unneeded dependency from the wast testsuite crate.