### PR TITLE
Add load_extend instructions for x86 SIMD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -188,7 +188,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", "simd_i64x2_arith") => return true, // FIXME Unsupported feature: proposed SIMD operator I64x2Mul
             ("simd", "simd_lane") => return true, // FIXME invalid u8 number: constant out of range: (v8x16.shuffle -1 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14...
             ("simd", "simd_load") => return true, // FIXME Unsupported feature: proposed SIMD operator I8x16Shl
-            ("simd", "simd_load_extend") => return true, // FIXME Unsupported feature: proposed SIMD operator I16x8Load8x8S { memarg: MemoryImmediate { flags: 0, offset: 0 } }
             ("simd", "simd_splat") => return true, // FIXME Unsupported feature: proposed SIMD operator I8x16ShrS
 
             // Still working on implementing these. See #929.

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -417,6 +417,30 @@ pub static PMINUD: [u8; 4] = [0x66, 0x0f, 0x38, 0x3b];
 /// xmm1 (SSE4.1).
 pub static PMINUW: [u8; 4] = [0x66, 0x0f, 0x38, 0x3a];
 
+/// Sign extend 8 packed 8-bit integers in the low 8 bytes of xmm2/m64 to 8 packed 16-bit
+/// integers in xmm1 (SSE4.1).
+pub static PMOVSXBW: [u8; 4] = [0x66, 0x0f, 0x38, 0x20];
+
+/// Sign extend 4 packed 16-bit integers in the low 8 bytes of xmm2/m64 to 4 packed 32-bit
+/// integers in xmm1 (SSE4.1).
+pub static PMOVSXWD: [u8; 4] = [0x66, 0x0f, 0x38, 0x23];
+
+/// Sign extend 2 packed 32-bit integers in the low 8 bytes of xmm2/m64 to 2 packed 64-bit
+/// integers in xmm1.
+pub static PMOVSXDQ: [u8; 4] = [0x66, 0x0f, 0x38, 0x25];
+
+/// Zero extend 8 packed 8-bit integers in the low 8 bytes of xmm2/m64 to 8 packed 16-bit
+/// integers in xmm1 (SSE4.1).
+pub static PMOVZXBW: [u8; 4] = [0x66, 0x0f, 0x38, 0x30];
+
+/// Zero extend 4 packed 16-bit integers in the low 8 bytes of xmm2/m64 to 4 packed 32-bit
+/// integers in xmm1 (SSE4.1).
+pub static PMOVZXWD: [u8; 4] = [0x66, 0x0f, 0x38, 0x33];
+
+/// Zero extend 2 packed 32-bit integers in the low 8 bytes of xmm2/m64 to 2 packed 64-bit
+/// integers in xmm1.
+pub static PMOVZXDQ: [u8; 4] = [0x66, 0x0f, 0x38, 0x35];
+
 /// Multiply the packed signed word integers in xmm1 and xmm2/m128, and store the low 16 bits of
 /// the results in xmm1 (SSE2).
 pub static PMULLW: [u8; 3] = [0x66, 0x0f, 0xd5];

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1147,6 +1147,123 @@ pub(crate) fn define(
         .can_store(true),
     );
 
+    let I16x8 = &TypeVar::new(
+        "I16x8",
+        "A SIMD vector with exactly 8 lanes of 16-bit values",
+        TypeSetBuilder::new()
+            .ints(16..16)
+            .simd_lanes(8..8)
+            .includes_scalars(false)
+            .build(),
+    );
+    let a = &Operand::new("a", I16x8).with_doc("Value loaded");
+
+    ig.push(
+        Inst::new(
+            "uload8x8",
+            r#"
+        Load an 8x8 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i16x8 
+        vector.
+        "#,
+            &formats.load,
+        )
+        .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "sload8x8",
+            r#"
+        Load an 8x8 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i16x8 
+        vector.
+        "#,
+            &formats.load,
+        )
+        .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    let I32x4 = &TypeVar::new(
+        "I32x4",
+        "A SIMD vector with exactly 4 lanes of 32-bit values",
+        TypeSetBuilder::new()
+            .ints(32..32)
+            .simd_lanes(4..4)
+            .includes_scalars(false)
+            .build(),
+    );
+    let a = &Operand::new("a", I32x4).with_doc("Value loaded");
+
+    ig.push(
+        Inst::new(
+            "uload16x4",
+            r#"
+        Load an 16x4 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i32x4 
+        vector.
+        "#,
+            &formats.load,
+        )
+        .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "sload16x4",
+            r#"
+        Load a 16x4 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i32x4 
+        vector.
+        "#,
+            &formats.load,
+        )
+        .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    let I64x2 = &TypeVar::new(
+        "I64x2",
+        "A SIMD vector with exactly 2 lanes of 64-bit values",
+        TypeSetBuilder::new()
+            .ints(64..64)
+            .simd_lanes(2..2)
+            .includes_scalars(false)
+            .build(),
+    );
+    let a = &Operand::new("a", I64x2).with_doc("Value loaded");
+
+    ig.push(
+        Inst::new(
+            "uload32x2",
+            r#"
+        Load an 32x2 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i64x2 
+        vector.
+        "#,
+            &formats.load,
+        )
+        .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "sload32x2",
+            r#"
+        Load a 32x2 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i64x2 
+        vector.
+        "#,
+            &formats.load,
+        )
+        .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
     let x = &Operand::new("x", Mem).with_doc("Value to be stored");
     let a = &Operand::new("a", Mem).with_doc("Value loaded");
     let Offset =

--- a/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
@@ -36,3 +36,33 @@ block0:
 
     return
 }
+
+function %uload_extend() {
+block0:
+    [-,%rdx]     v1 = iconst.i64 0x0123_4567_89ab_cdef
+    [-,%xmm2]    v3 = uload8x8 v1+0     ; bin: heap_oob 66 40 0f 38 30 12
+    [-,%xmm2]    v4 = uload8x8 v1+20    ; bin: heap_oob 66 40 0f 38 30 52 14
+    [-,%xmm2]    v5 = uload8x8 v1+256   ; bin: heap_oob 66 40 0f 38 30 92 00000100
+    [-,%xmm2]    v6 = uload16x4 v1+0    ; bin: heap_oob 66 40 0f 38 33 12
+    [-,%xmm2]    v7 = uload16x4 v1+20   ; bin: heap_oob 66 40 0f 38 33 52 14
+    [-,%xmm2]    v8 = uload16x4 v1+256  ; bin: heap_oob 66 40 0f 38 33 92 00000100
+    [-,%xmm2]    v9 = uload32x2 v1+0    ; bin: heap_oob 66 40 0f 38 35 12
+    [-,%xmm2]    v10 = uload32x2 v1+20  ; bin: heap_oob 66 40 0f 38 35 52 14
+    [-,%xmm2]    v11 = uload32x2 v1+256 ; bin: heap_oob 66 40 0f 38 35 92 00000100
+    return
+}
+
+function %sload_extend() {
+block0:
+    [-,%rdx]     v1 = iconst.i64 0x0123_4567_89ab_cdef
+    [-,%xmm2]    v3 = sload8x8 v1+0     ; bin: heap_oob 66 40 0f 38 20 12
+    [-,%xmm2]    v4 = sload8x8 v1+20    ; bin: heap_oob 66 40 0f 38 20 52 14
+    [-,%xmm2]    v5 = sload8x8 v1+256   ; bin: heap_oob 66 40 0f 38 20 92 00000100
+    [-,%xmm2]    v6 = sload16x4 v1+0    ; bin: heap_oob 66 40 0f 38 23 12
+    [-,%xmm2]    v7 = sload16x4 v1+20   ; bin: heap_oob 66 40 0f 38 23 52 14
+    [-,%xmm2]    v8 = sload16x4 v1+256  ; bin: heap_oob 66 40 0f 38 23 92 00000100
+    [-,%xmm2]    v9 = sload32x2 v1+0    ; bin: heap_oob 66 40 0f 38 25 12
+    [-,%xmm2]    v10 = sload32x2 v1+20  ; bin: heap_oob 66 40 0f 38 25 52 14
+    [-,%xmm2]    v11 = sload32x2 v1+256 ; bin: heap_oob 66 40 0f 38 25 92 00000100
+    return
+}

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -32,6 +32,7 @@ use crate::translation_utils::{FuncIndex, GlobalIndex, MemoryIndex, SignatureInd
 use crate::wasm_unsupported;
 use core::{i32, u32};
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
+use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{
     self, ConstantData, InstBuilder, JumpTableData, MemFlags, Value, ValueLabel,
@@ -650,6 +651,48 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             memarg: MemoryImmediate { flags: _, offset },
         } => {
             translate_load(*offset, ir::Opcode::Load, I8X16, builder, state, environ)?;
+        }
+        Operator::I16x8Load8x8S {
+            memarg: MemoryImmediate { flags: _, offset },
+        } => {
+            let (flags, base, offset) = prepare_load(*offset, builder, state, environ)?;
+            let loaded = builder.ins().sload8x8(flags, base, offset);
+            state.push1(loaded);
+        }
+        Operator::I16x8Load8x8U {
+            memarg: MemoryImmediate { flags: _, offset },
+        } => {
+            let (flags, base, offset) = prepare_load(*offset, builder, state, environ)?;
+            let loaded = builder.ins().uload8x8(flags, base, offset);
+            state.push1(loaded);
+        }
+        Operator::I32x4Load16x4S {
+            memarg: MemoryImmediate { flags: _, offset },
+        } => {
+            let (flags, base, offset) = prepare_load(*offset, builder, state, environ)?;
+            let loaded = builder.ins().sload16x4(flags, base, offset);
+            state.push1(loaded);
+        }
+        Operator::I32x4Load16x4U {
+            memarg: MemoryImmediate { flags: _, offset },
+        } => {
+            let (flags, base, offset) = prepare_load(*offset, builder, state, environ)?;
+            let loaded = builder.ins().uload16x4(flags, base, offset);
+            state.push1(loaded);
+        }
+        Operator::I64x2Load32x2S {
+            memarg: MemoryImmediate { flags: _, offset },
+        } => {
+            let (flags, base, offset) = prepare_load(*offset, builder, state, environ)?;
+            let loaded = builder.ins().sload32x2(flags, base, offset);
+            state.push1(loaded);
+        }
+        Operator::I64x2Load32x2U {
+            memarg: MemoryImmediate { flags: _, offset },
+        } => {
+            let (flags, base, offset) = prepare_load(*offset, builder, state, environ)?;
+            let loaded = builder.ins().uload32x2(flags, base, offset);
+            state.push1(loaded);
         }
         /****************************** Store instructions ***********************************
          * Wasm specifies an integer alignment flag but we drop it in Cranelift.
@@ -1518,13 +1561,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I32x4WidenLowI16x8S { .. }
         | Operator::I32x4WidenHighI16x8S { .. }
         | Operator::I32x4WidenLowI16x8U { .. }
-        | Operator::I32x4WidenHighI16x8U { .. }
-        | Operator::I16x8Load8x8S { .. }
-        | Operator::I16x8Load8x8U { .. }
-        | Operator::I32x4Load16x4S { .. }
-        | Operator::I32x4Load16x4U { .. }
-        | Operator::I64x2Load32x2S { .. }
-        | Operator::I64x2Load32x2U { .. } => {
+        | Operator::I32x4WidenHighI16x8U { .. } => {
             return Err(wasm_unsupported!("proposed SIMD operator {:?}", op));
         }
     };
@@ -1696,6 +1733,27 @@ fn get_heap_addr(
     }
 }
 
+/// Prepare for a load; factors out common functionality between load and load_extend operations.
+fn prepare_load<FE: FuncEnvironment + ?Sized>(
+    offset: u32,
+    builder: &mut FunctionBuilder,
+    state: &mut FuncTranslationState,
+    environ: &mut FE,
+) -> WasmResult<(MemFlags, Value, Offset32)> {
+    let addr32 = state.pop1();
+
+    // We don't yet support multiple linear memories.
+    let heap = state.get_heap(builder.func, 0, environ)?;
+    let (base, offset) = get_heap_addr(heap, addr32, offset, environ.pointer_type(), builder);
+
+    // Note that we don't set `is_aligned` here, even if the load instruction's
+    // alignment immediate says it's aligned, because WebAssembly's immediate
+    // field is just a hint, while Cranelift's aligned flag needs a guarantee.
+    let flags = MemFlags::new();
+
+    Ok((flags, base, offset.into()))
+}
+
 /// Translate a load instruction.
 fn translate_load<FE: FuncEnvironment + ?Sized>(
     offset: u32,
@@ -1705,17 +1763,8 @@ fn translate_load<FE: FuncEnvironment + ?Sized>(
     state: &mut FuncTranslationState,
     environ: &mut FE,
 ) -> WasmResult<()> {
-    let addr32 = state.pop1();
-    // We don't yet support multiple linear memories.
-    let heap = state.get_heap(builder.func, 0, environ)?;
-    let (base, offset) = get_heap_addr(heap, addr32, offset, environ.pointer_type(), builder);
-    // Note that we don't set `is_aligned` here, even if the load instruction's
-    // alignment immediate says it's aligned, because WebAssembly's immediate
-    // field is just a hint, while Cranelift's aligned flag needs a guarantee.
-    let flags = MemFlags::new();
-    let (load, dfg) = builder
-        .ins()
-        .Load(opcode, result_ty, flags, offset.into(), base);
+    let (flags, base, offset) = prepare_load(offset, builder, state, environ)?;
+    let (load, dfg) = builder.ins().Load(opcode, result_ty, flags, offset, base);
     state.push1(dfg.first_result(load));
     Ok(())
 }


### PR DESCRIPTION
This change adds Wasm SIMD [load extend] functionality to the x86 backend by adding new Cranelift instructions for each Wasm SIMD instruction. This closes #1176. 

[load extend]: https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#load-and-extend
