### PR TITLE
cranelift-module: expose trap information when defining functions

### DIFF
--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -152,10 +152,11 @@ impl Backend for FaerieBackend {
         ctx: &cranelift_codegen::Context,
         namespace: &ModuleNamespace<Self>,
         total_size: u32,
-    ) -> ModuleResult<FaerieCompiledFunction> {
+    ) -> ModuleResult<(FaerieCompiledFunction, Option<&Vec<TrapSite>>)> {
         let mut code: Vec<u8> = vec![0; total_size as usize];
         // TODO: Replace this with FaerieStackmapSink once it is implemented.
         let mut stackmap_sink = NullStackmapSink {};
+        let mut traps = None;
 
         // Non-lexical lifetimes would obviate the braces here.
         {
@@ -178,7 +179,7 @@ impl Backend for FaerieBackend {
                         &mut stackmap_sink,
                     )
                 };
-                trap_manifest.add_sink(trap_sink);
+                traps = Some(trap_manifest.add_sink(trap_sink));
             } else {
                 let mut trap_sink = NullTrapSink {};
                 unsafe {
@@ -200,7 +201,7 @@ impl Backend for FaerieBackend {
             .define(name, code)
             .expect("inconsistent declaration");
 
-        Ok(FaerieCompiledFunction { code_length })
+        Ok((FaerieCompiledFunction { code_length }, traps))
     }
 
     fn define_function_bytes(
@@ -210,22 +211,23 @@ impl Backend for FaerieBackend {
         bytes: &[u8],
         _namespace: &ModuleNamespace<Self>,
         traps: Vec<TrapSite>,
-    ) -> ModuleResult<FaerieCompiledFunction> {
+    ) -> ModuleResult<(FaerieCompiledFunction, Option<&Vec<TrapSite>>)> {
         let code_length: u32 = match bytes.len().try_into() {
             Ok(code_length) => code_length,
             _ => Err(ModuleError::FunctionTooLarge(name.to_string()))?,
         };
+        let mut ret_traps = None;
 
         if let Some(ref mut trap_manifest) = self.trap_manifest {
             let trap_sink = FaerieTrapSink::new_with_sites(name, code_length, traps);
-            trap_manifest.add_sink(trap_sink);
+            ret_traps = Some(trap_manifest.add_sink(trap_sink));
         }
 
         self.artifact
             .define(name, bytes.to_vec())
             .expect("inconsistent declaration");
 
-        Ok(FaerieCompiledFunction { code_length })
+        Ok((FaerieCompiledFunction { code_length }, ret_traps))
     }
 
     fn define_data(

--- a/cranelift/faerie/src/traps.rs
+++ b/cranelift/faerie/src/traps.rs
@@ -59,7 +59,8 @@ impl FaerieTrapManifest {
     }
 
     /// Put a `FaerieTrapSink` into manifest
-    pub fn add_sink(&mut self, sink: FaerieTrapSink) {
+    pub fn add_sink(&mut self, sink: FaerieTrapSink) -> &Vec<TrapSite> {
         self.sinks.push(sink);
+        &self.sinks.last().unwrap().sites
     }
 }

--- a/cranelift/faerie/src/traps.rs
+++ b/cranelift/faerie/src/traps.rs
@@ -59,7 +59,7 @@ impl FaerieTrapManifest {
     }
 
     /// Put a `FaerieTrapSink` into manifest
-    pub fn add_sink(&mut self, sink: FaerieTrapSink) -> &Vec<TrapSite> {
+    pub fn add_sink(&mut self, sink: FaerieTrapSink) -> &[TrapSite] {
         self.sinks.push(sink);
         &self.sinks.last().unwrap().sites
     }

--- a/cranelift/module/src/backend.rs
+++ b/cranelift/module/src/backend.rs
@@ -86,7 +86,7 @@ where
         ctx: &Context,
         namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> ModuleResult<Self::CompiledFunction>;
+    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)>;
 
     /// Define a function, taking the function body from the given `bytes`.
     ///
@@ -98,7 +98,7 @@ where
         bytes: &[u8],
         namespace: &ModuleNamespace<Self>,
         traps: Vec<TrapSite>,
-    ) -> ModuleResult<Self::CompiledFunction>;
+    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)>;
 
     /// Define a zero-initialized data object of the given size.
     ///

--- a/cranelift/module/src/backend.rs
+++ b/cranelift/module/src/backend.rs
@@ -86,7 +86,7 @@ where
         ctx: &Context,
         namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)>;
+    ) -> ModuleResult<(Self::CompiledFunction, &[TrapSite])>;
 
     /// Define a function, taking the function body from the given `bytes`.
     ///
@@ -98,7 +98,7 @@ where
         bytes: &[u8],
         namespace: &ModuleNamespace<Self>,
         traps: Vec<TrapSite>,
-    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)>;
+    ) -> ModuleResult<(Self::CompiledFunction, &[TrapSite])>;
 
     /// Define a zero-initialized data object of the given size.
     ///

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -354,7 +354,7 @@ where
 
 pub struct ModuleCompiledFunction<'a> {
     pub size: binemit::CodeOffset,
-    pub traps: Option<&'a Vec<TrapSite>>,
+    pub traps: &'a [TrapSite],
 }
 
 impl<B> Module<B>

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -189,7 +189,7 @@ impl Backend for ObjectBackend {
         ctx: &cranelift_codegen::Context,
         _namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> ModuleResult<(ObjectCompiledFunction, Option<&Vec<TrapSite>>)> {
+    ) -> ModuleResult<(ObjectCompiledFunction, &[TrapSite])> {
         let mut code: Vec<u8> = vec![0; code_size as usize];
         let mut reloc_sink = ObjectRelocSink::new(self.object.format());
         let mut trap_sink = ObjectTrapSink::default();
@@ -232,7 +232,7 @@ impl Backend for ObjectBackend {
         }
         let trapref = self.traps.index_mut(func_id);
         *trapref = trap_sink.sites;
-        Ok((ObjectCompiledFunction, Some(trapref)))
+        Ok((ObjectCompiledFunction, trapref))
     }
 
     fn define_function_bytes(
@@ -242,7 +242,7 @@ impl Backend for ObjectBackend {
         bytes: &[u8],
         _namespace: &ModuleNamespace<Self>,
         traps: Vec<TrapSite>,
-    ) -> ModuleResult<(ObjectCompiledFunction, Option<&Vec<TrapSite>>)> {
+    ) -> ModuleResult<(ObjectCompiledFunction, &[TrapSite])> {
         let symbol = self.functions[func_id].unwrap();
         let section = self.object.section_id(StandardSection::Text);
         let _offset = self
@@ -250,7 +250,7 @@ impl Backend for ObjectBackend {
             .add_symbol_data(symbol, section, bytes, self.function_alignment);
         let trapref = self.traps.index_mut(func_id);
         *trapref = traps;
-        Ok((ObjectCompiledFunction, Some(trapref)))
+        Ok((ObjectCompiledFunction, trapref))
     }
 
     fn define_data(

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -278,7 +278,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         ctx: &cranelift_codegen::Context,
         _namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> ModuleResult<Self::CompiledFunction> {
+    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)> {
         let size = code_size as usize;
         let ptr = self
             .memory
@@ -303,11 +303,14 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             )
         };
 
-        Ok(Self::CompiledFunction {
-            code: ptr,
-            size,
-            relocs: reloc_sink.relocs,
-        })
+        Ok((
+            Self::CompiledFunction {
+                code: ptr,
+                size,
+                relocs: reloc_sink.relocs,
+            },
+            None,
+        ))
     }
 
     fn define_function_bytes(
@@ -317,7 +320,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         bytes: &[u8],
         _namespace: &ModuleNamespace<Self>,
         _traps: Vec<TrapSite>,
-    ) -> ModuleResult<Self::CompiledFunction> {
+    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)> {
         let size = bytes.len();
         let ptr = self
             .memory
@@ -331,11 +334,14 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, size);
         }
 
-        Ok(Self::CompiledFunction {
-            code: ptr,
-            size,
-            relocs: vec![],
-        })
+        Ok((
+            Self::CompiledFunction {
+                code: ptr,
+                size,
+                relocs: vec![],
+            },
+            None,
+        ))
     }
 
     fn define_data(

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -278,7 +278,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         ctx: &cranelift_codegen::Context,
         _namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)> {
+    ) -> ModuleResult<(Self::CompiledFunction, &[TrapSite])> {
         let size = code_size as usize;
         let ptr = self
             .memory
@@ -309,7 +309,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
                 size,
                 relocs: reloc_sink.relocs,
             },
-            None,
+            &[],
         ))
     }
 
@@ -320,7 +320,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         bytes: &[u8],
         _namespace: &ModuleNamespace<Self>,
         _traps: Vec<TrapSite>,
-    ) -> ModuleResult<(Self::CompiledFunction, Option<&Vec<TrapSite>>)> {
+    ) -> ModuleResult<(Self::CompiledFunction, &[TrapSite])> {
         let size = bytes.len();
         let ptr = self
             .memory
@@ -340,7 +340,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
                 size,
                 relocs: vec![],
             },
-            None,
+            &[],
         ))
     }
 


### PR DESCRIPTION
- [X] This has been discussed in issue #1184.
- [X] A short description of what this does, why it is needed: The current interface of `cranelift-module` requires consumers who want to be informed about traps to discover that information through `Module::Product`, which is backend-specific.  Since it's advantageous to manipulate this information in a backend-agnostic way, this patch changes `Module::define_function{,_bytes}` to return information about the traps contained in the function being defined.
- [X] This PR does not contain test cases.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
