### PR TITLE
Tweak some API doc generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,17 +46,9 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: cargo doc --no-deps -p wasmtime-cli
-    - run: cargo doc --no-deps -p wasmtime
-    - run: cargo doc --no-deps -p wasmtime-debug
-    - run: cargo doc --no-deps -p wasmtime-environ
-    - run: cargo doc --no-deps -p wasmtime-interface-types
-    - run: cargo doc --no-deps -p wasmtime-jit
-    - run: cargo doc --no-deps -p wasmtime-obj
-    - run: cargo doc --no-deps -p wasmtime-runtime
-    - run: cargo doc --no-deps -p wasmtime-wasi
-    - run: cargo doc --no-deps -p wasmtime-wast
-    - run: cargo doc --no-deps -p wasi-common
+      with:
+        toolchain: nightly
+    - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs
     - uses: actions/upload-artifact@v1
       with:
         name: doc-api

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -192,6 +192,8 @@ impl Default for Config {
 }
 
 /// Possible Compilation strategies for a wasm module.
+///
+/// This is used as an argument to the [`Config::strategy`] method.
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub enum Strategy {
@@ -212,6 +214,9 @@ pub enum Strategy {
 
     /// A single-pass code generator that is faster than Cranelift but doesn't
     /// produce as high-quality code.
+    ///
+    /// To successfully pass this argument to [`Config::strategy`] the
+    /// `lightbeam` feature of this crate must be enabled.
     Lightbeam,
 }
 

--- a/crates/misc/py/Cargo.toml
+++ b/crates/misc/py/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 name = "_wasmtime"
 crate-type = ["cdylib"]
 test = false
+doc = false
 
 [dependencies]
 wasmtime = { path = "../../api" }

--- a/crates/wasi-c/Cargo.toml
+++ b/crates/wasi-c/Cargo.toml
@@ -32,3 +32,4 @@ maintenance = { status = "actively-developed" }
 [lib]
 test = false
 doctest = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,18 +21,22 @@ libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 name = "compile"
 path = "fuzz_targets/compile.rs"
 test = false
+doc = false
 
 [[bin]]
 name = "instantiate"
 path = "fuzz_targets/instantiate.rs"
 test = false
+doc = false
 
 [[bin]]
 name = "instantiate_translated"
 path = "fuzz_targets/instantiate_translated.rs"
 test = false
+doc = false
 
 [[bin]]
 name = "api_calls"
 path = "fuzz_targets/api_calls.rs"
 test = false
+doc = false


### PR DESCRIPTION
* Build docs with the nightly toolchain so [foo::bar] links work by
  default. This is a relatively new feature of rustdoc and I thought it
  was stabilized at this point but apparently it's not!

* Tweak some API docs on `wasmtime::Strategy`

* Use `--all` to build all local crate documentation instead of trying
  to list the number of local crates

* Tweak some documentation configuration to avoid warnings generated by
  Cargo.