### PR TITLE
Add tutorial for building and running hello-world.wasm

### DIFF
--- a/docs/tutorial-create-hello-world.md
+++ b/docs/tutorial-create-hello-world.md
@@ -18,8 +18,8 @@ $ cargo new hello-world
 
 After that, the hello-world folder should look like this.
 
-```
-hello-world
+```text
+hello-world/
 ├── Cargo.lock
 ├── Cargo.toml
 └── src
@@ -43,8 +43,8 @@ $ cargo build --target wasm32-wasi
 
 Now, in the `target` folder, there's a `hello-world.wasm` binary. You can find it here:
 
-```
-hello-world
+```text
+hello-world/
 ├── Cargo.lock
 ├── Cargo.toml
 ├── src

--- a/docs/tutorial-create-hello-world.md
+++ b/docs/tutorial-create-hello-world.md
@@ -1,8 +1,13 @@
 # Creating `hello-world.wasm`
 
-First, you'll need the standard rust toolchain.
+There are a number of ways to create `.wasm` files but for the purposes of this
+tutorial, we'll be using the Rust toolchain. You can find more information on
+creating `.wasm` files from other languages in the
+[Writing WebAssembly section](https://bytecodealliance.github.io/wasmtime/wasm.html).
 
-[follow these instructions to install `rustc`, `rustup` and `cargo`]: https://www.rust-lang.org/tools/install
+To build WebAssembly binaries with Rust, you'll need the standard Rust toolchain.
+
+[Follow these instructions to install `rustc`, `rustup` and `cargo`](https://www.rust-lang.org/tools/install)
 
 Next, you should add WebAssembly as a build target for cargo like so:
 
@@ -10,7 +15,7 @@ Next, you should add WebAssembly as a build target for cargo like so:
 $ rustup target add wasm32-wasi
 ```
 
-Finally, create a new Rust project called 'hello world'. You can do this by running:
+Finally, create a new Rust project called 'hello-world'. You can do this by running:
 
 ```sh
 $ cargo new hello-world
@@ -35,13 +40,13 @@ fn main() {
 
 ```
 
-Now, we can tell `cargo` to build a WebAssembly binary:
+Now, we can tell `cargo` to build a WebAssembly file:
 
 ```sh
 $ cargo build --target wasm32-wasi
 ```
 
-Now, in the `target` folder, there's a `hello-world.wasm` binary. You can find it here:
+Now, in the `target` folder, there's a `hello-world.wasm` file. You can find it here:
 
 ```text
 hello-world/

--- a/docs/tutorial-create-hello-world.md
+++ b/docs/tutorial-create-hello-world.md
@@ -1,3 +1,58 @@
 # Creating `hello-world.wasm`
 
-... more coming soon
+First, you'll need the standard rust toolchain.
+
+[follow these instructions to install `rustc`, `rustup` and `cargo`]: https://www.rust-lang.org/tools/install
+
+Next, you should add WebAssembly as a build target for cargo like so:
+
+```sh
+$ rustup target add wasm32-wasi
+```
+
+Finally, create a new Rust project called 'hello world'. You can do this by running:
+
+```sh
+$ cargo new hello-world
+```
+
+After that, the hello-world folder should look like this.
+
+```
+hello-world
+├── Cargo.lock
+├── Cargo.toml
+└── src
+   └── main.rs
+```
+
+And the `main.rs` file inside the `src` folder should contain the following rust code.
+
+```rust
+fn main() {
+    println!("Hello, world!");
+}
+
+```
+
+Now, we can tell `cargo` to build a WebAssembly binary:
+
+```sh
+$ cargo build --target wasm32-wasi
+```
+
+Now, in the `target` folder, there's a `hello-world.wasm` binary. You can find it here:
+
+```
+hello-world
+├── Cargo.lock
+├── Cargo.toml
+├── src
+└── target
+   └── ...
+   └── wasm32-wasi
+      └── debug
+         └── ...
+         └── hello-world.wasm
+
+```

--- a/docs/tutorial-create-hello-world.md
+++ b/docs/tutorial-create-hello-world.md
@@ -3,7 +3,7 @@
 There are a number of ways to create `.wasm` files but for the purposes of this
 tutorial, we'll be using the Rust toolchain. You can find more information on
 creating `.wasm` files from other languages in the
-[Writing WebAssembly section](https://bytecodealliance.github.io/wasmtime/wasm.html).
+[Writing WebAssembly section](./wasm.md).
 
 To build WebAssembly binaries with Rust, you'll need the standard Rust toolchain.
 

--- a/docs/tutorial-run-hello-world.md
+++ b/docs/tutorial-run-hello-world.md
@@ -1,10 +1,28 @@
 # Running `hello-world.wasm` with Wasmtime
 
-Now you have built the `hello-world.wasm` binary (If you haven't,
-the instructions for doing so are in the
-[previous section](https://bytecodealliance.github.io/wasmtime/tutorial-create-hello-world.html)).
+## Installing Wasmtime
 
-You can then run the binary with Wasmtime, like so:
+The Wasmtime CLI can be installed on Linux and macOS with a small install
+script:
+
+```sh
+$ curl https://wasmtime.dev/install.sh -sSf | bash
+```
+
+Windows or otherwise interested users can download installers and binaries
+directly from the
+[GitHub Releases](https://github.com/bytecodealliance/wasmtime/releases) page.
+
+## Running `hello-world.wasm`
+
+There are a number of ways to run a `.wasm` file with Wasmtime. In this
+tutorial, we'll be using the CLI, Wasmtime can also be embedded in your
+applications. More information on this can be found in the
+[Embedding Wasmtime section](https://bytecodealliance.github.io/wasmtime/embed.html).
+
+If you've built the `hello-world.wasm` file (the instructions for doing so are in the
+[previous section](https://bytecodealliance.github.io/wasmtime/tutorial-create-hello-world.html)),
+you can run it with Wasmtime from the command line like so:
 
 ```sh
 $ wasmtime target/wasm32-wasi/debug/hello-world.wasm

--- a/docs/tutorial-run-hello-world.md
+++ b/docs/tutorial-run-hello-world.md
@@ -1,3 +1,11 @@
 # Running `hello-world.wasm` with Wasmtime
 
-... more coming soon
+Now you have built the `hello-world.wasm` binary (If you haven't,
+the instructions for doing so are in the
+[previous section](https://bytecodealliance.github.io/wasmtime/tutorial-create-hello-world.html)).
+
+You can then run the binary with Wasmtime, like so:
+
+```sh
+$ wasmtime target/wasm32-wasi/debug/hello-world.wasm
+```

--- a/docs/tutorial-run-hello-world.md
+++ b/docs/tutorial-run-hello-world.md
@@ -9,19 +9,18 @@ script:
 $ curl https://wasmtime.dev/install.sh -sSf | bash
 ```
 
-Windows or otherwise interested users can download installers and binaries
-directly from the
-[GitHub Releases](https://github.com/bytecodealliance/wasmtime/releases) page.
+You can find more information about installing the Wasmtime CLI in the
+[CLI Installation section](./cli-install.md)
 
 ## Running `hello-world.wasm`
 
 There are a number of ways to run a `.wasm` file with Wasmtime. In this
 tutorial, we'll be using the CLI, Wasmtime can also be embedded in your
 applications. More information on this can be found in the
-[Embedding Wasmtime section](https://bytecodealliance.github.io/wasmtime/embed.html).
+[Embedding Wasmtime section](./embed.md).
 
 If you've built the `hello-world.wasm` file (the instructions for doing so are in the
-[previous section](https://bytecodealliance.github.io/wasmtime/tutorial-create-hello-world.html)),
+[previous section](./tutorial-create-hello-world.md)),
 you can run it with Wasmtime from the command line like so:
 
 ```sh


### PR DESCRIPTION
This PR adds a tutorial on creating and running `hello-world.wasm` with wasmtime to the docs.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
