### PR TITLE
[cranelift-simplejit] Remove panic when passed `PIC` flag

### DIFF
--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -64,7 +64,6 @@ impl SimpleJITBuilder {
         isa: Box<dyn TargetIsa>,
         libcall_names: Box<dyn Fn(ir::LibCall) -> String>,
     ) -> Self {
-        debug_assert!(!isa.flags().is_pic(), "SimpleJIT requires non-PIC code");
         let symbols = HashMap::new();
         Self {
             isa,


### PR DESCRIPTION
Since `PIC` has no effect, there is no reason to disallow the option.
This simplifies my life a little and has no impact on runtime behavior
(other than not panicking).
