### PR TITLE
Update wast to 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 5.0.1",
+ "wast 6.0.0",
 ]
 
 [[package]]
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1de68310854a9840d39487701a8c1acccb5c9f9f2650d5fce3cdfe6650c372"
+checksum = "3ed3db7029d1d31a15c10126e78b58e51781faefafbc8afb20fb01291b779984"
 dependencies = [
  "leb128",
 ]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../api" }
-wast = "5.0.1"
+wast = "6.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Due to API changes in wast, this removes all AssertReturn* directives and expands the functionality the single AssertReturn directive with the `nan:canonical` and `nan:arithmetic` patterns. See https://github.com/bytecodealliance/wat/pull/42 and https://github.com/WebAssembly/spec/pull/1104 for context.