### PR TITLE
Add support for hidden visibility

### DIFF
--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -383,8 +383,9 @@ fn translate_function_linkage(linkage: Linkage) -> faerie::Decl {
     match linkage {
         Linkage::Import => faerie::Decl::function_import().into(),
         Linkage::Local => faerie::Decl::function().into(),
-        Linkage::Export => faerie::Decl::function().global().into(),
         Linkage::Preemptible => faerie::Decl::function().weak().into(),
+        Linkage::Hidden => faerie::Decl::function().global().hidden().into(),
+        Linkage::Export => faerie::Decl::function().global().into(),
     }
 }
 
@@ -396,13 +397,19 @@ fn translate_data_linkage(linkage: Linkage, writable: bool, align: Option<u8>) -
             .with_writable(writable)
             .with_align(align)
             .into(),
-        Linkage::Export => faerie::Decl::data()
-            .global()
+        Linkage::Preemptible => faerie::Decl::data()
+            .weak()
             .with_writable(writable)
             .with_align(align)
             .into(),
-        Linkage::Preemptible => faerie::Decl::data()
-            .weak()
+        Linkage::Hidden => faerie::Decl::data()
+            .global()
+            .hidden()
+            .with_writable(writable)
+            .with_align(align)
+            .into(),
+        Linkage::Export => faerie::Decl::data()
+            .global()
             .with_writable(writable)
             .with_align(align)
             .into(),

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -474,6 +474,7 @@ fn translate_linkage(linkage: Linkage) -> (SymbolScope, bool) {
     let scope = match linkage {
         Linkage::Import => SymbolScope::Unknown,
         Linkage::Local => SymbolScope::Compilation,
+        Linkage::Hidden => SymbolScope::Linkage,
         Linkage::Export | Linkage::Preemptible => SymbolScope::Dynamic,
     };
     // TODO: this matches rustc_codegen_cranelift, but may be wrong.


### PR DESCRIPTION
This makes it possible to export less symbols from dylibs. This may be required to prevent conflicting definitions of a symbol. It also makes the linker faster when linking against a dylib compiled by Cranelift.

Fixes #1325