### PR TITLE
fix yanix compile with armv7

### DIFF
--- a/crates/wasi-common/yanix/src/file.rs
+++ b/crates/wasi-common/yanix/src/file.rs
@@ -244,6 +244,6 @@ pub unsafe fn fionread(fd: RawFd) -> Result<u32> {
 /// This function is unsafe because it operates on a raw file descriptor.
 /// It's provided, because std::io::Seek requires a mutable borrow.
 pub unsafe fn tell(fd: RawFd) -> Result<u64> {
-    let offset: i64 = Error::from_result(libc::lseek(fd, 0, libc::SEEK_CUR))?;
+    let offset: i64 = Error::from_result(libc::lseek(fd, 0, libc::SEEK_CUR))?.into();
     Ok(offset.try_into()?)
 }


### PR DESCRIPTION
this fixes the following error:

```
error[E0308]: try expression alternatives have incompatible types
   --> crates/wasi-common/yanix/src/file.rs:247:23
    |
247 |     let offset: i64 = Errno::from_result(libc::lseek(fd, 0, libc::SEEK_CUR))?;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                       |
    |                       expected `i64`, found `i32`
    |                       help: you can convert an `i32` to `i64`: `Errno::from_result(libc::lseek(fd, 0, libc::SEEK_CUR))?.into()`

```

- [ ] This has been discussed in issue #1219

@kubkon wanted to help me a bit with his, therefore tagging you along
