### PR TITLE
Set a more reasonable LC_ID_DYLIB entry on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -337,6 +337,12 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+    # Postprocess the macOS dylib a bit to have a more reasonable `LC_ID_DYLIB`
+    # directive than the default one that comes out of the linker when typically
+    # doing `cargo build`. For more info see #984
+    - run: install_name_tool -id "@rpath/libwasmtime.dylib" target/release/libwasmtime.dylib
+      if: matrix.os == 'macos-latest'
+
     # ... and now perform some goop to move all the relevant artifacts into
     # something that we'll upload from this action.
 


### PR DESCRIPTION
This should make our build slightly more deterministic but also a bit
more usable at runtime if you're dynamically or statically linking
against the artifact since it won't go probing in the CI's build
directory locally (failing to do so inevitably).

Closes #984