### PR TITLE
Add more CLI flags for wasm features

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -70,13 +70,18 @@ impl Config {
     /// be enabled through this method for appropriate wasm modules.
     ///
     /// This feature gates items such as shared memories and atomic
-    /// instructions.
+    /// instructions. Note that enabling the reference types feature will
+    /// also enable the bulk memory feature.
     ///
     /// This is `false` by default.
     ///
     /// [threads]: https://github.com/webassembly/threads
     pub fn wasm_threads(&mut self, enable: bool) -> &mut Self {
         self.features.threads = enable;
+        // The threads proposal depends on the bulk memory proposal
+        if enable {
+            self.features.bulk_memory = true;
+        }
         self
     }
 
@@ -90,13 +95,18 @@ impl Config {
     /// modules.
     ///
     /// This feature gates items such as the `anyref` type and multiple tables
-    /// being in a module.
+    /// being in a module. Note that enabling the reference types feature will
+    /// also enable the bulk memory feature.
     ///
     /// This is `false` by default.
     ///
     /// [proposal]: https://github.com/webassembly/reference-types
     pub fn wasm_reference_types(&mut self, enable: bool) -> &mut Self {
         self.features.reference_types = enable;
+        // The reference types proposal depends on the bulk memory proposal
+        if enable {
+            self.features.bulk_memory = true;
+        }
         self
     }
 

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -70,7 +70,7 @@ impl Config {
     /// be enabled through this method for appropriate wasm modules.
     ///
     /// This feature gates items such as shared memories and atomic
-    /// instructions. Note that enabling the reference types feature will
+    /// instructions. Note that enabling the threads feature will
     /// also enable the bulk memory feature.
     ///
     /// This is `false` by default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,10 @@ struct CommonOptions {
     #[structopt(long)]
     enable_bulk_memory: bool,
 
+    /// Enable all experimental wasm features
+    #[structopt(long)]
+    enable_all: bool,
+
     /// Use Lightbeam for all compilation
     #[structopt(long, conflicts_with = "cranelift")]
     lightbeam: bool,
@@ -124,11 +128,11 @@ impl CommonOptions {
         config
             .cranelift_debug_verifier(cfg!(debug_assertions))
             .debug_info(self.debug_info)
-            .wasm_bulk_memory(self.enable_bulk_memory)
-            .wasm_simd(self.enable_simd)
-            .wasm_reference_types(self.enable_reference_types)
-            .wasm_multi_value(self.enable_multi_value)
-            .wasm_threads(self.enable_threads)
+            .wasm_bulk_memory(self.enable_bulk_memory || self.enable_all)
+            .wasm_simd(self.enable_simd || self.enable_all)
+            .wasm_reference_types(self.enable_reference_types || self.enable_all)
+            .wasm_multi_value(self.enable_multi_value || self.enable_all)
+            .wasm_threads(self.enable_threads || self.enable_all)
             .strategy(pick_compilation_strategy(self.cranelift, self.lightbeam)?)?;
         if self.optimize {
             config.cranelift_opt_level(wasmtime::OptLevel::Speed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,15 +93,15 @@ struct CommonOptions {
     #[structopt(long)]
     enable_simd: bool,
 
-    /// Enable support for wasm reference types instructions
+    /// Enable support for reference types
     #[structopt(long)]
     enable_reference_types: bool,
 
-    /// Enable support for wasm multi-value
+    /// Enable support for multi-value functions
     #[structopt(long)]
     enable_multi_value: bool,
 
-    /// Enable support for wasm threads
+    /// Enable support for Wasm threads
     #[structopt(long)]
     enable_threads: bool,
 
@@ -109,7 +109,7 @@ struct CommonOptions {
     #[structopt(long)]
     enable_bulk_memory: bool,
 
-    /// Enable all experimental wasm features
+    /// Enable all experimental Wasm features
     #[structopt(long)]
     enable_all: bool,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ struct CommonOptions {
     #[structopt(long)]
     enable_threads: bool,
 
-    /// Enable support for wasm bulk memory instruction
+    /// Enable support for bulk memory instructions
     #[structopt(long)]
     enable_bulk_memory: bool,
 


### PR DESCRIPTION
This commit adds a few more flags to enable wasm features via the CLI,
mirroring the existing `--enable-simd` flag:

* `--enable-reference-types`
* `--enable-multi-value`
* `--enable-threads`
* `--enable-bulk-memory`

Additionally the bulk memory feature is now automatically enabled if
`reference-types` or `threads` are enabled since those two proposals
largely depend on `bulk-memory`.