### PR TITLE
Disable incremental compilation on CI

### DIFF
--- a/.github/actions/install-rust/main.js
+++ b/.github/actions/install-rust/main.js
@@ -11,3 +11,5 @@ if (process.platform === 'darwin') {
 child_process.execFileSync('rustup', ['set', 'profile', 'minimal']);
 child_process.execFileSync('rustup', ['update', toolchain, '--no-self-update']);
 child_process.execFileSync('rustup', ['default', toolchain]);
+
+console.log(`::set-env name=CARGO_INCREMENTAL::0`);


### PR DESCRIPTION
This should save us about 3GB of target directory disk space and it may
also be a tiny speed boost. There's no real benefit to using incremental
builds on CI because we're not changing code anyway!

