### PR TITLE
Don't generate DWARF sections when no functions were compiled.

### DIFF
--- a/crates/environ/src/address_map.rs
+++ b/crates/environ/src/address_map.rs
@@ -48,10 +48,22 @@ pub type ValueLabelsRanges = PrimaryMap<DefinedFuncIndex, cranelift_codegen::Val
 /// Stack slots for functions.
 pub type StackSlots = PrimaryMap<DefinedFuncIndex, ir::StackSlots>;
 
+/// Memory definition offset in the VMContext structure.
+#[derive(Debug, Clone)]
+pub enum ModuleMemoryOffset {
+    /// Not available.
+    None,
+    /// Offset to the defined memory.
+    Defined(u32),
+    /// Offset to the imported memory.
+    Imported(u32),
+}
+
 /// Module `vmctx` related info.
+#[derive(Debug, Clone)]
 pub struct ModuleVmctxInfo {
     /// The memory definition offset in the VMContext structure.
-    pub memory_offset: i64,
+    pub memory_offset: ModuleMemoryOffset,
 
     /// The functions stack slots.
     pub stack_slots: StackSlots,

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -40,7 +40,8 @@ pub mod cranelift;
 pub mod lightbeam;
 
 pub use crate::address_map::{
-    FunctionAddressMap, InstructionAddressMap, ModuleAddressMap, ModuleVmctxInfo, ValueLabelsRanges,
+    FunctionAddressMap, InstructionAddressMap, ModuleAddressMap, ModuleMemoryOffset,
+    ModuleVmctxInfo, ValueLabelsRanges,
 };
 pub use crate::cache::{create_new_config as cache_create_new_config, init as cache_init};
 pub use crate::compilation::{

--- a/crates/fuzzing/tests/regressions.rs
+++ b/crates/fuzzing/tests/regressions.rs
@@ -13,3 +13,9 @@ fn instantiate_empty_module() {
     let data = wat::parse_str(include_str!("./regressions/empty.wat")).unwrap();
     oracles::instantiate(&data, Strategy::Auto);
 }
+
+#[test]
+fn instantiate_empty_module_with_memory() {
+    let data = wat::parse_str(include_str!("./regressions/empty_with_memory.wat")).unwrap();
+    oracles::instantiate(&data, Strategy::Auto);
+}

--- a/crates/fuzzing/tests/regressions/empty_with_memory.wat
+++ b/crates/fuzzing/tests/regressions/empty_with_memory.wat
@@ -1,0 +1,1 @@
+(module (memory 1))


### PR DESCRIPTION
Fixes #887 

* Allow modules with no memory to generate a DWARF information
* Don't generate DWARF sections when no functions were compiled