### PR TITLE
Attempt to fix publication to Pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -517,7 +517,7 @@ jobs:
         find dist/ -name '*.whl' -type f -exec cp '{}' tmp/whl -v \;
 
     - name: Publish Python wheels on Pypi
-      uses: pypa/gh-action-pypi-publish@v1.0.0a0
+      uses: pypa/gh-action-pypi-publish@37e305e7413032d8422456179fee28fac7d25187
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       with:
         user: __token__


### PR DESCRIPTION
This commit is an attempt to fix the issue pointed out at
https://github.com/bytecodealliance/wasmtime/issues/312#issuecomment-576429580
where our publication to pypi is failing (and causes our binary release
process to also fail). By updating the dependency here we should pull in
the necessary support to support the `packages_dir` option.