### PR TITLE
Remove `HostRef` as a reexport from `wasmtime`

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::callable::Callable;
 pub use crate::externals::*;
 pub use crate::instance::Instance;
 pub use crate::module::Module;
-pub use crate::r#ref::{AnyRef, HostInfo, HostRef};
+pub use crate::r#ref::AnyRef;
 pub use crate::runtime::{Config, Engine, OptLevel, Store, Strategy};
 pub use crate::trap::{FrameInfo, Trap};
 pub use crate::types::*;

--- a/crates/api/src/wasm.rs
+++ b/crates/api/src/wasm.rs
@@ -7,9 +7,10 @@
 
 use super::{
     AnyRef, Callable, Engine, ExportType, Extern, ExternType, Func, FuncType, Global, GlobalType,
-    HostInfo, HostRef, ImportType, Instance, Limits, Memory, MemoryType, Module, Store, Table,
-    TableType, Trap, Val, ValType,
+    ImportType, Instance, Limits, Memory, MemoryType, Module, Store, Table, TableType, Trap, Val,
+    ValType,
 };
+use crate::r#ref::{HostInfo, HostRef};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::{mem, ptr, slice};

--- a/crates/api/tests/name.rs
+++ b/crates/api/tests/name.rs
@@ -1,48 +1,38 @@
 use wasmtime::*;
-use wat::parse_str;
 
 #[test]
-fn test_module_no_name() -> Result<(), String> {
+fn test_module_no_name() -> anyhow::Result<()> {
     let store = Store::default();
-    let binary = parse_str(
+    let binary = wat::parse_str(
         r#"
-                (module
-                (func (export "run") (nop))
-                )
-            "#,
-    )
-    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+            (module
+            (func (export "run") (nop))
+            )
+        "#,
+    )?;
 
-    let module = HostRef::new(
-        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?,
-    );
-    assert_eq!(module.borrow().name(), None);
+    let module = Module::new(&store, &binary)?;
+    assert_eq!(module.name(), None);
 
     Ok(())
 }
 
 #[test]
-fn test_module_name() -> Result<(), String> {
+fn test_module_name() -> anyhow::Result<()> {
     let store = Store::default();
-    let binary = parse_str(
+    let binary = wat::parse_str(
         r#"
-                (module $from_name_section
-                (func (export "run") (nop))
-                )
-            "#,
-    )
-    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+            (module $from_name_section
+            (func (export "run") (nop))
+            )
+        "#,
+    )?;
 
-    let module = HostRef::new(
-        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?,
-    );
-    assert_eq!(module.borrow().name(), Some("from_name_section"));
+    let module = Module::new(&store, &binary)?;
+    assert_eq!(module.name(), Some("from_name_section"));
 
-    let module = HostRef::new(
-        Module::new_with_name(&store, &binary, "override")
-            .map_err(|e| format!("failed to compile module: {}", e))?,
-    );
-    assert_eq!(module.borrow().name(), Some("override"));
+    let module = Module::new_with_name(&store, &binary, "override")?;
+    assert_eq!(module.name(), Some("override"));
 
     Ok(())
 }


### PR DESCRIPTION
This continues #788 and literally removes the type from the public API
of the `wasmtime` crate, making it inaccessible to the outside world.
Now it's purely an implementation detail, yay!