### PR TITLE
Remove no-longer-needed wasm-webidl-bindings dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.51.2",
+ "wasmparser",
  "wat",
 ]
 
@@ -1054,12 +1054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
 name = "indexmap"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,7 +1206,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "typemap",
- "wasmparser 0.51.2",
+ "wasmparser",
  "wat",
 ]
 
@@ -2348,32 +2342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walrus"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84651d7b04ebbecf715a28859d1dc5053b98c6a5a20bd7343d8f015947b86481"
-dependencies = [
- "anyhow",
- "id-arena",
- "leb128",
- "log",
- "walrus-macro",
- "wasmparser 0.48.2",
-]
-
-[[package]]
-name = "walrus-macro"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1845ca33b1fcec5624f0e5ea617e41a8adea37f71eb117d3ff81a089d5e3f9"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,24 +2368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-webidl-bindings"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42298d64a28700ecd5aa47d8037bcf832b7be0c88ad6b272ebb5d92d7e052a8c"
-dependencies = [
- "anyhow",
- "id-arena",
- "leb128",
- "walrus",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.48.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073da89bf1c84db000dd68ce660c1b4a08e3a2d28fd1e3394ab9e7abdde4a0f8"
-
-[[package]]
 name = "wasmparser"
 version = "0.51.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,7 +2380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd423d45b95fcee11775472bfdce66c63c45ada23c1b338e0a63d623a6c475b"
 dependencies = [
  "anyhow",
- "wasmparser 0.51.2",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2450,7 +2400,7 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasmparser 0.51.2",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-profiling",
@@ -2486,7 +2436,6 @@ dependencies = [
  "tempfile",
  "test-programs",
  "wasi-common",
- "wasm-webidl-bindings",
  "wasmtime",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -2509,7 +2458,7 @@ dependencies = [
  "more-asserts",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.51.2",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -2542,7 +2491,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "wasmparser 0.51.2",
+ "wasmparser",
  "winapi",
  "zstd",
 ]
@@ -2570,7 +2519,7 @@ dependencies = [
  "env_logger 0.7.1",
  "log",
  "rayon",
- "wasmparser 0.51.2",
+ "wasmparser",
  "wasmprinter",
  "wasmtime",
  "wat",
@@ -2591,7 +2540,7 @@ dependencies = [
  "region",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.51.2",
+ "wasmparser",
  "wasmtime-debug",
  "wasmtime-environ",
  "wasmtime-profiling",
@@ -2631,7 +2580,7 @@ dependencies = [
  "pyo3",
  "region",
  "target-lexicon",
- "wasmparser 0.51.2",
+ "wasmparser",
  "wasmtime",
  "wasmtime-wasi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ file-per-thread-logger = "0.1.1"
 wat = "1.0.10"
 libc = "0.2.60"
 rayon = "1.2.1"
-wasm-webidl-bindings = "0.8"
 
 [dev-dependencies]
 wasmtime-runtime = { path = "crates/runtime" }


### PR DESCRIPTION
Forgotten from previous interface types removal!
