### PR TITLE
Try to only publish crates/releases on wasmtime tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -544,7 +544,7 @@ jobs:
     - name: Calculate tag name
       run: |
         name=dev
-        if [[ $GITHUB_REF == refs/tags* ]]; then
+        if [[ $GITHUB_REF == refs/tags/v* ]]; then
           name=${GITHUB_REF:10}
         fi
         echo ::set-output name=val::$name
@@ -577,7 +577,7 @@ jobs:
 
     - name: Publish Python wheels on Pypi
       uses: pypa/gh-action-pypi-publish@37e305e7413032d8422456179fee28fac7d25187
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
@@ -588,7 +588,7 @@ jobs:
     # with this `sha`
     - name: Publish Release
       uses: ./.github/actions/github-release
-      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
       with:
         files: "dist/*"
         name: ${{ steps.tagname.outputs.val }}


### PR DESCRIPTION
We've got a cranelift-v0.60.0 release made with the recent
cranelift-v0.60.0 tag, but the release infrastructure is intended to
only get used for wasmtime tags. Let's see if we can coerce github
actions to only releasing for wasmtime tags.
