### PR TITLE
Support `Func` imports with zero shims

### DIFF
--- a/crates/api/examples/hello.rs
+++ b/crates/api/examples/hello.rs
@@ -1,18 +1,7 @@
 //! Translation of hello example
 
 use anyhow::{ensure, Context as _, Result};
-use std::rc::Rc;
 use wasmtime::*;
-
-struct HelloCallback;
-
-impl Callable for HelloCallback {
-    fn call(&self, _params: &[Val], _results: &mut [Val]) -> Result<(), Trap> {
-        println!("Calling back...");
-        println!("> Hello World!");
-        Ok(())
-    }
-}
 
 fn main() -> Result<()> {
     // Configure the initial compilation environment, creating the global
@@ -34,8 +23,10 @@ fn main() -> Result<()> {
     // Here we handle the imports of the module, which in this case is our
     // `HelloCallback` type and its associated implementation of `Callback.
     println!("Creating callback...");
-    let hello_type = FuncType::new(Box::new([]), Box::new([]));
-    let hello_func = Func::new(&store, hello_type, Rc::new(HelloCallback));
+    let hello_func = Func::wrap0(&store, || {
+        println!("Calling back...");
+        println!("> Hello World!");
+    });
 
     // Once we've got that all set up we can then move to the instantiation
     // phase, pairing together a compiled module as well as a set of imports.

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -1,12 +1,9 @@
-use crate::callable::{Callable, NativeCallable, WasmtimeFn, WrappedCallable};
-use crate::runtime::Store;
 use crate::trampoline::{generate_global_export, generate_memory_export, generate_table_export};
-use crate::trap::Trap;
-use crate::types::{ExternType, FuncType, GlobalType, MemoryType, TableType, ValType};
 use crate::values::{from_checked_anyfunc, into_checked_anyfunc, Val};
 use crate::Mutability;
+use crate::{ExternType, GlobalType, MemoryType, TableType, ValType};
+use crate::{Func, Store};
 use anyhow::{anyhow, bail, Result};
-use std::fmt;
 use std::rc::Rc;
 use std::slice;
 use wasmtime_environ::wasm;
@@ -137,121 +134,6 @@ impl From<Memory> for Extern {
 impl From<Table> for Extern {
     fn from(r: Table) -> Self {
         Extern::Table(r)
-    }
-}
-
-/// A WebAssembly function which can be called.
-///
-/// This type can represent a number of callable items, such as:
-///
-/// * An exported function from a WebAssembly module.
-/// * A user-defined function used to satisfy an import.
-///
-/// These types of callable items are all wrapped up in this `Func` and can be
-/// used to both instantiate an [`Instance`](crate::Instance) as well as be
-/// extracted from an [`Instance`](crate::Instance).
-///
-/// # `Func` and `Clone`
-///
-/// Functions are internally reference counted so you can `clone` a `Func`. The
-/// cloning process only performs a shallow clone, so two cloned `Func`
-/// instances are equivalent in their functionality.
-#[derive(Clone)]
-pub struct Func {
-    _store: Store,
-    callable: Rc<dyn WrappedCallable + 'static>,
-    ty: FuncType,
-}
-
-impl Func {
-    /// Creates a new `Func` with the given arguments, typically to create a
-    /// user-defined function to pass as an import to a module.
-    ///
-    /// * `store` - a cache of data where information is stored, typically
-    ///   shared with a [`Module`](crate::Module).
-    ///
-    /// * `ty` - the signature of this function, used to indicate what the
-    ///   inputs and outputs are, which must be WebAssembly types.
-    ///
-    /// * `callable` - a type implementing the [`Callable`] trait which
-    ///   is the implementation of this `Func` value.
-    ///
-    /// Note that the implementation of `callable` must adhere to the `ty`
-    /// signature given, error or traps may occur if it does not respect the
-    /// `ty` signature.
-    pub fn new(store: &Store, ty: FuncType, callable: Rc<dyn Callable + 'static>) -> Self {
-        let callable = Rc::new(NativeCallable::new(callable, &ty, &store));
-        Func::from_wrapped(store, ty, callable)
-    }
-
-    fn from_wrapped(
-        store: &Store,
-        ty: FuncType,
-        callable: Rc<dyn WrappedCallable + 'static>,
-    ) -> Func {
-        Func {
-            _store: store.clone(),
-            callable,
-            ty,
-        }
-    }
-
-    /// Returns the underlying wasm type that this `Func` has.
-    pub fn ty(&self) -> &FuncType {
-        &self.ty
-    }
-
-    /// Returns the number of parameters that this function takes.
-    pub fn param_arity(&self) -> usize {
-        self.ty.params().len()
-    }
-
-    /// Returns the number of results this function produces.
-    pub fn result_arity(&self) -> usize {
-        self.ty.results().len()
-    }
-
-    /// Invokes this function with the `params` given, returning the results and
-    /// any trap, if one occurs.
-    ///
-    /// The `params` here must match the type signature of this `Func`, or a
-    /// trap will occur. If a trap occurs while executing this function, then a
-    /// trap will also be returned.
-    ///
-    /// This function should not panic unless the underlying function itself
-    /// initiates a panic.
-    pub fn call(&self, params: &[Val]) -> Result<Box<[Val]>, Trap> {
-        let mut results = vec![Val::null(); self.result_arity()];
-        self.callable.call(params, &mut results)?;
-        Ok(results.into_boxed_slice())
-    }
-
-    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
-        self.callable.wasmtime_export()
-    }
-
-    pub(crate) fn from_wasmtime_function(
-        export: wasmtime_runtime::Export,
-        store: &Store,
-        instance_handle: InstanceHandle,
-    ) -> Self {
-        // This is only called with `Export::Function`, and since it's coming
-        // from wasmtime_runtime itself we should support all the types coming
-        // out of it, so assert such here.
-        let ty = if let wasmtime_runtime::Export::Function { signature, .. } = &export {
-            FuncType::from_wasmtime_signature(signature.clone())
-                .expect("core wasm signature should be supported")
-        } else {
-            panic!("expected function export")
-        };
-        let callable = WasmtimeFn::new(store, instance_handle, export);
-        Func::from_wrapped(store, ty, Rc::new(callable))
-    }
-}
-
-impl fmt::Debug for Func {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Func")
     }
 }
 

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -1,0 +1,120 @@
+use crate::{Store, FuncType, Callable, Val, Trap};
+use crate::callable::{WrappedCallable, WasmtimeFn, NativeCallable};
+use std::rc::Rc;
+use std::fmt;
+use wasmtime_jit::InstanceHandle;
+
+/// A WebAssembly function which can be called.
+///
+/// This type can represent a number of callable items, such as:
+///
+/// * An exported function from a WebAssembly module.
+/// * A user-defined function used to satisfy an import.
+///
+/// These types of callable items are all wrapped up in this `Func` and can be
+/// used to both instantiate an [`Instance`](crate::Instance) as well as be
+/// extracted from an [`Instance`](crate::Instance).
+///
+/// # `Func` and `Clone`
+///
+/// Functions are internally reference counted so you can `clone` a `Func`. The
+/// cloning process only performs a shallow clone, so two cloned `Func`
+/// instances are equivalent in their functionality.
+#[derive(Clone)]
+pub struct Func {
+    _store: Store,
+    callable: Rc<dyn WrappedCallable + 'static>,
+    ty: FuncType,
+}
+
+impl Func {
+    /// Creates a new `Func` with the given arguments, typically to create a
+    /// user-defined function to pass as an import to a module.
+    ///
+    /// * `store` - a cache of data where information is stored, typically
+    ///   shared with a [`Module`](crate::Module).
+    ///
+    /// * `ty` - the signature of this function, used to indicate what the
+    ///   inputs and outputs are, which must be WebAssembly types.
+    ///
+    /// * `callable` - a type implementing the [`Callable`] trait which
+    ///   is the implementation of this `Func` value.
+    ///
+    /// Note that the implementation of `callable` must adhere to the `ty`
+    /// signature given, error or traps may occur if it does not respect the
+    /// `ty` signature.
+    pub fn new(store: &Store, ty: FuncType, callable: Rc<dyn Callable + 'static>) -> Self {
+        let callable = Rc::new(NativeCallable::new(callable, &ty, &store));
+        Func::from_wrapped(store, ty, callable)
+    }
+
+    fn from_wrapped(
+        store: &Store,
+        ty: FuncType,
+        callable: Rc<dyn WrappedCallable + 'static>,
+    ) -> Func {
+        Func {
+            _store: store.clone(),
+            callable,
+            ty,
+        }
+    }
+
+    /// Returns the underlying wasm type that this `Func` has.
+    pub fn ty(&self) -> &FuncType {
+        &self.ty
+    }
+
+    /// Returns the number of parameters that this function takes.
+    pub fn param_arity(&self) -> usize {
+        self.ty.params().len()
+    }
+
+    /// Returns the number of results this function produces.
+    pub fn result_arity(&self) -> usize {
+        self.ty.results().len()
+    }
+
+    /// Invokes this function with the `params` given, returning the results and
+    /// any trap, if one occurs.
+    ///
+    /// The `params` here must match the type signature of this `Func`, or a
+    /// trap will occur. If a trap occurs while executing this function, then a
+    /// trap will also be returned.
+    ///
+    /// This function should not panic unless the underlying function itself
+    /// initiates a panic.
+    pub fn call(&self, params: &[Val]) -> Result<Box<[Val]>, Trap> {
+        let mut results = vec![Val::null(); self.result_arity()];
+        self.callable.call(params, &mut results)?;
+        Ok(results.into_boxed_slice())
+    }
+
+    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
+        self.callable.wasmtime_export()
+    }
+
+    pub(crate) fn from_wasmtime_function(
+        export: wasmtime_runtime::Export,
+        store: &Store,
+        instance_handle: InstanceHandle,
+    ) -> Self {
+        // This is only called with `Export::Function`, and since it's coming
+        // from wasmtime_runtime itself we should support all the types coming
+        // out of it, so assert such here.
+        let ty = if let wasmtime_runtime::Export::Function { signature, .. } = &export {
+            FuncType::from_wasmtime_signature(signature.clone())
+                .expect("core wasm signature should be supported")
+        } else {
+            panic!("expected function export")
+        };
+        let callable = WasmtimeFn::new(store, instance_handle, export);
+        Func::from_wrapped(store, ty, Rc::new(callable))
+    }
+}
+
+impl fmt::Debug for Func {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Func")
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod callable;
 mod externals;
+mod func;
 mod instance;
 mod module;
 mod r#ref;
@@ -21,6 +22,7 @@ mod values;
 
 pub use crate::callable::Callable;
 pub use crate::externals::*;
+pub use crate::func::Func;
 pub use crate::instance::Instance;
 pub use crate::module::Module;
 pub use crate::r#ref::{AnyRef, HostInfo, HostRef};

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,7 +22,7 @@ mod values;
 
 pub use crate::callable::Callable;
 pub use crate::externals::*;
-pub use crate::func::Func;
+pub use crate::func::{Func, WasmArg, WasmRet};
 pub use crate::instance::Instance;
 pub use crate::module::Module;
 pub use crate::r#ref::{AnyRef, HostInfo, HostRef};

--- a/crates/api/src/trampoline/mod.rs
+++ b/crates/api/src/trampoline/mod.rs
@@ -13,7 +13,9 @@ use self::memory::create_handle_with_memory;
 use self::table::create_handle_with_table;
 use super::{Callable, FuncType, GlobalType, MemoryType, Store, TableType, Val};
 use anyhow::Result;
+use std::any::Any;
 use std::rc::Rc;
+use wasmtime_runtime::VMFunctionBody;
 
 pub use self::global::GlobalState;
 
@@ -23,6 +25,20 @@ pub fn generate_func_export(
     store: &Store,
 ) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
     let instance = create_handle_with_function(ft, func, store)?;
+    let export = instance.lookup("trampoline").expect("trampoline export");
+    Ok((instance, export))
+}
+
+/// Note that this is `unsafe` since `func` must be a valid function pointer and
+/// have a signature which matches `ft`, otherwise the returned
+/// instance/export/etc may exhibit undefined behavior.
+pub unsafe fn generate_raw_func_export(
+    ft: &FuncType,
+    func: *const VMFunctionBody,
+    store: &Store,
+    state: Box<dyn Any>,
+) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
+    let instance = func::create_handle_with_raw_function(ft, func, store, state)?;
     let export = instance.lookup("trampoline").expect("trampoline export");
     Ok((instance, export))
 }

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -1,7 +1,5 @@
-use crate::externals::Func;
 use crate::r#ref::AnyRef;
-use crate::runtime::Store;
-use crate::types::ValType;
+use crate::{Func, Store, ValType};
 use anyhow::{bail, Result};
 use std::ptr;
 use wasmtime_environ::ir;

--- a/crates/api/tests/func.rs
+++ b/crates/api/tests/func.rs
@@ -1,0 +1,203 @@
+use anyhow::Result;
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use wasmtime::{Func, Instance, Module, Store, Trap, ValType};
+
+#[test]
+fn func_constructors() {
+    let store = Store::default();
+    Func::wrap0(&store, || {});
+    Func::wrap1(&store, |_: i32| {});
+    Func::wrap2(&store, |_: i32, _: i64| {});
+    Func::wrap2(&store, |_: f32, _: f64| {});
+    Func::wrap0(&store, || -> i32 { 0 });
+    Func::wrap0(&store, || -> i64 { 0 });
+    Func::wrap0(&store, || -> f32 { 0.0 });
+    Func::wrap0(&store, || -> f64 { 0.0 });
+
+    Func::wrap0(&store, || -> Result<(), Trap> { loop {} });
+    Func::wrap0(&store, || -> Result<i32, Trap> { loop {} });
+    Func::wrap0(&store, || -> Result<i64, Trap> { loop {} });
+    Func::wrap0(&store, || -> Result<f32, Trap> { loop {} });
+    Func::wrap0(&store, || -> Result<f64, Trap> { loop {} });
+}
+
+#[test]
+fn dtor_runs() {
+    static HITS: AtomicUsize = AtomicUsize::new(0);
+
+    struct A;
+
+    impl Drop for A {
+        fn drop(&mut self) {
+            HITS.fetch_add(1, SeqCst);
+        }
+    }
+
+    let store = Store::default();
+    let a = A;
+    assert_eq!(HITS.load(SeqCst), 0);
+    Func::wrap0(&store, move || {
+        drop(&a);
+    });
+    assert_eq!(HITS.load(SeqCst), 1);
+}
+
+#[test]
+fn dtor_delayed() -> Result<()> {
+    static HITS: AtomicUsize = AtomicUsize::new(0);
+
+    struct A;
+
+    impl Drop for A {
+        fn drop(&mut self) {
+            HITS.fetch_add(1, SeqCst);
+        }
+    }
+
+    let store = Store::default();
+    let a = A;
+    let func = Func::wrap0(&store, move || drop(&a));
+
+    assert_eq!(HITS.load(SeqCst), 0);
+    let wasm = wat::parse_str(r#"(import "" "" (func))"#)?;
+    let module = Module::new(&store, &wasm)?;
+    let instance = Instance::new(&module, &[func.into()])?;
+    assert_eq!(HITS.load(SeqCst), 0);
+    drop(instance);
+    assert_eq!(HITS.load(SeqCst), 1);
+    Ok(())
+}
+
+#[test]
+fn signatures_match() {
+    let store = Store::default();
+
+    let f = Func::wrap0(&store, || {});
+    assert_eq!(f.ty().params(), &[]);
+    assert_eq!(f.ty().results(), &[]);
+
+    let f = Func::wrap0(&store, || -> i32 { loop {} });
+    assert_eq!(f.ty().params(), &[]);
+    assert_eq!(f.ty().results(), &[ValType::I32]);
+
+    let f = Func::wrap0(&store, || -> i64 { loop {} });
+    assert_eq!(f.ty().params(), &[]);
+    assert_eq!(f.ty().results(), &[ValType::I64]);
+
+    let f = Func::wrap0(&store, || -> f32 { loop {} });
+    assert_eq!(f.ty().params(), &[]);
+    assert_eq!(f.ty().results(), &[ValType::F32]);
+
+    let f = Func::wrap0(&store, || -> f64 { loop {} });
+    assert_eq!(f.ty().params(), &[]);
+    assert_eq!(f.ty().results(), &[ValType::F64]);
+
+    let f = Func::wrap5(&store, |_: f32, _: f64, _: i32, _: i64, _: i32| -> f64 {
+        loop {}
+    });
+    assert_eq!(
+        f.ty().params(),
+        &[
+            ValType::F32,
+            ValType::F64,
+            ValType::I32,
+            ValType::I64,
+            ValType::I32
+        ]
+    );
+    assert_eq!(f.ty().results(), &[ValType::F64]);
+}
+
+#[test]
+fn import_works() -> Result<()> {
+    static HITS: AtomicUsize = AtomicUsize::new(0);
+
+    let wasm = wat::parse_str(
+        r#"
+            (import "" "" (func))
+            (import "" "" (func (param i32) (result i32)))
+            (import "" "" (func (param i32) (param i64)))
+            (import "" "" (func (param i32 i64 i32 f32 f64)))
+
+            (func $foo
+                call 0
+                i32.const 0
+                call 1
+                i32.const 1
+                i32.add
+                i64.const 3
+                call 2
+
+                i32.const 100
+                i64.const 200
+                i32.const 300
+                f32.const 400
+                f64.const 500
+                call 3
+            )
+            (start $foo)
+        "#,
+    )?;
+    let store = Store::default();
+    let module = Module::new(&store, &wasm)?;
+    Instance::new(
+        &module,
+        &[
+            Func::wrap0(&store, || {
+                assert_eq!(HITS.fetch_add(1, SeqCst), 0);
+            })
+            .into(),
+            Func::wrap1(&store, |x: i32| -> i32 {
+                assert_eq!(x, 0);
+                assert_eq!(HITS.fetch_add(1, SeqCst), 1);
+                1
+            })
+            .into(),
+            Func::wrap2(&store, |x: i32, y: i64| {
+                assert_eq!(x, 2);
+                assert_eq!(y, 3);
+                assert_eq!(HITS.fetch_add(1, SeqCst), 2);
+            })
+            .into(),
+            Func::wrap5(&store, |a: i32, b: i64, c: i32, d: f32, e: f64| {
+                assert_eq!(a, 100);
+                assert_eq!(b, 200);
+                assert_eq!(c, 300);
+                assert_eq!(d, 400.0);
+                assert_eq!(e, 500.0);
+                assert_eq!(HITS.fetch_add(1, SeqCst), 3);
+            })
+            .into(),
+        ],
+    )?;
+    Ok(())
+}
+
+#[test]
+fn trap_smoke() {
+    let store = Store::default();
+    let f = Func::wrap0(&store, || -> Result<(), Trap> { Err(Trap::new("test")) });
+    let err = f.call(&[]).unwrap_err();
+    assert_eq!(err.message(), "test");
+}
+
+#[test]
+fn trap_import() -> Result<()> {
+    let wasm = wat::parse_str(
+        r#"
+            (import "" "" (func))
+            (start 0)
+        "#,
+    )?;
+    let store = Store::default();
+    let module = Module::new(&store, &wasm)?;
+    let trap = Instance::new(
+        &module,
+        &[Func::wrap0(&store, || -> Result<(), Trap> { Err(Trap::new("foo")) }).into()],
+    )
+    .err()
+    .unwrap()
+    .downcast::<Trap>()?;
+    assert_eq!(trap.message(), "foo");
+    Ok(())
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -43,6 +43,7 @@ pub use crate::instance::{InstanceHandle, InstantiationError, LinkError};
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::mmap::Mmap;
 pub use crate::sig_registry::SignatureRegistry;
+pub use crate::trap_registry::TrapDescription;
 pub use crate::trap_registry::{get_mut_trap_registry, get_trap_registry, TrapRegistrationGuard};
 pub use crate::traphandlers::resume_panic;
 pub use crate::traphandlers::{raise_user_trap, wasmtime_call, wasmtime_call_trampoline, Trap};


### PR DESCRIPTION
This commit extends the `Func` type in the `wasmtime` crate with static
`wrap*` constructors. The goal of these constructors is to create a
`Func` type which has zero shims associated with it, creating as small
of a layer as possible between wasm code and calling imported Rust code.

This is achieved by creating an `extern "C"` shim function which matches
the ABI of what Cranelift will generate, and then the host function is
passed directly into an `InstanceHandle` to get called later. This also
enables enough inlining opportunities that LLVM will be able to see all
functions and inline everything to the point where your function is
called immediately from wasm, no questions asked.

There's a few items which I think need some more discussion on this PR before we land it, and I'm also just curious how others think of an API like this for embedding!

* Figuring out how traps work. Right now `Result<T, Trap>` is intended to be supported as a return from a Rust closure, but without generating a function shim it's not trivial to generate a trap. Currently the code sort of cops out by manually doing a segfault via `write_volatile`, but that feels pretty brittle. I'm curious if others have a good idea of how to trigger a trap from Rust code?

* Dealing with multi-value isn't supported yet. I talked with @fitzgen briefly but it sounds like we may not have a native ABI in Rust that matches up with multi-value returns. I'd ideally like to support Rust closures returning, for example, `(i32, i32)` to automatically get wired up to a multi-value return import, but the ABI of that Rust function I don't think matches what Cranelift currently does. I suspect that this will require some work in Cranelift to (maybe?) add a new ABI that matches the `extern "C"` abi for the native platform.

* I'm also curious to largely just get some more eyes on this. I'm shooting for an extremely low overhead `Func` wrapper, but naturally there's a lot of possible unsafety here if things don't line up precisely. Close review would definitely be appreciated!

I've wanted to do this for some time but recently I've been thinking that the `wasmtime-wasi` crate should move over to the `wasmtime` API, but to preserve the current functional semantics where it has zero shims at runtime I felt was important, so I wanted to try to pursue this style of creating a low-overhead `Func`.