### PR TITLE
Provide proper function index and name in the FrameInfo

### DIFF
--- a/crates/api/src/trap.rs
+++ b/crates/api/src/trap.rs
@@ -43,6 +43,7 @@ impl Trap {
                 wasm_trace.push(FrameInfo {
                     func_index: info.func_index as u32,
                     module_name: info.module_id.clone(),
+                    func_name: info.func_name.clone(),
                 })
             }
         }
@@ -87,6 +88,7 @@ impl std::error::Error for Trap {}
 pub struct FrameInfo {
     module_name: Option<String>,
     func_index: u32,
+    func_name: String,
 }
 
 impl FrameInfo {
@@ -108,5 +110,9 @@ impl FrameInfo {
 
     pub fn module_name(&self) -> Option<&str> {
         self.module_name.as_deref()
+    }
+
+    pub fn func_name(&self) -> &str {
+        &self.func_name
     }
 }

--- a/crates/api/src/trap.rs
+++ b/crates/api/src/trap.rs
@@ -42,8 +42,8 @@ impl Trap {
             if let Some(info) = wasmtime_runtime::jit_function_registry::find(pc) {
                 wasm_trace.push(FrameInfo {
                     func_index: info.func_index as u32,
-                    module_name: info.module_id.clone(),
-                    func_name: info.func_name.clone(),
+                    module_name: info.module_id.get().map(|s| s.to_string()),
+                    func_name: info.func_name.get().map(|s| s.to_string()),
                 })
             }
         }
@@ -88,7 +88,7 @@ impl std::error::Error for Trap {}
 pub struct FrameInfo {
     module_name: Option<String>,
     func_index: u32,
-    func_name: String,
+    func_name: Option<String>,
 }
 
 impl FrameInfo {
@@ -112,7 +112,7 @@ impl FrameInfo {
         self.module_name.as_deref()
     }
 
-    pub fn func_name(&self) -> &str {
-        &self.func_name
+    pub fn func_name(&self) -> Option<&str> {
+        self.func_name.as_deref()
     }
 }

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -114,9 +114,9 @@ fn test_trap_trace_cb() -> Result<(), String> {
     let trace = e.trace();
     assert_eq!(trace.len(), 2);
     assert_eq!(trace[0].module_name().unwrap(), "hello_mod");
-    assert_eq!(trace[0].func_index(), 1);
+    assert_eq!(trace[0].func_index(), 2);
     assert_eq!(trace[1].module_name().unwrap(), "hello_mod");
-    assert_eq!(trace[1].func_index(), 0);
+    assert_eq!(trace[1].func_index(), 1);
     assert_eq!(e.message(), "cb throw");
 
     Ok(())

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -69,8 +69,10 @@ fn test_trap_trace() -> Result<(), String> {
     assert_eq!(trace.len(), 2);
     assert_eq!(trace[0].module_name().unwrap(), "hello_mod");
     assert_eq!(trace[0].func_index(), 1);
+    assert_eq!(trace[0].func_name(), "hello");
     assert_eq!(trace[1].module_name().unwrap(), "hello_mod");
     assert_eq!(trace[1].func_index(), 0);
+    assert_eq!(trace[1].func_name(), "");
     assert!(e.message().contains("unreachable"));
 
     Ok(())
@@ -149,6 +151,7 @@ fn test_trap_stack_overflow() -> Result<(), String> {
     for i in 0..trace.len() {
         assert_eq!(trace[i].module_name().unwrap(), "rec_mod");
         assert_eq!(trace[i].func_index(), 0);
+        assert_eq!(trace[1].func_name(), "run");
     }
     assert!(e.message().contains("call stack exhausted"));
 

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -69,10 +69,10 @@ fn test_trap_trace() -> Result<(), String> {
     assert_eq!(trace.len(), 2);
     assert_eq!(trace[0].module_name().unwrap(), "hello_mod");
     assert_eq!(trace[0].func_index(), 1);
-    assert_eq!(trace[0].func_name(), "hello");
+    assert_eq!(trace[0].func_name(), Some("hello"));
     assert_eq!(trace[1].module_name().unwrap(), "hello_mod");
     assert_eq!(trace[1].func_index(), 0);
-    assert_eq!(trace[1].func_name(), "");
+    assert_eq!(trace[1].func_name(), None);
     assert!(e.message().contains("unreachable"));
 
     Ok(())
@@ -151,7 +151,7 @@ fn test_trap_stack_overflow() -> Result<(), String> {
     for i in 0..trace.len() {
         assert_eq!(trace[i].module_name().unwrap(), "rec_mod");
         assert_eq!(trace[i].func_index(), 0);
-        assert_eq!(trace[1].func_name(), "run");
+        assert_eq!(trace[1].func_name(), Some("run"));
     }
     assert!(e.message().contains("call stack exhausted"));
 

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::func_environ::BuiltinFunctionIndex;
 #[cfg(feature = "lightbeam")]
 pub use crate::lightbeam::Lightbeam;
 pub use crate::module::{
-    Export, MemoryPlan, MemoryStyle, Module, TableElements, TablePlan, TableStyle,
+    Export, MemoryPlan, MemoryStyle, Module, ModuleSyncString, TableElements, TablePlan, TableStyle,
 };
 pub use crate::module_environ::{
     translate_signature, DataInitializer, DataInitializerLocation, FunctionBodyData,

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -3,7 +3,7 @@
 use crate::module_environ::FunctionBodyData;
 use crate::tunables::Tunables;
 use cranelift_codegen::ir;
-use cranelift_entity::{EntityRef, PrimaryMap};
+use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
 use cranelift_wasm::{
     DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, Global,
     GlobalIndex, Memory, MemoryIndex, SignatureIndex, Table, TableIndex,
@@ -172,6 +172,9 @@ pub struct Module {
 
     /// Module name.
     pub name: Option<String>,
+
+    /// Function names.
+    pub func_names: SecondaryMap<FuncIndex, String>,
 }
 
 impl Module {
@@ -191,6 +194,7 @@ impl Module {
             start_func: None,
             table_elements: Vec::new(),
             name: None,
+            func_names: SecondaryMap::new(),
         }
     }
 

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -1,5 +1,5 @@
 use crate::func_environ::FuncEnvironment;
-use crate::module::{Export, MemoryPlan, Module, TableElements, TablePlan};
+use crate::module::{Export, MemoryPlan, Module, ModuleSyncString, TableElements, TablePlan};
 use crate::tunables::Tunables;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::{AbiParam, ArgumentPurpose};
@@ -371,7 +371,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn declare_func_name(&mut self, func_index: FuncIndex, name: &'data str) -> WasmResult<()> {
-        self.result.module.func_names[func_index] = name.to_string();
+        self.result.module.func_names[func_index] = ModuleSyncString::new(Some(name));
         Ok(())
     }
 }

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -369,6 +369,11 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         });
         Ok(())
     }
+
+    fn declare_func_name(&mut self, func_index: FuncIndex, name: &'data str) -> WasmResult<()> {
+        self.result.module.func_names[func_index] = name.to_string();
+        Ok(())
+    }
 }
 
 /// Add environment-specific function parameters.

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -168,7 +168,7 @@ impl Compiler {
                 .push((ptr as usize, ptr as usize + body_len));
             let tag = jit_function_registry::JITFunctionTag {
                 module_id: module.name.clone(),
-                func_index: i.index(),
+                func_index: module.func_index(i).index(),
             };
             jit_function_registry::register(ptr as usize, ptr as usize + body_len, tag);
         }

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -166,9 +166,16 @@ impl Compiler {
             let body_len = compilation.get(i).body.len();
             self.jit_function_ranges
                 .push((ptr as usize, ptr as usize + body_len));
+            let func_index = module.func_index(i);
+            let func_name = module
+                .func_names
+                .get(func_index)
+                .cloned()
+                .unwrap_or_else(Default::default);
             let tag = jit_function_registry::JITFunctionTag {
                 module_id: module.name.clone(),
-                func_index: module.func_index(i).index(),
+                func_index: func_index.index(),
+                func_name,
             };
             jit_function_registry::register(ptr as usize, ptr as usize + body_len, tag);
         }

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -16,6 +16,7 @@ use wasmtime_environ::entity::{BoxedSlice, PrimaryMap};
 use wasmtime_environ::wasm::{DefinedFuncIndex, SignatureIndex};
 use wasmtime_environ::{
     CompileError, DataInitializer, DataInitializerLocation, Module, ModuleEnvironment,
+    ModuleSyncString,
 };
 use wasmtime_runtime::{
     Export, GdbJitImageRegistration, Imports, InstanceHandle, InstantiationError, VMFunctionBody,
@@ -76,7 +77,7 @@ impl<'data> RawCompiledModule<'data> {
             None
         };
 
-        translation.module.name = module_name.map(|s| s.to_string());
+        translation.module.name = ModuleSyncString::new(module_name);
 
         let (allocated_functions, jt_offsets, relocations, dbg_image) = compiler.compile(
             &translation.module,

--- a/crates/runtime/src/jit_function_registry.rs
+++ b/crates/runtime/src/jit_function_registry.rs
@@ -3,6 +3,7 @@
 use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
+use wasmtime_environ::ModuleSyncString;
 
 lazy_static! {
     static ref REGISTRY: RwLock<JITFunctionRegistry> = RwLock::new(JITFunctionRegistry::default());
@@ -10,14 +11,14 @@ lazy_static! {
 
 #[derive(Clone)]
 pub struct JITFunctionTag {
-    pub module_id: Option<String>,
+    pub module_id: ModuleSyncString,
     pub func_index: usize,
-    pub func_name: String,
+    pub func_name: ModuleSyncString,
 }
 
 impl std::fmt::Debug for JITFunctionTag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(ref module_id) = self.module_id {
+        if let Some(ref module_id) = self.module_id.get() {
             write!(f, "{}", module_id)?;
         } else {
             write!(f, "(module)")?;

--- a/crates/runtime/src/jit_function_registry.rs
+++ b/crates/runtime/src/jit_function_registry.rs
@@ -12,6 +12,7 @@ lazy_static! {
 pub struct JITFunctionTag {
     pub module_id: Option<String>,
     pub func_index: usize,
+    pub func_name: String,
 }
 
 impl std::fmt::Debug for JITFunctionTag {


### PR DESCRIPTION
Changes:
* Wasm function index includes imported functions
* Use cranelift-wasm to provide found function name, and expose that via API's FrameInfo