### PR TITLE
Enable GDB JIT debugging

### DIFF
--- a/crates/debug/src/transform/mod.rs
+++ b/crates/debug/src/transform/mod.rs
@@ -71,8 +71,7 @@ pub fn transform_dwarf(
     let out_encoding = gimli::Encoding {
         format: gimli::Format::Dwarf32,
         // TODO: this should be configurable
-        // macOS doesn't seem to support DWARF > 3
-        version: 3,
+        version: 4,
         address_size: isa.pointer_bytes(),
     };
 


### PR DESCRIPTION
After hours of gdb the gdb, found the first issue that prevents JIT symbols to be loaded. It requires DWARF version 4+ to properly parse `DW_AT_high_pc`, e.g.

https://github.com/bminor/binutils-gdb/blob/0d4a4bc56fc947565ef0dd4b440a157e7d592b09/gdb/dwarf2/read.c#L18040-L18045

The increasing generated DWARF does not break MacOS, and fixes loading JIT symbols in GDB.



