### PR TITLE
Document and codify the release process

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,5 +33,6 @@
   - [Testing](./contributing-testing.md)
   - [Fuzzing](./contributing-fuzzing.md)
   - [CI](./contributing-ci.md)
+  - [Release Process](./contributing-release-process.md)
   - [Governance](./contributing-governance.md)
   - [Code of Conduct](./contributing-coc.md)

--- a/docs/contributing-release-process.md
+++ b/docs/contributing-release-process.md
@@ -1,0 +1,25 @@
+# Release Process
+
+This is intended to serve as documentation for wasmtime's release process. It's
+largely an internal checklist for those of us performing a wasmtime release, but
+others might be curious in this as well!
+
+To kick off the release process someone decides to do a release. Currently
+there's not a schedule for releases or something similar. Once the decision is
+made (there's also not really a body governing these decisions, it's more
+whimsical currently, or on request from others) then the following steps need to
+be executed to make the release:
+
+1. `git pull` - make sure you've got the latest changes
+2. Update the version numbers in `Cargo.toml` for all crates
+  * Edit `scripts/bump-wasmtime-version.sh`, notable the `version` variable
+  * Run the script
+  * Commit the changes
+3. Send this version update as a PR to the wasmtime repository, wait for a merge
+4. After merging, tag the merge as `vA.B.C`
+5. Push the tag to the repository
+  * This will trigger the release CI which will create all release artifacts and
+    publish them to GitHub releases.
+6. Run `scripts/publish-all.sh` to publish all crates to crates.io
+
+And that's it, then you've done a wasmtime release.

--- a/scripts/bump-wasmtime-version.sh
+++ b/scripts/bump-wasmtime-version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# This is a convenience script for maintainers publishing a new version of
+# Wasmtime to crates.io. To use, bump the version number below, run the
+# script, and then run the commands that the script prints.
+
+topdir=$(dirname "$0")/..
+cd "$topdir"
+
+# All the wasmtime-* crates have the same version number
+version="0.10.0"
+
+# Update the version numbers of the crates to $version.
+echo "Updating crate versions to $version"
+find -name Cargo.toml \
+    -not -path ./crates/wasi-common/wig/WASI/tools/witx/Cargo.toml \
+    -exec sed -i.bk -e "s/^version = \"[[:digit:]].*/version = \"$version\"/" {} \;
+
+# Update the required version numbers of path dependencies.
+find -name Cargo.toml \
+    -not -path ./crates/wasi-common/wig/WASI/tools/witx/Cargo.toml \
+    -exec sed -i.bk \
+        -e "/\> *= *{.*\<path *= *\"/s/version = \"[^\"]*\"/version = \"$version\"/" \
+        {} \;
+
+cargo build

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -8,36 +8,10 @@ set -euo pipefail
 topdir=$(dirname "$0")/..
 cd "$topdir"
 
-# All the wasmtime-* crates have the same version number
-version="0.9.0"
-
-# Update the version numbers of the crates to $version.
-echo "Updating crate versions to $version"
-find -name Cargo.toml \
-    -not -path ./crates/wasi-common/WASI/tools/witx/Cargo.toml \
-    -exec sed -i.bk -e "s/^version = \"[[:digit:]].*/version = \"$version\"/" {} \;
-
-# Update the required version numbers of path dependencies.
-find -name Cargo.toml \
-    -not -path ./crates/wasi-common/wig/WASI/tools/witx/Cargo.toml \
-    -exec sed -i.bk \
-        -e "/\> *= *{.*\<path *= *\"/s/version = \"[^\"]*\"/version = \"$version\"/" \
-        {} \;
-
-# Update our local Cargo.lock (not checked in).
-cargo update
-scripts/test-all.sh
-
 # Commands needed to publish.
 #
 # Note that libraries need to be published in topological order.
 
-echo git checkout -b bump-version-to-$version
-echo git commit -a -m "\"Bump version to $version"\"
-echo git tag v$version
-echo git push origin bump-version-to-$version
-echo "# Don't forget to click the above link to open a pull-request!"
-echo git push origin v$version
 for cargo_toml in \
     crates/wasi-common/wasi-common-cbindgen/Cargo.toml \
     crates/wasi-common/winx/Cargo.toml \


### PR DESCRIPTION
The `wasmtime` release procees seems like it's been a bit ad-hoc up to
this point, so I figured it'd be good to try to document what we do
today and codify what should be done as well as a form of release
checklist.

I've noticed that we have a number of releases (like v0.11.0) but the
`Cargo.toml` files in the repository don't reflect the current version
of `wasmtime`. Additionally I've noticed that the [most recent release]
ended up having failed tests because `Cargo.toml` was modified but
`Cargo.lock` wasn't updated. I'm hoping that by having a checklist we
can avoid these sorts of accidental issues in the future!

[release]: https://github.com/bytecodealliance/wasmtime/runs/434690272