### PR TITLE
Assert on CI `wasi-tests` workspace is locked

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,6 +165,7 @@ jobs:
     - run: rustup target add wasm32-wasi
 
     - run: cargo fetch --locked
+    - run: cargo fetch --locked --manifest-path crates/test-programs/wasi-tests/Cargo.toml
 
     # Build and test all features except for lightbeam
     - run: cargo test --features test_programs --all --exclude lightbeam -- --nocapture

--- a/crates/test-programs/wasi-tests/Cargo.lock
+++ b/crates/test-programs/wasi-tests/Cargo.lock
@@ -17,7 +17,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasi-tests"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Similar to the main workspace, assert that CI doesn't need to change the
manifest to ensure that PRs reflect any manifest updates necessary.