### PR TITLE
Docs driveby fix for `Memory::data`

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -455,7 +455,7 @@ impl Memory {
     ///
     /// # Safety
     ///
-    /// Marked unsafe due to posibility of getting aliased mutable references. It is up to caller
+    /// Marked unsafe due to possibility of getting aliased mutable references. It is up to the caller
     /// to ensure that the returned mutable reference is unique.
     pub unsafe fn data(&self) -> &mut [u8] {
         let definition = &*self.wasmtime_memory_definition();

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -452,9 +452,11 @@ impl Memory {
     }
 
     /// Returns a mutable slice the current memory.
+    ///
     /// # Safety
-    /// Marked unsafe due to posibility that wasmtime can resize internal memory
-    /// from other threads.
+    ///
+    /// Marked unsafe due to posibility of getting aliased mutable references. It is up to caller
+    /// to ensure that the returned mutable reference is unique.
     pub unsafe fn data(&self) -> &mut [u8] {
         let definition = &*self.wasmtime_memory_definition();
         slice::from_raw_parts_mut(definition.base, definition.current_length)


### PR DESCRIPTION
Reshape the safety warning around mutable aliases instead of threads.