### PR TITLE
[wiggle] missed versions and fields in wiggle cargo.toml

### DIFF
--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -4,16 +4,22 @@ version = "0.1.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2018"
+description = "Wiggle code generator"
+categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
+repository = "https://github.com/bytecodealliance/wasmtime"
+readme = "README.md"
+include = ["src/**/*", "LICENSE"]
 
 [lib]
 proc-macro = true
 
 [dependencies]
-wiggle-generate = { path = "crates/generate" }
+wiggle-generate = { path = "crates/generate", version = "0.1.0" }
 witx = "0.8.3"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-wiggle-runtime = { path = "crates/runtime" }
-wiggle-test = { path = "crates/test" }
+wiggle-runtime = { path = "crates/runtime", version = "0.1.0" }
+wiggle-test = { path = "crates/test", version = "0.1.0" }
 proptest = "0.9"


### PR DESCRIPTION
This was missing from my commits in #1297.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
