### PR TITLE
Build wasmtime-c-api differenty in run-examples

### DIFF
--- a/crates/misc/run-examples/src/main.rs
+++ b/crates/misc/run-examples/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
         .collect::<BTreeSet<_>>();
 
     println!("======== Building libwasmtime.a ===========");
-    run(Command::new("cargo").args(&["build", "-p", "wasmtime-c-api"]));
+    run(Command::new("cargo").args(&["build"]).current_dir("crates/c-api"));
 
     for (example, is_dir) in examples {
         if example == "README" {

--- a/crates/misc/run-examples/src/main.rs
+++ b/crates/misc/run-examples/src/main.rs
@@ -13,7 +13,9 @@ fn main() {
         .collect::<BTreeSet<_>>();
 
     println!("======== Building libwasmtime.a ===========");
-    run(Command::new("cargo").args(&["build"]).current_dir("crates/c-api"));
+    run(Command::new("cargo")
+        .args(&["build"])
+        .current_dir("crates/c-api"));
 
     for (example, is_dir) in examples {
         if example == "README" {


### PR DESCRIPTION
This tweaks how the wasmtime-c-api crate is built slightly, changing how
we invoke Cargo. Due to historical Cargo bugs this should help minimize
the number of rebuilds due to features since the feature selection will
be different.
