### PR TITLE
[wiggle] Tweaks from lucet integration

### DIFF
--- a/crates/wiggle/crates/generate/src/funcs.rs
+++ b/crates/wiggle/crates/generate/src/funcs.rs
@@ -2,6 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::lifetimes::anon_lifetime;
+use crate::module_trait::passed_by_reference;
 use crate::names::Names;
 
 pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
@@ -67,10 +68,10 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
         .map(|p| marshal_arg(names, p, error_handling(p.name.as_str())));
     let trait_args = func.params.iter().map(|param| {
         let name = names.func_param(&param.name);
-        match param.tref.type_().passed_by() {
-            witx::TypePassedBy::Value { .. } => quote!(#name),
-            witx::TypePassedBy::Pointer { .. } => quote!(&#name),
-            witx::TypePassedBy::PointerLengthPair { .. } => quote!(&#name),
+        if passed_by_reference(&*param.tref.type_()) {
+            quote!(&#name)
+        } else {
+            quote!(#name)
         }
     });
 

--- a/crates/wiggle/crates/generate/src/names.rs
+++ b/crates/wiggle/crates/generate/src/names.rs
@@ -38,7 +38,7 @@ impl Names {
             BuiltinType::F32 => quote!(f32),
             BuiltinType::F64 => quote!(f64),
             BuiltinType::Char8 => quote!(u8),
-            BuiltinType::USize => quote!(usize),
+            BuiltinType::USize => quote!(u32),
         }
     }
     pub fn atom_type(&self, atom: AtomType) -> TokenStream {

--- a/crates/wiggle/crates/generate/src/names.rs
+++ b/crates/wiggle/crates/generate/src/names.rs
@@ -66,7 +66,11 @@ impl Names {
                     let pointee_type = self.type_ref(&pointee, lifetime.clone());
                     quote!(wiggle_runtime::GuestPtr<#lifetime, #pointee_type>)
                 }
-                _ => unimplemented!("anonymous type ref"),
+                witx::Type::Array(pointee) => {
+                    let pointee_type = self.type_ref(&pointee, lifetime.clone());
+                    quote!(wiggle_runtime::GuestPtr<#lifetime, [#pointee_type]>)
+                }
+                _ => unimplemented!("anonymous type ref {:?}", tref),
             },
         }
     }

--- a/crates/wiggle/crates/runtime/src/guest_type.rs
+++ b/crates/wiggle/crates/runtime/src/guest_type.rs
@@ -108,9 +108,9 @@ macro_rules! primitives {
 
 primitives! {
     // signed
-    i8 i16 i32 i64 i128 isize
+    i8 i16 i32 i64 i128
     // unsigned
-    u8 u16 u32 u64 u128 usize
+    u8 u16 u32 u64 u128
     // floats
     f32 f64
 }

--- a/crates/wiggle/tests/flags.rs
+++ b/crates/wiggle/tests/flags.rs
@@ -14,7 +14,7 @@ impl<'a> flags::Flags for WasiCtx<'a> {
     fn configure_car(
         &self,
         old_config: types::CarConfig,
-        other_config_ptr: GuestPtr<types::CarConfig>,
+        other_config_ptr: &GuestPtr<types::CarConfig>,
     ) -> Result<types::CarConfig, types::Errno> {
         let other_config = other_config_ptr.read().map_err(|e| {
             eprintln!("old_config_ptr error: {}", e);

--- a/crates/wiggle/tests/pointers.rs
+++ b/crates/wiggle/tests/pointers.rs
@@ -13,9 +13,9 @@ impl<'a> pointers::Pointers for WasiCtx<'a> {
     fn pointers_and_enums<'b>(
         &self,
         input1: types::Excuse,
-        input2_ptr: GuestPtr<'b, types::Excuse>,
-        input3_ptr: GuestPtr<'b, types::Excuse>,
-        input4_ptr_ptr: GuestPtr<'b, GuestPtr<'b, types::Excuse>>,
+        input2_ptr: &GuestPtr<'b, types::Excuse>,
+        input3_ptr: &GuestPtr<'b, types::Excuse>,
+        input4_ptr_ptr: &GuestPtr<'b, GuestPtr<'b, types::Excuse>>,
     ) -> Result<(), types::Errno> {
         println!("BAZ input1 {:?}", input1);
         let input2: types::Excuse = input2_ptr.read().map_err(|e| {
@@ -52,7 +52,7 @@ impl<'a> pointers::Pointers for WasiCtx<'a> {
         println!("input4 {:?}", input4);
 
         // Write ptr value to mutable ptr:
-        input4_ptr_ptr.write(input2_ptr).map_err(|e| {
+        input4_ptr_ptr.write(*input2_ptr).map_err(|e| {
             eprintln!("input4_ptr_ptr error: {}", e);
             types::Errno::InvalidArg
         })?;

--- a/crates/wiggle/tests/structs.rs
+++ b/crates/wiggle/tests/structs.rs
@@ -44,10 +44,13 @@ impl<'a> structs::Structs for WasiCtx<'a> {
 
     fn return_pair_of_ptrs<'b>(
         &self,
-        first: GuestPtr<'b, i32>,
-        second: GuestPtr<'b, i32>,
+        first: &GuestPtr<'b, i32>,
+        second: &GuestPtr<'b, i32>,
     ) -> Result<types::PairIntPtrs<'b>, types::Errno> {
-        Ok(types::PairIntPtrs { first, second })
+        Ok(types::PairIntPtrs {
+            first: *first,
+            second: *second,
+        })
     }
 }
 

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -23,7 +23,7 @@ impl<'a> GuestErrorType<'a> for types::Errno {
 }
 
 impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
-    fn args_get(&self, _argv: GuestPtr<GuestPtr<u8>>, _argv_buf: GuestPtr<u8>) -> Result<()> {
+    fn args_get(&self, _argv: &GuestPtr<GuestPtr<u8>>, _argv_buf: &GuestPtr<u8>) -> Result<()> {
         unimplemented!("args_get")
     }
 
@@ -33,8 +33,8 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn environ_get(
         &self,
-        _environ: GuestPtr<GuestPtr<u8>>,
-        _environ_buf: GuestPtr<u8>,
+        _environ: &GuestPtr<GuestPtr<u8>>,
+        _environ_buf: &GuestPtr<u8>,
     ) -> Result<()> {
         unimplemented!("environ_get")
     }
@@ -153,7 +153,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
     fn fd_prestat_dir_name(
         &self,
         _fd: types::Fd,
-        _path: GuestPtr<u8>,
+        _path: &GuestPtr<u8>,
         _path_len: types::Size,
     ) -> Result<()> {
         unimplemented!("fd_prestat_dir_name")
@@ -175,7 +175,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
     fn fd_readdir(
         &self,
         _fd: types::Fd,
-        _buf: GuestPtr<u8>,
+        _buf: &GuestPtr<u8>,
         _buf_len: types::Size,
         _cookie: types::Dircookie,
     ) -> Result<types::Size> {
@@ -260,7 +260,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         &self,
         _fd: types::Fd,
         _path: &GuestPtr<'_, str>,
-        _buf: GuestPtr<u8>,
+        _buf: &GuestPtr<u8>,
         _buf_len: types::Size,
     ) -> Result<types::Size> {
         unimplemented!("path_readlink")
@@ -295,8 +295,8 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn poll_oneoff(
         &self,
-        _in_: GuestPtr<types::Subscription>,
-        _out: GuestPtr<types::Event>,
+        _in_: &GuestPtr<types::Subscription>,
+        _out: &GuestPtr<types::Event>,
         _nsubscriptions: types::Size,
     ) -> Result<types::Size> {
         unimplemented!("poll_oneoff")
@@ -314,7 +314,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         unimplemented!("sched_yield")
     }
 
-    fn random_get(&self, _buf: GuestPtr<u8>, _buf_len: types::Size) -> Result<()> {
+    fn random_get(&self, _buf: &GuestPtr<u8>, _buf_len: types::Size) -> Result<()> {
         unimplemented!("random_get")
     }
 


### PR DESCRIPTION
* wiggle-generate: fix bug where it would panic on an anonymous array type
* a witx `usize` is a rust `u32`, not a rust `usize`. Rust `isize` and `usize` are not `GuestType`s, because they have a different representation depending on the Rust host.
* always pass `GuestPtr` to the module trait methods by reference. This was inconsistent - would be reference for arrays and strings, but not for regular `@witx pointer` types.