### PR TITLE
[wasi-common] Add an `is_directory()` helper method.

### DIFF
--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -351,7 +351,7 @@ impl WasiCtxBuilder {
                     }
                 }
                 Descriptor::VirtualFile(virt) => {
-                    if virt.get_file_type() != types::Filetype::Directory {
+                    if !virt.is_directory() {
                         return Err(WasiCtxBuilderError::NotADirectory(guest_path));
                     }
                 }

--- a/crates/wasi-common/src/virtfs.rs
+++ b/crates/wasi-common/src/virtfs.rs
@@ -137,6 +137,10 @@ pub(crate) trait VirtualFile: MovableFile {
 
     fn get_file_type(&self) -> types::Filetype;
 
+    fn is_directory(&self) -> bool {
+        self.get_file_type() == types::Filetype::Directory
+    }
+
     fn get_rights_base(&self) -> types::Rights {
         types::Rights::empty()
     }


### PR DESCRIPTION
This allows `ctx` to avoid depending on wasi::FileType.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
