### PR TITLE
Update object to 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,6 @@ version = "0.60.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-module",
- "goblin",
  "object",
  "target-lexicon",
 ]
@@ -1369,18 +1368,15 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea44a4fd660ab0f38434934ca0212e90fbeaaee54126ef20a3451c30c95bafae"
+checksum = "e5666bbb90bc4d1e5bdcb26c0afda1822d25928341e9384ab187a9b37ab69e36"
 dependencies = [
  "crc32fast",
  "flate2",
- "goblin",
  "indexmap",
- "parity-wasm",
- "scroll",
  "target-lexicon",
- "uuid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1407,12 +1403,6 @@ checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "parity-wasm"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
 name = "paste"
@@ -2294,12 +2284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
-
-[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,7 +2547,6 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "gimli",
- "goblin",
  "lazy_static",
  "libc",
  "object",

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -11,9 +11,8 @@ edition = "2018"
 
 [dependencies]
 cranelift-module = { path = "../module", version = "0.60.0" }
-object = { version = "0.17", default-features = false, features = ["write"] }
+object = { version = "0.18", default-features = false, features = ["write"] }
 target-lexicon = "0.10"
-goblin = "0.1.0"
 
 [dependencies.cranelift-codegen]
 path = "../codegen"

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -515,7 +515,7 @@ impl ObjectProduct {
 
     /// Write the object bytes in memory.
     #[inline]
-    pub fn emit(self) -> Result<Vec<u8>, String> {
+    pub fn emit(self) -> Result<Vec<u8>, object::write::Error> {
         self.object.write()
     }
 }
@@ -584,7 +584,7 @@ impl RelocSink for ObjectRelocSink {
                     "ElfX86_64TlsGd is not supported for this file format"
                 );
                 (
-                    RelocationKind::Elf(goblin::elf64::reloc::R_X86_64_TLSGD),
+                    RelocationKind::Elf(object::elf::R_X86_64_TLSGD),
                     RelocationEncoding::Generic,
                     32,
                 )
@@ -598,7 +598,7 @@ impl RelocSink for ObjectRelocSink {
                 addend += 4; // X86_64_RELOC_TLV has an implicit addend of -4
                 (
                     RelocationKind::MachO {
-                        value: goblin::mach::relocation::X86_64_RELOC_TLV,
+                        value: object::macho::X86_64_RELOC_TLV,
                         relative: true,
                     },
                     RelocationEncoding::Generic,

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -14,10 +14,9 @@ edition = "2018"
 anyhow = "1.0"
 cfg-if = "0.1"
 gimli = { version = "0.20.0", optional = true }
-goblin = { version = "0.1.3", optional = true }
 lazy_static = "1.4"
 libc = { version = "0.2.60", default-features = false }
-object = { version = "0.17.0", optional = true }
+object = { version = "0.18.0", optional = true }
 scroll = { version = "0.10.1", optional = true }
 serde = { version = "1.0.99", features = ["derive"] }
 target-lexicon = "0.10.0"
@@ -28,4 +27,4 @@ wasmtime-runtime = { path = "../runtime", version = "0.12.0" }
 maintenance = { status = "actively-developed" }
 
 [features]
-jitdump = ['goblin', 'object', 'scroll', 'gimli']
+jitdump = ['object', 'scroll', 'gimli']


### PR DESCRIPTION
Object 0.18 completely rewrites the core parsing/writing of most object formats to not depend on `goblin` and to copy less data while parsing. This release also fixes several bugs, including some preventing linking of generated object files using `lld`.

https://github.com/gimli-rs/object/compare/0.17.0...0.18.0