### PR TITLE
Improve handling of strings for backtraces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,7 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "file-per-thread-logger",
+ "lazy_static",
  "libc",
  "pretty_env_logger",
  "rayon",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2"
 cfg-if = "0.1.9"
 backtrace = "0.3.42"
 rustc-demangle = "0.1.16"
+lazy_static = "1.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -108,8 +108,7 @@ impl Instance {
     /// [issue]: https://github.com/bytecodealliance/wasmtime/issues/727
     pub fn new(module: &Module, imports: &[Extern]) -> Result<Instance, Error> {
         let store = module.store();
-        let mut instance_handle =
-            instantiate(module.compiled_module().expect("compiled_module"), imports)?;
+        let mut instance_handle = instantiate(module.compiled_module(), imports)?;
 
         let exports = {
             let mut exports = Vec::with_capacity(module.exports().len());
@@ -124,6 +123,7 @@ impl Instance {
             }
             exports.into_boxed_slice()
         };
+        module.register_names();
         Ok(Instance {
             instance_handle,
             module: module.clone(),

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -4,7 +4,7 @@ use crate::runtime::Store;
 use anyhow::Result;
 use std::any::Any;
 use std::collections::HashSet;
-use std::rc::Rc;
+use std::sync::Arc;
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::Module;
@@ -37,7 +37,7 @@ pub(crate) fn create_handle(
         .unwrap_or_else(PrimaryMap::new);
 
     Ok(InstanceHandle::new(
-        Rc::new(module),
+        Arc::new(module),
         finished_functions.into_boxed_slice(),
         imports,
         &data_initializers,

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::func_environ::BuiltinFunctionIndex;
 #[cfg(feature = "lightbeam")]
 pub use crate::lightbeam::Lightbeam;
 pub use crate::module::{
-    Export, MemoryPlan, MemoryStyle, Module, ModuleSyncString, TableElements, TablePlan, TableStyle,
+    Export, MemoryPlan, MemoryStyle, Module, TableElements, TablePlan, TableStyle,
 };
 pub use crate::module_environ::{
     translate_signature, DataInitializer, DataInitializerLocation, FunctionBodyData,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -1,5 +1,5 @@
 use crate::func_environ::FuncEnvironment;
-use crate::module::{Export, MemoryPlan, Module, ModuleSyncString, TableElements, TablePlan};
+use crate::module::{Export, MemoryPlan, Module, TableElements, TablePlan};
 use crate::tunables::Tunables;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::{AbiParam, ArgumentPurpose};
@@ -371,7 +371,10 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn declare_func_name(&mut self, func_index: FuncIndex, name: &'data str) -> WasmResult<()> {
-        self.result.module.func_names[func_index] = ModuleSyncString::new(Some(name));
+        self.result
+            .module
+            .func_names
+            .insert(func_index, name.to_string());
         Ok(())
     }
 }

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -167,15 +167,9 @@ impl Compiler {
             self.jit_function_ranges
                 .push((ptr as usize, ptr as usize + body_len));
             let func_index = module.func_index(i);
-            let func_name = module
-                .func_names
-                .get(func_index)
-                .cloned()
-                .unwrap_or_else(Default::default);
             let tag = jit_function_registry::JITFunctionTag {
-                module_id: module.name.clone(),
-                func_index: func_index.index(),
-                func_name,
+                module_id: module.id,
+                func_index,
             };
             jit_function_registry::register(ptr as usize, ptr as usize + body_len, tag);
         }

--- a/crates/jit/src/context.rs
+++ b/crates/jit/src/context.rs
@@ -112,7 +112,6 @@ impl Context {
         instantiate(
             &mut *self.compiler,
             &data,
-            None,
             &mut self.namespace,
             debug_info,
         )
@@ -146,7 +145,7 @@ impl Context {
         self.validate(&data).map_err(SetupError::Validate)?;
         let debug_info = self.debug_info();
 
-        CompiledModule::new(&mut *self.compiler, data, None, debug_info)
+        CompiledModule::new(&mut *self.compiler, data, debug_info)
     }
 
     /// If `name` isn't None, register it for the given instance.

--- a/crates/jit/src/context.rs
+++ b/crates/jit/src/context.rs
@@ -109,12 +109,7 @@ impl Context {
         self.validate(&data).map_err(SetupError::Validate)?;
         let debug_info = self.debug_info();
 
-        instantiate(
-            &mut *self.compiler,
-            &data,
-            &mut self.namespace,
-            debug_info,
-        )
+        instantiate(&mut *self.compiler, &data, &mut self.namespace, debug_info)
     }
 
     /// Return the instance associated with the given name.

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -249,7 +249,6 @@ pub fn instantiate(
     resolver: &mut dyn Resolver,
     debug_info: bool,
 ) -> Result<InstanceHandle, SetupError> {
-    let instance =
-        CompiledModule::new(compiler, data, debug_info)?.instantiate(resolver)?;
+    let instance = CompiledModule::new(compiler, data, debug_info)?.instantiate(resolver)?;
     Ok(instance)
 }

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -9,13 +9,13 @@ use crate::link::link_module;
 use crate::resolver::Resolver;
 use std::io::Write;
 use std::rc::Rc;
+use std::sync::Arc;
 use thiserror::Error;
 use wasmtime_debug::read_debuginfo;
 use wasmtime_environ::entity::{BoxedSlice, PrimaryMap};
 use wasmtime_environ::wasm::{DefinedFuncIndex, SignatureIndex};
 use wasmtime_environ::{
     CompileError, DataInitializer, DataInitializerLocation, Module, ModuleEnvironment,
-    ModuleSyncString,
 };
 use wasmtime_runtime::{
     GdbJitImageRegistration, InstanceHandle, InstantiationError, VMFunctionBody,
@@ -59,12 +59,11 @@ impl<'data> RawCompiledModule<'data> {
     fn new(
         compiler: &mut Compiler,
         data: &'data [u8],
-        module_name: Option<&str>,
         debug_info: bool,
     ) -> Result<Self, SetupError> {
         let environ = ModuleEnvironment::new(compiler.frontend_config(), compiler.tunables());
 
-        let mut translation = environ
+        let translation = environ
             .translate(data)
             .map_err(|error| SetupError::Compile(CompileError::Wasm(error)))?;
 
@@ -73,8 +72,6 @@ impl<'data> RawCompiledModule<'data> {
         } else {
             None
         };
-
-        translation.module.name = ModuleSyncString::new(module_name);
 
         let (allocated_functions, jt_offsets, relocations, dbg_image) = compiler.compile(
             &translation.module,
@@ -136,7 +133,7 @@ impl<'data> RawCompiledModule<'data> {
 
 /// A compiled wasm module, ready to be instantiated.
 pub struct CompiledModule {
-    module: Rc<Module>,
+    module: Arc<Module>,
     finished_functions: BoxedSlice<DefinedFuncIndex, *const VMFunctionBody>,
     data_initializers: Box<[OwnedDataInitializer]>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
@@ -148,10 +145,9 @@ impl CompiledModule {
     pub fn new<'data>(
         compiler: &mut Compiler,
         data: &'data [u8],
-        module_name: Option<&str>,
         debug_info: bool,
     ) -> Result<Self, SetupError> {
-        let raw = RawCompiledModule::<'data>::new(compiler, data, module_name, debug_info)?;
+        let raw = RawCompiledModule::<'data>::new(compiler, data, debug_info)?;
 
         Ok(Self::from_parts(
             raw.module,
@@ -175,7 +171,7 @@ impl CompiledModule {
         dbg_jit_registration: Option<GdbJitImageRegistration>,
     ) -> Self {
         Self {
-            module: Rc::new(module),
+            module: Arc::new(module),
             finished_functions,
             data_initializers,
             signatures,
@@ -202,7 +198,7 @@ impl CompiledModule {
             .collect::<Vec<_>>();
         let imports = resolve_imports(&self.module, resolver)?;
         InstanceHandle::new(
-            Rc::clone(&self.module),
+            Arc::clone(&self.module),
             self.finished_functions.clone(),
             imports,
             &data_initializers,
@@ -213,8 +209,8 @@ impl CompiledModule {
     }
 
     /// Return a reference-counting pointer to a module.
-    pub fn module(&self) -> Rc<Module> {
-        self.module.clone()
+    pub fn module(&self) -> &Arc<Module> {
+        &self.module
     }
 
     /// Return a reference to a module.
@@ -250,21 +246,10 @@ impl OwnedDataInitializer {
 pub fn instantiate(
     compiler: &mut Compiler,
     data: &[u8],
-    module_name: Option<&str>,
     resolver: &mut dyn Resolver,
     debug_info: bool,
 ) -> Result<InstanceHandle, SetupError> {
-    let raw = RawCompiledModule::new(compiler, data, module_name, debug_info)?;
-    let imports = resolve_imports(&raw.module, resolver)
-        .map_err(|err| SetupError::Instantiate(InstantiationError::Link(err)))?;
-    InstanceHandle::new(
-        Rc::new(raw.module),
-        raw.finished_functions,
-        imports,
-        &*raw.data_initializers,
-        raw.signatures,
-        raw.dbg_jit_registration.map(Rc::new),
-        Box::new(()),
-    )
-    .map_err(SetupError::Instantiate)
+    let instance =
+        CompiledModule::new(compiler, data, debug_info)?.instantiate(resolver)?;
+    Ok(instance)
 }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -23,6 +23,7 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::ptr::NonNull;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::{mem, ptr, slice};
 use thiserror::Error;
 use wasmtime_environ::entity::{BoxedSlice, EntityRef, PrimaryMap};
@@ -288,7 +289,7 @@ pub(crate) struct Instance {
     mmap: Mmap,
 
     /// The `Module` this `Instance` was instantiated from.
-    module: Rc<Module>,
+    module: Arc<Module>,
 
     /// Offsets in the `vmctx` region.
     offsets: VMOffsets,
@@ -756,7 +757,7 @@ impl InstanceHandle {
 
     /// Create a new `InstanceHandle` pointing at a new `Instance`.
     pub fn new(
-        module: Rc<Module>,
+        module: Arc<Module>,
         finished_functions: BoxedSlice<DefinedFuncIndex, *const VMFunctionBody>,
         imports: Imports,
         data_initializers: &[DataInitializer<'_>],
@@ -904,8 +905,8 @@ impl InstanceHandle {
     }
 
     /// Return a reference-counting pointer to a module.
-    pub fn module(&self) -> Rc<Module> {
-        self.instance().module.clone()
+    pub fn module(&self) -> &Arc<Module> {
+        &self.instance().module
     }
 
     /// Return a reference to a module.
@@ -1119,7 +1120,7 @@ fn lookup_by_declaration(
 }
 
 fn check_table_init_bounds(instance: &mut Instance) -> Result<(), InstantiationError> {
-    let module = Rc::clone(&instance.module);
+    let module = Arc::clone(&instance.module);
     for init in &module.table_elements {
         let start = get_table_init_start(init, instance);
         let slice = get_table_slice(
@@ -1243,7 +1244,7 @@ fn get_table_slice<'instance>(
 /// Initialize the table memory from the provided initializers.
 fn initialize_tables(instance: &mut Instance) -> Result<(), InstantiationError> {
     let vmctx: *mut VMContext = instance.vmctx_mut();
-    let module = Rc::clone(&instance.module);
+    let module = Arc::clone(&instance.module);
     for init in &module.table_elements {
         let start = get_table_init_start(init, instance);
         let slice = get_table_slice(
@@ -1320,7 +1321,7 @@ fn create_globals(module: &Module) -> BoxedSlice<DefinedGlobalIndex, VMGlobalDef
 }
 
 fn initialize_globals(instance: &mut Instance) {
-    let module = Rc::clone(&instance.module);
+    let module = Arc::clone(&instance.module);
     let num_imports = module.imported_globals.len();
     for (index, global) in module.globals.iter().skip(num_imports) {
         let def_index = module.defined_global_index(index).unwrap();

--- a/crates/runtime/src/jit_function_registry.rs
+++ b/crates/runtime/src/jit_function_registry.rs
@@ -3,7 +3,7 @@
 use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
-use wasmtime_environ::ModuleSyncString;
+use wasmtime_environ::wasm::FuncIndex;
 
 lazy_static! {
     static ref REGISTRY: RwLock<JITFunctionRegistry> = RwLock::new(JITFunctionRegistry::default());
@@ -11,20 +11,8 @@ lazy_static! {
 
 #[derive(Clone)]
 pub struct JITFunctionTag {
-    pub module_id: ModuleSyncString,
-    pub func_index: usize,
-    pub func_name: ModuleSyncString,
-}
-
-impl std::fmt::Debug for JITFunctionTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(ref module_id) = self.module_id.get() {
-            write!(f, "{}", module_id)?;
-        } else {
-            write!(f, "(module)")?;
-        }
-        write!(f, ":{}", self.func_index)
-    }
+    pub module_id: usize,
+    pub func_index: FuncIndex,
 }
 
 struct JITFunctionRegistry {

--- a/crates/wasi/src/instantiate.rs
+++ b/crates/wasi/src/instantiate.rs
@@ -3,7 +3,7 @@ use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::DefinedFuncIndex;
 use std::fs::File;
-use std::rc::Rc;
+use std::sync::Arc;
 use target_lexicon::HOST;
 use wasi_common::hostcalls;
 use wasi_common::wasi;
@@ -79,7 +79,7 @@ pub fn instantiate_wasi_with_context(
     let signatures = PrimaryMap::new();
 
     InstanceHandle::new(
-        Rc::new(module),
+        Arc::new(module),
         finished_functions.into_boxed_slice(),
         imports,
         &data_initializers,

--- a/crates/wasi/src/old/snapshot_0/instantiate.rs
+++ b/crates/wasi/src/old/snapshot_0/instantiate.rs
@@ -3,7 +3,7 @@ use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::DefinedFuncIndex;
 use std::fs::File;
-use std::rc::Rc;
+use std::sync::Arc;
 use target_lexicon::HOST;
 use wasi_common::old::snapshot_0::hostcalls;
 use wasi_common::old::snapshot_0::{WasiCtx, WasiCtxBuilder};
@@ -79,7 +79,7 @@ pub fn instantiate_wasi_with_context(
     let signatures = PrimaryMap::new();
 
     InstanceHandle::new(
-        Rc::new(module),
+        Arc::new(module),
         finished_functions.into_boxed_slice(),
         imports,
         &data_initializers,

--- a/tests/instantiate.rs
+++ b/tests/instantiate.rs
@@ -21,6 +21,6 @@ fn test_environ_translate() {
 
     let mut resolver = NullResolver {};
     let mut compiler = Compiler::new(isa, CompilationStrategy::Auto);
-    let instance = instantiate(&mut compiler, &data, None, &mut resolver, false);
+    let instance = instantiate(&mut compiler, &data, &mut resolver, false);
     assert!(instance.is_ok());
 }


### PR DESCRIPTION
Largely avoid storing strings at all in the `wasmtime-*` internal
crates, and instead only store strings in a separate global cache
specific to the `wasmtime` crate itself. This global cache is inserted
and removed from dynamically as modules are created and deallocated, and
the global cache is consulted whenever a `Trap` is created to
symbolicate any wasm frames.

This also avoids the need to thread `module_name` through the jit crates
and back, and additionally removes the need for `ModuleSyncString`.