### PR TITLE
Windows fprs preservation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -200,7 +200,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
                 // See https://github.com/bytecodealliance/wasmtime/pull/1216.
                 #[cfg(windows)]
                 return true;
-            },
+            }
 
             _ => {}
         },

--- a/build.rs
+++ b/build.rs
@@ -194,8 +194,11 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", "table_copy_on_imported_tables") => return false,
             ("reference_types", _) => return true,
 
+            ("misc", "export_large_signature") |
+            ("spec", "call") |
+            ("multi_value", "call") |
             ("multi_value", "func") => {
-                // FIXME This involves a function with very large stack frame that Cranelift currently
+                // FIXME These involves functions with very large stack frames that Cranelift currently
                 // cannot compile using the fastcall (Windows) calling convention.
                 // See https://github.com/bytecodealliance/wasmtime/pull/1216.
                 #[cfg(windows)]

--- a/build.rs
+++ b/build.rs
@@ -194,6 +194,14 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", "table_copy_on_imported_tables") => return false,
             ("reference_types", _) => return true,
 
+            ("multi_value", "func") => {
+                // FIXME This involves a function with very large stack frame that Cranelift currently
+                // cannot compile using the fastcall (Windows) calling convention.
+                // See https://github.com/bytecodealliance/wasmtime/pull/1216.
+                #[cfg(windows)]
+                return true;
+            },
+
             _ => {}
         },
         _ => panic!("unrecognized strategy"),

--- a/build.rs
+++ b/build.rs
@@ -194,8 +194,8 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", "table_copy_on_imported_tables") => return false,
             ("reference_types", _) => return true,
 
-            ("misc", "export_large_signature") |
-            ("spec", "call") |
+            ("misc_testsuite", "export_large_signature") |
+            ("spec_testsuite", "call") |
             ("multi_value", "call") |
             ("multi_value", "func") => {
                 // FIXME These involves functions with very large stack frames that Cranelift currently

--- a/build.rs
+++ b/build.rs
@@ -194,10 +194,10 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", "table_copy_on_imported_tables") => return false,
             ("reference_types", _) => return true,
 
-            ("misc_testsuite", "export_large_signature") |
-            ("spec_testsuite", "call") |
-            ("multi_value", "call") |
-            ("multi_value", "func") => {
+            ("misc_testsuite", "export_large_signature")
+            | ("spec_testsuite", "call")
+            | ("multi_value", "call")
+            | ("multi_value", "func") => {
                 // FIXME These involves functions with very large stack frames that Cranelift currently
                 // cannot compile using the fastcall (Windows) calling convention.
                 // See https://github.com/bytecodealliance/wasmtime/pull/1216.

--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -206,8 +206,8 @@ impl Context {
         isa: &dyn TargetIsa,
         kind: FrameUnwindKind,
         sink: &mut dyn FrameUnwindSink,
-    ) {
-        isa.emit_unwind_info(&self.func, kind, sink);
+    ) -> CodegenResult<()> {
+        isa.emit_unwind_info(&self.func, kind, sink)
     }
 
     /// Run the verifier on the function.

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -398,7 +398,8 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
         _func: &ir::Function,
         _kind: binemit::FrameUnwindKind,
         _sink: &mut dyn binemit::FrameUnwindSink,
-    ) {
+    ) -> CodegenResult<()> {
+        Ok(())
         // No-op by default
     }
 }

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -399,8 +399,8 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
         _kind: binemit::FrameUnwindKind,
         _sink: &mut dyn binemit::FrameUnwindSink,
     ) -> CodegenResult<()> {
-        Ok(())
         // No-op by default
+        Ok(())
     }
 }
 

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -613,7 +613,7 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
         // the low 128 bits here, but we may find that in practice we should preserve all of
         // YMM6-15 (or even ZMM6-15?)
         let csr_arg =
-            ir::AbiParam::special_reg(types::F64X2, ir::ArgumentPurpose::CalleeSaved, fp_csr);
+            ir::AbiParam::special_reg(types::F64, ir::ArgumentPurpose::CalleeSaved, fp_csr);
         func.signature.params.push(csr_arg);
         func.signature.returns.push(csr_arg);
     }
@@ -852,7 +852,7 @@ fn insert_common_prologue(
 
         for reg in csrs.iter(FPR) {
             // Append param to entry Block
-            let csr_arg = pos.func.dfg.append_block_param(block, types::F64X2);
+            let csr_arg = pos.func.dfg.append_block_param(block, types::F64);
 
             // Assign it a location
             pos.func.locations[csr_arg] = ir::ValueLoc::Reg(reg);
@@ -1048,7 +1048,7 @@ fn insert_common_epilogue(
 
         for reg in csrs.iter(FPR) {
             let value = pos.ins().load(
-                types::F64X2,
+                types::F64,
                 ir::MemFlags::trusted(),
                 stack_addr,
                 fpr_offset,

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -857,7 +857,9 @@ fn insert_common_prologue(
             // Assign it a location
             pos.func.locations[csr_arg] = ir::ValueLoc::Reg(reg);
 
-            let reg_store_inst = pos.ins().store(ir::MemFlags::trusted(), csr_arg, stack_addr, fpr_offset);
+            let reg_store_inst =
+                pos.ins()
+                    .store(ir::MemFlags::trusted(), csr_arg, stack_addr, fpr_offset);
             fpr_offset += types::F64X2.bytes() as i32;
 
             if let Some(ref mut frame_layout) = pos.func.frame_layout {
@@ -1045,7 +1047,12 @@ fn insert_common_epilogue(
         pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rcx as u16);
 
         for reg in csrs.iter(FPR) {
-            let value = pos.ins().load(types::F64X2, ir::MemFlags::trusted(), stack_addr, fpr_offset);
+            let value = pos.ins().load(
+                types::F64X2,
+                ir::MemFlags::trusted(),
+                stack_addr,
+                fpr_offset,
+            );
             fpr_offset += types::F64X2.bytes() as i32;
 
             if let Some(ref mut cfa_state) = cfa_state.as_mut() {

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -626,8 +626,14 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
     // Set up the cursor and insert the prologue
     let entry_block = func.layout.entry_block().expect("missing entry block");
     let mut pos = EncCursor::new(func, isa).at_first_insertion_point(entry_block);
-    let prologue_cfa_state =
-        insert_common_prologue(&mut pos, local_stack_size, reg_type, &csrs, fpr_slot.as_ref(), isa);
+    let prologue_cfa_state = insert_common_prologue(
+        &mut pos,
+        local_stack_size,
+        reg_type,
+        &csrs,
+        fpr_slot.as_ref(),
+        isa,
+    );
 
     // Reset the cursor and insert the epilogue
     let mut pos = pos.at_position(CursorPosition::Nowhere);
@@ -886,7 +892,11 @@ fn insert_common_prologue(
         // `stack_store` is not directly encodable in x86_64 at the moment, so we'll need a base
         // address. We are well after postopt could run, so load the CSR region base once here,
         // instead of hoping that the addr/store will be combined later.
-        let stack_addr = pos.ins().stack_addr(types::I64, *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"), 0);
+        let stack_addr = pos.ins().stack_addr(
+            types::I64,
+            *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"),
+            0,
+        );
 
         // At this point we won't be using volatile registers for anything except for return
         // At this point we have not saved any CSRs yet, and arguments are all in registers. So
@@ -1010,7 +1020,11 @@ fn insert_common_epilogue(
         // `stack_store` is not directly encodable in x86_64 at the moment, so we'll need a base
         // address. We are well after postopt could run, so load the CSR region base once here,
         // instead of hoping that the addr/store will be combined later.
-        let stack_addr = pos.ins().stack_addr(types::I64, *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"), 0);
+        let stack_addr = pos.ins().stack_addr(
+            types::I64,
+            *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"),
+            0,
+        );
 
         // At this point we won't be using volatile registers for anything except for return
         // registers. Arbitrarily pick RBP as it won't hold an interesting value, and we're about

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -851,8 +851,8 @@ fn insert_common_prologue(
         pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rax as u16);
 
         for reg in csrs.iter(FPR) {
-            // Append param to entry EBB
-            let csr_arg = pos.func.dfg.append_ebb_param(ebb, types::F64X2);
+            // Append param to entry Block
+            let csr_arg = pos.func.dfg.append_block_param(block, types::F64X2);
 
             // Assign it a location
             pos.func.locations[csr_arg] = ir::ValueLoc::Reg(reg);

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -573,7 +573,7 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
     // Only create an FPR stack slot if we're going to save FPRs.
     let fpr_slot = if num_fprs > 0 {
         Some(func.create_stack_slot(ir::StackSlotData {
-            kind: ir::StackSlotKind::SpillSlot,
+            kind: ir::StackSlotKind::ExplicitSlot,
             size: (num_fprs * types::F64X2.bytes() as usize) as u32,
             offset: None,
         }))

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -574,7 +574,7 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
         csr_stack_size += (num_fprs * types::F64X2.bytes() as usize) as i32;
 
         // Ensure that csr stack space is 16-byte aligned for ideal SIMD value placement.
-        csr_stack_size = csr_stack_size & !0b1111 + 16;
+        csr_stack_size = (csr_stack_size + 15) & !0b1111;
     }
 
     // TODO: eventually use the 32 bytes (shadow store) as spill slot. This currently doesn't work
@@ -732,7 +732,7 @@ fn insert_common_prologue(
                 total_stack_size += csrs.iter(FPR).len() as i64 * types::F64X2.bytes() as i64;
 
                 // Ensure that csr stack space is 16-byte aligned for ideal SIMD value placement.
-                total_stack_size = total_stack_size & !0b1111 + 16;
+                total_stack_size = (total_stack_size + 15) & !0b1111;
             }
 
             insert_stack_check(pos, total_stack_size, stack_limit_arg);

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -1042,9 +1042,9 @@ fn insert_common_epilogue(
         let stack_addr = pos.ins().stack_addr(types::I64, *csr_slot, 0);
 
         // At this point we won't be using volatile registers for anything except for return
-        // registers. Arbitrarily pick R11 as a volatile register that is not used for return
-        // values.
-        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::r11 as u16);
+        // registers. Arbitrarily pick RBP as it won't hold an interesting value, and we're about
+        // to restore it at the end of the function anyway.
+        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rbp as u16);
 
         for reg in csrs.iter(FPR) {
             let value = pos.ins().load(

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -1042,9 +1042,9 @@ fn insert_common_epilogue(
         let stack_addr = pos.ins().stack_addr(types::I64, *csr_slot, 0);
 
         // At this point we won't be using volatile registers for anything except for return
-        // registers. Arbitrarily pick RCX as a volatile register that is not used for return
+        // registers. Arbitrarily pick R11 as a volatile register that is not used for return
         // values.
-        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rcx as u16);
+        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::r11 as u16);
 
         for reg in csrs.iter(FPR) {
             let value = pos.ins().load(

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -608,10 +608,12 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
 
     for fp_csr in csrs.iter(FPR) {
         // The calling convention described in
-        // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention only specifically
-        // discusses XMM6-XMM15, which are 128-bit registers. It may be sufficient to preserve only
-        // the low 128 bits here, but we may find that in practice we should preserve all of
-        // YMM6-15 (or even ZMM6-15?)
+        // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention only requires
+        // preserving the low 128 bits of XMM6-XMM15.
+        //
+        // TODO: For now, add just an `F64` rather than `F64X2` because `F64X2` would require
+        // encoding a fstDisp8 with REX bits set, and we currently can't encode that. F64 causes a
+        // whole XMM register to be preserved anyway.
         let csr_arg =
             ir::AbiParam::special_reg(types::F64, ir::ArgumentPurpose::CalleeSaved, fp_csr);
         func.signature.params.push(csr_arg);

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -1047,12 +1047,9 @@ fn insert_common_epilogue(
         pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rbp as u16);
 
         for reg in csrs.iter(FPR) {
-            let value = pos.ins().load(
-                types::F64,
-                ir::MemFlags::trusted(),
-                stack_addr,
-                fpr_offset,
-            );
+            let value = pos
+                .ins()
+                .load(types::F64, ir::MemFlags::trusted(), stack_addr, fpr_offset);
             fpr_offset += types::F64X2.bytes() as i32;
 
             if let Some(ref mut cfa_state) = cfa_state.as_mut() {

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -21,11 +21,11 @@ use crate::ir::{
     FrameLayoutChange, InstBuilder, ValueLoc,
 };
 use crate::isa::{CallConv, RegClass, RegUnit, TargetIsa};
-use alloc::vec::Vec;
 use crate::regalloc::RegisterSet;
 use crate::result::CodegenResult;
 use crate::stack_layout::layout_stack;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use core::i32;
 use std::boxed::Box;
 use target_lexicon::{PointerWidth, Triple};

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -407,7 +407,7 @@ fn callee_saved_fprs(isa: &dyn TargetIsa, call_conv: CallConv) -> &'static [RU] 
                 // "registers RBX, ... , and XMM6-15 are considered nonvolatile and must be saved
                 //  and restored by a function that uses them."
                 // as per https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention as of
-                // February 2nd, 2020.
+                // February 5th, 2020.
                 &[
                     RU::xmm6,
                     RU::xmm7,

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -1161,7 +1161,7 @@ pub fn emit_unwind_info(
         }
         FrameUnwindKind::Libunwind => {
             if func.frame_layout.is_some() {
-                emit_fde(func, isa, sink);
+                emit_fde(func, isa, sink)?;
             }
         }
     }

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -21,6 +21,7 @@ use crate::ir::{
     FrameLayoutChange, InstBuilder, ValueLoc,
 };
 use crate::isa::{CallConv, RegClass, RegUnit, TargetIsa};
+use alloc::vec::Vec;
 use crate::regalloc::RegisterSet;
 use crate::result::CodegenResult;
 use crate::stack_layout::layout_stack;
@@ -1014,7 +1015,7 @@ fn insert_common_epilogue(
 
     // Even though instructions to restore FPRs are inserted first, we have to append them after
     // restored GPRs to satisfy parameter order in the return.
-    let mut restored_fpr_values = alloc::vec::Vec::new();
+    let mut restored_fpr_values = Vec::new();
 
     // Restore FPRs before we move RSP and invalidate stack slots.
     if let Some(fpr_slot) = fpr_slot {
@@ -1149,12 +1150,12 @@ pub fn emit_unwind_info(
     isa: &dyn TargetIsa,
     kind: FrameUnwindKind,
     sink: &mut dyn FrameUnwindSink,
-) {
+) -> CodegenResult<()> {
     match kind {
         FrameUnwindKind::Fastcall => {
             // Assumption: RBP is being used as the frame pointer
             // In the future, Windows fastcall codegen should usually omit the frame pointer
-            if let Some(info) = UnwindInfo::try_from_func(func, isa, Some(RU::rbp.into())) {
+            if let Some(info) = UnwindInfo::try_from_func(func, isa, Some(RU::rbp.into()))? {
                 info.emit(sink);
             }
         }
@@ -1164,4 +1165,6 @@ pub fn emit_unwind_info(
             }
         }
     }
+
+    Ok(())
 }

--- a/cranelift/codegen/src/isa/x86/mod.rs
+++ b/cranelift/codegen/src/isa/x86/mod.rs
@@ -177,8 +177,8 @@ impl TargetIsa for Isa {
         func: &ir::Function,
         kind: FrameUnwindKind,
         sink: &mut dyn FrameUnwindSink,
-    ) {
-        abi::emit_unwind_info(func, self, kind, sink);
+    ) -> CodegenResult<()> {
+        abi::emit_unwind_info(func, self, kind, sink)
     }
 }
 

--- a/cranelift/codegen/src/isa/x86/unwind.rs
+++ b/cranelift/codegen/src/isa/x86/unwind.rs
@@ -35,10 +35,23 @@ fn write_u32<T: ByteOrder>(sink: &mut dyn FrameUnwindSink, v: u32) {
 /// Note: the Cranelift x86 ISA RU enum matches the Windows unwind GPR encoding values.
 #[derive(Debug, PartialEq, Eq)]
 enum UnwindCode {
-    PushRegister { offset: u8, reg: RegUnit },
-    SaveXmm { offset: u8, reg: RegUnit, stack_offset: u32 },
-    StackAlloc { offset: u8, size: u32 },
-    SetFramePointer { offset: u8, sp_offset: u8 },
+    PushRegister {
+        offset: u8,
+        reg: RegUnit,
+    },
+    SaveXmm {
+        offset: u8,
+        reg: RegUnit,
+        stack_offset: u32,
+    },
+    StackAlloc {
+        offset: u8,
+        size: u32,
+    },
+    SetFramePointer {
+        offset: u8,
+        sp_offset: u8,
+    },
 }
 
 impl UnwindCode {
@@ -61,7 +74,11 @@ impl UnwindCode {
                         | (UnwindOperation::PushNonvolatileRegister as u8),
                 );
             }
-            Self::SaveXmm { offset, reg, stack_offset } => {
+            Self::SaveXmm {
+                offset,
+                reg,
+                stack_offset,
+            } => {
                 write_u8(sink, *offset);
                 if *stack_offset <= core::u16::MAX as u32 {
                     write_u8(
@@ -124,7 +141,7 @@ impl UnwindCode {
                 } else {
                     3
                 }
-            },
+            }
             _ => 1,
         }
     }
@@ -229,7 +246,12 @@ impl UnwindInfo {
                         _ => {}
                     }
                 }
-                InstructionData::Store { opcode: Opcode::Store, args: [arg1, arg2], flags, offset } => {
+                InstructionData::Store {
+                    opcode: Opcode::Store,
+                    args: [arg1, _arg2],
+                    flags: _flags,
+                    offset,
+                } => {
                     if let ValueLoc::Reg(ru) = func.locations[arg1] {
                         let offset_int: i32 = offset.into();
                         assert!(offset_int >= 0);

--- a/cranelift/codegen/src/isa/x86/unwind.rs
+++ b/cranelift/codegen/src/isa/x86/unwind.rs
@@ -197,8 +197,6 @@ impl UnwindInfo {
         // save offsets to compute an offset from the frame base.
         let mut callee_save_offset = None;
 
-        let mut prologue_text = alloc::string::String::new();
-
         for (offset, inst, size) in func.inst_offsets(entry_block, &isa.encoding_info()) {
             // x64 ABI prologues cannot exceed 255 bytes in length
             if (offset + size) > 255 {
@@ -208,12 +206,6 @@ impl UnwindInfo {
             prologue_size += size;
 
             let unwind_offset = (offset + size) as u8;
-
-            prologue_text.push_str(&format!(
-                "offset {}: {} ; ",
-                offset,
-                func.dfg.display_inst(inst, isa)
-            ));
 
             match func.dfg[inst] {
                 InstructionData::Unary { opcode, arg } => {
@@ -346,7 +338,7 @@ impl UnwindInfo {
 
         if saved_fpr {
             if static_frame_allocation_size > 240 && saved_fpr {
-                panic!("stack frame is too large to use with Windows x64 SEH when preserving FPRs. size is {}, prologue is {}", static_frame_allocation_size, prologue_text);
+                panic!("stack frame is too large ({} bytes) to use with Windows x64 SEH when preserving FPRs", static_frame_allocation_size);
             }
             // Only test static frame size is 16-byte aligned when an FPR is saved to avoid
             // panicking when alignment is elided because no FPRs are saved and no child calls are

--- a/cranelift/codegen/src/isa/x86/unwind.rs
+++ b/cranelift/codegen/src/isa/x86/unwind.rs
@@ -207,6 +207,8 @@ impl UnwindInfo {
 
             let unwind_offset = (offset + size) as u8;
 
+            println!("inst offset {}: {}", offset, func.dfg.display_inst(inst, isa));
+
             match func.dfg[inst] {
                 InstructionData::Unary { opcode, arg } => {
                     match opcode {
@@ -336,10 +338,15 @@ impl UnwindInfo {
         if static_frame_allocation_size > 240 && saved_fpr {
             panic!("stack frame is too large to use with Windows x64 SEH when preserving FPRs");
         }
-        assert!(
-            static_frame_allocation_size % 16 == 0,
-            "static frame allocation must be a multiple of 16"
-        );
+        if static_frame_allocation_size % 16 != 0 {
+            eprintln!("static frame allocation size: {}", static_frame_allocation_size);
+            panic!("bad frame size");
+        } else {
+            assert!(
+                static_frame_allocation_size % 16 == 0,
+                "static frame allocation must be a multiple of 16"
+            );
+        }
 
         // Hack to avoid panicking unnecessarily. Because Cranelift generates prologues with RBP at
         // one end of the call frame, and RSP at the other, required offsets are arbitrarily large.

--- a/cranelift/codegen/src/isa/x86/unwind.rs
+++ b/cranelift/codegen/src/isa/x86/unwind.rs
@@ -281,10 +281,16 @@ impl UnwindInfo {
                         callee_save_region_reg = Some(frame_reg);
 
                         // Figure out the offset in the call frame that `frame_reg` will have.
-                        let frame_size = func.stack_slots.layout_info.expect("func's stack slots have layout info if stack operations exist").frame_size;
+                        let frame_size = func
+                            .stack_slots
+                            .layout_info
+                            .expect("func's stack slots have layout info if stack operations exist")
+                            .frame_size;
                         // Because we're well after the prologue has been constructed, stack slots
                         // must have been laid out...
-                        let slot_offset = func.stack_slots[stack_slot].offset.expect("callee-save slot has an offset computed");
+                        let slot_offset = func.stack_slots[stack_slot]
+                            .offset
+                            .expect("callee-save slot has an offset computed");
                         let frame_offset = frame_size as i32 + slot_offset;
 
                         callee_save_offset = Some(frame_offset as u32);
@@ -330,7 +336,10 @@ impl UnwindInfo {
         if static_frame_allocation_size > 240 && saved_fpr {
             panic!("stack frame is too large to use with Windows x64 SEH when preserving FPRs");
         }
-        assert!(static_frame_allocation_size % 16 == 0, "static frame allocation must be a multiple of 16");
+        assert!(
+            static_frame_allocation_size % 16 == 0,
+            "static frame allocation must be a multiple of 16"
+        );
 
         // Hack to avoid panicking unnecessarily. Because Cranelift generates prologues with RBP at
         // one end of the call frame, and RSP at the other, required offsets are arbitrarily large.

--- a/cranelift/codegen/src/isa/x86/unwind.rs
+++ b/cranelift/codegen/src/isa/x86/unwind.rs
@@ -338,7 +338,10 @@ impl UnwindInfo {
 
         if saved_fpr {
             if static_frame_allocation_size > 240 && saved_fpr {
-                panic!("stack frame is too large ({} bytes) to use with Windows x64 SEH when preserving FPRs", static_frame_allocation_size);
+                panic!("stack frame is too large ({} bytes) to use with Windows x64 SEH when preserving FPRs. \
+                    This is a Cranelift implementation limit, see \
+                    https://github.com/bytecodealliance/wasmtime/issues/1475",
+                    static_frame_allocation_size);
             }
             // Only test static frame size is 16-byte aligned when an FPR is saved to avoid
             // panicking when alignment is elided because no FPRs are saved and no child calls are

--- a/cranelift/codegen/src/isa/x86/unwind.rs
+++ b/cranelift/codegen/src/isa/x86/unwind.rs
@@ -474,7 +474,10 @@ mod tests {
 
         context.compile(&*isa).expect("expected compilation");
 
-        assert_eq!(UnwindInfo::try_from_func(&context.func, &*isa, None).expect("can emit unwind info"), None);
+        assert_eq!(
+            UnwindInfo::try_from_func(&context.func, &*isa, None).expect("can emit unwind info"),
+            None
+        );
     }
 
     #[test]

--- a/cranelift/codegen/src/regalloc/register_set.rs
+++ b/cranelift/codegen/src/regalloc/register_set.rs
@@ -46,11 +46,6 @@ impl RegisterSet {
         Self { avail: [0; 3] }
     }
 
-    /// Returns `true` if all registers in this set are available.
-    pub fn is_empty(&self) -> bool {
-        self.avail == [0; 3]
-    }
-
     /// Returns `true` if the specified register is available.
     pub fn is_avail(&self, rc: RegClass, reg: RegUnit) -> bool {
         let (idx, bits) = bitmask(rc, reg);

--- a/cranelift/codegen/src/regalloc/register_set.rs
+++ b/cranelift/codegen/src/regalloc/register_set.rs
@@ -46,6 +46,11 @@ impl RegisterSet {
         Self { avail: [0; 3] }
     }
 
+    /// Returns `true` if all registers in this set are available.
+    pub fn is_empty(&self) -> bool {
+        self.avail == [0; 3]
+    }
+
     /// Returns `true` if the specified register is available.
     pub fn is_avail(&self, rc: RegClass, reg: RegUnit) -> bool {
         let (idx, bits) = bitmask(rc, reg);

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -68,3 +68,29 @@ block0(v0: f32, v1: f64, v2: i64, v3: i64):
     return v1
 }
 ; check: function %ret_val_float(f32 [%xmm0], f64 [%xmm1], i64 [%r8], i64 [%r9], i64 fp [%rbp]) -> f64 [%xmm0], i64 fp [%rbp] windows_fastcall {
+
+function %internal_stack_arg_function_call(i64) -> i64 windows_fastcall {
+  fn0 = %foo(i64, i64, i64, i64) -> i64
+  fn1 = %foo2(i64, i64, i64, i64) -> i64
+block0(v0: i64):
+    v1 = load.i64 v0+0
+    v2 = load.i64 v0+8
+    v3 = load.i64 v0+16
+    v4 = load.i64 v0+24
+    v5 = load.i64 v0+32
+    v6 = load.i64 v0+40
+    v7 = load.i64 v0+48
+    v8 = load.i64 v0+56
+    v9 = load.i64 v0+64
+    v10 = call fn0(v1, v2, v3, v4)
+    store.i64 v1, v0+8
+    store.i64 v2, v0+16
+    store.i64 v3, v0+24
+    store.i64 v4, v0+32
+    store.i64 v5, v0+40
+    store.i64 v6, v0+48
+    store.i64 v7, v0+56
+    store.i64 v8, v0+64
+    store.i64 v9, v0+72
+    return v10
+}

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -48,8 +48,8 @@ ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
 ; nextln:                         store notrap aligned v8, v7
 ; nextln:                         store notrap aligned v9, v7+16
 ; check:                          v11 = stack_addr.i64 ss0
-; nextln: [Op2fldDisp8#410,%xmm7] v13 = load.f64x2 notrap aligned v11+16
-; nextln: [Op2fld#410,%xmm6]      v12 = load.f64x2 notrap aligned v11
+; nextln:                         v13 = load.f64x2 notrap aligned v11+16
+; nextln:                         v12 = load.f64x2 notrap aligned v11
 ; nextln:                         v10 = x86_pop.i64
 ; nextln:                         v10, v12, v13
 

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -34,14 +34,14 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 
 ; check that we preserve xmm6 and above if we're using them locally
 function %float_callee_saves(f64, f64, f64, f64) windows_fastcall {
-ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
+block0(v0: f64, v1: f64, v2: f64, v3: f64):
 ; explicitly use a callee-save register
 [-, %xmm6]  v4 = fadd v0, v1
 [-, %xmm7]  v5 = fadd v0, v1
     return
 }
 ; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7]) -> i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7] windows_fastcall {
-; check: ebb0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
+; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp
 ; nextln:                         v7 = stack_addr.i64 ss0

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -32,6 +32,16 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 }
 ; check: function %five_args(i64 [%rcx], i64 [%rdx], i64 [%r8], i64 [%r9], i64 [32], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
 
+; check that we preserve xmm6 and above if we're using them locally
+function %float_callee_saves(f64, f64, f64, f64) windows_fastcall {
+ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
+[-, %xmm6]  v4 = fadd v0, v1      ; bin: 66 0f db f3
+;[-, %xmm6]  v5 = fadd v4, v2      ; bin: 66 0f db f3
+;[-, %xmm6]  v6 = fadd v5, v3      ; bin: 66 0f db f3
+    return
+}
+; check: function %float_callee_saves(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], f64 [%xmm6], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+
 function %mixed_int_float(i64, f64, i64, f32) windows_fastcall {
 block0(v0: i64, v1: f64, v2: i64, v3: f32):
     return

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -41,6 +41,8 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
     return
 }
 ; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7]) -> i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7] windows_fastcall {
+; nextln:                         ss0 = spill_slot 32, offset -80
+; nextln:                         ss1 = incoming_arg 16, offset -48
 ; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64 [%xmm6], v9: f64 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -40,16 +40,16 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
 [-, %xmm7]  v5 = fadd v0, v1
     return
 }
-; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7]) -> i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7] windows_fastcall {
-; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
+; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7]) -> i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7] windows_fastcall {
+; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64 [%xmm6], v9: f64 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp
 ; nextln:                         v7 = stack_addr.i64 ss0
 ; nextln:                         store notrap aligned v8, v7
 ; nextln:                         store notrap aligned v9, v7+16
 ; check:                          v11 = stack_addr.i64 ss0
-; nextln:                         v13 = load.f64x2 notrap aligned v11+16
-; nextln:                         v12 = load.f64x2 notrap aligned v11
+; nextln:                         v13 = load.f64 notrap aligned v11+16
+; nextln:                         v12 = load.f64 notrap aligned v11
 ; nextln:                         v10 = x86_pop.i64
 ; nextln:                         v10, v12, v13
 

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -44,14 +44,16 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
 ; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64 [%xmm6], v9: f64 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp
+; nextln:                         adjust_sp_down_imm 64
 ; nextln:                         v7 = stack_addr.i64 ss0
 ; nextln:                         store notrap aligned v8, v7
 ; nextln:                         store notrap aligned v9, v7+16
-; check:                          v11 = stack_addr.i64 ss0
-; nextln:                         v13 = load.f64 notrap aligned v11+16
-; nextln:                         v12 = load.f64 notrap aligned v11
-; nextln:                         v10 = x86_pop.i64
-; nextln:                         v10, v12, v13
+; check:                          v10 = stack_addr.i64 ss0
+; nextln:                         v11 = load.f64 notrap aligned v10
+; nextln:                         v12 = load.f64 notrap aligned v10+16
+; nextln:                         adjust_sp_up_imm 64
+; nextln:                         v13 = x86_pop.i64
+; nextln:                         v13, v11, v12
 
 function %mixed_int_float(i64, f64, i64, f32) windows_fastcall {
 block0(v0: i64, v1: f64, v2: i64, v3: f32):

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -41,7 +41,7 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
     return
 }
 ; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7]) -> i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7] windows_fastcall {
-; nextln:                         ss0 = spill_slot 32, offset -80
+; nextln:                         ss0 = explicit_slot 32, offset -80
 ; nextln:                         ss1 = incoming_arg 16, offset -48
 ; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64 [%xmm6], v9: f64 [%xmm7]):
 ; nextln:                         x86_push v6

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -35,12 +35,23 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ; check that we preserve xmm6 and above if we're using them locally
 function %float_callee_saves(f64, f64, f64, f64) windows_fastcall {
 ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
-[-, %xmm6]  v4 = fadd v0, v1      ; bin: 66 0f db f3
-;[-, %xmm6]  v5 = fadd v4, v2      ; bin: 66 0f db f3
-;[-, %xmm6]  v6 = fadd v5, v3      ; bin: 66 0f db f3
+; explicitly use a callee-save register
+[-, %xmm6]  v4 = fadd v0, v1
+[-, %xmm7]  v5 = fadd v0, v1
     return
 }
-; check: function %float_callee_saves(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], f64 [%xmm6], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7]) -> i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7] windows_fastcall {
+; check: ebb0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
+; nextln:                         x86_push v6
+; nextln:                         copy_special %rsp -> %rbp
+; nextln:                         v7 = stack_addr.i64 ss0
+; nextln:                         store notrap aligned v8, v7
+; nextln:                         store notrap aligned v9, v7+16
+; check:                          v11 = stack_addr.i64 ss0
+; nextln: [Op2fldDisp8#410,%xmm7] v13 = load.f64x2 notrap aligned v11+16
+; nextln: [Op2fld#410,%xmm6]      v12 = load.f64x2 notrap aligned v11
+; nextln:                         v10 = x86_pop.i64
+; nextln:                         v10, v12, v13
 
 function %mixed_int_float(i64, f64, i64, f32) windows_fastcall {
 block0(v0: i64, v1: f64, v2: i64, v3: f32):

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -118,6 +118,41 @@ block0:
 ; nextln:     ],
 ; nextln: }
 
+function %fpr_with_function_call(i64, i64) windows_fastcall {
+    fn0 = %foo(f64, f64, i64, i64, i64) windows_fastcall;
+block0(v0: i64, v1: i64):
+    v2 = load.f64 v0+0
+    v3 = load.f64 v0+8
+    v4 = load.i64 v0+16
+    v15 = load.f64 v0+104
+    v16 = load.f64 v0+112
+    v17 = load.f64 v0+120
+    v18 = load.f64 v0+128
+    v19 = load.f64 v0+136
+    v20 = load.f64 v0+144
+    v21 = load.f64 v0+152
+    v22 = load.f64 v0+160
+    v23 = load.f64 v0+168
+    call fn0(v2, v3, v4, v1, v1)
+    store.f64 v15, v1+104
+    store.f64 v16, v1+112
+    store.f64 v17, v1+120
+    store.f64 v18, v1+128
+    store.f64 v19, v1+136
+    store.f64 v20, v1+144
+    store.f64 v21, v1+152
+    store.f64 v22, v1+160
+    store.f64 v23, v1+168
+    return
+}
+; sameln: UnwindInfo {
+; nextln:     version: 1,
+; nextln:     flags: 0,
+; nextln:     prologue_size: 17,
+; nextln:     unwind_code_count_raw: 5,
+; nextln:     frame_register: 5,
+; nextln:     frame_register_offset: 0,
+
 ; check a function that has CSRs
 function %lots_of_registers(i64, i64) windows_fastcall {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -145,6 +145,11 @@ block0(v0: i64, v1: i64):
     store.f64 v23, v1+168
     return
 }
+; Only check the first unwind code here because this test specifically looks to
+; see that in a function that is not a leaf, a callee-save FPR is stored in an
+; area that does not overlap either the callee's shadow space or stack argument
+; space.
+;
 ; sameln: UnwindInfo {
 ; nextln:     version: 1,
 ; nextln:     flags: 0,

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -134,6 +134,15 @@ block0(v0: i64, v1: i64):
     v12 = load.i32 v0+80
     v13 = load.i32 v0+88
     v14 = load.i32 v0+96
+    v15 = load.f64 v0+104
+    v16 = load.f64 v0+112
+    v17 = load.f64 v0+120
+    v18 = load.f64 v0+128
+    v19 = load.f64 v0+136
+    v20 = load.f64 v0+144
+    v21 = load.f64 v0+152
+    v22 = load.f64 v0+160
+    v23 = load.f64 v0+168
     store.i32 v2, v1+0
     store.i32 v3, v1+8
     store.i32 v4, v1+16
@@ -147,21 +156,54 @@ block0(v0: i64, v1: i64):
     store.i32 v12, v1+80
     store.i32 v13, v1+88
     store.i32 v14, v1+96
+    store.f64 v15, v1+104
+    store.f64 v16, v1+112
+    store.f64 v17, v1+120
+    store.f64 v18, v1+128
+    store.f64 v19, v1+136
+    store.f64 v20, v1+144
+    store.f64 v21, v1+152
+    store.f64 v22, v1+160
+    store.f64 v23, v1+168
     return
 }
 ; sameln: UnwindInfo {
 ; nextln:     version: 1,
 ; nextln:     flags: 0,
-; nextln:     prologue_size: 19,
-; nextln:     unwind_code_count_raw: 10,
+; nextln:     prologue_size: 42,
+; nextln:     unwind_code_count_raw: 16,
 ; nextln:     frame_register: 5,
 ; nextln:     frame_register_offset: 0,
 ; nextln:     unwind_codes: [
 ; nextln:         UnwindCode {
-; nextln:             offset: 19,
+; nextln:             offset: 42,
 ; nextln:             op: SmallStackAlloc,
-; nextln:             info: 3,
+; nextln:             info: 5,
 ; nextln:             value: None,
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:           offset: 38,
+; nextln:           op: SaveXmm128,
+; nextln:           info: 8,
+; nextln:           value: U16(
+; nextln:             2,
+; nextln:           ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:           offset: 32,
+; nextln:           op: SaveXmm128,
+; nextln:           info: 7,
+; nextln:           value: U16(
+; nextln:             1,
+; nextln:           ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:           offset: 27,
+; nextln:           op: SaveXmm128,
+; nextln:           info: 6,
+; nextln:           value: U16(
+; nextln:             0,
+; nextln:           ),
 ; nextln:         },
 ; nextln:         UnwindCode {
 ; nextln:             offset: 15,

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -148,10 +148,17 @@ block0(v0: i64, v1: i64):
 ; sameln: UnwindInfo {
 ; nextln:     version: 1,
 ; nextln:     flags: 0,
-; nextln:     prologue_size: 17,
-; nextln:     unwind_code_count_raw: 5,
+; nextln:     prologue_size: 26,
+; nextln:     unwind_code_count_raw: 7,
 ; nextln:     frame_register: 5,
-; nextln:     frame_register_offset: 0,
+; nextln:     frame_register_offset: 12,
+; nextln:     unwind_codes: [
+; nextln:       UnwindCode {
+; nextln:         offset: 26,
+; nextln:         op: SaveXmm128,
+; nextln:         info: 15,
+; nextln:         value: U16(
+; nextln:             3,
 
 ; check a function that has CSRs
 function %lots_of_registers(i64, i64) windows_fastcall {
@@ -205,13 +212,13 @@ block0(v0: i64, v1: i64):
 ; sameln: UnwindInfo {
 ; nextln:     version: 1,
 ; nextln:     flags: 0,
-; nextln:     prologue_size: 42,
+; nextln:     prologue_size: 44,
 ; nextln:     unwind_code_count_raw: 16,
 ; nextln:     frame_register: 5,
-; nextln:     frame_register_offset: 0,
+; nextln:     frame_register_offset: 10,
 ; nextln:     unwind_codes: [
 ; nextln:         UnwindCode {
-; nextln:             offset: 42,
+; nextln:             offset: 44,
 ; nextln:             op: SaveXmm128,
 ; nextln:             info: 8,
 ; nextln:             value: U16(
@@ -219,7 +226,7 @@ block0(v0: i64, v1: i64):
 ; nextln:             ),
 ; nextln:           },
 ; nextln:         UnwindCode {
-; nextln:             offset: 36,
+; nextln:             offset: 38,
 ; nextln:             op: SaveXmm128,
 ; nextln:             info: 7,
 ; nextln:             value: U16(
@@ -227,7 +234,7 @@ block0(v0: i64, v1: i64):
 ; nextln:             ),
 ; nextln:         },
 ; nextln:         UnwindCode {
-; nextln:             offset: 31,
+; nextln:             offset: 32,
 ; nextln:             op: SaveXmm128,
 ; nextln:             info: 6,
 ; nextln:             value: U16(

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -177,33 +177,33 @@ block0(v0: i64, v1: i64):
 ; nextln:     unwind_codes: [
 ; nextln:         UnwindCode {
 ; nextln:             offset: 42,
+; nextln:             op: SaveXmm128,
+; nextln:             info: 8,
+; nextln:             value: U16(
+; nextln:                 2,
+; nextln:             ),
+; nextln:           },
+; nextln:         UnwindCode {
+; nextln:             offset: 36,
+; nextln:             op: SaveXmm128,
+; nextln:             info: 7,
+; nextln:             value: U16(
+; nextln:                 1,
+; nextln:             ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:             offset: 31,
+; nextln:             op: SaveXmm128,
+; nextln:             info: 6,
+; nextln:             value: U16(
+; nextln:                 0,
+; nextln:             ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:             offset: 19,
 ; nextln:             op: SmallStackAlloc,
-; nextln:             info: 5,
+; nextln:             info: 12,
 ; nextln:             value: None,
-; nextln:         },
-; nextln:         UnwindCode {
-; nextln:           offset: 38,
-; nextln:           op: SaveXmm128,
-; nextln:           info: 8,
-; nextln:           value: U16(
-; nextln:             2,
-; nextln:           ),
-; nextln:         },
-; nextln:         UnwindCode {
-; nextln:           offset: 32,
-; nextln:           op: SaveXmm128,
-; nextln:           info: 7,
-; nextln:           value: U16(
-; nextln:             1,
-; nextln:           ),
-; nextln:         },
-; nextln:         UnwindCode {
-; nextln:           offset: 27,
-; nextln:           op: SaveXmm128,
-; nextln:           info: 6,
-; nextln:           value: U16(
-; nextln:             0,
-; nextln:           ),
 ; nextln:         },
 ; nextln:         UnwindCode {
 ; nextln:             offset: 15,

--- a/cranelift/filetests/src/test_fde.rs
+++ b/cranelift/filetests/src/test_fde.rs
@@ -64,7 +64,9 @@ impl SubTest for TestUnwind {
         }
 
         let mut sink = SimpleUnwindSink(Vec::new(), 0, Vec::new());
-        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Libunwind, &mut sink).expect("can emit unwind info");
+        comp_ctx
+            .emit_unwind_info(isa, FrameUnwindKind::Libunwind, &mut sink)
+            .expect("can emit unwind info");
 
         let mut text = String::new();
         if sink.0.is_empty() {

--- a/cranelift/filetests/src/test_fde.rs
+++ b/cranelift/filetests/src/test_fde.rs
@@ -64,7 +64,7 @@ impl SubTest for TestUnwind {
         }
 
         let mut sink = SimpleUnwindSink(Vec::new(), 0, Vec::new());
-        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Libunwind, &mut sink);
+        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Libunwind, &mut sink).expect("can emit unwind info");
 
         let mut text = String::new();
         if sink.0.is_empty() {

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -177,15 +177,15 @@ impl UnwindCode {
 
 #[derive(Debug)]
 enum UnwindOperation {
-    PushNonvolatileRegister,
-    LargeStackAlloc,
-    SmallStackAlloc,
-    SetFramePointer,
-    SaveNonvolatileRegister,
-    SaveNonvolatileRegisterFar,
-    SaveXmm128,
-    SaveXmm128Far,
-    PushMachineFrame,
+    PushNonvolatileRegister = 0,
+    LargeStackAlloc = 1,
+    SmallStackAlloc = 2,
+    SetFramePointer = 3,
+    SaveNonvolatileRegister = 4,
+    SaveNonvolatileRegisterFar = 5,
+    SaveXmm128 = 8,
+    SaveXmm128Far = 9,
+    PushMachineFrame = 10,
 }
 
 impl From<u8> for UnwindOperation {
@@ -198,9 +198,9 @@ impl From<u8> for UnwindOperation {
             3 => Self::SetFramePointer,
             4 => Self::SaveNonvolatileRegister,
             5 => Self::SaveNonvolatileRegisterFar,
-            6 => Self::SaveXmm128,
-            7 => Self::SaveXmm128Far,
-            8 => Self::PushMachineFrame,
+            8 => Self::SaveXmm128,
+            9 => Self::SaveXmm128Far,
+            10 => Self::PushMachineFrame,
             _ => panic!("unsupported unwind operation"),
         }
     }

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -59,7 +59,7 @@ impl SubTest for TestUnwind {
         }
 
         let mut sink = Sink(Vec::new());
-        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Fastcall, &mut sink);
+        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Fastcall, &mut sink).expect("can emit unwind info");
 
         let mut text = String::new();
         if sink.0.is_empty() {

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -59,7 +59,9 @@ impl SubTest for TestUnwind {
         }
 
         let mut sink = Sink(Vec::new());
-        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Fastcall, &mut sink).expect("can emit unwind info");
+        comp_ctx
+            .emit_unwind_info(isa, FrameUnwindKind::Fastcall, &mut sink)
+            .expect("can emit unwind info");
 
         let mut text = String::new();
         if sink.0.is_empty() {

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -188,7 +188,9 @@ fn make_trampoline(
         .map_err(|error| pretty_error(&context.func, Some(isa), error))
         .expect("compile_and_emit");
 
-    let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context);
+    let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context)
+        .map_err(|error| pretty_error(&context.func, Some(isa), error))
+        .expect("emit unwind info");
 
     code_memory
         .allocate_for_function(&CompiledFunction {

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -4,7 +4,7 @@
 use crate::cache::ModuleCacheDataTupleType;
 use crate::CacheConfig;
 use crate::ModuleTranslation;
-use cranelift_codegen::{binemit, ir, isa, Context};
+use cranelift_codegen::{binemit, ir, isa, Context, CodegenResult};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex, WasmError};
 use serde::{Deserialize, Serialize};
@@ -36,7 +36,7 @@ pub enum CompiledFunctionUnwindInfo {
 
 impl CompiledFunctionUnwindInfo {
     /// Constructs unwind info object.
-    pub fn new(isa: &dyn isa::TargetIsa, context: &Context) -> Self {
+    pub fn new(isa: &dyn isa::TargetIsa, context: &Context) -> CodegenResult<Self> {
         use cranelift_codegen::binemit::{
             FrameUnwindKind, FrameUnwindOffset, FrameUnwindSink, Reloc,
         };
@@ -75,24 +75,26 @@ impl CompiledFunctionUnwindInfo {
             CallConv::SystemV | CallConv::Fast | CallConv::Cold => FrameUnwindKind::Libunwind,
             CallConv::WindowsFastcall => FrameUnwindKind::Fastcall,
             _ => {
-                return CompiledFunctionUnwindInfo::None;
+                return Ok(CompiledFunctionUnwindInfo::None);
             }
         };
 
         let mut sink = Sink(Vec::new(), 0, Vec::new());
-        context.emit_unwind_info(isa, kind, &mut sink).expect("can emit unwind info");;
+        context.emit_unwind_info(isa, kind, &mut sink)?;
 
         let Sink(data, offset, relocs) = sink;
         if data.is_empty() {
-            return CompiledFunctionUnwindInfo::None;
+            return Ok(CompiledFunctionUnwindInfo::None);
         }
 
-        match kind {
+        let info = match kind {
             FrameUnwindKind::Fastcall => CompiledFunctionUnwindInfo::Windows(data),
             FrameUnwindKind::Libunwind => {
                 CompiledFunctionUnwindInfo::FrameLayout(data, offset, relocs)
             }
-        }
+        };
+
+        Ok(info)
     }
 
     /// Retuns true is no unwind info data.

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -80,7 +80,7 @@ impl CompiledFunctionUnwindInfo {
         };
 
         let mut sink = Sink(Vec::new(), 0, Vec::new());
-        context.emit_unwind_info(isa, kind, &mut sink);
+        context.emit_unwind_info(isa, kind, &mut sink).expect("can emit unwind info");;
 
         let Sink(data, offset, relocs) = sink;
         if data.is_empty() {

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -4,7 +4,7 @@
 use crate::cache::ModuleCacheDataTupleType;
 use crate::CacheConfig;
 use crate::ModuleTranslation;
-use cranelift_codegen::{binemit, ir, isa, Context, CodegenResult};
+use cranelift_codegen::{binemit, ir, isa, CodegenResult, Context};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex, WasmError};
 use serde::{Deserialize, Serialize};

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -264,7 +264,10 @@ fn compile(env: CompileEnv<'_>) -> Result<ModuleCacheDataTupleType, CompileError
                     CompileError::Codegen(pretty_error(&context.func, Some(isa), error))
                 })?;
 
-            let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context);
+            let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context)
+                .map_err(|error| {
+                    CompileError::Codegen(pretty_error(&context.func, Some(isa), error))
+                })?;
 
             let address_transform = if env.tunables.debug_info {
                 let body_len = code_buf.len();

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -264,10 +264,9 @@ fn compile(env: CompileEnv<'_>) -> Result<ModuleCacheDataTupleType, CompileError
                     CompileError::Codegen(pretty_error(&context.func, Some(isa), error))
                 })?;
 
-            let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context)
-                .map_err(|error| {
-                    CompileError::Codegen(pretty_error(&context.func, Some(isa), error))
-                })?;
+            let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context).map_err(|error| {
+                CompileError::Codegen(pretty_error(&context.func, Some(isa), error))
+            })?;
 
             let address_transform = if env.tunables.debug_info {
                 let body_len = code_buf.len();

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -355,14 +355,13 @@ pub fn make_trampoline(
             )))
         })?;
 
-    let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context)
-        .map_err(|error| {
-            SetupError::Compile(CompileError::Codegen(pretty_error(
-                &context.func,
-                Some(isa),
-                error,
-            )))
-        })?;
+    let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context).map_err(|error| {
+        SetupError::Compile(CompileError::Codegen(pretty_error(
+            &context.func,
+            Some(isa),
+            error,
+        )))
+    })?;
 
     let ptr = code_memory
         .allocate_for_function(&CompiledFunction {

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -355,7 +355,14 @@ pub fn make_trampoline(
             )))
         })?;
 
-    let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context);
+    let unwind_info = CompiledFunctionUnwindInfo::new(isa, &context)
+        .map_err(|error| {
+            SetupError::Compile(CompileError::Codegen(pretty_error(
+                &context.func,
+                Some(isa),
+                error,
+            )))
+        })?;
 
     let ptr = code_memory
         .allocate_for_function(&CompiledFunction {


### PR DESCRIPTION
Moved from https://github.com/bytecodealliance/cranelift/pull/1378.

- [x] This has been discussed in issue #1177 
- [x] A short description: Windows appears to have extended ABI constraints to require callees to save XMM6-XMM15 (see #1177 for links to reference material). This PR adds preserve/restore behavior for those registers.
- [x] This PR contains test cases.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

There were a few unresolved conversations from the original PR that I'll copy below.