### PR TITLE
Pass `Fd` by reference

### DIFF
--- a/crates/wasi-common/src/fdpool.rs
+++ b/crates/wasi-common/src/fdpool.rs
@@ -2,25 +2,8 @@
 //! pool. It's intended to be mainly used within the `WasiCtx`
 //! object(s).
 
-/// Any type wishing to be treated as a valid WASI file descriptor
-/// should implement this trait.
-///
-/// This trait is required as internally we use `u32` to represent
-/// and manage raw file descriptors.
-pub(crate) trait Fd {
-    /// Convert to `u32`.
-    fn as_raw(&self) -> u32;
-    /// Convert from `u32`.
-    fn from_raw(raw_fd: u32) -> Self;
-}
-
 /// This container tracks and manages all file descriptors that
 /// were already allocated.
-/// Internally, we use `u32` to represent the file descriptors;
-/// however, the caller may supply any type `T` such that it
-/// implements the `Fd` trait when requesting a new descriptor
-/// via the `allocate` method, or when returning one back via
-/// the `deallocate` method.
 #[derive(Debug)]
 pub(crate) struct FdPool {
     next_alloc: Option<u32>,
@@ -41,11 +24,11 @@ impl FdPool {
     /// descriptors (which would be equal to `2^32 + 1` accounting for `0`),
     /// then this method will return `None` to signal that case.
     /// Otherwise, a new file descriptor is return as `Some(fd)`.
-    pub fn allocate<T: Fd>(&mut self) -> Option<T> {
+    pub fn allocate(&mut self) -> Option<u32> {
         if let Some(fd) = self.available.pop() {
             // Since we've had free, unclaimed handle in the pool,
             // simply claim it and return.
-            return Some(T::from_raw(fd));
+            return Some(fd);
         }
         // There are no free handles available in the pool, so try
         // allocating an additional one into the pool. If we've
@@ -55,7 +38,7 @@ impl FdPool {
         // It's OK to not unpack the result of `fd.checked_add()` here which
         // can fail since we check for `None` in the snippet above.
         self.next_alloc = fd.checked_add(1);
-        Some(T::from_raw(fd))
+        Some(fd)
     }
 
     /// Return a file descriptor back to the pool.
@@ -63,8 +46,7 @@ impl FdPool {
     /// If the caller tries to return a file descriptor that was
     /// not yet allocated (via spoofing, etc.), this method
     /// will panic.
-    pub fn deallocate<T: Fd>(&mut self, fd: T) {
-        let fd = fd.as_raw();
+    pub fn deallocate(&mut self, fd: u32) {
         if let Some(next_alloc) = self.next_alloc {
             assert!(fd < next_alloc);
         }
@@ -76,44 +58,24 @@ impl FdPool {
 #[cfg(test)]
 mod test {
     use super::FdPool;
-    use std::ops::Deref;
-
-    #[derive(Debug)]
-    struct Fd(u32);
-
-    impl super::Fd for Fd {
-        fn as_raw(&self) -> u32 {
-            self.0
-        }
-        fn from_raw(raw_fd: u32) -> Self {
-            Self(raw_fd)
-        }
-    }
-
-    impl Deref for Fd {
-        type Target = u32;
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
 
     #[test]
     fn basics() {
         let mut fd_pool = FdPool::new();
-        let mut fd: Fd = fd_pool.allocate().expect("success allocating 0");
-        assert_eq!(*fd, 0);
+        let mut fd = fd_pool.allocate().expect("success allocating 0");
+        assert_eq!(fd, 0);
         fd = fd_pool.allocate().expect("success allocating 1");
-        assert_eq!(*fd, 1);
+        assert_eq!(fd, 1);
         fd = fd_pool.allocate().expect("success allocating 2");
-        assert_eq!(*fd, 2);
+        assert_eq!(fd, 2);
         fd_pool.deallocate(1u32);
         fd_pool.deallocate(0u32);
         fd = fd_pool.allocate().expect("success reallocating 0");
-        assert_eq!(*fd, 0);
+        assert_eq!(fd, 0);
         fd = fd_pool.allocate().expect("success reallocating 1");
-        assert_eq!(*fd, 1);
+        assert_eq!(fd, 1);
         fd = fd_pool.allocate().expect("success allocating 3");
-        assert_eq!(*fd, 3);
+        assert_eq!(fd, 3);
     }
 
     #[test]
@@ -128,6 +90,6 @@ mod test {
         let mut fd_pool = FdPool::new();
         // Spoof reaching the limit of allocs.
         fd_pool.next_alloc = None;
-        assert!(fd_pool.allocate::<Fd>().is_none());
+        assert!(fd_pool.allocate().is_none());
     }
 }

--- a/crates/wasi-common/src/fs/dir.rs
+++ b/crates/wasi-common/src/fs/dir.rs
@@ -18,12 +18,12 @@ use std::{io, path::Path};
 /// don't interoperate well with the capability-oriented security model.
 pub struct Dir<'ctx> {
     ctx: &'ctx WasiCtx,
-    fd: types::Fd,
+    fd: &'ctx types::Fd,
 }
 
 impl<'ctx> Dir<'ctx> {
     /// Constructs a new instance of `Self` from the given raw WASI file descriptor.
-    pub unsafe fn from_raw_wasi_fd(ctx: &'ctx WasiCtx, fd: types::Fd) -> Self {
+    pub unsafe fn from_raw_wasi_fd(ctx: &'ctx WasiCtx, fd: &'ctx types::Fd) -> Self {
         Self { ctx, fd }
     }
 
@@ -38,9 +38,6 @@ impl<'ctx> Dir<'ctx> {
     ///
     /// [`std::fs::File::open`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.open
     pub fn open_file<P: AsRef<Path>>(&mut self, path: P) -> io::Result<File> {
-        let path = path.as_ref();
-        let mut fd = types::Fd::from(0);
-
         // TODO: Refactor the hostcalls functions to split out the encoding/decoding
         // parts from the underlying functionality, so that we can call into the
         // underlying functionality directly.
@@ -51,6 +48,9 @@ impl<'ctx> Dir<'ctx> {
         // on `OsStrExt`.
         unimplemented!("Dir::open_file");
         /*
+        let path = path.as_ref();
+        let mut fd = types::Fd { raw: types::RawFd::from(0) };
+
         wasi_errno_to_io_error(hostcalls::path_open(
             self.ctx,
             self.fd,
@@ -63,10 +63,10 @@ impl<'ctx> Dir<'ctx> {
             0,
             &mut fd,
         ))?;
-        */
 
         let ctx = self.ctx;
         Ok(unsafe { File::from_raw_wasi_fd(ctx, fd) })
+        */
     }
 
     /// Opens a file at `path` with the options specified by `self`.
@@ -91,12 +91,12 @@ impl<'ctx> Dir<'ctx> {
     ///
     /// TODO: Not yet implemented. See the comment in `open_file`.
     pub fn open_dir<P: AsRef<Path>>(&mut self, path: P) -> io::Result<Self> {
-        let path = path.as_ref();
-        let mut fd = types::Fd::from(0);
-
         // TODO: See the comment in `open_file`.
         unimplemented!("Dir::open_dir");
         /*
+        let path = path.as_ref();
+        let mut fd = types::Fd { raw: types::RawFd::from(0) };
+
         wasi_errno_to_io_error(hostcalls::path_open(
             self.ctx,
             self.fd,
@@ -108,10 +108,10 @@ impl<'ctx> Dir<'ctx> {
             0,
             &mut fd,
         ))?;
-        */
 
         let ctx = self.ctx;
         Ok(unsafe { Dir::from_raw_wasi_fd(ctx, fd) })
+        */
     }
 
     /// Opens a file in write-only mode.
@@ -123,14 +123,14 @@ impl<'ctx> Dir<'ctx> {
     ///
     /// [`std::fs::File::create`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.create
     pub fn create_file<P: AsRef<Path>>(&mut self, path: P) -> io::Result<File> {
-        let path = path.as_ref();
-        let mut fd = types::Fd::from(0);
-
         // TODO: See the comments in `open_file`.
         //
         // TODO: Set the requested rights to be read+write.
         unimplemented!("Dir::create_file");
         /*
+        let path = path.as_ref();
+        let mut fd = types::Fd { raw: types::RawFd::from(0) };
+
         wasi_errno_to_io_error(hostcalls::path_open(
             self.ctx,
             self.fd,
@@ -143,10 +143,10 @@ impl<'ctx> Dir<'ctx> {
             0,
             &mut fd,
         ))?;
-        */
 
         let ctx = self.ctx;
         Ok(unsafe { File::from_raw_wasi_fd(ctx, fd) })
+        */
     }
 
     /// Returns an iterator over the entries within a directory.
@@ -159,13 +159,13 @@ impl<'ctx> Dir<'ctx> {
     /// now, use `into_read` instead.
     ///
     /// [`std::fs::read_dir`]: https://doc.rust-lang.org/std/fs/fn.read_dir.html
-    pub fn read(&mut self) -> io::Result<ReadDir> {
+    pub fn read(&mut self) -> io::Result<ReadDir<'ctx>> {
         unimplemented!("Dir::read")
     }
 
     /// Consumes self and returns an iterator over the entries within a directory
     /// in the manner of `read`.
-    pub fn into_read(self) -> ReadDir {
+    pub fn into_read(self) -> ReadDir<'ctx> {
         unsafe { ReadDir::from_raw_wasi_fd(self.fd) }
     }
 
@@ -189,7 +189,7 @@ impl<'ctx> Dir<'ctx> {
     /// relative to and within `self`.
     ///
     /// [`std::fs::read_dir`]: https://doc.rust-lang.org/std/fs/fn.read_dir.html
-    pub fn read_dir<P: AsRef<Path>>(&mut self, path: P) -> io::Result<ReadDir> {
+    pub fn read_dir<P: AsRef<Path>>(&mut self, path: P) -> io::Result<ReadDir<'ctx>> {
         self.open_dir(path)?.read()
     }
 }

--- a/crates/wasi-common/src/fs/file.rs
+++ b/crates/wasi-common/src/fs/file.rs
@@ -18,7 +18,7 @@ use std::io;
 /// [`Dir::create_file`]: struct.Dir.html#method.create_file
 pub struct File<'ctx> {
     ctx: &'ctx WasiCtx,
-    fd: types::Fd,
+    fd: &'ctx types::Fd,
 }
 
 impl<'ctx> File<'ctx> {
@@ -27,7 +27,7 @@ impl<'ctx> File<'ctx> {
     /// This corresponds to [`std::fs::File::from_raw_fd`].
     ///
     /// [`std::fs::File::from_raw_fd`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.from_raw_fd
-    pub unsafe fn from_raw_wasi_fd(ctx: &'ctx WasiCtx, fd: types::Fd) -> Self {
+    pub unsafe fn from_raw_wasi_fd(ctx: &'ctx WasiCtx, fd: &'ctx types::Fd) -> Self {
         Self { ctx, fd }
     }
 

--- a/crates/wasi-common/src/fs/readdir.rs
+++ b/crates/wasi-common/src/fs/readdir.rs
@@ -8,19 +8,19 @@ use crate::wasi::types;
 /// TODO: Not yet implemented.
 ///
 /// [`std::fs::ReadDir`]: https://doc.rust-lang.org/std/fs/struct.ReadDir.html
-pub struct ReadDir {
-    fd: types::Fd,
+pub struct ReadDir<'ctx> {
+    fd: &'ctx types::Fd,
 }
 
-impl ReadDir {
+impl<'ctx> ReadDir<'ctx> {
     /// Constructs a new instance of `Self` from the given raw WASI file descriptor.
-    pub unsafe fn from_raw_wasi_fd(fd: types::Fd) -> Self {
+    pub unsafe fn from_raw_wasi_fd(fd: &'ctx types::Fd) -> Self {
         Self { fd }
     }
 }
 
 /// TODO: Not yet implemented.
-impl Iterator for ReadDir {
+impl<'ctx> Iterator for ReadDir<'ctx> {
     type Item = DirEntry;
 
     /// TODO: Not yet implemented.

--- a/crates/wasi-common/src/old/snapshot_0/wasi.rs
+++ b/crates/wasi-common/src/old/snapshot_0/wasi.rs
@@ -226,12 +226,3 @@ pub fn whence_to_str(whence: __wasi_whence_t) -> &'static str {
 }
 
 pub const __WASI_DIRCOOKIE_START: __wasi_dircookie_t = 0;
-
-impl crate::fdpool::Fd for __wasi_fd_t {
-    fn as_raw(&self) -> u32 {
-        *self
-    }
-    fn from_raw(raw_fd: u32) -> Self {
-        raw_fd
-    }
-}

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -112,7 +112,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_advise(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         offset: types::Filesize,
         len: types::Filesize,
         advice: types::Advice,
@@ -141,7 +141,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_allocate(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         offset: types::Filesize,
         len: types::Filesize,
     ) -> Result<()> {
@@ -174,7 +174,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         }
     }
 
-    fn fd_close(&self, fd: types::Fd) -> Result<()> {
+    fn fd_close(&self, fd: &types::Fd) -> Result<()> {
         trace!("fd_close(fd={:?})", fd);
 
         if let Ok(fe) = self.get_entry(fd) {
@@ -188,7 +188,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(())
     }
 
-    fn fd_datasync(&self, fd: types::Fd) -> Result<()> {
+    fn fd_datasync(&self, fd: &types::Fd) -> Result<()> {
         trace!("fd_datasync(fd={:?})", fd);
 
         let entry = self.get_entry(fd)?;
@@ -201,7 +201,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(())
     }
 
-    fn fd_fdstat_get(&self, fd: types::Fd) -> Result<types::Fdstat> {
+    fn fd_fdstat_get(&self, fd: &types::Fd) -> Result<types::Fdstat> {
         trace!("fd_fdstat_get(fd={:?})", fd);
 
         let fe = self.get_entry(fd)?;
@@ -223,7 +223,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(fdstat)
     }
 
-    fn fd_fdstat_set_flags(&self, fd: types::Fd, flags: types::Fdflags) -> Result<()> {
+    fn fd_fdstat_set_flags(&self, fd: &types::Fd, flags: types::Fdflags) -> Result<()> {
         trace!("fd_fdstat_set_flags(fd={:?}, fdflags={})", fd, flags);
 
         let mut entry = self.get_entry_mut(fd)?;
@@ -252,7 +252,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_fdstat_set_rights(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         fs_rights_base: types::Rights,
         fs_rights_inheriting: types::Rights,
     ) -> Result<()> {
@@ -273,7 +273,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(())
     }
 
-    fn fd_filestat_get(&self, fd: types::Fd) -> Result<types::Filestat> {
+    fn fd_filestat_get(&self, fd: &types::Fd) -> Result<types::Filestat> {
         trace!("fd_filestat_get(fd={:?})", fd);
 
         let entry = self.get_entry(fd)?;
@@ -295,7 +295,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(host_filestat)
     }
 
-    fn fd_filestat_set_size(&self, fd: types::Fd, size: types::Filesize) -> Result<()> {
+    fn fd_filestat_set_size(&self, fd: &types::Fd, size: types::Filesize) -> Result<()> {
         trace!("fd_filestat_set_size(fd={:?}, size={})", fd, size);
 
         let entry = self.get_entry(fd)?;
@@ -320,7 +320,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_filestat_set_times(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         atim: types::Timestamp,
         mtim: types::Timestamp,
         fst_flags: types::Fstflags,
@@ -341,7 +341,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_pread(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         iovs: &types::IovecArray<'_>,
         offset: types::Filesize,
     ) -> Result<types::Size> {
@@ -395,7 +395,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(host_nread)
     }
 
-    fn fd_prestat_get(&self, fd: types::Fd) -> Result<types::Prestat> {
+    fn fd_prestat_get(&self, fd: &types::Fd) -> Result<types::Prestat> {
         trace!("fd_prestat_get(fd={:?})", fd);
 
         // TODO: should we validate any rights here?
@@ -414,7 +414,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_prestat_dir_name(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         path: &GuestPtr<u8>,
         path_len: types::Size,
     ) -> Result<()> {
@@ -449,7 +449,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_pwrite(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         ciovs: &types::CiovecArray<'_>,
         offset: types::Filesize,
     ) -> Result<types::Size> {
@@ -507,7 +507,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(host_nwritten)
     }
 
-    fn fd_read(&self, fd: types::Fd, iovs: &types::IovecArray<'_>) -> Result<types::Size> {
+    fn fd_read(&self, fd: &types::Fd, iovs: &types::IovecArray<'_>) -> Result<types::Size> {
         trace!("fd_read(fd={:?}, iovs={:?})", fd, iovs);
 
         let mut bc = GuestBorrows::new();
@@ -541,7 +541,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_readdir(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         buf: &GuestPtr<u8>,
         buf_len: types::Size,
         cookie: types::Dircookie,
@@ -600,7 +600,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(bufused)
     }
 
-    fn fd_renumber(&self, from: types::Fd, to: types::Fd) -> Result<()> {
+    fn fd_renumber(&self, from: &types::Fd, to: &types::Fd) -> Result<()> {
         trace!("fd_renumber(from={:?}, to={:?})", from, to);
 
         if !self.contains_entry(from) {
@@ -627,7 +627,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn fd_seek(
         &self,
-        fd: types::Fd,
+        fd: &types::Fd,
         offset: types::Filedelta,
         whence: types::Whence,
     ) -> Result<types::Filesize> {
@@ -667,7 +667,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(host_newoffset)
     }
 
-    fn fd_sync(&self, fd: types::Fd) -> Result<()> {
+    fn fd_sync(&self, fd: &types::Fd) -> Result<()> {
         trace!("fd_sync(fd={:?})", fd);
 
         let entry = self.get_entry(fd)?;
@@ -686,7 +686,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(())
     }
 
-    fn fd_tell(&self, fd: types::Fd) -> Result<types::Filesize> {
+    fn fd_tell(&self, fd: &types::Fd) -> Result<types::Filesize> {
         trace!("fd_tell(fd={:?})", fd);
 
         let mut entry = self.get_entry_mut(fd)?;
@@ -708,7 +708,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(host_offset)
     }
 
-    fn fd_write(&self, fd: types::Fd, ciovs: &types::CiovecArray<'_>) -> Result<types::Size> {
+    fn fd_write(&self, fd: &types::Fd, ciovs: &types::CiovecArray<'_>) -> Result<types::Size> {
         trace!("fd_write(fd={:?}, ciovs={:#x?})", fd, ciovs);
 
         let mut bc = GuestBorrows::new();
@@ -769,7 +769,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(host_nwritten.try_into()?)
     }
 
-    fn path_create_directory(&self, dirfd: types::Fd, path: &GuestPtr<'_, str>) -> Result<()> {
+    fn path_create_directory(&self, dirfd: &types::Fd, path: &GuestPtr<'_, str>) -> Result<()> {
         trace!("path_create_directory(dirfd={:?}, path={:?})", dirfd, path);
 
         let rights = types::Rights::PATH_OPEN | types::Rights::PATH_CREATE_DIRECTORY;
@@ -787,7 +787,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn path_filestat_get(
         &self,
-        dirfd: types::Fd,
+        dirfd: &types::Fd,
         flags: types::Lookupflags,
         path: &GuestPtr<'_, str>,
     ) -> Result<types::Filestat> {
@@ -827,7 +827,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn path_filestat_set_times(
         &self,
-        dirfd: types::Fd,
+        dirfd: &types::Fd,
         flags: types::Lookupflags,
         path: &GuestPtr<'_, str>,
         atim: types::Timestamp,
@@ -863,10 +863,10 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn path_link(
         &self,
-        old_fd: types::Fd,
+        old_fd: &types::Fd,
         old_flags: types::Lookupflags,
         old_path: &GuestPtr<'_, str>,
-        new_fd: types::Fd,
+        new_fd: &types::Fd,
         new_path: &GuestPtr<'_, str>,
     ) -> Result<()> {
         trace!(
@@ -905,7 +905,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn path_open(
         &self,
-        dirfd: types::Fd,
+        dirfd: &types::Fd,
         dirflags: types::Lookupflags,
         path: &GuestPtr<'_, str>,
         oflags: types::Oflags,
@@ -976,7 +976,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn path_readlink(
         &self,
-        dirfd: types::Fd,
+        dirfd: &types::Fd,
         path: &GuestPtr<'_, str>,
         buf: &GuestPtr<u8>,
         buf_len: types::Size,
@@ -1019,7 +1019,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(host_bufused)
     }
 
-    fn path_remove_directory(&self, dirfd: types::Fd, path: &GuestPtr<'_, str>) -> Result<()> {
+    fn path_remove_directory(&self, dirfd: &types::Fd, path: &GuestPtr<'_, str>) -> Result<()> {
         trace!("path_remove_directory(dirfd={:?}, path={:?})", dirfd, path);
 
         let entry = self.get_entry(dirfd)?;
@@ -1042,9 +1042,9 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn path_rename(
         &self,
-        old_fd: types::Fd,
+        old_fd: &types::Fd,
         old_path: &GuestPtr<'_, str>,
-        new_fd: types::Fd,
+        new_fd: &types::Fd,
         new_path: &GuestPtr<'_, str>,
     ) -> Result<()> {
         trace!(
@@ -1091,7 +1091,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
     fn path_symlink(
         &self,
         old_path: &GuestPtr<'_, str>,
-        dirfd: types::Fd,
+        dirfd: &types::Fd,
         new_path: &GuestPtr<'_, str>,
     ) -> Result<()> {
         trace!(
@@ -1127,7 +1127,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         }
     }
 
-    fn path_unlink_file(&self, dirfd: types::Fd, path: &GuestPtr<'_, str>) -> Result<()> {
+    fn path_unlink_file(&self, dirfd: &types::Fd, path: &GuestPtr<'_, str>) -> Result<()> {
         trace!("path_unlink_file(dirfd={:?}, path={:?})", dirfd, path);
 
         let entry = self.get_entry(dirfd)?;
@@ -1198,9 +1198,9 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
                     }
                 }
                 types::SubscriptionU::FdRead(fd_read) => {
-                    let fd = fd_read.file_descriptor;
+                    let fd = unsafe { types::Fd::from_raw(fd_read.file_descriptor) };
                     let rights = types::Rights::FD_READ | types::Rights::POLL_FD_READWRITE;
-                    let entry = match self.get_entry(fd) {
+                    let entry = match self.get_entry(&fd) {
                         Ok(entry) => entry,
                         Err(error) => {
                             events.push(types::Event {
@@ -1227,10 +1227,10 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
                         userdata: subscription.userdata,
                     });
                 }
-                types::SubscriptionU::FdWrite(fd_write) => {
-                    let fd = fd_write.file_descriptor;
+                types::SubscriptionU::FdWrite(ref fd_write) => {
+                    let fd = unsafe { types::Fd::from_raw(fd_write.file_descriptor) };
                     let rights = types::Rights::FD_WRITE | types::Rights::POLL_FD_READWRITE;
-                    let entry = match self.get_entry(fd) {
+                    let entry = match self.get_entry(&fd) {
                         Ok(entry) => entry,
                         Err(error) => {
                             events.push(types::Event {
@@ -1317,7 +1317,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn sock_recv(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _ri_data: &types::IovecArray<'_>,
         _ri_flags: types::Riflags,
     ) -> Result<(types::Size, types::Roflags)> {
@@ -1326,14 +1326,14 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
     fn sock_send(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _si_data: &types::CiovecArray<'_>,
         _si_flags: types::Siflags,
     ) -> Result<types::Size> {
         unimplemented!("sock_send")
     }
 
-    fn sock_shutdown(&self, _fd: types::Fd, _how: types::Sdflags) -> Result<()> {
+    fn sock_shutdown(&self, _fd: &types::Fd, _how: types::Sdflags) -> Result<()> {
         unimplemented!("sock_shutdown")
     }
 }

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -1198,9 +1198,8 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
                     }
                 }
                 types::SubscriptionU::FdRead(fd_read) => {
-                    let fd = unsafe { types::Fd::from_raw(fd_read.file_descriptor) };
                     let rights = types::Rights::FD_READ | types::Rights::POLL_FD_READWRITE;
-                    let entry = match self.get_entry(&fd) {
+                    let entry = match self.get_entry(&fd_read.file_descriptor) {
                         Ok(entry) => entry,
                         Err(error) => {
                             events.push(types::Event {
@@ -1228,9 +1227,8 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
                     });
                 }
                 types::SubscriptionU::FdWrite(ref fd_write) => {
-                    let fd = unsafe { types::Fd::from_raw(fd_write.file_descriptor) };
                     let rights = types::Rights::FD_WRITE | types::Rights::POLL_FD_READWRITE;
-                    let entry = match self.get_entry(&fd) {
+                    let entry = match self.get_entry(&fd_write.file_descriptor) {
                         Ok(entry) => entry,
                         Err(error) => {
                             events.push(types::Event {

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -206,12 +206,3 @@ impl RightsExt for types::Rights {
     }
 }
 pub(crate) const DIRCOOKIE_START: types::Dircookie = 0;
-
-impl crate::fdpool::Fd for types::Fd {
-    fn as_raw(&self) -> u32 {
-        (*self).into()
-    }
-    fn from_raw(raw_fd: u32) -> Self {
-        Self::from(raw_fd)
-    }
-}

--- a/crates/wiggle/crates/generate/src/lifetimes.rs
+++ b/crates/wiggle/crates/generate/src/lifetimes.rs
@@ -20,11 +20,9 @@ impl LifetimeExt for witx::Type {
         match self {
             witx::Type::Builtin(b) => b.is_transparent(),
             witx::Type::Struct(s) => s.is_transparent(),
-            witx::Type::Enum { .. }
-            | witx::Type::Flags { .. }
-            | witx::Type::Int { .. }
-            | witx::Type::Handle { .. } => true,
-            witx::Type::Union { .. }
+            witx::Type::Enum { .. } | witx::Type::Flags { .. } | witx::Type::Int { .. } => true,
+            witx::Type::Handle { .. }
+            | witx::Type::Union { .. }
             | witx::Type::Pointer { .. }
             | witx::Type::ConstPointer { .. }
             | witx::Type::Array { .. } => false,

--- a/crates/wiggle/crates/generate/src/module_trait.rs
+++ b/crates/wiggle/crates/generate/src/module_trait.rs
@@ -15,7 +15,10 @@ pub fn passed_by_reference(ty: &witx::Type) -> bool {
             witx::BuiltinType::String => true,
             _ => passed_by,
         },
-        witx::Type::Pointer(_) | witx::Type::ConstPointer(_) | witx::Type::Array(_) => true,
+        witx::Type::Handle(_)
+        | witx::Type::Pointer(_)
+        | witx::Type::ConstPointer(_)
+        | witx::Type::Array(_) => true,
         _ => passed_by,
     }
 }

--- a/crates/wiggle/crates/generate/src/types/handle.rs
+++ b/crates/wiggle/crates/generate/src/types/handle.rs
@@ -25,12 +25,6 @@ pub(super) fn define_handle(
             }
         }
 
-        impl Clone for #ident {
-            fn clone(&self) -> Self {
-                Self(self.0)
-            }
-        }
-
         impl From<#ident> for i32 {
             fn from(e: #ident) -> i32 {
                 e.0 as i32

--- a/crates/wiggle/crates/generate/src/types/handle.rs
+++ b/crates/wiggle/crates/generate/src/types/handle.rs
@@ -67,14 +67,5 @@ pub(super) fn define_handle(
             }
         }
 
-        unsafe impl<'a> wiggle_runtime::GuestTypeTransparent<'a> for #ident {
-            #[inline]
-            fn validate(_location: *mut #ident) -> Result<(), wiggle_runtime::GuestError> {
-                // All bit patterns accepted
-                Ok(())
-            }
-        }
-
-
     }
 }

--- a/crates/wiggle/crates/generate/src/types/handle.rs
+++ b/crates/wiggle/crates/generate/src/types/handle.rs
@@ -13,19 +13,21 @@ pub(super) fn define_handle(
     let size = h.mem_size_align().size as u32;
     let align = h.mem_size_align().align as usize;
     quote! {
-        #[repr(transparent)]
-        #[derive(Copy, Clone, Debug, ::std::hash::Hash, Eq, PartialEq)]
+        #[derive(Debug, PartialEq)]
         pub struct #ident(u32);
 
         impl #ident {
-            pub unsafe fn inner(&self) -> u32 {
+            pub unsafe fn from_raw(raw: u32) -> Self {
+                Self(raw)
+            }
+            pub fn as_raw(&self) -> u32 {
                 self.0
             }
         }
 
-        impl From<#ident> for u32 {
-            fn from(e: #ident) -> u32 {
-                e.0
+        impl Clone for #ident {
+            fn clone(&self) -> Self {
+                Self(self.0)
             }
         }
 
@@ -35,11 +37,6 @@ pub(super) fn define_handle(
             }
         }
 
-        impl From<u32> for #ident {
-            fn from(e: u32) -> #ident {
-                #ident(e)
-            }
-        }
         impl From<i32> for #ident {
             fn from(e: i32) -> #ident {
                 #ident(e as u32)

--- a/crates/wiggle/crates/generate/src/types/struct.rs
+++ b/crates/wiggle/crates/generate/src/types/struct.rs
@@ -76,6 +76,11 @@ pub(super) fn define_struct(
     } else {
         (quote!(), quote!(, PartialEq))
     };
+    let derive_clone = if s.is_clone() {
+        quote!(, Clone)
+    } else {
+        quote!()
+    };
 
     let transparent = if s.is_transparent() {
         let member_validate = s.member_layout().into_iter().map(|ml| {
@@ -104,7 +109,7 @@ pub(super) fn define_struct(
     };
 
     quote! {
-        #[derive(Clone, Debug #extra_derive)]
+        #[derive(Debug #derive_clone #extra_derive)]
         pub struct #ident #struct_lifetime {
             #(#member_decls),*
         }

--- a/crates/wiggle/crates/generate/src/types/union.rs
+++ b/crates/wiggle/crates/generate/src/types/union.rs
@@ -70,9 +70,14 @@ pub(super) fn define_union(names: &Names, name: &witx::Id, u: &witx::UnionDataty
     } else {
         (quote!(), quote!(, PartialEq))
     };
+    let derive_clone = if u.is_clone() {
+        quote!(, Clone)
+    } else {
+        quote!()
+    };
 
     quote! {
-        #[derive(Clone, Debug #extra_derive)]
+        #[derive(Debug #derive_clone #extra_derive)]
         pub enum #ident #enum_lifetime {
             #(#variants),*
         }

--- a/crates/wiggle/tests/handles.rs
+++ b/crates/wiggle/tests/handles.rs
@@ -13,11 +13,11 @@ impl_errno!(types::Errno);
 
 impl<'a> handle_examples::HandleExamples for WasiCtx<'a> {
     fn fd_create(&self) -> Result<types::Fd, types::Errno> {
-        Ok(types::Fd::from(FD_VAL))
+        Ok(unsafe { types::Fd::from_raw(FD_VAL) })
     }
-    fn fd_consume(&self, fd: types::Fd) -> Result<(), types::Errno> {
+    fn fd_consume(&self, fd: &types::Fd) -> Result<(), types::Errno> {
         println!("FD_CONSUME {}", fd);
-        if fd == types::Fd::from(FD_VAL) {
+        if *fd == unsafe { types::Fd::from_raw(FD_VAL) } {
             Ok(())
         } else {
             Err(types::Errno::InvalidArg)

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -57,7 +57,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn fd_advise(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _offset: types::Filesize,
         _len: types::Filesize,
         _advice: types::Advice,
@@ -67,49 +67,49 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn fd_allocate(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _offset: types::Filesize,
         _len: types::Filesize,
     ) -> Result<()> {
         unimplemented!("fd_allocate")
     }
 
-    fn fd_close(&self, _fd: types::Fd) -> Result<()> {
+    fn fd_close(&self, _fd: &types::Fd) -> Result<()> {
         unimplemented!("fd_close")
     }
 
-    fn fd_datasync(&self, _fd: types::Fd) -> Result<()> {
+    fn fd_datasync(&self, _fd: &types::Fd) -> Result<()> {
         unimplemented!("fd_datasync")
     }
 
-    fn fd_fdstat_get(&self, _fd: types::Fd) -> Result<types::Fdstat> {
+    fn fd_fdstat_get(&self, _fd: &types::Fd) -> Result<types::Fdstat> {
         unimplemented!("fd_fdstat_get")
     }
 
-    fn fd_fdstat_set_flags(&self, _fd: types::Fd, _flags: types::Fdflags) -> Result<()> {
+    fn fd_fdstat_set_flags(&self, _fd: &types::Fd, _flags: types::Fdflags) -> Result<()> {
         unimplemented!("fd_fdstat_set_flags")
     }
 
     fn fd_fdstat_set_rights(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _fs_rights_base: types::Rights,
         _fs_rights_inherting: types::Rights,
     ) -> Result<()> {
         unimplemented!("fd_fdstat_set_rights")
     }
 
-    fn fd_filestat_get(&self, _fd: types::Fd) -> Result<types::Filestat> {
+    fn fd_filestat_get(&self, _fd: &types::Fd) -> Result<types::Filestat> {
         unimplemented!("fd_filestat_get")
     }
 
-    fn fd_filestat_set_size(&self, _fd: types::Fd, _size: types::Filesize) -> Result<()> {
+    fn fd_filestat_set_size(&self, _fd: &types::Fd, _size: types::Filesize) -> Result<()> {
         unimplemented!("fd_filestat_set_size")
     }
 
     fn fd_filestat_set_times(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _atim: types::Timestamp,
         _mtim: types::Timestamp,
         _fst_flags: types::Fstflags,
@@ -119,7 +119,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn fd_pread(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         iovs: &types::IovecArray<'_>,
         _offset: types::Filesize,
     ) -> Result<types::Size> {
@@ -146,13 +146,13 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         unimplemented!("fd_pread")
     }
 
-    fn fd_prestat_get(&self, _fd: types::Fd) -> Result<types::Prestat> {
+    fn fd_prestat_get(&self, _fd: &types::Fd) -> Result<types::Prestat> {
         unimplemented!("fd_prestat_get")
     }
 
     fn fd_prestat_dir_name(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _path: &GuestPtr<u8>,
         _path_len: types::Size,
     ) -> Result<()> {
@@ -161,20 +161,20 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn fd_pwrite(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _ciovs: &types::CiovecArray<'_>,
         _offset: types::Filesize,
     ) -> Result<types::Size> {
         unimplemented!("fd_pwrite")
     }
 
-    fn fd_read(&self, _fd: types::Fd, _iovs: &types::IovecArray<'_>) -> Result<types::Size> {
+    fn fd_read(&self, _fd: &types::Fd, _iovs: &types::IovecArray<'_>) -> Result<types::Size> {
         unimplemented!("fd_read")
     }
 
     fn fd_readdir(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _buf: &GuestPtr<u8>,
         _buf_len: types::Size,
         _cookie: types::Dircookie,
@@ -182,38 +182,38 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         unimplemented!("fd_readdir")
     }
 
-    fn fd_renumber(&self, _fd: types::Fd, _to: types::Fd) -> Result<()> {
+    fn fd_renumber(&self, _fd: &types::Fd, _to: &types::Fd) -> Result<()> {
         unimplemented!("fd_renumber")
     }
 
     fn fd_seek(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _offset: types::Filedelta,
         _whence: types::Whence,
     ) -> Result<types::Filesize> {
         unimplemented!("fd_seek")
     }
 
-    fn fd_sync(&self, _fd: types::Fd) -> Result<()> {
+    fn fd_sync(&self, _fd: &types::Fd) -> Result<()> {
         unimplemented!("fd_sync")
     }
 
-    fn fd_tell(&self, _fd: types::Fd) -> Result<types::Filesize> {
+    fn fd_tell(&self, _fd: &types::Fd) -> Result<types::Filesize> {
         unimplemented!("fd_tell")
     }
 
-    fn fd_write(&self, _fd: types::Fd, _ciovs: &types::CiovecArray<'_>) -> Result<types::Size> {
+    fn fd_write(&self, _fd: &types::Fd, _ciovs: &types::CiovecArray<'_>) -> Result<types::Size> {
         unimplemented!("fd_write")
     }
 
-    fn path_create_directory(&self, _fd: types::Fd, _path: &GuestPtr<'_, str>) -> Result<()> {
+    fn path_create_directory(&self, _fd: &types::Fd, _path: &GuestPtr<'_, str>) -> Result<()> {
         unimplemented!("path_create_directory")
     }
 
     fn path_filestat_get(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _flags: types::Lookupflags,
         _path: &GuestPtr<'_, str>,
     ) -> Result<types::Filestat> {
@@ -222,7 +222,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn path_filestat_set_times(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _flags: types::Lookupflags,
         _path: &GuestPtr<'_, str>,
         _atim: types::Timestamp,
@@ -234,10 +234,10 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn path_link(
         &self,
-        _old_fd: types::Fd,
+        _old_fd: &types::Fd,
         _old_flags: types::Lookupflags,
         _old_path: &GuestPtr<'_, str>,
-        _new_fd: types::Fd,
+        _new_fd: &types::Fd,
         _new_path: &GuestPtr<'_, str>,
     ) -> Result<()> {
         unimplemented!("path_link")
@@ -245,7 +245,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn path_open(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _dirflags: types::Lookupflags,
         _path: &GuestPtr<'_, str>,
         _oflags: types::Oflags,
@@ -258,7 +258,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn path_readlink(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _path: &GuestPtr<'_, str>,
         _buf: &GuestPtr<u8>,
         _buf_len: types::Size,
@@ -266,15 +266,15 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         unimplemented!("path_readlink")
     }
 
-    fn path_remove_directory(&self, _fd: types::Fd, _path: &GuestPtr<'_, str>) -> Result<()> {
+    fn path_remove_directory(&self, _fd: &types::Fd, _path: &GuestPtr<'_, str>) -> Result<()> {
         unimplemented!("path_remove_directory")
     }
 
     fn path_rename(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _old_path: &GuestPtr<'_, str>,
-        _new_fd: types::Fd,
+        _new_fd: &types::Fd,
         _new_path: &GuestPtr<'_, str>,
     ) -> Result<()> {
         unimplemented!("path_rename")
@@ -283,13 +283,13 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
     fn path_symlink(
         &self,
         _old_path: &GuestPtr<'_, str>,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _new_path: &GuestPtr<'_, str>,
     ) -> Result<()> {
         unimplemented!("path_symlink")
     }
 
-    fn path_unlink_file(&self, _fd: types::Fd, _path: &GuestPtr<'_, str>) -> Result<()> {
+    fn path_unlink_file(&self, _fd: &types::Fd, _path: &GuestPtr<'_, str>) -> Result<()> {
         unimplemented!("path_unlink_file")
     }
 
@@ -320,7 +320,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn sock_recv(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _ri_data: &types::IovecArray<'_>,
         _ri_flags: types::Riflags,
     ) -> Result<(types::Size, types::Roflags)> {
@@ -329,14 +329,14 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
 
     fn sock_send(
         &self,
-        _fd: types::Fd,
+        _fd: &types::Fd,
         _si_data: &types::CiovecArray<'_>,
         _si_flags: types::Siflags,
     ) -> Result<types::Size> {
         unimplemented!("sock_send")
     }
 
-    fn sock_shutdown(&self, _fd: types::Fd, _how: types::Sdflags) -> Result<()> {
+    fn sock_shutdown(&self, _fd: &types::Fd, _how: types::Sdflags) -> Result<()> {
         unimplemented!("sock_shutdown")
     }
 }


### PR DESCRIPTION
This is a draft PR partially illustrating the idea mentioned in #1202 for passing `Fd` handles by reference.

This provides I/O safety within the WASI implementation code, though it depends on being careful around calling the `Fd::from_raw` function. It also simplifies the `FdPool`, by taking advantage of the new `EntryTable`.

This doesn't build at the moment, because it doesn't change the wiggle code, but it shows how the rest of the code would look.
 - `Fd` is passed by reference when it's an argument in host code.
 - `Fd` no longer needs to implement `Copy` or `Clone`.
 - File descriptors within structs -- `types::SubscriptionU::FdRead` and `types::SubscriptionU::FdWrite` still need to be stored as `u32`; it can be converted to an `Fd` by calling the `unsafe` `from_raw`

In Wiggle, would it be better to special-case Handle to implement pass-by-reference behavior, or add a new `TypePassedBy` kind in `witx`?