### PR TITLE
[wasi-common]: add armv7 support to wasi-common

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,18 +120,30 @@ jobs:
         RUST_BACKTRACE: 1
 
   # Install wasm32-unknown-emscripten target, and ensure `crates/wasi-common`
-  # compiles to Emscripten.
-  # TODO enable once rust-lang/rust#66308 is fixed
-  # emscripten:
-  #   name: Emscripten
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #     with:
-  #       submodules: true
-  #   - uses: ./.github/actions/install-rust
-  #   - run: rustup target add wasm32-unknown-emscripten
-  #   - run: cargo build --target wasm32-unknown-emscripten -p wasi-common
+  # compiles to it.
+  emscripten:
+    name: Emscripten
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - run: rustup target add wasm32-unknown-emscripten
+    - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
+  
+  # Install armv7-unknown-linux-gnueabihf target, and ensure `crates/wasi-common`
+  # compiles to it.
+  armv7:
+    name: armv7
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - run: rustup target add armv7-unknown-linux-gnueabihf
+    - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
 
   # Perform all tests (debug mode) for `wasmtime`. This runs stable/beta/nightly
   # channels of Rust as well as macOS/Linux/Windows.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,31 +119,22 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-  # Install wasm32-unknown-emscripten target, and ensure `crates/wasi-common`
-  # compiles to it.
-  emscripten:
-    name: Emscripten
+  # Check whether `crates/wasi-common` cross-compiles to the following targets:
+  # * wasm32-unknown-emscripten
+  # * armv7-unknown-linux-gnueabihf
+  crosscompile:
+    name: Cross-platform checks
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: rustup target add wasm32-unknown-emscripten
-    - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
-  
-  # Install armv7-unknown-linux-gnueabihf target, and ensure `crates/wasi-common`
-  # compiles to it.
-  armv7:
-    name: armv7
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-    - run: rustup target add armv7-unknown-linux-gnueabihf
-    - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
+    - run: |
+        rustup target add wasm32-unknown-emscripten
+        cargo check --target wasm32-unknown-emscripten -p wasi-common
+        rustup target add armv7-unknown-linux-gnueabihf
+        cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
 
   # Perform all tests (debug mode) for `wasmtime`. This runs stable/beta/nightly
   # channels of Rust as well as macOS/Linux/Windows.

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/emscripten/host_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/emscripten/host_impl.rs
@@ -1,15 +1,15 @@
-use crate::old::snapshot_0::{wasi, Result};
+use crate::old::snapshot_0::wasi::{self, WasiResult};
 
 pub(crate) const O_RSYNC: yanix::file::OFlag = yanix::file::OFlag::RSYNC;
 
-pub(crate) fn stdev_from_nix(dev: libc::dev_t) -> Result<wasi::__wasi_device_t> {
+pub(crate) fn stdev_from_nix(dev: libc::dev_t) -> WasiResult<wasi::__wasi_device_t> {
     Ok(wasi::__wasi_device_t::from(dev))
 }
 
-pub(crate) fn stino_from_nix(ino: libc::ino_t) -> Result<wasi::__wasi_inode_t> {
+pub(crate) fn stino_from_nix(ino: libc::ino_t) -> WasiResult<wasi::__wasi_inode_t> {
     Ok(wasi::__wasi_device_t::from(ino))
 }
 
-pub(crate) fn stnlink_from_nix(nlink: libc::nlink_t) -> Result<wasi::__wasi_linkcount_t> {
+pub(crate) fn stnlink_from_nix(nlink: libc::nlink_t) -> WasiResult<wasi::__wasi_linkcount_t> {
     Ok(nlink)
 }

--- a/crates/wasi-common/yanix/src/dir.rs
+++ b/crates/wasi-common/yanix/src/dir.rs
@@ -2,7 +2,8 @@ use crate::{
     file::FileType,
     sys::dir::{iter_impl, EntryImpl},
 };
-use std::io::Result;
+use std::convert::TryInto;
+use std::io::{Error, Result};
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::{ffi::CStr, io, ops::Deref, ptr};
 
@@ -97,6 +98,18 @@ pub struct SeekLoc(pub(crate) libc::c_long);
 impl SeekLoc {
     pub fn to_raw(&self) -> i64 {
         self.0.into()
+    }
+
+    pub unsafe fn from_raw(loc: i64) -> Result<Self> {
+        // The cookie (or `loc`) is an opaque value, and applications aren't supposed to do
+        // arithmetic on them or pick their own values or have any awareness of the numeric
+        // range of the values. They're just supposed to pass back in the values that we
+        // give them. And any value we give them will be convertable back to `long`,
+        // because that's the type the OS gives them to us in. So return an `EINVAL`.
+        let loc = loc
+            .try_into()
+            .map_err(|_| Error::from_raw_os_error(libc::EINVAL))?;
+        Ok(Self(loc))
     }
 }
 

--- a/crates/wasi-common/yanix/src/sys/bsd/dir.rs
+++ b/crates/wasi-common/yanix/src/sys/bsd/dir.rs
@@ -57,10 +57,3 @@ impl EntryExt for Entry {
         Ok(self.0.loc)
     }
 }
-
-impl SeekLoc {
-    pub unsafe fn from_raw(loc: i64) -> Result<Self> {
-        let loc = loc.into();
-        Ok(Self(loc))
-    }
-}

--- a/crates/wasi-common/yanix/src/sys/bsd/filetime.rs
+++ b/crates/wasi-common/yanix/src/sys/bsd/filetime.rs
@@ -2,33 +2,10 @@
 //! with setting the file times specific to BSD-style *nixes.
 use crate::filetime::FileTime;
 use crate::from_success_code;
-use cfg_if::cfg_if;
 use std::ffi::CStr;
 use std::fs::File;
 use std::io::Result;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
-
-cfg_if! {
-    if #[cfg(any(
-            target_os = "macos",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "dragonfly"
-    ))] {
-        pub(crate) const UTIME_NOW: i64 = -1;
-        pub(crate) const UTIME_OMIT: i64 = -2;
-    } else if #[cfg(target_os = "openbsd")] {
-        // These are swapped compared to macos, freebsd, ios, and dragonfly.
-        // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L187
-        pub(crate) const UTIME_NOW: i64 = -2;
-        pub(crate) const UTIME_OMIT: i64 = -1;
-    } else if #[cfg(target_os = "netbsd" )] {
-        // These are the same as for Linux.
-        // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?rev=1.69&content-type=text/x-cvsweb-markup&only_with_tag=MAIN
-        pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
-        pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
-    }
-}
 
 /// Wrapper for `utimensat` syscall, however, with an added twist such that `utimensat` symbol
 /// is firstly resolved (i.e., we check whether it exists on the host), and only used if that is

--- a/crates/wasi-common/yanix/src/sys/emscripten/filetime.rs
+++ b/crates/wasi-common/yanix/src/sys/emscripten/filetime.rs
@@ -5,9 +5,6 @@ use crate::from_success_code;
 use std::fs::File;
 use std::io::Result;
 
-pub(crate) const UTIME_NOW: i32 = 1_073_741_823;
-pub(crate) const UTIME_OMIT: i32 = 1_073_741_822;
-
 /// Wrapper for `utimensat` syscall. In Emscripten, there is no point in dynamically resolving
 /// if `utimensat` is available as it always was and will be.
 pub fn utimensat(

--- a/crates/wasi-common/yanix/src/sys/emscripten/mod.rs
+++ b/crates/wasi-common/yanix/src/sys/emscripten/mod.rs
@@ -5,21 +5,3 @@ pub(crate) mod fadvise;
 #[path = "../linux/file.rs"]
 pub(crate) mod file;
 pub(crate) mod filetime;
-
-use crate::dir::SeekLoc;
-use std::convert::TryInto;
-use std::io::{Error, Result};
-
-impl SeekLoc {
-    pub unsafe fn from_raw(loc: i64) -> Result<Self> {
-        // The cookie (or `loc`) is an opaque value, and applications aren't supposed to do
-        // arithmetic on them or pick their own values or have any awareness of the numeric
-        // range of the values. They're just supposed to pass back in the values that we
-        // give them. And any value we give them will be convertable back to `long`,
-        // because that's the type the OS gives them to us in. So return an `EINVAL`.
-        let loc = loc
-            .try_into()
-            .map_err(|_| Error::from_raw_os_error(libc::EINVAL))?;
-        Ok(Self(loc))
-    }
-}

--- a/crates/wasi-common/yanix/src/sys/linux/filetime.rs
+++ b/crates/wasi-common/yanix/src/sys/linux/filetime.rs
@@ -6,16 +6,6 @@ use std::fs::File;
 use std::io::Result;
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 
-cfg_if::cfg_if! {
-    if #[cfg(target_pointer_width = "64")] {
-        pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
-        pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
-    } else {
-        pub(crate) const UTIME_NOW: i32 = 1_073_741_823;
-        pub(crate) const UTIME_OMIT: i32 = 1_073_741_822;
-    }
-}
-
 /// Wrapper for `utimensat` syscall, however, with an added twist such that `utimensat` symbol
 /// is firstly resolved (i.e., we check whether it exists on the host), and only used if that is
 /// the case. Otherwise, the syscall resorts to a less accurate `utimesat` emulated syscall.

--- a/crates/wasi-common/yanix/src/sys/linux/filetime.rs
+++ b/crates/wasi-common/yanix/src/sys/linux/filetime.rs
@@ -6,8 +6,15 @@ use std::fs::File;
 use std::io::Result;
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 
-pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
-pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
+cfg_if::cfg_if! {
+    if #[cfg(target_pointer_width = "64")] {
+        pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
+        pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
+    } else {
+        pub(crate) const UTIME_NOW: i32 = 1_073_741_823;
+        pub(crate) const UTIME_OMIT: i32 = 1_073_741_822;
+    }
+}
 
 /// Wrapper for `utimensat` syscall, however, with an added twist such that `utimensat` symbol
 /// is firstly resolved (i.e., we check whether it exists on the host), and only used if that is

--- a/crates/wasi-common/yanix/src/sys/linux/mod.rs
+++ b/crates/wasi-common/yanix/src/sys/linux/mod.rs
@@ -8,8 +8,23 @@ use crate::dir::SeekLoc;
 use std::io::Result;
 
 impl SeekLoc {
+    #[cfg(target_pointer_width = "64")]
     pub unsafe fn from_raw(loc: i64) -> Result<Self> {
         let loc = loc.into();
+        Ok(Self(loc))
+    }
+    #[cfg(target_pointer_width = "32")]
+    pub unsafe fn from_raw(loc: i64) -> Result<Self> {
+        // The cookie (or `loc`) is an opaque value, and applications aren't supposed to do
+        // arithmetic on them or pick their own values or have any awareness of the numeric
+        // range of the values. They're just supposed to pass back in the values that we
+        // give them. And any value we give them will be convertable back to `long`,
+        // because that's the type the OS gives them to us in. So return an `EINVAL`.
+        use std::convert::TryInto;
+        use std::io::Error;
+        let loc = loc
+            .try_into()
+            .map_err(|_| Error::from_raw_os_error(libc::EINVAL))?;
         Ok(Self(loc))
     }
 }

--- a/crates/wasi-common/yanix/src/sys/linux/mod.rs
+++ b/crates/wasi-common/yanix/src/sys/linux/mod.rs
@@ -3,28 +3,3 @@ pub(crate) mod fadvise;
 pub(crate) mod file;
 pub(crate) mod filetime;
 pub(crate) mod utimesat;
-
-use crate::dir::SeekLoc;
-use std::io::Result;
-
-impl SeekLoc {
-    #[cfg(target_pointer_width = "64")]
-    pub unsafe fn from_raw(loc: i64) -> Result<Self> {
-        let loc = loc.into();
-        Ok(Self(loc))
-    }
-    #[cfg(target_pointer_width = "32")]
-    pub unsafe fn from_raw(loc: i64) -> Result<Self> {
-        // The cookie (or `loc`) is an opaque value, and applications aren't supposed to do
-        // arithmetic on them or pick their own values or have any awareness of the numeric
-        // range of the values. They're just supposed to pass back in the values that we
-        // give them. And any value we give them will be convertable back to `long`,
-        // because that's the type the OS gives them to us in. So return an `EINVAL`.
-        use std::convert::TryInto;
-        use std::io::Error;
-        let loc = loc
-            .try_into()
-            .map_err(|_| Error::from_raw_os_error(libc::EINVAL))?;
-        Ok(Self(loc))
-    }
-}

--- a/crates/wasi-common/yanix/src/sys/linux/utimesat.rs
+++ b/crates/wasi-common/yanix/src/sys/linux/utimesat.rs
@@ -1,4 +1,5 @@
 use crate::filetime::FileTime;
+use crate::filetime::FileTimeExt;
 use crate::from_success_code;
 use std::fs;
 use std::io::Result;
@@ -26,19 +27,16 @@ pub fn utimesat(
     let fd = unsafe { libc::openat(dirfd.as_raw_fd(), p.as_ptr(), flags) };
     let f = unsafe { fs::File::from_raw_fd(fd) };
     let (atime, mtime) = get_times(atime, mtime, || f.metadata().map_err(Into::into))?;
-    let times = [to_timeval(atime), to_timeval(mtime)];
+    let times = [to_timeval(atime)?, to_timeval(mtime)?];
     from_success_code(unsafe { libc::futimes(f.as_raw_fd(), times.as_ptr()) })
 }
 
-/// Converts `filetime::FileTime` to `libc::timeval`. This function was taken directly from
-/// [filetime] crate.
-///
-/// [filetime]: https://github.com/alexcrichton/filetime/blob/master/src/unix/utimes.rs#L93
-fn to_timeval(ft: filetime::FileTime) -> libc::timeval {
-    libc::timeval {
-        tv_sec: ft.seconds(),
-        tv_usec: (ft.nanoseconds() / 1000) as libc::suseconds_t,
-    }
+/// Converts `filetime::FileTime` to `libc::timeval`.
+fn to_timeval(ft: filetime::FileTime) -> Result<libc::timeval> {
+    Ok(libc::timeval {
+        tv_sec: ft.seconds_checked()?,
+        tv_usec: (ft.nanoseconds_checked()? / 1000) as libc::suseconds_t,
+    })
 }
 
 /// For a provided pair of access and modified `FileTime`s, converts the input to

--- a/crates/wasi-common/yanix/src/sys/linux/utimesat.rs
+++ b/crates/wasi-common/yanix/src/sys/linux/utimesat.rs
@@ -34,8 +34,8 @@ pub fn utimesat(
 /// Converts `filetime::FileTime` to `libc::timeval`.
 fn to_timeval(ft: filetime::FileTime) -> Result<libc::timeval> {
     Ok(libc::timeval {
-        tv_sec: ft.seconds_checked()?,
-        tv_usec: (ft.nanoseconds_checked()? / 1000) as libc::suseconds_t,
+        tv_sec: ft.seconds_()?,
+        tv_usec: (ft.nanoseconds_() / 1000) as libc::suseconds_t,
     })
 }
 


### PR DESCRIPTION
This commit enables `target_pointer_width = 32` compatibility for `wasi-common` (and by transitivity, any crate found inside, e.g., `yanix`). I've also added a simplistic (bare minimum) check to our CI to ensure that `wasi-common` cross-compiles to `armv7-unknown-gnueabihf` fine. While here, I've done the same for `wasm32-unknown-emscripten`.

To avoid code duplication, I've added a custom ext trait `FileTimeExt` which implements seconds and nanoseconds accessors for with different impls for different pointer widths. I'm not sure whether that's the cleanest approach but definitely seemed like it at the time. Lemme know what you reckon!

Fixes #1219 

cc @stefson hopefully this fixes it for you :-)