### PR TITLE
Two more label tweaks

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,6 +41,7 @@ fuzzing:
 wasi:
   - crates/wasi/*
   - crates/wasi-common/*
+  - crates/wiggle/*
 
 "wasmtime:api":
   - crates/api/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,12 @@
 cranelift:
   - cranelift/*
 
+"cranelift:module":
+  - cranelift/cranelift-module/*
+  - cranelift/cranelift-object/*
+  - cranelift/cranelift-faerie/*
+  - cranelift/cranelift-simplejit/*
+
 "cranelift:docs":
   - cranelift/docs/*
 


### PR DESCRIPTION
* the `cranelift:module` is a label for cranelift-module and its children, I personally watch those more closely than the general cranelift label
* put `crates/wiggle/*` under the `wasi` label


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
