### PR TITLE
specify units for fields of `Tunables`

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,13 +1,13 @@
 /// Tunable parameters for WebAssembly compilation.
 #[derive(Clone)]
 pub struct Tunables {
-    /// For static heaps, the size of the heap protected by bounds checking.
+    /// For static heaps, the size in wasm pages of the heap protected by bounds checking.
     pub static_memory_bound: u32,
 
-    /// The size of the offset guard for static heaps.
+    /// The size in bytes of the offset guard for static heaps.
     pub static_memory_offset_guard_size: u64,
 
-    /// The size of the offset guard for dynamic heaps.
+    /// The size in bytes of the offset guard for dynamic heaps.
     pub dynamic_memory_offset_guard_size: u64,
 }
 


### PR DESCRIPTION
...since the documentation in `impl Default for Tunables` doesn't get
translated anywhere, and the various fields have different units anyway.