### PR TITLE
Remove some obsolete re-exports in wasmtime-jit.

### DIFF
--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -6,8 +6,7 @@ use crate::values::Val;
 use std::ptr;
 use std::rc::Rc;
 use wasmtime_environ::ir;
-use wasmtime_jit::InstanceHandle;
-use wasmtime_runtime::Export;
+use wasmtime_runtime::{Export, InstanceHandle};
 
 /// A trait representing a function that can be imported and called from inside
 /// WebAssembly.

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -6,8 +6,7 @@ use std::mem;
 use std::panic::{self, AssertUnwindSafe};
 use std::ptr;
 use std::rc::Rc;
-use wasmtime_jit::InstanceHandle;
-use wasmtime_runtime::{VMContext, VMFunctionBody};
+use wasmtime_runtime::{InstanceHandle, VMContext, VMFunctionBody};
 
 /// A WebAssembly function which can be called.
 ///

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -40,9 +40,5 @@ pub use crate::link::link_module;
 pub use crate::resolver::{NullResolver, Resolver};
 pub use crate::target_tunables::target_tunables;
 
-// Re-export `InstanceHandle` so that users won't need to separately depend on
-// wasmtime-runtime in common cases.
-pub use wasmtime_runtime::{InstanceHandle, InstantiationError};
-
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
These were from when wasmtime-jit was trying to present a different API;
now they're not needed.