### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 	path = crates/api/c-examples/wasm-c-api
 	url = https://github.com/WebAssembly/wasm-c-api
 [submodule "crates/wasi-common/WASI"]
-	path = crates/wasi-common/WASI
+	path = crates/wasi-common/wig/WASI
 	url = https://github.com/WebAssembly/WASI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
+checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 
 [[package]]
 name = "arbitrary"
@@ -53,10 +53,11 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "atty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -66,6 +67,12 @@ name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
@@ -191,9 +198,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",
@@ -262,12 +269,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 dependencies = [
  "jobserver",
- "num_cpus",
 ]
 
 [[package]]
@@ -443,7 +449,7 @@ dependencies = [
  "log",
  "serde",
  "thiserror",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
 ]
 
 [[package]]
@@ -462,7 +468,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "cfg-if",
  "crossbeam-utils 0.7.0",
  "lazy_static",
@@ -472,10 +478,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
+checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
+ "cfg-if",
  "crossbeam-utils 0.7.0",
 ]
 
@@ -495,7 +502,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "cfg-if",
  "lazy_static",
 ]
@@ -723,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
@@ -764,9 +771,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a79ef1f0dad46fd78075b6f80f92d97710eddf87b3e18a15a66761e8942672"
+checksum = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
 dependencies = [
  "log",
  "plain",
@@ -784,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 dependencies = [
  "libc",
 ]
@@ -812,7 +819,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
 ]
 
 [[package]]
@@ -840,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cece20baea71d9f3435e7bbe9adf4765f091c5fe404975f844006964a71299"
+checksum = "2bf98296081bd2cb540acc09ef9c97f22b7e487841520350293605db1b2c7a27"
 dependencies = [
  "ctor",
  "ghost",
@@ -851,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "inventory-impl"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2869bf972e998977b1cb87e60df70341d48e48dca0823f534feb91ea44adaf9"
+checksum = "0a8e30575afe28eea36a9a39136b70b2fb6b0dd0a212a5bd1f30a498395c0274"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -877,13 +884,11 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
 name = "jobserver"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
+checksum = "230ae9adf468173aecd4176c7233bddc84a15871a586c5971ace9a55f881c075"
 dependencies = [
- "getrandom",
  "libc",
- "log",
 ]
 
 [[package]]
@@ -931,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "lightbeam"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -948,7 +953,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "typemap",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "wat",
 ]
 
@@ -1042,27 +1047,27 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
+checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-integer",
  "num-traits",
 ]
@@ -1073,18 +1078,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1175,13 +1180,28 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.2.6"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+checksum = "53c98547ceaea14eeb26fcadf51dc70d01a2479a7839170eae133721105e4428"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2bf5d493cf5d3e296beccfd61794e445e830dfc8070a9c248ad3ee071392c6c"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
+ "syn-mid",
 ]
 
 [[package]]
@@ -1197,18 +1217,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+checksum = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b338139584e698b341996e4f453c71fa937daa408aaf301e042383724e0caca"
+checksum = "e1bfe257586436fbe1296d917f14a167d4253d0873bf43e2c9b9bdd58a3f9f35"
 dependencies = [
  "indoc",
  "inventory",
@@ -1227,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-derive-backend"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8c805249a82c04a00d96f562e66537e8ddfe5d895bc2a414a8e6b6ae3d53be"
+checksum = "4882d8237fd8c7373cc25cb802fe0dab9ff70830fd56f47ef6c7f3f287fcc057"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1238,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3cls"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3575ad614aa547044119f3ff78aff7bdcba6bcde53fcd67065611546d2b8a122"
+checksum = "fdf321cfab555f7411298733c86d21e5136f5ded13f5872fabf9de3337beecda"
 dependencies = [
  "proc-macro2",
  "pyo3-derive-backend",
@@ -1250,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quickcheck"
@@ -1368,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43739f8831493b276363637423d3622d4bd6394ab6f0a9c4a552e208aeb7fddd"
+checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
 dependencies = [
  "crossbeam-deque",
  "either",
@@ -1379,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791"
+checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
@@ -1419,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+checksum = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1431,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+checksum = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
 
 [[package]]
 name = "region"
@@ -1492,6 +1512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0538bd897e17257b0128d2fd95c2ed6df939374073a36166051a79e2eb7986"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,18 +1571,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
+checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
+checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 dependencies = [
  "block-buffer",
  "digest",
@@ -1589,9 +1620,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "smallvec"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+checksum = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 
 [[package]]
 name = "spin"
@@ -1622,9 +1653,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
+checksum = "884ae79d6aad1e738f4a70dff314203fd498490a63ebc4d03ea83323c40b7b72"
 dependencies = [
  "clap",
  "structopt-derive",
@@ -1632,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
+checksum = "0a97f829a34a0a9d5b353a881025a23b8c9fd09d46be6045df6b22920dbd7a93"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1645,13 +1676,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
+checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd3937748a7eccff61ba5b90af1a20dbf610858923a9192ea0ecb0cb77db1d0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1697,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1745,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+checksum = "88ddf1ad580c7e3d1efff877d972bcc93f995556b9087a5a259630985c88ceab"
 dependencies = [
  "lazy_static",
 ]
@@ -1780,9 +1822,9 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trybuild"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75e31d624df08744532e935f1d4bfedd319a277d5a162c5b15f6ced59307575"
+checksum = "987d6fdc45ddd7f3be5aa7386c8c8a844d1655c95b9ed948a9cd9cded8f2b79f"
 dependencies = [
  "glob",
  "lazy_static",
@@ -1886,13 +1928,13 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.7.0"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1913,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common-cbindgen"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1947,9 +1989,9 @@ checksum = "1527c84a5bd585215f29c06b0e2a5274e478ad4dfc970d26ffad66fdc6cb311d"
 
 [[package]]
 name = "wasmparser"
-version = "0.45.1"
+version = "0.45.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee23c9b67aa5d7a2381ae56805ced08960d21b7cf6ca11f78b42d68e698d03b"
+checksum = "8b4eab1d9971d0803729cba3617b56eb04fcb4bd25361cb63880ed41a42f20d5"
 
 [[package]]
 name = "wasmprinter"
@@ -1963,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1974,19 +2016,17 @@ dependencies = [
  "region",
  "target-lexicon",
  "wasi-common",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
- "wasmtime-wasi",
- "wasmtime-wast",
  "wat",
  "winapi",
 ]
 
 [[package]]
 name = "wasmtime-cli"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "faerie",
@@ -2015,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "faerie",
@@ -2023,13 +2063,13 @@ dependencies = [
  "more-asserts",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.11.0",
@@ -2057,14 +2097,14 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "winapi",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-fuzz"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "arbitrary",
  "env_logger 0.7.1",
@@ -2077,14 +2117,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fuzzing"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arbitrary",
  "binaryen",
  "env_logger 0.7.1",
  "log",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
@@ -2094,12 +2134,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-interface-types"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "walrus",
  "wasm-webidl-bindings",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "wasmtime",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -2109,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2121,7 +2161,7 @@ dependencies = [
  "region",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "wasmtime-debug",
  "wasmtime-environ",
  "wasmtime-runtime",
@@ -2130,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "faerie",
@@ -2140,13 +2180,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-py"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "pyo3",
  "region",
  "target-lexicon",
- "wasmparser 0.45.1",
+ "wasmparser 0.45.2",
  "wasmtime",
  "wasmtime-environ",
  "wasmtime-interface-types",
@@ -2156,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2173,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -2184,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust-macro"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2193,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2210,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-c"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bindgen 0.51.1",
  "cmake",
@@ -2228,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -2246,15 +2286,6 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd03645007fe5c76cdacbcf51c145db79ab82756e977f7ed051b7cf896dc7df"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d1de68310854a9840d39487701a8c1acccb5c9f9f2650d5fce3cdfe6650c372"
@@ -2263,12 +2294,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.0.5"
+name = "wast"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ba86afa8d9f69291394de512e10e5ca6788998f4c426a56113770048826dc9"
+checksum = "3ed3db7029d1d31a15c10126e78b58e51781faefafbc8afb20fb01291b779984"
 dependencies = [
- "wast 4.0.0",
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d59ba5b224f5507d55e4f89d0b18cc6452d84640ab11b4c9086d61a3ee62d03"
+dependencies = [
+ "wast 6.0.0",
 ]
 
 [[package]]
@@ -2282,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.7.0"
+version = "0.9.2"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2333,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "cvt",
@@ -2343,6 +2383,8 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc432537dbc9940e06816ebc3e1c4694fc835b90720615c32038769d7b2967d"
 dependencies = [
  "clap",
  "thiserror",
@@ -2351,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "yanix"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Command-line interface for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "High-level API to expose the Wasmtime runtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,9 +13,9 @@ name = "wasmtime"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-wasmtime-runtime = { path = "../runtime" }
-wasmtime-environ = { path = "../environ" }
-wasmtime-jit = { path = "../jit" }
+wasmtime-runtime = { path = "../runtime", version = "0.9.0" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
+wasmtime-jit = { path = "../jit", version = "0.9.0" }
 wasmparser = { version = "0.45.1", default-features = false }
 target-lexicon = { version = "0.9.0", default-features = false }
 anyhow = "1.0.19"
@@ -28,10 +28,8 @@ winapi = "0.3.7"
 
 [dev-dependencies]
 # for wasmtime.rs
-wasi-common = { path = "../wasi-common" }
+wasi-common = { path = "../wasi-common", version = "0.9.0" }
 pretty_env_logger = "0.3.0"
-wasmtime-wast = { path = "../wast" }
-wasmtime-wasi = { path = "../wasi" }
 rayon = "1.2.1"
 file-per-thread-logger = "0.1.1"
 wat = "1.0"

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-debug"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Debug utils for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,7 +15,7 @@ edition = "2018"
 gimli = "0.19.0"
 wasmparser = "0.45.1"
 faerie = "0.13.0"
-wasmtime-environ = { path = "../environ" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
 target-lexicon = { version = "0.9.0", default-features = false }
 anyhow = "1.0"
 thiserror = "1.0.4"

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-environ"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Standalone environment support for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -17,7 +17,7 @@ cranelift-codegen = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-entity = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-wasm = { version = "0.52.0", features = ["enable-serde"] }
 wasmparser = "0.45.1"
-lightbeam = { path = "../lightbeam", optional = true }
+lightbeam = { path = "../lightbeam", optional = true, version = "0.9.0" }
 indexmap = "1.0.2"
 rayon = "1.2.1"
 thiserror = "1.0.4"

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -4,7 +4,7 @@ description = "Fuzzing infrastructure for Wasmtime"
 edition = "2018"
 name = "wasmtime-fuzzing"
 publish = false
-version = "0.1.0"
+version = "0.9.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,9 +16,9 @@ env_logger = { version = "0.7.1", optional = true }
 log = "0.4.8"
 wasmparser = "0.45.1"
 wasmprinter = "0.2.0"
-wasmtime = { path = "../api" }
-wasmtime-environ = { path = "../environ" }
-wasmtime-jit = { path = "../jit" }
+wasmtime = { path = "../api", version = "0.9.0" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
+wasmtime-jit = { path = "../jit", version = "0.9.0" }
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/interface-types/Cargo.toml
+++ b/crates/interface-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-interface-types"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Support for wasm interface types with wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,11 +15,11 @@ anyhow = "1.0.19"
 walrus = "0.13"
 wasmparser = { version = "0.45.1", default-features = false }
 wasm-webidl-bindings = "0.6"
-wasmtime = { path = '../api' }
-wasmtime-jit = { path = '../jit' }
-wasmtime-environ = { path = '../environ' }
-wasmtime-runtime = { path = '../runtime' }
-wasmtime-wasi = { path = '../wasi' }
+wasmtime = { path = "../api", version = "0.9.0" }
+wasmtime-jit = { path = "../jit", version = "0.9.0" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.9.0" }
+wasmtime-wasi = { path = "../wasi", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT-style execution for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -16,9 +16,9 @@ cranelift-entity = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-wasm = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-native = "0.52.0"
 cranelift-frontend = "0.52.0"
-wasmtime-environ = { path = "../environ" }
-wasmtime-runtime = { path = "../runtime" }
-wasmtime-debug = { path = "../debug" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.9.0" }
+wasmtime-debug = { path = "../debug", version = "0.9.0" }
 region = "2.0.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.9.0", default-features = false }

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightbeam"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Lightbeam Project Developers"]
 description = "An optimising one-pass streaming compiler for WebAssembly"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/misc/py/Cargo.toml
+++ b/crates/misc/py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-py"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Python extension for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -17,11 +17,11 @@ test = false
 doc = false
 
 [dependencies]
-wasmtime = { path = "../../api" }
-wasmtime-environ = { path = "../../environ" }
-wasmtime-interface-types = { path = "../../interface-types" }
-wasmtime-runtime = { path = "../../runtime" }
-wasmtime-wasi = { path = "../../wasi" }
+wasmtime = { path = "../../api", version = "0.9.0" }
+wasmtime-environ = { path = "../../environ", version = "0.9.0" }
+wasmtime-interface-types = { path = "../../interface-types", version = "0.9.0" }
+wasmtime-runtime = { path = "../../runtime", version = "0.9.0" }
+wasmtime-wasi = { path = "../../wasi", version = "0.9.0" }
 target-lexicon = { version = "0.9.0", default-features = false }
 anyhow = "1.0.19"
 region = "2.0.0"

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Rust extension for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,10 +15,10 @@ test = false
 doctest = false
 
 [dependencies]
-wasmtime-interface-types = { path = "../../interface-types" }
-wasmtime-rust-macro = { path = "./macro" }
-wasmtime-wasi = { path = "../../wasi" }
-wasmtime = { path = "../../api" }
+wasmtime-interface-types = { path = "../../interface-types", version = "0.9.0" }
+wasmtime-rust-macro = { path = "./macro", version = "0.9.0" }
+wasmtime-wasi = { path = "../../wasi", version = "0.9.0" }
+wasmtime = { path = "../../api", version = "0.9.0" }
 anyhow = "1.0.19"
 
 [badges]

--- a/crates/misc/rust/macro/Cargo.toml
+++ b/crates/misc/rust/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust-macro"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Macro support crate for wasmtime-rust"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-obj"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Native object file output for WebAsssembly code in Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmtime-environ = { path = "../environ" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
 faerie = "0.13.0"
 more-asserts = "0.2.1"
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-runtime"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-environ = { path = "../environ" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
 region = "2.0.0"
 lazy_static = "1.2.0"
 libc = { version = "0.2.60", default-features = false }

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-programs"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 readme = "README.md"
 edition = "2018"
@@ -10,12 +10,12 @@ publish = false
 cfg-if = "0.1.9"
 
 [dev-dependencies]
-wasi-common = { path = "../wasi-common" }
-wasmtime-runtime = { path = "../runtime" }
-wasmtime-environ = { path = "../environ" }
-wasmtime-jit = { path = "../jit" }
-wasmtime-wasi = { path = "../wasi" }
-wasmtime = { path = "../api" }
+wasi-common = { path = "../wasi-common", version = "0.9.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.9.0" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
+wasmtime-jit = { path = "../jit", version = "0.9.0" }
+wasmtime-wasi = { path = "../wasi", version = "0.9.0" }
+wasmtime = { path = "../api", version = "0.9.0" }
 target-lexicon = "0.9.0"
 pretty_env_logger = "0.3.0"
 tempfile = "3.1.0"

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-tests"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 readme = "README.md"
 edition = "2018"

--- a/crates/wasi-c/Cargo.toml
+++ b/crates/wasi-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-c"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-runtime = { path = "../runtime" }
-wasmtime-environ = { path = "../environ" }
-wasmtime-jit = { path = "../jit" }
+wasmtime-runtime = { path = "../runtime", version = "0.9.0" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
+wasmtime-jit = { path = "../jit", version = "0.9.0" }
 cranelift-codegen = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-entity = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-wasm = { version = "0.52.0", features = ["enable-serde"] }

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasi-common-cbindgen = { path = "wasi-common-cbindgen" }
+wasi-common-cbindgen = { path = "wasi-common-cbindgen", version = "0.9.0" }
 anyhow = "1.0"
 thiserror = "1.0"
 libc = "0.2"
@@ -21,13 +21,13 @@ log = "0.4"
 filetime = "0.2.7"
 lazy_static = "1.4.0"
 num = { version = "0.2.0", default-features = false }
-wig = { path = "wig" }
+wig = { path = "wig", version = "0.9.2" }
 
 [target.'cfg(unix)'.dependencies]
-yanix = { path = "yanix" }
+yanix = { path = "yanix", version = "0.9.0" }
 
 [target.'cfg(windows)'.dependencies]
-winx = { path = "winx" }
+winx = { path = "winx", version = "0.9.0" }
 winapi = "0.3"
 cpu-time = "1.0"
 

--- a/crates/wasi-common/wasi-common-cbindgen/Cargo.toml
+++ b/crates/wasi-common/wasi-common-cbindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common-cbindgen"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Jakub Konka <kubkon@jakubkonka.com>"]
 description = "Interface generator utilities used by wasi-common"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/wig/Cargo.toml
+++ b/crates/wasi-common/wig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wig"
-version = "0.7.0"
+version = "0.9.2"
 authors = ["Dan Gohman <sunfish@mozilla.com>"]
 description = "WebAssembly Interface Generator"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -8,6 +8,7 @@ categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition = "2018"
+include = ["src/**/*", "LICENSE", "WASI"]
 
 [lib]
 proc-macro = true
@@ -19,7 +20,7 @@ heck = "0.3.1"
 # We include the WASI repo primarily for the witx files, but it's also useful
 # to use the witx parser it contains, rather than the witx crate from
 # crates.io, so that it always matches the version of the witx files.
-witx = { path = "../WASI/tools/witx" }
+witx = "0.6.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wasi-common/wig/src/utils.rs
+++ b/crates/wasi-common/wig/src/utils.rs
@@ -28,7 +28,7 @@ pub(crate) fn witx_path_from_args(args: TokenStream) -> (String, String) {
 
 fn witx_path(phase: &str, id: &str) -> String {
     let root = env!("CARGO_MANIFEST_DIR");
-    format!("{}/../WASI/phases/{}/witx/{}.witx", root, phase, id)
+    format!("{}/WASI/phases/{}/witx/{}.witx", root, phase, id)
 }
 
 // Convert a `Literal` holding a string literal into the `String`.

--- a/crates/wasi-common/winx/Cargo.toml
+++ b/crates/wasi-common/winx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winx"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Jakub Konka <kubkon@jakubkonka.com>"]
 description = "Windows API helper library"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/yanix/Cargo.toml
+++ b/crates/wasi-common/yanix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yanix"
-version = "0.1.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Yet Another Nix crate: a Unix API helper library"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,17 +11,17 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime = { path = "../api" }
-wasmtime-runtime = { path = "../runtime" }
-wasmtime-environ = { path = "../environ" }
-wasmtime-jit = { path = "../jit" }
-wasi-common = { path = "../wasi-common" }
+wasmtime = { path = "../api", version = "0.9.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.9.0" }
+wasmtime-environ = { path = "../environ", version = "0.9.0" }
+wasmtime-jit = { path = "../jit", version = "0.9.0" }
+wasi-common = { path = "../wasi-common", version = "0.9.0" }
 cranelift-codegen = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-entity = { version = "0.52.0", features = ["enable-serde"] }
 cranelift-wasm = { version = "0.52.0", features = ["enable-serde"] }
 target-lexicon = "0.9.0"
 log = { version = "0.4.8", default-features = false }
-wig = { path = "../wasi-common/wig" }
+wig = { path = "../wasi-common/wig", version = "0.9.2" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wast"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 description = "wast testing support for wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.19"
-wasmtime = { path = "../api" }
+wasmtime = { path = "../api", version = "0.9.0" }
 wast = "5.0.1"
 
 [badges]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-fuzz"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 publish = false

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -9,7 +9,7 @@ topdir=$(dirname "$0")/..
 cd "$topdir"
 
 # All the wasmtime-* crates have the same version number
-version="0.7.0"
+version="0.9.0"
 
 # Update the version numbers of the crates to $version.
 echo "Updating crate versions to $version"
@@ -42,10 +42,10 @@ for cargo_toml in \
     crates/runtime/Cargo.toml \
     crates/debug/Cargo.toml \
     crates/jit/Cargo.toml \
-    crates/wast/Cargo.toml \
     crates/wasi-c/Cargo.toml \
-    crates/wasi/Cargo.toml \
     crates/api/Cargo.toml \
+    crates/wasi/Cargo.toml \
+    crates/wast/Cargo.toml \
     crates/interface-types/Cargo.toml \
     crates/misc/py/Cargo.toml \
     crates/misc/rust/macro/Cargo.toml \

--- a/src/commands/wasm2obj.rs
+++ b/src/commands/wasm2obj.rs
@@ -154,7 +154,7 @@ impl WasmToObjCommand {
                     &module_translation,
                     lazy_function_body_inputs,
                     &*isa,
-                    generate_debug_info,
+                    self.common.debug_info,
                 ),
                 #[cfg(not(feature = "lightbeam"))]
                 Strategy::Lightbeam => bail!("lightbeam support not enabled"),


### PR DESCRIPTION
 - Per-instance signal handlers
 - Improved Windows support
 - Lots of API improvements
 - Support for secure TTY output
