### PR TITLE
Disable rustdoc on the wasmtime cli binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ publish = false
 [lib]
 doctest = false
 
+[[bin]]
+name = "wasmtime"
+path = "src/bin/wasmtime.rs"
+doc = false
+
 [dependencies]
 # Enable all supported architectures by default.
 wasmtime = { path = "crates/api" }


### PR DESCRIPTION
Currently the wasmtime binary (src/bin/wasmtime) and the wasmtime API
crate (crates/api) share the same output filename.  This causes the
output files of the wasmtime binary to clobber the output files of the
wasmtime API crate.   So running `cargo doc --all` will often not build
the wasmtime API docs, which is the more useful of the two.

You can see this warning when running `cargo doc --all` in the root of the repo:

    warning: output filename collision.
    The bin target `wasmtime` in package `wasmtime-cli v0.9.0 (/tank/achin/devel/wasmtime)` has the same output filename as the lib target `wasmtime` in package `wasmtime v0.9.0 (/tank/achin/devel/wasmtime/crates/api)`.
    Colliding filename is: /tank/achin/devel/wasmtime/target/doc/wasmtime/index.html
    The targets should have unique names.
    This is a known bug where multiple crates with the same name use
    the same path; see <https://github.com/rust-lang/cargo/issues/6313>.


This is a rustdoc bug, and can be worked around by disabling
documentation for the wasmtime binary.  If someone wants the rustdocs for
the wasmtime CLI binary (which too be honest are not very useful), they can explicitly generate them with `cargo doc --bin wasmtime`