### PR TITLE
Put all labels and globs in quotes for automatic labeling config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,43 +17,43 @@
 #
 # Note that we keep the labels in alphabetical order below.
 
-cranelift:
-  - cranelift/**
+"cranelift":
+  - "cranelift/**"
 
 "cranelift:docs":
-  - cranelift/docs/**
+  - "cranelift/docs/**"
 
 "cranelift:meta":
-  - cranelift/codegen/meta/**
+  - "cranelift/codegen/meta/**"
 
 "cranelift:module":
-  - cranelift/faerie/**
-  - cranelift/module/**
-  - cranelift/object/**
-  - cranelift/simplejit/**
+  - "cranelift/faerie/**"
+  - "cranelift/module/**"
+  - "cranelift/object/**"
+  - "cranelift/simplejit/**"
 
 "cranelift:wasm":
-  - cranelift/wasm/**
-  - cranelift/wasmtests/**
+  - "cranelift/wasm/**"
+  - "cranelift/wasmtests/**"
 
-fuzzing:
-  - crates/fuzzing/**
-  - fuzz/**
+"fuzzing":
+  - "crates/fuzzing/**"
+  - "fuzz/**"
 
-lightbeam:
-  - crates/lightbeam/**
+"lightbeam":
+  - "crates/lightbeam/**"
 
-wasi:
-  - crates/wasi/**
-  - crates/wasi-common/**
-  - crates/wiggle/**
+"wasi":
+  - "crates/wasi/**"
+  - "crates/wasi-common/**"
+  - "crates/wiggle/**"
 
 "wasmtime:api":
-  - crates/api/**
+  - "crates/api/**"
 
 "wasmtime:c-api":
-  - crates/c-api/**
+  - "crates/c-api/**"
 
 "wasmtime:docs":
-  - *.md
-  - docs/**
+  - "*.md"
+  - "docs/**"


### PR DESCRIPTION
It is too easy to run afoul of yaml syntax with all these colons an asterisks,
e.g. we recently broke the bot like this:

```
YAMLException: unidentified alias ".md" at line 58, column 9:
      - *.md
            ^
    at generateError (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:8357:10)
    at throwError (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:8363:9)
    at readAlias (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9466:5)
    at composeNode (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9558:20)
    at readBlockMapping (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9226:16)
    at composeNode (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9549:12)
    at readBlockSequence (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9145:5)
    at composeNode (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9548:12)
    at readBlockMapping (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9279:11)
    at composeNode (/home/runner/work/_actions/bytecodealliance/labeler/schedule-fork/dist/index.js:9549:12)
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
