### PR TITLE
Fix infinite loop in DWARF address transform algorithm

### DIFF
--- a/crates/debug/src/transform/address_transform.rs
+++ b/crates/debug/src/transform/address_transform.rs
@@ -303,10 +303,10 @@ impl<'a> Iterator for TransformRangeEndIter<'a> {
         while let Some((first, tail)) = self.indicies.split_first() {
             let range_index = *first;
             let range = &self.ranges[range_index];
+            self.indicies = tail;
             if range.wasm_start >= self.addr {
                 continue;
             }
-            self.indicies = tail;
             let address = match range
                 .positions
                 .binary_search_by(|a| a.wasm_pos.cmp(&self.addr))


### PR DESCRIPTION
Currently `wasmtime` was switches to optimized mode by default. That discovered issue with debugging more complex wasm modules with optimized cranelift code. This PR fixes infinite loop in the DWARF transformation algorithm.

FWIW I'm working on adding debugging tests in #914 -- skipping tests here.