### PR TITLE
Fix broken API doc links

### DIFF
--- a/crates/api/src/frame_info.rs
+++ b/crates/api/src/frame_info.rs
@@ -134,6 +134,8 @@ impl Drop for GlobalFrameInfoRegistration {
 /// Whenever a WebAssembly trap occurs an instance of [`Trap`] is created. Each
 /// [`Trap`] has a backtrace of the WebAssembly frames that led to the trap, and
 /// each frame is described by this structure.
+///
+/// [`Trap`]: crate::Trap
 #[derive(Debug)]
 pub struct FrameInfo {
     module_name: Option<String>,

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -109,6 +109,7 @@ impl Instance {
     ///
     /// [inst]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
     /// [issue]: https://github.com/bytecodealliance/wasmtime/issues/727
+    /// [`ExternType`]: crate::ExternType
     pub fn new(module: &Module, imports: &[Extern]) -> Result<Instance, Error> {
         let store = module.store();
         let config = store.engine().config();
@@ -158,7 +159,7 @@ impl Instance {
     /// they're simply the values that are exported. To learn the value of each
     /// export you'll need to consult [`Module::exports`]. The list returned
     /// here maps 1:1 with the list that [`Module::exports`] returns, and
-    /// [`ExportType`] contains the name of each export.
+    /// [`ExportType`](crate::ExportType) contains the name of each export.
     pub fn exports(&self) -> &[Extern] {
         &self.exports
     }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -6,7 +6,7 @@
 //! and there to implement Rust idioms. This crate also defines the actual C API
 //! itself for consumption from other languages.
 
-#![deny(missing_docs)]
+#![deny(missing_docs, intra_doc_link_resolution_failure)]
 
 mod callable;
 mod externals;

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -234,7 +234,7 @@ impl Module {
     /// indicate what should be valid and what shouldn't be.
     ///
     /// Validation automatically happens as part of [`Module::new`], but is a
-    /// requirement for [`Module::new_unchecked`] to be safe.
+    /// requirement for [`Module::from_binary_unchecked`] to be safe.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Also enable the lint to guarantee they stay un-broken.