### PR TITLE
Add SIMD int-to-float conversion

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1568,6 +1568,7 @@ fn define_simd(
     let copy_nop = shared.by_name("copy_nop");
     let fadd = shared.by_name("fadd");
     let fcmp = shared.by_name("fcmp");
+    let fcvt_from_sint = shared.by_name("fcvt_from_sint");
     let fdiv = shared.by_name("fdiv");
     let fill = shared.by_name("fill");
     let fill_nop = shared.by_name("fill_nop");
@@ -1788,6 +1789,14 @@ fn define_simd(
                 0,
             );
         }
+    }
+
+    // SIMD conversions
+    {
+        let fcvt_from_sint_32 = fcvt_from_sint
+            .bind(vector(F32, sse_vector_size))
+            .bind(vector(I32, sse_vector_size));
+        e.enc_both(fcvt_from_sint_32, rec_furm.opcodes(&CVTDQ2PS));
     }
 
     // SIMD vconst for special cases (all zeroes, all ones)

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -77,6 +77,10 @@ pub static CMPPD: [u8; 3] = [0x66, 0x0f, 0xc2];
 /// imm8 as comparison predicate (SSE).
 pub static CMPPS: [u8; 2] = [0x0f, 0xc2];
 
+/// Convert four packed signed doubleword integers from xmm2/mem to four packed single-precision
+/// floating-point values in xmm1 (SSE2).
+pub static CVTDQ2PS: [u8; 2] = [0x0f, 0x5b];
+
 /// Convert scalar double-precision floating-point value to scalar single-precision
 /// floating-point value.
 pub static CVTSD2SS: [u8; 3] = [0xf2, 0x0f, 0x5a];

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-binemit.clif
@@ -9,3 +9,9 @@ block0:
 [-, %xmm2]  v2 = raw_bitcast.i32x4 v1       ; bin:
             return
 }
+
+function %fcvt_32(i32x4) {
+block0(v0: i32x4 [%xmm6]):
+[-, %xmm2]  v1 = fcvt_from_sint.f32x4 v0    ; bin: 40 0f 5b d6
+            return
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
@@ -1,0 +1,14 @@
+test run
+set enable_simd
+
+function %fcvt_from_sint() -> b1 {
+block0:
+    v0 = vconst.i32x4 [-1 0 1 123456789]
+    v1 = fcvt_from_sint.f32x4 v0
+
+    v2 = vconst.f32x4 [-0x1.0 0.0 0x1.0 0x75bcd18.0] ; 123456789 rounds to 123456792.0, an error of 3
+    v3 = fcmp eq v1, v2
+    v4 = vall_true v3
+    return v4
+}
+; run

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1467,6 +1467,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().fabs(a))
         }
+        Operator::F32x4ConvertI32x4S => {
+            let a = pop1_with_bitcast(state, I32X4, builder);
+            state.push1(builder.ins().fcvt_from_sint(F32X4, a))
+        }
         Operator::I8x16Shl
         | Operator::I8x16ShrS
         | Operator::I8x16ShrU
@@ -1477,7 +1481,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I32x4TruncSatF32x4U
         | Operator::I64x2TruncSatF64x2S
         | Operator::I64x2TruncSatF64x2U
-        | Operator::F32x4ConvertI32x4S
         | Operator::F32x4ConvertI32x4U
         | Operator::F64x2ConvertI64x2S
         | Operator::F64x2ConvertI64x2U { .. }


### PR DESCRIPTION
This adds support for [`f32x4.convert_i32x4_s`](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#integer-to-floating-point) for x86. This conversion is a simple 1:1 lowering; other conversions will not be (see https://github.com/WebAssembly/simd/issues/190).