### PR TITLE
Improve panics/traps from imported functions

### DIFF
--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -1,5 +1,5 @@
 use crate::runtime::Store;
-use crate::trampoline::{generate_func_export, take_api_trap};
+use crate::trampoline::generate_func_export;
 use crate::trap::Trap;
 use crate::types::FuncType;
 use crate::values::Val;
@@ -157,8 +157,7 @@ impl WrappedCallable for WasmtimeFn {
                 )
             })
         } {
-            let trap = take_api_trap().unwrap_or_else(|| Trap::from_jit(error));
-            return Err(trap);
+            return Err(Trap::from_jit(error));
         }
 
         // Load the return values out of `values_vec`.

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -129,9 +129,9 @@ unsafe extern "C" fn stub_fn(
             .downcast_ref::<TrampolineState>()
             .expect("state");
         state.func.call(&args, &mut returns)?;
-        for (i, r#return) in returns.iter_mut().enumerate() {
+        for (i, ret) in returns.iter_mut().enumerate() {
             // TODO check signature.returns[i].value_type ?
-            r#return.write_value_to(values_vec.add(i));
+            ret.write_value_to(values_vec.add(i));
         }
         Ok(())
     }

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -1,11 +1,12 @@
 //! Support for a calling of an imported function.
 
 use super::create_handle::create_handle;
-use super::trap::{record_api_trap, TrapSink, API_TRAP_CODE};
-use crate::{Callable, FuncType, Store, Val};
+use super::trap::TrapSink;
+use crate::{Callable, FuncType, Store, Trap, Val};
 use anyhow::{bail, Result};
 use std::cmp;
 use std::convert::TryFrom;
+use std::panic::{self, AssertUnwindSafe};
 use std::rc::Rc;
 use wasmtime_environ::entity::{EntityRef, PrimaryMap};
 use wasmtime_environ::ir::types;
@@ -69,42 +70,70 @@ unsafe extern "C" fn stub_fn(
     _caller_vmctx: *mut VMContext,
     call_id: u32,
     values_vec: *mut i128,
-) -> u32 {
-    let instance = InstanceHandle::from_vmctx(vmctx);
+) {
+    // Here we are careful to use `catch_unwind` to ensure Rust panics don't
+    // unwind past us. The primary reason for this is that Rust considers it UB
+    // to unwind past an `extern "C"` function. Here we are in an `extern "C"`
+    // function and the cross into wasm was through an `extern "C"` function at
+    // the base of the stack as well. We'll need to wait for assorted RFCs and
+    // language features to enable this to be done in a sound and stable fashion
+    // before avoiding catching the panic here.
+    //
+    // Also note that there are intentionally no local variables on this stack
+    // frame. The reason for that is that some of the "raise" functions we have
+    // below will trigger a longjmp, which won't run local destructors if we
+    // have any. To prevent leaks we avoid having any local destructors by
+    // avoiding local variables.
+    let result = panic::catch_unwind(AssertUnwindSafe(|| call_stub(vmctx, call_id, values_vec)));
 
-    let (args, returns_len) = {
-        let module = instance.module_ref();
-        let signature = &module.signatures[module.functions[FuncIndex::new(call_id as usize)]];
+    match result {
+        Ok(Ok(())) => {}
 
-        let mut args = Vec::new();
-        for i in 2..signature.params.len() {
-            args.push(Val::read_value_from(
-                values_vec.offset(i as isize - 2),
-                signature.params[i].value_type,
-            ))
-        }
-        (args, signature.returns.len())
-    };
+        // If a trap was raised (an error returned from the imported function)
+        // then we smuggle the trap through `Box<dyn Error>` through to the
+        // call-site, which gets unwrapped in `Trap::from_jit` later on as we
+        // convert from the internal `Trap` type to our own `Trap` type in this
+        // crate.
+        Ok(Err(trap)) => wasmtime_runtime::raise_user_trap(Box::new(trap)),
 
-    let mut returns = vec![Val::null(); returns_len];
-    let func = &instance
-        .host_state()
-        .downcast_ref::<TrampolineState>()
-        .expect("state")
-        .func;
+        // And finally if the imported function panicked, then we trigger the
+        // form of unwinding that's safe to jump over wasm code on all
+        // platforms.
+        Err(panic) => wasmtime_runtime::resume_panic(panic),
+    }
 
-    match func.call(&args, &mut returns) {
-        Ok(()) => {
-            for (i, r#return) in returns.iter_mut().enumerate() {
-                // TODO check signature.returns[i].value_type ?
-                r#return.write_value_to(values_vec.add(i));
+    unsafe fn call_stub(
+        vmctx: *mut VMContext,
+        call_id: u32,
+        values_vec: *mut i128,
+    ) -> Result<(), Trap> {
+        let instance = InstanceHandle::from_vmctx(vmctx);
+
+        let (args, returns_len) = {
+            let module = instance.module_ref();
+            let signature = &module.signatures[module.functions[FuncIndex::new(call_id as usize)]];
+
+            let mut args = Vec::new();
+            for i in 2..signature.params.len() {
+                args.push(Val::read_value_from(
+                    values_vec.offset(i as isize - 2),
+                    signature.params[i].value_type,
+                ))
             }
-            0
+            (args, signature.returns.len())
+        };
+
+        let mut returns = vec![Val::null(); returns_len];
+        let state = &instance
+            .host_state()
+            .downcast_ref::<TrampolineState>()
+            .expect("state");
+        state.func.call(&args, &mut returns)?;
+        for (i, r#return) in returns.iter_mut().enumerate() {
+            // TODO check signature.returns[i].value_type ?
+            r#return.write_value_to(values_vec.add(i));
         }
-        Err(trap) => {
-            record_api_trap(trap);
-            1
-        }
+        Ok(())
     }
 }
 
@@ -135,9 +164,6 @@ fn make_trampoline(
 
     // Add the `values_vec` parameter.
     stub_sig.params.push(ir::AbiParam::new(pointer_type));
-
-    // Add error/trap return.
-    stub_sig.returns.push(ir::AbiParam::new(types::I32));
 
     // Compute the size of the values vector. The vmctx and caller vmctx are passed separately.
     let value_size = 16;
@@ -195,12 +221,9 @@ fn make_trampoline(
         let callee_value = builder
             .ins()
             .iconst(pointer_type, stub_fn as *const VMFunctionBody as i64);
-        let call = builder
+        builder
             .ins()
             .call_indirect(new_sig, callee_value, &callee_args);
-
-        let call_result = builder.func.dfg.inst_results(call)[0];
-        builder.ins().trapnz(call_result, API_TRAP_CODE);
 
         let mflags = MemFlags::trusted();
         let mut results = Vec::new();

--- a/crates/api/src/trampoline/mod.rs
+++ b/crates/api/src/trampoline/mod.rs
@@ -16,7 +16,6 @@ use anyhow::Result;
 use std::rc::Rc;
 
 pub use self::global::GlobalState;
-pub use self::trap::take_api_trap;
 
 pub fn generate_func_export(
     ft: &FuncType,

--- a/crates/api/src/trampoline/trap.rs
+++ b/crates/api/src/trampoline/trap.rs
@@ -1,31 +1,6 @@
-use std::cell::Cell;
-
-use crate::Trap;
 use wasmtime_environ::ir::{SourceLoc, TrapCode};
 use wasmtime_environ::TrapInformation;
 use wasmtime_jit::trampoline::binemit;
-
-// Randomly selected user TrapCode magic number 13.
-pub const API_TRAP_CODE: TrapCode = TrapCode::User(13);
-
-thread_local! {
-    static RECORDED_API_TRAP: Cell<Option<Trap>> = Cell::new(None);
-}
-
-pub fn record_api_trap(trap: Trap) {
-    RECORDED_API_TRAP.with(|data| {
-        let trap = Cell::new(Some(trap));
-        data.swap(&trap);
-        assert!(
-            trap.take().is_none(),
-            "Only one API trap per thread can be recorded at a moment!"
-        );
-    });
-}
-
-pub fn take_api_trap() -> Option<Trap> {
-    RECORDED_API_TRAP.with(|data| data.take())
-}
 
 pub(crate) struct TrapSink {
     pub traps: Vec<TrapInformation>,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -44,7 +44,8 @@ pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::mmap::Mmap;
 pub use crate::sig_registry::SignatureRegistry;
 pub use crate::trap_registry::{get_mut_trap_registry, get_trap_registry, TrapRegistrationGuard};
-pub use crate::traphandlers::{wasmtime_call, wasmtime_call_trampoline, Trap};
+pub use crate::traphandlers::resume_panic;
+pub use crate::traphandlers::{raise_user_trap, wasmtime_call, wasmtime_call_trampoline, Trap};
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
     VMGlobalImport, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport, VMSharedSignatureIndex,

--- a/crates/runtime/src/trap_registry.rs
+++ b/crates/runtime/src/trap_registry.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use wasmtime_environ::ir;
 
@@ -20,6 +21,35 @@ pub struct TrapDescription {
     pub source_loc: ir::SourceLoc,
     /// Code of the trap.
     pub trap_code: ir::TrapCode,
+}
+
+impl fmt::Display for TrapDescription {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "wasm trap: {}, source location: {}",
+            trap_code_to_expected_string(self.trap_code),
+            self.source_loc
+        )
+    }
+}
+
+fn trap_code_to_expected_string(trap_code: ir::TrapCode) -> String {
+    use ir::TrapCode::*;
+    match trap_code {
+        StackOverflow => "call stack exhausted".to_string(),
+        HeapOutOfBounds => "out of bounds memory access".to_string(),
+        TableOutOfBounds => "undefined element".to_string(),
+        OutOfBounds => "out of bounds".to_string(), // Note: not covered by the test suite
+        IndirectCallToNull => "uninitialized element".to_string(),
+        BadSignature => "indirect call type mismatch".to_string(),
+        IntegerOverflow => "integer overflow".to_string(),
+        IntegerDivisionByZero => "integer divide by zero".to_string(),
+        BadConversionToInteger => "invalid conversion to integer".to_string(),
+        UnreachableCodeReached => "unreachable".to_string(),
+        Interrupt => "interrupt".to_string(), // Note: not covered by the test suite
+        User(x) => format!("user trap {}", x), // Note: not covered by the test suite
+    }
 }
 
 /// RAII guard for deregistering traps


### PR DESCRIPTION
This commit performs a few refactorings and fixes a bug as well. The
changes here are:

* The `thread_local!` in the `wasmtime` crate for trap information is
  removed. The thread local in the `wasmtime_runtime` crate is now
  leveraged to transmit trap information.

* Panics in user-provided functions are now caught explicitly to be
  carried across JIT code manually. Getting Rust panics unwinding
  through JIT code is pretty likely to be super tricky and difficult to
  do, so in the meantime we can get by with catching panics and resuming
  the panic once we've resumed in Rust code.

* Various take/record trap apis have all been removed in favor of
  working directly with `Trap` objects, where the internal trap object
  has been expanded slightly to encompass user-provided errors as well.

This borrows a bit #839 and otherwise will...

Closes #848