### PR TITLE
cranelift-object: mark output as using non-executable stacks

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -13,7 +13,9 @@ use cranelift_module::{
 use object::write::{
     Object, Relocation, SectionId, StandardSection, Symbol, SymbolId, SymbolSection,
 };
-use object::{RelocationEncoding, RelocationKind, SymbolFlags, SymbolKind, SymbolScope};
+use object::{
+    RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
+};
 use std::collections::HashMap;
 use std::mem;
 use target_lexicon::{BinaryFormat, PointerWidth};
@@ -378,6 +380,15 @@ impl Backend for ObjectBackend {
                     )
                     .unwrap();
             }
+        }
+
+        // Indicate that this object has a non-executable stack.
+        if self.object.format() == BinaryFormat::Elf {
+            self.object.add_section(
+                vec![],
+                ".note.GNU-stack".as_bytes().to_vec(),
+                SectionKind::Linker,
+            );
         }
 
         ObjectProduct {


### PR DESCRIPTION
The `faerie` crate does this by default.  `object` itself does not, but
it seems reasonable to make this change for parity between
`cranelift-faerie` and `cranelift-object`.
