### PR TITLE
Fix various tests to pass CI again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,7 @@ dependencies = [
  "wasmtime-interface-types",
  "wasmtime-jit",
  "wasmtime-obj",
+ "wasmtime-runtime",
  "wasmtime-wasi",
  "wasmtime-wasi-c",
  "wasmtime-wast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ rayon = "1.2.1"
 wasm-webidl-bindings = "0.6"
 
 [dev-dependencies]
+wasmtime-runtime = { path = "crates/runtime" }
 more-asserts = "0.2.1"
 # This feature requires the wasm32-wasi target be installed. It enables
 # wasm32-wasi integration tests. To enable, run

--- a/crates/test-programs/wasi-tests/src/bin/path_open_read_without_rights.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_read_without_rights.rs
@@ -1,6 +1,6 @@
 use std::{env, process};
 use wasi_tests::open_scratch_directory;
-use wasi_tests::{drop_rights, fd_get_rights, create_file};
+use wasi_tests::{create_file, drop_rights, fd_get_rights};
 
 const TEST_FILENAME: &'static str = "file";
 
@@ -27,8 +27,13 @@ unsafe fn try_read_file(dir_fd: wasi::Fd) {
     };
     // Since we no longer have the right to fd_read, trying to read a file
     // should be an error.
-    let err = wasi::fd_read(fd, &[iovec]).expect_err("reading bytes from file should fail");
-    assert_eq!(err, wasi::ERRNO_NOTCAPABLE, "the errno should be ENOTCAPABLE");
+    assert_eq!(
+        wasi::fd_read(fd, &[iovec])
+            .expect_err("reading bytes from file should fail")
+            .raw_error(),
+        wasi::ERRNO_NOTCAPABLE,
+        "the errno should be ENOTCAPABLE"
+    );
 }
 
 unsafe fn test_read_rights(dir_fd: wasi::Fd) {

--- a/tests/custom_signal_handler.rs
+++ b/tests/custom_signal_handler.rs
@@ -104,7 +104,7 @@ mod tests {
             println!("calling read_out_of_bounds...");
             let trap = invoke_export(&instance, &data, "read_out_of_bounds").unwrap_err();
             assert!(trap.root_cause().to_string().starts_with(
-                "trapped: Ref(Trap { message: \"wasm trap: out of bounds memory access"
+                "trapped: Trap { message: \"call error: wasm trap: out of bounds memory access"
             ));
         }
 
@@ -129,7 +129,7 @@ mod tests {
             let trap = read_out_of_bounds_func.borrow().call(&[]).unwrap_err();
             assert!(trap
                 .message()
-                .starts_with("wasm trap: out of bounds memory access"));
+                .starts_with("call error: wasm trap: out of bounds memory access"));
         }
     }
 

--- a/tests/custom_signal_handler.rs
+++ b/tests/custom_signal_handler.rs
@@ -74,11 +74,11 @@ mod tests {
 
     #[test]
     fn test_custom_signal_handler_single_instance() {
-        let engine = HostRef::new(Engine::new(&Config::default()));
-        let store = HostRef::new(Store::new(&engine));
+        let engine = Engine::new(&Config::default());
+        let store = Store::new(&engine);
         let data =
             std::fs::read("tests/custom_signal_handler.wasm").expect("failed to read wasm file");
-        let module = HostRef::new(Module::new(&store, &data).expect("failed to create module"));
+        let module = Module::new(&store, &data).expect("failed to create module");
         let instance = HostRef::new(
             Instance::new(&store, &module, &[]).expect("failed to instantiate module"),
         );
@@ -128,7 +128,6 @@ mod tests {
             println!("calling read_out_of_bounds...");
             let trap = read_out_of_bounds_func.borrow().call(&[]).unwrap_err();
             assert!(trap
-                .borrow()
                 .message()
                 .starts_with("wasm trap: out of bounds memory access"));
         }
@@ -136,11 +135,11 @@ mod tests {
 
     #[test]
     fn test_custom_signal_handler_multiple_instances() {
-        let engine = HostRef::new(Engine::new(&Config::default()));
-        let store = HostRef::new(Store::new(&engine));
+        let engine = Engine::new(&Config::default());
+        let store = Store::new(&engine);
         let data =
             std::fs::read("tests/custom_signal_handler.wasm").expect("failed to read wasm file");
-        let module = HostRef::new(Module::new(&store, &data).expect("failed to create module"));
+        let module = Module::new(&store, &data).expect("failed to create module");
 
         // Set up multiple instances
 
@@ -237,13 +236,13 @@ mod tests {
 
     #[test]
     fn test_custom_signal_handler_instance_calling_another_instance() {
-        let engine = HostRef::new(Engine::new(&Config::default()));
-        let store = HostRef::new(Store::new(&engine));
+        let engine = Engine::new(&Config::default());
+        let store = Store::new(&engine);
 
         // instance1 which defines 'read'
         let data1 =
             std::fs::read("tests/custom_signal_handler.wasm").expect("failed to read wasm file");
-        let module1 = HostRef::new(Module::new(&store, &data1).expect("failed to create module"));
+        let module1 = Module::new(&store, &data1).expect("failed to create module");
         let instance1: HostRef<Instance> = HostRef::new(
             Instance::new(&store, &module1, &[]).expect("failed to instantiate module"),
         );
@@ -262,7 +261,7 @@ mod tests {
         // instance2 wich calls 'instance1.read'
         let data2 =
             std::fs::read("tests/custom_signal_handler_2.wasm").expect("failed to read wasm file");
-        let module2 = HostRef::new(Module::new(&store, &data2).expect("failed to create module"));
+        let module2 = Module::new(&store, &data2).expect("failed to create module");
         let instance2 = HostRef::new(
             Instance::new(&store, &module2, &[instance1_read])
                 .expect("failed to instantiate module"),


### PR DESCRIPTION
Fixes `path_open_read_without_rights` test making the CI green again. :-) The bug must have snuck in #770.