### PR TITLE
[lightbeam] Updates dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 [[package]]
 name = "multi_mut"
 version = "0.1.5"
-source = "git+https://github.com/golddranks/multi_mut#561e9f7506e8aeddd7ee672d0f844437babe3da8"
+source = "git+https://github.com/golddranks/multi_mut?rev=561e9f7506e8aeddd7ee672d0f844437babe3da8#561e9f7506e8aeddd7ee672d0f844437babe3da8"
 
 [[package]]
 name = "nom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a393aaeb4441a48bcf47b5b6155971f82cc1eb77e22855403ccc0415ac8328d"
+checksum = "7dce4800e1140e94ad07e35e789df569516fd795223600a96f3b01887a42e0da"
 dependencies = [
  "byteorder",
  "memmap",
@@ -1020,9 +1020,8 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "multi_mut"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816df386e5557ac1843a96f1ba8a7cbf4ab175d05ccc15c87a3cda27b4fbdece"
+version = "0.1.5"
+source = "git+https://github.com/golddranks/multi_mut#561e9f7506e8aeddd7ee672d0f844437babe3da8"
 
 [[package]]
 name = "nom"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -11,24 +11,24 @@ keywords = ["webassembly", "wasm", "compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-smallvec = "1.0.0"
+smallvec = "1.2.0"
 dynasm = "0.5.2"
-dynasmrt = "0.5.2"
+dynasmrt = "0.6.0"
 wasmparser = "0.51.2"
 memoffset = "0.5.3"
 itertools = "0.8.2"
 capstone = "0.6.0"
-thiserror = "1.0.9"
+thiserror = "1.0.11"
 cranelift-codegen = "0.59.0"
-multi_mut = "0.1"
+multi_mut = { git = "https://github.com/golddranks/multi_mut" }
 either = "1.5"
 typemap = "0.3"
 more-asserts = "0.2.1"
 
 [dev-dependencies]
-lazy_static = "1.2"
-wat = "1.0.2"
-quickcheck = "0.9.0"
+lazy_static = "1.4.0"
+wat = "1.0.9"
+quickcheck = "0.9.2"
 anyhow = "1.0"
 
 [badges]

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.8.2"
 capstone = "0.6.0"
 thiserror = "1.0.11"
 cranelift-codegen = "0.59.0"
-multi_mut = { git = "https://github.com/golddranks/multi_mut" }
+multi_mut = { git = "https://github.com/golddranks/multi_mut", rev = "561e9f7506e8aeddd7ee672d0f844437babe3da8" }
 either = "1.5"
 typemap = "0.3"
 more-asserts = "0.2.1"


### PR DESCRIPTION
Updates dependencies of Lightbeam.

Note that [the `multi_mut` project](https://github.com/golddranks/multi_mut) was not updated for like 3 years (latest commit from 2017). Looks like the author had abandoned the project and is not replying to issues. However, it's unpublished `master` branch contains [fixes that theoretically should improve soundness](https://github.com/golddranks/multi_mut/commit/561e9f7506e8aeddd7ee672d0f844437babe3da8). Instead of direct transmutes of references it uses raw pointers. Whether it's at all sound remains an open question. For details [see the disclaimer](https://github.com/golddranks/multi_mut#disclaimer) of the project itself.

The whole `multi_mut` approach seems very tricky and error prone to me. Currently I'm investigating how corresponding Lightbeam logic could be rewritten so that it would no longer need `multi_mut`. It's [used in a single place](https://github.com/bytecodealliance/wasmtime/blob/master/crates/lightbeam/src/function_body.rs#L373) so it's probably doable.
