### PR TITLE
Skip vmctx and caller vmctx args in ExportBinding

### DIFF
--- a/crates/interface-types/src/lib.rs
+++ b/crates/interface-types/src/lib.rs
@@ -217,7 +217,7 @@ impl ExportBinding<'_> {
             ExportBindingKind::Raw(sig) => sig
                 .params
                 .iter()
-                .skip(1) // skip the VMContext argument
+                .skip(2) // skip vmctx and caller vmctx arguments
                 .enumerate()
                 .map(|(i, param)| default_incoming(i, param))
                 .collect(),
@@ -252,7 +252,7 @@ impl ExportBinding<'_> {
                     })
                     .collect()
             }
-            ExportBindingKind::Raw(sig) => sig.params.iter().skip(1).map(abi2ast).collect(),
+            ExportBindingKind::Raw(sig) => sig.params.iter().skip(2).map(abi2ast).collect(),
         }
     }
 


### PR DESCRIPTION
This commit skips both vmctx *and* caller vmctx arguments in
`ExportBinding::param_bindings` as well as `ExportBinding::param_types`
methods.

In essence, this commit adjust `ExportBinding` to the change
introduced in #789, which replaced global-exports mechanism
with a caller-vmctx mechanism.

EDIT: Fixes #855 