### PR TITLE
Increase the size of the sigaltstack.

### DIFF
--- a/crates/api/src/trap.rs
+++ b/crates/api/src/trap.rs
@@ -50,6 +50,9 @@ impl Trap {
             wasmtime_runtime::Trap::Wasm { desc, backtrace } => {
                 Trap::new_with_trace(desc.to_string(), backtrace)
             }
+            wasmtime_runtime::Trap::OOM { backtrace } => {
+                Trap::new_with_trace("Out of memory".to_string(), backtrace)
+            }
         }
     }
 

--- a/crates/runtime/signalhandlers/SignalHandlers.hpp
+++ b/crates/runtime/signalhandlers/SignalHandlers.hpp
@@ -34,6 +34,9 @@ void Unwind(void*);
 int
 EnsureEagerSignalHandlers(void);
 
+/// Report a fatal dynamic memory allocation failure.
+void RaiseOOMTrap(void) __attribute__((noreturn));
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/crates/runtime/signalhandlers/Trampolines.cpp
+++ b/crates/runtime/signalhandlers/Trampolines.cpp
@@ -1,12 +1,69 @@
+#include <unistd.h>
 #include <setjmp.h>
+#include <stdlib.h>
+#include <sys/mman.h>
 
 #include "SignalHandlers.hpp"
+
+// The size of the sigaltstack (not including the guard, which will be added).
+// Make this large enough to run our signal handlers.
+static const size_t sigaltstack_size = 4 * SIGSTKSZ;
+
+// A utility to register a new sigaltstack.
+namespace {
+  static thread_local class SigAltStack {
+    size_t guard_size;
+    size_t sigaltstack_alloc_size;
+    stack_t new_stack;
+
+  public:
+    SigAltStack();
+    ~SigAltStack();
+  } thread_sigaltstack;
+}
+
+SigAltStack::SigAltStack()
+  : guard_size(sysconf(_SC_PAGESIZE))
+  , sigaltstack_alloc_size(guard_size + sigaltstack_size)
+{
+  // Allocate memory.
+  void *ptr = mmap(NULL, sigaltstack_alloc_size, PROT_NONE,
+                   MAP_PRIVATE | MAP_ANON, -1, 0);
+  if (ptr == MAP_FAILED)
+    RaiseOOMTrap();
+
+  // Prepare the stack, register it, and sanity check the old stack.
+  void *stack_ptr = (void *)((uintptr_t)ptr + guard_size);
+  new_stack = (stack_t) { stack_ptr, 0, sigaltstack_size };
+  stack_t old_stack;
+  if (mprotect(stack_ptr, sigaltstack_size, PROT_READ | PROT_WRITE) != 0 ||
+      sigaltstack(&new_stack, &old_stack) != 0 ||
+      old_stack.ss_flags != 0 ||
+      old_stack.ss_size > sigaltstack_size)
+    abort();
+}
+
+SigAltStack::~SigAltStack() {
+  // Disable the sigaltstack. We don't restore the old sigaltstack because
+  // Rust may have restored its old sigaltstack already (the Rust at_exit
+  // mechanism doesn't interleave with __cxa_atexit). Fortunately, the thread
+  // is exiting so there's no need; we just make sure our sigaltstack is no
+  // longer registered before we free it.
+  static const stack_t disable_stack = { NULL, SS_DISABLE, SIGSTKSZ };
+  void *alloc_ptr = (void *)((uintptr_t)new_stack.ss_sp - guard_size);
+  if (sigaltstack(&disable_stack, NULL) != 0 ||
+      munmap(alloc_ptr, sigaltstack_alloc_size) != 0)
+    abort();
+}
 
 extern "C"
 int RegisterSetjmp(
     void **buf_storage,
     void (*body)(void*),
     void *payload) {
+  // Ensure that the thread-local sigaltstack is initialized.
+  thread_sigaltstack;
+
   jmp_buf buf;
   if (setjmp(buf) != 0) {
     return 0;


### PR DESCRIPTION
Rust's stack overflow handler installs a sigaltstack stack with size
SIGSTKSZ, which is too small for some of the things we do in signal
handlers. Install bigger sigaltstack stacks so that we have enough
space.

cc #900. The code here is a sketch of a possible
alternative. Advantages of this approach include not needing extra
prologue checks, not disabling the Rust stack overflow message, and
ensuring that we always have a guard page.


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
