### PR TITLE
Don't rebuild the test suite if wast files change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -139,7 +139,6 @@ fn write_testsuite_tests(
     strategy: &str,
 ) -> anyhow::Result<()> {
     let path = path.as_ref();
-    println!("cargo:rerun-if-changed={}", path.display());
     let testname = extract_name(path);
 
     writeln!(out, "#[test]")?;


### PR DESCRIPTION
They're read dynamically so there's no need to rebuild the test suite,
it'll automatically pick up the changes when it's read while the tests
are executed.