### PR TITLE
Re enable subscribe to label action and more bot configs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,3 +49,7 @@ wasi:
 
 "wasmtime:c-api":
   - crates/c-api/**
+
+"wasmtime:docs":
+  - *.md
+  - docs/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,10 @@ cranelift:
   - cranelift/cranelift-object/**
   - cranelift/cranelift-simplejit/**
 
+"cranelift:wasm":
+  - cranelift/wasm/**
+  - cranelift/wasmtests/**
+
 fuzzing:
   - crates/fuzzing/**
   - fuzz/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,10 +27,10 @@ cranelift:
   - cranelift/codegen/meta/**
 
 "cranelift:module":
-  - cranelift/cranelift-faerie/**
-  - cranelift/cranelift-module/**
-  - cranelift/cranelift-object/**
-  - cranelift/cranelift-simplejit/**
+  - cranelift/faerie/**
+  - cranelift/module/**
+  - cranelift/object/**
+  - cranelift/simplejit/**
 
 "cranelift:wasm":
   - cranelift/wasm/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,24 +20,24 @@
 cranelift:
   - cranelift/**
 
-"cranelift:module":
-  - cranelift/cranelift-module/**
-  - cranelift/cranelift-object/**
-  - cranelift/cranelift-faerie/**
-  - cranelift/cranelift-simplejit/**
-
 "cranelift:docs":
   - cranelift/docs/**
 
 "cranelift:meta":
   - cranelift/codegen/meta/**
 
-lightbeam:
-  - crates/lightbeam/**
+"cranelift:module":
+  - cranelift/cranelift-faerie/**
+  - cranelift/cranelift-module/**
+  - cranelift/cranelift-object/**
+  - cranelift/cranelift-simplejit/**
 
 fuzzing:
   - crates/fuzzing/**
   - fuzz/**
+
+lightbeam:
+  - crates/lightbeam/**
 
 wasi:
   - crates/wasi/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,6 +37,7 @@ lightbeam:
 
 fuzzing:
   - crates/fuzzing/**
+  - fuzz/**
 
 wasi:
   - crates/wasi/**

--- a/.github/subscribe-to-label.json
+++ b/.github/subscribe-to-label.json
@@ -1,3 +1,4 @@
 {
+  "fitzgen": ["fuzzing"],
   "peterhuene": ["wasmtime:api", "wasmtime:c-api"]
 }

--- a/.github/workflows/subscribe-to-label.yml
+++ b/.github/workflows/subscribe-to-label.yml
@@ -2,13 +2,12 @@ name: "Subscribe to Label"
 on:
   issues:
     types: ["labeled"]
-  # Temporarily disabled until we fix the bot...
-  # schedule:
-  #   # Run pull request triage every 5 minutes. Ideally, this would be on
-  #   # "labeled" types of pull request events, but that doesn't work if the pull
-  #   # request is from another fork. For example, see
-  #   # https://github.com/actions/labeler/issues/12
-  #   - cron: '*/5 * * * *'
+  schedule:
+    # Run pull request triage every 5 minutes. Ideally, this would be on
+    # "labeled" types of pull request events, but that doesn't work if the pull
+    # request is from another fork. For example, see
+    # https://github.com/actions/labeler/issues/12
+    - cron: '*/5 * * * *'
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I fixed the subscribe-to-label bot so it won't be spammy anymore. Time to re-enable it.

I also fixed up and expanded a bunch of the automatic labeling configuration.

See individual commits for details.