### PR TITLE
Update `wast` to 7.0.0, fix stack overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,7 +2142,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 6.0.0",
+ "wast 7.0.0",
 ]
 
 [[package]]
@@ -2156,20 +2156,20 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed3db7029d1d31a15c10126e78b58e51781faefafbc8afb20fb01291b779984"
+checksum = "12a729d076deb29c8509fa71f2d427729f9394f9496844ed8fcab152f35d163d"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d59ba5b224f5507d55e4f89d0b18cc6452d84640ab11b4c9086d61a3ee62d03"
+checksum = "5795e34a4b39893653dec97e644fac85c31398e0ce1abecc48967aac83d9e8ce"
 dependencies = [
- "wast 6.0.0",
+ "wast 7.0.0",
 ]
 
 [[package]]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../api", version = "0.9.0" }
-wast = "6.0.0"
+wast = "7.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -339,7 +339,6 @@ impl WastContext {
                     )
                 }
             }
-            AssertReturnFunc { .. } => bail!("need to implement assert_return_func"),
         }
 
         Ok(())


### PR DESCRIPTION
This updates the `wast` dependency to include bytecodealliance/wat#48
which fixes a stack overflow for deeply recursive `*.wat` files.