### PR TITLE
[wasmtime-api] Access to/override module name

### DIFF
--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -29,6 +29,7 @@ impl Resolver for SimpleResolver {
 pub fn instantiate_in_context(
     data: &[u8],
     imports: Vec<(String, String, Extern)>,
+    module_name: Option<String>,
     context: Context,
     exports: Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>>,
 ) -> Result<(InstanceHandle, HashSet<Context>), Error> {
@@ -38,6 +39,7 @@ pub fn instantiate_in_context(
     let instance = instantiate(
         &mut context.compiler(),
         data,
+        module_name,
         &mut resolver,
         exports,
         debug_info,
@@ -77,8 +79,13 @@ impl Instance {
             .zip(externs.iter())
             .map(|(i, e)| (i.module().to_string(), i.name().to_string(), e.clone()))
             .collect::<Vec<_>>();
-        let (mut instance_handle, contexts) =
-            instantiate_in_context(module.binary().expect("binary"), imports, context, exports)?;
+        let (mut instance_handle, contexts) = instantiate_in_context(
+            module.binary().expect("binary"),
+            imports,
+            module.name().cloned(),
+            context,
+            exports,
+        )?;
 
         let exports = {
             let mut exports = Vec::with_capacity(module.exports().len());

--- a/crates/api/tests/name.rs
+++ b/crates/api/tests/name.rs
@@ -1,0 +1,54 @@
+use wasmtime::*;
+use wat::parse_str;
+
+#[test]
+fn test_module_no_name() -> Result<(), String> {
+    let store = Store::default();
+    let binary = parse_str(
+        r#"
+                (module
+                (func (export "run") (nop))
+                )
+            "#,
+    )
+    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+
+    let module = HostRef::new(
+        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?,
+    );
+    assert_eq!(module.borrow().name().cloned(), None);
+
+    Ok(())
+}
+
+#[test]
+fn test_module_name() -> Result<(), String> {
+    let store = Store::default();
+    let binary = parse_str(
+        r#"
+                (module $from_name_section
+                (func (export "run") (nop))
+                )
+            "#,
+    )
+    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+
+    let module = HostRef::new(
+        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?,
+    );
+    assert_eq!(
+        module.borrow().name().cloned(),
+        Some("from_name_section".to_string())
+    );
+
+    let module = HostRef::new(
+        Module::new_with_name(&store, &binary, "override".to_string())
+            .map_err(|e| format!("failed to compile module: {}", e))?,
+    );
+    assert_eq!(
+        module.borrow().name().cloned(),
+        Some("override".to_string())
+    );
+
+    Ok(())
+}

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -168,6 +168,9 @@ pub struct Module {
 
     /// WebAssembly table initializers.
     pub table_elements: Vec<TableElements>,
+
+    /// Module name.
+    pub name: Option<String>,
 }
 
 impl Module {
@@ -186,6 +189,7 @@ impl Module {
             exports: IndexMap::new(),
             start_func: None,
             table_elements: Vec::new(),
+            name: None,
         }
     }
 

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -78,7 +78,14 @@ pub fn compile(wasm: &[u8], compilation_strategy: CompilationStrategy) {
     let mut compiler = Compiler::new(isa, compilation_strategy);
     let mut resolver = NullResolver {};
     let global_exports = Rc::new(RefCell::new(HashMap::new()));
-    let _ = CompiledModule::new(&mut compiler, wasm, &mut resolver, global_exports, false);
+    let _ = CompiledModule::new(
+        &mut compiler,
+        wasm,
+        None,
+        &mut resolver,
+        global_exports,
+        false,
+    );
 }
 
 /// Invoke the given API calls.

--- a/crates/jit/src/context.rs
+++ b/crates/jit/src/context.rs
@@ -117,6 +117,7 @@ impl Context {
         instantiate(
             &mut *self.compiler,
             &data,
+            None,
             &mut self.namespace,
             Rc::clone(&self.global_exports),
             debug_info,
@@ -154,6 +155,7 @@ impl Context {
         CompiledModule::new(
             &mut *self.compiler,
             data,
+            None,
             &mut self.namespace,
             Rc::clone(&self.global_exports),
             debug_info,

--- a/tests/instantiate.rs
+++ b/tests/instantiate.rs
@@ -25,6 +25,13 @@ fn test_environ_translate() {
     let mut resolver = NullResolver {};
     let mut compiler = Compiler::new(isa, CompilationStrategy::Auto);
     let global_exports = Rc::new(RefCell::new(HashMap::new()));
-    let instance = instantiate(&mut compiler, &data, &mut resolver, global_exports, false);
+    let instance = instantiate(
+        &mut compiler,
+        &data,
+        None,
+        &mut resolver,
+        global_exports,
+        false,
+    );
     assert!(instance.is_ok());
 }


### PR DESCRIPTION
Provides ability to identify wasm module by name: adds `name()` <del>and `set_name()`</del> to the `Module`.