### PR TITLE
Infer REX prefix for SIMD operations; fixes #1127

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -547,41 +547,35 @@ pub(crate) fn define<'shared>(
     );
 
     // XX /r
-    recipes.add_template(
-        Template::new(
-            EncodingRecipeBuilder::new("rr", &formats.binary, 1)
-                .operands_in(vec![gpr, gpr])
-                .operands_out(vec![0])
-                .emit(
-                    r#"
+    recipes.add_template_inferred(
+        EncodingRecipeBuilder::new("rr", &formats.binary, 1)
+            .operands_in(vec![gpr, gpr])
+            .operands_out(vec![0])
+            .emit(
+                r#"
                         {{PUT_OP}}(bits, rex2(in_reg0, in_reg1), sink);
                         modrm_rr(in_reg0, in_reg1, sink);
                     "#,
-                ),
-            regs,
-        )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
+            ),
+        "size_with_inferred_rex_for_inreg0_inreg1",
     );
 
     // XX /r with operands swapped. (RM form).
-    recipes.add_template(
-        Template::new(
-            EncodingRecipeBuilder::new("rrx", &formats.binary, 1)
-                .operands_in(vec![gpr, gpr])
-                .operands_out(vec![0])
-                .emit(
-                    r#"
+    recipes.add_template_inferred(
+        EncodingRecipeBuilder::new("rrx", &formats.binary, 1)
+            .operands_in(vec![gpr, gpr])
+            .operands_out(vec![0])
+            .emit(
+                r#"
                         {{PUT_OP}}(bits, rex2(in_reg1, in_reg0), sink);
                         modrm_rr(in_reg1, in_reg0, sink);
                     "#,
-                ),
-            regs,
-        )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
+            ),
+        "size_with_inferred_rex_for_inreg0_inreg1",
     );
 
     // XX /r with FPR ins and outs. A form.
-    recipes.add_template_recipe(
+    recipes.add_template_inferred(
         EncodingRecipeBuilder::new("fa", &formats.binary, 1)
             .operands_in(vec![fpr, fpr])
             .operands_out(vec![0])
@@ -591,10 +585,11 @@ pub(crate) fn define<'shared>(
                     modrm_rr(in_reg1, in_reg0, sink);
                 "#,
             ),
+        "size_with_inferred_rex_for_inreg0_inreg1",
     );
 
     // XX /r with FPR ins and outs. A form with input operands swapped.
-    recipes.add_template_recipe(
+    recipes.add_template_inferred(
         EncodingRecipeBuilder::new("fax", &formats.binary, 1)
             .operands_in(vec![fpr, fpr])
             .operands_out(vec![1])
@@ -604,11 +599,13 @@ pub(crate) fn define<'shared>(
                     modrm_rr(in_reg0, in_reg1, sink);
                 "#,
             ),
+        // The operand order does not matter for calculating whether a REX prefix is needed.
+        "size_with_inferred_rex_for_inreg0_inreg1",
     );
 
     // XX /r with FPR ins and outs. A form with a byte immediate.
     {
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("fa_ib", &formats.insert_lane, 2)
                 .operands_in(vec![fpr, fpr])
                 .operands_out(vec![0])
@@ -626,6 +623,7 @@ pub(crate) fn define<'shared>(
                     sink.put1(imm as u8);
                 "#,
                 ),
+            "size_with_inferred_rex_for_inreg0_inreg1",
         );
     }
 
@@ -740,7 +738,7 @@ pub(crate) fn define<'shared>(
     );
 
     // XX /r, RM form, FPR -> FPR.
-    recipes.add_template_recipe(
+    recipes.add_template_inferred(
         EncodingRecipeBuilder::new("furm", &formats.unary, 1)
             .operands_in(vec![fpr])
             .operands_out(vec![fpr])
@@ -751,6 +749,7 @@ pub(crate) fn define<'shared>(
                     modrm_rr(in_reg0, out_reg0, sink);
                 "#,
             ),
+        "size_with_inferred_rex_for_inreg0_outreg0",
     );
 
     // Same as furm, but with the source register specified directly.
@@ -768,21 +767,18 @@ pub(crate) fn define<'shared>(
     );
 
     // XX /r, RM form, GPR -> FPR.
-    recipes.add_template(
-        Template::new(
-            EncodingRecipeBuilder::new("frurm", &formats.unary, 1)
-                .operands_in(vec![gpr])
-                .operands_out(vec![fpr])
-                .clobbers_flags(false)
-                .emit(
-                    r#"
+    recipes.add_template_inferred(
+        EncodingRecipeBuilder::new("frurm", &formats.unary, 1)
+            .operands_in(vec![gpr])
+            .operands_out(vec![fpr])
+            .clobbers_flags(false)
+            .emit(
+                r#"
                         {{PUT_OP}}(bits, rex2(in_reg0, out_reg0), sink);
                         modrm_rr(in_reg0, out_reg0, sink);
                     "#,
-                ),
-            regs,
-        )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_outreg0"),
+            ),
+        "size_with_inferred_rex_for_inreg0_outreg0",
     );
 
     // XX /r, RM form, FPR -> GPR.
@@ -909,31 +905,28 @@ pub(crate) fn define<'shared>(
 
     // XX /n ib with 8-bit immediate sign-extended.
     {
-        recipes.add_template(
-            Template::new(
-                EncodingRecipeBuilder::new("r_ib", &formats.binary_imm, 2)
-                    .operands_in(vec![gpr])
-                    .operands_out(vec![0])
-                    .inst_predicate(InstructionPredicate::new_is_signed_int(
-                        &*formats.binary_imm,
-                        "imm",
-                        8,
-                        0,
-                    ))
-                    .emit(
-                        r#"
+        recipes.add_template_inferred(
+            EncodingRecipeBuilder::new("r_ib", &formats.binary_imm, 2)
+                .operands_in(vec![gpr])
+                .operands_out(vec![0])
+                .inst_predicate(InstructionPredicate::new_is_signed_int(
+                    &*formats.binary_imm,
+                    "imm",
+                    8,
+                    0,
+                ))
+                .emit(
+                    r#"
                             {{PUT_OP}}(bits, rex1(in_reg0), sink);
                             modrm_r_bits(in_reg0, bits, sink);
                             let imm: i64 = imm.into();
                             sink.put1(imm as u8);
                         "#,
-                    ),
-                regs,
-            )
-            .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
+                ),
+            "size_with_inferred_rex_for_inreg0",
         );
 
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("f_ib", &formats.binary_imm, 2)
                 .operands_in(vec![fpr])
                 .operands_out(vec![0])
@@ -951,6 +944,7 @@ pub(crate) fn define<'shared>(
                         sink.put1(imm as u8);
                     "#,
                 ),
+            "size_with_inferred_rex_for_inreg0",
         );
 
         // XX /n id with 32-bit immediate sign-extended.
@@ -981,7 +975,7 @@ pub(crate) fn define<'shared>(
 
     // XX /r ib with 8-bit unsigned immediate (e.g. for pshufd)
     {
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("r_ib_unsigned_fpr", &formats.extract_lane, 2)
                 .operands_in(vec![fpr])
                 .operands_out(vec![fpr])
@@ -999,12 +993,13 @@ pub(crate) fn define<'shared>(
                     sink.put1(imm as u8);
                 "#,
                 ),
+            "size_with_inferred_rex_for_inreg0_outreg0",
         );
     }
 
     // XX /r ib with 8-bit unsigned immediate (e.g. for extractlane)
     {
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("r_ib_unsigned_gpr", &formats.extract_lane, 2)
                 .operands_in(vec![fpr])
                 .operands_out(vec![gpr])
@@ -1018,13 +1013,13 @@ pub(crate) fn define<'shared>(
                     let imm:i64 = lane.into();
                     sink.put1(imm as u8);
                 "#,
-                ),
+                ), "size_with_inferred_rex_for_inreg0_outreg0"
         );
     }
 
     // XX /r ib with 8-bit unsigned immediate (e.g. for insertlane)
     {
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("r_ib_unsigned_r", &formats.insert_lane, 2)
                 .operands_in(vec![fpr, gpr])
                 .operands_out(vec![0])
@@ -1042,6 +1037,7 @@ pub(crate) fn define<'shared>(
                     sink.put1(imm as u8);
                 "#,
                 ),
+            "size_with_inferred_rex_for_inreg0_inreg1",
         );
     }
 
@@ -2825,7 +2821,7 @@ pub(crate) fn define<'shared>(
     );
 
     // XX /r, RM form. Compare two FPR registers and set flags.
-    recipes.add_template_recipe(
+    recipes.add_template_inferred(
         EncodingRecipeBuilder::new("fcmp", &formats.binary, 1)
             .operands_in(vec![fpr, fpr])
             .operands_out(vec![reg_rflags])
@@ -2835,6 +2831,7 @@ pub(crate) fn define<'shared>(
                     modrm_rr(in_reg1, in_reg0, sink);
                 "#,
             ),
+        "size_with_inferred_rex_for_inreg0_inreg1",
     );
 
     {
@@ -3089,7 +3086,7 @@ pub(crate) fn define<'shared>(
         .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
-    recipes.add_template_recipe(
+    recipes.add_template_inferred(
         EncodingRecipeBuilder::new("icscc_fpr", &formats.int_compare, 1)
             .operands_in(vec![fpr, fpr])
             .operands_out(vec![0])
@@ -3100,6 +3097,7 @@ pub(crate) fn define<'shared>(
                     modrm_rr(in_reg1, in_reg0, sink);
                 "#,
             ),
+        "size_with_inferred_rex_for_inreg0_inreg1",
     );
 
     {
@@ -3219,7 +3217,7 @@ pub(crate) fn define<'shared>(
             .iter()
             .map(|name| Literal::enumerator_for(floatcc, name))
             .collect();
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("pfcmp", &formats.float_compare, 2)
                 .operands_in(vec![fpr, fpr])
                 .operands_out(vec![0])
@@ -3248,6 +3246,7 @@ pub(crate) fn define<'shared>(
                     sink.put1(imm);
                 "#,
                 ),
+            "size_with_inferred_rex_for_inreg0_inreg1",
         );
     }
 

--- a/cranelift/codegen/src/isa/x86/binemit.rs
+++ b/cranelift/codegen/src/isa/x86/binemit.rs
@@ -197,7 +197,7 @@ fn put_dynrexmp2<CS: CodeSink + ?Sized>(bits: u16, rex: u8, sink: &mut CS) {
     sink.put1(bits as u8);
 }
 
-// Emit three-byte opcode (0F 3[8A] XX) with mandatory prefix.
+/// Emit three-byte opcode (0F 3[8A] XX) with mandatory prefix.
 fn put_mp3<CS: CodeSink + ?Sized>(bits: u16, rex: u8, sink: &mut CS) {
     debug_assert_eq!(bits & 0x8800, 0x0800, "Invalid encoding bits for Mp3*");
     debug_assert_eq!(rex, BASE_REX, "Invalid registers for REX-less Mp3 encoding");
@@ -208,12 +208,29 @@ fn put_mp3<CS: CodeSink + ?Sized>(bits: u16, rex: u8, sink: &mut CS) {
     sink.put1(bits as u8);
 }
 
-// Emit three-byte opcode (0F 3[8A] XX) with mandatory prefix and REX
+/// Emit three-byte opcode (0F 3[8A] XX) with mandatory prefix and REX
 fn put_rexmp3<CS: CodeSink + ?Sized>(bits: u16, rex: u8, sink: &mut CS) {
     debug_assert_eq!(bits & 0x0800, 0x0800, "Invalid encoding bits for RexMp3*");
     let enc = EncodingBits::from(bits);
     sink.put1(PREFIX[(enc.pp() - 1) as usize]);
     rex_prefix(bits, rex, sink);
+    sink.put1(0x0f);
+    sink.put1(OP3_BYTE2[(enc.mm() - 2) as usize]);
+    sink.put1(bits as u8);
+}
+
+/// Emit three-byte opcode (0F 3[8A] XX) with mandatory prefix and an inferred REX prefix.
+fn put_dynrexmp3<CS: CodeSink + ?Sized>(bits: u16, rex: u8, sink: &mut CS) {
+    debug_assert_eq!(
+        bits & 0x0800,
+        0x0800,
+        "Invalid encoding bits for DynRexMp3*"
+    );
+    let enc = EncodingBits::from(bits);
+    sink.put1(PREFIX[(enc.pp() - 1) as usize]);
+    if needs_rex(bits, rex) {
+        rex_prefix(bits, rex, sink);
+    }
     sink.put1(0x0f);
     sink.put1(OP3_BYTE2[(enc.mm() - 2) as usize]);
     sink.put1(bits as u8);

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
@@ -176,25 +176,49 @@ block0:
 
 function %float_arithmetic_f32x4(f32x4, f32x4) {
 block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm5]):
-[-, %xmm3]    v2 = fadd v0, v1      ; bin: 40 0f 58 dd
-[-, %xmm3]    v3 = fsub v0, v1      ; bin: 40 0f 5c dd
-[-, %xmm3]    v4 = fmul v0, v1      ; bin: 40 0f 59 dd
-[-, %xmm3]    v5 = fdiv v0, v1      ; bin: 40 0f 5e dd
-[-, %xmm3]    v6 = fmin v0, v1      ; bin: 40 0f 5d dd
-[-, %xmm3]    v7 = fmax v0, v1      ; bin: 40 0f 5f dd
-[-, %xmm3]    v8 = sqrt v0          ; bin: 40 0f 51 db
+[-, %xmm3]    v2 = fadd v0, v1      ; bin: 0f 58 dd
+[-, %xmm3]    v3 = fsub v0, v1      ; bin: 0f 5c dd
+[-, %xmm3]    v4 = fmul v0, v1      ; bin: 0f 59 dd
+[-, %xmm3]    v5 = fdiv v0, v1      ; bin: 0f 5e dd
+[-, %xmm3]    v6 = fmin v0, v1      ; bin: 0f 5d dd
+[-, %xmm3]    v7 = fmax v0, v1      ; bin: 0f 5f dd
+[-, %xmm3]    v8 = sqrt v0          ; bin: 0f 51 db
+    return
+}
+
+function %float_arithmetic_f32x4_rex(f32x4, f32x4) {
+block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm10]):
+[-, %xmm3]    v2 = fadd v0, v1      ; bin: 41 0f 58 da
+[-, %xmm3]    v3 = fsub v0, v1      ; bin: 41 0f 5c da
+[-, %xmm3]    v4 = fmul v0, v1      ; bin: 41 0f 59 da
+[-, %xmm3]    v5 = fdiv v0, v1      ; bin: 41 0f 5e da
+[-, %xmm3]    v6 = fmin v0, v1      ; bin: 41 0f 5d da
+[-, %xmm3]    v7 = fmax v0, v1      ; bin: 41 0f 5f da
+[-, %xmm3]    v8 = sqrt v1          ; bin: 41 0f 51 da
     return
 }
 
 function %float_arithmetic_f64x2(f64x2, f64x2) {
 block0(v0: f64x2 [%xmm3], v1: f64x2 [%xmm5]):
-[-, %xmm3]    v2 = fadd v0, v1      ; bin: 66 40 0f 58 dd
-[-, %xmm3]    v3 = fsub v0, v1      ; bin: 66 40 0f 5c dd
-[-, %xmm3]    v4 = fmul v0, v1      ; bin: 66 40 0f 59 dd
-[-, %xmm3]    v5 = fdiv v0, v1      ; bin: 66 40 0f 5e dd
-[-, %xmm3]    v6 = fmin v0, v1      ; bin: 66 40 0f 5d dd
-[-, %xmm3]    v7 = fmax v0, v1      ; bin: 66 40 0f 5f dd
-[-, %xmm3]    v8 = sqrt v0          ; bin: 66 40 0f 51 db
+[-, %xmm3]    v2 = fadd v0, v1      ; bin: 66 0f 58 dd
+[-, %xmm3]    v3 = fsub v0, v1      ; bin: 66 0f 5c dd
+[-, %xmm3]    v4 = fmul v0, v1      ; bin: 66 0f 59 dd
+[-, %xmm3]    v5 = fdiv v0, v1      ; bin: 66 0f 5e dd
+[-, %xmm3]    v6 = fmin v0, v1      ; bin: 66 0f 5d dd
+[-, %xmm3]    v7 = fmax v0, v1      ; bin: 66 0f 5f dd
+[-, %xmm3]    v8 = sqrt v0          ; bin: 66 0f 51 db
+    return
+}
+
+function %float_arithmetic_f64x2_rex(f64x2, f64x2) {
+block0(v0: f64x2 [%xmm11], v1: f64x2 [%xmm13]):
+[-, %xmm11]    v2 = fadd v0, v1      ; bin: 66 45 0f 58 dd
+[-, %xmm11]    v3 = fsub v0, v1      ; bin: 66 45 0f 5c dd
+[-, %xmm11]    v4 = fmul v0, v1      ; bin: 66 45 0f 59 dd
+[-, %xmm11]    v5 = fdiv v0, v1      ; bin: 66 45 0f 5e dd
+[-, %xmm11]    v6 = fmin v0, v1      ; bin: 66 45 0f 5d dd
+[-, %xmm11]    v7 = fmax v0, v1      ; bin: 66 45 0f 5f dd
+[-, %xmm11]    v8 = sqrt v0          ; bin: 66 45 0f 51 db
     return
 }
 

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
@@ -2,179 +2,57 @@ test binemit
 set enable_simd
 target x86_64 skylake
 
-function %iadd_i32x4() -> b1 {
-block0:
-[-, %xmm0]    v0 = vconst.i32x4 [1 1 1 1]
-[-, %xmm1]    v1 = vconst.i32x4 [1 2 3 4]
-[-, %xmm0]    v2 = iadd v0, v1      ; bin: 66 0f fe c1
+function %arithmetic_i8x16(i8x16, i8x16) {
+block0(v0: i8x16 [%xmm6], v1: i8x16 [%xmm2]):
+[-, %xmm6]    v2 = iadd v0, v1        ; bin: 66 0f fc f2
+[-, %xmm6]    v3 = isub v0, v1        ; bin: 66 0f f8 f2
+[-, %xmm6]    v4 = sadd_sat v0, v1    ; bin: 66 0f ec f2
+[-, %xmm6]    v5 = ssub_sat v0, v1    ; bin: 66 0f e8 f2
+[-, %xmm6]    v6 = usub_sat v0, v1    ; bin: 66 0f d8 f2
+[-, %xmm6]    v7 = avg_round v0, v1   ; bin: 66 0f e0 f2
 
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 2
-
-    v5 = extractlane v2, 3
-    v6 = icmp_imm eq v5, 5
-
-    v7 = band v4, v6
-    return v7
-}
-
-function %iadd_i8x16_with_overflow() -> b1 {
-block0:
-[-, %xmm0]    v0 = vconst.i8x16 [255 255 255 255 255 255 255 255 255 255 255 255 255 255 255 255]
-[-, %xmm7]    v1 = vconst.i8x16 [2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2]
-[-, %xmm0]    v2 = iadd v0, v1      ; bin: 66 0f fc c7
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 1
-
-    return v4
-}
-
-function %iadd_i16x8(i16x8, i16x8) -> i16x8 {
-block0(v0: i16x8 [%xmm1], v1: i16x8 [%xmm2]):
-[-, %xmm1]  v2 = iadd v0, v1      ; bin: 66 0f fd ca
-            return v2
-}
-
-function %iadd_i64x2(i64x2, i64x2) -> i64x2 {
-block0(v0: i64x2 [%xmm3], v1: i64x2 [%xmm4]):
-[-, %xmm3]  v2 = iadd v0, v1      ; bin: 66 0f d4 dc
-            return v2
-}
-
-function %isub_i32x4() -> b1 {
-block0:
-[-, %xmm3]    v0 = vconst.i32x4 [1 1 1 1]
-[-, %xmm5]    v1 = vconst.i32x4 [1 2 3 4]
-[-, %xmm3]    v2 = isub v0, v1  ; bin: 66 0f fa dd
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0
-
-    v5 = extractlane v2, 1
-    v6 = icmp_imm eq v5, 0xffffffff
-
-    v7 = band v4, v6
-    return v7
-}
-
-function %isub_i64x2(i64x2, i64x2) -> i64x2 {
-block0(v0: i64x2 [%xmm0], v1: i64x2 [%xmm1]):
-[-, %xmm0]  v2 = isub v0, v1      ; bin: 66 0f fb c1
-    return v2
-}
-
-function %isub_i16x8(i16x8, i16x8) -> i16x8 {
-block0(v0: i16x8 [%xmm3], v1: i16x8 [%xmm4]):
-[-, %xmm3]  v2 = isub v0, v1      ; bin: 66 0f f9 dc
-    return v2
-}
-
-function %isub_i8x16(i8x16, i8x16) -> i8x16 {
-block0(v0: i8x16 [%xmm3], v1: i8x16 [%xmm4]):
-[-, %xmm3]  v2 = isub v0, v1      ; bin: 66 0f f8 dc
-    return v2
-}
-
-function %imul_i32x4() -> b1 {
-block0:
-[-, %xmm0]    v0 = vconst.i32x4 [-1 0 1 0x80_00_00_01]
-[-, %xmm1]    v1 = vconst.i32x4 [2 2 2 2]
-[-, %xmm0]    v2 = imul v0, v1 ; bin: 66 0f 38 40 c1
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, -2
-
-    v5 = extractlane v2, 1
-    v6 = icmp_imm eq v5, 0
-
-    v7 = extractlane v2, 3
-    v8 = icmp_imm eq v7, 2 ; 0x80_00_00_01 * 2 == 0x1_00_00_00_02 (and the 1 is dropped)
-
-    v9 = band v4, v6
-    v10 = band v8, v9
-    return v10
-}
-
-
-function %imul_i16x8() -> b1 {
-block0:
-[-, %xmm1]    v0 = vconst.i16x8 [-1 0 1 0x7f_ff 0 0 0 0]
-[-, %xmm2]    v1 = vconst.i16x8 [2 2 2 2 0 0 0 0]
-[-, %xmm1]    v2 = imul v0, v1 ; bin: 66 0f d5 ca
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0xfffe ; 0xfffe == -2; -2 will not work here and below because v3 is
-    ; being uextend-ed, not sextend-ed
-
-    v5 = extractlane v2, 1
-    v6 = icmp_imm eq v5, 0
-
-    v7 = extractlane v2, 3
-    v8 = icmp_imm eq v7, 0xfffe ; 0x7f_ff * 2 == 0xff_fe
-
-    v9 = band v4, v6
-    v10 = band v8, v9
-
-    return v4
-}
-
-
-function %sadd_sat_i8x16() -> b1 {
-block0:
-[-, %xmm2]    v0 = vconst.i8x16 [127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
-[-, %xmm3]    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
-
-[-, %xmm2]    v2 = sadd_sat v0, v1 ; bin: 66 0f ec d3
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 127
-
-    return v4
-}
-
-
-function %uadd_sat_i16x8() -> b1 {
-block0:
-[-, %xmm2]    v0 = vconst.i16x8 [-1 0 0 0 0 0 0 0]
-[-, %xmm3]    v1 = vconst.i16x8 [-1 1 1 1 1 1 1 1]
-
-[-, %xmm2]    v2 = uadd_sat v0, v1 ; bin: 66 0f dd d3
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 65535
-
-    return v4
-}
-
-
-function %sub_sat_i8x16() -> b1 {
-block0:
-[-, %xmm2]    v0 = vconst.i8x16 [128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] ; 128 == 0x80 == -128
-[-, %xmm3]    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
-
-[-, %xmm2]    v2 = ssub_sat v0, v1 ; bin: 66 0f e8 d3
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0x80 ; 0x80 == -128
-
-    ; now re-use 0x80 as an unsigned 128
-[-, %xmm2]    v5 = usub_sat v0, v2 ; bin: 66 0f d8 d2
-    v6 = extractlane v5, 0
-    v7 = icmp_imm eq v6, 0
-
-    v8 = band v4, v7
-    return v8
-}
-
-
-function %sub_sat_i16x8() {
-block0:
-[-, %xmm3]    v0 = vconst.i16x8 [0 0 0 0 0 0 0 0]
-[-, %xmm5]    v1 = vconst.i16x8 [1 1 1 1 1 1 1 1]
-[-, %xmm3]    v2 = ssub_sat v0, v1 ; bin: 66 0f e9 dd
-[-, %xmm3]    v3 = usub_sat v0, v1 ; bin: 66 0f d9 dd
     return
 }
 
-function %float_arithmetic_f32x4(f32x4, f32x4) {
+function %arithmetic_i16x8(i16x8, i16x8) {
+block0(v0: i16x8 [%xmm3], v1: i16x8 [%xmm5]):
+[-, %xmm3]    v2 = iadd v0, v1        ; bin: 66 0f fd dd
+[-, %xmm3]    v3 = isub v0, v1        ; bin: 66 0f f9 dd
+[-, %xmm3]    v4 = imul v0, v1        ; bin: 66 0f d5 dd
+[-, %xmm3]    v5 = uadd_sat v0, v1    ; bin: 66 0f dd dd
+[-, %xmm3]    v6 = ssub_sat v0, v1    ; bin: 66 0f e9 dd
+[-, %xmm3]    v7 = usub_sat v0, v1    ; bin: 66 0f d9 dd
+[-, %xmm3]    v8 = avg_round v0, v1   ; bin: 66 0f e3 dd
+
+    return
+}
+
+function %arithmetic_i32x4(i32x4, i32x4) {
+block0(v0: i32x4 [%xmm0], v1: i32x4 [%xmm1]):
+[-, %xmm0]    v2 = iadd v0, v1        ; bin: 66 0f fe c1
+[-, %xmm0]    v3 = isub v0, v1        ; bin: 66 0f fa c1
+[-, %xmm0]    v4 = imul v0, v1        ; bin: 66 0f 38 40 c1
+
+    return
+}
+
+function %arithmetic_i64x2(i64x2, i64x2) {
+block0(v0: i64x2 [%xmm0], v1: i64x2 [%xmm2]):
+[-, %xmm0]    v2 = iadd v0, v1        ; bin: 66 0f d4 c2
+[-, %xmm0]    v3 = isub v0, v1        ; bin: 66 0f fb c2
+
+    return
+}
+
+function %arithmetic_i64x2_rex(i64x2, i64x2) {
+block0(v0: i64x2 [%xmm8], v1: i64x2 [%xmm10]):
+[-, %xmm8]    v2 = iadd v0, v1        ; bin: 66 45 0f d4 c2
+[-, %xmm8]    v3 = isub v0, v1        ; bin: 66 45 0f fb c2
+
+    return
+}
+
+function %arithmetic_f32x4(f32x4, f32x4) {
 block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm5]):
 [-, %xmm3]    v2 = fadd v0, v1      ; bin: 0f 58 dd
 [-, %xmm3]    v3 = fsub v0, v1      ; bin: 0f 5c dd
@@ -186,7 +64,7 @@ block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm5]):
     return
 }
 
-function %float_arithmetic_f32x4_rex(f32x4, f32x4) {
+function %arithmetic_f32x4_rex(f32x4, f32x4) {
 block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm10]):
 [-, %xmm3]    v2 = fadd v0, v1      ; bin: 41 0f 58 da
 [-, %xmm3]    v3 = fsub v0, v1      ; bin: 41 0f 5c da
@@ -198,7 +76,7 @@ block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm10]):
     return
 }
 
-function %float_arithmetic_f64x2(f64x2, f64x2) {
+function %arithmetic_f64x2(f64x2, f64x2) {
 block0(v0: f64x2 [%xmm3], v1: f64x2 [%xmm5]):
 [-, %xmm3]    v2 = fadd v0, v1      ; bin: 66 0f 58 dd
 [-, %xmm3]    v3 = fsub v0, v1      ; bin: 66 0f 5c dd
@@ -210,7 +88,7 @@ block0(v0: f64x2 [%xmm3], v1: f64x2 [%xmm5]):
     return
 }
 
-function %float_arithmetic_f64x2_rex(f64x2, f64x2) {
+function %arithmetic_f64x2_rex(f64x2, f64x2) {
 block0(v0: f64x2 [%xmm11], v1: f64x2 [%xmm13]):
 [-, %xmm11]    v2 = fadd v0, v1      ; bin: 66 45 0f 58 dd
 [-, %xmm11]    v3 = fsub v0, v1      ; bin: 66 45 0f 5c dd
@@ -219,17 +97,5 @@ block0(v0: f64x2 [%xmm11], v1: f64x2 [%xmm13]):
 [-, %xmm11]    v6 = fmin v0, v1      ; bin: 66 45 0f 5d dd
 [-, %xmm11]    v7 = fmax v0, v1      ; bin: 66 45 0f 5f dd
 [-, %xmm11]    v8 = sqrt v0          ; bin: 66 45 0f 51 db
-    return
-}
-
-function %average_rounding_i8x16(i8x16, i8x16) {
-block0(v0: i8x16 [%xmm6], v1: i8x16 [%xmm2]):
-[-, %xmm6]    v2 = avg_round v0, v1      ; bin: 66 0f e0 f2
-    return
-}
-
-function %average_rounding_i16x8(i16x8, i16x8) {
-block0(v0: i16x8 [%xmm6], v1: i16x8 [%xmm2]):
-[-, %xmm6]    v2 = avg_round v0, v1      ; bin: 66 0f e3 f2
     return
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
@@ -34,10 +34,10 @@ block0:
 }
 ; run
 
-function %isub_i32x4() -> b1 {
+function %isub_i32x4_rex() -> b1 {
 block0:
-    v0 = vconst.i32x4 [1 1 1 1]
-    v1 = vconst.i32x4 [1 2 3 4]
+[-,%xmm10]    v0 = vconst.i32x4 [1 1 1 1]
+[-,%xmm15]    v1 = vconst.i32x4 [1 2 3 4]
     v2 = isub v0, v1
 
     v3 = extractlane v2, 0

--- a/cranelift/filetests/filetests/isa/x86/simd-comparison-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-comparison-binemit.clif
@@ -87,26 +87,52 @@ block0(v0: i32x4 [%xmm2], v1: i32x4 [%xmm4]):
 
 function %fcmp_f32x4(f32x4, f32x4) {
 block0(v0: f32x4 [%xmm2], v1: f32x4 [%xmm4]):
-[-, %xmm2]  v2 = fcmp eq v0, v1     ; bin: 40 0f c2 d4 00
-[-, %xmm2]  v3 = fcmp lt v0, v1     ; bin: 40 0f c2 d4 01
-[-, %xmm2]  v4 = fcmp le v0, v1     ; bin: 40 0f c2 d4 02
-[-, %xmm2]  v5 = fcmp uno v0, v1    ; bin: 40 0f c2 d4 03
-[-, %xmm2]  v6 = fcmp ne v0, v1     ; bin: 40 0f c2 d4 04
-[-, %xmm2]  v7 = fcmp uge v0, v1    ; bin: 40 0f c2 d4 05
-[-, %xmm2]  v8 = fcmp ugt v0, v1    ; bin: 40 0f c2 d4 06
-[-, %xmm2]  v9 = fcmp ord v0, v1    ; bin: 40 0f c2 d4 07
+[-, %xmm2]  v2 = fcmp eq v0, v1     ; bin: 0f c2 d4 00
+[-, %xmm2]  v3 = fcmp lt v0, v1     ; bin: 0f c2 d4 01
+[-, %xmm2]  v4 = fcmp le v0, v1     ; bin: 0f c2 d4 02
+[-, %xmm2]  v5 = fcmp uno v0, v1    ; bin: 0f c2 d4 03
+[-, %xmm2]  v6 = fcmp ne v0, v1     ; bin: 0f c2 d4 04
+[-, %xmm2]  v7 = fcmp uge v0, v1    ; bin: 0f c2 d4 05
+[-, %xmm2]  v8 = fcmp ugt v0, v1    ; bin: 0f c2 d4 06
+[-, %xmm2]  v9 = fcmp ord v0, v1    ; bin: 0f c2 d4 07
+            return
+}
+
+function %fcmp_f32x4_rex(f32x4, f32x4) {
+block0(v0: f32x4 [%xmm8], v1: f32x4 [%xmm8]):
+[-, %xmm8]  v2 = fcmp eq v0, v1     ; bin: 45 0f c2 c0 00
+[-, %xmm8]  v3 = fcmp lt v0, v1     ; bin: 45 0f c2 c0 01
+[-, %xmm8]  v4 = fcmp le v0, v1     ; bin: 45 0f c2 c0 02
+[-, %xmm8]  v5 = fcmp uno v0, v1    ; bin: 45 0f c2 c0 03
+[-, %xmm8]  v6 = fcmp ne v0, v1     ; bin: 45 0f c2 c0 04
+[-, %xmm8]  v7 = fcmp uge v0, v1    ; bin: 45 0f c2 c0 05
+[-, %xmm8]  v8 = fcmp ugt v0, v1    ; bin: 45 0f c2 c0 06
+[-, %xmm8]  v9 = fcmp ord v0, v1    ; bin: 45 0f c2 c0 07
             return
 }
 
 function %fcmp_f64x2(f64x2, f64x2) {
 block0(v0: f64x2 [%xmm2], v1: f64x2 [%xmm0]):
-[-, %xmm2]  v2 = fcmp eq v0, v1     ; bin: 66 40 0f c2 d0 00
-[-, %xmm2]  v3 = fcmp lt v0, v1     ; bin: 66 40 0f c2 d0 01
-[-, %xmm2]  v4 = fcmp le v0, v1     ; bin: 66 40 0f c2 d0 02
-[-, %xmm2]  v5 = fcmp uno v0, v1    ; bin: 66 40 0f c2 d0 03
-[-, %xmm2]  v6 = fcmp ne v0, v1     ; bin: 66 40 0f c2 d0 04
-[-, %xmm2]  v7 = fcmp uge v0, v1    ; bin: 66 40 0f c2 d0 05
-[-, %xmm2]  v8 = fcmp ugt v0, v1    ; bin: 66 40 0f c2 d0 06
-[-, %xmm2]  v9 = fcmp ord v0, v1    ; bin: 66 40 0f c2 d0 07
+[-, %xmm2]  v2 = fcmp eq v0, v1     ; bin: 66 0f c2 d0 00
+[-, %xmm2]  v3 = fcmp lt v0, v1     ; bin: 66 0f c2 d0 01
+[-, %xmm2]  v4 = fcmp le v0, v1     ; bin: 66 0f c2 d0 02
+[-, %xmm2]  v5 = fcmp uno v0, v1    ; bin: 66 0f c2 d0 03
+[-, %xmm2]  v6 = fcmp ne v0, v1     ; bin: 66 0f c2 d0 04
+[-, %xmm2]  v7 = fcmp uge v0, v1    ; bin: 66 0f c2 d0 05
+[-, %xmm2]  v8 = fcmp ugt v0, v1    ; bin: 66 0f c2 d0 06
+[-, %xmm2]  v9 = fcmp ord v0, v1    ; bin: 66 0f c2 d0 07
+            return
+}
+
+function %fcmp_f64x2_rex(f64x2, f64x2) {
+block0(v0: f64x2 [%xmm9], v1: f64x2 [%xmm11]):
+[-, %xmm9]  v2 = fcmp eq v0, v1     ; bin: 66 45 0f c2 cb 00
+[-, %xmm9]  v3 = fcmp lt v0, v1     ; bin: 66 45 0f c2 cb 01
+[-, %xmm9]  v4 = fcmp le v0, v1     ; bin: 66 45 0f c2 cb 02
+[-, %xmm9]  v5 = fcmp uno v0, v1    ; bin: 66 45 0f c2 cb 03
+[-, %xmm9]  v6 = fcmp ne v0, v1     ; bin: 66 45 0f c2 cb 04
+[-, %xmm9]  v7 = fcmp uge v0, v1    ; bin: 66 45 0f c2 cb 05
+[-, %xmm9]  v8 = fcmp ugt v0, v1    ; bin: 66 45 0f c2 cb 06
+[-, %xmm9]  v9 = fcmp ord v0, v1    ; bin: 66 45 0f c2 cb 07
             return
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-comparison-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-comparison-binemit.clif
@@ -10,11 +10,11 @@ block0:
             return
 }
 
-function %icmp_i16x8() {
+function %icmp_i16x8_rex() {
 block0:
 [-, %xmm0]  v0 = vconst.i16x8 0x00
-[-, %xmm7]  v1 = vconst.i16x8 0xffffffffffffffffffffffffffffffff
-[-, %xmm0]  v2 = icmp eq v0, v1                                     ; bin: 66 0f 75 c7
+[-, %xmm15] v1 = vconst.i16x8 0xffffffffffffffffffffffffffffffff
+[-, %xmm0]  v2 = icmp eq v0, v1                                     ; bin: 66 41 0f 75 c7
             return
 }
 
@@ -26,11 +26,11 @@ block0:
             return
 }
 
-function %icmp_i64x2() {
+function %icmp_i64x2_rex() {
 block0:
-[-, %xmm0]  v0 = vconst.i64x2 0x00
+[-, %xmm8]  v0 = vconst.i64x2 0x00
 [-, %xmm1]  v1 = vconst.i64x2 0xffffffffffffffffffffffffffffffff
-[-, %xmm0]  v2 = icmp eq v0, v1                                     ; bin: 66 0f 38 29 c1
+[-, %xmm8]  v2 = icmp eq v0, v1                                     ; bin: 66 44 0f 38 29 c1
             return
 }
 

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit.clif
@@ -81,7 +81,7 @@ block0:
 function %pshufd() {
 block0:
 [-, %rax]   v0 = iconst.i32 42
-[-, %xmm0]  v1 = scalar_to_vector.i32x4 v0  ; bin: 66 40 0f 6e c0
+[-, %xmm0]  v1 = scalar_to_vector.i32x4 v0  ; bin: 66 0f 6e c0
 [-, %xmm0]  v2 = x86_pshufd v1, 0           ; bin: 66 0f 70 c0 00
             return
 }
@@ -89,9 +89,9 @@ block0:
 function %pshufb() {
 block0:
 [-, %rax]   v0 = iconst.i8 42
-[-, %xmm0]  v1 = scalar_to_vector.i8x16 v0   ; bin: 66 40 0f 6e c0
+[-, %xmm0]  v1 = scalar_to_vector.i8x16 v0   ; bin: 66 0f 6e c0
 [-, %rbx]   v2 = iconst.i8 43
-[-, %xmm4]  v3 = scalar_to_vector.i8x16 v2   ; bin: 66 40 0f 6e e3
-[-, %xmm0]  v4 = x86_pshufb v1, v3           ; bin: 66 0f 38 00 c4
+[-, %xmm12] v3 = scalar_to_vector.i8x16 v2   ; bin: 66 44 0f 6e e3
+[-, %xmm0]  v4 = x86_pshufb v1, v3           ; bin: 66 41 0f 38 00 c4
             return
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
@@ -8,8 +8,8 @@ block0(v0: i64 [%rax]):
 [-]           store v10, v0         ; bin: heap_oob 0f 11 00
 
               ; use displacement
-[-, %xmm0]    v11 = load.f32x4 v0+42 ; bin: heap_oob 0f 10 40 2a
-[-]           store v11, v0+42       ; bin: heap_oob 0f 11 40 2a
+[-, %xmm0]    v11 = load.f32x4 v0+42 ; bin: heap_oob 40 0f 10 40 2a
+[-]           store v11, v0+42       ; bin: heap_oob 40 0f 11 40 2a
 
               ; use REX prefix
 [-, %xmm8]    v12 = load.i8x16 v0   ; bin: heap_oob 44 0f 10 00
@@ -22,16 +22,17 @@ function %load_store_complex(i64, i64) {
 block0(v0: i64 [%rax], v1: i64 [%rbx]):
               ; %xmm1 corresponds to ModR/M 0x04; the 0b100 in the R/M slot indicates a SIB byte follows
               ; %rax and %rbx form the SIB 0x18
-[-, %xmm1]    v10 = load_complex.f64x2 v0+v1   ; bin: heap_oob 0f 10 0c 18
+[-, %xmm1]    v10 = load_complex.f64x2 v0+v1   ; bin: heap_oob 40 0f 10 0c 18
               ; enabling bit 6 of the ModR/M byte indicates a disp8 follows
-[-]           store_complex v10, v0+v1+5       ; bin: heap_oob 0f 11 4c 18 05
+[-]           store_complex v10, v0+v1+5       ; bin: heap_oob 40 0f 11 4c 18 05
 
     return
 }
 
 function %copy_to_ssa() {
 block0:
-[-, %xmm1]    v0 = copy_to_ssa.i64x2 %xmm3  ; bin: 0f 28 cb
+[-, %xmm1]    v0 = copy_to_ssa.i64x2 %xmm3  ; bin: 40 0f 28 cb
+[-, %xmm2]    v1 = copy_to_ssa.i64x2 %xmm15 ; bin: 41 0f 28 d7
 
     return
 }


### PR DESCRIPTION
- Convert recipes to have necessary size calculator
- Add a missing binemit function, `put_dynrexmp3`
- Modify the meta-encodings of x86 SIMD instructions to use `infer_rex()`, mostly through the `enc_both_inferred()` helper
- Fix up tests that previously always emitted a REX prefix

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
