### PR TITLE
Disable/ignore debug_dwarf tests in "cargo test"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,6 +190,12 @@ jobs:
         RUST_BACKTRACE: 1
         RUSTFLAGS: "-D warnings"
 
+    # Test debug (DWARF) related functionality.
+    - run: cargo test test_debug_dwarf_ -- --ignored --nocapture --test-threads 1
+      env:
+        RUST_BACKTRACE: 1
+        RUSTFLAGS: "-D warnings"
+
     # Build and test lightbeam if we're using the nightly toolchain. Note that
     # Lightbeam tests fail right now, but we don't want to block on that.
     - run: cargo build --package lightbeam
@@ -346,7 +352,7 @@ jobs:
     - run: $CENTOS cargo build --release --manifest-path crates/c-api/Cargo.toml
       shell: bash
     # Test what we just built
-    - run: $CENTOS cargo test --features test_programs --release --all --exclude lightbeam --exclude wasmtime --exclude wasmtime-c-api --exclude wasmtime-fuzzing -- --skip test_debug_dwarf_
+    - run: $CENTOS cargo test --features test_programs --release --all --exclude lightbeam --exclude wasmtime --exclude wasmtime-c-api --exclude wasmtime-fuzzing
       shell: bash
       env:
         RUST_BACKTRACE: 1

--- a/tests/debug/simulate.rs
+++ b/tests/debug/simulate.rs
@@ -25,6 +25,7 @@ fn check_wat(wat: &str) -> Result<()> {
 }
 
 #[test]
+#[ignore]
 #[cfg(all(
     any(target_os = "linux", target_os = "macos"),
     target_pointer_width = "64"

--- a/tests/debug/translate.rs
+++ b/tests/debug/translate.rs
@@ -25,6 +25,7 @@ fn check_wasm(wasm_path: &str, directives: &str) -> Result<()> {
 }
 
 #[test]
+#[ignore]
 #[cfg(all(
     any(target_os = "linux", target_os = "macos"),
     target_pointer_width = "64"


### PR DESCRIPTION
This PR makes it easier for developers to use `cargo test`. Currently `test_debug_dwarf_XXX` tests are run. They are required to have proper version  of llvm-dwarfdump (and, in the future, lldb) installed. This PR fixes that.
