### PR TITLE
[wasi-common] Clean up the use of mutable Entry

### DIFF
--- a/crates/wasi-common/src/entry.rs
+++ b/crates/wasi-common/src/entry.rs
@@ -5,7 +5,7 @@ use crate::wasi::types::{Filetype, Rights};
 use crate::wasi::{Errno, Result};
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::path::PathBuf;
 use std::{fmt, fs, io};
 
@@ -56,15 +56,6 @@ impl Descriptor {
     /// actual file/dir, and allowing operations which require an actual file and
     /// not just a stream or socket file descriptor.
     pub(crate) fn as_file<'descriptor>(&'descriptor self) -> Result<&'descriptor Self> {
-        match self {
-            Self::OsHandle(_) => Ok(self),
-            Self::VirtualFile(_) => Ok(self),
-            _ => Err(Errno::Badf),
-        }
-    }
-
-    /// Like `as_file`, but return a mutable reference.
-    pub(crate) fn as_file_mut<'descriptor>(&'descriptor mut self) -> Result<&'descriptor mut Self> {
         match self {
             Self::OsHandle(_) => Ok(self),
             Self::VirtualFile(_) => Ok(self),
@@ -261,11 +252,5 @@ impl<'descriptor> Deref for OsHandleRef<'descriptor> {
 
     fn deref(&self) -> &Self::Target {
         &self.handle
-    }
-}
-
-impl<'descriptor> DerefMut for OsHandleRef<'descriptor> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.handle
     }
 }

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -7,8 +7,8 @@ use crate::{clock, fd, path, poll};
 use log::{debug, error, trace};
 use std::cell::Ref;
 use std::convert::TryInto;
+use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::ops::DerefMut;
 use wiggle_runtime::{GuestBorrows, GuestPtr};
 
 impl<'a> WasiSnapshotPreview1 for WasiCtx {
@@ -124,10 +124,10 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             len,
             advice
         );
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let file = entry
-            .as_descriptor_mut(types::Rights::FD_ADVISE, types::Rights::empty())?
-            .as_file_mut()?;
+            .as_descriptor(types::Rights::FD_ADVISE, types::Rights::empty())?
+            .as_file()?;
         match file {
             Descriptor::OsHandle(fd) => fd::advise(&fd, advice, offset, len),
             Descriptor::VirtualFile(virt) => virt.advise(advice, offset, len),
@@ -361,13 +361,13 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             buf.push(io::IoSliceMut::new(slice));
         }
 
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let file = entry
-            .as_descriptor_mut(
+            .as_descriptor(
                 types::Rights::FD_READ | types::Rights::FD_SEEK,
                 types::Rights::empty(),
             )?
-            .as_file_mut()?;
+            .as_file()?;
 
         if offset > i64::max_value() as u64 {
             return Err(Errno::Io);
@@ -375,6 +375,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
         let host_nread = match file {
             Descriptor::OsHandle(fd) => {
+                let mut fd: &File = fd;
                 let cur_pos = fd.seek(SeekFrom::Current(0))?;
                 fd.seek(SeekFrom::Start(offset))?;
                 let nread = fd.read_vectored(&mut buf)?;
@@ -474,13 +475,13 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             buf.push(io::IoSlice::new(slice));
         }
 
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let file = entry
-            .as_descriptor_mut(
+            .as_descriptor(
                 types::Rights::FD_WRITE | types::Rights::FD_SEEK,
                 types::Rights::empty(),
             )?
-            .as_file_mut()?;
+            .as_file()?;
 
         if offset > i64::max_value() as u64 {
             return Err(Errno::Io);
@@ -488,6 +489,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
 
         let host_nwritten = match file {
             Descriptor::OsHandle(fd) => {
+                let mut fd: &File = fd;
                 let cur_pos = fd.seek(SeekFrom::Current(0))?;
                 fd.seek(SeekFrom::Start(offset))?;
                 let nwritten = fd.write_vectored(&buf)?;
@@ -524,10 +526,13 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             slices.push(io::IoSliceMut::new(slice));
         }
 
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let host_nread =
-            match entry.as_descriptor_mut(types::Rights::FD_READ, types::Rights::empty())? {
-                Descriptor::OsHandle(file) => file.read_vectored(&mut slices)?,
+            match entry.as_descriptor(types::Rights::FD_READ, types::Rights::empty())? {
+                Descriptor::OsHandle(file) => {
+                    let mut file: &File = file;
+                    file.read_vectored(&mut slices)?
+                }
                 Descriptor::VirtualFile(virt) => virt.read_vectored(&mut slices)?,
                 Descriptor::Stdin => io::stdin().read_vectored(&mut slices)?,
                 _ => return Err(Errno::Badf),
@@ -554,10 +559,10 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             cookie,
         );
 
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let file = entry
-            .as_descriptor_mut(types::Rights::FD_READDIR, types::Rights::empty())?
-            .as_file_mut()?;
+            .as_descriptor(types::Rights::FD_READDIR, types::Rights::empty())?
+            .as_file()?;
 
         fn copy_entities<T: Iterator<Item = Result<(types::Dirent, String)>>>(
             iter: T,
@@ -643,17 +648,20 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         } else {
             types::Rights::FD_SEEK | types::Rights::FD_TELL
         };
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let file = entry
-            .as_descriptor_mut(rights, types::Rights::empty())?
-            .as_file_mut()?;
+            .as_descriptor(rights, types::Rights::empty())?
+            .as_file()?;
         let pos = match whence {
             types::Whence::Cur => SeekFrom::Current(offset),
             types::Whence::End => SeekFrom::End(offset),
             types::Whence::Set => SeekFrom::Start(offset as u64),
         };
         let host_newoffset = match file {
-            Descriptor::OsHandle(fd) => fd.seek(pos)?,
+            Descriptor::OsHandle(fd) => {
+                let mut fd: &File = fd;
+                fd.seek(pos)?
+            }
             Descriptor::VirtualFile(virt) => virt.seek(pos)?,
             _ => {
                 unreachable!(
@@ -689,12 +697,15 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
     fn fd_tell(&self, fd: types::Fd) -> Result<types::Filesize> {
         trace!("fd_tell(fd={:?})", fd);
 
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let file = entry
-            .as_descriptor_mut(types::Rights::FD_TELL, types::Rights::empty())?
-            .as_file_mut()?;
+            .as_descriptor(types::Rights::FD_TELL, types::Rights::empty())?
+            .as_file()?;
         let host_offset = match file {
-            Descriptor::OsHandle(fd) => fd.seek(SeekFrom::Current(0))?,
+            Descriptor::OsHandle(fd) => {
+                let mut fd: &File = fd;
+                fd.seek(SeekFrom::Current(0))?
+            }
             Descriptor::VirtualFile(virt) => virt.seek(SeekFrom::Current(0))?,
             _ => {
                 unreachable!(
@@ -726,15 +737,17 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         }
 
         // perform unbuffered writes
-        let mut entry = self.get_entry_mut(fd)?;
+        let entry = self.get_entry(fd)?;
         let isatty = entry.isatty();
-        let desc = entry.as_descriptor_mut(types::Rights::FD_WRITE, types::Rights::empty())?;
+        let desc = entry.as_descriptor(types::Rights::FD_WRITE, types::Rights::empty())?;
         let host_nwritten = match desc {
             Descriptor::OsHandle(file) => {
+                let mut file: &File = file;
                 if isatty {
-                    SandboxedTTYWriter::new(file.deref_mut()).write_vectored(&slices)?
+                    // let mut file: &File = file;
+                    SandboxedTTYWriter::new(&mut file).write_vectored(&slices)?
                 } else {
-                    file.write_vectored(&slices)?
+                    (&mut file).write_vectored(&slices)?
                 }
             }
             Descriptor::VirtualFile(virt) => {

--- a/crates/wasi-common/src/sys/unix/bsd/fd.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/fd.rs
@@ -1,26 +1,21 @@
 use crate::sys::entry::OsHandle;
 use crate::wasi::Result;
-use std::sync::{Mutex, MutexGuard};
+use std::cell::RefMut;
 use yanix::dir::Dir;
 
-pub(crate) fn get_dir_from_os_handle<'a>(
-    os_handle: &'a mut OsHandle,
-) -> Result<MutexGuard<'a, Dir>> {
-    let dir = match os_handle.dir {
-        Some(ref mut dir) => dir,
-        None => {
-            // We need to duplicate the fd, because `opendir(3)`:
-            //     Upon successful return from fdopendir(), the file descriptor is under
-            //     control of the system, and if any attempt is made to close the file
-            //     descriptor, or to modify the state of the associated description other
-            //     than by means of closedir(), readdir(), readdir_r(), or rewinddir(),
-            //     the behaviour is undefined.
-            let fd = (*os_handle).try_clone()?;
-            let dir = Dir::from(fd)?;
-            os_handle.dir.get_or_insert(Mutex::new(dir))
-        }
-    };
-    // Note that from this point on, until the end of the parent scope (i.e., enclosing this
-    // function), we're locking the `Dir` member of this `OsHandle`.
-    Ok(dir.lock().unwrap())
+pub(crate) fn get_dir_from_os_handle(os_handle: &OsHandle) -> Result<RefMut<Dir>> {
+    if os_handle.dir.borrow().is_none() {
+        // We need to duplicate the fd, because `opendir(3)`:
+        //     Upon successful return from fdopendir(), the file descriptor is under
+        //     control of the system, and if any attempt is made to close the file
+        //     descriptor, or to modify the state of the associated description other
+        //     than by means of closedir(), readdir(), readdir_r(), or rewinddir(),
+        //     the behaviour is undefined.
+        let fd = (*os_handle).try_clone()?;
+        let d = Dir::from(fd)?;
+        *os_handle.dir.borrow_mut() = Some(d);
+    }
+    Ok(RefMut::map(os_handle.dir.borrow_mut(), |dir| {
+        dir.as_mut().unwrap()
+    }))
 }

--- a/crates/wasi-common/src/sys/unix/bsd/oshandle.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/oshandle.rs
@@ -1,7 +1,7 @@
+use std::cell::RefCell;
 use std::fs;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::os::unix::prelude::{AsRawFd, RawFd};
-use std::sync::Mutex;
 use yanix::dir::Dir;
 
 #[derive(Debug)]
@@ -18,12 +18,15 @@ pub(crate) struct OsHandle {
     //   > of the DIR pointer, dirp, from which they are derived.
     //   > If the directory is closed and then reopened, prior values
     //   > returned by telldir() will no longer be valid.
-    pub(crate) dir: Option<Mutex<Dir>>,
+    pub(crate) dir: RefCell<Option<Dir>>,
 }
 
 impl From<fs::File> for OsHandle {
     fn from(file: fs::File) -> Self {
-        Self { file, dir: None }
+        Self {
+            file,
+            dir: RefCell::new(None),
+        }
     }
 }
 
@@ -38,11 +41,5 @@ impl Deref for OsHandle {
 
     fn deref(&self) -> &Self::Target {
         &self.file
-    }
-}
-
-impl DerefMut for OsHandle {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.file
     }
 }

--- a/crates/wasi-common/src/sys/unix/fd.rs
+++ b/crates/wasi-common/src/sys/unix/fd.rs
@@ -44,7 +44,7 @@ pub(crate) fn filestat_get(file: &std::fs::File) -> Result<types::Filestat> {
 }
 
 pub(crate) fn readdir<'a>(
-    os_handle: &'a mut OsHandle,
+    os_handle: &'a OsHandle,
     cookie: types::Dircookie,
 ) -> Result<impl Iterator<Item = Result<(types::Dirent, String)>> + 'a> {
     use yanix::dir::{DirIter, Entry, EntryExt, SeekLoc};

--- a/crates/wasi-common/src/sys/unix/linux/fd.rs
+++ b/crates/wasi-common/src/sys/unix/linux/fd.rs
@@ -2,7 +2,7 @@ use crate::sys::entry::OsHandle;
 use crate::wasi::Result;
 use yanix::dir::Dir;
 
-pub(crate) fn get_dir_from_os_handle(os_handle: &mut OsHandle) -> Result<Box<Dir>> {
+pub(crate) fn get_dir_from_os_handle(os_handle: &OsHandle) -> Result<Box<Dir>> {
     // We need to duplicate the fd, because `opendir(3)`:
     //     After a successful call to fdopendir(), fd is used internally by the implementation,
     //     and should not otherwise be used by the application.

--- a/crates/wasi-common/src/sys/unix/linux/oshandle.rs
+++ b/crates/wasi-common/src/sys/unix/linux/oshandle.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::os::unix::prelude::{AsRawFd, RawFd};
 
 #[derive(Debug)]
@@ -22,11 +22,5 @@ impl Deref for OsHandle {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl DerefMut for OsHandle {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }

--- a/crates/wasi-common/src/sys/windows/entry.rs
+++ b/crates/wasi-common/src/sys/windows/entry.rs
@@ -3,7 +3,7 @@ use crate::wasi::{types, RightsExt};
 use std::fs::File;
 use std::io;
 use std::mem::ManuallyDrop;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::os::windows::prelude::{AsRawHandle, FromRawHandle, RawHandle};
 
 #[derive(Debug)]
@@ -26,12 +26,6 @@ impl Deref for OsHandle {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl DerefMut for OsHandle {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 


### PR DESCRIPTION
Until now, several syscalls including `fd_pwrite` etc. were relying on mutating `&mut Entry` by mutating its inner file handle. This is unnecessary in almost all cases since all methods mutating `std::fs::File` in Rust's libstd are also implemented for `&std::fs::File`. In part, this will prepare us to handle `Entry`s behind an `Rc` and `RefCell` combo.

While here, I've also modified `OsHandle` in BSD to include `RefCell<Option<Dir>>` rather than `Option<Mutex<Dir>>` as was until now. While `RefCell` could easily be replaced with `Mutex`, since going multithreading will require a lot of conceptual changes to `wasi-common`, I thought it'd be best not to mix single- with multithreading contexts and swap all places at once when it comes to it. If y'all feel this is not the right approach, lemme know!

I've also had to make some modifications to virtual FS which mainly swaps mutability for interior mutability in a handful of places.