### PR TITLE
Add wasmtime.h and wasi.h to package

### DIFF
--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -49,6 +49,7 @@ mkdir tmp/$api_pkgname/include
 cp LICENSE README.md tmp/$api_pkgname
 mv bins-$src/* tmp/$api_pkgname/lib
 cp crates/c-api/examples/wasm-c-api/include/wasm.h tmp/$api_pkgname/include
+cp crates/c-api/include/{wasmtime,wasi}.h tmp/$api_pkgname/include
 mktarball $api_pkgname
 
 # Move wheels to dist folder


### PR DESCRIPTION
We are not including these files in the distribution packages. This PR fixes that.