### PR TITLE
Remove unsafety from `Trap` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,7 +1971,6 @@ dependencies = [
  "rayon",
  "region",
  "target-lexicon",
- "thiserror",
  "wasi-common",
  "wasmparser 0.45.1",
  "wasmtime-environ",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -19,7 +19,6 @@ wasmtime-jit = { path = "../jit" }
 wasmparser = { version = "0.45.1", default-features = false }
 target-lexicon = { version = "0.9.0", default-features = false }
 anyhow = "1.0.19"
-thiserror = "1.0.4"
 region = "2.0.0"
 
 [dev-dependencies]

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -157,8 +157,8 @@ impl WrappedCallable for WasmtimeFn {
                 values_vec.as_mut_ptr() as *mut u8,
             )
         } {
-            let trap = take_api_trap()
-                .unwrap_or_else(|| Trap::new(format!("call error: {}", message)));
+            let trap =
+                take_api_trap().unwrap_or_else(|| Trap::new(format!("call error: {}", message)));
             return Err(trap);
         }
 

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -1,7 +1,6 @@
-use crate::r#ref::HostRef;
 use crate::runtime::Store;
 use crate::trampoline::{generate_func_export, take_api_trap};
-use crate::trap::{Trap, TrapInfo};
+use crate::trap::Trap;
 use crate::types::FuncType;
 use crate::values::Val;
 use std::rc::Rc;
@@ -159,8 +158,8 @@ impl WrappedCallable for WasmtimeFn {
             )
         } {
             let trap = take_api_trap()
-                .unwrap_or_else(|| HostRef::new(TrapInfo::new(format!("call error: {}", message))));
-            return Err(trap.into());
+                .unwrap_or_else(|| Trap::new(format!("call error: {}", message)));
+            return Err(trap);
         }
 
         // Load the return values out of `values_vec`.

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -45,7 +45,7 @@ pub fn instantiate_in_context(
     )
     .map_err(|e| -> Error {
         if let Some(trap) = take_api_trap() {
-            Trap::from(trap).into()
+            trap.into()
         } else if let SetupError::Instantiate(InstantiationError::StartTrap(msg)) = e {
             Trap::new(msg).into()
         } else {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -28,6 +28,6 @@ pub use crate::instance::Instance;
 pub use crate::module::Module;
 pub use crate::r#ref::{AnyRef, HostInfo, HostRef};
 pub use crate::runtime::{Config, Engine, OptLevel, Store, Strategy};
-pub use crate::trap::{FrameInfo, Trap, TrapInfo};
+pub use crate::trap::{FrameInfo, Trap};
 pub use crate::types::*;
 pub use crate::values::*;

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -95,7 +95,6 @@ unsafe extern "C" fn stub_fn(vmctx: *mut VMContext, call_id: u32, values_vec: *m
             0
         }
         Err(trap) => {
-            let trap = trap.trap_info_unchecked();
             record_api_trap(trap);
             1
         }

--- a/crates/api/src/trampoline/trap.rs
+++ b/crates/api/src/trampoline/trap.rs
@@ -1,7 +1,6 @@
 use std::cell::Cell;
 
-use crate::r#ref::HostRef;
-use crate::TrapInfo;
+use crate::Trap;
 use wasmtime_environ::ir::{SourceLoc, TrapCode};
 use wasmtime_environ::TrapInformation;
 use wasmtime_jit::trampoline::binemit;
@@ -10,10 +9,10 @@ use wasmtime_jit::trampoline::binemit;
 pub const API_TRAP_CODE: TrapCode = TrapCode::User(13);
 
 thread_local! {
-    static RECORDED_API_TRAP: Cell<Option<HostRef<TrapInfo>>> = Cell::new(None);
+    static RECORDED_API_TRAP: Cell<Option<Trap>> = Cell::new(None);
 }
 
-pub fn record_api_trap(trap: HostRef<TrapInfo>) {
+pub fn record_api_trap(trap: Trap) {
     RECORDED_API_TRAP.with(|data| {
         let trap = Cell::new(Some(trap));
         data.swap(&trap);
@@ -24,7 +23,7 @@ pub fn record_api_trap(trap: HostRef<TrapInfo>) {
     });
 }
 
-pub fn take_api_trap() -> Option<HostRef<TrapInfo>> {
+pub fn take_api_trap() -> Option<Trap> {
     RECORDED_API_TRAP.with(|data| data.take())
 }
 

--- a/crates/api/src/trap.rs
+++ b/crates/api/src/trap.rs
@@ -1,8 +1,65 @@
 use crate::instance::Instance;
-use crate::r#ref::HostRef;
 use std::fmt;
-use std::sync::{Arc, Mutex};
-use thiserror::Error;
+use std::sync::Arc;
+
+/// A struct representing an aborted instruction execution, with a message
+/// indicating the cause.
+#[derive(Clone)]
+pub struct Trap {
+    inner: Arc<TrapInner>,
+}
+
+struct TrapInner {
+    message: String,
+    trace: Vec<FrameInfo>,
+}
+
+fn _assert_trap_is_sync_and_send(t: &Trap) -> (&dyn Sync, &dyn Send) {
+    (t, t)
+}
+
+impl Trap {
+    /// Creates a new `Trap` with `message`.
+    /// # Example
+    /// ```
+    /// let trap = wasmtime::Trap::new("unexpected error");
+    /// assert_eq!("unexpected error", trap.message());
+    /// ```
+    pub fn new<I: Into<String>>(message: I) -> Self {
+        Trap {
+            inner: Arc::new(TrapInner {
+                message: message.into(),
+                trace: Vec::new(),
+            }),
+        }
+    }
+
+    /// Returns a reference the `message` stored in `Trap`.
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
+
+    pub fn trace(&self) -> &[FrameInfo] {
+        &self.inner.trace
+    }
+}
+
+impl fmt::Debug for Trap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Trap")
+            .field("message", &self.inner.message)
+            .field("trace", &self.inner.trace)
+            .finish()
+    }
+}
+
+impl fmt::Display for Trap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.message.fmt(f)
+    }
+}
+
+impl std::error::Error for Trap {}
 
 #[derive(Debug)]
 pub struct FrameInfo;
@@ -22,96 +79,5 @@ impl FrameInfo {
 
     pub fn module_offset() -> usize {
         unimplemented!("FrameInfo::module_offset");
-    }
-}
-
-#[derive(Debug)]
-pub struct TrapInfo {
-    message: String,
-    trace: Vec<FrameInfo>,
-}
-
-impl TrapInfo {
-    pub fn new<I: Into<String>>(message: I) -> Self {
-        Self {
-            message: message.into(),
-            trace: vec![],
-        }
-    }
-
-    /// Returns a reference the `message` stored in `Trap`.
-    pub fn message(&self) -> &str {
-        &self.message
-    }
-
-    pub fn origin(&self) -> Option<&FrameInfo> {
-        self.trace.first()
-    }
-
-    pub fn trace(&self) -> &[FrameInfo] {
-        &self.trace
-    }
-}
-
-/// A struct to hold unsafe TrapInfo host reference, designed
-/// to be Send-able. The only access for it provided via the
-/// Trap::trap_info_unchecked() method.
-struct UnsafeTrapInfo(HostRef<TrapInfo>);
-
-impl UnsafeTrapInfo {
-    fn trap_info(&self) -> HostRef<TrapInfo> {
-        self.0.clone()
-    }
-}
-
-unsafe impl Send for UnsafeTrapInfo {}
-
-impl fmt::Debug for UnsafeTrapInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "UnsafeTrapInfo")
-    }
-}
-
-/// A struct representing an aborted instruction execution, with a message
-/// indicating the cause.
-#[derive(Error, Debug, Clone)]
-#[error("Wasm trap: {message}")]
-pub struct Trap {
-    message: String,
-    info: Arc<Mutex<UnsafeTrapInfo>>,
-}
-
-fn _assert_trap_is_sync_and_send(t: &Trap) -> (&dyn Sync, &dyn Send) {
-    (t, t)
-}
-
-impl Trap {
-    /// Creates a new `Trap` with `message`.
-    /// # Example
-    /// ```
-    /// let trap = wasmtime::Trap::new("unexpected error");
-    /// assert_eq!("unexpected error", trap.message());
-    /// ```
-    pub fn new<I: Into<String>>(message: I) -> Self {
-        Trap::from(HostRef::new(TrapInfo::new(message)))
-    }
-
-    /// Returns a reference the `message` stored in `Trap`.
-    pub fn message(&self) -> &str {
-        &self.message
-    }
-
-    /// Returns inner TrapInfo assotiated with the Trap.
-    /// The method is unsafe: obtained TrapInfo is not thread safe.
-    pub(crate) unsafe fn trap_info_unchecked(&self) -> HostRef<TrapInfo> {
-        self.info.lock().unwrap().trap_info()
-    }
-}
-
-impl From<HostRef<TrapInfo>> for Trap {
-    fn from(trap_info: HostRef<TrapInfo>) -> Self {
-        let message = trap_info.borrow().message().to_string();
-        let info = Arc::new(Mutex::new(UnsafeTrapInfo(trap_info)));
-        Trap { message, info }
     }
 }


### PR DESCRIPTION
This commit removes the `unsafe impl Send` for `Trap` by removing the
internal `HostRef` and leaving `HostRef` entirely as an implementation
detail of the C API.

cc #708