### PR TITLE
Include the Windows DLL import library in binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,7 +421,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - run: cp target/release/libwasmtime.{dylib,a} dist
       if: matrix.os == 'macos-latest'
-    - run: cp target/release/wasmtime.{dll,lib} dist
+    - run: cp target/release/wasmtime.{dll,lib,dll.lib} dist
       shell: bash
       if: matrix.os == 'windows-latest'
 


### PR DESCRIPTION
This commit fixes an issue where you couldn't actually link to
`wasmtime.dll` via a C compiler because it was missing its import
library, `wasmtime.dll.lib`
