### PR TITLE
Remove cdylib/staticlib wasi-common crate types

### DIFF
--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -30,9 +30,5 @@ winx = { path = "winx", version = "0.12.0" }
 winapi = "0.3"
 cpu-time = "1.0"
 
-[lib]
-name = "wasi_common"
-crate-type = ["rlib", "staticlib", "cdylib"]
-
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
I don't think these are used right now and can lead to increased build
times, so I'd like to propose we remove them!
