### PR TITLE
Implement I8x16 shift for x86 SIMD

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -2179,6 +2179,7 @@ fn define_entity_ref(
     let formats = &shared_defs.formats;
 
     // Shorthands for instructions.
+    let const_addr = shared.by_name("const_addr");
     let func_addr = shared.by_name("func_addr");
     let stack_addr = shared.by_name("stack_addr");
     let symbol_value = shared.by_name("symbol_value");
@@ -2188,6 +2189,7 @@ fn define_entity_ref(
     let rec_allones_fnaddr8 = r.template("allones_fnaddr8");
     let rec_fnaddr4 = r.template("fnaddr4");
     let rec_fnaddr8 = r.template("fnaddr8");
+    let rec_const_addr = r.template("const_addr");
     let rec_got_fnaddr8 = r.template("got_fnaddr8");
     let rec_got_gvaddr8 = r.template("got_gvaddr8");
     let rec_gvaddr4 = r.template("gvaddr4");
@@ -2285,6 +2287,10 @@ fn define_entity_ref(
     // don't get legalized to stack_addr + load/store.
     e.enc32(stack_addr.bind(I32), rec_spaddr4_id.opcodes(&LEA));
     e.enc64(stack_addr.bind(I64), rec_spaddr8_id.opcodes(&LEA).rex().w());
+
+    // Constant addresses (PIC).
+    e.enc64(const_addr.bind(I64), rec_const_addr.opcodes(&LEA).rex().w());
+    e.enc32(const_addr.bind(I32), rec_const_addr.opcodes(&LEA));
 }
 
 /// Control flow opcodes.

--- a/cranelift/codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift/codegen/meta/src/isa/x86/legalize.rs
@@ -357,7 +357,6 @@ fn define_simd(shared: &mut SharedDefinitions, x86_instructions: &InstructionGro
     let x86_pshufd = x86_instructions.by_name("x86_pshufd");
     let x86_psll = x86_instructions.by_name("x86_psll");
     let x86_psra = x86_instructions.by_name("x86_psra");
-    let x86_psrl = x86_instructions.by_name("x86_psrl");
     let x86_ptest = x86_instructions.by_name("x86_ptest");
 
     let imm = &shared.imm;
@@ -493,16 +492,6 @@ fn define_simd(shared: &mut SharedDefinitions, x86_instructions: &InstructionGro
         narrow.legalize(
             def!(a = ishl(x, y)),
             vec![def!(b = bitcast(y)), def!(a = x86_psll(x, b))],
-        );
-    }
-
-    // SIMD shift right (logical)
-    for ty in &[I16, I32, I64] {
-        let ushr = ushr.bind(vector(*ty, sse_vector_size));
-        let bitcast = bitcast.bind(vector(I64, sse_vector_size));
-        narrow.legalize(
-            def!(a = ushr(x, y)),
-            vec![def!(b = bitcast(y)), def!(a = x86_psrl(x, b))],
         );
     }
 
@@ -695,6 +684,7 @@ fn define_simd(shared: &mut SharedDefinitions, x86_instructions: &InstructionGro
     narrow.custom_legalize(extractlane, "convert_extractlane");
     narrow.custom_legalize(insertlane, "convert_insertlane");
     narrow.custom_legalize(ineg, "convert_ineg");
+    narrow.custom_legalize(ushr, "convert_ushr");
 
     narrow.build_and_add_to(&mut shared.transform_groups);
 }

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -1463,6 +1463,21 @@ pub(crate) fn define<'shared>(
             ),
     );
 
+    // Constant addresses.
+
+    recipes.add_template_recipe(
+        EncodingRecipeBuilder::new("const_addr", &formats.unary_const, 5)
+            .operands_out(vec![gpr])
+            .clobbers_flags(false)
+            .emit(
+                r#"
+                    {{PUT_OP}}(bits, rex2(0, out_reg0), sink);
+                    modrm_riprel(out_reg0, sink);
+                    const_disp4(constant_handle, func, sink);
+                "#,
+            ),
+    );
+
     // Store recipes.
 
     {

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1542,6 +1542,21 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    let constant =
+        &Operand::new("constant", &imm.pool_constant).with_doc("A constant in the constant pool");
+    let address = &Operand::new("address", iAddr);
+    ig.push(
+        Inst::new(
+            "const_addr",
+            r#"
+        Calculate the base address of a value in the constant pool.
+        "#,
+            &formats.unary_const,
+        )
+        .operands_in(vec![constant])
+        .operands_out(vec![address]),
+    );
+
     let mask = &Operand::new("mask", &imm.uimm128)
         .with_doc("The 16 immediate bytes used for selecting the elements to shuffle");
     let Tx16 = &TypeVar::new(

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -382,6 +382,8 @@ pub enum AnyEntity {
     GlobalValue(GlobalValue),
     /// A jump table.
     JumpTable(JumpTable),
+    /// A constant.
+    Constant(Constant),
     /// An external function.
     FuncRef(FuncRef),
     /// A function call signature.
@@ -402,6 +404,7 @@ impl fmt::Display for AnyEntity {
             Self::StackSlot(r) => r.fmt(f),
             Self::GlobalValue(r) => r.fmt(f),
             Self::JumpTable(r) => r.fmt(f),
+            Self::Constant(r) => r.fmt(f),
             Self::FuncRef(r) => r.fmt(f),
             Self::SigRef(r) => r.fmt(f),
             Self::Heap(r) => r.fmt(f),
@@ -449,6 +452,12 @@ impl From<GlobalValue> for AnyEntity {
 impl From<JumpTable> for AnyEntity {
     fn from(r: JumpTable) -> Self {
         Self::JumpTable(r)
+    }
+}
+
+impl From<Constant> for AnyEntity {
+    fn from(r: Constant) -> Self {
+        Self::Constant(r)
     }
 }
 

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -6,7 +6,7 @@ use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::condcodes::{FloatCC, IntCC};
 use crate::ir::types::*;
-use crate::ir::{self, Function, Inst, InstBuilder};
+use crate::ir::{self, Function, Inst, InstBuilder, MemFlags};
 use crate::isa::constraints::*;
 use crate::isa::enc_tables::*;
 use crate::isa::encoding::base_size;
@@ -1315,6 +1315,73 @@ fn convert_ineg(
         pos.func.dfg.replace(inst).isub(zero_value, arg);
     } else {
         unreachable!()
+    }
+}
+
+// Unsigned shift masks for i8x16 shift.
+static USHR_MASKS: [u8; 128] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f,
+    0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f,
+    0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f, 0x1f,
+    0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f,
+    0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07,
+    0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+];
+
+// Convert a vector unsigned right shift. x86 has implementations for i16x8 and up (see `x86_pslr`),
+// but for i8x16 we translate the shift to a i16x8 shift and mask off the upper bits. This same
+// conversion could be provided in the CDSL if we could use varargs there (TODO); i.e. `load_complex`
+// has a varargs field that we can't modify with the CDSL in legalize.rs.
+fn convert_ushr(
+    inst: ir::Inst,
+    func: &mut ir::Function,
+    _cfg: &mut ControlFlowGraph,
+    isa: &dyn TargetIsa,
+) {
+    let mut pos = FuncCursor::new(func).at_inst(inst);
+    pos.use_srcloc(inst);
+
+    if let ir::InstructionData::Binary {
+        opcode: ir::Opcode::Ushr,
+        args: [arg0, arg1],
+    } = pos.func.dfg[inst]
+    {
+        // Note that for Wasm, the bounding of the shift index has happened during translation
+        let arg0_type = pos.func.dfg.value_type(arg0);
+        let arg1_type = pos.func.dfg.value_type(arg1);
+        assert!(!arg1_type.is_vector() && arg1_type.is_int());
+
+        // TODO it may be more clear to use scalar_to_vector here; the current issue is that
+        // scalar_to_vector has the restriction that the vector produced has a matching lane size
+        // (e.g. i32 -> i32x4) whereas bitcast allows moving any-to-any conversions (e.g. i32 ->
+        // i64x2). This matters because for some reason x86_psrl only allows i64x2 as the shift
+        // index type--this could be relaxed since it is not really meaningful.
+        let shift_index = pos.ins().bitcast(I64X2, arg1);
+
+        if arg0_type == I8X16 {
+            // First, shift the vector using an I16X8 shift.
+            let bitcasted = pos.ins().raw_bitcast(I16X8, arg0);
+            let shifted = pos.ins().x86_psrl(bitcasted, shift_index);
+            let shifted = pos.ins().raw_bitcast(I8X16, shifted);
+
+            // Then, fixup the even lanes that have incorrect upper bits. This uses the 128 mask
+            // bytes as a table that we index into. It is a substantial code-size increase but
+            // reduces the instruction count slightly.
+            let masks = pos.func.dfg.constants.insert(USHR_MASKS.as_ref().into());
+            let mask_address = pos.ins().const_addr(isa.pointer_type(), masks);
+            let mask_offset = pos.ins().ishl_imm(arg1, 4);
+            let mask =
+                pos.ins()
+                    .load_complex(arg0_type, MemFlags::new(), &[mask_address, mask_offset], 0);
+            pos.func.dfg.replace(inst).band(shifted, mask);
+        } else if arg0_type.is_vector() {
+            // x86 has encodings for these shifts.
+            pos.func.dfg.replace(inst).x86_psrl(arg0, shift_index);
+        } else {
+            unreachable!()
+        }
     }
 }
 

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -65,8 +65,9 @@ use crate::ir;
 use crate::ir::entities::AnyEntity;
 use crate::ir::instructions::{BranchInfo, CallInfo, InstructionFormat, ResolvedConstraint};
 use crate::ir::{
-    types, ArgumentLoc, Block, FuncRef, Function, GlobalValue, Inst, InstructionData, JumpTable,
-    Opcode, SigRef, StackSlot, StackSlotKind, Type, Value, ValueDef, ValueList, ValueLoc,
+    types, ArgumentLoc, Block, Constant, FuncRef, Function, GlobalValue, Inst, InstructionData,
+    JumpTable, Opcode, SigRef, StackSlot, StackSlotKind, Type, Value, ValueDef, ValueList,
+    ValueLoc,
 };
 use crate::isa::TargetIsa;
 use crate::iterators::IteratorExtras;
@@ -733,16 +734,23 @@ impl<'a> Verifier<'a> {
                     ));
                 }
             }
-
             Unary {
                 opcode: Opcode::Bitcast,
                 arg,
             } => {
                 self.verify_bitcast(inst, arg, errors)?;
             }
+            UnaryConst {
+                opcode: Opcode::Vconst,
+                constant_handle,
+                ..
+            } => {
+                self.verify_constant_size(inst, constant_handle, errors)?;
+            }
 
             // Exhaustive list so we can't forget to add new formats
             Unary { .. }
+            | UnaryConst { .. }
             | UnaryImm { .. }
             | UnaryIeee32 { .. }
             | UnaryIeee64 { .. }
@@ -752,7 +760,6 @@ impl<'a> Verifier<'a> {
             | Ternary { .. }
             | InsertLane { .. }
             | ExtractLane { .. }
-            | UnaryConst { .. }
             | Shuffle { .. }
             | IntCompare { .. }
             | IntCompareImm { .. }
@@ -1068,6 +1075,27 @@ impl<'a> Verifier<'a> {
                     "The bitcast argument {} doesn't fit in a type of {} bits",
                     arg,
                     typ.lane_bits()
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn verify_constant_size(
+        &self,
+        inst: Inst,
+        constant: Constant,
+        errors: &mut VerifierErrors,
+    ) -> VerifierStepResult<()> {
+        let type_size = self.func.dfg.ctrl_typevar(inst).bytes() as usize;
+        let constant_size = self.func.dfg.constants.get(constant).len();
+        if type_size != constant_size {
+            errors.fatal((
+                inst,
+                format!(
+                    "The instruction expects {} to have a size of {} bytes but it has {}",
+                    constant, type_size, constant_size
                 ),
             ))
         } else {

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -102,6 +102,11 @@ pub trait FuncWriter {
             self.write_entity_definition(w, func, jt.into(), jt_data)?;
         }
 
+        for (&cref, cval) in func.dfg.constants.iter() {
+            any = true;
+            self.write_entity_definition(w, func, cref.into(), cval)?;
+        }
+
         Ok(any)
     }
 
@@ -494,6 +499,9 @@ pub fn write_operands(
         UnaryIeee64 { imm, .. } => write!(w, " {}", imm),
         UnaryBool { imm, .. } => write!(w, " {}", imm),
         UnaryGlobalValue { global_value, .. } => write!(w, " {}", global_value),
+        UnaryConst {
+            constant_handle, ..
+        } => write!(w, " {}", constant_handle),
         Binary { args, .. } => write!(w, " {}, {}", args[0], args[1]),
         BinaryImm { arg, imm, .. } => write!(w, " {}, {}", arg, imm),
         Ternary { args, .. } => write!(w, " {}, {}, {}", args[0], args[1], args[2]),
@@ -507,12 +515,6 @@ pub fn write_operands(
         NullAry { .. } => write!(w, " "),
         InsertLane { lane, args, .. } => write!(w, " {}, {}, {}", args[0], lane, args[1]),
         ExtractLane { lane, arg, .. } => write!(w, " {}, {}", arg, lane),
-        UnaryConst {
-            constant_handle, ..
-        } => {
-            let constant_data = dfg.constants.get(constant_handle);
-            write!(w, " {}", constant_data)
-        }
         Shuffle { mask, args, .. } => {
             let data = dfg.immediates.get(mask).expect(
                 "Expected the shuffle mask to already be inserted into the immediates table",

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
@@ -3,10 +3,12 @@ set enable_simd
 target x86_64 skylake
 
 function %ineg_i32x4() -> b1 {
+; check:  const0 = 0x00000001000000010000000100000001
+; nextln: const1 = 0x00000000000000000000000000000000
 block0:
     v0 = vconst.i32x4 [1 1 1 1]
     v2 = ineg v0
-    ; check: v5 = vconst.i32x4 0x00
+    ; check: v5 = vconst.i32x4 const1
     ; nextln: v2 = isub v5, v0
 
     v3 = extractlane v2, 0
@@ -16,37 +18,39 @@ block0:
 }
 
 function %ineg_legalized() {
+; check: const0 = 0x00000000000000000000000000000000
 block0:
     v0 = vconst.i8x16 0x00
     v1 = ineg v0
-    ; check: v6 = vconst.i8x16 0x00
+    ; check: v6 = vconst.i8x16 const0
     ; nextln: v1 = isub v6, v0
 
     v2 = raw_bitcast.i16x8 v0
     v3 = ineg v2
-    ; check: v7 = vconst.i16x8 0x00
+    ; check: v7 = vconst.i16x8 const0
     ; nextln: v3 = isub v7, v2
 
     v4 = raw_bitcast.i64x2 v0
     v5 = ineg v4
-    ; check: v8 = vconst.i64x2 0x00
+    ; check: v8 = vconst.i64x2 const0
     ; nextln: v5 = isub v8, v4
 
     return
 }
 
 function %fneg_legalized() {
+; check: const2 = 0xffffffffffffffffffffffffffffffff
 block0:
     v0 = vconst.f32x4 [0x1.0 0x2.0 0x3.0 0x4.0]
     v1 = fneg v0
-    ; check: v4 = vconst.i32x4 0xffffffffffffffffffffffffffffffff
+    ; check: v4 = vconst.i32x4 const2
     ; nextln: v5 = ishl_imm v4, 31
     ; nextln: v6 = raw_bitcast.f32x4 v5
     ; nextln: v1 = bxor v0, v6
 
     v2 = vconst.f64x2 [0x1.0 0x2.0]
     v3 = fneg v2
-    ; check: v7 = vconst.i64x2 0xffffffffffffffffffffffffffffffff
+    ; check: v7 = vconst.i64x2 const2
     ; nextln: v8 = ishl_imm v7, 63
     ; nextln: v9 = raw_bitcast.f64x2 v8
     ; nextln: v3 = bxor v2, v9
@@ -55,10 +59,11 @@ block0:
 }
 
 function %fabs_legalized() {
+; check: const1 = 0xffffffffffffffffffffffffffffffff
 block0:
     v0 = vconst.f64x2 [0x1.0 -0x2.0]
     v1 = fabs v0
-    ; check: v2 = vconst.i64x2 0xffffffffffffffffffffffffffffffff
+    ; check: v2 = vconst.i64x2 const1
     ; nextln: v3 = ushr_imm v2, 1
     ; nextln: v4 = raw_bitcast.f64x2 v3
     ; nextln: v1 = band v0, v4

--- a/cranelift/filetests/filetests/isa/x86/simd-bitwise-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitwise-legalize.clif
@@ -2,6 +2,22 @@ test legalizer
 set enable_simd
 target x86_64 skylake
 
+function %ushr_i8x16() -> i8x16 {
+block0:
+    v0 = iconst.i32 1
+    v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
+    v2 = ushr v1, v0
+    ; check:  v3 = bitcast.i64x2 v0
+    ; nextln: v4 = raw_bitcast.i16x8 v1
+    ; nextln: v5 = x86_psrl v4, v3
+    ; nextln: v6 = raw_bitcast.i8x16 v5
+    ; nextln: v7 = const_addr.i64 const1
+    ; nextln: v8 = ishl_imm v0, 4
+    ; nextln: v9 = load_complex.i8x16 v7+v8
+    ; nextln: v2 = band v6, v9
+    return v2
+}
+
 function %ishl_i32x4() -> i32x4 {
 block0:
     v0 = iconst.i32 1

--- a/cranelift/filetests/filetests/isa/x86/simd-bitwise-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitwise-run.clif
@@ -38,6 +38,19 @@ block0:
 }
 ; run
 
+function %ushr_i8x16() -> b1 {
+block0:
+    v0 = iconst.i32 1
+    v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
+    v2 = ushr v1, v0
+
+    v3 = vconst.i8x16 [0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7]
+    v4 = icmp eq v2, v3
+    v5 = vall_true v4
+    return v5
+}
+; run
+
 function %ushr_i64x2() -> b1 {
 block0:
     v0 = iconst.i32 1

--- a/cranelift/filetests/filetests/isa/x86/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-comparison-legalize.clif
@@ -3,20 +3,22 @@ set enable_simd
 target x86_64 skylake
 
 function %icmp_ne_32x4(i32x4, i32x4) -> b32x4 {
+; check: const0 = 0xffffffffffffffffffffffffffffffff
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp ne v0, v1
     ; check: v3 = icmp eq v0, v1
-    ; nextln: v4 = vconst.b32x4 0xffffffffffffffffffffffffffffffff
+    ; nextln: v4 = vconst.b32x4 const0
     ; nextln: v2 = bxor v4, v3
     return v2
 }
 
 function %icmp_ugt_i32x4(i32x4, i32x4) -> b32x4 {
+; check: const0 = 0xffffffffffffffffffffffffffffffff
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp ugt v0, v1
     ; check: v3 = x86_pmaxu v0, v1
     ; nextln: v4 = icmp eq v3, v1
-    ; nextln: v5 = vconst.b32x4 0xffffffffffffffffffffffffffffffff
+    ; nextln: v5 = vconst.b32x4 const0
     ; nextln: v2 = bxor v5, v4
     return v2
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-legalize.clif
@@ -5,27 +5,30 @@ target x86_64 skylake
 ;; shuffle
 
 function %shuffle_different_ssa_values() -> i8x16 {
+; check:  const2 = 0x80000000000000000000000000000000
+; nextln: const3 = 0x01808080808080808080808080808080
 block0:
     v0 = vconst.i8x16 0x00
     v1 = vconst.i8x16 0x01
     v2 = shuffle v0, v1, 0x11000000000000000000000000000000     ; pick the second lane of v1, the rest use the first lane of v0
     return v2
 }
-; check:  v1 = vconst.i8x16 0x01
-; nextln: v3 = vconst.i8x16 0x80000000000000000000000000000000
+; check:  v1 = vconst.i8x16 const1
+; nextln: v3 = vconst.i8x16 const2
 ; nextln: v4 = x86_pshufb v0, v3
-; nextln: v5 = vconst.i8x16 0x01808080808080808080808080808080
+; nextln: v5 = vconst.i8x16 const3
 ; nextln: v6 = x86_pshufb v1, v5
 ; nextln: v2 = bor v4, v6
 
 function %shuffle_same_ssa_value() -> i8x16 {
+; check:  const1 = 0x03000000000000000000000000000000
 block0:
     v1 = vconst.i8x16 0x01
     v2 = shuffle v1, v1, 0x13000000000000000000000000000000     ; pick the fourth lane of v1 and the rest from the first lane of v1
     return v2
 }
-; check:  v1 = vconst.i8x16 0x01
-; nextln: v3 = vconst.i8x16 0x03000000000000000000000000000000
+; check:  v1 = vconst.i8x16 const0
+; nextln: v3 = vconst.i8x16 const1
 ; nextln: v2 = x86_pshufb v1, v3
 
 ;; splat
@@ -71,6 +74,7 @@ block0:
 ; nextln:     return v1
 
 function %splat_i8() -> i8x16 {
+; check: const0 = 0x00000000000000000000000000000000
 block0:
     v0 = iconst.i8 42
     v1 = splat.i8x16 v0
@@ -80,16 +84,17 @@ block0:
 ; nextln:     v2 = iconst.i32 42
 ; nextln:     v0 = ireduce.i8 v2
 ; nextln:     v3 = scalar_to_vector.i8x16 v0
-; nextln:     v4 = vconst.i8x16 0x00
+; nextln:     v4 = vconst.i8x16 const0
 ; nextln:     v1 = x86_pshufb v3, v4
 ; nextln:     return v1
 
 function %swizzle() -> i8x16 {
+; check: const1 = 0x70707070707070707070707070707070
 block0:
     v0 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
     v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
     v2 = swizzle.i8x16 v0, v1
-    ; check: v3 = vconst.i8x16 0x70707070707070707070707070707070
+    ; check: v3 = vconst.i8x16 const1
     ; nextln: v4 = uadd_sat v1, v3
     ; nextln: v2 = x86_pshufb v0, v4
     return v2

--- a/cranelift/filetests/filetests/isa/x86/simd-logical-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-logical-legalize.clif
@@ -3,9 +3,10 @@ set enable_simd
 target x86_64 skylake
 
 function %bnot_b32x4(b32x4) -> b32x4 {
+; check: const0 = 0xffffffffffffffffffffffffffffffff
 block0(v0: b32x4):
     v1 = bnot v0
-    ; check: v2 = vconst.b32x4 0xffffffffffffffffffffffffffffffff
+    ; check: v2 = vconst.b32x4 const0
     ; nextln: v1 = bxor v2, v0
     return v1
 }
@@ -19,9 +20,10 @@ block0(v0: b32x4):
 }
 
 function %vall_true_i64x2(i64x2) -> b1 {
+; check: const0 = 0x00000000000000000000000000000000
 block0(v0: i64x2):
     v1 = vall_true v0
-    ; check: v2 = vconst.i64x2 0x00
+    ; check: v2 = vconst.i64x2 const0
     ; nextln: v3 = icmp eq v0, v2
     ; nextln: v4 = x86_ptest v3, v3
     ; nextln: v1 = trueif eq v4

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-binemit.clif
@@ -19,3 +19,11 @@ block0:
 [-, %xmm3]  v1 = vconst.i32x4 const43  ; bin: 0f 10 1d 00000011 PCRelRodata4(31)
             return
 }
+
+function %address_of_vconst() {
+const42 = i32x4 [1 0 0 0]
+
+block0:
+[-, %rax]   v0 = const_addr.i64 const42  ; bin: 48 8d 05 00000001 PCRelRodata4(8)
+            return
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-binemit.clif
@@ -9,3 +9,13 @@ block0:
 [-, %xmm3]  v1 = vconst.b8x16 0x02  ; bin: 0f 10 1d 00000011 PCRelRodata4(31)
             return
 }
+
+function %vconst_with_preamble() {
+const42 = i32x4 [1 0 0 0]
+const43 = i32x4 [2 0 0 0]
+
+block0:
+[-, %xmm2]  v0 = vconst.i32x4 const42  ; bin: 0f 10 15 00000008 PCRelRodata4(15)
+[-, %xmm3]  v1 = vconst.i32x4 const43  ; bin: 0f 10 1d 00000011 PCRelRodata4(31)
+            return
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-compile.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-compile.clif
@@ -9,8 +9,8 @@ block0:
     v0 = vconst.i32x4 0x1234
     return v0
 }
-
+; check:   const0 = 0x00000000000000000000000000001234
 ; check:   block0:
-; nextln:     v0 = vconst.i32x4 0x1234
+; nextln:     v0 = vconst.i32x4 const0
 ; nextln:     return v0
 ; nextln: }

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
@@ -37,3 +37,13 @@ block11:
 }
 
 ; sameln: [1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F, 10]
+
+function %vconst_preamble() -> b16x8 {
+const42 = i32x4 [0 1 2 3]
+const43 = i32x4 [4 5 6 7]
+block0:
+    v0 = vconst.b16x8 const42
+    return v0
+}
+
+; sameln: [0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0]

--- a/cranelift/filetests/filetests/verifier/constant.clif
+++ b/cranelift/filetests/filetests/verifier/constant.clif
@@ -1,0 +1,9 @@
+test verifier
+set enable_simd
+
+function %incorrect_constant_size() {
+const13 = [1 2 3 4 5]  ; this constant has 5 bytes
+block0:
+    v0 = vconst.i32x4 const13 ; error: The instruction expects const13 to have a size of 16 bytes but it has 5
+    return
+}

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1262,13 +1262,15 @@ block0:
         assert_eq!(
             func.display(None).to_string(),
             "function %sample() -> i8x16, b8x16, f32x4 system_v {
+    const0 = 0x00000000000000000000000000000000
+
 block0:
     v5 = f32const 0.0
     v6 = splat.f32x4 v5
     v2 -> v6
-    v4 = vconst.b8x16 0x00
+    v4 = vconst.b8x16 const0
     v1 -> v4
-    v3 = vconst.i8x16 0x00
+    v3 = vconst.i8x16 const0
     v0 -> v3
     return v0, v1, v2
 }

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -39,6 +39,7 @@ pub enum Token<'a> {
     Heap(u32),            // heap2
     Table(u32),           // table2
     JumpTable(u32),       // jt2
+    Constant(u32),        // const2
     FuncRef(u32),         // fn2
     SigRef(u32),          // sig2
     UserRef(u32),         // u345
@@ -345,6 +346,7 @@ impl<'a> Lexer<'a> {
             "heap" => Some(Token::Heap(number)),
             "table" => Some(Token::Table(number)),
             "jt" => Some(Token::JumpTable(number)),
+            "const" => Some(Token::Constant(number)),
             "fn" => Some(Token::FuncRef(number)),
             "sig" => Some(Token::SigRef(number)),
             "u" => Some(Token::UserRef(number)),
@@ -656,7 +658,7 @@ mod tests {
 
     #[test]
     fn lex_names() {
-        let mut lex = Lexer::new("%0 %x3 %function %123_abc %ss0 %v3 %block11 %_");
+        let mut lex = Lexer::new("%0 %x3 %function %123_abc %ss0 %v3 %block11 %const42 %_");
 
         assert_eq!(lex.next(), token(Token::Name("0"), 1));
         assert_eq!(lex.next(), token(Token::Name("x3"), 1));
@@ -665,6 +667,7 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Name("ss0"), 1));
         assert_eq!(lex.next(), token(Token::Name("v3"), 1));
         assert_eq!(lex.next(), token(Token::Name("block11"), 1));
+        assert_eq!(lex.next(), token(Token::Name("const42"), 1));
         assert_eq!(lex.next(), token(Token::Name("_"), 1));
     }
 

--- a/cranelift/reader/src/sourcemap.rs
+++ b/cranelift/reader/src/sourcemap.rs
@@ -10,7 +10,7 @@ use crate::error::{Location, ParseResult};
 use crate::lexer::split_entity_name;
 use cranelift_codegen::ir::entities::AnyEntity;
 use cranelift_codegen::ir::{
-    Block, FuncRef, GlobalValue, Heap, JumpTable, SigRef, StackSlot, Table, Value,
+    Block, Constant, FuncRef, GlobalValue, Heap, JumpTable, SigRef, StackSlot, Table, Value,
 };
 use std::collections::HashMap;
 
@@ -66,6 +66,11 @@ impl SourceMap {
     /// Look up a jump table entity.
     pub fn contains_jt(&self, jt: JumpTable) -> bool {
         self.locations.contains_key(&jt.into())
+    }
+
+    /// Look up a constant entity.
+    pub fn contains_constant(&self, c: Constant) -> bool {
+        self.locations.contains_key(&c.into())
     }
 
     /// Look up an entity by source name.
@@ -195,6 +200,11 @@ impl SourceMap {
 
     /// Define the jump table `entity`.
     pub fn def_jt(&mut self, entity: JumpTable, loc: Location) -> ParseResult<()> {
+        self.def_entity(entity.into(), loc)
+    }
+
+    /// Define the jump table `entity`.
+    pub fn def_constant(&mut self, entity: Constant, loc: Location) -> ParseResult<()> {
         self.def_entity(entity.into(), loc)
     }
 

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1406,7 +1406,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let b_mod_bitwidth = builder.ins().band_imm(b, bitwidth - 1);
             state.push1(builder.ins().ishl(bitcast_a, b_mod_bitwidth))
         }
-        Operator::I16x8ShrU | Operator::I32x4ShrU | Operator::I64x2ShrU => {
+        Operator::I8x16ShrU | Operator::I16x8ShrU | Operator::I32x4ShrU | Operator::I64x2ShrU => {
             let (a, b) = state.pop2();
             let bitcast_a = optionally_bitcast_vector(a, type_of(op), builder);
             let bitwidth = i64::from(builder.func.dfg.value_type(a).bits());
@@ -1542,7 +1542,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::I8x16Shl
         | Operator::I8x16ShrS
-        | Operator::I8x16ShrU
         | Operator::I8x16Mul
         | Operator::I64x2Mul
         | Operator::I64x2ShrS

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1282,8 +1282,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::I8x16ExtractLaneU { lane } | Operator::I16x8ExtractLaneU { lane } => {
             let vector = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().extractlane(vector, lane.clone()));
-            // on x86, PEXTRB zeroes the upper bits of the destination register of extractlane so uextend is elided; of course, this depends on extractlane being legalized to a PEXTRB
+            let extracted = builder.ins().extractlane(vector, lane.clone());
+            state.push1(builder.ins().uextend(I32, extracted));
+            // On x86, PEXTRB zeroes the upper bits of the destination register of extractlane so
+            // uextend could be elided; for now, uextend is needed for Cranelift's type checks to
+            // work.
         }
         Operator::I32x4ExtractLane { lane }
         | Operator::I64x2ExtractLane { lane }


### PR DESCRIPTION
This PR adds an implementation of i8x16 shift. Since x86 does not have such an instruction (i.e. it stops at i16x8), we spent a considerable time discussing the best way to implement this for x86 in [a spec issue](https://github.com/WebAssembly/simd/issues/117). In the end, I chose to implement this with constant masks, for which I had to:
 - Make constants declarable in the function preamble: `const42 = 0x.....`
 - Add a `const_addr` instruction in order to get the base address of a constant in the constant pool

With this functionality in place, I then legalized `ushr.i8x16` to the equivalent of these seven instructions:
```
v0 = band_imm [shift index], 7  # this is pre-existent in code_translator.rs
v1 = bitcast i64x2 v0           # this moves the shift index into an XMM register (could be scalar_to_vector)
v2 = x86_psrl v1                # I'm eliding some raw_bitcasts around this for clarity
v3 = ishl_imm [shift index], 4  # this gets the index into the mask
v4 = const_addr [mask ref]      # a RIP-relative LEA
v5 = load_complex v3, v4        # MOVUPS the mask
v6 = band v2, v5                # mask off the bits that would have been zeroed in a true ushr.i8x16```
```

2f648ea is actually not directly related to this PR but is useful for the benchmark I am attempting to run.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
