### PR TITLE
cranelift-{module, faerie}: minor improvements to error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
- "faerie",
+ "faerie 0.15.0",
  "goblin",
  "target-lexicon",
 ]
@@ -499,6 +499,7 @@ dependencies = [
 name = "cranelift-module"
 version = "0.59.0"
 dependencies = [
+ "anyhow",
  "cranelift-codegen",
  "cranelift-entity",
  "hashbrown",
@@ -848,6 +849,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b9ed6159e4a6212c61d9c6a86bee01876b192a64accecf58d5b5ae3b667b52"
 dependencies = [
  "anyhow",
+ "goblin",
+ "indexmap",
+ "log",
+ "scroll",
+ "string-interner",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
+name = "faerie"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
+dependencies = [
  "goblin",
  "indexmap",
  "log",
@@ -2424,7 +2440,7 @@ name = "wasmtime-cli"
 version = "0.12.0"
 dependencies = [
  "anyhow",
- "faerie",
+ "faerie 0.14.0",
  "file-per-thread-logger",
  "filecheck",
  "libc",
@@ -2453,7 +2469,7 @@ name = "wasmtime-debug"
 version = "0.12.0"
 dependencies = [
  "anyhow",
- "faerie",
+ "faerie 0.14.0",
  "gimli",
  "more-asserts",
  "target-lexicon",
@@ -2553,7 +2569,7 @@ name = "wasmtime-obj"
 version = "0.12.0"
 dependencies = [
  "anyhow",
- "faerie",
+ "faerie 0.14.0",
  "more-asserts",
  "wasmtime-environ",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
- "faerie 0.15.0",
+ "faerie",
  "goblin",
  "target-lexicon",
 ]
@@ -841,22 +841,6 @@ dependencies = [
 [[package]]
 name = "example-fib-debug-wasm"
 version = "0.1.0"
-
-[[package]]
-name = "faerie"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b9ed6159e4a6212c61d9c6a86bee01876b192a64accecf58d5b5ae3b667b52"
-dependencies = [
- "anyhow",
- "goblin",
- "indexmap",
- "log",
- "scroll",
- "string-interner",
- "target-lexicon",
- "thiserror",
-]
 
 [[package]]
 name = "faerie"
@@ -2440,7 +2424,7 @@ name = "wasmtime-cli"
 version = "0.12.0"
 dependencies = [
  "anyhow",
- "faerie 0.14.0",
+ "faerie",
  "file-per-thread-logger",
  "filecheck",
  "libc",
@@ -2469,7 +2453,7 @@ name = "wasmtime-debug"
 version = "0.12.0"
 dependencies = [
  "anyhow",
- "faerie 0.14.0",
+ "faerie",
  "gimli",
  "more-asserts",
  "target-lexicon",
@@ -2569,7 +2553,7 @@ name = "wasmtime-obj"
 version = "0.12.0"
 dependencies = [
  "anyhow",
- "faerie 0.14.0",
+ "faerie",
  "more-asserts",
  "wasmtime-environ",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wasmtime-wast = { path = "crates/wast" }
 wasmtime-wasi = { path = "crates/wasi" }
 wasi-common = { path = "crates/wasi-common" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
-faerie = "0.14.0"
+faerie = "0.15.0"
 anyhow = "1.0.19"
 target-lexicon = { version = "0.10.0", default-features = false }
 pretty_env_logger = "0.3.0"

--- a/cranelift/faerie/Cargo.toml
+++ b/cranelift/faerie/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-module = { path = "../module", version = "0.59.0" }
-faerie = "0.14.0"
+faerie = "0.15.0"
 goblin = "0.1.0"
 anyhow = "1.0"
 target-lexicon = "0.10"

--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -2,7 +2,7 @@
 
 use crate::container;
 use crate::traps::{FaerieTrapManifest, FaerieTrapSink};
-use anyhow::Error;
+use anyhow::anyhow;
 use cranelift_codegen::binemit::{
     Addend, CodeOffset, NullStackmapSink, NullTrapSink, Reloc, RelocSink, Stackmap, StackmapSink,
 };
@@ -57,9 +57,9 @@ impl FaerieBuilder {
         libcall_names: Box<dyn Fn(ir::LibCall) -> String>,
     ) -> ModuleResult<Self> {
         if !isa.flags().is_pic() {
-            return Err(ModuleError::Backend(
-                "faerie requires TargetIsa be PIC".to_owned(),
-            ));
+            return Err(ModuleError::Backend(anyhow!(
+                "faerie requires TargetIsa be PIC"
+            )));
         }
         Ok(Self {
             isa,
@@ -257,7 +257,7 @@ impl Backend for FaerieBackend {
                     to,
                     at: u64::from(offset),
                 })
-                .map_err(|e| ModuleError::Backend(e.to_string()))?;
+                .map_err(|e| ModuleError::Backend(e.into()))?;
         }
         for &(offset, id, addend) in data_relocs {
             debug_assert_eq!(
@@ -271,7 +271,7 @@ impl Backend for FaerieBackend {
                     to,
                     at: u64::from(offset),
                 })
-                .map_err(|e| ModuleError::Backend(e.to_string()))?;
+                .map_err(|e| ModuleError::Backend(e.into()))?;
         }
 
         match *init {
@@ -369,12 +369,12 @@ impl FaerieProduct {
     }
 
     /// Call `emit` on the faerie `Artifact`, producing bytes in memory.
-    pub fn emit(&self) -> Result<Vec<u8>, Error> {
+    pub fn emit(&self) -> Result<Vec<u8>, faerie::ArtifactError> {
         self.artifact.emit()
     }
 
     /// Call `write` on the faerie `Artifact`, writing to a file.
-    pub fn write(&self, sink: File) -> Result<(), Error> {
+    pub fn write(&self, sink: File) -> Result<(), faerie::ArtifactError> {
         self.artifact.write(sink)
     }
 }

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -16,6 +16,7 @@ cranelift-entity = { path = "../entity", version = "0.59.0" }
 hashbrown = { version = "0.6", optional = true }
 log = { version = "0.4.6", default-features = false }
 thiserror = "1.0.4"
+anyhow = "1.0"
 
 [features]
 default = ["std"]

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -149,7 +149,7 @@ pub enum ModuleError {
     Compilation(#[from] CodegenError),
     /// Wraps a generic error from a backend
     #[error("Backend error: {0}")]
-    Backend(String),
+    Backend(#[source] anyhow::Error),
 }
 
 /// A convenient alias for a `Result` that uses `ModuleError` as the error type.

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 gimli = "0.20.0"
 wasmparser = "0.51.2"
-faerie = "0.14.0"
+faerie = "0.15.0"
 wasmtime-environ = { path = "../environ", version = "0.12.0" }
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0"

--- a/crates/debug/src/write_debuginfo.rs
+++ b/crates/debug/src/write_debuginfo.rs
@@ -35,7 +35,8 @@ pub fn emit_dwarf(
             id.name(),
             Decl::section(SectionKind::Debug),
             s.writer.take(),
-        )
+        )?;
+        Ok(())
     })?;
     sections.for_each_mut(|id, s| -> anyhow::Result<()> {
         for reloc in &s.relocs {

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 wasmtime-environ = { path = "../environ", version = "0.12.0" }
-faerie = "0.14.0"
+faerie = "0.15.0"
 more-asserts = "0.2.1"
 
 [badges]


### PR DESCRIPTION
I [updated faerie](https://github.com/m4b/faerie/pull/112) to always return the fully structured
`ArtifactError` type throughout its API. This PR makes sure we also return that structured
error type in the `FaerieProduct` methods.

I have also revised the `cranelift_module::ModuleError::Backend` error variant, which appears
to only be used by the faerie backend, to contain an `anyhow::Error` instead of a `String`. This
way we retain more error information without breaking the abstraction that cranelift-module
doesn't know anything specific (like types) from its backends.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
