### PR TITLE
Ignore DWARF expressions with Wasm globals

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -327,7 +327,11 @@ where
             // WebAssembly DWARF extension
             pc.read_u8()?;
             let ty = pc.read_uleb128()?;
-            assert_eq!(ty, 0);
+            // Supporting only wasm locals.
+            if ty != 0 {
+                // TODO support wasm globals?
+                return Ok(None);
+            }
             let index = pc.read_sleb128()?;
             pc.read_u8()?; // consume 159
             if !code_chunk.is_empty() {


### PR DESCRIPTION
Fixes #1403

Latest LLVM can produce DWARF expressions that refer Wasm globals. Ignoring such expressions for now.

/cc @abrown 