### PR TITLE
Add dependency versions and a README.md

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 wasmtime-runtime = { path = "../runtime", version = "0.12.0" }
 wasmtime-environ = { path = "../environ", version = "0.12.0" }
 wasmtime-jit = { path = "../jit", version = "0.12.0" }
-wasmtime-profiling = { path = "../profiling" }
+wasmtime-profiling = { path = "../profiling", version = "0.12.0" }
 wasmparser = "0.51.2"
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0.19"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -19,7 +19,7 @@ cranelift-frontend = "0.59.0"
 wasmtime-environ = { path = "../environ", version = "0.12.0" }
 wasmtime-runtime = { path = "../runtime", version = "0.12.0" }
 wasmtime-debug = { path = "../debug", version = "0.12.0" }
-wasmtime-profiling = { path = "../profiling" }
+wasmtime-profiling = { path = "../profiling", version = "0.12.0" }
 region = "2.0.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.10.0", default-features = false }

--- a/crates/profiling/README.md
+++ b/crates/profiling/README.md
@@ -1,0 +1,2 @@
+This is the `wasmtime-profiling` crate, which contains runtime performance
+profiling support for Wasmtime.

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-profiling = { path = "../profiling" }
+wasmtime-profiling = { path = "../profiling", version = "0.12.0" }
 wasmtime-environ = { path = "../environ", version = "0.12.0" }
 region = "2.0.0"
 libc = { version = "0.2.60", default-features = false }

--- a/crates/wasi-common/wig/Cargo.toml
+++ b/crates/wasi-common/wig/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 heck = "0.3.1"
-witx = { path = "WASI/tools/witx" }
+witx = { path = "WASI/tools/witx", version = "0.8.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
`cargo publish` requires path dependencies to have version numbers, and cargo-profiling's Cargo.toml had a `readme` declaration so add a `README.md` file for it.