### PR TITLE
[wiggle] Don't make generated structs and unions `Copy`.

### DIFF
--- a/crates/wasi-common/src/clock.rs
+++ b/crates/wasi-common/src/clock.rs
@@ -5,7 +5,7 @@ use std::time::SystemTime;
 
 pub(crate) use sys::clock::*;
 
-pub(crate) fn to_relative_ns_delay(clock: SubscriptionClock) -> Result<u128> {
+pub(crate) fn to_relative_ns_delay(clock: &SubscriptionClock) -> Result<u128> {
     if clock.flags != Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME {
         return Ok(u128::from(clock.timeout));
     }

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -1178,7 +1178,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         for subscription in subscriptions {
             match subscription.u {
                 types::SubscriptionU::Clock(clock) => {
-                    let delay = clock::to_relative_ns_delay(clock)?;
+                    let delay = clock::to_relative_ns_delay(&clock)?;
                     log::debug!("poll_oneoff event.u.clock = {:?}", clock);
                     log::debug!("poll_oneoff delay = {:?}ns", delay);
                     let current = poll::ClockEventData {

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -95,7 +95,7 @@ impl AsBytes for types::Dirent {
         let mut bytes: Vec<u8> = Vec::with_capacity(offset);
         bytes.resize(offset, 0);
         let ptr = bytes.as_mut_ptr() as *mut Self;
-        unsafe { ptr.write_unaligned(*self) };
+        unsafe { ptr.write_unaligned(self.clone()) };
         Ok(bytes)
     }
 }

--- a/crates/wiggle/crates/generate/src/types/struct.rs
+++ b/crates/wiggle/crates/generate/src/types/struct.rs
@@ -74,7 +74,7 @@ pub(super) fn define_struct(
     let (struct_lifetime, extra_derive) = if s.needs_lifetime() {
         (quote!(<'a>), quote!())
     } else {
-        (quote!(), quote!(, Copy, PartialEq))
+        (quote!(), quote!(, PartialEq))
     };
 
     let transparent = if s.is_transparent() {

--- a/crates/wiggle/crates/generate/src/types/union.rs
+++ b/crates/wiggle/crates/generate/src/types/union.rs
@@ -68,7 +68,7 @@ pub(super) fn define_union(names: &Names, name: &witx::Id, u: &witx::UnionDataty
     let (enum_lifetime, extra_derive) = if u.needs_lifetime() {
         (quote!(<'a>), quote!())
     } else {
-        (quote!(), quote!(, Copy, PartialEq))
+        (quote!(), quote!(, PartialEq))
     };
 
     quote! {


### PR DESCRIPTION
Some structs and unions are large enough that making them `Copy` isn't
ideal. wasi-common only needed `Copy` in a few places that were easy to
fix. `SubscriptionClock` is 32 bytes, so it's not a bad a idea to pass
it by reference anyway.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
