### PR TITLE
Change default opt-level for Config to `speed`.

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -46,6 +46,11 @@ impl Config {
             .set("enable_verifier", "false")
             .expect("should be valid flag");
 
+        // Turn on cranelift speed optimizations by default
+        flags
+            .set("opt_level", "speed")
+            .expect("should be valid flag");
+
         Config {
             debug_info: false,
             validating_config: ValidatingParserConfig {

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use wasmtime::{Config, Engine, Store, Strategy};
+use wasmtime::{Config, Engine, OptLevel, Store, Strategy};
 use wasmtime_wast::WastContext;
 
 include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
@@ -24,6 +24,12 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
         .wasm_multi_value(multi_val)
         .strategy(strategy)?
         .cranelift_debug_verifier(true);
+
+    // FIXME: https://github.com/bytecodealliance/cranelift/issues/1409
+    if simd {
+        cfg.cranelift_opt_level(OptLevel::None);
+    }
+
     let store = Store::new(&Engine::new(&cfg));
     let mut wast_context = WastContext::new(store);
     wast_context.register_spectest()?;


### PR DESCRIPTION
This PR changes the default opt-level for a new `Config` to `speed`.

Fixes #981.