### PR TITLE
fuzz: Don't panic on module compilation errors

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -23,10 +23,6 @@ use wasmtime::*;
 ///
 /// You can control which compiler is used via passing a `Strategy`.
 pub fn instantiate(wasm: &[u8], strategy: Strategy) {
-    if wasmparser::validate(wasm, None).is_err() {
-        return;
-    }
-
     let mut config = Config::new();
     config
         .strategy(strategy)
@@ -34,7 +30,10 @@ pub fn instantiate(wasm: &[u8], strategy: Strategy) {
     let engine = Engine::new(&config);
     let store = Store::new(&engine);
 
-    let module = Module::new(&store, wasm).expect("Failed to compile a valid Wasm module!");
+    let module = match Module::new(&store, wasm) {
+        Ok(module) => module,
+        Err(_) => return,
+    };
 
     let imports = match dummy_imports(&store, module.imports()) {
         Ok(imps) => imps,


### PR DESCRIPTION
Let's avoid having two phases of checks and just ignore the module
compilation errors during the instantiate oracle, only relying on one check.