### PR TITLE
Disallow values to cross stores

### DIFF
--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -141,7 +141,8 @@ impl Val {
             // TODO: need to implement this once we actually finalize what
             // `anyref` will look like and it's actually implemented to pass it
             // to compiled wasm as well.
-            Val::AnyRef(_) => false,
+            Val::AnyRef(AnyRef::Ref(_)) | Val::AnyRef(AnyRef::Other(_)) => false,
+            Val::AnyRef(AnyRef::Null) => true,
 
             // Integers have no association with any particular store, so
             // they're always considered as "yes I came from that store",

--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -137,7 +137,15 @@ impl Val {
     pub(crate) fn comes_from_same_store(&self, store: &Store) -> bool {
         match self {
             Val::FuncRef(f) => Store::same(store, f.store()),
-            _ => true,
+
+            // TODO: need to implement this once we actually finalize what
+            // `anyref` will look like and it's actually implemented to pass it
+            // to compiled wasm as well.
+            Val::AnyRef(_) => false,
+
+            // Integers have no association with any particular store, so
+            // they're always considered as "yes I came from that store",
+            Val::I32(_) | Val::I64(_) | Val::F32(_) | Val::F64(_) | Val::V128(_) => true,
         }
     }
 }

--- a/crates/api/tests/externals.rs
+++ b/crates/api/tests/externals.rs
@@ -52,3 +52,61 @@ fn bad_tables() {
     assert!(t.grow(1, Val::I32(0)).is_err());
     assert_eq!(t.size(), 1);
 }
+
+#[test]
+fn cross_store() -> anyhow::Result<()> {
+    let mut cfg = Config::new();
+    cfg.wasm_reference_types(true);
+    let store1 = Store::new(&Engine::new(&cfg));
+    let store2 = Store::new(&Engine::new(&cfg));
+
+    // ============ Cross-store instantiation ==============
+
+    let func = Func::wrap0(&store2, || {});
+    let ty = GlobalType::new(ValType::I32, Mutability::Const);
+    let global = Global::new(&store2, ty, Val::I32(0))?;
+    let ty = MemoryType::new(Limits::new(1, None));
+    let memory = Memory::new(&store2, ty);
+    let ty = TableType::new(ValType::FuncRef, Limits::new(1, None));
+    let table = Table::new(&store2, ty, Val::AnyRef(AnyRef::Null))?;
+
+    let need_func = Module::new(&store1, r#"(module (import "" "" (func)))"#)?;
+    assert!(Instance::new(&need_func, &[func.into()]).is_err());
+
+    let need_global = Module::new(&store1, r#"(module (import "" "" (global i32)))"#)?;
+    assert!(Instance::new(&need_global, &[global.into()]).is_err());
+
+    let need_table = Module::new(&store1, r#"(module (import "" "" (table 1 funcref)))"#)?;
+    assert!(Instance::new(&need_table, &[table.into()]).is_err());
+
+    let need_memory = Module::new(&store1, r#"(module (import "" "" (memory 1)))"#)?;
+    assert!(Instance::new(&need_memory, &[memory.into()]).is_err());
+
+    // ============ Cross-store globals ==============
+
+    let store1val = Val::FuncRef(Func::wrap0(&store1, || {}));
+    let store2val = Val::FuncRef(Func::wrap0(&store2, || {}));
+
+    let ty = GlobalType::new(ValType::FuncRef, Mutability::Var);
+    assert!(Global::new(&store2, ty.clone(), store1val.clone()).is_err());
+    if let Ok(g) = Global::new(&store2, ty.clone(), store2val.clone()) {
+        assert!(g.set(store1val.clone()).is_err());
+    }
+
+    // ============ Cross-store tables ==============
+
+    let ty = TableType::new(ValType::FuncRef, Limits::new(1, None));
+    assert!(Table::new(&store2, ty.clone(), store1val.clone()).is_err());
+    let t1 = Table::new(&store2, ty.clone(), store2val.clone())?;
+    assert!(t1.set(0, store1val.clone()).is_err());
+    assert!(t1.grow(0, store1val.clone()).is_err());
+    let t2 = Table::new(&store1, ty.clone(), store1val.clone())?;
+    assert!(Table::copy(&t1, 0, &t2, 0, 0).is_err());
+
+    // ============ Cross-store funcs ==============
+
+    // TODO: need to actually fill this out once we support anyref params/locals
+    // let module = Module::new(&store1, r#"(module (func (export "a") (param funcref)))"#)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Lots of internals in the wasmtime-{jit,runtime} crates are highly
unsafe, so it's up to the `wasmtime` API crate to figure out how to make
it safe. One guarantee we need to provide is that values never cross
between stores. For example you can't take a function in one store and
move it over into a different instance in a different store. This
dynamic check can't be performed at compile time and it's up to
`wasmtime` to do the check itself.

This adds a number of checks, but not all of them, to the codebase for
now. This primarily adds checks around instantiation, globals, and
tables. The main hole in this is functions, where you can pass in
arguments or return values that are not from the right store. For now
though we can't compile modules with `anyref` parameters/returns anyway,
so we should be good. Eventually when that is supported we'll need to
put the guards in place.

Closes #958