### PR TITLE
Generate trace logs in wiggle albeit behind a feature flag

### DIFF
--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -36,6 +36,11 @@ cpu-time = "1.0"
 maintenance = { status = "actively-developed" }
 
 [features]
+default = ["trace_log"]
+# This feature enables `log::trace` calls in syscalls shims, in effect
+# emulating something like `strace`. This feature is an opt-out and hence
+# enabled by default.
+trace_log = []
 # Need to make the wiggle_metadata feature available to consumers of this
 # crate if they want the snapshots to have metadata available.
 wiggle_metadata = ["wiggle/wiggle_metadata"]

--- a/crates/wasi-common/src/entry.rs
+++ b/crates/wasi-common/src/entry.rs
@@ -115,9 +115,9 @@ impl EntryRights {
 
 impl fmt::Display for EntryRights {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(
+        write!(
             f,
-            "EntryRights {{\n\tbase: {},\n\tinheriting: {}\n}}",
+            "EntryRights {{ base: {}, inheriting: {} }}",
             self.base, self.inheriting
         )
     }


### PR DESCRIPTION
This commit augments `wiggle` with trace log generation for the shims,
returned errno values, and returned values proper (if any, i.e.,
different than unit type `()`). What that means is that every syscall
will have auto-generated up to 3 traces, for instance,

```
 TRACE wasi_common::wasi::wasi_snapshot_preview1 > fd_prestat_get(fd=Fd(3))
 TRACE wasi_common::wasi::wasi_snapshot_preview1 >      | result=(buf=Dir(PrestatDir { pr_name_len: 1 }))
 TRACE wasi_common::wasi::wasi_snapshot_preview1 >      | errno=No error occurred. System call completed successfully. (Errno::Success(0))
```

Putting logging behind a feature flag in this case means that the log calls
are generated by the `wiggle` crate regardless if the client requested
the feature or not, however, then their usage in the client lib is
dictated by the presence of the feature flag. So, for instance, `wasi-common`
has this feature enabled by default, while any other client lib
using `wiggle` if they don't want tracing enabled, they will just
leave the feature off. I'm not sure if this is what we wanted
but seemed easiest to implement quickly. Lemme y'all know your thoughts
about this!

Closes #1420.