### PR TITLE
Fix Cranelift's `test rodata`

### DIFF
--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
@@ -17,3 +17,23 @@ block0:
 }
 
 ; sameln: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0]
+
+
+; Since both jump tables and constants are emitted after the function body, it is important that they do not interfere.
+; This test shows that even in the presence of jump tables, constants are emitted correctly
+function %vconst_with_jumptables() {
+jt0 = jump_table [block0]
+
+block10:
+    v10 = iconst.i64 0
+    br_table v10, block1, jt0
+block0:
+    jump block11
+block1:
+    jump block11
+block11:
+    v11 = vconst.i8x16 [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]
+    return
+}
+
+; sameln: [1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F, 10]

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-run.clif
@@ -17,5 +17,29 @@ block0:
     v6 = band v4, v5
     return v6
 }
+; run
 
+; Since both jump tables and constants are emitted after the function body, it is important that any RIP-relative
+; addressing of constants is not incorrect in the presence of jump tables. This test confirms that, even when both
+; jump tables and constants are emitted, the constant addressing works correctly.
+function %vconst_with_jumptables() -> b1 {
+jt0 = jump_table [block0]
+
+block10:
+    v10 = iconst.i64 0
+    br_table v10, block1, jt0
+block0:
+    v0 = iconst.i64 100
+    jump block11(v0)
+block1:
+    v1 = iconst.i64 101
+    jump block11(v1)
+block11(v11: i64):
+    v12 = icmp_imm eq v11, 100        ; We should have jumped through block 0.
+    v13 = vconst.i32x4 [1 2 3 4]
+    v14 = extractlane.i32x4 v13, 1 ; Extract the second element...
+    v15 = icmp_imm eq v14, 2       ; ...which should be the value 2.
+    v16 = band v12, v15
+    return v16
+}
 ; run


### PR DESCRIPTION
Previously `test rodata` would cause failures when compiling Cranelift IR that had assertions about the current sink offset (e.g. multiple blocks, see `emit_function` in `binemit/mod.rs`). This was because `RodataSink` was not keeping track of other emitted bytes; a692365 changes that.

Additionally, I started to worry that having jump tables and constants might cause issues with RIP-relative addressing. f1c698e adds two tests to show that there is no issue.