### PR TITLE
Implement `data.drop` and `memory.init` and get the rest of the bulk memory spec tests passing

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -199,8 +199,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             // Still working on implementing these. See #928
             ("bulk_memory_operations", "bulk")
             | ("bulk_memory_operations", "data")
-            | ("bulk_memory_operations", "memory_init")
-            | ("bulk_memory_operations", "imports") => return true,
+            | ("bulk_memory_operations", "memory_init") => return true,
 
             _ => {}
         },

--- a/build.rs
+++ b/build.rs
@@ -196,9 +196,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", "table_copy_on_imported_tables") => return false,
             ("reference_types", _) => return true,
 
-            // Still working on implementing these. See #928
-            ("bulk_memory_operations", "bulk") => return true,
-
             _ => {}
         },
         _ => panic!("unrecognized strategy"),

--- a/build.rs
+++ b/build.rs
@@ -197,9 +197,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", _) => return true,
 
             // Still working on implementing these. See #928
-            ("bulk_memory_operations", "bulk")
-            | ("bulk_memory_operations", "data")
-            | ("bulk_memory_operations", "memory_init") => return true,
+            ("bulk_memory_operations", "bulk") => return true,
 
             _ => {}
         },

--- a/crates/environ/src/data_structures.rs
+++ b/crates/environ/src/data_structures.rs
@@ -22,7 +22,7 @@ pub mod entity {
 
 pub mod wasm {
     pub use cranelift_wasm::{
-        get_vmctx_value_label, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex,
+        get_vmctx_value_label, DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex,
         DefinedTableIndex, ElemIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Memory,
         MemoryIndex, SignatureIndex, Table, TableElementType, TableIndex,
     };

--- a/crates/environ/src/func_environ.rs
+++ b/crates/environ/src/func_environ.rs
@@ -72,9 +72,13 @@ impl BuiltinFunctionIndex {
     pub const fn get_imported_memory_fill_index() -> Self {
         Self(10)
     }
+    /// Returns an index for wasm's `memory.init` instruction.
+    pub const fn get_memory_init_index() -> Self {
+        Self(11)
+    }
     /// Returns the total number of builtin functions.
     pub const fn builtin_functions_total_number() -> u32 {
-        11
+        12
     }
 
     /// Return the index as an u32 number.
@@ -120,6 +124,9 @@ pub struct FuncEnvironment<'module_environment> {
     /// (it's the same for both local and imported memories).
     memory_fill_sig: Option<ir::SigRef>,
 
+    /// The external function signature for implementing wasm's `memory.init`.
+    memory_init_sig: Option<ir::SigRef>,
+
     /// Offsets to struct fields accessed by JIT code.
     offsets: VMOffsets,
 }
@@ -140,6 +147,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             elem_drop_sig: None,
             memory_copy_sig: None,
             memory_fill_sig: None,
+            memory_init_sig: None,
             offsets: VMOffsets::new(target_config.pointer_bytes(), module),
         }
     }
@@ -421,6 +429,37 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                 BuiltinFunctionIndex::get_imported_memory_fill_index(),
             )
         }
+    }
+
+    fn get_memory_init_sig(&mut self, func: &mut Function) -> ir::SigRef {
+        let sig = self.memory_init_sig.unwrap_or_else(|| {
+            func.import_signature(Signature {
+                params: vec![
+                    AbiParam::special(self.pointer_type(), ArgumentPurpose::VMContext),
+                    // Memory index.
+                    AbiParam::new(I32),
+                    // Data index.
+                    AbiParam::new(I32),
+                    // Destination address.
+                    AbiParam::new(I32),
+                    // Source index within the data segment.
+                    AbiParam::new(I32),
+                    // Length.
+                    AbiParam::new(I32),
+                    // Source location.
+                    AbiParam::new(I32),
+                ],
+                returns: vec![],
+                call_conv: self.target_config.default_call_conv,
+            })
+        });
+        self.memory_init_sig = Some(sig);
+        sig
+    }
+
+    fn get_memory_init_func(&mut self, func: &mut Function) -> (ir::SigRef, BuiltinFunctionIndex) {
+        let sig = self.get_memory_init_sig(func);
+        (sig, BuiltinFunctionIndex::get_memory_init_index())
     }
 
     /// Translates load of builtin function and returns a pair of values `vmctx`
@@ -1076,17 +1115,38 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
     fn translate_memory_init(
         &mut self,
-        _pos: FuncCursor,
-        _index: MemoryIndex,
+        mut pos: FuncCursor,
+        memory_index: MemoryIndex,
         _heap: ir::Heap,
-        _seg_index: u32,
-        _dst: ir::Value,
-        _src: ir::Value,
-        _len: ir::Value,
+        seg_index: u32,
+        dst: ir::Value,
+        src: ir::Value,
+        len: ir::Value,
     ) -> WasmResult<()> {
-        Err(WasmError::Unsupported(
-            "bulk memory: `memory.init`".to_string(),
-        ))
+        let (func_sig, func_idx) = self.get_memory_init_func(&mut pos.func);
+
+        let memory_index_arg = pos.ins().iconst(I32, memory_index.index() as i64);
+        let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
+        let src_loc = pos.srcloc();
+        let src_loc_arg = pos.ins().iconst(I32, src_loc.bits() as i64);
+
+        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+
+        pos.ins().call_indirect(
+            func_sig,
+            func_addr,
+            &[
+                vmctx,
+                memory_index_arg,
+                seg_index_arg,
+                dst,
+                src,
+                len,
+                src_loc_arg,
+            ],
+        );
+
+        Ok(())
     }
 
     fn translate_data_drop(&mut self, _pos: FuncCursor, _seg_index: u32) -> WasmResult<()> {

--- a/crates/environ/src/func_environ.rs
+++ b/crates/environ/src/func_environ.rs
@@ -76,9 +76,13 @@ impl BuiltinFunctionIndex {
     pub const fn get_memory_init_index() -> Self {
         Self(11)
     }
+    /// Returns an index for wasm's `data.drop` instruction.
+    pub const fn get_data_drop_index() -> Self {
+        Self(12)
+    }
     /// Returns the total number of builtin functions.
     pub const fn builtin_functions_total_number() -> u32 {
-        12
+        13
     }
 
     /// Return the index as an u32 number.
@@ -127,6 +131,9 @@ pub struct FuncEnvironment<'module_environment> {
     /// The external function signature for implementing wasm's `memory.init`.
     memory_init_sig: Option<ir::SigRef>,
 
+    /// The external function signature for implementing wasm's `data.drop`.
+    data_drop_sig: Option<ir::SigRef>,
+
     /// Offsets to struct fields accessed by JIT code.
     offsets: VMOffsets,
 }
@@ -148,6 +155,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             memory_copy_sig: None,
             memory_fill_sig: None,
             memory_init_sig: None,
+            data_drop_sig: None,
             offsets: VMOffsets::new(target_config.pointer_bytes(), module),
         }
     }
@@ -460,6 +468,27 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     fn get_memory_init_func(&mut self, func: &mut Function) -> (ir::SigRef, BuiltinFunctionIndex) {
         let sig = self.get_memory_init_sig(func);
         (sig, BuiltinFunctionIndex::get_memory_init_index())
+    }
+
+    fn get_data_drop_sig(&mut self, func: &mut Function) -> ir::SigRef {
+        let sig = self.data_drop_sig.unwrap_or_else(|| {
+            func.import_signature(Signature {
+                params: vec![
+                    AbiParam::special(self.pointer_type(), ArgumentPurpose::VMContext),
+                    // Data index.
+                    AbiParam::new(I32),
+                ],
+                returns: vec![],
+                call_conv: self.target_config.default_call_conv,
+            })
+        });
+        self.data_drop_sig = Some(sig);
+        sig
+    }
+
+    fn get_data_drop_func(&mut self, func: &mut Function) -> (ir::SigRef, BuiltinFunctionIndex) {
+        let sig = self.get_data_drop_sig(func);
+        (sig, BuiltinFunctionIndex::get_data_drop_index())
     }
 
     /// Translates load of builtin function and returns a pair of values `vmctx`
@@ -1149,10 +1178,13 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         Ok(())
     }
 
-    fn translate_data_drop(&mut self, _pos: FuncCursor, _seg_index: u32) -> WasmResult<()> {
-        Err(WasmError::Unsupported(
-            "bulk memory: `data.drop`".to_string(),
-        ))
+    fn translate_data_drop(&mut self, mut pos: FuncCursor, seg_index: u32) -> WasmResult<()> {
+        let (func_sig, func_idx) = self.get_data_drop_func(&mut pos.func);
+        let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
+        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        pos.ins()
+            .call_indirect(func_sig, func_addr, &[vmctx, seg_index_arg]);
+        Ok(())
     }
 
     fn translate_table_size(

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -5,8 +5,9 @@ use crate::WASM_MAX_PAGES;
 use cranelift_codegen::ir;
 use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_wasm::{
-    DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, ElemIndex,
-    FuncIndex, Global, GlobalIndex, Memory, MemoryIndex, SignatureIndex, Table, TableIndex,
+    DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
+    ElemIndex, FuncIndex, Global, GlobalIndex, Memory, MemoryIndex, SignatureIndex, Table,
+    TableIndex,
 };
 use indexmap::IndexMap;
 use more_asserts::assert_ge;
@@ -168,6 +169,9 @@ pub struct Module {
     /// WebAssembly passive elements.
     pub passive_elements: HashMap<ElemIndex, Box<[FuncIndex]>>,
 
+    /// WebAssembly passive data segments.
+    pub passive_data: HashMap<DataIndex, Box<[u8]>>,
+
     /// WebAssembly table initializers.
     pub func_names: HashMap<FuncIndex, String>,
 }
@@ -223,6 +227,7 @@ impl Module {
             start_func: None,
             table_elements: Vec::new(),
             passive_elements: HashMap::new(),
+            passive_data: HashMap::new(),
             func_names: HashMap::new(),
             local: ModuleLocal {
                 num_imported_funcs: 0,

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -12,7 +12,10 @@ use cranelift_wasm::{
 use indexmap::IndexMap;
 use more_asserts::assert_ge;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering::SeqCst},
+    Arc,
+};
 
 /// A WebAssembly table initializer.
 #[derive(Clone, Debug, Hash)]
@@ -170,7 +173,7 @@ pub struct Module {
     pub passive_elements: HashMap<ElemIndex, Box<[FuncIndex]>>,
 
     /// WebAssembly passive data segments.
-    pub passive_data: HashMap<DataIndex, Box<[u8]>>,
+    pub passive_data: HashMap<DataIndex, Arc<[u8]>>,
 
     /// WebAssembly table initializers.
     pub func_names: HashMap<FuncIndex, String>,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -11,6 +11,7 @@ use cranelift_wasm::{
     TargetEnvironment, WasmResult,
 };
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 /// Contains function data: byte code and its offset in the module.
 #[derive(Hash)]
@@ -400,7 +401,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
             .result
             .module
             .passive_data
-            .insert(data_index, data.to_vec().into_boxed_slice());
+            .insert(data_index, Arc::from(data));
         debug_assert!(
             old.is_none(),
             "a module can't have duplicate indices, this would be a cranelift-wasm bug"

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -321,3 +321,10 @@ pub unsafe extern "C" fn wasmtime_memory_init(
         raise_lib_trap(trap);
     }
 }
+
+/// Implementation of `data.drop`.
+pub unsafe extern "C" fn wasmtime_data_drop(vmctx: *mut VMContext, data_index: u32) {
+    let data_index = DataIndex::from_u32(data_index);
+    let instance = (&mut *vmctx).instance();
+    instance.data_drop(data_index)
+}

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -36,7 +36,7 @@ use crate::table::Table;
 use crate::traphandlers::raise_lib_trap;
 use crate::vmcontext::VMContext;
 use wasmtime_environ::ir;
-use wasmtime_environ::wasm::{DefinedMemoryIndex, ElemIndex, MemoryIndex, TableIndex};
+use wasmtime_environ::wasm::{DataIndex, DefinedMemoryIndex, ElemIndex, MemoryIndex, TableIndex};
 
 /// Implementation of f32.ceil
 pub extern "C" fn wasmtime_f32_ceil(x: f32) -> f32 {
@@ -294,6 +294,28 @@ pub unsafe extern "C" fn wasmtime_imported_memory_fill(
         let source_loc = ir::SourceLoc::new(source_loc);
         let instance = (&mut *vmctx).instance();
         instance.imported_memory_fill(memory_index, dst, val, len, source_loc)
+    };
+    if let Err(trap) = result {
+        raise_lib_trap(trap);
+    }
+}
+
+/// Implementation of `memory.init`.
+pub unsafe extern "C" fn wasmtime_memory_init(
+    vmctx: *mut VMContext,
+    memory_index: u32,
+    data_index: u32,
+    dst: u32,
+    src: u32,
+    len: u32,
+    source_loc: u32,
+) {
+    let result = {
+        let memory_index = MemoryIndex::from_u32(memory_index);
+        let data_index = DataIndex::from_u32(data_index);
+        let source_loc = ir::SourceLoc::new(source_loc);
+        let instance = (&mut *vmctx).instance();
+        instance.memory_init(memory_index, data_index, dst, src, len, source_loc)
     };
     if let Err(trap) = result {
         raise_lib_trap(trap);

--- a/crates/runtime/src/trap_registry.rs
+++ b/crates/runtime/src/trap_registry.rs
@@ -84,7 +84,7 @@ fn trap_code_to_expected_string(trap_code: ir::TrapCode) -> String {
     match trap_code {
         StackOverflow => "call stack exhausted".to_string(),
         HeapOutOfBounds => "out of bounds memory access".to_string(),
-        TableOutOfBounds => "undefined element: out of bounds".to_string(),
+        TableOutOfBounds => "undefined element: out of bounds table access".to_string(),
         OutOfBounds => "out of bounds".to_string(), // Note: not covered by the test suite
         IndirectCallToNull => "uninitialized element".to_string(),
         BadSignature => "indirect call type mismatch".to_string(),

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -565,6 +565,8 @@ impl VMBuiltinFunctionsArray {
             wasmtime_memory_fill as usize;
         ptrs[BuiltinFunctionIndex::get_imported_memory_fill_index().index() as usize] =
             wasmtime_imported_memory_fill as usize;
+        ptrs[BuiltinFunctionIndex::get_memory_init_index().index() as usize] =
+            wasmtime_memory_init as usize;
 
         debug_assert!(ptrs.iter().cloned().all(|p| p != 0));
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -567,6 +567,8 @@ impl VMBuiltinFunctionsArray {
             wasmtime_imported_memory_fill as usize;
         ptrs[BuiltinFunctionIndex::get_memory_init_index().index() as usize] =
             wasmtime_memory_init as usize;
+        ptrs[BuiltinFunctionIndex::get_data_drop_index().index() as usize] =
+            wasmtime_data_drop as usize;
 
         debug_assert!(ptrs.iter().cloned().all(|p| p != 0));
 


### PR DESCRIPTION
This PR adds support for

* passive data segments
* the `data.drop` instruction
* the `memory.init` instruction

and gets the final handful of bulk memory spec tests passing. They all pass now!