### PR TITLE
Symbolize start trap traces

### DIFF
--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -123,6 +123,7 @@ impl Instance {
             }
         }
 
+        module.register_frame_info();
         let config = store.engine().config();
         let instance_handle = instantiate(
             config,
@@ -141,7 +142,6 @@ impl Instance {
                 export,
             ));
         }
-        module.register_frame_info();
         Ok(Instance {
             instance_handle,
             module: module.clone(),


### PR DESCRIPTION
Make sure we've registered the frame info early enough so traps during
instantiation give frames as well.
