### PR TITLE
Enable bulk memory in the fuzzers

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -23,6 +23,7 @@ fn fuzz_default_config(strategy: Strategy) -> Config {
     config
         .cranelift_debug_verifier(true)
         .wasm_multi_value(true)
+        .wasm_bulk_memory(true)
         .strategy(strategy)
         .expect("failed to enable lightbeam");
     return config;


### PR DESCRIPTION
I plan on adding all the spec tests to the corpora as well, but I want to wait until after we merge this so that they look like new interesting inputs that cover new code paths.