### PR TITLE
Add a safe method `GuestPtr::copy_from_slice`

### DIFF
--- a/crates/wiggle/crates/runtime/src/error.rs
+++ b/crates/wiggle/crates/runtime/src/error.rs
@@ -15,6 +15,8 @@ pub enum GuestError {
     PtrNotAligned(Region, u32),
     #[error("Pointer already borrowed: {0:?}")]
     PtrBorrowed(Region),
+    #[error("Slice length mismatch")]
+    SliceLengthsDiffer,
     #[error("In func {funcname}:{location}:")]
     InFunc {
         funcname: &'static str,


### PR DESCRIPTION
This commit adds a safe method to wiggle pointers to copy slices of data
from the host to the guest.
