### PR TITLE
Don't spend build time optimizing build-time-only crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ tempfile = "3.1.0"
 [build-dependencies]
 anyhow = "1.0.19"
 
+[profile.release.build-override]
+opt-level = 0
+
 [workspace]
 members = [
   "crates/fuzzing",


### PR DESCRIPTION
Crates used exclusively at build time, such as proc-macro crates and
their dependencies, don't benefit substantially from optimization; they
take far longer to optimize than time saved when running them during the
build. No machine code from these crates will appear in the final
compiled binary.

Use the new profile-overrides mechanism in Rust 1.41
(https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) to
build such crates with opt-level 0.

On a 4-thread laptop, this brings build time from 6m27s to 4m21s, and
CPU time spent from 23m43s to 16m23s.