### PR TITLE
Generate trampolines based on signatures

### DIFF
--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -160,7 +160,7 @@ impl WrappedCallable for WasmtimeFn {
         let exec_code_buf = self
             .store
             .compiler_mut()
-            .get_published_trampoline(body, &signature, value_size)
+            .get_published_trampoline(&signature, value_size)
             .map_err(|e| Trap::new(format!("trampoline error: {:?}", e)))?;
 
         // Call the trampoline.
@@ -169,6 +169,7 @@ impl WrappedCallable for WasmtimeFn {
                 vmctx,
                 ptr::null_mut(),
                 exec_code_buf,
+                body,
                 values_vec.as_mut_ptr() as *mut u8,
             )
         } {

--- a/crates/runtime/signalhandlers/Trampolines.cpp
+++ b/crates/runtime/signalhandlers/Trampolines.cpp
@@ -7,7 +7,8 @@ int WasmtimeCallTrampoline(
     void **buf_storage,
     void *vmctx,
     void *caller_vmctx,
-    void (*body)(void*, void*, void*),
+    void (*trampoline)(void*, void*, void*, void*),
+    void *body,
     void *args)
 {
   jmp_buf buf;
@@ -15,12 +16,16 @@ int WasmtimeCallTrampoline(
     return 0;
   }
   *buf_storage = &buf;
-  body(vmctx, caller_vmctx, args);
+  trampoline(vmctx, caller_vmctx, body, args);
   return 1;
 }
 
 extern "C"
-int WasmtimeCall(void **buf_storage, void *vmctx, void *caller_vmctx, void (*body)(void*, void*)) {
+int WasmtimeCall(
+    void **buf_storage,
+    void *vmctx,
+    void *caller_vmctx,
+    void (*body)(void*, void*)) {
   jmp_buf buf;
   if (setjmp(buf) != 0) {
     return 0;

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -17,7 +17,7 @@ extern "C" {
         jmp_buf: *mut *const u8,
         vmctx: *mut u8,
         caller_vmctx: *mut u8,
-        trampolien: *const VMFunctionBody,
+        trampoline: *const VMFunctionBody,
         callee: *const VMFunctionBody,
         values_vec: *mut u8,
     ) -> i32;

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -17,6 +17,7 @@ extern "C" {
         jmp_buf: *mut *const u8,
         vmctx: *mut u8,
         caller_vmctx: *mut u8,
+        trampolien: *const VMFunctionBody,
         callee: *const VMFunctionBody,
         values_vec: *mut u8,
     ) -> i32;
@@ -133,13 +134,23 @@ impl fmt::Display for Trap {
 
 impl std::error::Error for Trap {}
 
-/// Call the wasm function pointed to by `callee`. `values_vec` points to
-/// a buffer which holds the incoming arguments, and to which the outgoing
-/// return values will be written.
-#[no_mangle]
-pub unsafe extern "C" fn wasmtime_call_trampoline(
+/// Call the wasm function pointed to by `callee`.
+///
+/// * `vmctx` - the callee vmctx argument
+/// * `caller_vmctx` - the caller vmctx argument
+/// * `trampoline` - the jit-generated trampoline whose ABI takes 4 values, the
+///   callee vmctx, the caller vmctx, the `callee` argument below, and then the
+///   `values_vec` argument.
+/// * `callee` - the third argument to the `trampoline` function
+/// * `values_vec` - points to a buffer which holds the incoming arguments, and to
+///   which the outgoing return values will be written.
+///
+/// Wildly unsafe because it calls raw function pointers and reads/writes raw
+/// function pointers.
+pub unsafe fn wasmtime_call_trampoline(
     vmctx: *mut VMContext,
     caller_vmctx: *mut VMContext,
+    trampoline: *const VMFunctionBody,
     callee: *const VMFunctionBody,
     values_vec: *mut u8,
 ) -> Result<(), Trap> {
@@ -148,6 +159,7 @@ pub unsafe extern "C" fn wasmtime_call_trampoline(
             cx.jmp_buf.as_ptr(),
             vmctx as *mut u8,
             caller_vmctx as *mut u8,
+            trampoline,
             callee,
             values_vec,
         )
@@ -156,8 +168,7 @@ pub unsafe extern "C" fn wasmtime_call_trampoline(
 
 /// Call the wasm function pointed to by `callee`, which has no arguments or
 /// return values.
-#[no_mangle]
-pub unsafe extern "C" fn wasmtime_call(
+pub unsafe fn wasmtime_call(
     vmctx: *mut VMContext,
     caller_vmctx: *mut VMContext,
     callee: *const VMFunctionBody,


### PR DESCRIPTION
Instead of generating a trampoline-per-function generate a
trampoline-per-signature. This should hopefully greatly increase the
cache hit rate on trampolines within a module and avoid generating a
function-per-function.