### PR TITLE
Propertly simulate DWARF information when imports present 

### DIFF
--- a/crates/debug/src/transform/address_transform.rs
+++ b/crates/debug/src/transform/address_transform.rs
@@ -737,6 +737,7 @@ mod tests {
             &WasmFileInfo {
                 path: None,
                 code_section_offset: 1,
+                imported_func_count: 0,
                 funcs: Box::new([]),
             },
         );

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -333,7 +333,14 @@ where
                 return Ok(None);
             }
             let index = pc.read_sleb128()?;
-            pc.read_u8()?; // consume 159
+            if pc.read_u8()? != 159 {
+                // FIXME The following operator is not DW_OP_stack_value, e.g. :
+                // DW_AT_location  (0x00000ea5:
+                //   [0x00001e19, 0x00001e26): DW_OP_WASM_location 0x0 +1, DW_OP_plus_uconst 0x10, DW_OP_stack_value
+                //   [0x00001e5a, 0x00001e72): DW_OP_WASM_location 0x0 +20, DW_OP_stack_value
+                // )
+                return Ok(None);
+            }
             if !code_chunk.is_empty() {
                 parts.push(CompiledExpressionPart::Code(code_chunk));
                 code_chunk = Vec::new();

--- a/crates/debug/src/transform/unit.rs
+++ b/crates/debug/src/transform/unit.rs
@@ -10,8 +10,8 @@ use anyhow::{Context, Error};
 use gimli::write;
 use gimli::{AttributeValue, DebuggingInformationEntry, Unit};
 use std::collections::HashSet;
-use wasmtime_environ::entity::EntityRef;
 use wasmtime_environ::isa::TargetIsa;
+use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::{ModuleVmctxInfo, ValueLabelsRanges};
 
 struct InheritedAttr<T> {
@@ -148,7 +148,7 @@ pub(crate) fn clone_unit<'a, R>(
     module_info: &ModuleVmctxInfo,
     out_units: &mut write::UnitTable,
     out_strings: &mut write::StringTable,
-    translated: &mut HashSet<u32>,
+    translated: &mut HashSet<DefinedFuncIndex>,
     isa: &dyn TargetIsa,
 ) -> Result<Option<(write::UnitId, UnitRefsMap, PendingDebugInfoRefs)>, Error>
 where
@@ -270,7 +270,7 @@ where
                 {
                     current_value_range.push(new_stack_len, frame_info);
                 }
-                translated.insert(func_index.index() as u32);
+                translated.insert(func_index);
                 current_scope_ranges.push(new_stack_len, range_builder.get_ranges(addr_tr));
                 Some(range_builder)
             } else {

--- a/tests/debug/simulate.rs
+++ b/tests/debug/simulate.rs
@@ -54,3 +54,24 @@ fn test_debug_dwarf_simulate_simple_x86_64() -> Result<()> {
 )"#,
     )
 }
+
+#[test]
+#[ignore]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    target_pointer_width = "64"
+))]
+fn test_debug_dwarf_simulate_with_imports_x86_64() -> Result<()> {
+    check_wat(
+        r#"
+;; check: DW_TAG_compile_unit 
+(module
+;; check: DW_TAG_subprogram 
+;; check: DW_AT_name	("func1")
+    (import "foo" "bar" (func $import1) )
+    (func $func1 (result i32)
+        i32.const 1
+    )
+)"#,
+    )
+}


### PR DESCRIPTION
Before PR the simulated DWARF contained wrong function names, which makes stack trace unusable -- fixing that.

Bonus fix for LLVM 10 generated DWARF expressions.