### PR TITLE
Enable the "Subscribe to Label" github action

### DIFF
--- a/.github/subscribe-to-label.json
+++ b/.github/subscribe-to-label.json
@@ -1,0 +1,3 @@
+{
+  "peterhuene": ["wasmtime:api", "wasmtime:c-api"]
+}

--- a/.github/workflows/subscribe-to-label.yml
+++ b/.github/workflows/subscribe-to-label.yml
@@ -1,0 +1,13 @@
+name: "Subscribe to Label"
+on:
+  pull_request:
+    types: ["labeled"]
+  issues:
+    types: ["labeled"]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: bytecodealliance/subscribe-to-label-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This allows users to follow certain labels and automatically get @-mentioned
when they are applied to an issue or a pull request.

See https://github.com/bytecodealliance/subscribe-to-label-action for details.

Fixes #1234 