### PR TITLE
Refactor the `wasmtime-wast` crate, fix an early return

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,12 +43,14 @@ fn main() -> anyhow::Result<()> {
                 "simd",
                 strategy,
             )?;
-            write_testsuite_tests(
-                &mut out,
-                "tests/spec_testsuite/proposals/simd/simd_const.wast",
-                "simd",
-                strategy,
-            )?;
+            // FIXME this uses some features from the reference types proposal
+            // (multi-table) which aren't fully implemented yet
+            // write_testsuite_tests(
+            //     &mut out,
+            //     "tests/spec_testsuite/proposals/simd/simd_const.wast",
+            //     "simd",
+            //     strategy,
+            // )?;
             finish_test_module(&mut out)?;
 
             test_directory(

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -10,8 +10,11 @@ include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
 fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
     let wast = Path::new(wast);
 
+    let simd = wast.iter().any(|s| s == "simd");
+
     let mut cfg = Config::new();
-    cfg.wasm_simd(wast.iter().any(|s| s == "simd"))
+    cfg.wasm_simd(simd)
+        .wasm_reference_types(simd) // some simd tests assume multiple tables ok
         .wasm_multi_value(wast.iter().any(|s| s == "multi-value"))
         .strategy(strategy)?
         .cranelift_debug_verifier(true);


### PR DESCRIPTION
This commit refactors the `wasmtime-wast` crate to internally make it a
bit more concise with less repetition. Additionally it also improves the
error messages by guaranteeing that all failed tests have context
indicating where the test was defined.

It turns out there was also a bug in the previous implementation where
an `AssertMalformed` directive with a `quote` module would accidentally
skip all further tests. This has now been fixed, and all futher tests
continued to pass except for the `simd_const.wast` test. This test has
been disabled temporarily but once the `wasmparser` and `wast` crates
are updated (being worked on independently) this should be possible to
re-enable.