### PR TITLE
Don't render errors twice, only once

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -264,10 +264,10 @@ impl RunCommand {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let instance = HostRef::new(match Instance::new(store, &module, &imports) {
-            Ok(instance) => instance,
-            Err(trap) => bail!("Failed to instantiate {:?}: {:?}", path, trap),
-        });
+        let instance = HostRef::new(
+            Instance::new(store, &module, &imports)
+                .context(format!("failed to instantiate {:?}", path))?,
+        );
 
         Ok((instance, module, data))
     }


### PR DESCRIPTION
Change a `bail!` macro which renders the debug representation of an
error to a call to `context` which preserves the original error object
and improves rendering later on down the road.