### PR TITLE
CI: add cargo audit job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -593,3 +593,18 @@ jobs:
         files: "dist/*"
         name: ${{ steps.tagname.outputs.val }}
         token: ${{ secrets.GITHUB_TOKEN }}
+
+  cargo-audit:
+    env:
+      CARGO_AUDIT_VERSION: 0.11.2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/cache@v1
+      with:
+        path: ${{ runner.tool_cache }}/cargo-audit
+        key: cargo-audit-bin-${{ env.CARGO_AUDIT_VERSION }}
+    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-audit/bin"
+    - run: |
+        cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
+        cargo audit


### PR DESCRIPTION
This PR adds a [`cargo-audit`](https://github.com/RustSec/cargo-audit) job to the github actions workflow to scan `Cargo.lock` for crates with known security vulnerabilities.

The first time the job is run, or whenever a new `cargo-audit` release is published, the job will take a few minutes since it has to fetch and build the binary. However, the binary is cached so subsequent runs will only take a few seconds.