### PR TITLE
wiggle: emit a metadata module containing witx document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,6 +2346,7 @@ dependencies = [
  "wiggle-runtime",
  "winapi",
  "winx",
+ "witx",
  "yanix",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,7 +2346,6 @@ dependencies = [
  "wiggle-runtime",
  "winapi",
  "winx",
- "witx",
  "yanix",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,6 +2704,7 @@ name = "wiggle-runtime"
 version = "0.1.0"
 dependencies = [
  "thiserror",
+ "witx",
 ]
 
 [[package]]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -21,9 +21,8 @@ filetime = "0.2.7"
 lazy_static = "1.4.0"
 num = { version = "0.2.0", default-features = false }
 wig = { path = "wig", version = "0.12.0" }
-wiggle = { path = "../wiggle" }
+wiggle = { path = "../wiggle", default-features = false }
 wiggle-runtime = { path = "../wiggle/crates/runtime" }
-witx = { path = "wig/WASI/tools/witx", version = "0.8.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 yanix = { path = "yanix", version = "0.12.0" }
@@ -35,10 +34,3 @@ cpu-time = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
-
-[features]
-default = []
-# wiggle_metadata is an optional extra feature that can be enabled by
-# consumers of this crate. It requires a dependency on `witx` which is
-# otherwise unnecessary.
-wiggle_metadata = []

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -34,3 +34,8 @@ cpu-time = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+# Need to make the wiggle_metadata feature available to consumers of this
+# crate if they want the snapshots to have metadata available.
+wiggle_metadata = []

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -23,6 +23,7 @@ num = { version = "0.2.0", default-features = false }
 wig = { path = "wig", version = "0.12.0" }
 wiggle = { path = "../wiggle" }
 wiggle-runtime = { path = "../wiggle/crates/runtime" }
+witx = { path = "wig/WASI/tools/witx", version = "0.8.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 yanix = { path = "yanix", version = "0.12.0" }
@@ -34,3 +35,10 @@ cpu-time = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+default = []
+# wiggle_metadata is an optional extra feature that can be enabled by
+# consumers of this crate. It requires a dependency on `witx` which is
+# otherwise unnecessary.
+wiggle_metadata = []

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -38,4 +38,4 @@ maintenance = { status = "actively-developed" }
 [features]
 # Need to make the wiggle_metadata feature available to consumers of this
 # crate if they want the snapshots to have metadata available.
-wiggle_metadata = []
+wiggle_metadata = ["wiggle/wiggle_metadata", "wiggle-runtime/wiggle_metadata"]

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -31,7 +31,7 @@ pub mod old;
 mod path;
 mod poll;
 mod sandboxed_tty_writer;
-mod snapshots;
+pub mod snapshots;
 mod sys;
 mod virtfs;
 pub mod wasi;

--- a/crates/wasi-common/src/snapshots/mod.rs
+++ b/crates/wasi-common/src/snapshots/mod.rs
@@ -1,1 +1,1 @@
-mod wasi_snapshot_preview1;
+pub mod wasi_snapshot_preview1;

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -16,11 +16,11 @@ proc-macro = true
 
 [dependencies]
 wiggle-generate = { path = "crates/generate", version = "0.1.0" }
+wiggle-runtime = { path = "crates/runtime", version = "0.1.0" }
 witx = { path = "../wasi-common/wig/WASI/tools/witx", version = "0.8.4" }
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-wiggle-runtime = { path = "crates/runtime", version = "0.1.0" }
 wiggle-test = { path = "crates/test", version = "0.1.0" }
 proptest = "0.9"
 

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -23,3 +23,15 @@ syn = { version = "1.0", features = ["full"] }
 wiggle-runtime = { path = "crates/runtime", version = "0.1.0" }
 wiggle-test = { path = "crates/test", version = "0.1.0" }
 proptest = "0.9"
+
+[features]
+# These features have no effect on the users of this crate. They are only
+# necessary for testing.
+# The wiggle proc-macro emits some code (inside `pub mod metadata`) guarded
+# by the `wiggle_metadata` feature flag. We use this feature flag so that
+# users of wiggle are not forced to take a direct dependency on the `witx`
+# crate unless they want it.
+wiggle_metadata = []
+# In order to test that the contents of this metadata module meet
+# expectations, we must have this feature enabled for the crate by default.
+default = ["wiggle_metadata"]

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -31,7 +31,7 @@ proptest = "0.9"
 # by the `wiggle_metadata` feature flag. We use this feature flag so that
 # users of wiggle are not forced to take a direct dependency on the `witx`
 # crate unless they want it.
-wiggle_metadata = []
+wiggle_metadata = ["wiggle-runtime/wiggle_metadata"]
 # In order to test that the contents of this metadata module meet
 # expectations, we must have this feature enabled for the crate by default.
 default = ["wiggle_metadata"]

--- a/crates/wiggle/crates/generate/src/config.rs
+++ b/crates/wiggle/crates/generate/src/config.rs
@@ -12,6 +12,7 @@ use syn::{
 pub struct Config {
     pub witx: WitxConf,
     pub ctx: CtxConf,
+    pub emit_metadata: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -59,6 +60,7 @@ impl Config {
             ctx: ctx
                 .take()
                 .ok_or_else(|| Error::new(err_loc, "`ctx` field required"))?,
+            emit_metadata: false,
         })
     }
 }

--- a/crates/wiggle/crates/generate/src/lib.rs
+++ b/crates/wiggle/crates/generate/src/lib.rs
@@ -35,10 +35,21 @@ pub fn generate(doc: &witx::Document, config: &Config) -> TokenStream {
         )
     });
 
+    let doc_text = &format!("{}", doc);
+    let metadata = quote! {
+        pub mod metadata {
+            pub const DOC_TEXT: &str = #doc_text;
+            pub fn document() -> witx::Document {
+                witx::parse(DOC_TEXT).unwrap()
+            }
+        }
+    };
+
     quote!(
         pub mod types {
             #(#types)*
         }
         #(#modules)*
+        #metadata
     )
 }

--- a/crates/wiggle/crates/generate/src/lib.rs
+++ b/crates/wiggle/crates/generate/src/lib.rs
@@ -37,6 +37,7 @@ pub fn generate(doc: &witx::Document, config: &Config) -> TokenStream {
 
     let doc_text = &format!("{}", doc);
     let metadata = quote! {
+        #[cfg(feature = "wiggle_metadata")]
         pub mod metadata {
             pub const DOC_TEXT: &str = #doc_text;
             pub fn document() -> witx::Document {

--- a/crates/wiggle/crates/generate/src/lib.rs
+++ b/crates/wiggle/crates/generate/src/lib.rs
@@ -40,8 +40,8 @@ pub fn generate(doc: &witx::Document, config: &Config) -> TokenStream {
         quote! {
             pub mod metadata {
                 pub const DOC_TEXT: &str = #doc_text;
-                pub fn document() -> witx::Document {
-                    witx::parse(DOC_TEXT).unwrap()
+                pub fn document() -> wiggle_runtime::witx::Document {
+                    wiggle_runtime::witx::parse(DOC_TEXT).unwrap()
                 }
             }
         }

--- a/crates/wiggle/crates/generate/src/lib.rs
+++ b/crates/wiggle/crates/generate/src/lib.rs
@@ -35,15 +35,18 @@ pub fn generate(doc: &witx::Document, config: &Config) -> TokenStream {
         )
     });
 
-    let doc_text = &format!("{}", doc);
-    let metadata = quote! {
-        #[cfg(feature = "wiggle_metadata")]
-        pub mod metadata {
-            pub const DOC_TEXT: &str = #doc_text;
-            pub fn document() -> witx::Document {
-                witx::parse(DOC_TEXT).unwrap()
+    let metadata = if config.emit_metadata {
+        let doc_text = &format!("{}", doc);
+        quote! {
+            pub mod metadata {
+                pub const DOC_TEXT: &str = #doc_text;
+                pub fn document() -> witx::Document {
+                    witx::parse(DOC_TEXT).unwrap()
+                }
             }
         }
+    } else {
+        quote!()
     };
 
     quote!(

--- a/crates/wiggle/crates/runtime/Cargo.toml
+++ b/crates/wiggle/crates/runtime/Cargo.toml
@@ -12,6 +12,10 @@ include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 thiserror = "1"
+witx = { path = "../../../wasi-common/wig/WASI/tools/witx", version = "0.8.4", optional = true }
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+wiggle_metadata = ['witx']

--- a/crates/wiggle/crates/runtime/src/lib.rs
+++ b/crates/wiggle/crates/runtime/src/lib.rs
@@ -6,6 +6,9 @@ use std::slice;
 use std::str;
 use std::sync::Arc;
 
+#[cfg(feature = "wiggle_metadata")]
+pub use witx;
+
 mod borrow;
 mod error;
 mod guest_type;

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -87,6 +87,12 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
     config.witx.make_paths_relative_to(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR env var"),
     );
+
+    #[cfg(feature = "wiggle_metadata")]
+    {
+        config.emit_metadata = true;
+    }
+
     let doc = witx::load(&config.witx.paths).expect("loading witx");
     TokenStream::from(wiggle_generate::generate(&doc, &config))
 }

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -1,10 +1,25 @@
 use wiggle_runtime::{GuestBorrows, GuestError, GuestErrorType, GuestPtr};
 use wiggle_test::WasiCtx;
 
+// This test file exists to make sure that the entire `wasi.witx` file can be
+// handled by wiggle, producing code that compiles correctly.
+// The trait impls here are never executed, and just exist to validate that the
+// witx is exposed with the type signatures that we expect.
+
 wiggle::from_witx!({
     witx: ["tests/wasi.witx"],
     ctx: WasiCtx,
 });
+
+// The only test in this file is to verify that the witx document provided by the
+// proc macro in the `metadata` module is equal to the document on the disk.
+#[test]
+fn document_equivelant() {
+    let macro_doc = metadata::document();
+    let disk_doc = witx::load(&["tests/wasi.witx"]).expect("load wasi.witx from disk");
+
+    assert_eq!(macro_doc, disk_doc);
+}
 
 type Result<T> = std::result::Result<T, types::Errno>;
 


### PR DESCRIPTION
Over in Lucet, we'll be using some wiggle-adjacent proc macros to generate bindings to wasi-common. I'd like to make the witx document that wiggle used available in wasi-common's public interface so that I can generate the bindings straight from there, eliminating the possibility of getting our wires crossed.

The biggest issue I have with this PR is that it means all users of `wiggle` will have to take a `witx` runtime dependency that they otherwise may not need. In order to avoid this, wiggle emits the new metadata behind a new feature flag `wiggle_metadata` that consumer crates can opt-in to. As a result, we had to add the witx dependency to wasi-common, but its able to be optional if wasmtime doesnt want to use it. I haven't used cargo features as a library author before, or in a proc macro context, so I'd like to ask @alexcrichton for feedback if I did this right.


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
