### PR TITLE
Make WASI and `wat` support optional in the C API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,51 @@ jobs:
         name: doc-api
         path: target/doc
 
+  # Quick checks of various feature combinations and whether things
+  # compile. The goal here isn't to run tests, mostly just serve as a
+  # double-check that Rust code compiles and is likely to work everywhere else.
+  checks:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly
+
+    # Check some feature combinations of the `wasmtime` crate
+    - run: cargo check --manifest-path crates/api/Cargo.toml --no-default-features
+    - run: cargo check --manifest-path crates/api/Cargo.toml --features wat
+    - run: cargo check --manifest-path crates/api/Cargo.toml --features lightbeam
+    - run: cargo check --manifest-path crates/api/Cargo.toml --features jitdump
+
+    # Check some feature combinations of the `wasmtime-c-api` crate
+    - run: cargo check --manifest-path crates/c-api/Cargo.toml --no-default-features
+    - run: cargo check --manifest-path crates/c-api/Cargo.toml --features wat
+    - run: cargo check --manifest-path crates/c-api/Cargo.toml --features wasi
+
+    # Check a few builds of the cranelift backend
+    # - only x86 backend support,
+    # - only arm64 backend support,
+    # - no debug_assertions.
+    - run: cargo check --manifest-path=./cranelift/Cargo.toml --bin clif-util --no-default-features --features=cranelift-codegen/arm64
+    - run: cargo check --manifest-path=./cranelift/Cargo.toml --bin clif-util --no-default-features --features=cranelift-codegen/x86
+    - run: cargo check --manifest-path=./cranelift/Cargo.toml --bin clif-util
+      env:
+        CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: false
+
+    # Check whether `crates/wasi-common` cross-compiles to the following targets:
+    # * wasm32-unknown-emscripten
+    # * armv7-unknown-linux-gnueabihf
+    - run: |
+        rustup target add wasm32-unknown-emscripten
+        rustup target add armv7-unknown-linux-gnueabihf
+    - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
+    - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
+
+
   # Download our libFuzzer corpus and make sure that we can still handle all the
   # inputs.
   fuzz_corpora:
@@ -119,23 +164,6 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-  # Check whether `crates/wasi-common` cross-compiles to the following targets:
-  # * wasm32-unknown-emscripten
-  # * armv7-unknown-linux-gnueabihf
-  crosscompile:
-    name: Cross-platform checks
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-    - run: |
-        rustup target add wasm32-unknown-emscripten
-        cargo check --target wasm32-unknown-emscripten -p wasi-common
-        rustup target add armv7-unknown-linux-gnueabihf
-        cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
-
   # Perform all tests (debug mode) for `wasmtime`. This runs stable/beta/nightly
   # channels of Rust as well as macOS/Linux/Windows.
   test:
@@ -192,12 +220,6 @@ jobs:
     - run: cargo fetch --locked
     - run: cargo fetch --locked --manifest-path crates/test-programs/wasi-tests/Cargo.toml
 
-    # Build some various feature combinations
-    - run: cargo build --manifest-path crates/api/Cargo.toml --no-default-features
-    - run: cargo build --manifest-path crates/api/Cargo.toml --features wat
-    - run: cargo build --manifest-path crates/api/Cargo.toml --features lightbeam
-      if: matrix.rust == 'nightly'
-
     # Ensure all our examples build and execute
     - run: cargo run -p run-examples
 
@@ -233,17 +255,6 @@ jobs:
       continue-on-error: true
       env:
         RUST_BACKTRACE: 1
-
-    # Perform various builds of Cranelift under different configurations:
-    # - only x86 backend support,
-    # - only arm64 backend support,
-    # - no debug_assertions.
-    - run: cargo build --manifest-path=./cranelift/Cargo.toml --bin clif-util --no-default-features --features=cranelift-codegen/arm64
-      shell: bash
-    - run: cargo build --manifest-path=./cranelift/Cargo.toml --bin clif-util --no-default-features --features=cranelift-codegen/x86
-      shell: bash
-    - run: cargo rustc --manifest-path=./cranelift/Cargo.toml --bin clif-util -- -C debug_assertions=off
-      shell: bash
 
   # Verify that cranelift's code generation is deterministic
   meta_determinist_check:

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -20,12 +20,17 @@ doctest = false
 anyhow = "1.0"
 once_cell = "1.3"
 wasmtime = { path = "../api", default-features = false }
-wasi-common = { path = "../wasi-common" }
-wasmtime-wasi = { path = "../wasi" }
 wasmtime-c-api-macros = { path = "macros" }
-wat = "1.0"
+
+# Optional dependency for the `wat2wasm` API
+wat = { version = "1.0", optional = true }
+
+# Optional dependencies for the `wasi` feature
+wasi-common = { path = "../wasi-common", optional = true }
+wasmtime-wasi = { path = "../wasi", optional = true }
 
 [features]
-default = ['jitdump']
+default = ['jitdump', 'wat', 'wasi']
 lightbeam = ["wasmtime/lightbeam"]
 jitdump = ["wasmtime/jitdump"]
+wasi = ['wasi-common', 'wasmtime-wasi']

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -21,8 +21,6 @@ mod trap;
 mod types;
 mod val;
 mod vec;
-mod wasi;
-mod wat2wasm;
 
 pub use crate::config::*;
 pub use crate::engine::*;
@@ -40,7 +38,15 @@ pub use crate::trap::*;
 pub use crate::types::*;
 pub use crate::val::*;
 pub use crate::vec::*;
+
+#[cfg(feature = "wasi")]
+mod wasi;
+#[cfg(feature = "wasi")]
 pub use crate::wasi::*;
+
+#[cfg(feature = "wat")]
+mod wat2wasm;
+#[cfg(feature = "wat")]
 pub use crate::wat2wasm::*;
 
 #[repr(C)]

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -1,4 +1,4 @@
-use crate::{wasi_instance_t, wasm_extern_t, wasm_store_t, ExternHost};
+use crate::{wasm_extern_t, wasm_store_t, ExternHost};
 use crate::{wasm_instance_t, wasm_module_t, wasm_name_t, wasm_trap_t};
 use std::str;
 use wasmtime::{Extern, Linker};
@@ -51,10 +51,11 @@ pub extern "C" fn wasmtime_linker_define(
     linker.define(module, name, item).is_ok()
 }
 
+#[cfg(feature = "wasi")]
 #[no_mangle]
 pub extern "C" fn wasmtime_linker_define_wasi(
     linker: &mut wasmtime_linker_t,
-    instance: &wasi_instance_t,
+    instance: &crate::wasi_instance_t,
 ) -> bool {
     let linker = &mut linker.linker;
     instance.add_to_linker(linker).is_ok()

--- a/crates/c-api/src/wat2wasm.rs
+++ b/crates/c-api/src/wat2wasm.rs
@@ -1,5 +1,4 @@
 use crate::wasm_byte_vec_t;
-use std::str;
 
 #[no_mangle]
 pub extern "C" fn wasmtime_wat2wasm(
@@ -7,7 +6,7 @@ pub extern "C" fn wasmtime_wat2wasm(
     ret: &mut wasm_byte_vec_t,
     error: Option<&mut wasm_byte_vec_t>,
 ) -> bool {
-    let wat = match str::from_utf8(wat.as_slice()) {
+    let wat = match std::str::from_utf8(wat.as_slice()) {
         Ok(s) => s,
         Err(_) => {
             if let Some(error) = error {


### PR DESCRIPTION
Add some crate features to compile out support for these features of the
C API. Avoiding these two features if they're not necessary shaves about
2MB off the final shared object in some local tests!
