### PR TITLE
Support sealing blocks created by cranelift_frontend::Switch

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -259,7 +259,7 @@ impl<'a> FunctionBuilder<'a> {
         self.handle_ssa_side_effects(side_effects);
     }
 
-    /// Effectively calls seal_block on all blocks in the function.
+    /// Effectively calls seal_block on all unsealed blocks in the function.
     ///
     /// It's more efficient to seal `Block`s as soon as possible, during
     /// translation, but for frontends where this is impractical to do, this

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -372,7 +372,7 @@ impl SSABuilder {
         mem::replace(&mut self.side_effects, SideEffects::new())
     }
 
-    /// Completes the global value numbering for all `Block`s in `func`.
+    /// Completes the global value numbering for all unsealed `Block`s in `func`.
     ///
     /// It's more efficient to seal `Block`s as soon as possible, during
     /// translation, but for frontends where this is impractical to do, this
@@ -383,7 +383,9 @@ impl SSABuilder {
         // and creation of new blocks, however such new blocks are sealed on
         // the fly, so we don't need to account for them here.
         for block in self.ssa_blocks.keys() {
-            self.seal_one_block(block, func);
+            if !self.is_sealed(block) {
+                self.seal_one_block(block, func);
+            }
         }
         mem::replace(&mut self.side_effects, SideEffects::new())
     }


### PR DESCRIPTION
This PR introduces a method to seal generated blocks during `emit` in `cranelift_frontend::Switch`. Fixes #1323.