### PR TITLE
Add a `RELEASES.md` file to track release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,50 @@
+# Wasmtime Releases
+
+--------------------------------------------------------------------------------
+
+## 0.12.0
+
+Released 2020-02-26.
+
+### Added
+
+* Support for the [WebAssembly text annotations proposal][annotations-proposal]
+  has been added.
+  [#998](https://github.com/bytecodealliance/wasmtime/pull/998)
+
+* An initial C API for instantiating WASI modules has been added.
+  [#977](https://github.com/bytecodealliance/wasmtime/pull/977)
+
+* A new suite of `Func::getN` functions have been added to the `wasmtime` API to
+  call statically-known function signatures in a highly optimized fashion.
+  [#955](https://github.com/bytecodealliance/wasmtime/pull/955)
+
+* Initial support for profiling JIT code through perf jitdump has been added.
+  [#360](https://github.com/bytecodealliance/wasmtime/pull/360)
+
+* More CLI flags corresponding to proposed WebAssembly features have been added.
+  [#917](https://github.com/bytecodealliance/wasmtime/pull/917)
+
+[annotations-proposal]: https://github.com/webassembly/annotations
+
+### Changed
+
+* The `wasmtime` CLI as well as embedding API will optimize WebAssembly code by
+  default now.
+  [#973](https://github.com/bytecodealliance/wasmtime/pull/973)
+  [#988](https://github.com/bytecodealliance/wasmtime/pull/988)
+
+* The `verifier` pass in Cranelift is now no longer run by default when using
+  the embedding API.
+  [#882](https://github.com/bytecodealliance/wasmtime/pull/882)
+
+### Fixed
+
+* Code caching now accurately accounts for optimization levels, ensuring that if
+  you ask for optimized code you're not accidentally handed unoptimized code
+  from the cache.
+  [#974](https://github.com/bytecodealliance/wasmtime/pull/974)
+
+* Automated releases for tags should be up and running again, along with
+  automatic publication of the `wasmtime` Python package.
+  [#971](https://github.com/bytecodealliance/wasmtime/pull/971)

--- a/docs/contributing-release-process.md
+++ b/docs/contributing-release-process.md
@@ -11,15 +11,17 @@ whimsical currently, or on request from others) then the following steps need to
 be executed to make the release:
 
 1. `git pull` - make sure you've got the latest changes
-2. Update the version numbers in `Cargo.toml` for all crates
+1. Update the version numbers in `Cargo.toml` for all crates
   * Edit `scripts/bump-wasmtime-version.sh`, notable the `version` variable
   * Run the script
   * Commit the changes
-3. Send this version update as a PR to the wasmtime repository, wait for a merge
-4. After merging, tag the merge as `vA.B.C`
-5. Push the tag to the repository
+1. Make sure `RELEASES.md` is up-to-date, and fill it out if it doesn't have an
+   entry yet for the current release.
+1. Send this version update as a PR to the wasmtime repository, wait for a merge
+1. After merging, tag the merge as `vA.B.C`
+1. Push the tag to the repository
   * This will trigger the release CI which will create all release artifacts and
     publish them to GitHub releases.
-6. Run `scripts/publish-all.sh` to publish all crates to crates.io
+1. Run `scripts/publish-all.sh` to publish all crates to crates.io
 
 And that's it, then you've done a wasmtime release.


### PR DESCRIPTION
This is intended to be a form of release notes for wasmtime where we can
keep track of what's changed over time in a more dense way than `git
log` that should be interesting for most users.