### PR TITLE
Update the `filecheck` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,28 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,13 +881,12 @@ dependencies = [
 
 [[package]]
 name = "filecheck"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded7985594ab426ef685362e5183168eb3b5aacc9f4e26819e8d82d224f33449"
+checksum = "2fe00b427b7c4835f8b82170eb7b9a63634376b63d73b9a9093367e82570bbaa"
 dependencies = [
- "failure",
- "failure_derive",
  "regex",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ more-asserts = "0.2.1"
 # `cargo test --features test-programs`.
 test-programs = { path = "crates/test-programs" }
 tempfile = "3.1.0"
-filecheck = "0.4.0"
+filecheck = "0.5.0"
 
 [build-dependencies]
 anyhow = "1.0.19"

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -29,7 +29,7 @@ cranelift-object = { path = "object", version = "0.60.0" }
 cranelift-simplejit = { path = "simplejit", version = "0.60.0" }
 cranelift-preopt = { path = "preopt", version = "0.60.0" }
 cranelift = { path = "umbrella", version = "0.60.0" }
-filecheck = "0.4.0"
+filecheck = "0.5.0"
 clap = "2.32.0"
 serde = "1.0.8"
 term = "0.6.1"

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-native = { path = "../native", version = "0.60.0" }
 cranelift-reader = { path = "../reader", version = "0.60.0" }
 cranelift-preopt = { path = "../preopt", version = "0.60.0" }
 file-per-thread-logger = "0.1.2"
-filecheck = "0.4.0"
+filecheck = "0.5.0"
 gimli = { version = "0.20.0", default-features = false, features = ["read"] }
 log = "0.4.6"
 memmap = "0.7.0"


### PR DESCRIPTION
Removes an edge towards the `synstructure` dependency in our dependency
graph which, if removed entirely, is hoped to reduce build times locally
and on CI as you switch between `cargo build` and `cargo test` because
deep dependencies like `syn` won't have their features alternating back
and forth.
