### PR TITLE
Hexadecimal parsing for immediates

### DIFF
--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
@@ -78,7 +78,7 @@ block0(v0: i8x16 [%xmm3], v1: i8x16 [%xmm4]):
 
 function %imul_i32x4() -> b1 {
 block0:
-[-, %xmm0]    v0 = vconst.i32x4 [-1 0 1 -2147483647] ; e.g. -2147483647 == 0x80_00_00_01
+[-, %xmm0]    v0 = vconst.i32x4 [-1 0 1 0x80_00_00_01]
 [-, %xmm1]    v1 = vconst.i32x4 [2 2 2 2]
 [-, %xmm0]    v2 = imul v0, v1 ; bin: 66 0f 38 40 c1
 
@@ -99,7 +99,7 @@ block0:
 
 function %imul_i16x8() -> b1 {
 block0:
-[-, %xmm1]    v0 = vconst.i16x8 [-1 0 1 32767 0 0 0 0] ; e.g. 32767 == 0x7f_ff
+[-, %xmm1]    v0 = vconst.i16x8 [-1 0 1 0x7f_ff 0 0 0 0]
 [-, %xmm2]    v1 = vconst.i16x8 [2 2 2 2 0 0 0 0]
 [-, %xmm1]    v2 = imul v0, v1 ; bin: 66 0f d5 ca
 

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
@@ -67,7 +67,7 @@ block0:
 
 function %imul_i32x4() -> b1 {
 block0:
-    v0 = vconst.i32x4 [-1 0 1 -2147483647] ; e.g. -2147483647 == 0x80_00_00_01
+    v0 = vconst.i32x4 [-1 0 1 0x80_00_00_01]
     v1 = vconst.i32x4 [2 2 2 2]
     v2 = imul v0, v1
 
@@ -88,7 +88,7 @@ block0:
 
 function %imul_i16x8() -> b1 {
 block0:
-    v0 = vconst.i16x8 [-1 0 1 32767 0 0 0 0] ; e.g. 32767 == 0x7f_ff
+    v0 = vconst.i16x8 [-1 0 1 0x7f_ff 0 0 0 0]
     v1 = vconst.i16x8 [2 2 2 2 0 0 0 0]
     v2 = imul v0, v1
 
@@ -268,9 +268,9 @@ block0:
 
 function %average_rounding_i16x8() -> b1 {
 block0:
-    v0 = vconst.i16x8 [0 0 0 1 42 19 -1 -1]
+    v0 = vconst.i16x8 [0 0 0 1 42 19 -1 0xffff]
     v1 = vconst.i16x8 [0 1 2 4 42 18 -1 0]
-    v2 = vconst.i16x8 [0 1 1 3 42 19 -1 -32768] ; -1 (0xffff) + 0 + 1 == -32768 (0x8000)
+    v2 = vconst.i16x8 [0 1 1 3 42 19 -1 0x8000]
 
     v3 = avg_round v0, v1
     v4 = icmp eq v2, v3

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -704,7 +704,7 @@ impl<'a> Parser<'a> {
                 value = u16::from_str_radix(&text[2..], 16)
                     .map_err(|_| self.error("unable to parse i16 as a hexadecimal immediate"))?;
             } else {
-            // Parse it as a i16 to check for overflow and other issues.
+                // Parse it as a i16 to check for overflow and other issues.
                 value = text
                     .parse()
                     .map_err(|_| self.error("expected i16 decimal immediate"))?;
@@ -743,7 +743,7 @@ impl<'a> Parser<'a> {
                 value = u32::from_str_radix(&text[2..], 16)
                     .map_err(|_| self.error("unable to parse i32 as a hexadecimal immediate"))?;
             } else {
-            // Parse it as a i32 to check for overflow and other issues.
+                // Parse it as a i32 to check for overflow and other issues.
                 value = text
                     .parse()
                     .map_err(|_| self.error("expected i32 decimal immediate"))?;
@@ -3361,6 +3361,78 @@ mod tests {
         assert_eq!(parse_as_uimm8("0xff").unwrap(), 255);
         assert!(parse_as_uimm8("-1").is_err());
         assert!(parse_as_uimm8("0xffa").is_err());
+    }
+
+    #[test]
+    fn i16_as_hex() {
+        fn parse_as_imm16(text: &str) -> ParseResult<i16> {
+            Parser::new(text).match_imm16("unable to parse i16")
+        }
+
+        assert_eq!(parse_as_imm16("0x8000").unwrap(), -32768);
+        assert_eq!(parse_as_imm16("0xffff").unwrap(), -1);
+        assert_eq!(parse_as_imm16("0").unwrap(), 0);
+        assert_eq!(parse_as_imm16("0x7fff").unwrap(), 32767);
+        assert_eq!(
+            parse_as_imm16("-0x0001").unwrap(),
+            parse_as_imm16("0xffff").unwrap()
+        );
+        assert_eq!(
+            parse_as_imm16("-0x7fff").unwrap(),
+            parse_as_imm16("0x8001").unwrap()
+        );
+        assert!(parse_as_imm16("0xffffa").is_err());
+    }
+
+    #[test]
+    fn i32_as_hex() {
+        fn parse_as_imm32(text: &str) -> ParseResult<i32> {
+            Parser::new(text).match_imm32("unable to parse i32")
+        }
+
+        assert_eq!(parse_as_imm32("0x80000000").unwrap(), -2147483648);
+        assert_eq!(parse_as_imm32("0xffffffff").unwrap(), -1);
+        assert_eq!(parse_as_imm32("0").unwrap(), 0);
+        assert_eq!(parse_as_imm32("0x7fffffff").unwrap(), 2147483647);
+        assert_eq!(
+            parse_as_imm32("-0x00000001").unwrap(),
+            parse_as_imm32("0xffffffff").unwrap()
+        );
+        assert_eq!(
+            parse_as_imm32("-0x7fffffff").unwrap(),
+            parse_as_imm32("0x80000001").unwrap()
+        );
+        assert!(parse_as_imm32("0xffffffffa").is_err());
+    }
+
+    #[test]
+    fn i64_as_hex() {
+        fn parse_as_imm64(text: &str) -> ParseResult<Imm64> {
+            Parser::new(text).match_imm64("unable to parse Imm64")
+        }
+
+        assert_eq!(
+            parse_as_imm64("0x8000000000000000").unwrap(),
+            Imm64::new(-9223372036854775808)
+        );
+        assert_eq!(
+            parse_as_imm64("0xffffffffffffffff").unwrap(),
+            Imm64::new(-1)
+        );
+        assert_eq!(parse_as_imm64("0").unwrap(), Imm64::new(0));
+        assert_eq!(
+            parse_as_imm64("0x7fffffffffffffff").unwrap(),
+            Imm64::new(9223372036854775807)
+        );
+        assert_eq!(
+            parse_as_imm64("-0x0000000000000001").unwrap(),
+            parse_as_imm64("0xffffffffffffffff").unwrap()
+        );
+        assert_eq!(
+            parse_as_imm64("-0x7fffffffffffffff").unwrap(),
+            parse_as_imm64("0x8000000000000001").unwrap()
+        );
+        assert!(parse_as_imm64("0xffffffffffffffffa").is_err());
     }
 
     #[test]


### PR DESCRIPTION
This PR adds support for hexadecimal parsing and fixes #1182.

It turns out `Imm64` already supported that so I didn't modify the parsing for that but just added some tests, as with the others.

The issue didn't say anything about parsing negative hex literals, but since `Imm64` supported that too, I decided to go ahead and add that functionality as well (e.g., `-0x7fff == 0x8001 == -32767i16`).

I did a quick scan through some of the SIMD tests and changed some of the negative values to hex but I didn't try to be particularly thorough about it. I could change more of the tests if someone has suggestions on where to look.

Let me know if there are stylistic changes you'd like me to make or anything like that.