### PR TITLE
Move back to only one WASI submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "crates/c-api/examples/wasm-c-api"]
 	path = crates/c-api/wasm-c-api
 	url = https://github.com/WebAssembly/wasm-c-api
-[submodule "crates/wasi-common/WASI"]
-	path = crates/wasi-common/wig/WASI
-	url = https://github.com/WebAssembly/WASI
 [submodule "WASI"]
 	path = crates/wasi-common/WASI
 	url = https://github.com/WebAssembly/WASI

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -11,6 +11,11 @@ readme = "README.md"
 edition = "2018"
 include = ["src/**/*", "LICENSE", "WASI/phases"]
 
+# This doesn't actually link to a native library, but it allows us to set env
+# vars like `DEP_WASI_COMMON_14_*` for crates that have build scripts and depend
+# on this crate, allowing other crates to use the same witx files.
+links = "wasi-common-14"
+
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0"

--- a/crates/wasi-common/build.rs
+++ b/crates/wasi-common/build.rs
@@ -1,0 +1,8 @@
+// Tell any dependencies, if necessary, where our WASI submodule is so they can
+// use the same witx files if they want.
+fn main() {
+    let cwd = std::env::current_dir().unwrap();
+    let wasi = cwd.join("WASI");
+    println!("cargo:wasi={}", wasi.display());
+    println!("cargo:rustc-env=WASI_ROOT={}", wasi.display());
+}

--- a/crates/wasi-common/src/old/snapshot_0/host.rs
+++ b/crates/wasi-common/src/old/snapshot_0/host.rs
@@ -8,7 +8,7 @@ use crate::old::snapshot_0::wasi::*;
 use std::{convert::TryInto, io, mem, slice};
 use wig::witx_host_types;
 
-witx_host_types!("old/snapshot_0" "wasi_unstable");
+witx_host_types!("phases/old/snapshot_0/witx/wasi_unstable.witx");
 
 pub(crate) unsafe fn ciovec_to_host(ciovec: &__wasi_ciovec_t) -> io::IoSlice {
     let slice = slice::from_raw_parts(ciovec.buf as *const u8, ciovec.buf_len);

--- a/crates/wasi-common/src/old/snapshot_0/mod.rs
+++ b/crates/wasi-common/src/old/snapshot_0/mod.rs
@@ -9,7 +9,7 @@ pub mod wasi;
 pub mod wasi32;
 
 pub mod hostcalls {
-    wig::define_hostcalls!("old/snapshot_0" "wasi_unstable");
+    wig::define_hostcalls!("phases/old/snapshot_0/witx/wasi_unstable.witx");
 }
 
 pub use ctx::{WasiCtx, WasiCtxBuilder};

--- a/crates/wasi-common/src/old/snapshot_0/wasi.rs
+++ b/crates/wasi-common/src/old/snapshot_0/wasi.rs
@@ -8,7 +8,7 @@
 
 use wig::witx_wasi_types;
 
-witx_wasi_types!("old/snapshot_0" "wasi_unstable");
+witx_wasi_types!("phases/old/snapshot_0/witx/wasi_unstable.witx");
 
 pub type WasiResult<T> = Result<T, WasiError>;
 

--- a/crates/wasi-common/src/old/snapshot_0/wasi32.rs
+++ b/crates/wasi-common/src/old/snapshot_0/wasi32.rs
@@ -12,4 +12,4 @@ use wig::witx_wasi32_types;
 pub type uintptr_t = u32;
 pub type size_t = u32;
 
-witx_wasi32_types!("old/snapshot_0" "wasi_unstable");
+witx_wasi32_types!("phases/old/snapshot_0/witx/wasi_unstable.witx");

--- a/crates/wasi-common/wig/Cargo.toml
+++ b/crates/wasi-common/wig/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 heck = "0.3.1"
-witx = { path = "WASI/tools/witx", version = "0.8.4" }
+witx = { path = "../WASI/tools/witx", version = "0.8.4" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wasi-common/wig/src/hostcalls.rs
+++ b/crates/wasi-common/wig/src/hostcalls.rs
@@ -3,21 +3,17 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 pub fn define(args: TokenStream) -> TokenStream {
-    let (path, phase) = utils::witx_path_from_args(args);
+    let path = utils::witx_path_from_args(args);
     let doc = match witx::load(&[&path]) {
         Ok(doc) => doc,
         Err(e) => {
-            panic!("error opening file {}: {}", path, e);
+            panic!("error opening file {}: {}", path.display(), e);
         }
     };
 
     let mut ret = TokenStream::new();
 
-    let old = match phase.as_str() {
-        "snapshot" => false,
-        "old/snapshot_0" => true,
-        s => panic!("unsupported phase: {}", s),
-    };
+    let old = true;
 
     for module in doc.modules() {
         for func in module.funcs() {

--- a/crates/wasi-common/wig/src/raw_types.rs
+++ b/crates/wasi-common/wig/src/raw_types.rs
@@ -25,11 +25,11 @@ impl Mode {
 pub fn gen(args: TokenStream, mode: Mode) -> TokenStream {
     let mut output = TokenStream::new();
 
-    let (path, _phase) = utils::witx_path_from_args(args);
+    let path = utils::witx_path_from_args(args);
     let doc = match witx::load(&[&path]) {
         Ok(doc) => doc,
         Err(e) => {
-            panic!("error opening file {}: {}", path, e);
+            panic!("error opening file {}: {}", path.display(), e);
         }
     };
 

--- a/crates/wasi-common/wig/src/utils.rs
+++ b/crates/wasi-common/wig/src/utils.rs
@@ -1,8 +1,9 @@
 use proc_macro2::{Ident, Literal, TokenStream, TokenTree};
+use std::path::PathBuf;
 
 /// Given the input tokens to a macro invocation, return the path to the
 /// witx file to process.
-pub(crate) fn witx_path_from_args(args: TokenStream) -> (String, String) {
+pub(crate) fn witx_path_from_args(args: TokenStream) -> PathBuf {
     let mut strings = Vec::new();
 
     for arg in args {
@@ -15,20 +16,11 @@ pub(crate) fn witx_path_from_args(args: TokenStream) -> (String, String) {
         }
     }
 
-    if strings.len() != 2 {
-        panic!("expected two string literals");
+    if strings.len() != 1 {
+        panic!("expected one string literals");
     }
-
-    let phase = &strings[0];
-    let id = &strings[1];
-    let path = witx_path(phase, id);
-
-    (path, phase.clone())
-}
-
-fn witx_path(phase: &str, id: &str) -> String {
-    let root = env!("CARGO_MANIFEST_DIR");
-    format!("{}/WASI/phases/{}/witx/{}.witx", root, phase, id)
+    let root = PathBuf::from(std::env::var("WASI_ROOT").unwrap());
+    return root.join(&strings[0])
 }
 
 // Convert a `Literal` holding a string literal into the `String`.

--- a/crates/wasi-common/wig/src/utils.rs
+++ b/crates/wasi-common/wig/src/utils.rs
@@ -20,7 +20,7 @@ pub(crate) fn witx_path_from_args(args: TokenStream) -> PathBuf {
         panic!("expected one string literals");
     }
     let root = PathBuf::from(std::env::var("WASI_ROOT").unwrap());
-    return root.join(&strings[0])
+    return root.join(&strings[0]);
 }
 
 // Convert a `Literal` holding a string literal into the `String`.

--- a/crates/wasi-common/wig/src/wasi.rs
+++ b/crates/wasi-common/wig/src/wasi.rs
@@ -21,11 +21,11 @@ enum Abi {
 /// I'd recommend using `cargo +nightly expand` to explore the output of this
 /// macro some more.
 pub fn define_struct(args: TokenStream) -> TokenStream {
-    let (path, _phase) = utils::witx_path_from_args(args);
+    let path = utils::witx_path_from_args(args);
     let doc = match witx::load(&[&path]) {
         Ok(doc) => doc,
         Err(e) => {
-            panic!("error opening file {}: {}", path, e);
+            panic!("error opening file {}: {}", path.display(), e);
         }
     };
 
@@ -265,11 +265,11 @@ pub fn define_struct(args: TokenStream) -> TokenStream {
 }
 
 pub fn define_struct_for_wiggle(args: TokenStream) -> TokenStream {
-    let (path, _phase) = utils::witx_path_from_args(args);
+    let path = utils::witx_path_from_args(args);
     let doc = match witx::load(&[&path]) {
         Ok(doc) => doc,
         Err(e) => {
-            panic!("error opening file {}: {}", path, e);
+            panic!("error opening file {}: {}", path.display(), e);
         }
     };
 

--- a/crates/wasi/build.rs
+++ b/crates/wasi/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let wasi_root = std::env::var("DEP_WASI_COMMON_14_WASI").unwrap();
+    println!("cargo:rustc-env=WASI_ROOT={}", wasi_root);
+}

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -4,9 +4,7 @@ pub use wasi_common::{WasiCtx, WasiCtxBuilder};
 
 // Defines a `struct Wasi` with member fields and appropriate APIs for dealing
 // with all the various WASI exports.
-wig::define_wasi_struct_for_wiggle!(
-    "snapshot" "wasi_snapshot_preview1"
-);
+wig::define_wasi_struct_for_wiggle!("phases/snapshot/witx/wasi_snapshot_preview1.witx");
 
 pub fn is_wasi_module(name: &str) -> bool {
     // FIXME: this should be more conservative, but while WASI is in flux and

--- a/crates/wasi/src/old/snapshot_0.rs
+++ b/crates/wasi/src/old/snapshot_0.rs
@@ -3,9 +3,7 @@ pub use wasi_common::old::snapshot_0::{WasiCtx, WasiCtxBuilder};
 
 // Defines a `struct Wasi` with member fields and appropriate APIs for dealing
 // with all the various WASI exports.
-wig::define_wasi_struct!(
-    "old/snapshot_0" "wasi_unstable"
-);
+wig::define_wasi_struct!("phases/old/snapshot_0/witx/wasi_unstable.witx");
 
 pub fn is_wasi_module(name: &str) -> bool {
     // FIXME: this should be more conservative, but while WASI is in flux and

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 thiserror = "1"
-witx = { path = "../wasi-common/wig/WASI/tools/witx", version = "0.8.4", optional = true }
+witx = { path = "../wasi-common/WASI/tools/witx", version = "0.8.4", optional = true }
 wiggle-macro = { path = "macro", version = "0.14.0" }
 
 [badges]

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "LICENSE"]
 [lib]
 
 [dependencies]
-witx = { version = "0.8.4", path = "../../wasi-common/wig/WASI/tools/witx" }
+witx = { version = "0.8.4", path = "../../wasi-common/WASI/tools/witx" }
 quote = "1.0"
 proc-macro2 = "1.0"
 heck = "0.3"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 
 [dependencies]
 wiggle-generate = { path = "../generate", version = "0.14.0" }
-witx = { path = "../../wasi-common/wig/WASI/tools/witx", version = "0.8.4" }
+witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.4" }
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/scripts/bump-cranelift-version.sh
+++ b/scripts/bump-cranelift-version.sh
@@ -22,7 +22,6 @@ done
 # Update the required version numbers of path dependencies.
 find -name Cargo.toml \
     -not -path ./crates/wasi-common/WASI/tools/witx/Cargo.toml \
-    -not -path ./crates/wasi-common/wig/WASI/tools/witx/Cargo.toml \
     -exec sed -i.bk \
         -e "/^cranelift/s/version = \"[^\"]*\"/version = \"$version\"/" \
         {} \;

--- a/scripts/bump-wasmtime-version.sh
+++ b/scripts/bump-wasmtime-version.sh
@@ -16,7 +16,6 @@ version="0.14.0"
 echo "Updating crate versions to $version"
 find crates -name Cargo.toml \
     -not -path crates/wasi-common/WASI/tools/witx/Cargo.toml \
-    -not -path crates/wasi-common/wig/WASI/tools/witx/Cargo.toml \
     -exec sed -i.bk -e "s/^version = \"[.*[^0.].*\"$/version = \"$version\"/" {} \;
 
 # Updat the top-level Cargo.toml too.
@@ -25,13 +24,11 @@ sed -i.bk -e "s/^version = \"[.*[^0.].*\"$/version = \"$version\"/" Cargo.toml
 # Update the required version numbers of path dependencies.
 find -name Cargo.toml \
     -not -path ./crates/wasi-common/WASI/tools/witx/Cargo.toml \
-    -not -path ./crates/wasi-common/wig/WASI/tools/witx/Cargo.toml \
     -exec sed -i.bk \
     -e "/^\(wasmtime\|wiggle\)/s/version = \"[^\"]*\"/version = \"$version\"/" \
     {} \;
 find -name Cargo.toml \
     -not -path ./crates/wasi-common/WASI/tools/witx/Cargo.toml \
-    -not -path ./crates/wasi-common/wig/WASI/tools/witx/Cargo.toml \
     -exec sed -i.bk \
     -e "/^\(wasi-common\|wig\|yanix\|winx\|lightbeam\) = /s/version = \"[^\"]*\"/version = \"$version\"/" \
     {} \;


### PR DESCRIPTION
This commit fixes the issue where we have two WASI submodules for build
reasons in this repository. The fix was to place the submodule in the
`wasi-common` crate, and then anyone using the `wig` crate has to be
sure to define a `WASI_ROOT` env var in a build script to be able to
parse witx files.

With all that in place `wasi-common` becomes the source of truth for the
witx files we're parsing, and crates like `wasmtime-wasi` use
build-scripts shenanigans to read the same witx files. This should
hopefully get us so we're compatible with publishing and still only have
one submodule!

Closes https://github.com/bytecodealliance/wasmtime/issues/1427