### PR TITLE
Run the subscribe-to-label action on a schedule rather than on pull request events

### DIFF
--- a/.github/workflows/subscribe-to-label.yml
+++ b/.github/workflows/subscribe-to-label.yml
@@ -1,9 +1,14 @@
 name: "Subscribe to Label"
 on:
-  pull_request:
-    types: ["labeled"]
   issues:
     types: ["labeled"]
+on:
+  schedule:
+    # Run pull request triage every 5 minutes. Ideally, this would be on
+    # "labeled" types of pull request events, but that doesn't work if the pull
+    # request is from another fork. For example, see
+    # https://github.com/actions/labeler/issues/12
+    - cron: '*/5 * * * *'
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ideally, this would be on "labeled" types of pull request events, but that
doesn't work if the pull request is from another fork. For example, see
https://github.com/actions/labeler/issues/12

Note that the issue labeled events work fine, and this is only for pull requests.