### PR TITLE
Update wast to 5.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,7 +2216,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 4.0.0",
+ "wast 5.0.1",
 ]
 
 [[package]]
@@ -2233,6 +2233,15 @@ name = "wast"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd03645007fe5c76cdacbcf51c145db79ab82756e977f7ed051b7cf896dc7df"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1de68310854a9840d39487701a8c1acccb5c9f9f2650d5fce3cdfe6650c372"
 dependencies = [
  "leb128",
 ]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../api" }
-wast = "4.0.0"
+wast = "5.0.1"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This allows me to run more SIMD spec tests without failure. cc: @alexcrichton