### PR TITLE
Don't panic on shared memories

### DIFF
--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -3,7 +3,7 @@ use crate::types::{
     ExportType, ExternType, FuncType, GlobalType, ImportType, Limits, MemoryType, Mutability,
     TableType, ValType,
 };
-use anyhow::{Error, Result};
+use anyhow::{bail, Error, Result};
 use lazy_static::lazy_static;
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -16,9 +16,11 @@ use wasmparser::{
 };
 use wasmtime_jit::CompiledModule;
 
-fn into_memory_type(mt: wasmparser::MemoryType) -> MemoryType {
-    assert!(!mt.shared);
-    MemoryType::new(Limits::new(mt.limits.initial, mt.limits.maximum))
+fn into_memory_type(mt: wasmparser::MemoryType) -> Result<MemoryType> {
+    if mt.shared {
+        bail!("shared memories are not supported yet");
+    }
+    Ok(MemoryType::new(Limits::new(mt.limits.initial, mt.limits.maximum)))
 }
 
 fn into_global_type(gt: wasmparser::GlobalType) -> GlobalType {
@@ -341,7 +343,7 @@ impl Module {
                     let section = section.get_memory_section_reader()?;
                     memories.reserve_exact(section.get_count() as usize);
                     for entry in section {
-                        memories.push(into_memory_type(entry?));
+                        memories.push(into_memory_type(entry?)?);
                     }
                 }
                 SectionCode::Type => {
@@ -389,7 +391,7 @@ impl Module {
                                 ExternType::Table(table)
                             }
                             ImportSectionEntryType::Memory(mt) => {
-                                let memory = into_memory_type(mt);
+                                let memory = into_memory_type(mt)?;
                                 memories.push(memory.clone());
                                 ExternType::Memory(memory)
                             }

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -20,7 +20,10 @@ fn into_memory_type(mt: wasmparser::MemoryType) -> Result<MemoryType> {
     if mt.shared {
         bail!("shared memories are not supported yet");
     }
-    Ok(MemoryType::new(Limits::new(mt.limits.initial, mt.limits.maximum)))
+    Ok(MemoryType::new(Limits::new(
+        mt.limits.initial,
+        mt.limits.maximum,
+    )))
 }
 
 fn into_global_type(gt: wasmparser::GlobalType) -> GlobalType {

--- a/tests/misc_testsuite/threads.wast
+++ b/tests/misc_testsuite/threads.wast
@@ -1,0 +1,1 @@
+(assert_invalid (module (memory 1 1 shared)) "not supported")


### PR DESCRIPTION
Instead return a first-class error