### PR TITLE
Improve trap error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,7 @@ dependencies = [
  "pretty_env_logger",
  "rayon",
  "region",
+ "rustc-demangle",
  "target-lexicon",
  "wasi-common",
  "wasmparser 0.47.0",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -19,6 +19,7 @@ region = "2.0.0"
 libc = "0.2"
 cfg-if = "0.1.9"
 backtrace = "0.3.42"
+rustc-demangle = "0.1.16"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"

--- a/crates/api/src/trap.rs
+++ b/crates/api/src/trap.rs
@@ -78,7 +78,14 @@ impl fmt::Debug for Trap {
 
 impl fmt::Display for Trap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.message.fmt(f)
+        write!(f, "{}", self.inner.message)?;
+        if self.trace().len() > 0 {
+            writeln!(f, "\nwasm backtrace:")?;
+            for (i, frame) in self.trace().iter().enumerate() {
+                writeln!(f, "  {}: {}", i, frame)?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -114,5 +121,18 @@ impl FrameInfo {
 
     pub fn func_name(&self) -> Option<&str> {
         self.func_name.as_deref()
+    }
+}
+
+impl fmt::Display for FrameInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(name) = self.func_name() {
+            return match rustc_demangle::try_demangle(name) {
+                Ok(name) => name.fmt(f),
+                Err(_) => name.fmt(f),
+            };
+        }
+        write!(f, "<wasm function {}>", self.func_index)?;
+        Ok(())
     }
 }

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -1,9 +1,9 @@
+use anyhow::Result;
 use std::rc::Rc;
 use wasmtime::*;
-use wat::parse_str;
 
 #[test]
-fn test_trap_return() -> Result<(), String> {
+fn test_trap_return() -> Result<()> {
     struct HelloCallback;
 
     impl Callable for HelloCallback {
@@ -13,24 +13,20 @@ fn test_trap_return() -> Result<(), String> {
     }
 
     let store = Store::default();
-    let binary = parse_str(
+    let binary = wat::parse_str(
         r#"
             (module
             (func $hello (import "" "hello"))
             (func (export "run") (call $hello))
             )
         "#,
-    )
-    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+    )?;
 
-    let module =
-        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?;
+    let module = Module::new(&store, &binary)?;
     let hello_type = FuncType::new(Box::new([]), Box::new([]));
     let hello_func = Func::new(&store, hello_type, Rc::new(HelloCallback));
 
-    let imports = vec![hello_func.into()];
-    let instance = Instance::new(&module, &imports)
-        .map_err(|e| format!("failed to instantiate module: {:?}", e))?;
+    let instance = Instance::new(&module, &[hello_func.into()])?;
     let run_func = instance.exports()[0]
         .func()
         .expect("expected function export");
@@ -43,22 +39,19 @@ fn test_trap_return() -> Result<(), String> {
 }
 
 #[test]
-fn test_trap_trace() -> Result<(), String> {
+fn test_trap_trace() -> Result<()> {
     let store = Store::default();
-    let binary = parse_str(
+    let binary = wat::parse_str(
         r#"
             (module $hello_mod
                 (func (export "run") (call $hello))
                 (func $hello (unreachable))
             )
         "#,
-    )
-    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+    )?;
 
-    let module =
-        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?;
-    let instance = Instance::new(&module, &[])
-        .map_err(|e| format!("failed to instantiate module: {:?}", e))?;
+    let module = Module::new(&store, &binary)?;
+    let instance = Instance::new(&module, &[])?;
     let run_func = instance.exports()[0]
         .func()
         .expect("expected function export");
@@ -79,7 +72,7 @@ fn test_trap_trace() -> Result<(), String> {
 }
 
 #[test]
-fn test_trap_trace_cb() -> Result<(), String> {
+fn test_trap_trace_cb() -> Result<()> {
     struct ThrowCallback;
 
     impl Callable for ThrowCallback {
@@ -89,7 +82,7 @@ fn test_trap_trace_cb() -> Result<(), String> {
     }
 
     let store = Store::default();
-    let binary = parse_str(
+    let binary = wat::parse_str(
         r#"
             (module $hello_mod
                 (import "" "throw" (func $throw))
@@ -97,16 +90,13 @@ fn test_trap_trace_cb() -> Result<(), String> {
                 (func $hello (call $throw))
             )
         "#,
-    )
-    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+    )?;
 
     let fn_type = FuncType::new(Box::new([]), Box::new([]));
     let fn_func = Func::new(&store, fn_type, Rc::new(ThrowCallback));
 
-    let module =
-        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?;
-    let instance = Instance::new(&module, &[fn_func.into()])
-        .map_err(|e| format!("failed to instantiate module: {:?}", e))?;
+    let module = Module::new(&store, &binary)?;
+    let instance = Instance::new(&module, &[fn_func.into()])?;
     let run_func = instance.exports()[0]
         .func()
         .expect("expected function export");
@@ -125,21 +115,18 @@ fn test_trap_trace_cb() -> Result<(), String> {
 }
 
 #[test]
-fn test_trap_stack_overflow() -> Result<(), String> {
+fn test_trap_stack_overflow() -> Result<()> {
     let store = Store::default();
-    let binary = parse_str(
+    let binary = wat::parse_str(
         r#"
             (module $rec_mod
                 (func $run (export "run") (call $run))
             )
         "#,
-    )
-    .map_err(|e| format!("failed to parse WebAssembly text source: {}", e))?;
+    )?;
 
-    let module =
-        Module::new(&store, &binary).map_err(|e| format!("failed to compile module: {}", e))?;
-    let instance = Instance::new(&module, &[])
-        .map_err(|e| format!("failed to instantiate module: {:?}", e))?;
+    let module = Module::new(&store, &binary)?;
+    let instance = Instance::new(&module, &[])?;
     let run_func = instance.exports()[0]
         .func()
         .expect("expected function export");
@@ -151,7 +138,7 @@ fn test_trap_stack_overflow() -> Result<(), String> {
     for i in 0..trace.len() {
         assert_eq!(trace[i].module_name().unwrap(), "rec_mod");
         assert_eq!(trace[i].func_index(), 0);
-        assert_eq!(trace[1].func_name(), Some("run"));
+        assert_eq!(trace[i].func_name(), Some("run"));
     }
     assert!(e.message().contains("call stack exhausted"));
 

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -71,13 +71,10 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         .context("expected a _start export")?
         .clone();
 
-    if let Err(trap) = export
+    export
         .func()
         .context("expected export to be a func")?
-        .call(&[])
-    {
-        bail!("trapped: {:?}", trap);
-    }
+        .call(&[])?;
 
     Ok(())
 }


### PR DESCRIPTION
The new trap error message for the issue #828 looks like:

```
thread 'main' panicked at 'a', /proc/self/fd/11:1:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
Error: failed to run main module `test.wasm`

Caused by:
    0: failed to invoke `_start`
    1: wasm trap: unreachable, source location: @6cea
       wasm backtrace:
         0: __rust_start_panic
         1: rust_panic
         2: std::panicking::rust_panic_with_hook::h57f0cff11449798f
         3: std::panicking::begin_panic::hd620695467c5dd1f
         4: test::main::ha54db001eabbde1b
         5: std::rt::lang_start::{{closure}}::h5acfb82693695869
         6: std::sys_common::backtrace::__rust_begin_short_backtrace::h39e8b9420da241f9
         7: std::panicking::try::do_call::hb7ebfcd70d5f703e
         8: __rust_maybe_catch_panic
         9: std::rt::lang_start_internal::hd5f64f52a5c5315c
         10: std::rt::lang_start::h2a51d79994dd0c4b
         11: __original_main
         12: _start
```

Closes #828