### PR TITLE
Exit with a more severe error code if the program traps.

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -123,22 +123,22 @@ impl RunCommand {
                 // If the program exited because of a trap, return an error code
                 // to the outside environment indicating a more severe problem
                 // than a simple failure.
-                if let Some(source) = e.source() {
-                    if let Some(source) = source.source() {
-                        if source.is::<Trap>() {
-                            // Print the error message in the usual way.
-                            eprintln!("Error: {:?}", e);
+                let mut err = e.source();
+                while let Some(source) = err {
+                    if source.is::<Trap>() {
+                        // Print the error message in the usual way.
+                        eprintln!("Error: {:?}", e);
 
-                            // On Unix, return the error code of an abort.
-                            #[cfg(unix)]
-                            process::exit(128 + libc::SIGABRT);
+                        // On Unix, return the error code of an abort.
+                        #[cfg(unix)]
+                        process::exit(128 + libc::SIGABRT);
 
-                            // On Windows, return 3.
-                            // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
-                            #[cfg(windows)]
-                            process::exit(3);
-                        }
+                        // On Windows, return 3.
+                        // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
+                        #[cfg(windows)]
+                        process::exit(3);
                     }
+                    err = source.source();
                 }
                 return Err(e);
             }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -128,14 +128,17 @@ impl RunCommand {
                         // Print the error message in the usual way.
                         eprintln!("Error: {:?}", e);
 
-                        // On Unix, return the error code of an abort.
-                        #[cfg(unix)]
-                        process::exit(128 + libc::SIGABRT);
-
-                        // On Windows, return 3.
-                        // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
-                        #[cfg(windows)]
-                        process::exit(3);
+                        if cfg!(unix) {
+                            // On Unix, return the error code of an abort.
+                            process::exit(128 + libc::SIGABRT);
+                        } else if cfg!(windows) {
+                            // On Windows, return 3.
+                            // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
+                            process::exit(3);
+                        } else {
+                            // Otherwise just exit with a normal error.
+                            break;
+                        }
                     }
                 }
                 return Err(e);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -123,9 +123,8 @@ impl RunCommand {
                 // If the program exited because of a trap, return an error code
                 // to the outside environment indicating a more severe problem
                 // than a simple failure.
-                let mut err = e.source();
-                while let Some(source) = err {
-                    if source.is::<Trap>() {
+                for cause in e.chain() {
+                    if cause.is::<Trap>() {
                         // Print the error message in the usual way.
                         eprintln!("Error: {:?}", e);
 
@@ -138,7 +137,6 @@ impl RunCommand {
                         #[cfg(windows)]
                         process::exit(3);
                     }
-                    err = source.source();
                 }
                 return Err(e);
             }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -123,22 +123,17 @@ impl RunCommand {
                 // If the program exited because of a trap, return an error code
                 // to the outside environment indicating a more severe problem
                 // than a simple failure.
-                for cause in e.chain() {
-                    if cause.is::<Trap>() {
-                        // Print the error message in the usual way.
-                        eprintln!("Error: {:?}", e);
+                if e.is::<Trap>() {
+                    // Print the error message in the usual way.
+                    eprintln!("Error: {:?}", e);
 
-                        if cfg!(unix) {
-                            // On Unix, return the error code of an abort.
-                            process::exit(128 + libc::SIGABRT);
-                        } else if cfg!(windows) {
-                            // On Windows, return 3.
-                            // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
-                            process::exit(3);
-                        } else {
-                            // Otherwise just exit with a normal error.
-                            break;
-                        }
+                    if cfg!(unix) {
+                        // On Unix, return the error code of an abort.
+                        process::exit(128 + libc::SIGABRT);
+                    } else if cfg!(windows) {
+                        // On Windows, return 3.
+                        // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
+                        process::exit(3);
                     }
                 }
                 return Err(e);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -6,10 +6,11 @@ use std::{
     ffi::{OsStr, OsString},
     fs::File,
     path::{Component, Path, PathBuf},
+    process,
 };
 use structopt::{clap::AppSettings, StructOpt};
 use wasi_common::preopen_dir;
-use wasmtime::{Engine, Instance, Module, Store};
+use wasmtime::{Engine, Instance, Module, Store, Trap};
 use wasmtime_interface_types::ModuleData;
 use wasmtime_wasi::{old::snapshot_0::Wasi as WasiSnapshot0, Wasi};
 
@@ -113,8 +114,35 @@ impl RunCommand {
         }
 
         // Load the main wasm module.
-        self.handle_module(&store, &module_registry)
-            .with_context(|| format!("failed to run main module `{}`", self.module.display()))?;
+        match self
+            .handle_module(&store, &module_registry)
+            .with_context(|| format!("failed to run main module `{}`", self.module.display()))
+        {
+            Ok(()) => (),
+            Err(e) => {
+                // If the program exited because of a trap, return an error code
+                // to the outside environment indicating a more severe problem
+                // than a simple failure.
+                if let Some(source) = e.source() {
+                    if let Some(source) = source.source() {
+                        if source.is::<Trap>() {
+                            // Print the error message in the usual way.
+                            eprintln!("Error: {:?}", e);
+
+                            // On Unix, return the error code of an abort.
+                            #[cfg(unix)]
+                            process::exit(128 + libc::SIGABRT);
+
+                            // On Windows, return 3.
+                            // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
+                            #[cfg(windows)]
+                            process::exit(3);
+                        }
+                    }
+                }
+                return Err(e);
+            }
+        }
 
         Ok(())
     }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -88,8 +88,8 @@ fn run_wasmtime_unreachable_wat() -> Result<()> {
     let wasm = build_wasm("tests/wasm/unreachable.wat")?;
     let output = run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;
 
-    assert!(output.stdout.is_empty());
-    assert!(!output.stderr.is_empty());
+    assert_ne!(output.stderr, b"");
+    assert_eq!(output.stdout, b"");
     assert!(!output.status.success());
 
     let code = output

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -101,7 +101,7 @@ fn run_wasmtime_unreachable_wat() -> Result<()> {
     #[cfg(unix)]
     assert_eq!(code, 128 + libc::SIGABRT);
     #[cfg(windows)]
-    assert_eq!(code, 4);
+    assert_eq!(code, 3);
 
     Ok(())
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,15 +1,22 @@
 use anyhow::{bail, Result};
 use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 use tempfile::NamedTempFile;
 
-fn run_wasmtime(args: &[&str]) -> Result<String> {
+// Run the wasmtime CLI with the provided args and return the `Output`.
+fn run_wasmtime_for_output(args: &[&str]) -> Result<Output> {
     let mut me = std::env::current_exe()?;
     me.pop(); // chop off the file name
     me.pop(); // chop off `deps`
     me.push("wasmtime");
-    let output = Command::new(&me).args(args).output()?;
+    Command::new(&me).args(args).output().map_err(Into::into)
+}
+
+// Run the wasmtime CLI with the provided args and, if it succeeds, return
+// the standard output in a `String`.
+fn run_wasmtime(args: &[&str]) -> Result<String> {
+    let output = run_wasmtime_for_output(args)?;
     if !output.status.success() {
         bail!(
             "Failed to execute wasmtime with: {:?}\n{}",
@@ -72,5 +79,29 @@ fn run_wasmtime_simple_wat() -> Result<()> {
         "--disable-cache",
         "4",
     ])?;
+    Ok(())
+}
+
+// Running a wat that traps.
+#[test]
+fn run_wasmtime_unreachable_wat() -> Result<()> {
+    let wasm = build_wasm("tests/wasm/unreachable.wat")?;
+    let output = run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;
+
+    assert!(output.stdout.is_empty());
+    assert!(!output.stderr.is_empty());
+    assert!(!output.status.success());
+
+    let code = output
+        .status
+        .code()
+        .expect("wasmtime process should exit normally");
+
+    // Test for the specific error code Wasmtime uses to indicate a trap return.
+    #[cfg(unix)]
+    assert_eq!(code, 128 + libc::SIGABRT);
+    #[cfg(windows)]
+    assert_eq!(code, 4);
+
     Ok(())
 }

--- a/tests/wasm/unreachable.wat
+++ b/tests/wasm/unreachable.wat
@@ -1,0 +1,5 @@
+(module
+    (func (export "_start")
+        unreachable
+    )
+)


### PR DESCRIPTION
Previously, the wasmtime CLI would return with a regular failure
error code, eg. 1 on Unix. However, a program trap indicates a bug in
the program, which can be useful to distinguish from a simple error
status. Check for the trap case, and return an appropriate OS-specific
exit status.



<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
