### PR TITLE
lightbeam: fix comment typo for BrIf

### DIFF
--- a/crates/lightbeam/src/microwasm.rs
+++ b/crates/lightbeam/src/microwasm.rs
@@ -470,8 +470,8 @@ pub enum Operator<Label> {
         /// Returning from the function is just calling the "return" block
         target: BrTarget<Label>,
     },
-    /// Pop a value off the top of the stack, jump to the `else_` label if this value is `true`
-    /// and the `then` label otherwise. The `then` and `else_` blocks must have the same parameters.
+    /// Pop a value off the top of the stack, jump to the `then` label if this value is `true`
+    /// and the `else_` label otherwise. The `then` and `else_` blocks must have the same parameters.
     BrIf {
         /// Label to jump to if the value at the top of the stack is true
         then: BrTargetDrop<Label>,


### PR DESCRIPTION
Signed-off-by: Tibor Vass <teabee89@gmail.com>

I've already opened this PR to the now archived lightbeam repo: https://github.com/CraneStation/lightbeam/pull/20

Which prompts me to ask: why is an older version of lightbeam in wasmtime? Was it just an oversight?