### PR TITLE
Disable cranelift's verifier by default

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -34,6 +34,11 @@ impl Config {
             .enable("avoid_div_traps")
             .expect("should be valid flag");
 
+        // Invert cranelift's default-on verification to instead default off.
+        flags
+            .set("enable_verifier", "false")
+            .expect("should be valid flag");
+
         Config {
             debug_info: false,
             features: Default::default(),

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -25,6 +25,7 @@ use wasmtime::*;
 pub fn instantiate(wasm: &[u8], strategy: Strategy) {
     let mut config = Config::new();
     config
+        .cranelift_debug_verifier(true)
         .strategy(strategy)
         .expect("failed to enable lightbeam");
     let engine = Engine::new(&config);
@@ -60,7 +61,10 @@ pub fn instantiate(wasm: &[u8], strategy: Strategy) {
 /// You can control which compiler is used via passing a `Strategy`.
 pub fn compile(wasm: &[u8], strategy: Strategy) {
     let mut config = Config::new();
-    config.strategy(strategy).unwrap();
+    config
+        .cranelift_debug_verifier(true)
+        .strategy(strategy)
+        .unwrap();
     let engine = Engine::new(&config);
     let store = Store::new(&engine);
     let _ = Module::new(&store, wasm);
@@ -254,7 +258,9 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
         match call {
             ApiCall::ConfigNew => {
                 assert!(config.is_none());
-                config = Some(Config::new());
+                let mut cfg = Config::new();
+                cfg.cranelift_debug_verifier(true);
+                config = Some(cfg);
             }
 
             ApiCall::ConfigDebugInfo(b) => {


### PR DESCRIPTION
The intention of the `wasmtime` crate was to disable this verifier by
default, but it looks like cranelift actually has it turned on by
default which was making our documentation incorrect!

This was discovered by seeing a number of timeouts when fuzzing. The
debug verifier is great for fuzzing, however, so fuzzing is updated to
enable this unconditionally, meaning we'll still have timeouts. For
general users though this should make the documentation correct that the
`wasmtime` crate, by default, disables the debug verifier.