### PR TITLE
Deny missing documentation in `wasmtime` crate

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -6,6 +6,8 @@
 //! and there to implement Rust idioms. This crate also defines the actual C API
 //! itself for consumption from other languages.
 
+#![deny(missing_docs)]
+
 mod callable;
 mod externals;
 mod instance;

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -218,6 +218,7 @@ impl Module {
         validate(binary, Some(config)).map_err(Error::new)
     }
 
+    #[doc(hidden)]
     pub fn from_exports(store: &Store, exports: Box<[ExportType]>) -> Self {
         let mut ret = Module::empty(store);
         Rc::get_mut(&mut ret.inner).unwrap().exports = exports;

--- a/crates/api/src/ref.rs
+++ b/crates/api/src/ref.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::any::Any;
 use std::cell::{self, RefCell};
 use std::fmt;

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -116,9 +116,13 @@ impl ValType {
 /// can either be imported or exported.
 #[derive(Debug, Clone)]
 pub enum ExternType {
+    /// This external type is the type of a WebAssembly function.
     Func(FuncType),
+    /// This external type is the type of a WebAssembly global.
     Global(GlobalType),
+    /// This external type is the type of a WebAssembly table.
     Table(TableType),
+    /// This external type is the type of a WebAssembly memory.
     Memory(MemoryType),
 }
 

--- a/crates/api/src/windows.rs
+++ b/crates/api/src/windows.rs
@@ -13,7 +13,9 @@ use crate::Instance;
 
 /// Extensions for the [`Instance`] type only available on Windows.
 pub trait InstanceExt {
-    // TODO: docs?
+    /// Configures a custom signal handler to execute.
+    ///
+    /// TODO: needs more documentation.
     unsafe fn set_signal_handler<H>(&self, handler: H)
     where
         H: 'static + Fn(winapi::um::winnt::EXCEPTION_POINTERS) -> bool;


### PR DESCRIPTION
Everything is largely documented now, so let's be sure to keep it that
way!