### PR TITLE
wiggle: make paths relative to use site of macro

### DIFF
--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -5,7 +5,10 @@ use syn::parse_macro_input;
 
 #[proc_macro]
 pub fn from_witx(args: TokenStream) -> TokenStream {
-    let config = parse_macro_input!(args as wiggle_generate::Config);
+    let mut config = parse_macro_input!(args as wiggle_generate::Config);
+    config.witx.make_paths_relative_to(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR env var"),
+    );
     let doc = witx::load(&config.witx.paths).expect("loading witx");
     TokenStream::from(wiggle_generate::generate(&doc, &config))
 }


### PR DESCRIPTION
prior to this change, they were relative to CARGO_MANIFEST_DIR for the
wiggle-generate crate.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
