### PR TITLE
Reel in unsafety around `InstanceHandle`

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -420,12 +420,9 @@ fn set_table_item(
     item_index: u32,
     item: wasmtime_runtime::VMCallerCheckedAnyfunc,
 ) -> Result<()> {
-    if let Some(item_ref) = handle.table_get_mut(table_index, item_index) {
-        *item_ref = item;
-        Ok(())
-    } else {
-        bail!("table element index out of bounds")
-    }
+    handle
+        .table_set(table_index, item_index, item)
+        .map_err(|()| anyhow!("table element index out of bounds"))
 }
 
 impl Table {

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -36,14 +36,15 @@ pub(crate) fn create_handle(
         })
         .unwrap_or_else(PrimaryMap::new);
 
-    Ok(InstanceHandle::new(
-        Arc::new(module),
-        finished_functions.into_boxed_slice(),
-        imports,
-        &data_initializers,
-        signatures.into_boxed_slice(),
-        None,
-        state,
-    )
-    .expect("instance"))
+    unsafe {
+        Ok(InstanceHandle::new(
+            Arc::new(module),
+            finished_functions.into_boxed_slice(),
+            imports,
+            &data_initializers,
+            signatures.into_boxed_slice(),
+            None,
+            state,
+        )?)
+    }
 }

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -70,7 +70,7 @@ unsafe extern "C" fn stub_fn(
     call_id: u32,
     values_vec: *mut i128,
 ) -> u32 {
-    let mut instance = InstanceHandle::from_vmctx(vmctx);
+    let instance = InstanceHandle::from_vmctx(vmctx);
 
     let (args, returns_len) = {
         let module = instance.module_ref();
@@ -89,7 +89,7 @@ unsafe extern "C" fn stub_fn(
     let mut returns = vec![Val::null(); returns_len];
     let func = &instance
         .host_state()
-        .downcast_mut::<TrampolineState>()
+        .downcast_ref::<TrampolineState>()
         .expect("state")
         .func;
 

--- a/crates/api/src/trampoline/global.rs
+++ b/crates/api/src/trampoline/global.rs
@@ -34,12 +34,12 @@ pub fn create_global(gt: &GlobalType, val: Val) -> Result<(wasmtime_runtime::Exp
         },
         initializer: wasm::GlobalInit::Import, // TODO is it right?
     };
-    let mut handle =
+    let handle =
         create_handle(Module::new(), None, PrimaryMap::new(), Box::new(())).expect("handle");
     Ok((
         wasmtime_runtime::Export::Global {
             definition: definition.as_mut(),
-            vmctx: handle.vmctx_mut_ptr(),
+            vmctx: handle.vmctx_ptr(),
             global,
         },
         GlobalState { definition, handle },

--- a/crates/api/src/trampoline/mod.rs
+++ b/crates/api/src/trampoline/mod.rs
@@ -23,7 +23,7 @@ pub fn generate_func_export(
     func: &Rc<dyn Callable + 'static>,
     store: &Store,
 ) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
-    let mut instance = create_handle_with_function(ft, func, store)?;
+    let instance = create_handle_with_function(ft, func, store)?;
     let export = instance.lookup("trampoline").expect("trampoline export");
     Ok((instance, export))
 }
@@ -38,7 +38,7 @@ pub fn generate_global_export(
 pub fn generate_memory_export(
     m: &MemoryType,
 ) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
-    let mut instance = create_handle_with_memory(m)?;
+    let instance = create_handle_with_memory(m)?;
     let export = instance.lookup("memory").expect("memory export");
     Ok((instance, export))
 }
@@ -46,7 +46,7 @@ pub fn generate_memory_export(
 pub fn generate_table_export(
     t: &TableType,
 ) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
-    let mut instance = create_handle_with_table(t)?;
+    let instance = create_handle_with_table(t)?;
     let export = instance.lookup("table").expect("table export");
     Ok((instance, export))
 }

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -217,7 +217,7 @@ pub(crate) fn into_checked_anyfunc(
 }
 
 pub(crate) fn from_checked_anyfunc(
-    item: &wasmtime_runtime::VMCallerCheckedAnyfunc,
+    item: wasmtime_runtime::VMCallerCheckedAnyfunc,
     store: &Store,
 ) -> Val {
     if item.type_index == wasmtime_runtime::VMSharedSignatureIndex::default() {

--- a/crates/jit/src/action.rs
+++ b/crates/jit/src/action.rs
@@ -231,7 +231,7 @@ pub fn inspect_memory<'instance>(
     start: usize,
     len: usize,
 ) -> Result<&'instance [u8], ActionError> {
-    let definition = match unsafe { instance.lookup_immutable(memory_name) } {
+    let definition = match instance.lookup(memory_name) {
         Some(Export::Memory {
             definition,
             memory: _memory,
@@ -259,7 +259,7 @@ pub fn inspect_memory<'instance>(
 
 /// Read a global in the given instance identified by an export name.
 pub fn get(instance: &InstanceHandle, global_name: &str) -> Result<RuntimeValue, ActionError> {
-    let (definition, global) = match unsafe { instance.lookup_immutable(global_name) } {
+    let (definition, global) = match instance.lookup(global_name) {
         Some(Export::Global {
             definition,
             vmctx: _,

--- a/crates/jit/src/context.rs
+++ b/crates/jit/src/context.rs
@@ -105,7 +105,7 @@ impl Context {
             .map_err(|e| format!("module did not validate: {}", e.to_string()))
     }
 
-    fn instantiate(&mut self, data: &[u8]) -> Result<InstanceHandle, SetupError> {
+    unsafe fn instantiate(&mut self, data: &[u8]) -> Result<InstanceHandle, SetupError> {
         self.validate(&data).map_err(SetupError::Validate)?;
         let debug_info = self.debug_info();
 
@@ -125,7 +125,11 @@ impl Context {
     }
 
     /// Instantiate a module instance and register the instance.
-    pub fn instantiate_module(
+    ///
+    /// # Unsafety
+    ///
+    /// See `InstanceHandle::new`
+    pub unsafe fn instantiate_module(
         &mut self,
         instance_name: Option<String>,
         data: &[u8],

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -184,7 +184,11 @@ impl CompiledModule {
     /// Note that if only one instance of this module is needed, it may be more
     /// efficient to call the top-level `instantiate`, since that avoids copying
     /// the data initializers.
-    pub fn instantiate(
+    ///
+    /// # Unsafety
+    ///
+    /// See `InstanceHandle::new`
+    pub unsafe fn instantiate(
         &self,
         resolver: &mut dyn Resolver,
     ) -> Result<InstanceHandle, InstantiationError> {
@@ -242,8 +246,12 @@ impl OwnedDataInitializer {
 ///
 /// This is equivalent to createing a `CompiledModule` and calling `instantiate()` on it,
 /// but avoids creating an intermediate copy of the data initializers.
+///
+/// # Unsafety
+///
+/// See `InstanceHandle::new`
 #[allow(clippy::implicit_hasher)]
-pub fn instantiate(
+pub unsafe fn instantiate(
     compiler: &mut Compiler,
     data: &[u8],
     resolver: &mut dyn Resolver,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -202,9 +202,7 @@ impl Instance {
 
     /// Return a pointer to the `VMSharedSignatureIndex`s.
     fn signature_ids_ptr(&self) -> *mut VMSharedSignatureIndex {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_signature_ids_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_signature_ids_begin()) }
     }
 
     /// Return the indexed `VMFunctionImport`.
@@ -214,9 +212,7 @@ impl Instance {
 
     /// Return a pointer to the `VMFunctionImport`s.
     fn imported_functions_ptr(&self) -> *mut VMFunctionImport {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_imported_functions_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_imported_functions_begin()) }
     }
 
     /// Return the index `VMTableImport`.
@@ -226,9 +222,7 @@ impl Instance {
 
     /// Return a pointer to the `VMTableImports`s.
     fn imported_tables_ptr(&self) -> *mut VMTableImport {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_imported_tables_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_imported_tables_begin()) }
     }
 
     /// Return the indexed `VMMemoryImport`.
@@ -238,9 +232,7 @@ impl Instance {
 
     /// Return a pointer to the `VMMemoryImport`s.
     fn imported_memories_ptr(&self) -> *mut VMMemoryImport {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_imported_memories_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_imported_memories_begin()) }
     }
 
     /// Return the indexed `VMGlobalImport`.
@@ -250,9 +242,7 @@ impl Instance {
 
     /// Return a pointer to the `VMGlobalImport`s.
     fn imported_globals_ptr(&self) -> *mut VMGlobalImport {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_imported_globals_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_imported_globals_begin()) }
     }
 
     /// Return the indexed `VMTableDefinition`.
@@ -268,9 +258,7 @@ impl Instance {
 
     /// Return a pointer to the `VMTableDefinition`s.
     fn tables_ptr(&self) -> *mut VMTableDefinition {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_tables_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_tables_begin()) }
     }
 
     /// Return the indexed `VMMemoryDefinition`.
@@ -285,9 +273,7 @@ impl Instance {
 
     /// Return a pointer to the `VMMemoryDefinition`s.
     fn memories_ptr(&self) -> *mut VMMemoryDefinition {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_memories_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_memories_begin()) }
     }
 
     /// Return the indexed `VMGlobalDefinition`.
@@ -302,16 +288,12 @@ impl Instance {
 
     /// Return a pointer to the `VMGlobalDefinition`s.
     fn globals_ptr(&self) -> *mut VMGlobalDefinition {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_globals_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_globals_begin()) }
     }
 
     /// Return a pointer to the `VMBuiltinFunctionsArray`.
     fn builtin_functions_ptr(&self) -> *mut VMBuiltinFunctionsArray {
-        unsafe {
-            self.vmctx_plus_offset(self.offsets.vmctx_builtin_functions_begin())
-        }
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_builtin_functions_begin()) }
     }
 
     /// Return a reference to the vmctx used by compiled wasm code.

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -18,7 +18,7 @@ use crate::vmcontext::{
 use memoffset::offset_of;
 use more_asserts::assert_lt;
 use std::any::Any;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::ptr::NonNull;
@@ -36,149 +36,6 @@ use wasmtime_environ::{DataInitializer, Module, TableElements, VMOffsets};
 thread_local! {
     /// A stack of currently-running `Instance`s, if any.
     pub(crate) static CURRENT_INSTANCE: RefCell<Vec<NonNull<Instance>>> = RefCell::new(Vec::new());
-}
-
-fn signature_id(
-    vmctx: &VMContext,
-    offsets: &VMOffsets,
-    index: SignatureIndex,
-) -> VMSharedSignatureIndex {
-    #[allow(clippy::cast_ptr_alignment)]
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmshared_signature_id(index)).unwrap());
-        *(ptr as *const VMSharedSignatureIndex)
-    }
-}
-
-fn imported_function<'vmctx>(
-    vmctx: &'vmctx VMContext,
-    offsets: &VMOffsets,
-    index: FuncIndex,
-) -> &'vmctx VMFunctionImport {
-    #[allow(clippy::cast_ptr_alignment)]
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmfunction_import(index)).unwrap());
-        &*(ptr as *const VMFunctionImport)
-    }
-}
-
-fn imported_table<'vmctx>(
-    vmctx: &'vmctx VMContext,
-    offsets: &VMOffsets,
-    index: TableIndex,
-) -> &'vmctx VMTableImport {
-    #[allow(clippy::cast_ptr_alignment)]
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmtable_import(index)).unwrap());
-        &*(ptr as *const VMTableImport)
-    }
-}
-
-fn imported_memory<'vmctx>(
-    vmctx: &'vmctx VMContext,
-    offsets: &VMOffsets,
-    index: MemoryIndex,
-) -> &'vmctx VMMemoryImport {
-    #[allow(clippy::cast_ptr_alignment)]
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmmemory_import(index)).unwrap());
-        &*(ptr as *const VMMemoryImport)
-    }
-}
-
-fn imported_global<'vmctx>(
-    vmctx: &'vmctx VMContext,
-    offsets: &VMOffsets,
-    index: GlobalIndex,
-) -> &'vmctx VMGlobalImport {
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmglobal_import(index)).unwrap());
-        #[allow(clippy::cast_ptr_alignment)]
-        &*(ptr as *const VMGlobalImport)
-    }
-}
-
-fn table<'vmctx>(
-    vmctx: &'vmctx VMContext,
-    offsets: &VMOffsets,
-    index: DefinedTableIndex,
-) -> &'vmctx VMTableDefinition {
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmtable_definition(index)).unwrap());
-        #[allow(clippy::cast_ptr_alignment)]
-        &*(ptr as *const VMTableDefinition)
-    }
-}
-
-fn table_mut<'vmctx>(
-    vmctx: &'vmctx mut VMContext,
-    offsets: &VMOffsets,
-    index: DefinedTableIndex,
-) -> &'vmctx mut VMTableDefinition {
-    unsafe {
-        let ptr = (vmctx as *mut VMContext as *mut u8)
-            .add(usize::try_from(offsets.vmctx_vmtable_definition(index)).unwrap());
-        #[allow(clippy::cast_ptr_alignment)]
-        &mut *(ptr as *mut VMTableDefinition)
-    }
-}
-
-fn memory<'vmctx>(
-    vmctx: &'vmctx VMContext,
-    offsets: &VMOffsets,
-    index: DefinedMemoryIndex,
-) -> &'vmctx VMMemoryDefinition {
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmmemory_definition(index)).unwrap());
-        #[allow(clippy::cast_ptr_alignment)]
-        &*(ptr as *const VMMemoryDefinition)
-    }
-}
-
-fn memory_mut<'vmctx>(
-    vmctx: &'vmctx mut VMContext,
-    offsets: &VMOffsets,
-    index: DefinedMemoryIndex,
-) -> &'vmctx mut VMMemoryDefinition {
-    unsafe {
-        let ptr = (vmctx as *mut VMContext as *mut u8)
-            .add(usize::try_from(offsets.vmctx_vmmemory_definition(index)).unwrap());
-        #[allow(clippy::cast_ptr_alignment)]
-        &mut *(ptr as *mut VMMemoryDefinition)
-    }
-}
-
-fn global<'vmctx>(
-    vmctx: &'vmctx VMContext,
-    offsets: &VMOffsets,
-    index: DefinedGlobalIndex,
-) -> &'vmctx VMGlobalDefinition {
-    unsafe {
-        let ptr = (vmctx as *const VMContext as *const u8)
-            .add(usize::try_from(offsets.vmctx_vmglobal_definition(index)).unwrap());
-        #[allow(clippy::cast_ptr_alignment)]
-        &*(ptr as *const VMGlobalDefinition)
-    }
-}
-
-fn global_mut<'vmctx>(
-    vmctx: &'vmctx mut VMContext,
-    offsets: &VMOffsets,
-    index: DefinedGlobalIndex,
-) -> &'vmctx mut VMGlobalDefinition {
-    unsafe {
-        let ptr = (vmctx as *mut VMContext as *mut u8)
-            .add(usize::try_from(offsets.vmctx_vmglobal_definition(index)).unwrap());
-        #[allow(clippy::cast_ptr_alignment)]
-        &mut *(ptr as *mut VMGlobalDefinition)
-    }
 }
 
 cfg_if::cfg_if! {
@@ -207,12 +64,18 @@ cfg_if::cfg_if! {
                     return false;
                 } else {
                     unsafe {
-                        let f = &current_instance
+                        let last =
+                        &current_instance
                             .last()
                             .expect("current instance not none")
-                            .as_ref()
-                            .signal_handler;
-                        f(signum, siginfo, context)
+                            .as_ref();
+
+                        let f = last
+                            .signal_handler
+                            .replace(Box::new(signal_handler_none));
+                        let ret = f(signum, siginfo, context);
+                        drop(last.signal_handler.replace(f));
+                        ret
                     }
                 }
             })
@@ -225,7 +88,7 @@ cfg_if::cfg_if! {
             where
                 H: 'static + Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool,
             {
-                self.instance_mut().signal_handler = Box::new(handler) as Box<SignalHandler>;
+                drop(self.instance().signal_handler.replace(Box::new(handler)));
             }
         }
     } else if #[cfg(target_os = "windows")] {
@@ -266,7 +129,7 @@ cfg_if::cfg_if! {
             where
                 H: 'static + Fn(winapi::um::winnt::EXCEPTION_POINTERS) -> bool,
             {
-                self.instance_mut().signal_handler = Box::new(handler) as Box<SignalHandler>;
+                self.instance().signal_handler.replace(Box::new(handler));
             }
         }
     }
@@ -278,7 +141,7 @@ cfg_if::cfg_if! {
 #[repr(C)]
 pub(crate) struct Instance {
     /// The number of references to this `Instance`.
-    refcount: usize,
+    refcount: Cell<usize>,
 
     /// `Instance`s from which this `Instance` imports. These won't
     /// create reference cycles because wasm instances can't cyclically
@@ -286,7 +149,7 @@ pub(crate) struct Instance {
     dependencies: HashSet<InstanceHandle>,
 
     /// The underlying mmap that holds this `Instance`.
-    mmap: Mmap,
+    mmap: Cell<Mmap>,
 
     /// The `Module` this `Instance` was instantiated from.
     module: Arc<Module>,
@@ -310,7 +173,7 @@ pub(crate) struct Instance {
     dbg_jit_registration: Option<Rc<GdbJitImageRegistration>>,
 
     /// Handler run when `SIGBUS`, `SIGFPE`, `SIGILL`, or `SIGSEGV` are caught by the instance thread.
-    signal_handler: Box<SignalHandler>,
+    signal_handler: Cell<Box<SignalHandler>>,
 
     /// Additional context used by compiled wasm code. This field is last, and
     /// represents a dynamically-sized array that extends beyond the nominal
@@ -321,15 +184,14 @@ pub(crate) struct Instance {
 #[allow(clippy::cast_ptr_alignment)]
 impl Instance {
     /// Return the indexed `VMSharedSignatureIndex`.
-    #[allow(dead_code)]
     fn signature_id(&self, index: SignatureIndex) -> VMSharedSignatureIndex {
-        signature_id(&self.vmctx, &self.offsets, index)
+        unsafe { *self.signature_ids_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMSharedSignatureIndex`s.
-    fn signature_ids_ptr(&mut self) -> *mut VMSharedSignatureIndex {
+    fn signature_ids_ptr(&self) -> *mut VMSharedSignatureIndex {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_signature_ids_begin()).unwrap())
                 as *mut VMSharedSignatureIndex
         }
@@ -337,28 +199,27 @@ impl Instance {
 
     /// Return the indexed `VMFunctionImport`.
     fn imported_function(&self, index: FuncIndex) -> &VMFunctionImport {
-        imported_function(&self.vmctx, &self.offsets, index)
+        unsafe { &*self.imported_functions_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMFunctionImport`s.
-    fn imported_functions_ptr(&mut self) -> *mut VMFunctionImport {
+    fn imported_functions_ptr(&self) -> *mut VMFunctionImport {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_imported_functions_begin()).unwrap())
                 as *mut VMFunctionImport
         }
     }
 
     /// Return the index `VMTableImport`.
-    #[allow(dead_code)]
     fn imported_table(&self, index: TableIndex) -> &VMTableImport {
-        imported_table(&self.vmctx, &self.offsets, index)
+        unsafe { &*self.imported_tables_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMTableImports`s.
-    fn imported_tables_ptr(&mut self) -> *mut VMTableImport {
+    fn imported_tables_ptr(&self) -> *mut VMTableImport {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_imported_tables_begin()).unwrap())
                 as *mut VMTableImport
         }
@@ -366,13 +227,13 @@ impl Instance {
 
     /// Return the indexed `VMMemoryImport`.
     fn imported_memory(&self, index: MemoryIndex) -> &VMMemoryImport {
-        imported_memory(&self.vmctx, &self.offsets, index)
+        unsafe { &*self.imported_memories_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMMemoryImport`s.
-    fn imported_memories_ptr(&mut self) -> *mut VMMemoryImport {
+    fn imported_memories_ptr(&self) -> *mut VMMemoryImport {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_imported_memories_begin()).unwrap())
                 as *mut VMMemoryImport
         }
@@ -380,13 +241,13 @@ impl Instance {
 
     /// Return the indexed `VMGlobalImport`.
     fn imported_global(&self, index: GlobalIndex) -> &VMGlobalImport {
-        imported_global(&self.vmctx, &self.offsets, index)
+        unsafe { &*self.imported_globals_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMGlobalImport`s.
-    fn imported_globals_ptr(&mut self) -> *mut VMGlobalImport {
+    fn imported_globals_ptr(&self) -> *mut VMGlobalImport {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_imported_globals_begin()).unwrap())
                 as *mut VMGlobalImport
         }
@@ -395,19 +256,18 @@ impl Instance {
     /// Return the indexed `VMTableDefinition`.
     #[allow(dead_code)]
     fn table(&self, index: DefinedTableIndex) -> &VMTableDefinition {
-        table(&self.vmctx, &self.offsets, index)
+        unsafe { &*self.table_ptr(index) }
     }
 
     /// Return the indexed `VMTableDefinition`.
-    #[allow(dead_code)]
-    fn table_mut(&mut self, index: DefinedTableIndex) -> &mut VMTableDefinition {
-        table_mut(&mut self.vmctx, &self.offsets, index)
+    fn table_ptr(&self, index: DefinedTableIndex) -> *mut VMTableDefinition {
+        unsafe { self.tables_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMTableDefinition`s.
-    fn tables_ptr(&mut self) -> *mut VMTableDefinition {
+    fn tables_ptr(&self) -> *mut VMTableDefinition {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_tables_begin()).unwrap())
                 as *mut VMTableDefinition
         }
@@ -415,47 +275,46 @@ impl Instance {
 
     /// Return the indexed `VMMemoryDefinition`.
     fn memory(&self, index: DefinedMemoryIndex) -> &VMMemoryDefinition {
-        memory(&self.vmctx, &self.offsets, index)
+        unsafe { &*self.memory_ptr(index) }
     }
 
     /// Return the indexed `VMMemoryDefinition`.
-    fn memory_mut(&mut self, index: DefinedMemoryIndex) -> &mut VMMemoryDefinition {
-        memory_mut(&mut self.vmctx, &self.offsets, index)
+    fn memory_ptr(&self, index: DefinedMemoryIndex) -> *mut VMMemoryDefinition {
+        unsafe { self.memories_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMMemoryDefinition`s.
-    fn memories_ptr(&mut self) -> *mut VMMemoryDefinition {
+    fn memories_ptr(&self) -> *mut VMMemoryDefinition {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_memories_begin()).unwrap())
                 as *mut VMMemoryDefinition
         }
     }
 
     /// Return the indexed `VMGlobalDefinition`.
-    #[allow(dead_code)]
     fn global(&self, index: DefinedGlobalIndex) -> &VMGlobalDefinition {
-        global(&self.vmctx, &self.offsets, index)
+        unsafe { &*self.global_ptr(index) }
     }
 
     /// Return the indexed `VMGlobalDefinition`.
-    fn global_mut(&mut self, index: DefinedGlobalIndex) -> &mut VMGlobalDefinition {
-        global_mut(&mut self.vmctx, &self.offsets, index)
+    fn global_ptr(&self, index: DefinedGlobalIndex) -> *mut VMGlobalDefinition {
+        unsafe { self.globals_ptr().add(index.as_u32() as usize) }
     }
 
     /// Return a pointer to the `VMGlobalDefinition`s.
-    fn globals_ptr(&mut self) -> *mut VMGlobalDefinition {
+    fn globals_ptr(&self) -> *mut VMGlobalDefinition {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_globals_begin()).unwrap())
                 as *mut VMGlobalDefinition
         }
     }
 
     /// Return a pointer to the `VMBuiltinFunctionsArray`.
-    fn builtin_functions_ptr(&mut self) -> *mut VMBuiltinFunctionsArray {
+    fn builtin_functions_ptr(&self) -> *mut VMBuiltinFunctionsArray {
         unsafe {
-            (&mut self.vmctx as *mut VMContext as *mut u8)
+            (self.vmctx_ptr() as *mut u8)
                 .add(usize::try_from(self.offsets.vmctx_builtin_functions_begin()).unwrap())
                 as *mut VMBuiltinFunctionsArray
         }
@@ -467,22 +326,12 @@ impl Instance {
     }
 
     /// Return a raw pointer to the vmctx used by compiled wasm code.
-    pub fn vmctx_ptr(&self) -> *const VMContext {
-        self.vmctx()
-    }
-
-    /// Return a mutable reference to the vmctx used by compiled wasm code.
-    pub fn vmctx_mut(&mut self) -> &mut VMContext {
-        &mut self.vmctx
-    }
-
-    /// Return a mutable raw pointer to the vmctx used by compiled wasm code.
-    pub fn vmctx_mut_ptr(&mut self) -> *mut VMContext {
-        self.vmctx_mut()
+    pub fn vmctx_ptr(&self) -> *mut VMContext {
+        self.vmctx() as *const VMContext as *mut VMContext
     }
 
     /// Lookup an export with the given name.
-    pub fn lookup(&mut self, field: &str) -> Option<Export> {
+    pub fn lookup(&self, field: &str) -> Option<Export> {
         let export = if let Some(export) = self.module.exports.get(field) {
             export.clone()
         } else {
@@ -491,42 +340,62 @@ impl Instance {
         Some(self.lookup_by_declaration(&export))
     }
 
-    /// Lookup an export with the given name.
-    ///
-    /// # Safety
-    /// This takes an immutable reference, and the result is an `Export` that
-    /// the type system doesn't prevent from being used to mutate the instance,
-    /// so this function is unsafe.
-    pub unsafe fn lookup_immutable(&self, field: &str) -> Option<Export> {
-        #[allow(clippy::cast_ref_to_mut)]
-        let temporary_mut = &mut *(self as *const Self as *mut Self);
-        temporary_mut.lookup(field)
-    }
-
     /// Lookup an export with the given export declaration.
-    pub fn lookup_by_declaration(&mut self, export: &wasmtime_environ::Export) -> Export {
-        lookup_by_declaration(
-            &self.module,
-            &mut self.vmctx,
-            &self.offsets,
-            &self.finished_functions,
-            export,
-        )
-    }
-
-    /// Lookup an export with the given export declaration.
-    ///
-    /// # Safety
-    /// This takes an immutable reference, and the result is an `Export` that
-    /// the type system doesn't prevent from being used to mutate the instance,
-    /// so this function is unsafe.
-    pub unsafe fn lookup_immutable_by_declaration(
-        &self,
-        export: &wasmtime_environ::Export,
-    ) -> Export {
-        #[allow(clippy::cast_ref_to_mut)]
-        let temporary_mut = &mut *(self as *const Self as *mut Self);
-        temporary_mut.lookup_by_declaration(export)
+    pub fn lookup_by_declaration(&self, export: &wasmtime_environ::Export) -> Export {
+        match export {
+            wasmtime_environ::Export::Function(index) => {
+                let signature = self.module.signatures[self.module.functions[*index]].clone();
+                let (address, vmctx) =
+                    if let Some(def_index) = self.module.defined_func_index(*index) {
+                        (self.finished_functions[def_index], self.vmctx_ptr())
+                    } else {
+                        let import = self.imported_function(*index);
+                        (import.body, import.vmctx)
+                    };
+                Export::Function {
+                    address,
+                    signature,
+                    vmctx,
+                }
+            }
+            wasmtime_environ::Export::Table(index) => {
+                let (definition, vmctx) =
+                    if let Some(def_index) = self.module.defined_table_index(*index) {
+                        (self.table_ptr(def_index), self.vmctx_ptr())
+                    } else {
+                        let import = self.imported_table(*index);
+                        (import.from, import.vmctx)
+                    };
+                Export::Table {
+                    definition,
+                    vmctx,
+                    table: self.module.table_plans[*index].clone(),
+                }
+            }
+            wasmtime_environ::Export::Memory(index) => {
+                let (definition, vmctx) =
+                    if let Some(def_index) = self.module.defined_memory_index(*index) {
+                        (self.memory_ptr(def_index), self.vmctx_ptr())
+                    } else {
+                        let import = self.imported_memory(*index);
+                        (import.from, import.vmctx)
+                    };
+                Export::Memory {
+                    definition,
+                    vmctx,
+                    memory: self.module.memory_plans[*index].clone(),
+                }
+            }
+            wasmtime_environ::Export::Global(index) => Export::Global {
+                definition: if let Some(def_index) = self.module.defined_global_index(*index) {
+                    self.global_ptr(def_index)
+                } else {
+                    self.imported_global(*index).from
+                },
+                vmctx: self.vmctx_ptr(),
+                global: self.module.globals[*index],
+            },
+        }
     }
 
     /// Return an iterator over the exports of this instance.
@@ -539,11 +408,11 @@ impl Instance {
     }
 
     /// Return a reference to the custom state attached to this instance.
-    pub fn host_state(&mut self) -> &mut dyn Any {
-        &mut *self.host_state
+    pub fn host_state(&self) -> &dyn Any {
+        &*self.host_state
     }
 
-    fn invoke_function(&mut self, index: FuncIndex) -> Result<(), InstantiationError> {
+    fn invoke_function(&self, index: FuncIndex) -> Result<(), InstantiationError> {
         // TODO: Check that the callee's calling convention matches what we expect.
 
         let (callee_address, callee_vmctx) = match self.module.defined_func_index(index) {
@@ -552,7 +421,7 @@ impl Instance {
                     .finished_functions
                     .get(defined_index)
                     .expect("function index is out of bounds");
-                (body, self.vmctx_mut() as *mut VMContext)
+                (body, self.vmctx_ptr())
             }
             None => {
                 assert_lt!(index.index(), self.module.imported_funcs.len());
@@ -562,12 +431,12 @@ impl Instance {
         };
 
         // Make the call.
-        unsafe { wasmtime_call(callee_vmctx, self.vmctx_mut_ptr(), callee_address) }
+        unsafe { wasmtime_call(callee_vmctx, self.vmctx_ptr(), callee_address) }
             .map_err(InstantiationError::StartTrap)
     }
 
     /// Invoke the WebAssembly start function of the instance, if one is present.
-    fn invoke_start_function(&mut self) -> Result<(), InstantiationError> {
+    fn invoke_start_function(&self) -> Result<(), InstantiationError> {
         if let Some(start_index) = self.module.start_func {
             self.invoke_function(start_index)
         } else {
@@ -616,19 +485,17 @@ impl Instance {
     ///
     /// Returns `None` if memory can't be grown by the specified amount
     /// of pages.
-    pub(crate) fn memory_grow(
-        &mut self,
-        memory_index: DefinedMemoryIndex,
-        delta: u32,
-    ) -> Option<u32> {
+    pub(crate) fn memory_grow(&self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
         let result = self
             .memories
-            .get_mut(memory_index)
+            .get(memory_index)
             .unwrap_or_else(|| panic!("no memory for index {}", memory_index.index()))
             .grow(delta);
 
         // Keep current the VMContext pointers used by compiled wasm code.
-        *self.memory_mut(memory_index) = self.memories[memory_index].vmmemory();
+        unsafe {
+            *self.memory_ptr(memory_index) = self.memories[memory_index].vmmemory();
+        }
 
         result
     }
@@ -642,20 +509,20 @@ impl Instance {
     /// This and `imported_memory_size` are currently unsafe because they
     /// dereference the memory import's pointers.
     pub(crate) unsafe fn imported_memory_grow(
-        &mut self,
+        &self,
         memory_index: MemoryIndex,
         delta: u32,
     ) -> Option<u32> {
         let import = self.imported_memory(memory_index);
-        let foreign_instance = (&mut *import.vmctx).instance();
-        let foreign_memory = &mut *import.from;
+        let foreign_instance = (&*import.vmctx).instance();
+        let foreign_memory = &*import.from;
         let foreign_index = foreign_instance.memory_index(foreign_memory);
 
         foreign_instance.memory_grow(foreign_index, delta)
     }
 
     /// Returns the number of allocated wasm pages.
-    pub(crate) fn memory_size(&mut self, memory_index: DefinedMemoryIndex) -> u32 {
+    pub(crate) fn memory_size(&self, memory_index: DefinedMemoryIndex) -> u32 {
         self.memories
             .get(memory_index)
             .unwrap_or_else(|| panic!("no memory for index {}", memory_index.index()))
@@ -667,7 +534,7 @@ impl Instance {
     /// # Safety
     /// This and `imported_memory_grow` are currently unsafe because they
     /// dereference the memory import's pointers.
-    pub(crate) unsafe fn imported_memory_size(&mut self, memory_index: MemoryIndex) -> u32 {
+    pub(crate) unsafe fn imported_memory_size(&self, memory_index: MemoryIndex) -> u32 {
         let import = self.imported_memory(memory_index);
         let foreign_instance = (&mut *import.vmctx).instance();
         let foreign_memory = &mut *import.from;
@@ -680,41 +547,43 @@ impl Instance {
     ///
     /// Returns `None` if table can't be grown by the specified amount
     /// of elements.
-    pub(crate) fn table_grow(&mut self, table_index: DefinedTableIndex, delta: u32) -> Option<u32> {
+    pub(crate) fn table_grow(&self, table_index: DefinedTableIndex, delta: u32) -> Option<u32> {
         let result = self
             .tables
-            .get_mut(table_index)
+            .get(table_index)
             .unwrap_or_else(|| panic!("no table for index {}", table_index.index()))
             .grow(delta);
 
         // Keep current the VMContext pointers used by compiled wasm code.
-        *self.table_mut(table_index) = self.tables[table_index].vmtable();
+        unsafe {
+            *self.table_ptr(table_index) = self.tables[table_index].vmtable();
+        }
 
         result
     }
 
     // Get table element by index.
-    pub(crate) fn table_get(
+    fn table_get(
         &self,
         table_index: DefinedTableIndex,
         index: u32,
-    ) -> Option<&VMCallerCheckedAnyfunc> {
+    ) -> Option<VMCallerCheckedAnyfunc> {
         self.tables
             .get(table_index)
             .unwrap_or_else(|| panic!("no table for index {}", table_index.index()))
             .get(index)
     }
 
-    // Get table mutable element by index.
-    pub(crate) fn table_get_mut(
-        &mut self,
+    fn table_set(
+        &self,
         table_index: DefinedTableIndex,
         index: u32,
-    ) -> Option<&mut VMCallerCheckedAnyfunc> {
+        val: VMCallerCheckedAnyfunc,
+    ) -> Result<(), ()> {
         self.tables
-            .get_mut(table_index)
+            .get(table_index)
             .unwrap_or_else(|| panic!("no table for index {}", table_index.index()))
-            .get_mut(index)
+            .set(index, val)
     }
 }
 
@@ -748,7 +617,21 @@ impl InstanceHandle {
     }
 
     /// Create a new `InstanceHandle` pointing at a new `Instance`.
-    pub fn new(
+    ///
+    /// # Unsafety
+    ///
+    /// This method is not necessarily inherently unsafe to call, but in general
+    /// the APIs of an `Instance` are quite unsafe and have not been really
+    /// audited for safety that much. As a result the unsafety here on this
+    /// method is a low-overhead way of saying "this is an extremely unsafe type
+    /// to work with".
+    ///
+    /// Extreme care must be taken when working with `InstanceHandle` and it's
+    /// recommended to have relatively intimate knowledge of how it works
+    /// internally if you'd like to do so. If possible it's recommended to use
+    /// the `wasmtime` crate API rather than this type since that is vetted for
+    /// safety.
+    pub unsafe fn new(
         module: Arc<Module>,
         finished_functions: BoxedSlice<DefinedFuncIndex, *const VMFunctionBody>,
         imports: Imports,
@@ -757,17 +640,17 @@ impl InstanceHandle {
         dbg_jit_registration: Option<Rc<GdbJitImageRegistration>>,
         host_state: Box<dyn Any>,
     ) -> Result<Self, InstantiationError> {
-        let mut tables = create_tables(&module);
-        let mut memories = create_memories(&module)?;
+        let tables = create_tables(&module);
+        let memories = create_memories(&module)?;
 
         let vmctx_tables = tables
-            .values_mut()
+            .values()
             .map(Table::vmtable)
             .collect::<PrimaryMap<DefinedTableIndex, _>>()
             .into_boxed_slice();
 
         let vmctx_memories = memories
-            .values_mut()
+            .values()
             .map(LinearMemory::vmmemory)
             .collect::<PrimaryMap<DefinedMemoryIndex, _>>()
             .into_boxed_slice();
@@ -787,9 +670,9 @@ impl InstanceHandle {
             #[allow(clippy::cast_ptr_alignment)]
             let instance_ptr = instance_mmap.as_mut_ptr() as *mut Instance;
             let instance = Instance {
-                refcount: 1,
+                refcount: Cell::new(1),
                 dependencies: imports.dependencies,
-                mmap: instance_mmap,
+                mmap: Cell::new(instance_mmap),
                 module,
                 offsets,
                 memories,
@@ -797,61 +680,57 @@ impl InstanceHandle {
                 finished_functions,
                 dbg_jit_registration,
                 host_state,
-                signal_handler: Box::new(signal_handler_none) as Box<SignalHandler>,
+                signal_handler: Cell::new(Box::new(signal_handler_none)),
                 vmctx: VMContext {},
             };
-            unsafe {
-                ptr::write(instance_ptr, instance);
-                &mut *instance_ptr
-            }
+            ptr::write(instance_ptr, instance);
+            &mut *instance_ptr
         };
 
-        unsafe {
-            ptr::copy(
-                vmshared_signatures.values().as_slice().as_ptr(),
-                instance.signature_ids_ptr() as *mut VMSharedSignatureIndex,
-                vmshared_signatures.len(),
-            );
-            ptr::copy(
-                imports.functions.values().as_slice().as_ptr(),
-                instance.imported_functions_ptr() as *mut VMFunctionImport,
-                imports.functions.len(),
-            );
-            ptr::copy(
-                imports.tables.values().as_slice().as_ptr(),
-                instance.imported_tables_ptr() as *mut VMTableImport,
-                imports.tables.len(),
-            );
-            ptr::copy(
-                imports.memories.values().as_slice().as_ptr(),
-                instance.imported_memories_ptr() as *mut VMMemoryImport,
-                imports.memories.len(),
-            );
-            ptr::copy(
-                imports.globals.values().as_slice().as_ptr(),
-                instance.imported_globals_ptr() as *mut VMGlobalImport,
-                imports.globals.len(),
-            );
-            ptr::copy(
-                vmctx_tables.values().as_slice().as_ptr(),
-                instance.tables_ptr() as *mut VMTableDefinition,
-                vmctx_tables.len(),
-            );
-            ptr::copy(
-                vmctx_memories.values().as_slice().as_ptr(),
-                instance.memories_ptr() as *mut VMMemoryDefinition,
-                vmctx_memories.len(),
-            );
-            ptr::copy(
-                vmctx_globals.values().as_slice().as_ptr(),
-                instance.globals_ptr() as *mut VMGlobalDefinition,
-                vmctx_globals.len(),
-            );
-            ptr::write(
-                instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
-                VMBuiltinFunctionsArray::initialized(),
-            );
-        }
+        ptr::copy(
+            vmshared_signatures.values().as_slice().as_ptr(),
+            instance.signature_ids_ptr() as *mut VMSharedSignatureIndex,
+            vmshared_signatures.len(),
+        );
+        ptr::copy(
+            imports.functions.values().as_slice().as_ptr(),
+            instance.imported_functions_ptr() as *mut VMFunctionImport,
+            imports.functions.len(),
+        );
+        ptr::copy(
+            imports.tables.values().as_slice().as_ptr(),
+            instance.imported_tables_ptr() as *mut VMTableImport,
+            imports.tables.len(),
+        );
+        ptr::copy(
+            imports.memories.values().as_slice().as_ptr(),
+            instance.imported_memories_ptr() as *mut VMMemoryImport,
+            imports.memories.len(),
+        );
+        ptr::copy(
+            imports.globals.values().as_slice().as_ptr(),
+            instance.imported_globals_ptr() as *mut VMGlobalImport,
+            imports.globals.len(),
+        );
+        ptr::copy(
+            vmctx_tables.values().as_slice().as_ptr(),
+            instance.tables_ptr() as *mut VMTableDefinition,
+            vmctx_tables.len(),
+        );
+        ptr::copy(
+            vmctx_memories.values().as_slice().as_ptr(),
+            instance.memories_ptr() as *mut VMMemoryDefinition,
+            vmctx_memories.len(),
+        );
+        ptr::copy(
+            vmctx_globals.values().as_slice().as_ptr(),
+            instance.globals_ptr() as *mut VMGlobalDefinition,
+            vmctx_globals.len(),
+        );
+        ptr::write(
+            instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
+            VMBuiltinFunctionsArray::initialized(),
+        );
 
         // Check initializer bounds before initializing anything.
         check_table_init_bounds(instance)?;
@@ -881,8 +760,10 @@ impl InstanceHandle {
     /// be a `VMContext` allocated as part of an `Instance`.
     pub unsafe fn from_vmctx(vmctx: *mut VMContext) -> Self {
         let instance = (&mut *vmctx).instance();
-        instance.refcount += 1;
-        Self { instance }
+        instance.refcount.set(instance.refcount.get() + 1);
+        Self {
+            instance: instance as *const Instance as *mut Instance,
+        }
     }
 
     /// Return a reference to the vmctx used by compiled wasm code.
@@ -891,7 +772,7 @@ impl InstanceHandle {
     }
 
     /// Return a raw pointer to the vmctx used by compiled wasm code.
-    pub fn vmctx_ptr(&self) -> *const VMContext {
+    pub fn vmctx_ptr(&self) -> *mut VMContext {
         self.instance().vmctx_ptr()
     }
 
@@ -905,47 +786,14 @@ impl InstanceHandle {
         &self.instance().module
     }
 
-    /// Return a mutable reference to the vmctx used by compiled wasm code.
-    pub fn vmctx_mut(&mut self) -> &mut VMContext {
-        self.instance_mut().vmctx_mut()
-    }
-
-    /// Return a mutable raw pointer to the vmctx used by compiled wasm code.
-    pub fn vmctx_mut_ptr(&mut self) -> *mut VMContext {
-        self.instance_mut().vmctx_mut_ptr()
-    }
-
     /// Lookup an export with the given name.
-    pub fn lookup(&mut self, field: &str) -> Option<Export> {
-        self.instance_mut().lookup(field)
-    }
-
-    /// Lookup an export with the given name.
-    ///
-    /// # Safety
-    /// This takes an immutable reference, and the result is an `Export` that
-    /// the type system doesn't prevent from being used to mutate the instance,
-    /// so this function is unsafe.
-    pub unsafe fn lookup_immutable(&self, field: &str) -> Option<Export> {
-        self.instance().lookup_immutable(field)
+    pub fn lookup(&self, field: &str) -> Option<Export> {
+        self.instance().lookup(field)
     }
 
     /// Lookup an export with the given export declaration.
-    pub fn lookup_by_declaration(&mut self, export: &wasmtime_environ::Export) -> Export {
-        self.instance_mut().lookup_by_declaration(export)
-    }
-
-    /// Lookup an export with the given export declaration.
-    ///
-    /// # Safety
-    /// This takes an immutable reference, and the result is an `Export` that
-    /// the type system doesn't prevent from being used to mutate the instance,
-    /// so this function is unsafe.
-    pub unsafe fn lookup_immutable_by_declaration(
-        &self,
-        export: &wasmtime_environ::Export,
-    ) -> Export {
-        self.instance().lookup_immutable_by_declaration(export)
+    pub fn lookup_by_declaration(&self, export: &wasmtime_environ::Export) -> Export {
+        self.instance().lookup_by_declaration(export)
     }
 
     /// Return an iterator over the exports of this instance.
@@ -958,8 +806,8 @@ impl InstanceHandle {
     }
 
     /// Return a reference to the custom state attached to this instance.
-    pub fn host_state(&mut self) -> &mut dyn Any {
-        self.instance_mut().host_state()
+    pub fn host_state(&self) -> &dyn Any {
+        self.instance().host_state()
     }
 
     /// Return the memory index for the given `VMMemoryDefinition` in this instance.
@@ -971,8 +819,8 @@ impl InstanceHandle {
     ///
     /// Returns `None` if memory can't be grown by the specified amount
     /// of pages.
-    pub fn memory_grow(&mut self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
-        self.instance_mut().memory_grow(memory_index, delta)
+    pub fn memory_grow(&self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
+        self.instance().memory_grow(memory_index, delta)
     }
 
     /// Return the table index for the given `VMTableDefinition` in this instance.
@@ -984,8 +832,8 @@ impl InstanceHandle {
     ///
     /// Returns `None` if memory can't be grown by the specified amount
     /// of pages.
-    pub fn table_grow(&mut self, table_index: DefinedTableIndex, delta: u32) -> Option<u32> {
-        self.instance_mut().table_grow(table_index, delta)
+    pub fn table_grow(&self, table_index: DefinedTableIndex, delta: u32) -> Option<u32> {
+        self.instance().table_grow(table_index, delta)
     }
 
     /// Get table element reference.
@@ -995,37 +843,32 @@ impl InstanceHandle {
         &self,
         table_index: DefinedTableIndex,
         index: u32,
-    ) -> Option<&VMCallerCheckedAnyfunc> {
+    ) -> Option<VMCallerCheckedAnyfunc> {
         self.instance().table_get(table_index, index)
     }
 
-    /// Get mutable table element reference.
+    /// Set table element reference.
     ///
-    /// Returns `None` if index is out of bounds.
-    pub fn table_get_mut(
-        &mut self,
+    /// Returns an error if the index is out of bounds
+    pub fn table_set(
+        &self,
         table_index: DefinedTableIndex,
         index: u32,
-    ) -> Option<&mut VMCallerCheckedAnyfunc> {
-        self.instance_mut().table_get_mut(table_index, index)
+        val: VMCallerCheckedAnyfunc,
+    ) -> Result<(), ()> {
+        self.instance().table_set(table_index, index, val)
     }
-}
 
-impl InstanceHandle {
     /// Return a reference to the contained `Instance`.
     fn instance(&self) -> &Instance {
         unsafe { &*(self.instance as *const Instance) }
-    }
-
-    /// Return a mutable reference to the contained `Instance`.
-    fn instance_mut(&mut self) -> &mut Instance {
-        unsafe { &mut *(self.instance as *mut Instance) }
     }
 }
 
 impl Clone for InstanceHandle {
     fn clone(&self) -> Self {
-        unsafe { &mut *(self.instance as *mut Instance) }.refcount += 1;
+        let instance = self.instance();
+        instance.refcount.set(instance.refcount.get() + 1);
         Self {
             instance: self.instance,
         }
@@ -1034,79 +877,14 @@ impl Clone for InstanceHandle {
 
 impl Drop for InstanceHandle {
     fn drop(&mut self) {
-        let instance = self.instance_mut();
-        instance.refcount -= 1;
-        if instance.refcount == 0 {
-            let mmap = mem::replace(&mut instance.mmap, Mmap::new());
-            unsafe { ptr::drop_in_place(instance) };
+        let instance = self.instance();
+        let count = instance.refcount.get();
+        instance.refcount.set(count - 1);
+        if count == 1 {
+            let mmap = instance.mmap.replace(Mmap::new());
+            unsafe { ptr::drop_in_place(self.instance) };
             mem::drop(mmap);
         }
-    }
-}
-
-fn lookup_by_declaration(
-    module: &Module,
-    vmctx: &mut VMContext,
-    offsets: &VMOffsets,
-    finished_functions: &BoxedSlice<DefinedFuncIndex, *const VMFunctionBody>,
-    export: &wasmtime_environ::Export,
-) -> Export {
-    match export {
-        wasmtime_environ::Export::Function(index) => {
-            let signature = module.signatures[module.functions[*index]].clone();
-            let (address, vmctx) = if let Some(def_index) = module.defined_func_index(*index) {
-                (finished_functions[def_index], vmctx as *mut VMContext)
-            } else {
-                let import = imported_function(vmctx, offsets, *index);
-                (import.body, import.vmctx)
-            };
-            Export::Function {
-                address,
-                signature,
-                vmctx,
-            }
-        }
-        wasmtime_environ::Export::Table(index) => {
-            let (definition, vmctx) = if let Some(def_index) = module.defined_table_index(*index) {
-                (
-                    table_mut(vmctx, offsets, def_index) as *mut VMTableDefinition,
-                    vmctx as *mut VMContext,
-                )
-            } else {
-                let import = imported_table(vmctx, offsets, *index);
-                (import.from, import.vmctx)
-            };
-            Export::Table {
-                definition,
-                vmctx,
-                table: module.table_plans[*index].clone(),
-            }
-        }
-        wasmtime_environ::Export::Memory(index) => {
-            let (definition, vmctx) = if let Some(def_index) = module.defined_memory_index(*index) {
-                (
-                    memory_mut(vmctx, offsets, def_index) as *mut VMMemoryDefinition,
-                    vmctx as *mut VMContext,
-                )
-            } else {
-                let import = imported_memory(vmctx, offsets, *index);
-                (import.from, import.vmctx)
-            };
-            Export::Memory {
-                definition,
-                vmctx,
-                memory: module.memory_plans[*index].clone(),
-            }
-        }
-        wasmtime_environ::Export::Global(index) => Export::Global {
-            definition: if let Some(def_index) = module.defined_global_index(*index) {
-                global_mut(vmctx, offsets, def_index)
-            } else {
-                imported_global(vmctx, offsets, *index).from
-            },
-            vmctx,
-            global: module.globals[*index],
-        },
     }
 }
 
@@ -1114,15 +892,10 @@ fn check_table_init_bounds(instance: &mut Instance) -> Result<(), InstantiationE
     let module = Arc::clone(&instance.module);
     for init in &module.table_elements {
         let start = get_table_init_start(init, instance);
-        let slice = get_table_slice(
-            init,
-            &instance.module,
-            &mut instance.tables,
-            &instance.vmctx,
-            &instance.offsets,
-        );
+        let table = get_table(init, instance);
 
-        if slice.get_mut(start..start + init.elements.len()).is_none() {
+        let size = usize::try_from(table.size()).unwrap();
+        if size < start + init.elements.len() {
             return Err(InstantiationError::Link(LinkError(
                 "elements segment does not fit".to_owned(),
             )));
@@ -1137,12 +910,14 @@ fn get_memory_init_start(init: &DataInitializer<'_>, instance: &mut Instance) ->
     let mut start = init.location.offset;
 
     if let Some(base) = init.location.base {
-        let global = if let Some(def_index) = instance.module.defined_global_index(base) {
-            instance.global_mut(def_index)
-        } else {
-            instance.imported_global(base).from
+        let val = unsafe {
+            if let Some(def_index) = instance.module.defined_global_index(base) {
+                *instance.global(def_index).as_u32()
+            } else {
+                *(*instance.imported_global(base).from).as_u32()
+            }
         };
-        start += usize::try_from(*unsafe { (*global).as_u32() }).unwrap();
+        start += usize::try_from(val).unwrap();
     }
 
     start
@@ -1202,67 +977,60 @@ fn get_table_init_start(init: &TableElements, instance: &mut Instance) -> usize 
     let mut start = init.offset;
 
     if let Some(base) = init.base {
-        let global = if let Some(def_index) = instance.module.defined_global_index(base) {
-            instance.global_mut(def_index)
-        } else {
-            instance.imported_global(base).from
+        let val = unsafe {
+            if let Some(def_index) = instance.module.defined_global_index(base) {
+                *instance.global(def_index).as_u32()
+            } else {
+                *(*instance.imported_global(base).from).as_u32()
+            }
         };
-        start += usize::try_from(*unsafe { (*global).as_u32() }).unwrap();
+        start += usize::try_from(val).unwrap();
     }
 
     start
 }
 
 /// Return a byte-slice view of a table's data.
-fn get_table_slice<'instance>(
-    init: &TableElements,
-    module: &Module,
-    tables: &'instance mut BoxedSlice<DefinedTableIndex, Table>,
-    vmctx: &VMContext,
-    offsets: &VMOffsets,
-) -> &'instance mut [VMCallerCheckedAnyfunc] {
-    if let Some(defined_table_index) = module.defined_table_index(init.table_index) {
-        tables[defined_table_index].as_mut()
+fn get_table<'instance>(init: &TableElements, instance: &'instance Instance) -> &'instance Table {
+    if let Some(defined_table_index) = instance.module.defined_table_index(init.table_index) {
+        &instance.tables[defined_table_index]
     } else {
-        let import = imported_table(vmctx, offsets, init.table_index);
+        let import = instance.imported_table(init.table_index);
         let foreign_instance = unsafe { (&mut *(import).vmctx).instance() };
         let foreign_table = unsafe { &mut *(import).from };
         let foreign_index = foreign_instance.table_index(foreign_table);
-        foreign_instance.tables[foreign_index].as_mut()
+        &foreign_instance.tables[foreign_index]
     }
 }
 
 /// Initialize the table memory from the provided initializers.
 fn initialize_tables(instance: &mut Instance) -> Result<(), InstantiationError> {
-    let vmctx: *mut VMContext = instance.vmctx_mut();
+    let vmctx = instance.vmctx_ptr();
     let module = Arc::clone(&instance.module);
     for init in &module.table_elements {
         let start = get_table_init_start(init, instance);
-        let slice = get_table_slice(
-            init,
-            &instance.module,
-            &mut instance.tables,
-            &instance.vmctx,
-            &instance.offsets,
-        );
+        let table = get_table(init, instance);
 
-        let subslice = &mut slice[start..start + init.elements.len()];
         for (i, func_idx) in init.elements.iter().enumerate() {
             let callee_sig = instance.module.functions[*func_idx];
             let (callee_ptr, callee_vmctx) =
                 if let Some(index) = instance.module.defined_func_index(*func_idx) {
                     (instance.finished_functions[index], vmctx)
                 } else {
-                    let imported_func =
-                        imported_function(&instance.vmctx, &instance.offsets, *func_idx);
+                    let imported_func = instance.imported_function(*func_idx);
                     (imported_func.body, imported_func.vmctx)
                 };
-            let type_index = signature_id(&instance.vmctx, &instance.offsets, callee_sig);
-            subslice[i] = VMCallerCheckedAnyfunc {
-                func_ptr: callee_ptr,
-                type_index,
-                vmctx: callee_vmctx,
-            };
+            let type_index = instance.signature_id(callee_sig);
+            table
+                .set(
+                    u32::try_from(start + i).unwrap(),
+                    VMCallerCheckedAnyfunc {
+                        func_ptr: callee_ptr,
+                        type_index,
+                        vmctx: callee_vmctx,
+                    },
+                )
+                .unwrap();
         }
     }
 
@@ -1316,23 +1084,25 @@ fn initialize_globals(instance: &mut Instance) {
     let num_imports = module.imported_globals.len();
     for (index, global) in module.globals.iter().skip(num_imports) {
         let def_index = module.defined_global_index(index).unwrap();
-        let to: *mut VMGlobalDefinition = instance.global_mut(def_index);
-        match global.initializer {
-            GlobalInit::I32Const(x) => *unsafe { (*to).as_i32_mut() } = x,
-            GlobalInit::I64Const(x) => *unsafe { (*to).as_i64_mut() } = x,
-            GlobalInit::F32Const(x) => *unsafe { (*to).as_f32_bits_mut() } = x,
-            GlobalInit::F64Const(x) => *unsafe { (*to).as_f64_bits_mut() } = x,
-            GlobalInit::V128Const(x) => *unsafe { (*to).as_u128_bits_mut() } = x.0,
-            GlobalInit::GetGlobal(x) => {
-                let from = if let Some(def_x) = module.defined_global_index(x) {
-                    instance.global_mut(def_x)
-                } else {
-                    instance.imported_global(x).from
-                };
-                unsafe { *to = *from };
+        unsafe {
+            let to = instance.global_ptr(def_index);
+            match global.initializer {
+                GlobalInit::I32Const(x) => *(*to).as_i32_mut() = x,
+                GlobalInit::I64Const(x) => *(*to).as_i64_mut() = x,
+                GlobalInit::F32Const(x) => *(*to).as_f32_bits_mut() = x,
+                GlobalInit::F64Const(x) => *(*to).as_f64_bits_mut() = x,
+                GlobalInit::V128Const(x) => *(*to).as_u128_bits_mut() = x.0,
+                GlobalInit::GetGlobal(x) => {
+                    let from = if let Some(def_x) = module.defined_global_index(x) {
+                        *instance.global(def_x)
+                    } else {
+                        (*instance.imported_global(x).from)
+                    };
+                    *to = from;
+                }
+                GlobalInit::Import => panic!("locally-defined global initialized as import"),
+                GlobalInit::RefNullConst => unimplemented!(),
             }
-            GlobalInit::Import => panic!("locally-defined global initialized as import"),
-            GlobalInit::RefNullConst => unimplemented!(),
         }
     }
 }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -197,7 +197,8 @@ impl Instance {
 
     /// Return the indexed `VMSharedSignatureIndex`.
     fn signature_id(&self, index: SignatureIndex) -> VMSharedSignatureIndex {
-        unsafe { *self.signature_ids_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { *self.signature_ids_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMSharedSignatureIndex`s.
@@ -207,7 +208,8 @@ impl Instance {
 
     /// Return the indexed `VMFunctionImport`.
     fn imported_function(&self, index: FuncIndex) -> &VMFunctionImport {
-        unsafe { &*self.imported_functions_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { &*self.imported_functions_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMFunctionImport`s.
@@ -217,7 +219,8 @@ impl Instance {
 
     /// Return the index `VMTableImport`.
     fn imported_table(&self, index: TableIndex) -> &VMTableImport {
-        unsafe { &*self.imported_tables_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { &*self.imported_tables_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMTableImports`s.
@@ -227,7 +230,8 @@ impl Instance {
 
     /// Return the indexed `VMMemoryImport`.
     fn imported_memory(&self, index: MemoryIndex) -> &VMMemoryImport {
-        unsafe { &*self.imported_memories_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { &*self.imported_memories_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMMemoryImport`s.
@@ -237,7 +241,8 @@ impl Instance {
 
     /// Return the indexed `VMGlobalImport`.
     fn imported_global(&self, index: GlobalIndex) -> &VMGlobalImport {
-        unsafe { &*self.imported_globals_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { &*self.imported_globals_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMGlobalImport`s.
@@ -253,7 +258,8 @@ impl Instance {
 
     /// Return the indexed `VMTableDefinition`.
     fn table_ptr(&self, index: DefinedTableIndex) -> *mut VMTableDefinition {
-        unsafe { self.tables_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { self.tables_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMTableDefinition`s.
@@ -268,7 +274,8 @@ impl Instance {
 
     /// Return the indexed `VMMemoryDefinition`.
     fn memory_ptr(&self, index: DefinedMemoryIndex) -> *mut VMMemoryDefinition {
-        unsafe { self.memories_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { self.memories_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMMemoryDefinition`s.
@@ -283,7 +290,8 @@ impl Instance {
 
     /// Return the indexed `VMGlobalDefinition`.
     fn global_ptr(&self, index: DefinedGlobalIndex) -> *mut VMGlobalDefinition {
-        unsafe { self.globals_ptr().add(index.as_u32() as usize) }
+        let index = usize::try_from(index.as_u32()).unwrap();
+        unsafe { self.globals_ptr().add(index) }
     }
 
     /// Return a pointer to the `VMGlobalDefinition`s.

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -73,7 +73,7 @@ cfg_if::cfg_if! {
                             .signal_handler
                             .replace(Box::new(signal_handler_none));
                         let ret = f(signum, siginfo, context);
-                        drop(last.signal_handler.replace(f));
+                        last.signal_handler.set(f);
                         ret
                     }
                 }
@@ -87,7 +87,7 @@ cfg_if::cfg_if! {
             where
                 H: 'static + Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool,
             {
-                drop(self.instance().signal_handler.replace(Box::new(handler)));
+                self.instance().signal_handler.set(Box::new(handler));
             }
         }
     } else if #[cfg(target_os = "windows")] {
@@ -120,7 +120,7 @@ cfg_if::cfg_if! {
                             .signal_handler
                             .replace(Box::new(signal_handler_none));
                         let ret = f(exception_info);
-                        drop(last.signal_handler.replace(f));
+                        last.signal_handler.set(f);
                         ret
                     }
                 }
@@ -133,7 +133,7 @@ cfg_if::cfg_if! {
             where
                 H: 'static + Fn(winapi::um::winnt::EXCEPTION_POINTERS) -> bool,
             {
-                drop(self.instance().signal_handler.replace(Box::new(handler)));
+                self.instance().signal_handler.set(Box::new(handler));
             }
         }
     }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -187,6 +187,14 @@ pub(crate) struct Instance {
 
 #[allow(clippy::cast_ptr_alignment)]
 impl Instance {
+    /// Helper function to access various locations offset from our `*mut
+    /// VMContext` object.
+    unsafe fn vmctx_plus_offset<T>(&self, offset: u32) -> *mut T {
+        (self.vmctx_ptr() as *mut u8)
+            .add(usize::try_from(offset).unwrap())
+            .cast()
+    }
+
     /// Return the indexed `VMSharedSignatureIndex`.
     fn signature_id(&self, index: SignatureIndex) -> VMSharedSignatureIndex {
         unsafe { *self.signature_ids_ptr().add(index.as_u32() as usize) }
@@ -195,9 +203,7 @@ impl Instance {
     /// Return a pointer to the `VMSharedSignatureIndex`s.
     fn signature_ids_ptr(&self) -> *mut VMSharedSignatureIndex {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_signature_ids_begin()).unwrap())
-                as *mut VMSharedSignatureIndex
+            self.vmctx_plus_offset(self.offsets.vmctx_signature_ids_begin())
         }
     }
 
@@ -209,9 +215,7 @@ impl Instance {
     /// Return a pointer to the `VMFunctionImport`s.
     fn imported_functions_ptr(&self) -> *mut VMFunctionImport {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_imported_functions_begin()).unwrap())
-                as *mut VMFunctionImport
+            self.vmctx_plus_offset(self.offsets.vmctx_imported_functions_begin())
         }
     }
 
@@ -223,9 +227,7 @@ impl Instance {
     /// Return a pointer to the `VMTableImports`s.
     fn imported_tables_ptr(&self) -> *mut VMTableImport {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_imported_tables_begin()).unwrap())
-                as *mut VMTableImport
+            self.vmctx_plus_offset(self.offsets.vmctx_imported_tables_begin())
         }
     }
 
@@ -237,9 +239,7 @@ impl Instance {
     /// Return a pointer to the `VMMemoryImport`s.
     fn imported_memories_ptr(&self) -> *mut VMMemoryImport {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_imported_memories_begin()).unwrap())
-                as *mut VMMemoryImport
+            self.vmctx_plus_offset(self.offsets.vmctx_imported_memories_begin())
         }
     }
 
@@ -251,9 +251,7 @@ impl Instance {
     /// Return a pointer to the `VMGlobalImport`s.
     fn imported_globals_ptr(&self) -> *mut VMGlobalImport {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_imported_globals_begin()).unwrap())
-                as *mut VMGlobalImport
+            self.vmctx_plus_offset(self.offsets.vmctx_imported_globals_begin())
         }
     }
 
@@ -271,9 +269,7 @@ impl Instance {
     /// Return a pointer to the `VMTableDefinition`s.
     fn tables_ptr(&self) -> *mut VMTableDefinition {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_tables_begin()).unwrap())
-                as *mut VMTableDefinition
+            self.vmctx_plus_offset(self.offsets.vmctx_tables_begin())
         }
     }
 
@@ -290,9 +286,7 @@ impl Instance {
     /// Return a pointer to the `VMMemoryDefinition`s.
     fn memories_ptr(&self) -> *mut VMMemoryDefinition {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_memories_begin()).unwrap())
-                as *mut VMMemoryDefinition
+            self.vmctx_plus_offset(self.offsets.vmctx_memories_begin())
         }
     }
 
@@ -309,18 +303,14 @@ impl Instance {
     /// Return a pointer to the `VMGlobalDefinition`s.
     fn globals_ptr(&self) -> *mut VMGlobalDefinition {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_globals_begin()).unwrap())
-                as *mut VMGlobalDefinition
+            self.vmctx_plus_offset(self.offsets.vmctx_globals_begin())
         }
     }
 
     /// Return a pointer to the `VMBuiltinFunctionsArray`.
     fn builtin_functions_ptr(&self) -> *mut VMBuiltinFunctionsArray {
         unsafe {
-            (self.vmctx_ptr() as *mut u8)
-                .add(usize::try_from(self.offsets.vmctx_builtin_functions_begin()).unwrap())
-                as *mut VMBuiltinFunctionsArray
+            self.vmctx_plus_offset(self.offsets.vmctx_builtin_functions_begin())
         }
     }
 

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -252,8 +252,15 @@ impl Instance {
 
     /// Return the indexed `VMTableDefinition`.
     #[allow(dead_code)]
-    fn table(&self, index: DefinedTableIndex) -> &VMTableDefinition {
-        unsafe { &*self.table_ptr(index) }
+    fn table(&self, index: DefinedTableIndex) -> VMTableDefinition {
+        unsafe { *self.table_ptr(index) }
+    }
+
+    /// Updates the value for a defined table to `VMTableDefinition`.
+    fn set_table(&self, index: DefinedTableIndex, table: VMTableDefinition) {
+        unsafe {
+            *self.table_ptr(index) = table;
+        }
     }
 
     /// Return the indexed `VMTableDefinition`.
@@ -268,8 +275,15 @@ impl Instance {
     }
 
     /// Return the indexed `VMMemoryDefinition`.
-    fn memory(&self, index: DefinedMemoryIndex) -> &VMMemoryDefinition {
-        unsafe { &*self.memory_ptr(index) }
+    fn memory(&self, index: DefinedMemoryIndex) -> VMMemoryDefinition {
+        unsafe { *self.memory_ptr(index) }
+    }
+
+    /// Set the indexed memory to `VMMemoryDefinition`.
+    fn set_memory(&self, index: DefinedMemoryIndex, mem: VMMemoryDefinition) {
+        unsafe {
+            *self.memory_ptr(index) = mem;
+        }
     }
 
     /// Return the indexed `VMMemoryDefinition`.
@@ -284,8 +298,16 @@ impl Instance {
     }
 
     /// Return the indexed `VMGlobalDefinition`.
-    fn global(&self, index: DefinedGlobalIndex) -> &VMGlobalDefinition {
-        unsafe { &*self.global_ptr(index) }
+    fn global(&self, index: DefinedGlobalIndex) -> VMGlobalDefinition {
+        unsafe { *self.global_ptr(index) }
+    }
+
+    /// Set the indexed global to `VMGlobalDefinition`.
+    #[allow(dead_code)]
+    fn set_global(&self, index: DefinedGlobalIndex, global: VMGlobalDefinition) {
+        unsafe {
+            *self.global_ptr(index) = global;
+        }
     }
 
     /// Return the indexed `VMGlobalDefinition`.
@@ -477,9 +499,7 @@ impl Instance {
             .grow(delta);
 
         // Keep current the VMContext pointers used by compiled wasm code.
-        unsafe {
-            *self.memory_ptr(memory_index) = self.memories[memory_index].vmmemory();
-        }
+        self.set_memory(memory_index, self.memories[memory_index].vmmemory());
 
         result
     }
@@ -539,9 +559,7 @@ impl Instance {
             .grow(delta);
 
         // Keep current the VMContext pointers used by compiled wasm code.
-        unsafe {
-            *self.table_ptr(table_index) = self.tables[table_index].vmtable();
-        }
+        self.set_table(table_index, self.tables[table_index].vmtable());
 
         result
     }
@@ -1078,9 +1096,9 @@ fn initialize_globals(instance: &mut Instance) {
                 GlobalInit::V128Const(x) => *(*to).as_u128_bits_mut() = x.0,
                 GlobalInit::GetGlobal(x) => {
                     let from = if let Some(def_x) = module.defined_global_index(x) {
-                        *instance.global(def_x)
+                        instance.global(def_x)
                     } else {
-                        (*instance.imported_global(x).from)
+                        *instance.imported_global(x).from
                     };
                     *to = from;
                 }

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -5,7 +5,7 @@
 use crate::mmap::Mmap;
 use crate::vmcontext::VMMemoryDefinition;
 use more_asserts::{assert_ge, assert_le};
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::convert::TryFrom;
 use wasmtime_environ::{MemoryPlan, MemoryStyle, WASM_MAX_PAGES, WASM_PAGE_SIZE};
 
@@ -13,10 +13,7 @@ use wasmtime_environ::{MemoryPlan, MemoryStyle, WASM_MAX_PAGES, WASM_PAGE_SIZE};
 #[derive(Debug)]
 pub struct LinearMemory {
     // The underlying allocation.
-    mmap: RefCell<Mmap>,
-
-    // The current logical size in wasm pages of this linear memory.
-    current: Cell<u32>,
+    mmap: RefCell<WasmMmap>,
 
     // The optional maximum size in wasm pages of this linear memory.
     maximum: Option<u32>,
@@ -28,6 +25,14 @@ pub struct LinearMemory {
     // Records whether we're using a bounds-checking strategy which requires
     // handlers to catch trapping accesses.
     pub(crate) needs_signal_handlers: bool,
+}
+
+#[derive(Debug)]
+struct WasmMmap {
+    // Our OS allocation of mmap'd memory.
+    alloc: Mmap,
+    // The current logical size in wasm pages of this linear memory.
+    size: u32,
 }
 
 impl LinearMemory {
@@ -60,11 +65,13 @@ impl LinearMemory {
         let mapped_pages = plan.memory.minimum as usize;
         let mapped_bytes = mapped_pages * WASM_PAGE_SIZE as usize;
 
-        let mmap = Mmap::accessible_reserved(mapped_bytes, request_bytes)?;
+        let mmap = WasmMmap {
+            alloc: Mmap::accessible_reserved(mapped_bytes, request_bytes)?,
+            size: plan.memory.minimum,
+        };
 
         Ok(Self {
             mmap: mmap.into(),
-            current: plan.memory.minimum.into(),
             maximum: plan.memory.maximum,
             offset_guard_size: offset_guard_bytes,
             needs_signal_handlers,
@@ -73,7 +80,7 @@ impl LinearMemory {
 
     /// Returns the number of allocated wasm pages.
     pub fn size(&self) -> u32 {
-        self.current.get()
+        self.mmap.borrow().size
     }
 
     /// Grow memory by the specified amount of wasm pages.
@@ -82,16 +89,17 @@ impl LinearMemory {
     /// of wasm pages.
     pub fn grow(&self, delta: u32) -> Option<u32> {
         // Optimization of memory.grow 0 calls.
+        let mut mmap = self.mmap.borrow_mut();
         if delta == 0 {
-            return Some(self.current.get());
+            return Some(mmap.size);
         }
 
-        let new_pages = match self.current.get().checked_add(delta) {
+        let new_pages = match mmap.size.checked_add(delta) {
             Some(new_pages) => new_pages,
             // Linear memory size overflow.
             None => return None,
         };
-        let prev_pages = self.current.get();
+        let prev_pages = mmap.size;
 
         if let Some(maximum) = self.maximum {
             if new_pages > maximum {
@@ -112,8 +120,7 @@ impl LinearMemory {
         let prev_bytes = usize::try_from(prev_pages).unwrap() * WASM_PAGE_SIZE as usize;
         let new_bytes = usize::try_from(new_pages).unwrap() * WASM_PAGE_SIZE as usize;
 
-        let mut mmap = self.mmap.borrow_mut();
-        if new_bytes > mmap.len() - self.offset_guard_size {
+        if new_bytes > mmap.alloc.len() - self.offset_guard_size {
             // If the new size is within the declared maximum, but needs more memory than we
             // have on hand, it's a dynamic heap and it can move.
             let guard_bytes = self.offset_guard_size;
@@ -121,16 +128,16 @@ impl LinearMemory {
 
             let mut new_mmap = Mmap::accessible_reserved(new_bytes, request_bytes).ok()?;
 
-            let copy_len = mmap.len() - self.offset_guard_size;
-            new_mmap.as_mut_slice()[..copy_len].copy_from_slice(&mmap.as_slice()[..copy_len]);
+            let copy_len = mmap.alloc.len() - self.offset_guard_size;
+            new_mmap.as_mut_slice()[..copy_len].copy_from_slice(&mmap.alloc.as_slice()[..copy_len]);
 
-            *mmap = new_mmap;
+            mmap.alloc = new_mmap;
         } else if delta_bytes > 0 {
             // Make the newly allocated pages accessible.
-            mmap.make_accessible(prev_bytes, delta_bytes).ok()?;
+            mmap.alloc.make_accessible(prev_bytes, delta_bytes).ok()?;
         }
 
-        self.current.set(new_pages);
+        mmap.size = new_pages;
 
         Some(prev_pages)
     }
@@ -139,8 +146,8 @@ impl LinearMemory {
     pub fn vmmemory(&self) -> VMMemoryDefinition {
         let mut mmap = self.mmap.borrow_mut();
         VMMemoryDefinition {
-            base: mmap.as_mut_ptr(),
-            current_length: self.current.get() as usize * WASM_PAGE_SIZE as usize,
+            base: mmap.alloc.as_mut_ptr(),
+            current_length: mmap.size as usize * WASM_PAGE_SIZE as usize,
         }
     }
 }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -605,16 +605,16 @@ impl VMContext {
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
     /// be a `VMContext` allocated as part of an `Instance`.
     #[allow(clippy::cast_ptr_alignment)]
-    pub(crate) unsafe fn instance(&mut self) -> &mut Instance {
-        &mut *((self as *mut Self as *mut u8).offset(-Instance::vmctx_offset()) as *mut Instance)
+    pub(crate) unsafe fn instance(&self) -> &Instance {
+        &*((self as *const Self as *mut u8).offset(-Instance::vmctx_offset()) as *const Instance)
     }
 
-    /// Return a mutable reference to the host state associated with this `Instance`.
+    /// Return a reference to the host state associated with this `Instance`.
     ///
     /// # Safety
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
     /// be a `VMContext` allocated as part of an `Instance`.
-    pub unsafe fn host_state(&mut self) -> &mut dyn Any {
+    pub unsafe fn host_state(&self) -> &dyn Any {
         self.instance().host_state()
     }
 }

--- a/crates/wasi-common/wig/src/wasi.rs
+++ b/crates/wasi-common/wig/src/wasi.rs
@@ -201,8 +201,8 @@ pub fn add_wrappers_to_module(args: TokenStream) -> TokenStream {
                         #format_str,
                         #(#format_args),*
                     );
-                    let wasi_ctx = match get_wasi_ctx(&mut *ctx) {
-                        Ok(e) => e,
+                    let mut wasi_ctx = match get_wasi_ctx(&mut *ctx) {
+                        Ok(e) => e.borrow_mut(),
                         Err(e) => #handle_early_error,
                     };
                     let memory = match get_memory(&mut *caller_ctx) {
@@ -210,7 +210,7 @@ pub fn add_wrappers_to_module(args: TokenStream) -> TokenStream {
                         Err(e) => #handle_early_error,
                     };
                     hostcalls::#name_ident(
-                        wasi_ctx,
+                        &mut *wasi_ctx,
                         memory,
                         #(#hostcall_args),*
                     ) #cvt_ret

--- a/crates/wasi/src/instantiate.rs
+++ b/crates/wasi/src/instantiate.rs
@@ -2,6 +2,7 @@ use cranelift_codegen::ir::types;
 use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::DefinedFuncIndex;
+use std::cell::RefCell;
 use std::fs::File;
 use std::sync::Arc;
 use target_lexicon::HOST;
@@ -78,15 +79,17 @@ pub fn instantiate_wasi_with_context(
     let data_initializers = Vec::new();
     let signatures = PrimaryMap::new();
 
-    InstanceHandle::new(
-        Arc::new(module),
-        finished_functions.into_boxed_slice(),
-        imports,
-        &data_initializers,
-        signatures.into_boxed_slice(),
-        None,
-        Box::new(wasi_ctx),
-    )
+    unsafe {
+        InstanceHandle::new(
+            Arc::new(module),
+            finished_functions.into_boxed_slice(),
+            imports,
+            &data_initializers,
+            signatures.into_boxed_slice(),
+            None,
+            Box::new(wasi_ctx),
+        )
+    }
 }
 
 wig::define_add_wrappers_to_module!(
@@ -94,11 +97,11 @@ wig::define_add_wrappers_to_module!(
 );
 
 // Used by `add_wrappers_to_module` defined in the macro above
-fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&mut WasiCtx, wasi::__wasi_errno_t> {
+fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&RefCell<WasiCtx>, wasi::__wasi_errno_t> {
     unsafe {
         vmctx
             .host_state()
-            .downcast_mut::<WasiCtx>()
+            .downcast_ref()
             .ok_or_else(|| panic!("no host state named WasiCtx available"))
     }
 }

--- a/crates/wasi/src/instantiate.rs
+++ b/crates/wasi/src/instantiate.rs
@@ -87,7 +87,7 @@ pub fn instantiate_wasi_with_context(
             &data_initializers,
             signatures.into_boxed_slice(),
             None,
-            Box::new(wasi_ctx),
+            Box::new(RefCell::new(wasi_ctx)),
         )
     }
 }

--- a/crates/wasi/src/old/snapshot_0/instantiate.rs
+++ b/crates/wasi/src/old/snapshot_0/instantiate.rs
@@ -2,6 +2,7 @@ use cranelift_codegen::ir::types;
 use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::DefinedFuncIndex;
+use std::cell::RefCell;
 use std::fs::File;
 use std::sync::Arc;
 use target_lexicon::HOST;
@@ -78,23 +79,25 @@ pub fn instantiate_wasi_with_context(
     let data_initializers = Vec::new();
     let signatures = PrimaryMap::new();
 
-    InstanceHandle::new(
-        Arc::new(module),
-        finished_functions.into_boxed_slice(),
-        imports,
-        &data_initializers,
-        signatures.into_boxed_slice(),
-        None,
-        Box::new(wasi_ctx),
-    )
+    unsafe {
+        InstanceHandle::new(
+            Arc::new(module),
+            finished_functions.into_boxed_slice(),
+            imports,
+            &data_initializers,
+            signatures.into_boxed_slice(),
+            None,
+            Box::new(wasi_ctx),
+        )
+    }
 }
 
 // Used by `add_wrappers_to_module` defined in the macro above
-fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&mut WasiCtx, wasi::__wasi_errno_t> {
+fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&RefCell<WasiCtx>, wasi::__wasi_errno_t> {
     unsafe {
         vmctx
             .host_state()
-            .downcast_mut::<WasiCtx>()
+            .downcast_ref()
             .ok_or_else(|| panic!("no host state named WasiCtx available"))
     }
 }

--- a/crates/wasi/src/old/snapshot_0/instantiate.rs
+++ b/crates/wasi/src/old/snapshot_0/instantiate.rs
@@ -87,7 +87,7 @@ pub fn instantiate_wasi_with_context(
             &data_initializers,
             signatures.into_boxed_slice(),
             None,
-            Box::new(wasi_ctx),
+            Box::new(RefCell::new(wasi_ctx)),
         )
     }
 }

--- a/tests/instantiate.rs
+++ b/tests/instantiate.rs
@@ -21,6 +21,8 @@ fn test_environ_translate() {
 
     let mut resolver = NullResolver {};
     let mut compiler = Compiler::new(isa, CompilationStrategy::Auto);
-    let instance = instantiate(&mut compiler, &data, &mut resolver, false);
-    assert!(instance.is_ok());
+    unsafe {
+        let instance = instantiate(&mut compiler, &data, &mut resolver, false);
+        assert!(instance.is_ok());
+    }
 }


### PR DESCRIPTION
This commit is an attempt, or at least is targeted at being a start, at
reeling in the unsafety around the `InstanceHandle` type. Currently this
type represents a sort of moral `Rc<Instance>` but is a bit more
specialized since the underlying memory is allocated through mmap.

Additionally, though, `InstanceHandle` exposes a fundamental flaw in its
safety by safetly allowing mutable access so long as you have `&mut
InstanceHandle`. This type, however, is trivially created by simply
cloning a `InstanceHandle` to get an owned reference. This means that
`&mut InstanceHandle` does not actually provide any guarantees about
uniqueness, so there's no more safety than `&InstanceHandle` itself.

This commit removes all `&mut self` APIs from `InstanceHandle`,
additionally removing some where `&self` was `unsafe` and `&mut self`
was safe (since it was trivial to subvert this "safety"). In doing so
interior mutability patterns are now used much more extensively through
structures such as `Table` and `Memory`. Additionally a number of
methods were refactored to be a bit clearer and use helper functions
where possible.

This is a relatively large commit unfortunately, but it snowballed very
quickly into touching quite a few places. My hope though is that this
will prevent developers working on wasmtime internals as well as
developers still yet to migrate to the `wasmtime` crate from falling
into trivial unsafe traps by accidentally using `&mut` when they can't.
All existing users relying on `&mut` will need to migrate to some form
of interior mutability, such as using `RefCell` or `Cell`.

This commit also additionally marks `InstanceHandle::new` as an `unsafe`
function. The rationale for this is that the `&mut`-safety is only the
beginning for the safety of `InstanceHandle`. In general the wasmtime
internals are extremely unsafe and haven't been audited for appropriate
usage of `unsafe`. Until that's done it's hoped that we can warn users
with this `unsafe` constructor and otherwise push users to the
`wasmtime` crate which we know is safe.