### PR TITLE
github ci: disable fail-fast in Test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -351,6 +351,7 @@ jobs:
     name: Build wasmtime
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,6 +142,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         build: [stable, beta, nightly, windows, macos]
         include:


### PR DESCRIPTION
There appear to be some failures on the Test workflow on nightly, and perhaps elsewhere. Currently, the first job to fail in the Test job cancels all the others. Setting `fail-fast` to `false` will disable that behavior, so we can determine if its only nightly thats failing or some deeper issue.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
