### PR TITLE
Store module name on `wasmtime_environ::Module`

### DIFF
--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -128,6 +128,9 @@ pub struct DummyEnvironment {
     /// Instructs to collect debug data during translation.
     debug_info: bool,
 
+    /// Name of the module from the wasm file.
+    pub module_name: Option<String>,
+
     /// Function names.
     function_names: SecondaryMap<FuncIndex, String>,
 }
@@ -141,6 +144,7 @@ impl DummyEnvironment {
             func_bytecode_sizes: Vec::new(),
             return_mode,
             debug_info,
+            module_name: None,
             function_names: SecondaryMap::new(),
         }
     }
@@ -723,6 +727,11 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         };
         self.func_bytecode_sizes.push(body_bytes.len());
         self.info.function_bodies.push(func);
+        Ok(())
+    }
+
+    fn declare_module_name(&mut self, name: &'data str) -> WasmResult<()> {
+        self.module_name = Some(String::from(name));
         Ok(())
     }
 

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -648,6 +648,14 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         data: &'data [u8],
     ) -> WasmResult<()>;
 
+    /// Declares the name of a module to the environment.
+    ///
+    /// By default this does nothing, but implementations can use this to read
+    /// the module name subsection of the custom name section if desired.
+    fn declare_module_name(&mut self, _name: &'data str) -> WasmResult<()> {
+        Ok(())
+    }
+
     /// Declares the name of a function to the environment.
     ///
     /// By default this does nothing, but implementations can use this to read

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -429,9 +429,13 @@ pub fn parse_name_section<'data>(
                         environ.declare_func_name(index, name)?;
                     }
                 }
-                return Ok(());
             }
-            wasmparser::Name::Local(_) | wasmparser::Name::Module(_) => {}
+            wasmparser::Name::Module(module) => {
+                if let Ok(name) = module.get_name() {
+                    environ.declare_module_name(name)?;
+                }
+            }
+            wasmparser::Name::Local(_) => {}
         };
     }
     Ok(())

--- a/crates/api/src/frame_info.rs
+++ b/crates/api/src/frame_info.rs
@@ -1,6 +1,6 @@
-use crate::module::Names;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
+use wasmtime_environ::Module;
 use wasmtime_environ::entity::EntityRef;
 use wasmtime_environ::wasm::FuncIndex;
 use wasmtime_jit::CompiledModule;
@@ -39,7 +39,7 @@ pub struct GlobalFrameInfoRegistration {
 struct ModuleFrameInfo {
     start: usize,
     functions: BTreeMap<usize, (usize, FuncIndex)>,
-    names: Arc<Names>,
+    module: Arc<Module>,
 }
 
 impl GlobalFrameInfo {
@@ -51,7 +51,6 @@ impl GlobalFrameInfo {
     /// dropped, will be used to unregister all name information from this map.
     pub fn register(
         &self,
-        names: &Arc<Names>,
         module: &CompiledModule,
     ) -> Option<GlobalFrameInfoRegistration> {
         let mut min = usize::max_value();
@@ -92,7 +91,7 @@ impl GlobalFrameInfo {
             ModuleFrameInfo {
                 start: min,
                 functions,
-                names: names.clone(),
+                module: module.module().clone(),
             },
         );
         assert!(prev.is_none());
@@ -114,9 +113,9 @@ impl GlobalFrameInfo {
             return None;
         }
         Some(FrameInfo {
-            module_name: info.names.module_name.clone(),
+            module_name: info.module.name.clone(),
             func_index: func_index.index() as u32,
-            func_name: info.names.module.func_names.get(func_index).cloned(),
+            func_name: info.module.func_names.get(func_index).cloned(),
         })
     }
 }

--- a/crates/api/src/frame_info.rs
+++ b/crates/api/src/frame_info.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
-use wasmtime_environ::Module;
 use wasmtime_environ::entity::EntityRef;
 use wasmtime_environ::wasm::FuncIndex;
+use wasmtime_environ::Module;
 use wasmtime_jit::CompiledModule;
 
 lazy_static::lazy_static! {
@@ -49,10 +49,7 @@ impl GlobalFrameInfo {
     /// compiled functions within `module`. If the `module` has no functions
     /// then `None` will be returned. Otherwise the returned object, when
     /// dropped, will be used to unregister all name information from this map.
-    pub fn register(
-        &self,
-        module: &CompiledModule,
-    ) -> Option<GlobalFrameInfoRegistration> {
+    pub fn register(&self, module: &CompiledModule) -> Option<GlobalFrameInfoRegistration> {
         let mut min = usize::max_value();
         let mut max = 0;
         let mut functions = BTreeMap::new();

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -141,6 +141,9 @@ pub struct Module {
     /// A unique identifier (within this process) for this module.
     pub id: usize,
 
+    /// The name of this wasm module, often found in the wasm file.
+    pub name: Option<String>,
+
     /// Local information about a module which is the bare minimum necessary to
     /// translate a function body. This is derived as `Hash` whereas this module
     /// isn't, since it contains too much information needed to translate a
@@ -222,6 +225,7 @@ impl Module {
 
         Self {
             id: NEXT_ID.fetch_add(1, SeqCst),
+            name: None,
             imported_funcs: PrimaryMap::new(),
             imported_tables: PrimaryMap::new(),
             imported_memories: PrimaryMap::new(),

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -409,6 +409,11 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         Ok(())
     }
 
+    fn declare_module_name(&mut self, name: &'data str) -> WasmResult<()> {
+        self.result.module.name = Some(name.to_string());
+        Ok(())
+    }
+
     fn declare_func_name(&mut self, func_index: FuncIndex, name: &'data str) -> WasmResult<()> {
         self.result
             .module

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -252,6 +252,11 @@ impl CompiledModule {
         &self.module
     }
 
+    /// Return a reference-counting pointer to a module.
+    pub fn module_mut(&mut self) -> &mut Arc<Module> {
+        &mut self.module
+    }
+
     /// Return a reference to a module.
     pub fn module_ref(&self) -> &Module {
         &self.module


### PR DESCRIPTION
This keeps all name information in one place so we dont' have to keep
extra structures around in `wasmtime::Module`.
