### PR TITLE
Fuzz the multi-value support

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -52,7 +52,6 @@ impl Arbitrary for WasmOptTtf {
 pub struct DifferentialConfig {
     strategy: DifferentialStrategy,
     opt_level: DifferentialOptLevel,
-    multi_value: bool,
 }
 
 impl DifferentialConfig {
@@ -68,7 +67,6 @@ impl DifferentialConfig {
             DifferentialOptLevel::Speed => wasmtime::OptLevel::Speed,
             DifferentialOptLevel::SpeedAndSize => wasmtime::OptLevel::SpeedAndSize,
         });
-        config.wasm_multi_value(self.multi_value);
         Ok(config)
     }
 }

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -52,6 +52,7 @@ impl Arbitrary for WasmOptTtf {
 pub struct DifferentialConfig {
     strategy: DifferentialStrategy,
     opt_level: DifferentialOptLevel,
+    multi_value: bool,
 }
 
 impl DifferentialConfig {
@@ -67,6 +68,7 @@ impl DifferentialConfig {
             DifferentialOptLevel::Speed => wasmtime::OptLevel::Speed,
             DifferentialOptLevel::SpeedAndSize => wasmtime::OptLevel::SpeedAndSize,
         });
+        config.wasm_multi_value(self.multi_value);
         Ok(config)
     }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -16,6 +16,16 @@ use dummy::{dummy_imports, dummy_values};
 use std::collections::{HashMap, HashSet};
 use wasmtime::*;
 
+fn fuzz_default_config(strategy: Strategy) -> Config {
+    let mut config = Config::new();
+    config
+        .cranelift_debug_verifier(true)
+        .wasm_multi_value(true)
+        .strategy(strategy)
+        .expect("failed to enable lightbeam");
+    return config;
+}
+
 /// Instantiate the Wasm buffer, and implicitly fail if we have an unexpected
 /// panic or segfault or anything else that can be detected "passively".
 ///
@@ -23,12 +33,7 @@ use wasmtime::*;
 ///
 /// You can control which compiler is used via passing a `Strategy`.
 pub fn instantiate(wasm: &[u8], strategy: Strategy) {
-    let mut config = Config::new();
-    config
-        .cranelift_debug_verifier(true)
-        .strategy(strategy)
-        .expect("failed to enable lightbeam");
-    instantiate_with_config(wasm, config);
+    instantiate_with_config(wasm, fuzz_default_config(strategy));
 }
 
 /// Instantiate the Wasm buffer, and implicitly fail if we have an unexpected
@@ -70,12 +75,7 @@ pub fn instantiate_with_config(wasm: &[u8], config: Config) {
 ///
 /// You can control which compiler is used via passing a `Strategy`.
 pub fn compile(wasm: &[u8], strategy: Strategy) {
-    let mut config = Config::new();
-    config
-        .cranelift_debug_verifier(true)
-        .strategy(strategy)
-        .unwrap();
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&fuzz_default_config(strategy));
     let store = Store::new(&engine);
     let _ = Module::new(&store, wasm);
 }


### PR DESCRIPTION
This commit enables multi-value by default for the fuzzers, in theory
allowing us to find panics and such in the multi-value implementation.
Or even runtime errors through the differential fuzzing!

@fitzgen do you think that the implementation is ready for fuzzing? Or should we hold off and fix more bugs before we throw fuzzers at it?