### PR TITLE
Remove memory-related cases from `RelocationTarget`

### DIFF
--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -247,14 +247,6 @@ pub enum RelocationTarget {
     UserFunc(FuncIndex),
     /// A compiler-generated libcall.
     LibCall(ir::LibCall),
-    /// Function for growing a locally-defined 32-bit memory by the specified amount of pages.
-    Memory32Grow,
-    /// Function for growing an imported 32-bit memory by the specified amount of pages.
-    ImportedMemory32Grow,
-    /// Function for query current size of a locally-defined 32-bit linear memory.
-    Memory32Size,
-    /// Function for query current size of an imported 32-bit linear memory.
-    ImportedMemory32Size,
     /// Jump table index.
     JumpTable(FuncIndex, ir::JumpTable),
 }

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -6,10 +6,7 @@ use crate::compilation::{
     Compilation, CompileError, CompiledFunction, CompiledFunctionUnwindInfo, Relocation,
     RelocationTarget, TrapInformation,
 };
-use crate::func_environ::{
-    get_func_name, get_imported_memory32_grow_name, get_imported_memory32_size_name,
-    get_memory32_grow_name, get_memory32_size_name, FuncEnvironment,
-};
+use crate::func_environ::{get_func_name, FuncEnvironment};
 use crate::module::Module;
 use crate::module_environ::FunctionBodyData;
 use crate::CacheConfig;
@@ -46,15 +43,7 @@ impl binemit::RelocSink for RelocSink {
         name: &ExternalName,
         addend: binemit::Addend,
     ) {
-        let reloc_target = if *name == get_memory32_grow_name() {
-            RelocationTarget::Memory32Grow
-        } else if *name == get_imported_memory32_grow_name() {
-            RelocationTarget::ImportedMemory32Grow
-        } else if *name == get_memory32_size_name() {
-            RelocationTarget::Memory32Size
-        } else if *name == get_imported_memory32_size_name() {
-            RelocationTarget::ImportedMemory32Size
-        } else if let ExternalName::User { namespace, index } = *name {
+        let reloc_target = if let ExternalName::User { namespace, index } = *name {
             debug_assert_eq!(namespace, 0);
             RelocationTarget::UserFunc(FuncIndex::from_u32(index))
         } else if let ExternalName::LibCall(libcall) = *name {

--- a/crates/environ/src/func_environ.rs
+++ b/crates/environ/src/func_environ.rs
@@ -22,30 +22,6 @@ pub fn get_func_name(func_index: FuncIndex) -> ir::ExternalName {
     ir::ExternalName::user(0, func_index.as_u32())
 }
 
-/// Compute an `ir::ExternalName` for the `memory.grow` libcall for
-/// 32-bit locally-defined memories.
-pub fn get_memory32_grow_name() -> ir::ExternalName {
-    ir::ExternalName::user(1, 0)
-}
-
-/// Compute an `ir::ExternalName` for the `memory.grow` libcall for
-/// 32-bit imported memories.
-pub fn get_imported_memory32_grow_name() -> ir::ExternalName {
-    ir::ExternalName::user(1, 1)
-}
-
-/// Compute an `ir::ExternalName` for the `memory.size` libcall for
-/// 32-bit locally-defined memories.
-pub fn get_memory32_size_name() -> ir::ExternalName {
-    ir::ExternalName::user(1, 2)
-}
-
-/// Compute an `ir::ExternalName` for the `memory.size` libcall for
-/// 32-bit imported memories.
-pub fn get_imported_memory32_size_name() -> ir::ExternalName {
-    ir::ExternalName::user(1, 3)
-}
-
 /// An index type for builtin functions.
 pub struct BuiltinFunctionIndex(u32);
 

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -29,10 +29,6 @@ pub fn link_module(
                     }
                     None => panic!("direct call to import"),
                 },
-                RelocationTarget::Memory32Grow => wasmtime_memory32_grow as usize,
-                RelocationTarget::Memory32Size => wasmtime_memory32_size as usize,
-                RelocationTarget::ImportedMemory32Grow => wasmtime_imported_memory32_grow as usize,
-                RelocationTarget::ImportedMemory32Size => wasmtime_imported_memory32_size as usize,
                 RelocationTarget::LibCall(libcall) => {
                     use cranelift_codegen::ir::LibCall::*;
                     match libcall {


### PR DESCRIPTION
This commit shrinks the `RelocationTarget` enumeration to remove
intrinsic-related relocations since they are no longer used. Instead
these function calls are done indirectly via a table in the `VMContext`.
This means that all of this is essentially dead code!