### PR TITLE
Log to stderr by default.

### DIFF
--- a/docs/cli-logging.md
+++ b/docs/cli-logging.md
@@ -1,0 +1,26 @@
+# Logging in the `wasmtime` CLI
+
+Wasmtime's libraries use Rust's [`log`] crate to log diagnostic
+information, and the `wasmtime` CLI executable uses [`pretty_env_logger`]
+by default for logging this information to the console.
+
+Basic logging is controlled by the `RUST_LOG` environment variable. For example,
+To enable logging of WASI system calls, similar to the `strace` command on Linux,
+set `RUST_LOG=wasi_common=trace`.
+
+```sh
+$ RUST_LOG=wasi_common=trace wasmtime hello.wasm
+[...]
+ TRACE wasi_common::hostcalls_impl::fs                       > fd_write(fd=1, iovs_ptr=0x10408, iovs_len=1, nwritten=0x10404)
+Hello, world!
+ TRACE wasi_common::hostcalls_impl::fs                       >      | *nwritten=14
+ TRACE wasi_common::hostcalls                                >      | errno=ESUCCESS (No error occurred. System call completed successfully.)
+ TRACE wasi_common::hostcalls_impl::misc                     > proc_exit(rval=1)
+```
+
+Wasmtime can also redirect the log messages into log files, with the
+`--log-to-files` option. It creates one file per thread within Wasmtime, with
+the files named `wasmtime.dbg.*`.
+
+[`log`]: https://crates.io/crates/log
+[`pretty_env_logger`]: https://crates.io/crates/pretty_env_logger

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,5 +20,5 @@ $ wasmtime --invoke _start foo.wasm
 ```
 
 For more information be sure to check out [how to install the
-CLI](cli-install.md) as well as [the list of options you can
-pass](cli-options.md).
+CLI](cli-install.md), [the list of options you can
+pass](cli-options.md), and [how to enable logging](cli-logging.md).

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -89,11 +89,11 @@ pub struct RunCommand {
 impl RunCommand {
     /// Executes the command.
     pub fn execute(&self) -> Result<()> {
-        if self.common.debug {
-            pretty_env_logger::init();
-        } else {
+        if self.common.log_to_files {
             let prefix = "wasmtime.dbg.";
             init_file_per_thread_logger(prefix);
+        } else {
+            pretty_env_logger::init();
         }
 
         let config = self.common.config()?;

--- a/src/commands/wasm2obj.rs
+++ b/src/commands/wasm2obj.rs
@@ -54,11 +54,11 @@ impl WasmToObjCommand {
     }
 
     fn handle_module(&self) -> Result<()> {
-        if self.common.debug {
-            pretty_env_logger::init();
-        } else {
+        if self.common.log_to_files {
             let prefix = "wasm2obj.dbg.";
             init_file_per_thread_logger(prefix);
+        } else {
+            pretty_env_logger::init();
         }
 
         let cache_config = if self.common.disable_cache {

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -26,11 +26,11 @@ pub struct WastCommand {
 impl WastCommand {
     /// Executes the command.
     pub fn execute(&self) -> Result<()> {
-        if self.common.debug {
-            pretty_env_logger::init();
-        } else {
+        if self.common.log_to_files {
             let prefix = "wast.dbg.";
             init_file_per_thread_logger(prefix);
+        } else {
+            pretty_env_logger::init();
         }
 
         let config = self.common.config()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,9 @@ struct CommonOptions {
     #[structopt(long, conflicts_with = "lightbeam")]
     cranelift: bool,
 
-    /// Enable debug output
-    #[structopt(short, long)]
-    debug: bool,
+    /// Log to per-thread log files instead of stderr.
+    #[structopt(long)]
+    log_to_files: bool,
 
     /// Generate debug information
     #[structopt(short = "g")]


### PR DESCRIPTION
Change the default from file-per-thread-logger to pretty-env-logger,
which is more common in Rust projects, and change the option from `-d`
to `--log-to-files`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
