### PR TITLE
Implement FIXME in debug/src/expression.rs

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -27,6 +27,16 @@ pub fn instantiate(wasm: &[u8], strategy: Strategy) {
     config
         .strategy(strategy)
         .expect("failed to enable lightbeam");
+    instantiate_with_config(wasm, config);
+}
+
+/// Instantiate the Wasm buffer, and implicitly fail if we have an unexpected
+/// panic or segfault or anything else that can be detected "passively".
+///
+/// The engine will be configured using provided config.
+///
+/// See also `instantiate` functions.
+pub fn instantiate_with_config(wasm: &[u8], config: Config) {
     let engine = Engine::new(&config);
     let store = Store::new(&engine);
 

--- a/crates/fuzzing/tests/regressions.rs
+++ b/crates/fuzzing/tests/regressions.rs
@@ -5,7 +5,7 @@
 //! use the Wasm binary by including it via
 //! `include_bytes!("./regressions/some-descriptive-name.wasm")`.
 
-use wasmtime::Strategy;
+use wasmtime::{Config, Strategy};
 use wasmtime_fuzzing::oracles;
 
 #[test]
@@ -18,4 +18,12 @@ fn instantiate_empty_module() {
 fn instantiate_empty_module_with_memory() {
     let data = wat::parse_str(include_str!("./regressions/empty_with_memory.wat")).unwrap();
     oracles::instantiate(&data, Strategy::Auto);
+}
+
+#[test]
+fn instantiate_module_that_compiled_to_x64_has_register_32() {
+    let mut config = Config::new();
+    config.debug_info(true);
+    let data = wat::parse_str(include_str!("./regressions/issue694.wat")).unwrap();
+    oracles::instantiate_with_config(&data, config);
 }

--- a/crates/fuzzing/tests/regressions/issue694.wat
+++ b/crates/fuzzing/tests/regressions/issue694.wat
@@ -1,0 +1,49 @@
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (param i64)))
+  (func (;0;) (type 0))
+  (func (;1;) (type 0))
+  (func (;2;) (type 0))
+  (func (;3;) (type 0))
+  (func (;4;) (type 1) (param i64)
+    (local f32 f32 f32)
+    loop (result i64)  ;; label = @1
+      global.get 0
+      if  ;; label = @2
+        local.get 1
+        return
+      end
+      block (result i64)  ;; label = @2
+        loop  ;; label = @3
+          block  ;; label = @4
+            global.get 0
+            if  ;; label = @5
+              i32.const 5
+              if (result f32)  ;; label = @6
+                block (result f32)  ;; label = @7
+                  call 0
+                  i32.const 7
+                  if (result f32)  ;; label = @8
+                    local.get 2
+                  else
+                    f32.const 0x1p+0 (;=1;)
+                  end
+                end
+              else
+                f32.const 0x1p+0 (;=1;)
+              end
+              local.tee 1
+              local.set 3
+            end
+          end
+        end
+        i32.const 8
+        br_if 1 (;@1;)
+        i64.const 4
+      end
+    end
+    return)
+  (memory (;0;) 1)
+  (global (;0;) i32 (i32.const 0))
+)
+


### PR DESCRIPTION
Fixes #694 

The patch just implements "// FIXME" comment. The codegen uses register with ID=32 for the provided in #694 WebAssembly code.
