### PR TITLE
Introduce a `HostString` type for helping interact with host APIs.

### DIFF
--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -6,10 +6,12 @@ use crate::helpers::*;
 use crate::memory::*;
 use crate::sandboxed_tty_writer::SandboxedTTYWriter;
 use crate::sys::hostcalls_impl::fs_helpers::path_open_rights;
+use crate::sys::hoststring_from_osstring;
 use crate::sys::{host_impl, hostcalls_impl};
 use crate::{helpers, host, wasi, wasi32, Error, Result};
 use filetime::{set_file_handle_times, FileTime};
 use log::trace;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::ops::DerefMut;
@@ -917,7 +919,9 @@ pub(crate) unsafe fn path_symlink(
     let fe = wasi_ctx.get_fd_entry(dirfd)?;
     let resolved_new = path_get(fe, wasi::__WASI_RIGHTS_PATH_SYMLINK, 0, 0, new_path, true)?;
 
-    hostcalls_impl::path_symlink(old_path, resolved_new)
+    let owned_old = hoststring_from_osstring(OsStr::new(old_path).to_os_string());
+
+    hostcalls_impl::path_symlink(owned_old.as_ref(), resolved_new)
 }
 
 pub(crate) unsafe fn path_unlink_file(

--- a/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
@@ -1,14 +1,17 @@
 #![allow(non_camel_case_types)]
-use crate::sys::host_impl;
 use crate::sys::hostcalls_impl::fs_helpers::*;
+use crate::sys::{
+    hoststring_ends_with_slash, hoststring_from_osstring, osstr_ends_with_slash, HostString,
+};
 use crate::{error::WasiError, fdentry::FdEntry, wasi, Error, Result};
+use std::ffi::OsStr;
 use std::fs::File;
 use std::path::{Component, Path};
 
 #[derive(Debug)]
 pub(crate) struct PathGet {
     dirfd: File,
-    path: String,
+    path: HostString,
 }
 
 impl PathGet {
@@ -16,7 +19,7 @@ impl PathGet {
         &self.dirfd
     }
 
-    pub(crate) fn path(&self) -> &str {
+    pub(crate) fn path(&self) -> &HostString {
         &self.path
     }
 }
@@ -57,7 +60,7 @@ pub(crate) fn path_get(
 
     // Stack of paths left to process. This is initially the `path` argument to this function, but
     // any symlinks we encounter are processed by pushing them on the stack.
-    let mut path_stack = vec![path.to_owned()];
+    let mut path_stack = vec![OsStr::new(path).to_os_string()];
 
     // Track the number of symlinks we've expanded, so we can return `ELOOP` after too many.
     let mut symlink_expansions = 0;
@@ -69,7 +72,7 @@ pub(crate) fn path_get(
             Some(cur_path) => {
                 log::debug!("path_get cur_path = {:?}", cur_path);
 
-                let ends_with_slash = cur_path.ends_with('/');
+                let ends_with_slash = osstr_ends_with_slash(&cur_path);
                 let mut components = Path::new(&cur_path).components();
                 let head = match components.next() {
                     None => return Err(Error::ENOENT),
@@ -78,9 +81,9 @@ pub(crate) fn path_get(
                 let tail = components.as_path();
 
                 if tail.components().next().is_some() {
-                    let mut tail = host_impl::path_from_host(tail.as_os_str())?;
+                    let mut tail = tail.as_os_str().to_os_string();
                     if ends_with_slash {
-                        tail.push('/');
+                        tail.push("/");
                     }
                     path_stack.push(tail);
                 }
@@ -105,14 +108,16 @@ pub(crate) fn path_get(
                         }
                     }
                     Component::Normal(head) => {
-                        let mut head = host_impl::path_from_host(head)?;
+                        let mut head = head.to_os_string();
                         if ends_with_slash {
                             // preserve trailing slash
-                            head.push('/');
+                            head.push("/");
                         }
+                        let head = hoststring_from_osstring(head);
 
                         if !path_stack.is_empty() || (ends_with_slash && !needs_final_component) {
-                            match openat(dir_stack.last().ok_or(Error::ENOTCAPABLE)?, &head) {
+                            match openat(dir_stack.last().ok_or(Error::ENOTCAPABLE)?, head.as_ref())
+                            {
                                 Ok(new_dir) => {
                                     dir_stack.push(new_dir);
                                 }
@@ -127,7 +132,7 @@ pub(crate) fn path_get(
                                             // attempt symlink expansion
                                             let mut link_path = readlinkat(
                                                 dir_stack.last().ok_or(Error::ENOTCAPABLE)?,
-                                                &head,
+                                                head.as_ref(),
                                             )?;
 
                                             symlink_expansions += 1;
@@ -135,8 +140,8 @@ pub(crate) fn path_get(
                                                 return Err(Error::ELOOP);
                                             }
 
-                                            if head.ends_with('/') {
-                                                link_path.push('/');
+                                            if hoststring_ends_with_slash(&head) {
+                                                link_path.push("/");
                                             }
 
                                             log::debug!(
@@ -159,15 +164,18 @@ pub(crate) fn path_get(
                         {
                             // if there's a trailing slash, or if `LOOKUP_SYMLINK_FOLLOW` is set, attempt
                             // symlink expansion
-                            match readlinkat(dir_stack.last().ok_or(Error::ENOTCAPABLE)?, &head) {
+                            match readlinkat(
+                                dir_stack.last().ok_or(Error::ENOTCAPABLE)?,
+                                head.as_ref(),
+                            ) {
                                 Ok(mut link_path) => {
                                     symlink_expansions += 1;
                                     if symlink_expansions > MAX_SYMLINK_EXPANSIONS {
                                         return Err(Error::ELOOP);
                                     }
 
-                                    if head.ends_with('/') {
-                                        link_path.push('/');
+                                    if hoststring_ends_with_slash(&head) {
+                                        link_path.push("/");
                                     }
 
                                     log::debug!(
@@ -205,7 +213,7 @@ pub(crate) fn path_get(
                 // input path has trailing slashes and `needs_final_component` is not set
                 return Ok(PathGet {
                     dirfd: dir_stack.pop().ok_or(Error::ENOTCAPABLE)?,
-                    path: String::from("."),
+                    path: hoststring_from_osstring(OsStr::new(".").to_os_string()),
                 });
             }
         }

--- a/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs_helpers.rs
@@ -22,6 +22,11 @@ impl PathGet {
     pub(crate) fn path(&self) -> &HostString {
         &self.path
     }
+
+    #[allow(dead_code)] // not all hosts need this
+    pub(crate) fn into_path(self) -> HostString {
+        self.path
+    }
 }
 
 /// Normalizes a path to ensure that the target path is located under the directory provided.

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs.rs
@@ -9,8 +9,10 @@ use crate::old::snapshot_0::sys::hostcalls_impl::fs_helpers::path_open_rights;
 use crate::old::snapshot_0::sys::{host_impl, hostcalls_impl};
 use crate::old::snapshot_0::{helpers, host, wasi, wasi32, Error, Result};
 use crate::sandboxed_tty_writer::SandboxedTTYWriter;
+use crate::sys::hoststring_from_osstring;
 use filetime::{set_file_handle_times, FileTime};
 use log::trace;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::ops::DerefMut;
@@ -900,7 +902,9 @@ pub(crate) unsafe fn path_symlink(
     let fe = wasi_ctx.get_fd_entry(dirfd)?;
     let resolved_new = path_get(fe, wasi::__WASI_RIGHTS_PATH_SYMLINK, 0, 0, new_path, true)?;
 
-    hostcalls_impl::path_symlink(old_path, resolved_new)
+    let owned_old = hoststring_from_osstring(OsStr::new(old_path).to_os_string());
+
+    hostcalls_impl::path_symlink(owned_old.as_ref(), resolved_new)
 }
 
 pub(crate) unsafe fn path_unlink_file(

--- a/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/old/snapshot_0/hostcalls_impl/fs_helpers.rs
@@ -22,6 +22,11 @@ impl PathGet {
     pub(crate) fn path(&self) -> &HostString {
         &self.path
     }
+
+    #[allow(dead_code)] // not all hosts need this
+    pub(crate) fn into_path(self) -> HostString {
+        self.path
+    }
 }
 
 /// Normalizes a path to ensure that the target path is located under the directory provided.

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
@@ -69,7 +69,7 @@ pub(crate) fn path_symlink(old_path: &CStr, resolved: PathGet) -> Result<()> {
                     // the trailing slash and check if the path exists, and
                     // adjust the error code appropriately.
                     let dirfd = resolved.dirfd().as_raw_fd();
-                    let new_path = trim_end_slashes(resolved.into_path());
+                    let new_path = trim_end_slashes(resolved.path().clone());
                     if let Ok(_) = unsafe { fstatat(dirfd, new_path, AtFlag::SYMLINK_NOFOLLOW) } {
                         Err(Error::EEXIST)
                     } else {

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
@@ -1,6 +1,7 @@
 use crate::old::snapshot_0::hostcalls_impl::PathGet;
 use crate::old::snapshot_0::{Error, Result};
-use std::ffi::CStr;
+use crate::sys::HostString;
+use std::ffi::{CStr, CString};
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
@@ -67,14 +68,9 @@ pub(crate) fn path_symlink(old_path: &CStr, resolved: PathGet) -> Result<()> {
                     // the trailing slash in the target path. Thus, we strip
                     // the trailing slash and check if the path exists, and
                     // adjust the error code appropriately.
-                    let new_path = resolved.path().trim_end_matches('/');
-                    if let Ok(_) = unsafe {
-                        fstatat(
-                            resolved.dirfd().as_raw_fd(),
-                            new_path,
-                            AtFlag::SYMLINK_NOFOLLOW,
-                        )
-                    } {
+                    let dirfd = resolved.dirfd().as_raw_fd();
+                    let new_path = trim_end_slashes(resolved.into_path());
+                    if let Ok(_) = unsafe { fstatat(dirfd, new_path, AtFlag::SYMLINK_NOFOLLOW) } {
                         Err(Error::EEXIST)
                     } else {
                         Err(Error::ENOTDIR)
@@ -123,7 +119,7 @@ pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> Resul
                         )
                     } {
                         // check if destination contains a trailing slash
-                        if resolved_new.path().contains('/') {
+                        if resolved_new.path().as_bytes().contains(&b'/') {
                             Err(Error::ENOTDIR)
                         } else {
                             Err(Error::ENOENT)
@@ -167,4 +163,13 @@ pub(crate) mod fd_readdir_impl {
         // function), we're locking the `Dir` member of this `OsHandle`.
         Ok(dir.lock().unwrap())
     }
+}
+
+/// Trim trailing slash characters from the given `HostString`.
+fn trim_end_slashes(host: HostString) -> HostString {
+    let mut bytes = host.into_bytes();
+    while let Some(b'/') = bytes.last() {
+        bytes.pop();
+    }
+    unsafe { CString::from_vec_unchecked(bytes) }
 }

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
@@ -1,5 +1,6 @@
 use crate::old::snapshot_0::hostcalls_impl::PathGet;
 use crate::old::snapshot_0::{Error, Result};
+use std::ffi::CStr;
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
@@ -48,7 +49,7 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
     .map_err(Into::into)
 }
 
-pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
+pub(crate) fn path_symlink(old_path: &CStr, resolved: PathGet) -> Result<()> {
     use yanix::{
         file::{fstatat, symlinkat, AtFlag},
         Errno, YanixError,

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -2,6 +2,7 @@
 #![allow(unused_unsafe)]
 use crate::old::snapshot_0::sys::host_impl;
 use crate::old::snapshot_0::{wasi, Result};
+use std::ffi::{CStr, OsString};
 use std::fs::File;
 use yanix::file::OFlag;
 
@@ -36,7 +37,7 @@ pub(crate) fn path_open_rights(
     (needed_base, needed_inheriting)
 }
 
-pub(crate) fn openat(dirfd: &File, path: &str) -> Result<File> {
+pub(crate) fn openat(dirfd: &File, path: &CStr) -> Result<File> {
     use std::os::unix::prelude::{AsRawFd, FromRawFd};
     use yanix::file::{openat, Mode};
 
@@ -54,13 +55,11 @@ pub(crate) fn openat(dirfd: &File, path: &str) -> Result<File> {
     .map_err(Into::into)
 }
 
-pub(crate) fn readlinkat(dirfd: &File, path: &str) -> Result<String> {
+pub(crate) fn readlinkat(dirfd: &File, path: &CStr) -> Result<OsString> {
     use std::os::unix::prelude::AsRawFd;
     use yanix::file::readlinkat;
 
     log::debug!("path_get readlinkat path = {:?}", path);
 
-    unsafe { readlinkat(dirfd.as_raw_fd(), path) }
-        .map_err(Into::into)
-        .and_then(host_impl::path_from_host)
+    unsafe { readlinkat(dirfd.as_raw_fd(), path) }.map_err(Into::into)
 }

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/filetime.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/filetime.rs
@@ -1,6 +1,7 @@
 //! This internal module consists of helper types and functions for dealing
 //! with setting the file times specific to Linux.
 use crate::old::snapshot_0::{sys::unix::filetime::FileTime, Result};
+use std::ffi::CStr;
 use std::fs::File;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
@@ -14,15 +15,14 @@ pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
 /// The original implementation can be found here: [filetime::unix::linux::set_times]
 ///
 /// [filetime::unix::linux::set_times]: https://github.com/alexcrichton/filetime/blob/master/src/unix/linux.rs#L64
-pub(crate) fn utimensat(
+pub(crate) fn utimensat<P: AsRef<CStr>>(
     dirfd: &File,
-    path: &str,
+    path: P,
     atime: FileTime,
     mtime: FileTime,
     symlink_nofollow: bool,
 ) -> Result<()> {
     use crate::old::snapshot_0::sys::unix::filetime::to_timespec;
-    use std::ffi::CString;
     use std::os::unix::prelude::*;
 
     let flags = if symlink_nofollow {
@@ -35,13 +35,12 @@ pub(crate) fn utimensat(
     // current kernel then fall back to an older syscall.
     static INVALID: AtomicBool = AtomicBool::new(false);
     if !INVALID.load(Relaxed) {
-        let p = CString::new(path.as_bytes())?;
         let times = [to_timespec(&atime)?, to_timespec(&mtime)?];
         let rc = unsafe {
             libc::syscall(
                 libc::SYS_utimensat,
                 dirfd.as_raw_fd(),
-                p.as_ptr(),
+                path.as_ref().as_ptr(),
                 times.as_ptr(),
                 flags,
             )

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/hostcalls_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/hostcalls_impl.rs
@@ -1,5 +1,6 @@
 use crate::old::snapshot_0::hostcalls_impl::PathGet;
 use crate::old::snapshot_0::Result;
+use std::ffi::CStr;
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
@@ -14,14 +15,20 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
     .map_err(Into::into)
 }
 
-pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
+pub(crate) fn path_symlink(old_path: &CStr, resolved: PathGet) -> Result<()> {
     use yanix::file::symlinkat;
 
     log::debug!("path_symlink old_path = {:?}", old_path);
     log::debug!("path_symlink resolved = {:?}", resolved);
 
-    unsafe { symlinkat(old_path, resolved.dirfd().as_raw_fd(), resolved.path()) }
-        .map_err(Into::into)
+    unsafe {
+        symlinkat(
+            old_path,
+            resolved.dirfd().as_raw_fd(),
+            resolved.path().as_ref(),
+        )
+    }
+    .map_err(Into::into)
 }
 
 pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> Result<()> {

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/utimesat.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/utimesat.rs
@@ -1,28 +1,27 @@
 use crate::old::snapshot_0::sys::unix::filetime::FileTime;
 use crate::old::snapshot_0::Result;
+use std::ffi::CStr;
 use std::{fs, io};
 
 /// Combines `openat` with `utimes` to emulate `utimensat` on platforms where it is
 /// not available. The logic for setting file times is based on [filetime::unix::set_file_handles_times].
 ///
 /// [filetime::unix::set_file_handles_times]: https://github.com/alexcrichton/filetime/blob/master/src/unix/utimes.rs#L24
-pub(crate) fn utimesat(
+pub(crate) fn utimesat<P: AsRef<CStr>>(
     dirfd: &fs::File,
-    path: &str,
+    path: P,
     atime: FileTime,
     mtime: FileTime,
     symlink_nofollow: bool,
 ) -> Result<()> {
-    use std::ffi::CString;
     use std::os::unix::prelude::*;
     // emulate *at syscall by reading the path from a combination of
     // (fd, path)
-    let p = CString::new(path.as_bytes())?;
     let mut flags = libc::O_RDWR;
     if symlink_nofollow {
         flags |= libc::O_NOFOLLOW;
     }
-    let fd = unsafe { libc::openat(dirfd.as_raw_fd(), p.as_ptr(), flags) };
+    let fd = unsafe { libc::openat(dirfd.as_raw_fd(), path.as_ref().as_ptr(), flags) };
     let f = unsafe { fs::File::from_raw_fd(fd) };
     let (atime, mtime) = get_times(atime, mtime, || f.metadata().map_err(Into::into))?;
     let times = [to_timeval(atime), to_timeval(mtime)];

--- a/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/windows/hostcalls_impl/fs_helpers.rs
@@ -71,7 +71,7 @@ pub(crate) fn openat(dirfd: &File, path: &str) -> Result<File> {
         })
 }
 
-pub(crate) fn readlinkat(dirfd: &File, s_path: &str) -> Result<String> {
+pub(crate) fn readlinkat(dirfd: &File, s_path: &str) -> Result<OsString> {
     use winx::file::get_file_path;
     use winx::winerror::WinError;
 
@@ -87,7 +87,7 @@ pub(crate) fn readlinkat(dirfd: &File, s_path: &str) -> Result<String> {
             target_path
                 .strip_prefix(dir_path)
                 .map_err(|_| Error::ENOTCAPABLE)
-                .and_then(|path| path.to_str().map(String::from).ok_or(Error::EILSEQ))
+                .and_then(Into::into)
         }
         Err(e) => match e.raw_os_error() {
             Some(e) => {

--- a/crates/wasi-common/src/sys/unix/bsd/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/filetime.rs
@@ -35,15 +35,14 @@ cfg_if! {
 /// The original implementation can be found here: [filetime::unix::macos::set_times]
 ///
 /// [filetime::unix::macos::set_times]: https://github.com/alexcrichton/filetime/blob/master/src/unix/macos.rs#L49
-pub(crate) fn utimensat(
+pub(crate) fn utimensat<P: AsRef<CStr>>(
     dirfd: &File,
-    path: &str,
+    path: P,
     atime: FileTime,
     mtime: FileTime,
     symlink_nofollow: bool,
 ) -> Result<()> {
     use crate::sys::unix::filetime::to_timespec;
-    use std::ffi::CString;
     use std::os::unix::prelude::*;
 
     // Attempt to use the `utimensat` syscall, but if it's not supported by the
@@ -55,9 +54,15 @@ pub(crate) fn utimensat(
             0
         };
 
-        let p = CString::new(path.as_bytes())?;
         let times = [to_timespec(&atime)?, to_timespec(&mtime)?];
-        let rc = unsafe { func(dirfd.as_raw_fd(), p.as_ptr(), times.as_ptr(), flags) };
+        let rc = unsafe {
+            func(
+                dirfd.as_raw_fd(),
+                path.as_ref().as_ptr(),
+                times.as_ptr(),
+                flags,
+            )
+        };
         if rc == 0 {
             return Ok(());
         } else {

--- a/crates/wasi-common/src/sys/unix/bsd/hostcalls_impl.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/hostcalls_impl.rs
@@ -1,5 +1,6 @@
 use crate::hostcalls_impl::PathGet;
 use crate::{Error, Result};
+use std::ffi::CStr;
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
@@ -48,7 +49,7 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
     .map_err(Into::into)
 }
 
-pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
+pub(crate) fn path_symlink(old_path: &CStr, resolved: PathGet) -> Result<()> {
     use yanix::{
         file::{fstatat, symlinkat, AtFlag},
         Errno, YanixError,

--- a/crates/wasi-common/src/sys/unix/bsd/hostcalls_impl.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/hostcalls_impl.rs
@@ -73,7 +73,7 @@ pub(crate) fn path_symlink(old_path: &CStr, resolved: PathGet) -> Result<()> {
                     // the trailing slash and check if the path exists, and
                     // adjust the error code appropriately.
                     let dirfd = resolved.dirfd().as_raw_fd();
-                    let new_path = trim_end_slashes(resolved.into_path());
+                    let new_path = trim_end_slashes(resolved.path().clone());
                     eprintln!("        path_symlink: new_path='{:?}'", new_path);
                     if let Ok(_) = unsafe { fstatat(dirfd, new_path, AtFlag::SYMLINK_NOFOLLOW) } {
                         eprintln!("          path_symlink: EEXIST");

--- a/crates/wasi-common/src/sys/unix/emscripten/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/emscripten/filetime.rs
@@ -9,9 +9,9 @@ pub(crate) const UTIME_OMIT: i32 = 1_073_741_822;
 
 /// Wrapper for `utimensat` syscall. In Emscripten, there is no point in dynamically resolving
 /// if `utimensat` is available as it always was and will be.
-pub(crate) fn utimensat(
+pub(crate) fn utimensat<P: AsRef<CStr>>(
     dirfd: &File,
-    path: &str,
+    path: P,
     atime: FileTime,
     mtime: FileTime,
     symlink_nofollow: bool,
@@ -27,7 +27,14 @@ pub(crate) fn utimensat(
     };
     let p = CString::new(path.as_bytes())?;
     let times = [to_timespec(&atime)?, to_timespec(&mtime)?];
-    let rc = unsafe { libc::utimensat(dirfd.as_raw_fd(), p.as_ptr(), times.as_ptr(), flags) };
+    let rc = unsafe {
+        libc::utimensat(
+            dirfd.as_raw_fd(),
+            path.as_ref().as_ptr(),
+            times.as_ptr(),
+            flags,
+        )
+    };
     if rc == 0 {
         Ok(())
     } else {

--- a/crates/wasi-common/src/sys/unix/host_string.rs
+++ b/crates/wasi-common/src/sys/unix/host_string.rs
@@ -1,0 +1,24 @@
+use std::ffi::{CString, OsStr, OsString};
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+/// A string in the format OS APIs prefer to consume. For Unix-style
+/// platforms, this is similar to `OsString`, but we also need the
+/// strings to be NUL-terminated, so we use `CString`.
+pub(crate) type HostString = CString;
+
+/// Convert an `OsString` to a `HostString`.
+pub(crate) fn hoststring_from_osstring(os: OsString) -> HostString {
+    let vec = os.into_vec();
+    assert!(!vec.contains(&b'\0'));
+    unsafe { HostString::from_vec_unchecked(vec) }
+}
+
+/// Test whether the given `HostString` ends with a slash.
+pub(crate) fn hoststring_ends_with_slash(host: &HostString) -> bool {
+    host.to_bytes().ends_with(b"/")
+}
+
+/// Test whether the given `OsStr` ends with a slash.
+pub(crate) fn osstr_ends_with_slash(os: &OsStr) -> bool {
+    os.as_bytes().ends_with(b"/")
+}

--- a/crates/wasi-common/src/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -2,6 +2,7 @@
 #![allow(unused_unsafe)]
 use crate::sys::host_impl;
 use crate::{wasi, Result};
+use std::ffi::{CStr, OsString};
 use std::fs::File;
 use yanix::file::OFlag;
 
@@ -36,7 +37,7 @@ pub(crate) fn path_open_rights(
     (needed_base, needed_inheriting)
 }
 
-pub(crate) fn openat(dirfd: &File, path: &str) -> Result<File> {
+pub(crate) fn openat(dirfd: &File, path: &CStr) -> Result<File> {
     use std::os::unix::prelude::{AsRawFd, FromRawFd};
     use yanix::file::{openat, Mode};
 
@@ -54,13 +55,11 @@ pub(crate) fn openat(dirfd: &File, path: &str) -> Result<File> {
     .map_err(Into::into)
 }
 
-pub(crate) fn readlinkat(dirfd: &File, path: &str) -> Result<String> {
+pub(crate) fn readlinkat(dirfd: &File, path: &CStr) -> Result<OsString> {
     use std::os::unix::prelude::AsRawFd;
     use yanix::file::readlinkat;
 
     log::debug!("path_get readlinkat path = {:?}", path);
 
-    unsafe { readlinkat(dirfd.as_raw_fd(), path) }
-        .map_err(Into::into)
-        .and_then(host_impl::path_from_host)
+    unsafe { readlinkat(dirfd.as_raw_fd(), path) }.map_err(Into::into)
 }

--- a/crates/wasi-common/src/sys/unix/linux/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/linux/filetime.rs
@@ -1,6 +1,7 @@
 //! This internal module consists of helper types and functions for dealing
 //! with setting the file times specific to Linux.
 use crate::{sys::unix::filetime::FileTime, Result};
+use std::ffi::CStr;
 use std::fs::File;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
@@ -14,15 +15,14 @@ pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
 /// The original implementation can be found here: [filetime::unix::linux::set_times]
 ///
 /// [filetime::unix::linux::set_times]: https://github.com/alexcrichton/filetime/blob/master/src/unix/linux.rs#L64
-pub(crate) fn utimensat(
+pub(crate) fn utimensat<P: AsRef<CStr>>(
     dirfd: &File,
-    path: &str,
+    path: P,
     atime: FileTime,
     mtime: FileTime,
     symlink_nofollow: bool,
 ) -> Result<()> {
     use crate::sys::unix::filetime::to_timespec;
-    use std::ffi::CString;
     use std::os::unix::prelude::*;
 
     let flags = if symlink_nofollow {
@@ -35,13 +35,12 @@ pub(crate) fn utimensat(
     // current kernel then fall back to an older syscall.
     static INVALID: AtomicBool = AtomicBool::new(false);
     if !INVALID.load(Relaxed) {
-        let p = CString::new(path.as_bytes())?;
         let times = [to_timespec(&atime)?, to_timespec(&mtime)?];
         let rc = unsafe {
             libc::syscall(
                 libc::SYS_utimensat,
                 dirfd.as_raw_fd(),
-                p.as_ptr(),
+                path.as_ref().as_ptr(),
                 times.as_ptr(),
                 flags,
             )

--- a/crates/wasi-common/src/sys/unix/linux/hostcalls_impl.rs
+++ b/crates/wasi-common/src/sys/unix/linux/hostcalls_impl.rs
@@ -1,5 +1,6 @@
 use crate::hostcalls_impl::PathGet;
 use crate::Result;
+use std::ffi::CStr;
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
@@ -14,14 +15,20 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> Result<()> {
     .map_err(Into::into)
 }
 
-pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> Result<()> {
+pub(crate) fn path_symlink(old_path: &CStr, resolved: PathGet) -> Result<()> {
     use yanix::file::symlinkat;
 
     log::debug!("path_symlink old_path = {:?}", old_path);
     log::debug!("path_symlink resolved = {:?}", resolved);
 
-    unsafe { symlinkat(old_path, resolved.dirfd().as_raw_fd(), resolved.path()) }
-        .map_err(Into::into)
+    unsafe {
+        symlinkat(
+            old_path,
+            resolved.dirfd().as_raw_fd(),
+            resolved.path().as_ref(),
+        )
+    }
+    .map_err(Into::into)
 }
 
 pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> Result<()> {

--- a/crates/wasi-common/src/sys/unix/mod.rs
+++ b/crates/wasi-common/src/sys/unix/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod fdentry_impl;
 pub(crate) mod host_impl;
+mod host_string;
 pub(crate) mod hostcalls_impl;
 
 mod filetime;
@@ -25,6 +26,10 @@ cfg_if::cfg_if! {
 use crate::Result;
 use std::fs::{File, OpenOptions};
 use std::path::Path;
+
+pub(crate) use host_string::{
+    hoststring_ends_with_slash, hoststring_from_osstring, osstr_ends_with_slash, HostString,
+};
 
 pub(crate) fn dev_null() -> Result<File> {
     OpenOptions::new()

--- a/crates/wasi-common/src/sys/windows/host_string.rs
+++ b/crates/wasi-common/src/sys/windows/host_string.rs
@@ -1,0 +1,21 @@
+use std::ffi::{OsStr, OsString};
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+/// A string in the format OS APIs prefer to consume. For Windows, this is
+/// just `OsString`.
+pub(crate) type HostString = OsString;
+
+/// Convert an `OsString` to a `HostString`.
+pub(crate) fn hoststring_from_osstring(os: OsString) -> HostString {
+    os
+}
+
+/// Test whether the given `HostString` ends with a slash.
+pub(crate) fn hoststring_ends_with_slash(host: &HostString) -> bool {
+    osstr_ends_with_slash(host)
+}
+
+/// Test whether the given `OsStr` ends with a slash.
+pub(crate) fn osstr_ends_with_slash(os: &OsStr) {
+    os.encode_wide().last() == Some(u16, '/')
+}

--- a/crates/wasi-common/src/sys/windows/host_string.rs
+++ b/crates/wasi-common/src/sys/windows/host_string.rs
@@ -1,5 +1,5 @@
 use std::ffi::{OsStr, OsString};
-use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::os::windows::ffi::OsStrExt;
 
 /// A string in the format OS APIs prefer to consume. For Windows, this is
 /// just `OsString`.
@@ -17,5 +17,5 @@ pub(crate) fn hoststring_ends_with_slash(host: &HostString) -> bool {
 
 /// Test whether the given `OsStr` ends with a slash.
 pub(crate) fn osstr_ends_with_slash(os: &OsStr) {
-    os.encode_wide().last() == Some(u16, '/')
+    os.encode_wide().last() == Some('/' as u16)
 }

--- a/crates/wasi-common/src/sys/windows/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/sys/windows/hostcalls_impl/fs_helpers.rs
@@ -71,7 +71,7 @@ pub(crate) fn openat(dirfd: &File, path: &str) -> Result<File> {
         })
 }
 
-pub(crate) fn readlinkat(dirfd: &File, s_path: &str) -> Result<String> {
+pub(crate) fn readlinkat(dirfd: &File, s_path: &str) -> Result<OsString> {
     use winx::file::get_file_path;
     use winx::winerror::WinError;
 
@@ -87,7 +87,7 @@ pub(crate) fn readlinkat(dirfd: &File, s_path: &str) -> Result<String> {
             target_path
                 .strip_prefix(dir_path)
                 .map_err(|_| Error::ENOTCAPABLE)
-                .and_then(|path| path.to_str().map(String::from).ok_or(Error::EILSEQ))
+                .and_then(Into::into)
         }
         Err(e) => match e.raw_os_error() {
             Some(e) => {

--- a/crates/wasi-common/src/sys/windows/mod.rs
+++ b/crates/wasi-common/src/sys/windows/mod.rs
@@ -1,10 +1,15 @@
 pub(crate) mod fdentry_impl;
 pub(crate) mod host_impl;
+mod host_string;
 pub(crate) mod hostcalls_impl;
 
 use crate::Result;
 use std::fs::{File, OpenOptions};
 use std::path::Path;
+
+pub(crate) use host_string::{
+    hoststring_ends_with_slash, hoststring_from_osstring, osstr_ends_with_slash, HostString,
+};
 
 pub(crate) fn dev_null() -> Result<File> {
     OpenOptions::new()


### PR DESCRIPTION
On Unix, the `OsString` class has the encoding needed for talking with
host APIs, but not the NUL terminator. Add a `HostString` type to
handle this.

With `HostString`, we can reduce the number of temporary `String` and
`CString` allocations, and fewer unnecessary redundant intermediate-step
UTF-8 validations in `path_get`.

This is also a step towards a broader plan for non-Unicode filenames.
filenames.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
