### PR TITLE
wiggle: remove versions and dont publish wiggle-test

### DIFF
--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -19,7 +19,7 @@ wiggle-macro = { path = "macro", version = "0.14.0" }
 maintenance = { status = "actively-developed" }
 
 [dev-dependencies]
-wiggle-test = { path = "test-helpers", version = "0.14.0" }
+wiggle-test = { path = "test-helpers" }
 proptest = "0.9"
 
 [features]

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 proptest = "0.9"
-wiggle = { path = "..", version = "0.14.0" }
+wiggle = { path = ".." }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/scripts/publish-wasmtime.sh
+++ b/scripts/publish-wasmtime.sh
@@ -24,7 +24,6 @@ for cargo_toml in \
     crates/wiggle/generate/Cargo.toml \
     crates/wiggle/macro/Cargo.toml \
     crates/wiggle/Cargo.toml \
-    crates/wiggle/test-helper/Cargo.toml \
     crates/wasi-common/Cargo.toml \
     crates/lightbeam/Cargo.toml \
     crates/environ/Cargo.toml \


### PR DESCRIPTION
Replaces #1445 with @alexcrichton's suggestion:

* remove `version = "..."` dependencies from wiggle to wiggle-test, and vice versa
* remove wiggle-test from the publish script

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
