### PR TITLE
Refactor wasmtime_runtime::Instance internals

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -87,7 +87,7 @@ impl VMOffsets {
 
 /// Offsets for `*const VMFunctionBody`.
 impl VMOffsets {
-    /// The size of the `current_elements` field.
+    /// The size of a `*const VMFunctionBody`.
     #[allow(clippy::identity_op)]
     pub fn size_of_vmfunction_body_ptr(&self) -> u8 {
         1 * self.pointer_size
@@ -180,7 +180,7 @@ impl VMOffsets {
 
     /// The size of the `current_length` field.
     pub fn size_of_vmmemory_definition_current_length(&self) -> u8 {
-        4
+        self.pointer_size
     }
 
     /// Return the size of `VMMemoryDefinition`.

--- a/crates/runtime/src/export.rs
+++ b/crates/runtime/src/export.rs
@@ -79,7 +79,8 @@ impl From<ExportMemory> for Export {
 pub struct ExportGlobal {
     /// The address of the global storage.
     pub definition: *mut VMGlobalDefinition,
-    /// Pointer to the containing `VMContext`.
+    /// Pointer to a `VMContext` which has a lifetime at least as long as the
+    /// global. This may not be the `VMContext` which defines the global.
     pub vmctx: *mut VMContext,
     /// The global declaration, used for compatibilty checking.
     pub global: Global,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -937,15 +937,19 @@ impl InstanceHandle {
             instance.imported_globals_ptr() as *mut VMGlobalImport,
             imports.globals.len(),
         );
-        for (index, vmctx_table) in instance.tables
+        for (index, vmctx_table) in instance
+            .tables
             .iter()
-            .map(|(index, table)| (index, table.vmtable())) {
-                instance.set_table(index, vmctx_table);
+            .map(|(index, table)| (index, table.vmtable()))
+        {
+            instance.set_table(index, vmctx_table);
         }
-        for (index, vmctx_memory) in instance.memories
+        for (index, vmctx_memory) in instance
+            .memories
             .iter()
-            .map(|(index, memory)| (index, memory.vmmemory())) {
-                instance.set_memory(index, vmctx_memory);
+            .map(|(index, memory)| (index, memory.vmmemory()))
+        {
+            instance.set_memory(index, vmctx_memory);
         }
         ptr::write(
             instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -863,8 +863,6 @@ impl InstanceHandle {
             .collect::<PrimaryMap<DefinedMemoryIndex, _>>()
             .into_boxed_slice();
 
-        let vmctx_globals = create_globals(&module);
-
         let offsets = VMOffsets::new(mem::size_of::<*const u8>() as u8, &module.local);
 
         let passive_data = RefCell::new(module.passive_data.clone());
@@ -933,11 +931,6 @@ impl InstanceHandle {
             vmctx_memories.values().as_slice().as_ptr(),
             instance.memories_ptr() as *mut VMMemoryDefinition,
             vmctx_memories.len(),
-        );
-        ptr::copy(
-            vmctx_globals.values().as_slice().as_ptr(),
-            instance.globals_ptr() as *mut VMGlobalDefinition,
-            vmctx_globals.len(),
         );
         ptr::write(
             instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
@@ -1319,18 +1312,6 @@ fn initialize_memories(
     }
 
     Ok(())
-}
-
-/// Allocate memory for just the globals of the current module.
-fn create_globals(module: &Module) -> BoxedSlice<DefinedGlobalIndex, VMGlobalDefinition> {
-    let num_imports = module.imported_globals.len();
-    let mut vmctx_globals = PrimaryMap::with_capacity(module.local.globals.len() - num_imports);
-
-    for _ in &module.local.globals.values().as_slice()[num_imports..] {
-        vmctx_globals.push(VMGlobalDefinition::new());
-    }
-
-    vmctx_globals.into_boxed_slice()
 }
 
 fn initialize_globals(instance: &Instance) {

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1321,8 +1321,7 @@ fn initialize_memories(
     Ok(())
 }
 
-/// Allocate memory for just the globals of the current module,
-/// with initializers applied.
+/// Allocate memory for just the globals of the current module.
 fn create_globals(module: &Module) -> BoxedSlice<DefinedGlobalIndex, VMGlobalDefinition> {
     let num_imports = module.imported_globals.len();
     let mut vmctx_globals = PrimaryMap::with_capacity(module.local.globals.len() - num_imports);

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -315,10 +315,10 @@ impl Instance {
 
     /// Lookup an export with the given export declaration.
     pub fn lookup_by_declaration(&self, export: &wasmtime_environ::Export) -> Export {
-        match export {
+        match *export {
             wasmtime_environ::Export::Function(index) => {
-                let signature = self.signature_id(self.module.local.functions[*index]);
-                let (address, vmctx) = self.get_vmfunction(*index);
+                let signature = self.signature_id(self.module.local.functions[index]);
+                let (address, vmctx) = self.get_vmfunction(index);
                 ExportFunction {
                     address,
                     signature,
@@ -328,43 +328,43 @@ impl Instance {
             }
             wasmtime_environ::Export::Table(index) => {
                 let (definition, vmctx) =
-                    if let Some(def_index) = self.module.local.defined_table_index(*index) {
+                    if let Some(def_index) = self.module.local.defined_table_index(index) {
                         (self.table_ptr(def_index), self.vmctx_ptr())
                     } else {
-                        let import = self.imported_table(*index);
+                        let import = self.imported_table(index);
                         (import.from, import.vmctx)
                     };
                 ExportTable {
                     definition,
                     vmctx,
-                    table: self.module.local.table_plans[*index].clone(),
+                    table: self.module.local.table_plans[index].clone(),
                 }
                 .into()
             }
             wasmtime_environ::Export::Memory(index) => {
                 let (definition, vmctx) =
-                    if let Some(def_index) = self.module.local.defined_memory_index(*index) {
+                    if let Some(def_index) = self.module.local.defined_memory_index(index) {
                         (self.memory_ptr(def_index), self.vmctx_ptr())
                     } else {
-                        let import = self.imported_memory(*index);
+                        let import = self.imported_memory(index);
                         (import.from, import.vmctx)
                     };
                 ExportMemory {
                     definition,
                     vmctx,
-                    memory: self.module.local.memory_plans[*index].clone(),
+                    memory: self.module.local.memory_plans[index].clone(),
                 }
                 .into()
             }
             wasmtime_environ::Export::Global(index) => ExportGlobal {
-                definition: if let Some(def_index) = self.module.local.defined_global_index(*index)
+                definition: if let Some(def_index) = self.module.local.defined_global_index(index)
                 {
                     self.global_ptr(def_index)
                 } else {
-                    self.imported_global(*index).from
+                    self.imported_global(index).from
                 },
                 vmctx: self.vmctx_ptr(),
-                global: self.module.local.globals[*index],
+                global: self.module.local.globals[index],
             }
             .into(),
         }

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -75,9 +75,7 @@ impl Table {
 
     /// Set reference to the specified element.
     ///
-    /// # Panics
-    ///
-    /// Panics if `index` is out of bounds.
+    /// Returns an error if `index` is out of bounds.
     pub fn set(&self, index: u32, func: VMCallerCheckedAnyfunc) -> Result<(), ()> {
         match self.vec.borrow_mut().get_mut(index as usize) {
             Some(slot) => {

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -204,12 +204,10 @@ mod test_vmmemory_definition {
             offset_of!(VMMemoryDefinition, current_length),
             usize::from(offsets.vmmemory_definition_current_length())
         );
-        /* TODO: Assert that the size of `current_length` matches.
         assert_eq!(
             size_of::<VMMemoryDefinition::current_length>(),
             usize::from(offsets.size_of_vmmemory_definition_current_length())
         );
-        */
     }
 }
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -139,6 +139,10 @@ mod test_vmmemory_import {
 
 /// The fields compiled code needs to access to utilize a WebAssembly global
 /// variable imported from another instance.
+///
+/// Note that unlike with functions, tables, and memories, `VMGlobalImport`
+/// doesn't include a `vmctx` pointer. Globals are never resized, and don't
+/// require a `vmctx` pointer to access.
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct VMGlobalImport {

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -617,8 +617,6 @@ impl VMInvokeArgument {
 /// The struct here is empty, as the sizes of these fields are dynamic, and
 /// we can't describe them in Rust's type system. Sufficient memory is
 /// allocated at runtime.
-///
-/// TODO: We could move the globals into the `vmctx` allocation too.
 #[derive(Debug)]
 #[repr(C, align(16))] // align 16 since globals are aligned to that and contained inside
 pub struct VMContext {}

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -188,7 +188,7 @@ pub struct VMMemoryDefinition {
 #[cfg(test)]
 mod test_vmmemory_definition {
     use super::VMMemoryDefinition;
-    use memoffset::offset_of;
+    use memoffset::{offset_of, span_of};
     use std::mem::size_of;
     use wasmtime_environ::{Module, VMOffsets};
 
@@ -209,7 +209,7 @@ mod test_vmmemory_definition {
             usize::from(offsets.vmmemory_definition_current_length())
         );
         assert_eq!(
-            size_of::<VMMemoryDefinition::current_length>(),
+            span_of!(VMMemoryDefinition, current_length).len(),
             usize::from(offsets.size_of_vmmemory_definition_current_length())
         );
     }
@@ -230,7 +230,7 @@ pub struct VMTableDefinition {
 #[cfg(test)]
 mod test_vmtable_definition {
     use super::VMTableDefinition;
-    use memoffset::offset_of;
+    use memoffset::{offset_of, span_of};
     use std::mem::size_of;
     use wasmtime_environ::{Module, VMOffsets};
 
@@ -249,6 +249,10 @@ mod test_vmtable_definition {
         assert_eq!(
             offset_of!(VMTableDefinition, current_elements),
             usize::from(offsets.vmtable_definition_current_elements())
+        );
+        assert_eq!(
+            span_of!(VMTableDefinition, current_elements).len(),
+            usize::from(offsets.size_of_vmtable_definition_current_elements())
         );
     }
 }


### PR DESCRIPTION
This sequence of patches cleans up some old code which is no longer relevant, factors out more of the low-level instance querying logic into helper functions, and updates some comments. There's room for more refactoring here, but this is a start.