### PR TITLE
Pre-generate trampoline functions

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -83,10 +83,10 @@ impl Extern {
 
     pub(crate) fn get_wasmtime_export(&self) -> wasmtime_runtime::Export {
         match self {
-            Extern::Func(f) => f.wasmtime_export().clone(),
-            Extern::Global(g) => g.wasmtime_export().clone(),
-            Extern::Memory(m) => m.wasmtime_export().clone(),
-            Extern::Table(t) => t.wasmtime_export().clone(),
+            Extern::Func(f) => f.wasmtime_function().clone().into(),
+            Extern::Global(g) => g.inner.wasmtime_export.clone().into(),
+            Extern::Memory(m) => m.wasmtime_export.clone().into(),
+            Extern::Table(t) => t.wasmtime_export.clone().into(),
         }
     }
 
@@ -96,17 +96,17 @@ impl Extern {
         export: wasmtime_runtime::Export,
     ) -> Extern {
         match export {
-            wasmtime_runtime::Export::Function { .. } => {
-                Extern::Func(Func::from_wasmtime_function(export, store, instance_handle))
+            wasmtime_runtime::Export::Function(f) => {
+                Extern::Func(Func::from_wasmtime_function(f, store, instance_handle))
             }
-            wasmtime_runtime::Export::Memory { .. } => {
-                Extern::Memory(Memory::from_wasmtime_memory(export, store, instance_handle))
+            wasmtime_runtime::Export::Memory(m) => {
+                Extern::Memory(Memory::from_wasmtime_memory(m, store, instance_handle))
             }
-            wasmtime_runtime::Export::Global { .. } => {
-                Extern::Global(Global::from_wasmtime_global(export, store, instance_handle))
+            wasmtime_runtime::Export::Global(g) => {
+                Extern::Global(Global::from_wasmtime_global(g, store, instance_handle))
             }
-            wasmtime_runtime::Export::Table { .. } => {
-                Extern::Table(Table::from_wasmtime_table(export, store, instance_handle))
+            wasmtime_runtime::Export::Table(t) => {
+                Extern::Table(Table::from_wasmtime_table(t, store, instance_handle))
             }
         }
     }
@@ -165,7 +165,7 @@ impl From<Table> for Extern {
 pub struct Global {
     store: Store,
     ty: GlobalType,
-    wasmtime_export: wasmtime_runtime::Export,
+    wasmtime_export: wasmtime_runtime::ExportGlobal,
     wasmtime_handle: InstanceHandle,
 }
 
@@ -202,17 +202,10 @@ impl Global {
         &self.ty
     }
 
-    fn wasmtime_global_definition(&self) -> *mut wasmtime_runtime::VMGlobalDefinition {
-        match self.wasmtime_export {
-            wasmtime_runtime::Export::Global { definition, .. } => definition,
-            _ => panic!("global definition not found"),
-        }
-    }
-
     /// Returns the current [`Val`] of this global.
     pub fn get(&self) -> Val {
-        let definition = unsafe { &mut *self.wasmtime_global_definition() };
         unsafe {
+            let definition = &mut *self.inner.wasmtime_export.definition;
             match self.ty().content() {
                 ValType::I32 => Val::from(*definition.as_i32()),
                 ValType::I64 => Val::from(*definition.as_i64()),
@@ -243,8 +236,8 @@ impl Global {
         if !val.comes_from_same_store(&self.store) {
             bail!("cross-`Store` values are not supported");
         }
-        let definition = unsafe { &mut *self.wasmtime_global_definition() };
         unsafe {
+            let definition = &mut *self.inner.wasmtime_export.definition;
             match val {
                 Val::I32(i) => *definition.as_i32_mut() = i,
                 Val::I64(i) => *definition.as_i64_mut() = i,
@@ -256,28 +249,19 @@ impl Global {
         Ok(())
     }
 
-    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
-        &self.wasmtime_export
-    }
-
     pub(crate) fn from_wasmtime_global(
-        export: wasmtime_runtime::Export,
+        wasmtime_export: wasmtime_runtime::ExportGlobal,
         store: &Store,
         wasmtime_handle: InstanceHandle,
     ) -> Global {
-        let global = if let wasmtime_runtime::Export::Global { ref global, .. } = export {
-            global
-        } else {
-            panic!("wasmtime export is not global")
-        };
         // The original export is coming from wasmtime_runtime itself we should
         // support all the types coming out of it, so assert such here.
-        let ty = GlobalType::from_wasmtime_global(&global)
+        let ty = GlobalType::from_wasmtime_global(&wasmtime_export.global)
             .expect("core wasm global type should be supported");
         Global {
             store: store.clone(),
             ty: ty,
-            wasmtime_export: export,
+            wasmtime_export,
             wasmtime_handle,
         }
     }
@@ -303,11 +287,11 @@ pub struct Table {
     store: Store,
     ty: TableType,
     wasmtime_handle: InstanceHandle,
-    wasmtime_export: wasmtime_runtime::Export,
+    wasmtime_export: wasmtime_runtime::ExportTable,
 }
 
 fn set_table_item(
-    handle: &mut InstanceHandle,
+    handle: &InstanceHandle,
     table_index: wasm::DefinedTableIndex,
     item_index: u32,
     item: wasmtime_runtime::VMCallerCheckedAnyfunc,
@@ -331,18 +315,13 @@ impl Table {
     /// Returns an error if `init` does not match the element type of the table.
     pub fn new(store: &Store, ty: TableType, init: Val) -> Result<Table> {
         let item = into_checked_anyfunc(init, store)?;
-        let (mut wasmtime_handle, wasmtime_export) = generate_table_export(store, &ty)?;
+        let (wasmtime_handle, wasmtime_export) = generate_table_export(store, &ty)?;
 
         // Initialize entries with the init value.
-        match wasmtime_export {
-            wasmtime_runtime::Export::Table { definition, .. } => {
-                let index = wasmtime_handle.table_index(unsafe { &*definition });
-                let len = unsafe { (*definition).current_elements };
-                for i in 0..len {
-                    set_table_item(&mut wasmtime_handle, index, i, item.clone())?;
-                }
-            }
-            _ => unreachable!("export should be a table"),
+        let definition = unsafe { &*wasmtime_export.definition };
+        let index = wasmtime_handle.table_index(definition);
+        for i in 0..definition.current_elements {
+            set_table_item(&wasmtime_handle, index, i, item.clone())?;
         }
 
         Ok(Table {
@@ -360,11 +339,9 @@ impl Table {
     }
 
     fn wasmtime_table_index(&self) -> wasm::DefinedTableIndex {
-        match self.wasmtime_export {
-            wasmtime_runtime::Export::Table { definition, .. } => {
-                self.wasmtime_handle.table_index(unsafe { &*definition })
-            }
-            _ => panic!("global definition not found"),
+        unsafe {
+            self.wasmtime_handle
+                .table_index(&*self.wasmtime_export.definition)
         }
     }
 
@@ -385,19 +362,13 @@ impl Table {
     /// the right type to be stored in this table.
     pub fn set(&self, index: u32, val: Val) -> Result<()> {
         let table_index = self.wasmtime_table_index();
-        let mut wasmtime_handle = self.wasmtime_handle.clone();
         let item = into_checked_anyfunc(val, &self.store)?;
-        set_table_item(&mut wasmtime_handle, table_index, index, item)
+        set_table_item(&self.wasmtime_handle, table_index, index, item)
     }
 
     /// Returns the current size of this table.
     pub fn size(&self) -> u32 {
-        match self.wasmtime_export {
-            wasmtime_runtime::Export::Table { definition, .. } => unsafe {
-                (*definition).current_elements
-            },
-            _ => panic!("global definition not found"),
-        }
+        unsafe { (&*self.wasmtime_export.definition).current_elements }
     }
 
     /// Grows the size of this table by `delta` more elements, initialization
@@ -462,26 +433,17 @@ impl Table {
         Ok(())
     }
 
-    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
-        &self.wasmtime_export
-    }
-
     pub(crate) fn from_wasmtime_table(
-        export: wasmtime_runtime::Export,
+        wasmtime_export: wasmtime_runtime::ExportTable,
         store: &Store,
-        instance_handle: wasmtime_runtime::InstanceHandle,
+        wasmtime_handle: wasmtime_runtime::InstanceHandle,
     ) -> Table {
-        let table = if let wasmtime_runtime::Export::Table { ref table, .. } = export {
-            table
-        } else {
-            panic!("wasmtime export is not table")
-        };
-        let ty = TableType::from_wasmtime_table(&table.table);
+        let ty = TableType::from_wasmtime_table(&wasmtime_export.table.table);
         Table {
             store: store.clone(),
-            ty: ty,
-            wasmtime_handle: instance_handle,
-            wasmtime_export: export,
+            ty,
+            wasmtime_handle,
+            wasmtime_export,
         }
     }
 }
@@ -511,7 +473,7 @@ pub struct Memory {
     store: Store,
     ty: MemoryType,
     wasmtime_handle: InstanceHandle,
-    wasmtime_export: wasmtime_runtime::Export,
+    wasmtime_export: wasmtime_runtime::ExportMemory,
 }
 
 impl Memory {
@@ -534,13 +496,6 @@ impl Memory {
     /// Returns the underlying type of this memory.
     pub fn ty(&self) -> &MemoryType {
         &self.ty
-    }
-
-    fn wasmtime_memory_definition(&self) -> *mut wasmtime_runtime::VMMemoryDefinition {
-        match self.wasmtime_export {
-            wasmtime_runtime::Export::Memory { definition, .. } => definition,
-            _ => panic!("memory definition not found"),
-        }
     }
 
     /// Returns this memory as a slice view that can be read natively in Rust.
@@ -584,7 +539,7 @@ impl Memory {
     /// and in general you probably want to result to unsafe accessors and the
     /// `data` methods below.
     pub unsafe fn data_unchecked_mut(&self) -> &mut [u8] {
-        let definition = &*self.wasmtime_memory_definition();
+        let definition = &*self.wasmtime_export.definition;
         slice::from_raw_parts_mut(definition.base, definition.current_length)
     }
 
@@ -595,14 +550,14 @@ impl Memory {
     /// of [`Memory::data_unchecked`] to make sure that you can safely
     /// read/write the memory.
     pub fn data_ptr(&self) -> *mut u8 {
-        unsafe { (*self.wasmtime_memory_definition()).base }
+        unsafe { (*self.wasmtime_export.definition).base }
     }
 
     /// Returns the byte length of this memory.
     ///
     /// The returned value will be a multiple of the wasm page size, 64k.
     pub fn data_size(&self) -> usize {
-        unsafe { (*self.wasmtime_memory_definition()).current_length }
+        unsafe { (*self.wasmtime_export.definition).current_length }
     }
 
     /// Returns the size, in pages, of this wasm memory.
@@ -625,39 +580,33 @@ impl Memory {
     /// Returns an error if memory could not be grown, for example if it exceeds
     /// the maximum limits of this memory.
     pub fn grow(&self, delta: u32) -> Result<u32> {
-        match self.wasmtime_export {
-            wasmtime_runtime::Export::Memory { definition, .. } => {
-                let definition = unsafe { &(*definition) };
-                let index = self.wasmtime_handle.memory_index(definition);
-                self.wasmtime_handle
-                    .clone()
-                    .memory_grow(index, delta)
-                    .ok_or_else(|| anyhow!("failed to grow memory"))
-            }
-            _ => panic!("memory definition not found"),
-        }
-    }
-
-    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
-        &self.wasmtime_export
+        let index = self
+            .wasmtime_handle
+            .memory_index(unsafe { &*self.wasmtime_export.definition });
+        self.wasmtime_handle
+            .clone()
+            .memory_grow(index, delta)
+            .ok_or_else(|| anyhow!("failed to grow memory"))
     }
 
     pub(crate) fn from_wasmtime_memory(
-        export: wasmtime_runtime::Export,
+        wasmtime_export: wasmtime_runtime::ExportMemory,
         store: &Store,
-        instance_handle: wasmtime_runtime::InstanceHandle,
+        wasmtime_handle: wasmtime_runtime::InstanceHandle,
     ) -> Memory {
-        let memory = if let wasmtime_runtime::Export::Memory { ref memory, .. } = export {
-            memory
-        } else {
-            panic!("wasmtime export is not memory")
-        };
-        let ty = MemoryType::from_wasmtime_memory(&memory.memory);
+        let ty = MemoryType::from_wasmtime_memory(&wasmtime_export.memory.memory);
         Memory {
+<<<<<<< HEAD
             store: store.clone(),
             ty: ty,
             wasmtime_handle: instance_handle,
             wasmtime_export: export,
+=======
+            _store: store.clone(),
+            ty,
+            wasmtime_handle,
+            wasmtime_export,
+>>>>>>> Refactor wasmtime_runtime::Export
         }
     }
 }

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -84,7 +84,7 @@ impl Extern {
     pub(crate) fn get_wasmtime_export(&self) -> wasmtime_runtime::Export {
         match self {
             Extern::Func(f) => f.wasmtime_function().clone().into(),
-            Extern::Global(g) => g.inner.wasmtime_export.clone().into(),
+            Extern::Global(g) => g.wasmtime_export.clone().into(),
             Extern::Memory(m) => m.wasmtime_export.clone().into(),
             Extern::Table(t) => t.wasmtime_export.clone().into(),
         }
@@ -205,7 +205,7 @@ impl Global {
     /// Returns the current [`Val`] of this global.
     pub fn get(&self) -> Val {
         unsafe {
-            let definition = &mut *self.inner.wasmtime_export.definition;
+            let definition = &mut *self.wasmtime_export.definition;
             match self.ty().content() {
                 ValType::I32 => Val::from(*definition.as_i32()),
                 ValType::I64 => Val::from(*definition.as_i64()),
@@ -237,7 +237,7 @@ impl Global {
             bail!("cross-`Store` values are not supported");
         }
         unsafe {
-            let definition = &mut *self.inner.wasmtime_export.definition;
+            let definition = &mut *self.wasmtime_export.definition;
             match val {
                 Val::I32(i) => *definition.as_i32_mut() = i,
                 Val::I64(i) => *definition.as_i64_mut() = i,
@@ -596,17 +596,10 @@ impl Memory {
     ) -> Memory {
         let ty = MemoryType::from_wasmtime_memory(&wasmtime_export.memory.memory);
         Memory {
-<<<<<<< HEAD
             store: store.clone(),
             ty: ty,
-            wasmtime_handle: instance_handle,
-            wasmtime_export: export,
-=======
-            _store: store.clone(),
-            ty,
             wasmtime_handle,
             wasmtime_export,
->>>>>>> Refactor wasmtime_runtime::Export
         }
     }
 }

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -553,24 +553,20 @@ impl Func {
         Ok(results.into_boxed_slice())
     }
 
-    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
-        self.callable.wasmtime_export()
+    pub(crate) fn wasmtime_function(&self) -> &wasmtime_runtime::ExportFunction {
+        self.callable.wasmtime_function()
     }
 
     pub(crate) fn from_wasmtime_function(
-        export: wasmtime_runtime::Export,
+        export: wasmtime_runtime::ExportFunction,
         store: &Store,
         instance_handle: InstanceHandle,
     ) -> Self {
         // This is only called with `Export::Function`, and since it's coming
         // from wasmtime_runtime itself we should support all the types coming
         // out of it, so assert such here.
-        let ty = if let wasmtime_runtime::Export::Function { signature, .. } = &export {
-            FuncType::from_wasmtime_signature(signature.clone())
-                .expect("core wasm signature should be supported")
-        } else {
-            panic!("expected function export")
-        };
+        let ty = FuncType::from_wasmtime_signature(export.signature.clone())
+            .expect("core wasm signature should be supported");
         let callable = WasmtimeFn::new(store, instance_handle, export);
         Func::from_wrapped(store, ty, Rc::new(callable))
     }

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -184,23 +184,53 @@ macro_rules! wrappers {
                 }
             }
 
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn trampoline<F, $($args,)* R>(
+                callee_vmctx: *mut VMContext,
+                caller_vmctx: *mut VMContext,
+                ptr: *const VMFunctionBody,
+                args: *mut u128,
+            )
+            where
+                F: Fn($($args),*) -> R + 'static,
+                $($args: WasmTy,)*
+                R: WasmRet,
+            {
+                let ptr = mem::transmute::<
+                    *const VMFunctionBody,
+                    unsafe extern "C" fn(
+                        *mut VMContext,
+                        *mut VMContext,
+                        $($args::Abi,)*
+                    ) -> R::Abi,
+                >(ptr);
+
+                let mut _next = args as *const u128;
+                $(let $args = $args::load(&mut _next);)*
+
+                let ret = ptr(callee_vmctx, caller_vmctx, $($args),*);
+                R::store(ret, args);
+            }
+
             let mut _args = Vec::new();
             $($args::push(&mut _args);)*
             let mut ret = Vec::new();
             R::push(&mut ret);
             let ty = FuncType::new(_args.into(), ret.into());
             unsafe {
+                let trampoline = trampoline::<F, $($args,)* R>;
                 let (instance, export) = crate::trampoline::generate_raw_func_export(
                     &ty,
                     std::slice::from_raw_parts_mut(
                         shim::<F, $($args,)* R> as *mut _,
                         0,
                     ),
+                    trampoline,
                     store,
                     Box::new(func),
                 )
                 .expect("failed to generate export");
-                let callable = Rc::new(WasmtimeFn::new(store, instance, export));
+                let callable = Rc::new(WasmtimeFn::new(store, instance, export, trampoline));
                 Func::from_wrapped(store, ty, callable)
             }
         }
@@ -214,8 +244,8 @@ macro_rules! getters {
     )*) => ($(
         $(#[$doc])*
         #[allow(non_snake_case)]
-        pub fn $name<$($args,)* R>(&self)
-            -> anyhow::Result<impl Fn($($args,)*) -> Result<R, Trap>>
+        pub fn $name<'a, $($args,)* R>(&'a self)
+            -> anyhow::Result<impl Fn($($args,)*) -> Result<R, Trap> + 'a>
         where
             $($args: WasmTy,)*
             R: WasmTy,
@@ -239,28 +269,23 @@ macro_rules! getters {
 
             // ... and then once we've passed the typechecks we can hand out our
             // object since our `transmute` below should be safe!
-            let (address, vmctx) = match self.wasmtime_export() {
-                wasmtime_runtime::Export::Function { address, vmctx, signature: _} => {
-                    (*address, *vmctx)
-                }
-                _ => panic!("expected function export"),
-            };
+            let f = self.wasmtime_function();
             Ok(move |$($args: $args),*| -> Result<R, Trap> {
                 unsafe {
-                    let f = mem::transmute::<
+                    let fnptr = mem::transmute::<
                         *const VMFunctionBody,
                         unsafe extern "C" fn(
                             *mut VMContext,
                             *mut VMContext,
                             $($args::Abi,)*
                         ) -> R::Abi,
-                    >(address);
+                    >(f.address);
                     let mut ret = None;
                     $(let $args = $args.into_abi();)*
-                    wasmtime_runtime::catch_traps(vmctx, || {
-                        ret = Some(f(vmctx, ptr::null_mut(), $($args,)*));
+                    wasmtime_runtime::catch_traps(f.vmctx, || {
+                        ret = Some(fnptr(f.vmctx, ptr::null_mut(), $($args,)*));
                     }).map_err(Trap::from_jit)?;
-                    Ok(R::from_abi(vmctx, ret.unwrap()))
+                    Ok(R::from_abi(f.vmctx, ret.unwrap()))
                 }
             })
         }
@@ -562,12 +587,28 @@ impl Func {
         store: &Store,
         instance_handle: InstanceHandle,
     ) -> Self {
+        // Signatures should always be registered in the store's registry of
+        // shared signatures, so we should be able to unwrap safely here.
+        let sig = store
+            .compiler()
+            .signatures()
+            .lookup(export.signature)
+            .expect("failed to lookup signature");
+
         // This is only called with `Export::Function`, and since it's coming
         // from wasmtime_runtime itself we should support all the types coming
         // out of it, so assert such here.
-        let ty = FuncType::from_wasmtime_signature(export.signature.clone())
+        let ty = FuncType::from_wasmtime_signature(sig)
             .expect("core wasm signature should be supported");
-        let callable = WasmtimeFn::new(store, instance_handle, export);
+
+        // Each function signature in a module should have a trampoline stored
+        // on that module as well, so unwrap the result here since otherwise
+        // it's a bug in wasmtime.
+        let trampoline = instance_handle
+            .trampoline(export.signature)
+            .expect("failed to retrieve trampoline from module");
+
+        let callable = WasmtimeFn::new(store, instance_handle, export, trampoline);
         Func::from_wrapped(store, ty, Rc::new(callable))
     }
 
@@ -723,6 +764,10 @@ pub trait WasmTy {
     fn from_abi(vmctx: *mut VMContext, abi: Self::Abi) -> Self;
     #[doc(hidden)]
     fn into_abi(self) -> Self::Abi;
+    #[doc(hidden)]
+    unsafe fn load(ptr: &mut *const u128) -> Self::Abi;
+    #[doc(hidden)]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128);
 }
 
 impl WasmTy for () {
@@ -739,6 +784,10 @@ impl WasmTy for () {
     fn into_abi(self) -> Self::Abi {
         self
     }
+    #[inline]
+    unsafe fn load(_ptr: &mut *const u128) -> Self::Abi {}
+    #[inline]
+    unsafe fn store(_abi: Self::Abi, _ptr: *mut u128) {}
 }
 
 impl WasmTy for i32 {
@@ -762,6 +811,16 @@ impl WasmTy for i32 {
     #[inline]
     fn into_abi(self) -> Self::Abi {
         self
+    }
+    #[inline]
+    unsafe fn load(ptr: &mut *const u128) -> Self::Abi {
+        let ret = **ptr as Self;
+        *ptr = (*ptr).add(1);
+        return ret;
+    }
+    #[inline]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128) {
+        *ptr = abi as u128;
     }
 }
 
@@ -787,6 +846,16 @@ impl WasmTy for i64 {
     fn into_abi(self) -> Self::Abi {
         self
     }
+    #[inline]
+    unsafe fn load(ptr: &mut *const u128) -> Self::Abi {
+        let ret = **ptr as Self;
+        *ptr = (*ptr).add(1);
+        return ret;
+    }
+    #[inline]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128) {
+        *ptr = abi as u128;
+    }
 }
 
 impl WasmTy for f32 {
@@ -810,6 +879,16 @@ impl WasmTy for f32 {
     #[inline]
     fn into_abi(self) -> Self::Abi {
         self
+    }
+    #[inline]
+    unsafe fn load(ptr: &mut *const u128) -> Self::Abi {
+        let ret = f32::from_bits(**ptr as u32);
+        *ptr = (*ptr).add(1);
+        return ret;
+    }
+    #[inline]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128) {
+        *ptr = abi.to_bits() as u128;
     }
 }
 
@@ -835,6 +914,16 @@ impl WasmTy for f64 {
     fn into_abi(self) -> Self::Abi {
         self
     }
+    #[inline]
+    unsafe fn load(ptr: &mut *const u128) -> Self::Abi {
+        let ret = f64::from_bits(**ptr as u64);
+        *ptr = (*ptr).add(1);
+        return ret;
+    }
+    #[inline]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128) {
+        *ptr = abi.to_bits() as u128;
+    }
 }
 
 /// A trait implemented for types which can be returned from closures passed to
@@ -854,6 +943,8 @@ pub trait WasmRet {
     fn matches(tys: impl Iterator<Item = ValType>) -> anyhow::Result<()>;
     #[doc(hidden)]
     fn into_abi(self) -> Self::Abi;
+    #[doc(hidden)]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128);
 }
 
 impl<T: WasmTy> WasmRet for T {
@@ -870,6 +961,11 @@ impl<T: WasmTy> WasmRet for T {
     fn into_abi(self) -> Self::Abi {
         T::into_abi(self)
     }
+
+    #[inline]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128) {
+        T::store(abi, ptr);
+    }
 }
 
 impl<T: WasmTy> WasmRet for Result<T, Trap> {
@@ -885,12 +981,17 @@ impl<T: WasmTy> WasmRet for Result<T, Trap> {
     #[inline]
     fn into_abi(self) -> Self::Abi {
         match self {
-            Ok(val) => return val.into_abi(),
+            Ok(val) => return T::into_abi(val),
             Err(trap) => handle_trap(trap),
         }
 
         fn handle_trap(trap: Trap) -> ! {
             unsafe { wasmtime_runtime::raise_user_trap(Box::new(trap)) }
         }
+    }
+
+    #[inline]
+    unsafe fn store(abi: Self::Abi, ptr: *mut u128) {
+        T::store(abi, ptr);
     }
 }

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -124,24 +124,21 @@ impl Instance {
         let config = store.engine().config();
         let instance_handle = instantiate(config, module.compiled_module(), imports)?;
 
-        let exports = {
-            let mut exports = Vec::with_capacity(module.exports().len());
-            for export in module.exports() {
-                let name = export.name().to_string();
-                let export = instance_handle.lookup(&name).expect("export");
-                exports.push(Extern::from_wasmtime_export(
-                    store,
-                    instance_handle.clone(),
-                    export,
-                ));
-            }
-            exports.into_boxed_slice()
-        };
+        let mut exports = Vec::with_capacity(module.exports().len());
+        for export in module.exports() {
+            let name = export.name().to_string();
+            let export = instance_handle.lookup(&name).expect("export");
+            exports.push(Extern::from_wasmtime_export(
+                store,
+                instance_handle.clone(),
+                export,
+            ));
+        }
         module.register_frame_info();
         Ok(Instance {
             instance_handle,
             module: module.clone(),
-            exports,
+            exports: exports.into_boxed_slice(),
         })
     }
 

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -4,7 +4,7 @@ use crate::runtime::{Config, Store};
 use crate::trap::Trap;
 use anyhow::{bail, Error, Result};
 use wasmtime_jit::{CompiledModule, Resolver};
-use wasmtime_runtime::{Export, InstanceHandle, InstantiationError};
+use wasmtime_runtime::{Export, InstanceHandle, InstantiationError, SignatureRegistry};
 
 struct SimpleResolver<'a> {
     imports: &'a [Extern],
@@ -22,6 +22,7 @@ fn instantiate(
     config: &Config,
     compiled_module: &CompiledModule,
     imports: &[Extern],
+    sig_registry: &SignatureRegistry,
 ) -> Result<InstanceHandle, Error> {
     let mut resolver = SimpleResolver { imports };
     unsafe {
@@ -29,6 +30,7 @@ fn instantiate(
             .instantiate(
                 config.validating_config.operator_config.enable_bulk_memory,
                 &mut resolver,
+                sig_registry,
             )
             .map_err(|e| -> Error {
                 match e {
@@ -122,7 +124,12 @@ impl Instance {
         }
 
         let config = store.engine().config();
-        let instance_handle = instantiate(config, module.compiled_module(), imports)?;
+        let instance_handle = instantiate(
+            config,
+            module.compiled_module(),
+            imports,
+            store.compiler().signatures(),
+        )?;
 
         let mut exports = Vec::with_capacity(module.exports().len());
         for export in module.exports() {

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -3,17 +3,20 @@
 use crate::runtime::Store;
 use anyhow::Result;
 use std::any::Any;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::Module;
-use wasmtime_runtime::{Imports, InstanceHandle, VMFunctionBody};
+use wasmtime_runtime::{
+    Imports, InstanceHandle, VMFunctionBody, VMSharedSignatureIndex, VMTrampoline,
+};
 
 pub(crate) fn create_handle(
     module: Module,
     store: &Store,
     finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    trampolines: HashMap<VMSharedSignatureIndex, VMTrampoline>,
     state: Box<dyn Any>,
 ) -> Result<InstanceHandle> {
     let imports = Imports::new(
@@ -38,6 +41,7 @@ pub(crate) fn create_handle(
             Arc::new(module),
             store.compiler().trap_registry().register_traps(Vec::new()),
             finished_functions.into_boxed_slice(),
+            trampolines,
             imports,
             &data_initializers,
             signatures.into_boxed_slice(),

--- a/crates/api/src/trampoline/global.rs
+++ b/crates/api/src/trampoline/global.rs
@@ -30,6 +30,12 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<Instanc
         "global".to_string(),
         wasmtime_environ::Export::Global(global_id),
     );
-    let handle = create_handle(module, store, PrimaryMap::new(), Box::new(()))?;
+    let handle = create_handle(
+        module,
+        store,
+        PrimaryMap::new(),
+        Default::default(),
+        Box::new(()),
+    )?;
     Ok(handle)
 }

--- a/crates/api/src/trampoline/memory.rs
+++ b/crates/api/src/trampoline/memory.rs
@@ -23,5 +23,11 @@ pub fn create_handle_with_memory(store: &Store, memory: &MemoryType) -> Result<I
         wasmtime_environ::Export::Memory(memory_id),
     );
 
-    create_handle(module, store, PrimaryMap::new(), Box::new(()))
+    create_handle(
+        module,
+        store,
+        PrimaryMap::new(),
+        Default::default(),
+        Box::new(()),
+    )
 }

--- a/crates/api/src/trampoline/mod.rs
+++ b/crates/api/src/trampoline/mod.rs
@@ -14,13 +14,16 @@ use super::{Callable, FuncType, GlobalType, MemoryType, Store, TableType, Val};
 use anyhow::Result;
 use std::any::Any;
 use std::rc::Rc;
-use wasmtime_runtime::VMFunctionBody;
+use wasmtime_runtime::{VMFunctionBody, VMTrampoline};
 
 pub fn generate_func_export(
     ft: &FuncType,
     func: &Rc<dyn Callable + 'static>,
     store: &Store,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportFunction)> {
+) -> Result<(
+    wasmtime_runtime::InstanceHandle,
+    wasmtime_runtime::ExportFunction,
+)> {
     let instance = create_handle_with_function(ft, func, store)?;
     match instance.lookup("trampoline").expect("trampoline export") {
         wasmtime_runtime::Export::Function(f) => Ok((instance, f)),
@@ -34,10 +37,14 @@ pub fn generate_func_export(
 pub unsafe fn generate_raw_func_export(
     ft: &FuncType,
     func: *mut [VMFunctionBody],
+    trampoline: VMTrampoline,
     store: &Store,
     state: Box<dyn Any>,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportFunction)> {
-    let instance = func::create_handle_with_raw_function(ft, func, store, state)?;
+) -> Result<(
+    wasmtime_runtime::InstanceHandle,
+    wasmtime_runtime::ExportFunction,
+)> {
+    let instance = func::create_handle_with_raw_function(ft, func, trampoline, store, state)?;
     match instance.lookup("trampoline").expect("trampoline export") {
         wasmtime_runtime::Export::Function(f) => Ok((instance, f)),
         _ => unreachable!(),
@@ -48,7 +55,10 @@ pub fn generate_global_export(
     store: &Store,
     gt: &GlobalType,
     val: Val,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportGlobal)> {
+) -> Result<(
+    wasmtime_runtime::InstanceHandle,
+    wasmtime_runtime::ExportGlobal,
+)> {
     let instance = create_global(store, gt, val)?;
     match instance.lookup("global").expect("global export") {
         wasmtime_runtime::Export::Global(g) => Ok((instance, g)),
@@ -59,7 +69,10 @@ pub fn generate_global_export(
 pub fn generate_memory_export(
     store: &Store,
     m: &MemoryType,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportMemory)> {
+) -> Result<(
+    wasmtime_runtime::InstanceHandle,
+    wasmtime_runtime::ExportMemory,
+)> {
     let instance = create_handle_with_memory(store, m)?;
     match instance.lookup("memory").expect("memory export") {
         wasmtime_runtime::Export::Memory(m) => Ok((instance, m)),
@@ -70,7 +83,10 @@ pub fn generate_memory_export(
 pub fn generate_table_export(
     store: &Store,
     t: &TableType,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportTable)> {
+) -> Result<(
+    wasmtime_runtime::InstanceHandle,
+    wasmtime_runtime::ExportTable,
+)> {
     let instance = create_handle_with_table(store, t)?;
     match instance.lookup("table").expect("table export") {
         wasmtime_runtime::Export::Table(t) => Ok((instance, t)),

--- a/crates/api/src/trampoline/mod.rs
+++ b/crates/api/src/trampoline/mod.rs
@@ -20,10 +20,12 @@ pub fn generate_func_export(
     ft: &FuncType,
     func: &Rc<dyn Callable + 'static>,
     store: &Store,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
+) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportFunction)> {
     let instance = create_handle_with_function(ft, func, store)?;
-    let export = instance.lookup("trampoline").expect("trampoline export");
-    Ok((instance, export))
+    match instance.lookup("trampoline").expect("trampoline export") {
+        wasmtime_runtime::Export::Function(f) => Ok((instance, f)),
+        _ => unreachable!(),
+    }
 }
 
 /// Note that this is `unsafe` since `func` must be a valid function pointer and
@@ -34,36 +36,44 @@ pub unsafe fn generate_raw_func_export(
     func: *mut [VMFunctionBody],
     store: &Store,
     state: Box<dyn Any>,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
+) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportFunction)> {
     let instance = func::create_handle_with_raw_function(ft, func, store, state)?;
-    let export = instance.lookup("trampoline").expect("trampoline export");
-    Ok((instance, export))
+    match instance.lookup("trampoline").expect("trampoline export") {
+        wasmtime_runtime::Export::Function(f) => Ok((instance, f)),
+        _ => unreachable!(),
+    }
 }
 
 pub fn generate_global_export(
     store: &Store,
     gt: &GlobalType,
     val: Val,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
+) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportGlobal)> {
     let instance = create_global(store, gt, val)?;
-    let export = instance.lookup("global").expect("global export");
-    Ok((instance, export))
+    match instance.lookup("global").expect("global export") {
+        wasmtime_runtime::Export::Global(g) => Ok((instance, g)),
+        _ => unreachable!(),
+    }
 }
 
 pub fn generate_memory_export(
     store: &Store,
     m: &MemoryType,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
+) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportMemory)> {
     let instance = create_handle_with_memory(store, m)?;
-    let export = instance.lookup("memory").expect("memory export");
-    Ok((instance, export))
+    match instance.lookup("memory").expect("memory export") {
+        wasmtime_runtime::Export::Memory(m) => Ok((instance, m)),
+        _ => unreachable!(),
+    }
 }
 
 pub fn generate_table_export(
     store: &Store,
     t: &TableType,
-) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export)> {
+) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::ExportTable)> {
     let instance = create_handle_with_table(store, t)?;
-    let export = instance.lookup("table").expect("table export");
-    Ok((instance, export))
+    match instance.lookup("table").expect("table export") {
+        wasmtime_runtime::Export::Table(t) => Ok((instance, t)),
+        _ => unreachable!(),
+    }
 }

--- a/crates/api/src/trampoline/table.rs
+++ b/crates/api/src/trampoline/table.rs
@@ -26,5 +26,11 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Inst
         wasmtime_environ::Export::Table(table_id),
     );
 
-    create_handle(module, store, PrimaryMap::new(), Box::new(()))
+    create_handle(
+        module,
+        store,
+        PrimaryMap::new(),
+        Default::default(),
+        Box::new(()),
+    )
 }

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -202,10 +202,9 @@ pub(crate) fn into_checked_anyfunc(
         },
         Val::FuncRef(f) => {
             let f = f.wasmtime_function();
-            let type_index = store.compiler().signatures().register(&f.signature);
             wasmtime_runtime::VMCallerCheckedAnyfunc {
                 func_ptr: f.address,
-                type_index,
+                type_index: f.signature,
                 vmctx: f.vmctx,
             }
         }
@@ -220,15 +219,10 @@ pub(crate) fn from_checked_anyfunc(
     if item.type_index == wasmtime_runtime::VMSharedSignatureIndex::default() {
         Val::AnyRef(AnyRef::Null);
     }
-    let signature = store
-        .compiler()
-        .signatures()
-        .lookup(item.type_index)
-        .expect("signature");
     let instance_handle = unsafe { wasmtime_runtime::InstanceHandle::from_vmctx(item.vmctx) };
     let export = wasmtime_runtime::ExportFunction {
         address: item.func_ptr,
-        signature,
+        signature: item.type_index,
         vmctx: item.vmctx,
     };
     let f = Func::from_wasmtime_function(export, store, instance_handle);

--- a/crates/api/tests/func.rs
+++ b/crates/api/tests/func.rs
@@ -289,3 +289,41 @@ fn get_from_module() -> anyhow::Result<()> {
     assert!(f2.get1::<i32, f32>().is_err());
     Ok(())
 }
+
+#[test]
+fn call_wrapped_func() -> Result<()> {
+    let store = Store::default();
+    let f = Func::wrap4(&store, |a: i32, b: i64, c: f32, d: f64| {
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+        assert_eq!(c, 3.0);
+        assert_eq!(d, 4.0);
+    });
+    f.call(&[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()])?;
+    f.get4::<i32, i64, f32, f64, ()>()?(1, 2, 3.0, 4.0)?;
+
+    let f = Func::wrap0(&store, || 1i32);
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_i32(), 1);
+    assert_eq!(f.get0::<i32>()?()?, 1);
+
+    let f = Func::wrap0(&store, || 2i64);
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_i64(), 2);
+    assert_eq!(f.get0::<i64>()?()?, 2);
+
+    let f = Func::wrap0(&store, || 3.0f32);
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_f32(), 3.0);
+    assert_eq!(f.get0::<f32>()?()?, 3.0);
+
+    let f = Func::wrap0(&store, || 4.0f64);
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_f64(), 4.0);
+    assert_eq!(f.get0::<f64>()?()?, 4.0);
+    Ok(())
+}

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -167,6 +167,17 @@ impl Compiler {
             if trampolines.contains_key(&index) {
                 continue;
             }
+            // FIXME(#1303) we should be generating a trampoline for all
+            // functions in a module, not just those with less than 40
+            // arguments. Currently though cranelift dies in spec tests when one
+            // function has 100 arguments. This looks to be a cranelift bug, so
+            // let's work around it for now by skipping generating a trampoline
+            // for that massive function. The trampoline isn't actually needed
+            // at this time, and we'll hopefully get the cranelift bug fixed
+            // soon enough to remove this condition.
+            if sig.params.len() > 40 {
+                continue;
+            }
             trampolines.insert(
                 index,
                 make_trampoline(

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -11,6 +11,7 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_wasm::ModuleTranslationState;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 use wasmtime_debug::{emit_debugsections_image, DebugInfoData};
 use wasmtime_environ::entity::{EntityRef, PrimaryMap};
 use wasmtime_environ::isa::{TargetFrontendConfig, TargetIsa};
@@ -23,7 +24,7 @@ use wasmtime_environ::{
 use wasmtime_profiling::ProfilingAgent;
 use wasmtime_runtime::{
     InstantiationError, SignatureRegistry, TrapRegistration, TrapRegistry, VMFunctionBody,
-    VMSharedSignatureIndex,
+    VMSharedSignatureIndex, VMTrampoline,
 };
 
 /// Select which kind of compilation to use.
@@ -53,13 +54,9 @@ pub struct Compiler {
 
     code_memory: CodeMemory,
     trap_registry: TrapRegistry,
-    trampoline_park: HashMap<VMSharedSignatureIndex, *const VMFunctionBody>,
-    signatures: SignatureRegistry,
+    signatures: Arc<SignatureRegistry>,
     strategy: CompilationStrategy,
     cache_config: CacheConfig,
-
-    /// The `FunctionBuilderContext`, shared between trampline function compilations.
-    fn_builder_ctx: FunctionBuilderContext,
 }
 
 impl Compiler {
@@ -72,9 +69,7 @@ impl Compiler {
         Self {
             isa,
             code_memory: CodeMemory::new(),
-            trampoline_park: HashMap::new(),
-            signatures: SignatureRegistry::new(),
-            fn_builder_ctx: FunctionBuilderContext::new(),
+            signatures: Arc::new(SignatureRegistry::new()),
             strategy,
             trap_registry: TrapRegistry::default(),
             cache_config,
@@ -103,6 +98,7 @@ impl Compiler {
     ) -> Result<
         (
             PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+            HashMap<VMSharedSignatureIndex, VMTrampoline>,
             PrimaryMap<DefinedFuncIndex, ir::JumpTableOffsets>,
             Relocations,
             Option<Vec<u8>>,
@@ -145,6 +141,8 @@ impl Compiler {
         }
         .map_err(SetupError::Compile)?;
 
+        // Allocate all of the compiled functions into executable memory,
+        // copying over their contents.
         let allocated_functions =
             allocate_functions(&mut self.code_memory, &compilation).map_err(|message| {
                 SetupError::Instantiate(InstantiationError::Resource(format!(
@@ -153,7 +151,33 @@ impl Compiler {
                 )))
             })?;
 
+        // Create a registration value for all traps in our allocated
+        // functions. This registration will allow us to map a trapping PC
+        // value to what the trap actually means if it came from JIT code.
         let trap_registration = register_traps(&allocated_functions, &traps, &self.trap_registry);
+
+        // Eagerly generate a entry trampoline for every type signature in the
+        // module. This should be "relatively lightweight" for most modules and
+        // guarantees that all functions (including indirect ones through
+        // tables) have a trampoline when invoked through the wasmtime API.
+        let mut cx = FunctionBuilderContext::new();
+        let mut trampolines = HashMap::new();
+        for sig in module.local.signatures.values() {
+            let index = self.signatures.register(sig);
+            if trampolines.contains_key(&index) {
+                continue;
+            }
+            trampolines.insert(
+                index,
+                make_trampoline(
+                    &*self.isa,
+                    &mut self.code_memory,
+                    &mut cx,
+                    sig,
+                    std::mem::size_of::<u128>(),
+                )?,
+            );
+        }
 
         // Translate debug info (DWARF) only if at least one function is present.
         let dbg = if debug_data.is_some() && !allocated_functions.is_empty() {
@@ -199,43 +223,12 @@ impl Compiler {
 
         Ok((
             allocated_functions,
+            trampolines,
             jt_offsets,
             relocations,
             dbg,
             trap_registration,
         ))
-    }
-
-    /// Create a trampoline for invoking a function.
-    pub(crate) fn get_trampoline(
-        &mut self,
-        signature: &ir::Signature,
-        value_size: usize,
-    ) -> Result<*const VMFunctionBody, SetupError> {
-        let index = self.signatures.register(signature);
-        if let Some(trampoline) = self.trampoline_park.get(&index) {
-            return Ok(*trampoline);
-        }
-        let body = make_trampoline(
-            &*self.isa,
-            &mut self.code_memory,
-            &mut self.fn_builder_ctx,
-            signature,
-            value_size,
-        )?;
-        self.trampoline_park.insert(index, body);
-        return Ok(body);
-    }
-
-    /// Create and publish a trampoline for invoking a function.
-    pub fn get_published_trampoline(
-        &mut self,
-        signature: &ir::Signature,
-        value_size: usize,
-    ) -> Result<*const VMFunctionBody, SetupError> {
-        let result = self.get_trampoline(signature, value_size)?;
-        self.publish_compiled_code();
-        Ok(result)
     }
 
     /// Make memory containing compiled code executable.
@@ -254,7 +247,7 @@ impl Compiler {
     }
 
     /// Shared signature registry.
-    pub fn signatures(&self) -> &SignatureRegistry {
+    pub fn signatures(&self) -> &Arc<SignatureRegistry> {
         &self.signatures
     }
 
@@ -265,13 +258,13 @@ impl Compiler {
 }
 
 /// Create a trampoline for invoking a function.
-fn make_trampoline(
+pub fn make_trampoline(
     isa: &dyn TargetIsa,
     code_memory: &mut CodeMemory,
     fn_builder_ctx: &mut FunctionBuilderContext,
     signature: &ir::Signature,
     value_size: usize,
-) -> Result<*const VMFunctionBody, SetupError> {
+) -> Result<VMTrampoline, SetupError> {
     let pointer_type = isa.pointer_type();
     let mut wrapper_sig = ir::Signature::new(isa.frontend_config().default_call_conv);
 
@@ -373,14 +366,15 @@ fn make_trampoline(
 
     let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context);
 
-    Ok(code_memory
+    let ptr = code_memory
         .allocate_for_function(&CompiledFunction {
             body: code_buf,
             jt_offsets: context.func.jt_offsets,
             unwind_info,
         })
         .map_err(|message| SetupError::Instantiate(InstantiationError::Resource(message)))?
-        .as_ptr())
+        .as_ptr();
+    Ok(unsafe { std::mem::transmute::<*const VMFunctionBody, VMTrampoline>(ptr) })
 }
 
 fn allocate_functions(

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -11,7 +11,6 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_wasm::ModuleTranslationState;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::sync::Arc;
 use wasmtime_debug::{emit_debugsections_image, DebugInfoData};
 use wasmtime_environ::entity::{EntityRef, PrimaryMap};
 use wasmtime_environ::isa::{TargetFrontendConfig, TargetIsa};
@@ -54,7 +53,7 @@ pub struct Compiler {
 
     code_memory: CodeMemory,
     trap_registry: TrapRegistry,
-    signatures: Arc<SignatureRegistry>,
+    signatures: SignatureRegistry,
     strategy: CompilationStrategy,
     cache_config: CacheConfig,
 }
@@ -69,7 +68,7 @@ impl Compiler {
         Self {
             isa,
             code_memory: CodeMemory::new(),
-            signatures: Arc::new(SignatureRegistry::new()),
+            signatures: SignatureRegistry::new(),
             strategy,
             trap_registry: TrapRegistry::default(),
             cache_config,
@@ -258,7 +257,7 @@ impl Compiler {
     }
 
     /// Shared signature registry.
-    pub fn signatures(&self) -> &Arc<SignatureRegistry> {
+    pub fn signatures(&self) -> &SignatureRegistry {
         &self.signatures
     }
 

--- a/crates/jit/src/imports.rs
+++ b/crates/jit/src/imports.rs
@@ -22,28 +22,24 @@ pub fn resolve_imports(module: &Module, resolver: &mut dyn Resolver) -> Result<I
     for (index, (module_name, field, import_idx)) in module.imported_funcs.iter() {
         match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
-                Export::Function {
-                    address,
-                    signature,
-                    vmctx,
-                } => {
+                Export::Function(f) => {
                     let import_signature = &module.local.signatures[module.local.functions[index]];
-                    if signature != *import_signature {
+                    if f.signature != *import_signature {
                         // TODO: If the difference is in the calling convention,
                         // we could emit a wrapper function to fix it up.
                         return Err(LinkError(format!(
                             "{}/{}: incompatible import type: exported function with signature {} \
                              incompatible with function import with signature {}",
-                            module_name, field, signature, import_signature
+                            module_name, field, f.signature, import_signature
                         )));
                     }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(vmctx) });
+                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(f.vmctx) });
                     function_imports.push(VMFunctionImport {
-                        body: address,
-                        vmctx,
+                        body: f.address,
+                        vmctx: f.vmctx,
                     });
                 }
-                Export::Table { .. } | Export::Memory { .. } | Export::Global { .. } => {
+                Export::Table(_) | Export::Memory(_) | Export::Global(_) => {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: export incompatible with function import",
                         module_name, field
@@ -63,26 +59,22 @@ pub fn resolve_imports(module: &Module, resolver: &mut dyn Resolver) -> Result<I
     for (index, (module_name, field, import_idx)) in module.imported_tables.iter() {
         match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
-                Export::Table {
-                    definition,
-                    vmctx,
-                    table,
-                } => {
+                Export::Table(t) => {
                     let import_table = &module.local.table_plans[index];
-                    if !is_table_compatible(&table, import_table) {
+                    if !is_table_compatible(&t.table, import_table) {
                         return Err(LinkError(format!(
                             "{}/{}: incompatible import type: exported table incompatible with \
                              table import",
                             module_name, field,
                         )));
                     }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(vmctx) });
+                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(t.vmctx) });
                     table_imports.push(VMTableImport {
-                        from: definition,
-                        vmctx,
+                        from: t.definition,
+                        vmctx: t.vmctx,
                     });
                 }
-                Export::Global { .. } | Export::Memory { .. } | Export::Function { .. } => {
+                Export::Global(_) | Export::Memory(_) | Export::Function(_) => {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: export incompatible with table import",
                         module_name, field
@@ -102,13 +94,9 @@ pub fn resolve_imports(module: &Module, resolver: &mut dyn Resolver) -> Result<I
     for (index, (module_name, field, import_idx)) in module.imported_memories.iter() {
         match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
-                Export::Memory {
-                    definition,
-                    vmctx,
-                    memory,
-                } => {
+                Export::Memory(m) => {
                     let import_memory = &module.local.memory_plans[index];
-                    if !is_memory_compatible(&memory, import_memory) {
+                    if !is_memory_compatible(&m.memory, import_memory) {
                         return Err(LinkError(format!(
                             "{}/{}: incompatible import type: exported memory incompatible with \
                              memory import",
@@ -123,19 +111,19 @@ pub fn resolve_imports(module: &Module, resolver: &mut dyn Resolver) -> Result<I
                         MemoryStyle::Static {
                             bound: import_bound,
                         },
-                    ) = (memory.style, &import_memory.style)
+                    ) = (m.memory.style, &import_memory.style)
                     {
                         assert_ge!(bound, *import_bound);
                     }
-                    assert_ge!(memory.offset_guard_size, import_memory.offset_guard_size);
+                    assert_ge!(m.memory.offset_guard_size, import_memory.offset_guard_size);
 
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(vmctx) });
+                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(m.vmctx) });
                     memory_imports.push(VMMemoryImport {
-                        from: definition,
-                        vmctx,
+                        from: m.definition,
+                        vmctx: m.vmctx,
                     });
                 }
-                Export::Table { .. } | Export::Global { .. } | Export::Function { .. } => {
+                Export::Table(_) | Export::Global(_) | Export::Function(_) => {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: export incompatible with memory import",
                         module_name, field
@@ -155,28 +143,24 @@ pub fn resolve_imports(module: &Module, resolver: &mut dyn Resolver) -> Result<I
     for (index, (module_name, field, import_idx)) in module.imported_globals.iter() {
         match resolver.resolve(*import_idx, module_name, field) {
             Some(export_value) => match export_value {
-                Export::Table { .. } | Export::Memory { .. } | Export::Function { .. } => {
+                Export::Table(_) | Export::Memory(_) | Export::Function(_) => {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: exported global incompatible with \
                          global import",
                         module_name, field
                     )));
                 }
-                Export::Global {
-                    definition,
-                    vmctx,
-                    global,
-                } => {
+                Export::Global(g) => {
                     let imported_global = module.local.globals[index];
-                    if !is_global_compatible(&global, &imported_global) {
+                    if !is_global_compatible(&g.global, &imported_global) {
                         return Err(LinkError(format!(
                             "{}/{}: incompatible import type: exported global incompatible with \
                              global import",
                             module_name, field
                         )));
                     }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(vmctx) });
-                    global_imports.push(VMGlobalImport { from: definition });
+                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(g.vmctx) });
+                    global_imports.push(VMGlobalImport { from: g.definition });
                 }
             },
             None => {

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -34,7 +34,7 @@ pub mod native;
 pub mod trampoline;
 
 pub use crate::code_memory::CodeMemory;
-pub use crate::compiler::{CompilationStrategy, Compiler};
+pub use crate::compiler::{make_trampoline, CompilationStrategy, Compiler};
 pub use crate::instantiate::{instantiate, CompiledModule, SetupError};
 pub use crate::link::link_module;
 pub use crate::resolver::{NullResolver, Resolver};

--- a/crates/runtime/src/export.rs
+++ b/crates/runtime/src/export.rs
@@ -1,7 +1,7 @@
 use crate::vmcontext::{
-    VMContext, VMFunctionBody, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
+    VMContext, VMFunctionBody, VMGlobalDefinition, VMMemoryDefinition, VMSharedSignatureIndex,
+    VMTableDefinition,
 };
-use wasmtime_environ::ir;
 use wasmtime_environ::wasm::Global;
 use wasmtime_environ::{MemoryPlan, TablePlan};
 
@@ -29,7 +29,9 @@ pub struct ExportFunction {
     /// Pointer to the containing `VMContext`.
     pub vmctx: *mut VMContext,
     /// The function signature declaration, used for compatibilty checking.
-    pub signature: ir::Signature,
+    ///
+    /// Note that this indexes within the module associated with `vmctx`.
+    pub signature: VMSharedSignatureIndex,
 }
 
 impl From<ExportFunction> for Export {

--- a/crates/runtime/src/export.rs
+++ b/crates/runtime/src/export.rs
@@ -9,96 +9,82 @@ use wasmtime_environ::{MemoryPlan, TablePlan};
 #[derive(Debug, Clone)]
 pub enum Export {
     /// A function export value.
-    Function {
-        /// The address of the native-code function.
-        address: *const VMFunctionBody,
-        /// Pointer to the containing `VMContext`.
-        vmctx: *mut VMContext,
-        /// The function signature declaration, used for compatibilty checking.
-        signature: ir::Signature,
-    },
+    Function(ExportFunction),
 
     /// A table export value.
-    Table {
-        /// The address of the table descriptor.
-        definition: *mut VMTableDefinition,
-        /// Pointer to the containing `VMContext`.
-        vmctx: *mut VMContext,
-        /// The table declaration, used for compatibilty checking.
-        table: TablePlan,
-    },
+    Table(ExportTable),
 
     /// A memory export value.
-    Memory {
-        /// The address of the memory descriptor.
-        definition: *mut VMMemoryDefinition,
-        /// Pointer to the containing `VMContext`.
-        vmctx: *mut VMContext,
-        /// The memory declaration, used for compatibilty checking.
-        memory: MemoryPlan,
-    },
+    Memory(ExportMemory),
 
     /// A global export value.
-    Global {
-        /// The address of the global storage.
-        definition: *mut VMGlobalDefinition,
-        /// Pointer to the containing `VMContext`.
-        vmctx: *mut VMContext,
-        /// The global declaration, used for compatibilty checking.
-        global: Global,
-    },
+    Global(ExportGlobal),
 }
 
-impl Export {
-    /// Construct a function export value.
-    pub fn function(
-        address: *const VMFunctionBody,
-        vmctx: *mut VMContext,
-        signature: ir::Signature,
-    ) -> Self {
-        Self::Function {
-            address,
-            vmctx,
-            signature,
-        }
-    }
+/// A function export value.
+#[derive(Debug, Clone)]
+pub struct ExportFunction {
+    /// The address of the native-code function.
+    pub address: *const VMFunctionBody,
+    /// Pointer to the containing `VMContext`.
+    pub vmctx: *mut VMContext,
+    /// The function signature declaration, used for compatibilty checking.
+    pub signature: ir::Signature,
+}
 
-    /// Construct a table export value.
-    pub fn table(
-        definition: *mut VMTableDefinition,
-        vmctx: *mut VMContext,
-        table: TablePlan,
-    ) -> Self {
-        Self::Table {
-            definition,
-            vmctx,
-            table,
-        }
+impl From<ExportFunction> for Export {
+    fn from(func: ExportFunction) -> Export {
+        Export::Function(func)
     }
+}
 
-    /// Construct a memory export value.
-    pub fn memory(
-        definition: *mut VMMemoryDefinition,
-        vmctx: *mut VMContext,
-        memory: MemoryPlan,
-    ) -> Self {
-        Self::Memory {
-            definition,
-            vmctx,
-            memory,
-        }
+/// A table export value.
+#[derive(Debug, Clone)]
+pub struct ExportTable {
+    /// The address of the table descriptor.
+    pub definition: *mut VMTableDefinition,
+    /// Pointer to the containing `VMContext`.
+    pub vmctx: *mut VMContext,
+    /// The table declaration, used for compatibilty checking.
+    pub table: TablePlan,
+}
+
+impl From<ExportTable> for Export {
+    fn from(func: ExportTable) -> Export {
+        Export::Table(func)
     }
+}
 
-    /// Construct a global export value.
-    pub fn global(
-        definition: *mut VMGlobalDefinition,
-        vmctx: *mut VMContext,
-        global: Global,
-    ) -> Self {
-        Self::Global {
-            definition,
-            vmctx,
-            global,
-        }
+/// A memory export value.
+#[derive(Debug, Clone)]
+pub struct ExportMemory {
+    /// The address of the memory descriptor.
+    pub definition: *mut VMMemoryDefinition,
+    /// Pointer to the containing `VMContext`.
+    pub vmctx: *mut VMContext,
+    /// The memory declaration, used for compatibilty checking.
+    pub memory: MemoryPlan,
+}
+
+impl From<ExportMemory> for Export {
+    fn from(func: ExportMemory) -> Export {
+        Export::Memory(func)
+    }
+}
+
+/// A global export value.
+#[derive(Debug, Clone)]
+pub struct ExportGlobal {
+    /// The address of the global storage.
+    pub definition: *mut VMGlobalDefinition,
+    /// Pointer to the containing `VMContext`.
+    pub vmctx: *mut VMContext,
+    /// The global declaration, used for compatibilty checking.
+    pub global: Global,
+}
+
+impl From<ExportGlobal> for Export {
+    fn from(func: ExportGlobal) -> Export {
+        Export::Global(func)
     }
 }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -32,7 +32,12 @@ use wasmtime_environ::wasm::{
     DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
     ElemIndex, FuncIndex, GlobalIndex, GlobalInit, MemoryIndex, SignatureIndex, TableIndex,
 };
+<<<<<<< HEAD
 use wasmtime_environ::{ir, DataInitializer, Module, TableElements, VMOffsets};
+=======
+use wasmtime_environ::{DataInitializer, Module, TableElements, VMOffsets};
+use crate::{ExportFunction, ExportTable, ExportMemory, ExportGlobal};
+>>>>>>> Refactor wasmtime_runtime::Export
 
 cfg_if::cfg_if! {
     if #[cfg(unix)] {
@@ -313,11 +318,12 @@ impl Instance {
                         let import = self.imported_function(*index);
                         (import.body, import.vmctx)
                     };
-                Export::Function {
+                ExportFunction {
                     address,
                     signature,
                     vmctx,
                 }
+                .into()
             }
             wasmtime_environ::Export::Table(index) => {
                 let (definition, vmctx) =
@@ -327,11 +333,12 @@ impl Instance {
                         let import = self.imported_table(*index);
                         (import.from, import.vmctx)
                     };
-                Export::Table {
+                ExportTable {
                     definition,
                     vmctx,
                     table: self.module.local.table_plans[*index].clone(),
                 }
+                .into()
             }
             wasmtime_environ::Export::Memory(index) => {
                 let (definition, vmctx) =
@@ -341,22 +348,23 @@ impl Instance {
                         let import = self.imported_memory(*index);
                         (import.from, import.vmctx)
                     };
-                Export::Memory {
+                ExportMemory {
                     definition,
                     vmctx,
                     memory: self.module.local.memory_plans[*index].clone(),
                 }
+                .into()
             }
-            wasmtime_environ::Export::Global(index) => Export::Global {
-                definition: if let Some(def_index) = self.module.local.defined_global_index(*index)
-                {
+            wasmtime_environ::Export::Global(index) => ExportGlobal {
+                definition: if let Some(def_index) = self.module.local.defined_global_index(*index) {
                     self.global_ptr(def_index)
                 } else {
                     self.imported_global(*index).from
                 },
                 vmctx: self.vmctx_ptr(),
                 global: self.module.local.globals[*index],
-            },
+            }
+            .into(),
         }
     }
 

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -12,16 +12,16 @@ use crate::traphandlers::{catch_traps, Trap};
 use crate::vmcontext::{
     VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport,
     VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMSharedSignatureIndex,
-    VMTableDefinition, VMTableImport,
+    VMTableDefinition, VMTableImport, VMTrampoline,
 };
 use crate::TrapRegistration;
+use crate::{ExportFunction, ExportGlobal, ExportMemory, ExportTable};
 use memoffset::offset_of;
 use more_asserts::assert_lt;
 use std::alloc::{self, Layout};
 use std::any::Any;
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -32,12 +32,7 @@ use wasmtime_environ::wasm::{
     DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
     ElemIndex, FuncIndex, GlobalIndex, GlobalInit, MemoryIndex, SignatureIndex, TableIndex,
 };
-<<<<<<< HEAD
 use wasmtime_environ::{ir, DataInitializer, Module, TableElements, VMOffsets};
-=======
-use wasmtime_environ::{DataInitializer, Module, TableElements, VMOffsets};
-use crate::{ExportFunction, ExportTable, ExportMemory, ExportGlobal};
->>>>>>> Refactor wasmtime_runtime::Export
 
 cfg_if::cfg_if! {
     if #[cfg(unix)] {
@@ -103,6 +98,9 @@ pub(crate) struct Instance {
 
     /// Pointers to functions in executable memory.
     finished_functions: BoxedSlice<DefinedFuncIndex, *mut [VMFunctionBody]>,
+
+    /// Pointers to trampoline functions used to enter particular signatures
+    trampolines: HashMap<VMSharedSignatureIndex, VMTrampoline>,
 
     /// Hosts can store arbitrary per-instance information here.
     host_state: Box<dyn Any>,
@@ -306,8 +304,7 @@ impl Instance {
     pub fn lookup_by_declaration(&self, export: &wasmtime_environ::Export) -> Export {
         match export {
             wasmtime_environ::Export::Function(index) => {
-                let signature =
-                    self.module.local.signatures[self.module.local.functions[*index]].clone();
+                let signature = self.signature_id(self.module.local.functions[*index]);
                 let (address, vmctx) =
                     if let Some(def_index) = self.module.local.defined_func_index(*index) {
                         (
@@ -356,7 +353,8 @@ impl Instance {
                 .into()
             }
             wasmtime_environ::Export::Global(index) => ExportGlobal {
-                definition: if let Some(def_index) = self.module.local.defined_global_index(*index) {
+                definition: if let Some(def_index) = self.module.local.defined_global_index(*index)
+                {
                     self.global_ptr(def_index)
                 } else {
                     self.imported_global(*index).from
@@ -861,6 +859,7 @@ impl InstanceHandle {
         module: Arc<Module>,
         trap_registration: TrapRegistration,
         finished_functions: BoxedSlice<DefinedFuncIndex, *mut [VMFunctionBody]>,
+        trampolines: HashMap<VMSharedSignatureIndex, VMTrampoline>,
         imports: Imports,
         data_initializers: &[DataInitializer<'_>],
         vmshared_signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
@@ -900,6 +899,7 @@ impl InstanceHandle {
                 passive_elements: Default::default(),
                 passive_data,
                 finished_functions,
+                trampolines,
                 dbg_jit_registration,
                 host_state,
                 signal_handler: Cell::new(None),
@@ -1099,6 +1099,11 @@ impl InstanceHandle {
     /// Get a table defined locally within this module.
     pub fn get_defined_table(&self, index: DefinedTableIndex) -> &Table {
         self.instance().get_defined_table(index)
+    }
+
+    /// Gets the trampoline pre-registered for a particular signature
+    pub fn trampoline(&self, sig: VMSharedSignatureIndex) -> Option<VMTrampoline> {
+        self.instance().trampolines.get(&sig).cloned()
     }
 
     /// Return a reference to the contained `Instance`.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::traphandlers::{
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
     VMGlobalImport, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport, VMSharedSignatureIndex,
-    VMTableDefinition, VMTableImport,
+    VMTableDefinition, VMTableImport, VMTrampoline,
 };
 
 /// Version number of this crate.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -36,7 +36,7 @@ mod vmcontext;
 
 pub mod libcalls;
 
-pub use crate::export::Export;
+pub use crate::export::*;
 pub use crate::imports::Imports;
 pub use crate::instance::{InstanceHandle, InstantiationError, LinkError};
 pub use crate::jit_int::GdbJitImageRegistration;

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -3,7 +3,7 @@
 
 use crate::instance::{InstanceHandle, SignalHandler};
 use crate::trap_registry::TrapDescription;
-use crate::vmcontext::{VMContext, VMFunctionBody};
+use crate::vmcontext::{VMContext, VMFunctionBody, VMTrampoline};
 use backtrace::Backtrace;
 use std::any::Any;
 use std::cell::Cell;
@@ -170,7 +170,7 @@ impl Trap {
 pub unsafe fn wasmtime_call_trampoline(
     vmctx: *mut VMContext,
     caller_vmctx: *mut VMContext,
-    trampoline: *const VMFunctionBody,
+    trampoline: VMTrampoline,
     callee: *const VMFunctionBody,
     values_vec: *mut u8,
 ) -> Result<(), Trap> {

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -645,3 +645,11 @@ impl VMContext {
         self.instance().host_state()
     }
 }
+
+///
+pub type VMTrampoline = unsafe extern "C" fn(
+    *mut VMContext,        // callee vmctx
+    *mut VMContext,        // caller vmctx
+    *const VMFunctionBody, // function we're actually calling
+    *mut u128,             // space for arguments and return values
+);

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -58,6 +58,8 @@ impl wasmtime::WasmTy for WasiCallerMemory {
     }
 
     fn into_abi(self) {}
+    unsafe fn load(_ptr: &mut *const u128) {}
+    unsafe fn store(_abi: Self::Abi, _ptr: *mut u128) {}
 }
 
 impl WasiCallerMemory {

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -45,13 +45,9 @@ impl wasmtime::WasmTy for WasiCallerMemory {
     fn from_abi(vmctx: *mut wasmtime_runtime::VMContext, _abi: ()) -> Self {
         unsafe {
             match wasmtime_runtime::InstanceHandle::from_vmctx(vmctx).lookup("memory") {
-                Some(wasmtime_runtime::Export::Memory {
-                    definition,
-                    vmctx: _,
-                    memory: _,
-                }) => WasiCallerMemory {
-                    base: (*definition).base,
-                    len: (*definition).current_length,
+                Some(wasmtime_runtime::Export::Memory(m)) => WasiCallerMemory {
+                    base: (*m.definition).base,
+                    len: (*m.definition).current_length,
                 },
                 _ => WasiCallerMemory {
                     base: std::ptr::null_mut(),


### PR DESCRIPTION


The `wasmtime` crate supports calling arbitrary function signatures in
wasm code, and to do this it generates "trampoline functions" which have
a known ABI that then internally convert to a particular signature's ABI
and call it. These trampoline functions are currently generated
on-the-fly and are cached in the global `Store` structure. This,
however, is suboptimal for a few reasons:

* Due to how code memory is managed each trampoline resides in its own
  64kb allocation of memory. This means if you have N trampolines you're
  using N * 64kb of memory, which is quite a lot of overhead!

* Trampolines are never free'd, even if the referencing module goes
  away. This is similar to #925.

* Trampolines are a source of shared state which prevents `Store` from
  being easily thread safe.

This commit refactors how trampolines are managed inside of the
`wasmtime` crate and jit/runtime internals. All trampolines are now
allocated in the same pass of `CodeMemory` that the main module is
allocated into. A trampoline is generated per-signature in a module as
well, instead of per-function. This cache of trampolines is stored
directly inside of an `Instance`. Trampolines are stored based on
`VMSharedSignatureIndex` so they can be looked up from the internals of
the `ExportFunction` value.

The `Func` API has been updated with various bits and pieces to ensure
the right trampolines are registered in the right places. Overall this
should ensure that all trampolines necessary are generated up-front
rather than lazily. This allows us to remove the trampoline cache from
the `Compiler` type, and move one step closer to making `Compiler`
threadsafe for usage across multiple threads.

Note that as one small caveat the `Func::wrap*` family of functions
don't need to generate a trampoline at runtime, they actually generate
the trampoline at compile time which gets passed in.

Also in addition to shuffling a lot of code around this fixes one minor
bug found in `code_memory.rs`, where `self.position` was loaded before
allocation, but the allocation may push a new chunk which would cause
`self.position` to be zero instead.

