### PR TITLE
Avoid `infer_rex` and `w` on the same encoding template

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -156,7 +156,7 @@ impl PerCpuModeEncodings {
         self.enc64(inst.bind(I32), template.infer_rex());
 
         // I64 on x86_64: REX.W set; REX.RXB determined at runtime from registers.
-        self.enc64(inst.bind(I64), template.infer_rex().w());
+        self.enc64(inst.bind(I64), template.rex().w());
     }
 
     /// Adds I32/I64 encodings as appropriate for a typed instruction.
@@ -192,7 +192,7 @@ impl PerCpuModeEncodings {
         self.enc64(inst.bind(B32), template.infer_rex());
 
         // B64 on x86_64: REX.W set; REX.RXB determined at runtime from registers.
-        self.enc64(inst.bind(B64), template.infer_rex().w());
+        self.enc64(inst.bind(B64), template.rex().w());
     }
 
     /// Add encodings for `inst.i32` to X86_32.

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -335,6 +335,7 @@ impl<'builder> Template<'builder> {
                 ("Rex".to_string() + opcode, self.op_bytes.len() as u64 + 1)
             }
             RecipePrefixKind::InferRex => {
+                assert_eq!(self.w_bit, 0, "A REX.W bit always requires a REX prefix; avoid using `infer_rex().w()` and use `rex().w()` instead.");
                 // Hook up the right function for inferred compute_size().
                 assert!(
                     self.inferred_rex_compute_size.is_some(),

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -16,8 +16,6 @@ use crate::isa::{self, TargetIsa};
 use crate::predicates;
 use crate::regalloc::RegDiversions;
 
-use cranelift_codegen_shared::isa::x86::EncodingBits;
-
 include!(concat!(env!("OUT_DIR"), "/encoding-x86.rs"));
 include!(concat!(env!("OUT_DIR"), "/legalize-x86.rs"));
 
@@ -132,8 +130,8 @@ fn size_plus_maybe_sib_or_offset_inreg1_plus_rex_prefix_for_inreg0_inreg1(
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg)
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(0, inst, divert, func, is_extended_reg)
         || test_input(1, inst, divert, func, is_extended_reg);
     size_plus_maybe_sib_or_offset_for_inreg_1(sizing, enc, inst, divert, func)
         + if needs_rex { 1 } else { 0 }
@@ -148,8 +146,8 @@ fn size_plus_maybe_sib_inreg1_plus_rex_prefix_for_inreg0_inreg1(
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg)
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(0, inst, divert, func, is_extended_reg)
         || test_input(1, inst, divert, func, is_extended_reg);
     size_plus_maybe_sib_for_inreg_1(sizing, enc, inst, divert, func) + if needs_rex { 1 } else { 0 }
 }
@@ -164,8 +162,8 @@ fn size_plus_maybe_sib_or_offset_for_inreg_0_plus_rex_prefix_for_inreg0_outreg0(
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg)
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(0, inst, divert, func, is_extended_reg)
         || test_result(0, inst, divert, func, is_extended_reg);
     size_plus_maybe_sib_or_offset_for_inreg_0(sizing, enc, inst, divert, func)
         + if needs_rex { 1 } else { 0 }
@@ -181,8 +179,8 @@ fn size_plus_maybe_sib_for_inreg_0_plus_rex_prefix_for_inreg0_outreg0(
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg)
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(0, inst, divert, func, is_extended_reg)
         || test_result(0, inst, divert, func, is_extended_reg);
     size_plus_maybe_sib_for_inreg_0(sizing, enc, inst, divert, func) + if needs_rex { 1 } else { 0 }
 }
@@ -194,39 +192,39 @@ fn size_plus_maybe_sib_for_inreg_0_plus_rex_prefix_for_inreg0_outreg0(
 ///  2. Registers are used that require REX.R or REX.B bits for encoding.
 fn size_with_inferred_rex_for_inreg0(
     sizing: &RecipeSizing,
-    enc: Encoding,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg);
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(0, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
 
 /// Infers whether a dynamic REX prefix will be emitted, based on the second operand.
 fn size_with_inferred_rex_for_inreg1(
     sizing: &RecipeSizing,
-    enc: Encoding,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(1, inst, divert, func, is_extended_reg);
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(1, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
 
 /// Infers whether a dynamic REX prefix will be emitted, based on the third operand.
 fn size_with_inferred_rex_for_inreg2(
     sizing: &RecipeSizing,
-    enc: Encoding,
+    _: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(2, inst, divert, func, is_extended_reg);
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(2, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
 
@@ -237,13 +235,13 @@ fn size_with_inferred_rex_for_inreg2(
 ///  2. Registers are used that require REX.R or REX.B bits for encoding.
 fn size_with_inferred_rex_for_inreg0_inreg1(
     sizing: &RecipeSizing,
-    enc: Encoding,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg)
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(0, inst, divert, func, is_extended_reg)
         || test_input(1, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
@@ -252,13 +250,13 @@ fn size_with_inferred_rex_for_inreg0_inreg1(
 /// input register and a single output register.
 fn size_with_inferred_rex_for_inreg0_outreg0(
     sizing: &RecipeSizing,
-    enc: Encoding,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg)
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(0, inst, divert, func, is_extended_reg)
         || test_result(0, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
@@ -266,13 +264,13 @@ fn size_with_inferred_rex_for_inreg0_outreg0(
 /// Infers whether a dynamic REX prefix will be emitted, based on a single output register.
 fn size_with_inferred_rex_for_outreg0(
     sizing: &RecipeSizing,
-    enc: Encoding,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_result(0, inst, divert, func, is_extended_reg);
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_result(0, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
 
@@ -281,13 +279,13 @@ fn size_with_inferred_rex_for_outreg0(
 /// CMOV uses 3 inputs, with the REX is inferred from reg1 and reg2.
 fn size_with_inferred_rex_for_cmov(
     sizing: &RecipeSizing,
-    enc: Encoding,
+    _enc: Encoding,
     inst: Inst,
     divert: &RegDiversions,
     func: &Function,
 ) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(1, inst, divert, func, is_extended_reg)
+    // No need to check for REX.W in `needs_rex` because `infer_rex().w()` is not allowed.
+    let needs_rex = test_input(1, inst, divert, func, is_extended_reg)
         || test_input(2, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }

--- a/cranelift/filetests/filetests/isa/x86/legalize-br-icmp.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-br-icmp.clif
@@ -15,7 +15,7 @@ block1:
 ; sameln: function %br_icmp(i64 [%rdi]) fast {
 ; nextln:                                 block0(v0: i64):
 ; nextln: [RexOp1pu_id#b8]                    v1 = iconst.i64 0
-; nextln: [DynRexOp1icscc#8039]               v2 = icmp eq v0, v1
+; nextln: [RexOp1icscc#8039]                  v2 = icmp eq v0, v1
 ; nextln: [RexOp1t8jccb#75]                   brnz v2, block1
 ; nextln: [Op1jmpb#eb]                        jump block1
 ; nextln: 
@@ -37,7 +37,7 @@ block1(v2: i64):
 ; sameln: function %br_icmp_args(i64 [%rdi]) fast {
 ; nextln:                                 block0(v0: i64):
 ; nextln: [RexOp1pu_id#b8]                    v1 = iconst.i64 0
-; nextln: [DynRexOp1icscc#8039]               v3 = icmp eq v0, v1
+; nextln: [RexOp1icscc#8039]                  v3 = icmp eq v0, v1
 ; nextln: [RexOp1t8jccb#75]                   brnz v3, block1(v0)
 ; nextln: [Op1jmpb#eb]                        jump block1(v0)
 ; nextln: 

--- a/cranelift/filetests/filetests/isa/x86/relax_branch.clif
+++ b/cranelift/filetests/filetests/isa/x86/relax_branch.clif
@@ -22,7 +22,7 @@ function u0:2691(i32 [%rdi], i32 [%rsi], i64 vmctx [%r14]) -> i64 uext [%rax] ba
 
                                 block3(v8: i32 [%rdi], v19: i32 [%rsi]):
 @0005 [RexOp1ldDisp8#808b,%rax]        v7 = load.i64 v2+48
-@0005 [DynRexOp1rcmp_ib#f083,%rflags]  v91 = ifcmp_imm v7, 0
+@0005 [RexOp1rcmp_ib#f083,%rflags]     v91 = ifcmp_imm v7, 0
 @0005 [trapif#00]                      trapif ne v91, interrupt
 [DynRexOp1umr#89,%rax]                 v105 = copy v8
 @000b [DynRexOp1r_ib#83,%rax]          v10 = iadd_imm v105, 1

--- a/cranelift/filetests/filetests/postopt/complex_memory_ops.clif
+++ b/cranelift/filetests/filetests/postopt/complex_memory_ops.clif
@@ -3,7 +3,7 @@ target x86_64
 
 function %dual_loads(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
-[DynRexOp1rr#8001] v3 = iadd v0, v1
+[RexOp1rr#8001]    v3 = iadd v0, v1
                    v4 = load.i64 v3
                    v5 = uload8.i64 v3
                    v6 = sload8.i64 v3
@@ -29,7 +29,7 @@ block0(v0: i64, v1: i64):
 
 function %dual_loads2(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
-[DynRexOp1rr#8001] v3 = iadd v0, v1
+[RexOp1rr#8001]    v3 = iadd v0, v1
                    v4 = load.i64 v3+1
                    v5 = uload8.i64 v3+1
                    v6 = sload8.i64 v3+1
@@ -55,7 +55,7 @@ block0(v0: i64, v1: i64):
 
 function %dual_stores(i64, i64, i64) {
 block0(v0: i64, v1: i64, v2: i64):
-[DynRexOp1rr#8001] v3 = iadd v0, v1
+[RexOp1rr#8001]    v3 = iadd v0, v1
 [RexOp1st#8089]    store.i64 v2, v3
 [RexOp1st#88]      istore8.i64 v2, v3
 [RexMp1st#189]     istore16.i64 v2, v3
@@ -75,7 +75,7 @@ block0(v0: i64, v1: i64, v2: i64):
 
 function %dual_stores2(i64, i64, i64) {
 block0(v0: i64, v1: i64, v2: i64):
-[DynRexOp1rr#8001] v3 = iadd v0, v1
+[RexOp1rr#8001]         v3 = iadd v0, v1
 [RexOp1stDisp8#8089]    store.i64 v2, v3+1
 [RexOp1stDisp8#88]      istore8.i64 v2, v3+1
 [RexMp1stDisp8#189]     istore16.i64 v2, v3+1

--- a/cranelift/filetests/filetests/regalloc/coloring-227.clif
+++ b/cranelift/filetests/filetests/regalloc/coloring-227.clif
@@ -40,9 +40,9 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
                           block16:
 [RexOp1pu_id#b8]              v21 = iconst.i32 0
 [RexOp1umr#89]                v79 = uextend.i64 v5
-[DynRexOp1r_ib#8083]          v80 = iadd_imm.i64 v4, 0
+[RexOp1r_ib#8083]             v80 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v81 = load.i64 v80
-[DynRexOp1rr#8001]            v22 = iadd v81, v79
+[RexOp1rr#8001]               v22 = iadd v81, v79
 [RexMp1st#189]                istore16 v21, v22
 [Op1jmpb#eb]                  jump block9
 
@@ -81,14 +81,14 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 
                           block19:
 [RexOp1umr#89]                v82 = uextend.i64 v52
-[DynRexOp1r_ib#8083]          v83 = iadd_imm.i64 v4, 0
+[RexOp1r_ib#8083]             v83 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v84 = load.i64 v83
-[DynRexOp1rr#8001]            v57 = iadd v84, v82
+[RexOp1rr#8001]               v57 = iadd v84, v82
 [RexOp1ld#8b]                 v58 = load.i32 v57
 [RexOp1umr#89]                v85 = uextend.i64 v58
-[DynRexOp1r_ib#8083]          v86 = iadd_imm.i64 v4, 0
+[RexOp1r_ib#8083]             v86 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v87 = load.i64 v86
-[DynRexOp1rr#8001]            v64 = iadd v87, v85
+[RexOp1rr#8001]               v64 = iadd v87, v85
 [RexOp1st#88]                 istore8 v59, v64
 [RexOp1pu_id#b8]              v65 = iconst.i32 0
 [Op1jmpb#eb]                  jump block13(v65)
@@ -98,9 +98,9 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 
                           block13(v51: i32):
 [RexOp1umr#89]                v88 = uextend.i64 v45
-[DynRexOp1r_ib#8083]          v89 = iadd_imm.i64 v4, 0
+[RexOp1r_ib#8083]             v89 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v90 = load.i64 v89
-[DynRexOp1rr#8001]            v71 = iadd v90, v88
+[RexOp1rr#8001]               v71 = iadd v90, v88
 [RexOp1st#89]                 store v51, v71
 [Op1jmpb#eb]                  jump block12
 


### PR DESCRIPTION
This relates to #1342; in #1335, @bnjbvr and I [discussed](https://github.com/bytecodealliance/wasmtime/pull/1335#discussion_r393784241) that we should disallow code like `infer_rex().w()` in  the meta crate since the presence of a REX.W by necessity requires a REX prefix. To avoid ambiguity, we now require `rex().w()` instead.

Though all the tests pass, the tricky part of this PR is deciding whether the subsequent two commits, the "Skip extra work..." optimizations, are always correct. What these should do is avoid checks on the REX.W bit when we are dealing with a recipe that has inferred REX prefixes; since `infer_rex()` and `w()` can no longer go together, the thought is that we could avoid some (negligible) extra work checking for this bit when determining if a REX prefix is needed--i.e. we only need to check the RXB bits. I am open to removing these commits or adding tests (but which ones?) to prove this is correct since I am rather wary that the "we are dealing with a recipe that has inferred REX prefixes" assumption always holds.

I'll tag multiple people as reviewers for extra eyes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
