### PR TITLE
Move around some panics in `wasmtime`

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -163,8 +163,12 @@ impl Func {
         store: &Store,
         instance_handle: InstanceHandle,
     ) -> Self {
+        // This is only called with `Export::Function`, and since it's coming
+        // from wasmtime_runtime itself we should support all the types coming
+        // out of it, so assert such here.
         let ty = if let wasmtime_runtime::Export::Function { signature, .. } = &export {
             FuncType::from_wasmtime_signature(signature.clone())
+                .expect("core wasm signature should be supported")
         } else {
             panic!("expected function export")
         };
@@ -258,9 +262,12 @@ impl Global {
         let global = if let wasmtime_runtime::Export::Global { ref global, .. } = export {
             global
         } else {
-            panic!("wasmtime export is not memory")
+            panic!("wasmtime export is not global")
         };
-        let ty = GlobalType::from_wasmtime_global(&global);
+        // The original export is coming from wasmtime_runtime itself we should
+        // support all the types coming out of it, so assert such here.
+        let ty = GlobalType::from_wasmtime_global(&global)
+            .expect("core wasm global type should be supported");
         Global {
             inner: Rc::new(GlobalInner {
                 _store: store.clone(),

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -132,7 +132,14 @@ impl Instance {
                 // imported into this store using the from_handle() method.
                 let _ = store.register_wasmtime_signature(signature);
             }
-            let extern_type = ExternType::from_wasmtime_export(&export);
+
+            // We should support everything supported by wasmtime_runtime, or
+            // otherwise we've got a bug in this crate, so panic if anything
+            // fails to convert here.
+            let extern_type = match ExternType::from_wasmtime_export(&export) {
+                Some(ty) => ty,
+                None => panic!("unsupported core wasm external type {:?}", export),
+            };
             exports_types.push(ExportType::new(name, extern_type));
             exports.push(Extern::from_wasmtime_export(
                 store,

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -3,7 +3,7 @@
 use super::create_handle::create_handle;
 use super::trap::{record_api_trap, TrapSink, API_TRAP_CODE};
 use crate::{Callable, FuncType, Store, Val};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use std::cmp;
 use std::convert::TryFrom;
 use std::rc::Rc;
@@ -234,7 +234,10 @@ pub fn create_handle_with_function(
     func: &Rc<dyn Callable + 'static>,
     store: &Store,
 ) -> Result<InstanceHandle> {
-    let sig = ft.get_wasmtime_signature().clone();
+    let sig = match ft.get_wasmtime_signature() {
+        Some(sig) => sig.clone(),
+        None => bail!("not a supported core wasm signature {:?}", ft),
+    };
 
     let isa = {
         let isa_builder = native::builder();

--- a/crates/api/src/trampoline/global.rs
+++ b/crates/api/src/trampoline/global.rs
@@ -1,6 +1,6 @@
 use super::create_handle::create_handle;
 use crate::{GlobalType, Mutability, Val};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::{wasm, Module};
 use wasmtime_runtime::{InstanceHandle, VMGlobalDefinition};
@@ -24,7 +24,10 @@ pub fn create_global(gt: &GlobalType, val: Val) -> Result<(wasmtime_runtime::Exp
     }
 
     let global = wasm::Global {
-        ty: gt.content().get_wasmtime_type(),
+        ty: match gt.content().get_wasmtime_type() {
+            Some(t) => t,
+            None => bail!("cannot support {:?} as a wasm global type", gt.content()),
+        },
         mutability: match gt.mutability() {
             Mutability::Const => false,
             Mutability::Var => true,

--- a/crates/api/src/trampoline/table.rs
+++ b/crates/api/src/trampoline/table.rs
@@ -1,6 +1,6 @@
 use super::create_handle::create_handle;
 use crate::{TableType, ValType};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::{wasm, Module};
 use wasmtime_runtime::InstanceHandle;
@@ -13,7 +13,10 @@ pub fn create_handle_with_table(table: &TableType) -> Result<InstanceHandle> {
         maximum: table.limits().max(),
         ty: match table.element() {
             ValType::FuncRef => wasm::TableElementType::Func,
-            _ => wasm::TableElementType::Val(table.element().get_wasmtime_type()),
+            _ => match table.element().get_wasmtime_type() {
+                Some(t) => wasm::TableElementType::Val(t),
+                None => bail!("cannot support {:?} as a table element", table.element()),
+            },
         },
     };
     let tunable = Default::default();


### PR DESCRIPTION
In preparation for eventual support for wasm interface types this commit
moves around a few panics internally inside of conversions between the
`wasmtime` crate and the underlying jit support crates. This should have
any immediately-visible user changes, but the goal is that this'll help
support interface types which means `wasmtime` will have types that are
not supported by wasmtime itself and we'll be able to more gracefully
support that with error messages instead of accidental panics.