### PR TITLE
Only require `str` in `new_with_name`

### DIFF
--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -27,7 +27,7 @@ impl Resolver for SimpleResolver<'_> {
 pub fn instantiate_in_context(
     data: &[u8],
     imports: &[Extern],
-    module_name: Option<String>,
+    module_name: Option<&str>,
     context: Context,
     exports: Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>>,
 ) -> Result<(InstanceHandle, HashSet<Context>), Error> {
@@ -74,7 +74,7 @@ impl Instance {
         let (mut instance_handle, contexts) = instantiate_in_context(
             module.binary().expect("binary"),
             externs,
-            module.name().cloned(),
+            module.name(),
             context,
             exports,
         )?;

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -270,9 +270,9 @@ impl Module {
     /// data. The provided `name` will be used in traps/backtrace details.
     ///
     /// See [`Module::new`] for other details.
-    pub fn new_with_name(store: &Store, binary: &[u8], name: String) -> Result<Module> {
+    pub fn new_with_name(store: &Store, binary: &[u8], name: &str) -> Result<Module> {
         Self::validate(store, binary)?;
-        unsafe { Self::create(store, binary, Some(name)) }
+        unsafe { Self::create(store, binary, Some(name.to_string())) }
     }
 
     /// Creates a new WebAssembly `Module` from the given in-memory `binary`
@@ -376,8 +376,8 @@ impl Module {
 
     /// Returns identifier/name that this [`Module`] has. This name
     /// is used in traps/backtrace details.
-    pub fn name(&self) -> Option<&String> {
-        self.inner.name.as_ref()
+    pub fn name(&self) -> Option<&str> {
+        self.inner.name.as_deref()
     }
 
     /// Returns the list of imports that this [`Module`] has and must be

--- a/crates/api/tests/name.rs
+++ b/crates/api/tests/name.rs
@@ -42,7 +42,7 @@ fn test_module_name() -> Result<(), String> {
     );
 
     let module = HostRef::new(
-        Module::new_with_name(&store, &binary, "override".to_string())
+        Module::new_with_name(&store, &binary, "override")
             .map_err(|e| format!("failed to compile module: {}", e))?,
     );
     assert_eq!(

--- a/crates/api/tests/name.rs
+++ b/crates/api/tests/name.rs
@@ -16,7 +16,7 @@ fn test_module_no_name() -> Result<(), String> {
     let module = HostRef::new(
         Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?,
     );
-    assert_eq!(module.borrow().name().cloned(), None);
+    assert_eq!(module.borrow().name(), None);
 
     Ok(())
 }
@@ -36,19 +36,13 @@ fn test_module_name() -> Result<(), String> {
     let module = HostRef::new(
         Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?,
     );
-    assert_eq!(
-        module.borrow().name().cloned(),
-        Some("from_name_section".to_string())
-    );
+    assert_eq!(module.borrow().name(), Some("from_name_section"));
 
     let module = HostRef::new(
         Module::new_with_name(&store, &binary, "override")
             .map_err(|e| format!("failed to compile module: {}", e))?,
     );
-    assert_eq!(
-        module.borrow().name().cloned(),
-        Some("override".to_string())
-    );
+    assert_eq!(module.borrow().name(), Some("override"));
 
     Ok(())
 }

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -60,7 +60,7 @@ impl<'data> RawCompiledModule<'data> {
     fn new(
         compiler: &mut Compiler,
         data: &'data [u8],
-        module_name: Option<String>,
+        module_name: Option<&str>,
         resolver: &mut dyn Resolver,
         debug_info: bool,
     ) -> Result<Self, SetupError> {
@@ -76,7 +76,7 @@ impl<'data> RawCompiledModule<'data> {
             None
         };
 
-        translation.module.name = module_name;
+        translation.module.name = module_name.map(|s| s.to_string());
 
         let (allocated_functions, jt_offsets, relocations, dbg_image) = compiler.compile(
             &translation.module,
@@ -155,7 +155,7 @@ impl CompiledModule {
     pub fn new<'data>(
         compiler: &mut Compiler,
         data: &'data [u8],
-        module_name: Option<String>,
+        module_name: Option<&str>,
         resolver: &mut dyn Resolver,
         global_exports: Rc<RefCell<HashMap<String, Option<Export>>>>,
         debug_info: bool,
@@ -263,7 +263,7 @@ impl OwnedDataInitializer {
 pub fn instantiate(
     compiler: &mut Compiler,
     data: &[u8],
-    module_name: Option<String>,
+    module_name: Option<&str>,
     resolver: &mut dyn Resolver,
     global_exports: Rc<RefCell<HashMap<String, Option<Export>>>>,
     debug_info: bool,


### PR DESCRIPTION
It's a bit more idiomatic to have APIs require `&str` rather than
`String`, and the allocation doesn't matter much here since creating a
`Module` is pretty expensive anyway.