### PR TITLE
Remove another thread local in `instance.rs`

### DIFF
--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -148,14 +148,12 @@ impl WrappedCallable for WasmtimeFn {
 
         // Call the trampoline.
         if let Err(error) = unsafe {
-            self.instance.with_signals_on(|| {
-                wasmtime_runtime::wasmtime_call_trampoline(
-                    vmctx,
-                    ptr::null_mut(),
-                    exec_code_buf,
-                    values_vec.as_mut_ptr() as *mut u8,
-                )
-            })
+            wasmtime_runtime::wasmtime_call_trampoline(
+                vmctx,
+                ptr::null_mut(),
+                exec_code_buf,
+                values_vec.as_mut_ptr() as *mut u8,
+            )
         } {
             return Err(Trap::from_jit(error));
         }

--- a/crates/api/src/windows.rs
+++ b/crates/api/src/windows.rs
@@ -18,13 +18,13 @@ pub trait InstanceExt {
     /// TODO: needs more documentation.
     unsafe fn set_signal_handler<H>(&self, handler: H)
     where
-        H: 'static + Fn(winapi::um::winnt::EXCEPTION_POINTERS) -> bool;
+        H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool;
 }
 
 impl InstanceExt for Instance {
     unsafe fn set_signal_handler<H>(&self, handler: H)
     where
-        H: 'static + Fn(winapi::um::winnt::EXCEPTION_POINTERS) -> bool,
+        H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool,
     {
         self.instance_handle.clone().set_signal_handler(handler);
     }

--- a/crates/jit/src/action.rs
+++ b/crates/jit/src/action.rs
@@ -190,14 +190,12 @@ pub fn invoke(
     // Call the trampoline. Pass a null `caller_vmctx` argument as `invoke` is
     // all about calling from the outside world rather than from an instance.
     if let Err(trap) = unsafe {
-        instance.with_signals_on(|| {
-            wasmtime_call_trampoline(
-                callee_vmctx,
-                ptr::null_mut(),
-                exec_code_buf,
-                values_vec.as_mut_ptr() as *mut u8,
-            )
-        })
+        wasmtime_call_trampoline(
+            callee_vmctx,
+            ptr::null_mut(),
+            exec_code_buf,
+            values_vec.as_mut_ptr() as *mut u8,
+        )
     } {
         return Ok(ActionOutcome::Trapped(trap));
     }

--- a/crates/runtime/signalhandlers/SignalHandlers.cpp
+++ b/crates/runtime/signalhandlers/SignalHandlers.cpp
@@ -399,41 +399,6 @@ struct AutoHandlingTrap
 
 }
 
-static
-#if defined(__GNUC__) || defined(__clang__)
-__attribute__ ((warn_unused_result))
-#endif
-bool
-HandleTrap(CONTEXT* context, bool reset_guard_page)
-{
-    assert(sAlreadyHandlingTrap);
-
-    void *JmpBuf = RecordTrap(ContextToPC(context), reset_guard_page);
-    if (JmpBuf == nullptr) {
-      return false;
-    }
-
-    // Unwind calls longjmp, so it doesn't run the automatic
-    // sAlreadhHanldingTrap cleanups, so reset it manually before doing
-    // a longjmp.
-    sAlreadyHandlingTrap = false;
-
-#if defined(USE_APPLE_MACH_PORTS)
-    // Reroute the PC to run the Unwind function on the main stack after the
-    // handler exits. This doesn't yet work for stack overflow traps, because
-    // in that case the main thread doesn't have any space left to run.
-    assert(false); // this branch isn't implemented here
-    // SetContextPC(context, reinterpret_cast<const uint8_t*>(&Unwind));
-#else
-    // For now, just call Unwind directly, rather than redirecting the PC there,
-    // so that it runs on the alternate signal handler stack. To run on the main
-    // stack, reroute the context PC like this:
-    Unwind(JmpBuf);
-#endif
-
-    return true;
-}
-
 // =============================================================================
 // The following platform-specific handlers funnel all signals/exceptions into
 // the shared HandleTrap() above.
@@ -467,16 +432,19 @@ WasmTrapHandler(LPEXCEPTION_POINTERS exception)
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
-    bool handled = InstanceSignalHandler(exception);
+    void *JmpBuf = HandleTrap(ContextToPC(exception->ContextRecord), exception);
+    // Test if a custom instance signal handler handled the exception
+    if (((size_t) JmpBuf) == 1)
+        return EXCEPTION_CONTINUE_EXECUTION;
 
-    if (!handled) {
-        if (!HandleTrap(exception->ContextRecord,
-                        record->ExceptionCode == EXCEPTION_STACK_OVERFLOW)) {
-            return EXCEPTION_CONTINUE_SEARCH;
-        }
+    // Otherwise test if we need to longjmp to this buffer
+    if (JmpBuf != nullptr) {
+        sAlreadyHandlingTrap = false;
+        Unwind(JmpBuf);
     }
 
-    return EXCEPTION_CONTINUE_EXECUTION;
+    // ... and otherwise keep looking for a handler
+    return EXCEPTION_CONTINUE_SEARCH;
 }
 
 #elif defined(USE_APPLE_MACH_PORTS)
@@ -638,15 +606,20 @@ WasmTrapHandler(int signum, siginfo_t* info, void* context)
         AutoHandlingTrap aht;
         assert(signum == SIGSEGV || signum == SIGBUS || signum == SIGFPE || signum == SIGILL);
 
-        if (InstanceSignalHandler(signum, info, (ucontext_t*) context)) {
+        void *JmpBuf = HandleTrap(ContextToPC(static_cast<CONTEXT*>(context)), signum, info, context);
+
+        // Test if a custom instance signal handler handled the exception
+        if (((size_t) JmpBuf) == 1)
             return;
+
+        // Otherwise test if we need to longjmp to this buffer
+        if (JmpBuf != nullptr) {
+            sAlreadyHandlingTrap = false;
+            Unwind(JmpBuf);
         }
 
-        if (HandleTrap(static_cast<CONTEXT*>(context), false)) {
-            return;
-        }
+        // ... and otherwise call the previous signal handler, if one is there
     }
-
 
     struct sigaction* previousSignal = nullptr;
     switch (signum) {

--- a/crates/runtime/signalhandlers/SignalHandlers.cpp
+++ b/crates/runtime/signalhandlers/SignalHandlers.cpp
@@ -401,7 +401,8 @@ struct AutoHandlingTrap
 
 // =============================================================================
 // The following platform-specific handlers funnel all signals/exceptions into
-// the shared HandleTrap() above.
+// the HandleTrap() function defined in Rust. Note that the Rust function has a
+// different ABI depending on the platform.
 // =============================================================================
 
 #if defined(_WIN32)

--- a/crates/runtime/signalhandlers/SignalHandlers.hpp
+++ b/crates/runtime/signalhandlers/SignalHandlers.hpp
@@ -13,18 +13,12 @@
 extern "C" {
 #endif
 
-// Record the Trap code and wasm bytecode offset in TLS somewhere
-void* RecordTrap(const uint8_t* pc, bool reset_guard_page);
-
 #if defined(_WIN32)
 #include <windows.h>
 #include <winternl.h>
-bool InstanceSignalHandler(LPEXCEPTION_POINTERS);
-#elif defined(USE_APPLE_MACH_PORTS)
-bool InstanceSignalHandler(int, siginfo_t *, void *);
+void* HandleTrap(const uint8_t*, LPEXCEPTION_POINTERS);
 #else
-#include <sys/ucontext.h>
-bool InstanceSignalHandler(int, siginfo_t *, ucontext_t *);
+void* HandleTrap(const uint8_t*, int, siginfo_t *, void *);
 #endif
 
 void Unwind(void*);

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -18,10 +18,9 @@ use crate::vmcontext::{
 use memoffset::offset_of;
 use more_asserts::assert_lt;
 use std::any::Any;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{mem, ptr, slice};
@@ -33,53 +32,9 @@ use wasmtime_environ::wasm::{
 };
 use wasmtime_environ::{DataInitializer, Module, TableElements, VMOffsets};
 
-thread_local! {
-    /// A stack of currently-running `Instance`s, if any.
-    pub(crate) static CURRENT_INSTANCE: RefCell<Vec<NonNull<Instance>>> = RefCell::new(Vec::new());
-}
-
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "macos"))] {
         pub type SignalHandler = dyn Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool;
-
-        pub fn signal_handler_none(
-            _signum: libc::c_int,
-            _siginfo: *const libc::siginfo_t,
-            _context: *const libc::c_void,
-        ) -> bool {
-            false
-        }
-
-        #[no_mangle]
-        pub extern "C" fn InstanceSignalHandler(
-            signum: libc::c_int,
-            siginfo: *mut libc::siginfo_t,
-            context: *mut libc::c_void,
-        ) -> bool {
-            CURRENT_INSTANCE.with(|current_instance| {
-                let current_instance = current_instance
-                    .try_borrow()
-                    .expect("borrow current instance");
-                if current_instance.is_empty() {
-                    return false;
-                } else {
-                    unsafe {
-                        let last = &current_instance
-                            .last()
-                            .expect("current instance not none")
-                            .as_ref();
-
-                        let f = last
-                            .signal_handler
-                            .replace(Box::new(signal_handler_none));
-                        let ret = f(signum, siginfo, context);
-                        last.signal_handler.set(f);
-                        ret
-                    }
-                }
-            })
-        }
-
 
         impl InstanceHandle {
             /// Set a custom signal handler
@@ -87,53 +42,19 @@ cfg_if::cfg_if! {
             where
                 H: 'static + Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool,
             {
-                self.instance().signal_handler.set(Box::new(handler));
+                self.instance().signal_handler.set(Some(Box::new(handler)));
             }
         }
     } else if #[cfg(target_os = "windows")] {
-        pub type SignalHandler = dyn Fn(winapi::um::winnt::EXCEPTION_POINTERS) -> bool;
-
-        pub fn signal_handler_none(
-            _exception_info: winapi::um::winnt::EXCEPTION_POINTERS
-        ) -> bool {
-            false
-        }
-
-        #[no_mangle]
-        pub extern "C" fn InstanceSignalHandler(
-            exception_info: winapi::um::winnt::EXCEPTION_POINTERS
-        ) -> bool {
-            CURRENT_INSTANCE.with(|current_instance| {
-                let current_instance = current_instance
-                    .try_borrow()
-                    .expect("borrow current instance");
-                if current_instance.is_empty() {
-                    return false;
-                } else {
-                    unsafe {
-                        let last = &current_instance
-                            .last()
-                            .expect("current instance not none")
-                            .as_ref();
-
-                        let f = last
-                            .signal_handler
-                            .replace(Box::new(signal_handler_none));
-                        let ret = f(exception_info);
-                        last.signal_handler.set(f);
-                        ret
-                    }
-                }
-            })
-        }
+        pub type SignalHandler = dyn Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool;
 
         impl InstanceHandle {
             /// Set a custom signal handler
             pub fn set_signal_handler<H>(&mut self, handler: H)
             where
-                H: 'static + Fn(winapi::um::winnt::EXCEPTION_POINTERS) -> bool,
+                H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool,
             {
-                self.instance().signal_handler.set(Box::new(handler));
+                self.instance().signal_handler.set(Some(Box::new(handler)));
             }
         }
     }
@@ -177,7 +98,7 @@ pub(crate) struct Instance {
     dbg_jit_registration: Option<Rc<GdbJitImageRegistration>>,
 
     /// Handler run when `SIGBUS`, `SIGFPE`, `SIGILL`, or `SIGSEGV` are caught by the instance thread.
-    signal_handler: Cell<Box<SignalHandler>>,
+    pub(crate) signal_handler: Cell<Option<Box<SignalHandler>>>,
 
     /// Additional context used by compiled wasm code. This field is last, and
     /// represents a dynamically-sized array that extends beyond the nominal
@@ -596,28 +517,6 @@ pub struct InstanceHandle {
 }
 
 impl InstanceHandle {
-    #[doc(hidden)]
-    pub fn with_signals_on<F, R>(&self, action: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        CURRENT_INSTANCE.with(|current_instance| {
-            current_instance
-                .borrow_mut()
-                .push(unsafe { NonNull::new_unchecked(self.instance) });
-        });
-
-        let result = action();
-
-        CURRENT_INSTANCE.with(|current_instance| {
-            let mut current_instance = current_instance.borrow_mut();
-            assert!(!current_instance.is_empty());
-            current_instance.pop();
-        });
-
-        result
-    }
-
     /// Create a new `InstanceHandle` pointing at a new `Instance`.
     ///
     /// # Unsafety
@@ -682,7 +581,7 @@ impl InstanceHandle {
                 finished_functions,
                 dbg_jit_registration,
                 host_state,
-                signal_handler: Cell::new(Box::new(signal_handler_none)),
+                signal_handler: Cell::new(None),
                 vmctx: VMContext {},
             };
             ptr::write(instance_ptr, instance);
@@ -862,7 +761,7 @@ impl InstanceHandle {
     }
 
     /// Return a reference to the contained `Instance`.
-    fn instance(&self) -> &Instance {
+    pub(crate) fn instance(&self) -> &Instance {
         unsafe { &*(self.instance as *const Instance) }
     }
 }


### PR DESCRIPTION
This commit removes another usage of `thread_local!` in the continued
effort to centralize all thread-local state per-call (or basically state
needed for traps) in one location. This removal is targeted at the
support for custom signal handlers on instances, removing the previous
stack of instances with instead a linked list of instances.

The `with_signals_on` method is no longer necessary (since it was always
called anyway) and is inferred from the first `vmctx` argument of the
entrypoints into wasm. These functions establish a linked list of
instances on the stack, if needed, to handle signals when they happen.

This involved some refactoring where some C++ glue was moved into Rust,
so now Rust handles a bit more of the signal handling logic.