### PR TITLE
More fixes for 0.14.

### DIFF
--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -8,7 +8,6 @@ description = "Wiggle code generator"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
-readme = "README.md"
 include = ["src/**/*", "LICENSE"]
 
 [lib]

--- a/scripts/publish-wasmtime.sh
+++ b/scripts/publish-wasmtime.sh
@@ -22,9 +22,9 @@ for cargo_toml in \
     crates/wasi-common/yanix/Cargo.toml \
     crates/wasi-common/wig/Cargo.toml \
     crates/wiggle/generate/Cargo.toml \
-    crates/wiggle/test/Cargo.toml \
     crates/wiggle/macro/Cargo.toml \
     crates/wiggle/Cargo.toml \
+    crates/wiggle/test-helper/Cargo.toml \
     crates/wasi-common/Cargo.toml \
     crates/lightbeam/Cargo.toml \
     crates/environ/Cargo.toml \


### PR DESCRIPTION
Working on publishing 0.14. Current issue is that wiggle and wiggle-test-helpers have a circular dependency with each other.