### PR TITLE
Thread-safe compilation API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "indexmap",
+ "lazy_static",
  "libc",
  "memoffset",
  "more-asserts",

--- a/crates/api/src/callable.rs
+++ b/crates/api/src/callable.rs
@@ -158,7 +158,7 @@ impl WrappedCallable for WasmtimeFn {
         // Get the trampoline to call for this function.
         let exec_code_buf = self
             .store
-            .compiler_mut()
+            .compiler()
             .get_published_trampoline(&signature, value_size)
             .map_err(|e| Trap::new(format!("trampoline error: {:?}", e)))?;
 

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -250,7 +250,7 @@ impl Module {
 
     unsafe fn compile(store: &Store, binary: &[u8]) -> Result<Self> {
         let compiled = CompiledModule::new(
-            &mut store.compiler_mut(),
+            store.compiler(),
             binary,
             store.engine().config().debug_info,
             store.engine().config().profiler.as_ref(),

--- a/crates/api/src/trampoline/create_handle.rs
+++ b/crates/api/src/trampoline/create_handle.rs
@@ -13,7 +13,7 @@ use wasmtime_runtime::{Imports, InstanceHandle, VMFunctionBody};
 pub(crate) fn create_handle(
     module: Module,
     store: &Store,
-    finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    finished_functions: PrimaryMap<DefinedFuncIndex, *const [VMFunctionBody]>,
     state: Box<dyn Any>,
 ) -> Result<InstanceHandle> {
     let imports = Imports::new(

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -264,7 +264,7 @@ pub fn create_handle_with_function(
 
     let mut fn_builder_ctx = FunctionBuilderContext::new();
     let mut module = Module::new();
-    let mut finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]> =
+    let mut finished_functions: PrimaryMap<DefinedFuncIndex, *const [VMFunctionBody]> =
         PrimaryMap::new();
     let mut code_memory = CodeMemory::new();
 
@@ -296,7 +296,7 @@ pub fn create_handle_with_function(
 
 pub unsafe fn create_handle_with_raw_function(
     ft: &FuncType,
-    func: *mut [VMFunctionBody],
+    func: *const [VMFunctionBody],
     store: &Store,
     state: Box<dyn Any>,
 ) -> Result<InstanceHandle> {

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -11,7 +11,10 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_wasm::ModuleTranslationState;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::sync::{atomic::{AtomicPtr, Ordering}, RwLock};
+use std::sync::{
+    atomic::{AtomicPtr, Ordering},
+    RwLock,
+};
 use wasmtime_debug::{emit_debugsections_image, DebugInfoData};
 use wasmtime_environ::entity::{EntityRef, PrimaryMap};
 use wasmtime_environ::isa::{TargetFrontendConfig, TargetIsa};
@@ -83,7 +86,7 @@ impl Compiler {
                 code_memory: CodeMemory::new(),
                 trampoline_park: HashMap::new(),
                 fn_builder_ctx: FunctionBuilderContext::new(),
-            })
+            }),
         }
     }
 }
@@ -145,8 +148,8 @@ impl Compiler {
             .map_err(SetupError::Compile)?;
 
         let mut inner = self.inner.write().unwrap();
-        let allocated_functions =
-            allocate_functions(&mut inner.code_memory, &compilation).map_err(|message| {
+        let allocated_functions = allocate_functions(&mut inner.code_memory, &compilation)
+            .map_err(|message| {
                 SetupError::Instantiate(InstantiationError::Resource(format!(
                     "failed to allocate memory for functions: {}",
                     message
@@ -250,7 +253,10 @@ impl Compiler {
         module_name: &str,
         dbg_image: Option<&[u8]>,
     ) -> () {
-        self.inner.write().unwrap().code_memory
+        self.inner
+            .write()
+            .unwrap()
+            .code_memory
             .profiler_module_load(profiler, module_name, dbg_image);
     }
 

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -11,6 +11,7 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_wasm::ModuleTranslationState;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::RwLock;
 use wasmtime_debug::{emit_debugsections_image, DebugInfoData};
 use wasmtime_environ::entity::{EntityRef, PrimaryMap};
 use wasmtime_environ::isa::{TargetFrontendConfig, TargetIsa};
@@ -51,13 +52,19 @@ pub enum CompilationStrategy {
 pub struct Compiler {
     isa: Box<dyn TargetIsa>,
 
-    code_memory: CodeMemory,
     trap_registry: TrapRegistry,
-    trampoline_park: HashMap<VMSharedSignatureIndex, *const VMFunctionBody>,
     signatures: SignatureRegistry,
     strategy: CompilationStrategy,
     cache_config: CacheConfig,
+    inner: RwLock<CompilerInner>,
+}
 
+unsafe impl Send for CompilerInner {}
+unsafe impl Sync for CompilerInner {}
+
+struct CompilerInner {
+    code_memory: CodeMemory,
+    trampoline_park: HashMap<VMSharedSignatureIndex, *const VMFunctionBody>,
     /// The `FunctionBuilderContext`, shared between trampline function compilations.
     fn_builder_ctx: FunctionBuilderContext,
 }
@@ -71,13 +78,15 @@ impl Compiler {
     ) -> Self {
         Self {
             isa,
-            code_memory: CodeMemory::new(),
-            trampoline_park: HashMap::new(),
             signatures: SignatureRegistry::new(),
-            fn_builder_ctx: FunctionBuilderContext::new(),
             strategy,
             trap_registry: TrapRegistry::default(),
             cache_config,
+            inner: RwLock::new(CompilerInner {
+                code_memory: CodeMemory::new(),
+                trampoline_park: HashMap::new(),
+                fn_builder_ctx: FunctionBuilderContext::new(),
+            })
         }
     }
 }
@@ -95,14 +104,14 @@ impl Compiler {
 
     /// Compile the given function bodies.
     pub(crate) fn compile<'data>(
-        &mut self,
+        &self,
         module: &Module,
         module_translation: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<DefinedFuncIndex, FunctionBodyData<'data>>,
         debug_data: Option<DebugInfoData>,
     ) -> Result<
         (
-            PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+            PrimaryMap<DefinedFuncIndex, *const [VMFunctionBody]>,
             PrimaryMap<DefinedFuncIndex, ir::JumpTableOffsets>,
             Relocations,
             Option<Vec<u8>>,
@@ -138,8 +147,9 @@ impl Compiler {
             }
             .map_err(SetupError::Compile)?;
 
+        let mut inner = self.inner.write().unwrap();
         let allocated_functions =
-            allocate_functions(&mut self.code_memory, &compilation).map_err(|message| {
+            allocate_functions(&mut inner.code_memory, &compilation).map_err(|message| {
                 SetupError::Instantiate(InstantiationError::Resource(format!(
                     "failed to allocate memory for functions: {}",
                     message
@@ -201,28 +211,29 @@ impl Compiler {
 
     /// Create a trampoline for invoking a function.
     pub(crate) fn get_trampoline(
-        &mut self,
+        &self,
         signature: &ir::Signature,
         value_size: usize,
     ) -> Result<*const VMFunctionBody, SetupError> {
         let index = self.signatures.register(signature);
-        if let Some(trampoline) = self.trampoline_park.get(&index) {
+        let inner = &mut *self.inner.write().unwrap();
+        if let Some(trampoline) = inner.trampoline_park.get(&index) {
             return Ok(*trampoline);
         }
         let body = make_trampoline(
             &*self.isa,
-            &mut self.code_memory,
-            &mut self.fn_builder_ctx,
+            &mut inner.code_memory,
+            &mut inner.fn_builder_ctx,
             signature,
             value_size,
         )?;
-        self.trampoline_park.insert(index, body);
+        inner.trampoline_park.insert(index, body);
         return Ok(body);
     }
 
     /// Create and publish a trampoline for invoking a function.
     pub fn get_published_trampoline(
-        &mut self,
+        &self,
         signature: &ir::Signature,
         value_size: usize,
     ) -> Result<*const VMFunctionBody, SetupError> {
@@ -232,17 +243,17 @@ impl Compiler {
     }
 
     /// Make memory containing compiled code executable.
-    pub(crate) fn publish_compiled_code(&mut self) {
-        self.code_memory.publish();
+    pub(crate) fn publish_compiled_code(&self) {
+        self.inner.write().unwrap().code_memory.publish();
     }
 
     pub(crate) fn profiler_module_load(
-        &mut self,
+        &self,
         profiler: &mut Box<dyn ProfilingAgent + Send>,
         module_name: &str,
         dbg_image: Option<&[u8]>,
     ) -> () {
-        self.code_memory
+        self.inner.write().unwrap().code_memory
             .profiler_module_load(profiler, module_name, dbg_image);
     }
 
@@ -379,20 +390,20 @@ fn make_trampoline(
 fn allocate_functions(
     code_memory: &mut CodeMemory,
     compilation: &Compilation,
-) -> Result<PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>, String> {
+) -> Result<PrimaryMap<DefinedFuncIndex, *const [VMFunctionBody]>, String> {
     let fat_ptrs = code_memory.allocate_for_compilation(compilation)?;
 
     // Second, create a PrimaryMap from result vector of pointers.
     let mut result = PrimaryMap::with_capacity(compilation.len());
     for i in 0..fat_ptrs.len() {
-        let fat_ptr: *mut [VMFunctionBody] = fat_ptrs[i];
+        let fat_ptr: *const [VMFunctionBody] = fat_ptrs[i];
         result.push(fat_ptr);
     }
     Ok(result)
 }
 
 fn register_traps(
-    allocated_functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    allocated_functions: &PrimaryMap<DefinedFuncIndex, *const [VMFunctionBody]>,
     traps: &Traps,
     registry: &TrapRegistry,
 ) -> TrapRegistration {

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -44,7 +44,11 @@ pub enum SetupError {
     DebugInfo(#[from] anyhow::Error),
 }
 
+// A thread-safe wrapper for function pointers.
 struct FinishedFunctions(BoxedSlice<DefinedFuncIndex, *const [VMFunctionBody]>);
+
+// This is safe because the pointers are not modified and are only returned
+// through a reference bound to RawCompiledModule instance
 unsafe impl Send for FinishedFunctions {}
 unsafe impl Sync for FinishedFunctions {}
 

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -14,7 +14,7 @@ use wasmtime_runtime::VMFunctionBody;
 /// Performs all required relocations inside the function code, provided the necessary metadata.
 pub fn link_module(
     module: &Module,
-    allocated_functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    allocated_functions: &PrimaryMap<DefinedFuncIndex, *const [VMFunctionBody]>,
     jt_offsets: &PrimaryMap<DefinedFuncIndex, JumpTableOffsets>,
     relocations: Relocations,
 ) {

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.4"
 more-asserts = "0.2.1"
 cfg-if = "0.1.9"
 backtrace = "0.3.42"
+lazy_static = "1.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi"] }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -23,7 +23,6 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::{mem, ptr, slice};
 use thiserror::Error;
@@ -93,13 +92,13 @@ pub(crate) struct Instance {
     passive_elements: RefCell<HashMap<ElemIndex, Box<[VMCallerCheckedAnyfunc]>>>,
 
     /// Pointers to functions in executable memory.
-    finished_functions: BoxedSlice<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    finished_functions: BoxedSlice<DefinedFuncIndex, *const [VMFunctionBody]>,
 
     /// Hosts can store arbitrary per-instance information here.
     host_state: Box<dyn Any>,
 
     /// Optional image of JIT'ed code for debugger registration.
-    dbg_jit_registration: Option<Rc<GdbJitImageRegistration>>,
+    dbg_jit_registration: Option<Arc<GdbJitImageRegistration>>,
 
     /// Handler run when `SIGBUS`, `SIGFPE`, `SIGILL`, or `SIGSEGV` are caught by the instance thread.
     pub(crate) signal_handler: Cell<Option<Box<SignalHandler>>>,
@@ -797,11 +796,11 @@ impl InstanceHandle {
     pub unsafe fn new(
         module: Arc<Module>,
         trap_registration: TrapRegistration,
-        finished_functions: BoxedSlice<DefinedFuncIndex, *mut [VMFunctionBody]>,
+        finished_functions: BoxedSlice<DefinedFuncIndex, *const [VMFunctionBody]>,
         imports: Imports,
         data_initializers: &[DataInitializer<'_>],
         vmshared_signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
-        dbg_jit_registration: Option<Rc<GdbJitImageRegistration>>,
+        dbg_jit_registration: Option<Arc<GdbJitImageRegistration>>,
         is_bulk_memory: bool,
         host_state: Box<dyn Any>,
     ) -> Result<Self, InstantiationError> {

--- a/crates/runtime/src/jit_int.rs
+++ b/crates/runtime/src/jit_int.rs
@@ -3,7 +3,10 @@
 //! or unregister generated object images with debuggers.
 
 use std::ptr;
-use std::sync::{atomic::{AtomicPtr, Ordering}, Mutex};
+use std::sync::{
+    atomic::{AtomicPtr, Ordering},
+    Mutex,
+};
 
 #[repr(C)]
 struct JITCodeEntry {


### PR DESCRIPTION
This makes `Module` implement `Send` and `Sync`, allowing instances to be created and executed in different threads.

Closes #777
