### PR TITLE
Autolabel wasi-common PRs as wasi

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,6 +34,7 @@ fuzzing:
 
 wasi:
   - crates/wasi/*
+  - crates/wasi-common/*
 
 "wasmtime:api":
   - crates/api/*


### PR DESCRIPTION
It seems we missed that one in the labeler, so adding now.
