### PR TITLE
Add more SIMD memory instructions

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1566,6 +1566,7 @@ fn define_simd(
     let bxor = shared.by_name("bxor");
     let copy = shared.by_name("copy");
     let copy_nop = shared.by_name("copy_nop");
+    let copy_to_ssa = shared.by_name("copy_to_ssa");
     let fadd = shared.by_name("fadd");
     let fcmp = shared.by_name("fcmp");
     let fcvt_from_sint = shared.by_name("fcvt_from_sint");
@@ -1633,6 +1634,7 @@ fn define_simd(
     let rec_fstDisp32 = r.template("fstDisp32");
     let rec_fstDisp8 = r.template("fstDisp8");
     let rec_furm = r.template("furm");
+    let rec_furm_reg_to_ssa = r.template("furm_reg_to_ssa");
     let rec_icscc_fpr = r.template("icscc_fpr");
     let rec_null_fpr = r.recipe("null_fpr");
     let rec_pfcmp = r.template("pfcmp");
@@ -1875,6 +1877,8 @@ fn define_simd(
         // Copy
         let bound_copy = copy.bind(vector(ty, sse_vector_size));
         e.enc_32_64(bound_copy, rec_furm.opcodes(&MOVAPS_LOAD));
+        let bound_copy_to_ssa = copy_to_ssa.bind(vector(ty, sse_vector_size));
+        e.enc_32_64(bound_copy_to_ssa, rec_furm_reg_to_ssa.opcodes(&MOVAPS_LOAD));
         let bound_copy_nop = copy_nop.bind(vector(ty, sse_vector_size));
         e.enc_32_64_rec(bound_copy_nop, rec_stacknull, 0);
     }

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1594,6 +1594,7 @@ fn define_simd(
     let sshr_imm = shared.by_name("sshr_imm");
     let ssub_sat = shared.by_name("ssub_sat");
     let store = shared.by_name("store");
+    let store_complex = shared.by_name("store_complex");
     let uadd_sat = shared.by_name("uadd_sat");
     let ushr_imm = shared.by_name("ushr_imm");
     let usub_sat = shared.by_name("usub_sat");
@@ -1637,6 +1638,9 @@ fn define_simd(
     let rec_fst = r.template("fst");
     let rec_fstDisp32 = r.template("fstDisp32");
     let rec_fstDisp8 = r.template("fstDisp8");
+    let rec_fstWithIndex = r.template("fstWithIndex");
+    let rec_fstWithIndexDisp32 = r.template("fstWithIndexDisp32");
+    let rec_fstWithIndexDisp8 = r.template("fstWithIndexDisp8");
     let rec_furm = r.template("furm");
     let rec_furm_reg_to_ssa = r.template("furm_reg_to_ssa");
     let rec_icscc_fpr = r.template("icscc_fpr");
@@ -1850,6 +1854,21 @@ fn define_simd(
         );
         e.enc_32_64(bound_store.clone(), rec_fstDisp8.opcodes(&MOVUPS_STORE));
         e.enc_32_64(bound_store, rec_fstDisp32.opcodes(&MOVUPS_STORE));
+
+        // Store complex
+        let bound_store_complex = store_complex.bind(vector(ty, sse_vector_size));
+        e.enc_32_64(
+            bound_store_complex.clone(),
+            rec_fstWithIndex.opcodes(&MOVUPS_STORE),
+        );
+        e.enc_32_64(
+            bound_store_complex.clone(),
+            rec_fstWithIndexDisp8.opcodes(&MOVUPS_STORE),
+        );
+        e.enc_32_64(
+            bound_store_complex,
+            rec_fstWithIndexDisp32.opcodes(&MOVUPS_STORE),
+        );
 
         // Load
         let bound_load = load.bind(vector(ty, sse_vector_size)).bind(Any);

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1582,6 +1582,7 @@ fn define_simd(
     let imul = shared.by_name("imul");
     let ishl_imm = shared.by_name("ishl_imm");
     let load = shared.by_name("load");
+    let load_complex = shared.by_name("load_complex");
     let raw_bitcast = shared.by_name("raw_bitcast");
     let regfill = shared.by_name("regfill");
     let regmove = shared.by_name("regmove");
@@ -1625,6 +1626,9 @@ fn define_simd(
     let rec_fld = r.template("fld");
     let rec_fldDisp32 = r.template("fldDisp32");
     let rec_fldDisp8 = r.template("fldDisp8");
+    let rec_fldWithIndex = r.template("fldWithIndex");
+    let rec_fldWithIndexDisp32 = r.template("fldWithIndexDisp32");
+    let rec_fldWithIndexDisp8 = r.template("fldWithIndexDisp8");
     let rec_fregfill32 = r.template("fregfill32");
     let rec_fregspill32 = r.template("fregspill32");
     let rec_frmov = r.template("frmov");
@@ -1855,6 +1859,21 @@ fn define_simd(
         );
         e.enc_32_64(bound_load.clone(), rec_fldDisp8.opcodes(&MOVUPS_LOAD));
         e.enc_32_64(bound_load, rec_fldDisp32.opcodes(&MOVUPS_LOAD));
+
+        // Load complex
+        let bound_load_complex = load_complex.bind(vector(ty, sse_vector_size));
+        e.enc_32_64(
+            bound_load_complex.clone(),
+            rec_fldWithIndex.opcodes(&MOVUPS_LOAD),
+        );
+        e.enc_32_64(
+            bound_load_complex.clone(),
+            rec_fldWithIndexDisp8.opcodes(&MOVUPS_LOAD),
+        );
+        e.enc_32_64(
+            bound_load_complex,
+            rec_fldWithIndexDisp32.opcodes(&MOVUPS_LOAD),
+        );
 
         // Spill
         let bound_spill = spill.bind(vector(ty, sse_vector_size));

--- a/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
@@ -1,0 +1,37 @@
+test binemit
+set enable_simd
+target x86_64 skylake
+
+function %load_store_simple(i64) {
+block0(v0: i64 [%rax]):
+[-, %xmm0]    v10 = load.i32x4 v0   ; bin: heap_oob 0f 10 00
+[-]           store v10, v0         ; bin: heap_oob 0f 11 00
+
+              ; use displacement
+[-, %xmm0]    v11 = load.f32x4 v0+42 ; bin: heap_oob 0f 10 40 2a
+[-]           store v11, v0+42       ; bin: heap_oob 0f 11 40 2a
+
+              ; use REX prefix
+[-, %xmm8]    v12 = load.i8x16 v0   ; bin: heap_oob 44 0f 10 00
+[-]           store v12, v0         ; bin: heap_oob 44 0f 11 00
+
+    return
+}
+
+function %load_store_complex(i64, i64) {
+block0(v0: i64 [%rax], v1: i64 [%rbx]):
+              ; %xmm1 corresponds to ModR/M 0x04; the 0b100 in the R/M slot indicates a SIB byte follows
+              ; %rax and %rbx form the SIB 0x18
+[-, %xmm1]    v10 = load_complex.f64x2 v0+v1   ; bin: heap_oob 0f 10 0c 18
+              ; enabling bit 6 of the ModR/M byte indicates a disp8 follows
+[-]           store_complex v10, v0+v1+5       ; bin: heap_oob 0f 11 4c 18 05
+
+    return
+}
+
+function %copy_to_ssa() {
+block0:
+[-, %xmm1]    v0 = copy_to_ssa.i64x2 %xmm3  ; bin: 0f 28 cb
+
+    return
+}


### PR DESCRIPTION
In attempting to run a Wasm workload, I realized that these instructions were necessary to compile the module. I followed what I observed from the scalar versions of these instructions but would appreciate confirmation on why these are being used:
 - I think `postopt.rs` is attempting to convert regular loads and stores into their complex version?
 - I think `copy_to_ssa` is being used to temporarily move something into a virtual register--but why?