### PR TITLE
Fix typo in Memory.Maximum doc string.

### DIFF
--- a/crates/misc/dotnet/src/Memory.cs
+++ b/crates/misc/dotnet/src/Memory.cs
@@ -20,7 +20,7 @@ namespace Wasmtime
         public uint Minimum { get; private set; }
 
         /// <summary>
-        /// The minimum memory size (in WebAssembly page units).
+        /// The maximum memory size (in WebAssembly page units).
         /// </summary>
         public uint Maximum { get; private set; }
 


### PR DESCRIPTION
Not discussed in an issue because it's a minor typo.