### PR TITLE
Don't rebuild `wasmtime-cli` on all file changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
     let out_dir = PathBuf::from(
         env::var_os("OUT_DIR").expect("The OUT_DIR environment variable must be set"),
     );


### PR DESCRIPTION
Print out an explicit `rerun-if-changed` annotation in the `build.rs`
for the `wasmtime-cli` crate to avoid rebuilding it constantly as files
like tests change which don't need to cause a rebuild.