### PR TITLE
Update dependencies to current versions, reducing duplicate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
  "goblin",
  "indexmap",
  "log",
- "scroll 0.10.1",
+ "scroll",
  "string-interner",
  "target-lexicon 0.10.0",
  "thiserror",
@@ -773,7 +773,7 @@ checksum = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
 dependencies = [
  "log",
  "plain",
- "scroll 0.10.1",
+ "scroll",
 ]
 
 [[package]]
@@ -1117,7 +1117,7 @@ dependencies = [
  "flate2",
  "goblin",
  "parity-wasm",
- "scroll 0.10.1",
+ "scroll",
  "target-lexicon 0.10.0",
  "uuid",
 ]
@@ -1518,15 +1518,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
-dependencies = [
- "rustc_version",
-]
 
 [[package]]
 name = "scroll"
@@ -2180,7 +2171,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "object",
- "scroll 0.9.2",
+ "scroll",
  "serde",
  "target-lexicon 0.4.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
  "log",
  "serde",
  "smallvec",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "thiserror",
 ]
 
@@ -383,7 +383,7 @@ dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.10.0",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -394,7 +394,7 @@ checksum = "564ee82268bc25b914fcf331edfc2452f2d9ca34f976b187b4ca668beba250c8"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
- "target-lexicon 0.10.0",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ dependencies = [
  "log",
  "scroll",
  "string-interner",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "thiserror",
 ]
 
@@ -1118,7 +1118,7 @@ dependencies = [
  "goblin",
  "parity-wasm",
  "scroll",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "uuid",
 ]
 
@@ -1696,17 +1696,6 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ab4982b8945c35cc1c46a83a9094c414f6828a099ce5dcaa8ee2b04642dcb"
-dependencies = [
- "failure",
- "failure_derive",
- "serde_json",
-]
-
-[[package]]
-name = "target-lexicon"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
@@ -1742,7 +1731,7 @@ dependencies = [
  "cfg-if",
  "os_pipe",
  "pretty_env_logger",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "tempfile",
  "wasi-common",
  "wasmtime",
@@ -1992,7 +1981,7 @@ dependencies = [
  "rayon",
  "region",
  "rustc-demangle",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "wasi-common",
  "wasmparser 0.51.2",
  "wasmtime-environ",
@@ -2023,7 +2012,7 @@ dependencies = [
  "pretty_env_logger",
  "rayon",
  "structopt",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "tempfile",
  "test-programs",
  "wasi-common",
@@ -2049,7 +2038,7 @@ dependencies = [
  "faerie",
  "gimli",
  "more-asserts",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "thiserror",
  "wasmparser 0.51.2",
  "wasmtime-environ",
@@ -2080,7 +2069,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha2",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "tempfile",
  "thiserror",
  "toml",
@@ -2142,7 +2131,7 @@ dependencies = [
  "cranelift-wasm",
  "more-asserts",
  "region",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "thiserror",
  "wasmparser 0.51.2",
  "wasmtime-debug",
@@ -2173,7 +2162,7 @@ dependencies = [
  "object",
  "scroll",
  "serde",
- "target-lexicon 0.4.0",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -2183,7 +2172,7 @@ dependencies = [
  "anyhow",
  "pyo3",
  "region",
- "target-lexicon 0.10.0",
+ "target-lexicon",
  "wasmparser 0.51.2",
  "wasmtime",
  "wasmtime-interface-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,23 +1877,23 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
 name = "walrus"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ce93ab0c27412ba41d509f2410fa575ecbfdb4a6aba0e02e79e12c09745485"
+checksum = "84651d7b04ebbecf715a28859d1dc5053b98c6a5a20bd7343d8f015947b86481"
 dependencies = [
  "anyhow",
  "id-arena",
  "leb128",
  "log",
  "walrus-macro",
- "wasmparser 0.39.3",
+ "wasmparser 0.48.2",
 ]
 
 [[package]]
 name = "walrus-macro"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8757b0da38353d55a9687f4dee68a8f441f980dd36e16ab07d6e6c673f505f76"
+checksum = "2b1845ca33b1fcec5624f0e5ea617e41a8adea37f71eb117d3ff81a089d5e3f9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1929,21 +1929,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-webidl-bindings"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cae185868c6038a48f487b9af3766ee0c68d4a85fa3610c3a0522092b3cec1"
+checksum = "42298d64a28700ecd5aa47d8037bcf832b7be0c88ad6b272ebb5d92d7e052a8c"
 dependencies = [
  "anyhow",
  "id-arena",
  "leb128",
  "walrus",
 ]
-
-[[package]]
-name = "wasmparser"
-version = "0.39.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c702914acda5feeeffbc29e4d953e5b9ce79d8b98da4dbf18a77086e116c5470"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,8 +150,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -474,8 +474,8 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
 dependencies = [
- "quote 1.0.2",
- "syn 1.0.15",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -493,8 +493,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab2f0544254a47cabc58956cc7ebda74c3b796bb2761e3fe8f29fdde632ad95"
 dependencies = [
- "proc-macro2 1.0.8",
- "syn 1.0.15",
+ "proc-macro2",
+ "syn",
  "synstructure",
 ]
 
@@ -545,9 +545,9 @@ dependencies = [
  "byteorder",
  "lazy_static",
  "owning_ref",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -620,7 +620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b9ed6159e4a6212c61d9c6a86bee01876b192a64accecf58d5b5ae3b667b52"
 dependencies = [
  "anyhow",
- "goblin 0.1.3",
+ "goblin",
  "indexmap",
  "log",
  "scroll 0.10.1",
@@ -645,9 +645,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
  "synstructure",
 ]
 
@@ -740,9 +740,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a36606a68532b5640dc86bb1f33c64b45c4682aad4c50f3937b317ea387f3d6"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -764,28 +764,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "goblin"
-version = "0.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55d53401eb2fd30afd025c570b1946b6966344acf21b42e31286f3bf89e6a8"
-dependencies = [
- "log",
- "plain",
- "scroll 0.9.2",
-]
-
-[[package]]
-name = "goblin"
-version = "0.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3fa261d919c1ae9d1e4533c4a2f99e10938603c4208d56c05bec7a872b661b0"
-dependencies = [
- "log",
- "plain",
- "scroll 0.9.2",
-]
 
 [[package]]
 name = "goblin"
@@ -857,9 +835,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b714fc08d0961716390977cdff1536234415ac37b509e34e5a983def8340fb75"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
  "unindent",
 ]
 
@@ -880,9 +858,9 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a8e30575afe28eea36a9a39136b70b2fb6b0dd0a212a5bd1f30a498395c0274"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1132,14 +1110,15 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.12.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4af347f5ac3d0e83e78c26be33cd10e8e874dcb68517a909ad802ba50a90b5"
+checksum = "ea44a4fd660ab0f38434934ca0212e90fbeaaee54126ef20a3451c30c95bafae"
 dependencies = [
  "flate2",
- "goblin 0.0.22",
+ "goblin",
  "parity-wasm",
- "scroll 0.9.2",
+ "scroll 0.10.1",
+ "target-lexicon 0.10.0",
  "uuid",
 ]
 
@@ -1170,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d7e522a7f994cc4ae32970b1ce0d99ecf91b8e1df080517a26faa6d2e2ee62"
+checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
 name = "paste"
@@ -1191,9 +1170,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1232,10 +1211,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2",
+ "quote",
  "rustversion",
- "syn 1.0.15",
+ "syn",
 ]
 
 [[package]]
@@ -1244,10 +1223,10 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d175bef481c7902e63e3165627123fff3502f06ac043d3ef42d08c1246da9253"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2",
+ "quote",
  "rustversion",
- "syn 1.0.15",
+ "syn",
  "syn-mid",
 ]
 
@@ -1257,18 +1236,9 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1277,7 +1247,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1307,9 +1277,9 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4882d8237fd8c7373cc25cb802fe0dab9ff70830fd56f47ef6c7f3f287fcc057"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1318,10 +1288,10 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf321cfab555f7411298733c86d21e5136f5ded13f5872fabf9de3337beecda"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2",
  "pyo3-derive-backend",
- "quote 1.0.2",
- "syn 1.0.15",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1344,20 +1314,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1541,9 +1502,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1565,7 +1526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
 dependencies = [
  "rustc_version",
- "scroll_derive 0.9.5",
 ]
 
 [[package]]
@@ -1574,18 +1534,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
 dependencies = [
- "scroll_derive 0.10.1",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1aa96c45e7f5a91cb7fabe7b279f02fea7126239fc40b732316e8b6a2d0fcb"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -1594,9 +1543,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1629,9 +1578,9 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1715,20 +1664,9 @@ checksum = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
-]
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1737,9 +1675,9 @@ version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0294dc449adc58bb6592fff1a23d3e5e6e235afc6a0ffca2657d19e7bbffe5"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1748,9 +1686,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1759,10 +1697,10 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1845,9 +1783,9 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1914,12 +1852,6 @@ checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
@@ -1941,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 
 [[package]]
 name = "vec_map"
@@ -1984,9 +1916,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8757b0da38353d55a9687f4dee68a8f441f980dd36e16ab07d6e6c673f505f76"
 dependencies = [
  "heck",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2244,7 +2176,7 @@ name = "wasmtime-profiling"
 version = "0.1.0"
 dependencies = [
  "gimli",
- "goblin 0.0.24",
+ "goblin",
  "lazy_static",
  "libc",
  "object",
@@ -2300,9 +2232,9 @@ dependencies = [
 name = "wasmtime-rust-macro"
 version = "0.9.0"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.15",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2376,8 +2308,8 @@ name = "wig"
 version = "0.9.2"
 dependencies = [
  "heck",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2",
+ "quote",
  "witx",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,12 +79,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -438,24 +432,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
+ "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -472,11 +468,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -488,7 +484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
 dependencies = [
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -507,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab2f0544254a47cabc58956cc7ebda74c3b796bb2761e3fe8f29fdde632ad95"
 dependencies = [
  "proc-macro2 1.0.8",
- "syn 1.0.14",
+ "syn 1.0.15",
  "synstructure",
 ]
 
@@ -560,7 +556,7 @@ dependencies = [
  "owning_ref",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -660,7 +656,7 @@ checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
  "synstructure",
 ]
 
@@ -755,7 +751,7 @@ checksum = "2a36606a68532b5640dc86bb1f33c64b45c4682aad4c50f3937b317ea387f3d6"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -859,7 +855,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -881,7 +877,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
  "unindent",
 ]
 
@@ -904,7 +900,7 @@ checksum = "0a8e30575afe28eea36a9a39136b70b2fb6b0dd0a212a5bd1f30a498395c0274"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -951,9 +947,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1017,10 +1013,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.3.2"
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memchr"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -1097,7 +1099,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -1107,7 +1109,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -1117,7 +1119,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1128,7 +1130,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da4dc79f9e6c81bef96148c8f6b8e72ad4541caa4a24373e900a36da07de03a3"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1139,7 +1141,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1215,7 +1217,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1257,7 +1259,7 @@ dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "rustversion",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1269,7 +1271,7 @@ dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "rustversion",
- "syn 1.0.14",
+ "syn 1.0.15",
  "syn-mid",
 ]
 
@@ -1281,7 +1283,7 @@ checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1331,7 +1333,7 @@ checksum = "4882d8237fd8c7373cc25cb802fe0dab9ff70830fd56f47ef6c7f3f287fcc057"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1343,7 +1345,7 @@ dependencies = [
  "proc-macro2 1.0.8",
  "pyo3-derive-backend",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1565,7 +1567,7 @@ checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1618,7 +1620,7 @@ checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1653,7 +1655,7 @@ checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1739,7 +1741,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1755,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "7a0294dc449adc58bb6592fff1a23d3e5e6e235afc6a0ffca2657d19e7bbffe5"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
@@ -1772,7 +1774,7 @@ checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -1783,7 +1785,7 @@ checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
  "unicode-xid 0.2.0",
 ]
 
@@ -1869,7 +1871,7 @@ checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -2008,7 +2010,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -2324,7 +2326,7 @@ version = "0.9.0"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.14",
+ "syn 1.0.15",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,7 +2229,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 7.0.0",
+ "wast 8.0.0",
 ]
 
 [[package]]
@@ -2237,15 +2237,6 @@ name = "wast"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233648f540f07fce9b972436f2fbcae8a750c1121b6d32d949e1a44b4d9fc7b1"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a729d076deb29c8509fa71f2d427729f9394f9496844ed8fcab152f35d163d"
 dependencies = [
  "leb128",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,15 +53,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -180,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -350,7 +341,7 @@ dependencies = [
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.20.0",
+ "gimli",
  "log",
  "serde",
  "smallvec",
@@ -756,25 +747,16 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162d18ae5f2e3b90a993d202f1ba17a5633c2484426f8bcae201f86194bacd00"
-dependencies = [
- "arrayvec 0.4.12",
- "byteorder",
- "fallible-iterator",
- "indexmap",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
 dependencies = [
+ "arrayvec",
  "byteorder",
+ "fallible-iterator",
  "indexmap",
+ "smallvec",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1063,12 +1045,6 @@ name = "multi_mut"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "816df386e5557ac1843a96f1ba8a7cbf4ab175d05ccc15c87a3cda27b4fbdece"
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -2148,7 +2124,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "faerie",
- "gimli 0.19.0",
+ "gimli",
  "more-asserts",
  "target-lexicon 0.10.0",
  "thiserror",
@@ -2267,7 +2243,7 @@ dependencies = [
 name = "wasmtime-profiling"
 version = "0.1.0"
 dependencies = [
- "gimli 0.19.0",
+ "gimli",
  "goblin 0.0.24",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ file-per-thread-logger = "0.1.1"
 wat = "1.0.2"
 libc = "0.2.60"
 rayon = "1.2.1"
-wasm-webidl-bindings = "0.6"
+wasm-webidl-bindings = "0.8"
 
 [dev-dependencies]
 wasmtime-runtime = { path = "crates/runtime" }

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-gimli = "0.19.0"
+gimli = "0.20.0"
 wasmparser = "0.51.0"
 faerie = "0.14.0"
 wasmtime-environ = { path = "../environ", version = "0.9.0" }

--- a/crates/interface-types/Cargo.toml
+++ b/crates/interface-types/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.19"
-walrus = "0.13"
+walrus = "0.15"
 wasmparser = "0.51.0"
-wasm-webidl-bindings = "0.6"
+wasm-webidl-bindings = "0.8"
 wasmtime = { path = "../api", version = "0.9.0" }
 wasmtime-jit = { path = "../jit", version = "0.9.0" }
 wasmtime-environ = { path = "../environ", version = "0.9.0" }

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -12,11 +12,11 @@ edition = "2018"
 
 [dependencies]
 libc = { version = "0.2.60", default-features = false }
-goblin = "0.0.24"
+goblin = "0.1.3"
 serde = { version = "1.0.99", features = ["derive"] }
 scroll = "0.9.2"
 gimli = "0.20.0"
-object = "0.12.0"
+object = "0.17.0"
 target-lexicon = "0.4.0"
 lazy_static = "1.4"
 

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.99", features = ["derive"] }
 scroll = "0.10.1"
 gimli = "0.20.0"
 object = "0.17.0"
-target-lexicon = "0.4.0"
+target-lexicon = "0.10.0"
 lazy_static = "1.4"
 
 [badges]

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -15,7 +15,7 @@ libc = { version = "0.2.60", default-features = false }
 goblin = "0.0.24"
 serde = { version = "1.0.99", features = ["derive"] }
 scroll = "0.9.2"
-gimli = "0.19.0"
+gimli = "0.20.0"
 object = "0.12.0"
 target-lexicon = "0.4.0"
 lazy_static = "1.4"

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 libc = { version = "0.2.60", default-features = false }
 goblin = "0.1.3"
 serde = { version = "1.0.99", features = ["derive"] }
-scroll = "0.9.2"
+scroll = "0.10.1"
 gimli = "0.20.0"
 object = "0.17.0"
 target-lexicon = "0.4.0"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../api", version = "0.9.0" }
-wast = "7.0.0"
+wast = "8.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
With the help of "cargo tree -d", eliminate as many duplicate versions
of dependencies in wasmtime's dependency tree as possible, by updating
to current versions. This reduces compilation time and binary size.

Overall, this eliminates duplicate versions of wast, target-lexicon,
scroll, scroll_derive, proc-macro2, quote, syn, unicode-xid, gimli,
arrayvec, autocfg, *two* duplicate versions of goblin, one of the three
duplicate versions of wasmparser, and all versions of nodrop.

The only remaining duplicate dependencies are wasmparser (which will
require new releases of walrus and cranelift) and wast (which will
require a new release of witx).

Every commit in this series builds and passes tests; please don't
squash.