### PR TITLE
[wasi-common] Fix a warning about unreachable code.

### DIFF
--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -1281,7 +1281,6 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         // TODO: Rather than call std::process::exit here, we should trigger a
         // stack unwind similar to a trap.
         std::process::exit(rval as i32);
-        Ok(())
     }
 
     fn proc_raise(&self, _sig: types::Signal) -> Result<()> {


### PR DESCRIPTION
`exit` doesn't return, so code after it is unreachable.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
