### PR TITLE
Path symlink follow

### DIFF
--- a/crates/wasi-common/src/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/hostcalls_impl/fs.rs
@@ -650,7 +650,9 @@ pub(crate) unsafe fn path_link(
         false,
     )?;
 
-    hostcalls_impl::path_link(resolved_old, resolved_new)
+    let follow_symlinks = old_flags & wasi::__WASI_LOOKUPFLAGS_SYMLINK_FOLLOW != 0;
+
+    hostcalls_impl::path_link(resolved_old, resolved_new, follow_symlinks)
 }
 
 pub(crate) unsafe fn path_open(

--- a/crates/wasi-common/src/sys/unix/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/sys/unix/hostcalls_impl/fs.rs
@@ -71,15 +71,24 @@ pub(crate) fn path_create_directory(base: &File, path: &str) -> WasiResult<()> {
     unsafe { mkdirat(base.as_raw_fd(), path, Mode::from_bits_truncate(0o777)) }.map_err(Into::into)
 }
 
-pub(crate) fn path_link(resolved_old: PathGet, resolved_new: PathGet) -> WasiResult<()> {
+pub(crate) fn path_link(
+    resolved_old: PathGet,
+    resolved_new: PathGet,
+    follow_symlinks: bool,
+) -> WasiResult<()> {
     use yanix::file::{linkat, AtFlag};
+    let flags = if follow_symlinks {
+        AtFlag::SYMLINK_FOLLOW
+    } else {
+        AtFlag::empty()
+    };
     unsafe {
         linkat(
             resolved_old.dirfd().as_raw_fd(),
             resolved_old.path(),
             resolved_new.dirfd().as_raw_fd(),
             resolved_new.path(),
-            AtFlag::SYMLINK_FOLLOW,
+            flags,
         )
     }
     .map_err(Into::into)

--- a/crates/wasi-common/src/sys/windows/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/sys/windows/hostcalls_impl/fs.rs
@@ -129,7 +129,11 @@ pub(crate) fn path_create_directory(file: &File, path: &str) -> WasiResult<()> {
     std::fs::create_dir(&path).map_err(Into::into)
 }
 
-pub(crate) fn path_link(resolved_old: PathGet, resolved_new: PathGet) -> WasiResult<()> {
+pub(crate) fn path_link(
+    resolved_old: PathGet,
+    resolved_new: PathGet,
+    follow_symlinks: bool,
+) -> WasiResult<()> {
     unimplemented!("path_link")
 }
 


### PR DESCRIPTION
Currently, `path_link` doesn't take `old_flags` into account and always follows symlinks. Besides, the tests are incorrect: it's okay to create a hardlink to the dangling symlink or a symlink loop as long as symlinks are not being followed.

This PR fixes the tests and makes sure that `path_link` follows symlinks only when asked to. 

I've discovered this issue while working on the implementation of `path_link` for Windows and decided it's going to be easier to discuss the issue together with a fix.