### PR TITLE
fuzzing: Enable Cranelift's IR verifier for differential fuzzing

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -64,6 +64,7 @@ impl DifferentialConfig {
     /// Convert this differential fuzzing config into a `wasmtime::Config`.
     pub fn to_wasmtime_config(&self) -> anyhow::Result<wasmtime::Config> {
         let mut config = wasmtime::Config::new();
+        config.cranelift_debug_verifier(true);
         config.strategy(match self.strategy {
             DifferentialStrategy::Cranelift => wasmtime::Strategy::Cranelift,
             DifferentialStrategy::Lightbeam => wasmtime::Strategy::Lightbeam,


### PR DESCRIPTION
The reason we weren't seeing the verifier errors in the fuzz targers in #1331 but were seeing them via `wasmtime --invoke` was because the differential fuzzing configs forgot to enable the IR verifier.