### PR TITLE
Only infer REX prefixes in i64 mode; fixes #1421

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1945,15 +1945,8 @@ fn define_simd(
         for recipe in &[rec_fld, rec_fldDisp8, rec_fldDisp32] {
             let inst = *inst;
             let template = recipe.opcodes(*opcodes);
-            e.enc32_maybe_isap(inst.clone().bind(I32), template.clone(), isap);
-            // REX-less encoding must come after REX encoding so we don't use it by
-            // default. Otherwise reg-alloc would never use r8 and up.
-            e.enc64_maybe_isap(inst.clone().bind(I32), template.clone().rex(), isap);
-            e.enc64_maybe_isap(inst.clone().bind(I32), template.clone(), isap);
-            // Similar to above; TODO some of this duplication can be cleaned up by infer_rex()
-            // tracked in https://github.com/bytecodealliance/cranelift/issues/1090
-            e.enc64_maybe_isap(inst.clone().bind(I64), template.clone().rex(), isap);
-            e.enc64_maybe_isap(inst.bind(I64), template, isap);
+            e.enc_both_inferred_maybe_isap(inst.clone().bind(I32), template.clone(), isap);
+            e.enc64_maybe_isap(inst.bind(I64), template.infer_rex(), isap);
         }
     }
 

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1866,8 +1866,8 @@ fn define_simd(
         // Store
         let bound_store = store.bind(vector(ty, sse_vector_size)).bind(Any);
         e.enc_both_inferred(bound_store.clone(), rec_fst.opcodes(&MOVUPS_STORE));
-        e.enc_both(bound_store.clone(), rec_fstDisp8.opcodes(&MOVUPS_STORE));
-        e.enc_both(bound_store, rec_fstDisp32.opcodes(&MOVUPS_STORE));
+        e.enc_both_inferred(bound_store.clone(), rec_fstDisp8.opcodes(&MOVUPS_STORE));
+        e.enc_both_inferred(bound_store, rec_fstDisp32.opcodes(&MOVUPS_STORE));
 
         // Store complex
         let bound_store_complex = store_complex.bind(vector(ty, sse_vector_size));
@@ -1887,8 +1887,8 @@ fn define_simd(
         // Load
         let bound_load = load.bind(vector(ty, sse_vector_size)).bind(Any);
         e.enc_both_inferred(bound_load.clone(), rec_fld.opcodes(&MOVUPS_LOAD));
-        e.enc_both(bound_load.clone(), rec_fldDisp8.opcodes(&MOVUPS_LOAD));
-        e.enc_both(bound_load, rec_fldDisp32.opcodes(&MOVUPS_LOAD));
+        e.enc_both_inferred(bound_load.clone(), rec_fldDisp8.opcodes(&MOVUPS_LOAD));
+        e.enc_both_inferred(bound_load, rec_fldDisp32.opcodes(&MOVUPS_LOAD));
 
         // Load complex
         let bound_load_complex = load_complex.bind(vector(ty, sse_vector_size));

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -313,10 +313,10 @@ impl PerCpuModeEncodings {
     }
 
     /// Add two encodings for `inst`:
-    /// - X86_32, dynamically infer the REX prefix.
+    /// - X86_32, no REX prefix, since this is not valid in 32-bit mode.
     /// - X86_64, dynamically infer the REX prefix.
     fn enc_both_inferred(&mut self, inst: impl Clone + Into<InstSpec>, template: Template) {
-        self.enc32(inst.clone(), template.infer_rex());
+        self.enc32(inst.clone(), template.clone());
         self.enc64(inst, template.infer_rex());
     }
     fn enc_both_inferred_maybe_isap(
@@ -325,7 +325,7 @@ impl PerCpuModeEncodings {
         template: Template,
         isap: Option<SettingPredicateNumber>,
     ) {
-        self.enc32_maybe_isap(inst.clone(), template.infer_rex(), isap);
+        self.enc32_maybe_isap(inst.clone(), template.clone(), isap);
         self.enc64_maybe_isap(inst, template.infer_rex(), isap);
     }
 

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -2087,7 +2087,7 @@ pub(crate) fn define<'shared>(
         );
 
         // XX /r float load with 8-bit offset.
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("fldDisp8", &formats.load, 2)
                 .operands_in(vec![gpr])
                 .operands_out(vec![fpr])
@@ -2110,6 +2110,7 @@ pub(crate) fn define<'shared>(
                         sink.put1(offset as u8);
                     "#,
                 ),
+            "size_plus_maybe_sib_for_inreg_0_plus_rex_prefix_for_inreg0_outreg0",
         );
 
         let has_big_offset =
@@ -2142,7 +2143,7 @@ pub(crate) fn define<'shared>(
         );
 
         // XX /r float load with 32-bit offset.
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("fldDisp32", &formats.load, 5)
                 .operands_in(vec![gpr])
                 .operands_out(vec![fpr])
@@ -2165,6 +2166,7 @@ pub(crate) fn define<'shared>(
                         sink.put4(offset as u32);
                     "#,
                 ),
+            "size_plus_maybe_sib_for_inreg_0_plus_rex_prefix_for_inreg0_outreg0",
         );
     }
 

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -1604,7 +1604,7 @@ pub(crate) fn define<'shared>(
         );
 
         // XX /r register-indirect store with 8-bit offset of FPR.
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("fstDisp8", &formats.store, 2)
                 .operands_in(vec![fpr, gpr])
                 .inst_predicate(has_small_offset)
@@ -1626,6 +1626,7 @@ pub(crate) fn define<'shared>(
                         sink.put1(offset as u8);
                     "#,
                 ),
+            "size_plus_maybe_sib_inreg1_plus_rex_prefix_for_inreg0_inreg1",
         );
 
         // XX /r register-indirect store with 32-bit offset.
@@ -1682,7 +1683,7 @@ pub(crate) fn define<'shared>(
         );
 
         // XX /r register-indirect store with 32-bit offset of FPR.
-        recipes.add_template_recipe(
+        recipes.add_template_inferred(
             EncodingRecipeBuilder::new("fstDisp32", &formats.store, 5)
                 .operands_in(vec![fpr, gpr])
                 .clobbers_flags(false)
@@ -1703,6 +1704,7 @@ pub(crate) fn define<'shared>(
                         sink.put4(offset as u32);
                     "#,
                 ),
+            "size_plus_maybe_sib_inreg1_plus_rex_prefix_for_inreg0_inreg1",
         );
     }
 

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -156,6 +156,22 @@ fn size_plus_maybe_sib_or_offset_for_inreg_0_plus_rex_prefix_for_inreg0_outreg0(
         + if needs_rex { 1 } else { 0 }
 }
 
+/// Calculates the size while inferring if the first input register (inreg0) and first output
+/// register (outreg0) require a dynamic REX and if the first input register (inreg0) requires a
+/// SIB.
+fn size_plus_maybe_sib_for_inreg_0_plus_rex_prefix_for_inreg0_outreg0(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
+        || test_input(0, inst, divert, func, is_extended_reg)
+        || test_result(0, inst, divert, func, is_extended_reg);
+    size_plus_maybe_sib_for_inreg_0(sizing, enc, inst, divert, func) + if needs_rex { 1 } else { 0 }
+}
+
 /// Infers whether a dynamic REX prefix will be emitted, for use with one input reg.
 ///
 /// A REX prefix is known to be emitted if either:

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -139,6 +139,21 @@ fn size_plus_maybe_sib_or_offset_inreg1_plus_rex_prefix_for_inreg0_inreg1(
         + if needs_rex { 1 } else { 0 }
 }
 
+/// Calculates the size while inferring if the first and second input registers (inreg0, inreg1)
+/// require a dynamic REX prefix and if the second input register (inreg1) requires a SIB.
+fn size_plus_maybe_sib_inreg1_plus_rex_prefix_for_inreg0_inreg1(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
+        || test_input(0, inst, divert, func, is_extended_reg)
+        || test_input(1, inst, divert, func, is_extended_reg);
+    size_plus_maybe_sib_for_inreg_1(sizing, enc, inst, divert, func) + if needs_rex { 1 } else { 0 }
+}
+
 /// Calculates the size while inferring if the first input register (inreg0) and first output
 /// register (outreg0) require a dynamic REX and if the first input register (inreg0) requires a
 /// SIB or offset.

--- a/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
@@ -7,13 +7,30 @@ block0(v0: i64 [%rax]):
 [-, %xmm0]    v10 = load.i32x4 v0   ; bin: heap_oob 0f 10 00
 [-]           store v10, v0         ; bin: heap_oob 0f 11 00
 
-              ; use displacement
-[-, %xmm0]    v11 = load.f32x4 v0+42 ; bin: heap_oob 40 0f 10 40 2a
-[-]           store v11, v0+42       ; bin: heap_oob 40 0f 11 40 2a
-
               ; use REX prefix
 [-, %xmm8]    v12 = load.i8x16 v0   ; bin: heap_oob 44 0f 10 00
 [-]           store v12, v0         ; bin: heap_oob 44 0f 11 00
+
+    return
+}
+
+function %load_store_with_displacement(i64) {
+block0(v0: i64 [%rax]):
+              ; use 8-bit displacement
+[-, %xmm0]    v1 = load.f32x4 v0+42 ; bin: heap_oob 0f 10 40 2a
+[-]           store v1, v0+42       ; bin: heap_oob 0f 11 40 2a
+
+              ; use 8-bit displacement with REX prefix
+[-, %xmm8]    v2 = load.i8x16 v0   ; bin: heap_oob 44 0f 10 00
+[-]           store v2, v0         ; bin: heap_oob 44 0f 11 00
+
+              ; use 32-bit displacement
+[-, %xmm0]    v3 = load.f32x4 v0+256 ; bin: heap_oob 0f 10 80 00000100
+[-]           store v3, v0+256       ; bin: heap_oob 0f 11 80 00000100
+
+              ; use 32-bit displacement with REX prefix
+[-, %xmm8]    v4 = load.f32x4 v0+256 ; bin: heap_oob 44 0f 10 80 00000100
+[-]           store v4, v0+256       ; bin: heap_oob 44 0f 11 80 00000100
 
     return
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
@@ -40,29 +40,29 @@ block0:
 function %uload_extend() {
 block0:
     [-,%rdx]     v1 = iconst.i64 0x0123_4567_89ab_cdef
-    [-,%xmm2]    v3 = uload8x8 v1+0     ; bin: heap_oob 66 40 0f 38 30 12
-    [-,%xmm2]    v4 = uload8x8 v1+20    ; bin: heap_oob 66 40 0f 38 30 52 14
-    [-,%xmm2]    v5 = uload8x8 v1+256   ; bin: heap_oob 66 40 0f 38 30 92 00000100
-    [-,%xmm2]    v6 = uload16x4 v1+0    ; bin: heap_oob 66 40 0f 38 33 12
-    [-,%xmm2]    v7 = uload16x4 v1+20   ; bin: heap_oob 66 40 0f 38 33 52 14
-    [-,%xmm2]    v8 = uload16x4 v1+256  ; bin: heap_oob 66 40 0f 38 33 92 00000100
-    [-,%xmm2]    v9 = uload32x2 v1+0    ; bin: heap_oob 66 40 0f 38 35 12
-    [-,%xmm2]    v10 = uload32x2 v1+20  ; bin: heap_oob 66 40 0f 38 35 52 14
-    [-,%xmm2]    v11 = uload32x2 v1+256 ; bin: heap_oob 66 40 0f 38 35 92 00000100
+    [-,%xmm2]    v3 = uload8x8 v1+0     ; bin: heap_oob 66 0f 38 30 12
+    [-,%xmm2]    v4 = uload8x8 v1+20    ; bin: heap_oob 66 0f 38 30 52 14
+    [-,%xmm2]    v5 = uload8x8 v1+256   ; bin: heap_oob 66 0f 38 30 92 00000100
+    [-,%xmm2]    v6 = uload16x4 v1+0    ; bin: heap_oob 66 0f 38 33 12
+    [-,%xmm2]    v7 = uload16x4 v1+20   ; bin: heap_oob 66 0f 38 33 52 14
+    [-,%xmm2]    v8 = uload16x4 v1+256  ; bin: heap_oob 66 0f 38 33 92 00000100
+    [-,%xmm10]   v9 = uload32x2 v1+0    ; bin: heap_oob 66 44 0f 38 35 12
+    [-,%xmm10]   v10 = uload32x2 v1+20  ; bin: heap_oob 66 44 0f 38 35 52 14
+    [-,%xmm10]   v11 = uload32x2 v1+256 ; bin: heap_oob 66 44 0f 38 35 92 00000100
     return
 }
 
 function %sload_extend() {
 block0:
     [-,%rdx]     v1 = iconst.i64 0x0123_4567_89ab_cdef
-    [-,%xmm2]    v3 = sload8x8 v1+0     ; bin: heap_oob 66 40 0f 38 20 12
-    [-,%xmm2]    v4 = sload8x8 v1+20    ; bin: heap_oob 66 40 0f 38 20 52 14
-    [-,%xmm2]    v5 = sload8x8 v1+256   ; bin: heap_oob 66 40 0f 38 20 92 00000100
-    [-,%xmm2]    v6 = sload16x4 v1+0    ; bin: heap_oob 66 40 0f 38 23 12
-    [-,%xmm2]    v7 = sload16x4 v1+20   ; bin: heap_oob 66 40 0f 38 23 52 14
-    [-,%xmm2]    v8 = sload16x4 v1+256  ; bin: heap_oob 66 40 0f 38 23 92 00000100
-    [-,%xmm2]    v9 = sload32x2 v1+0    ; bin: heap_oob 66 40 0f 38 25 12
-    [-,%xmm2]    v10 = sload32x2 v1+20  ; bin: heap_oob 66 40 0f 38 25 52 14
-    [-,%xmm2]    v11 = sload32x2 v1+256 ; bin: heap_oob 66 40 0f 38 25 92 00000100
+    [-,%xmm2]    v3 = sload8x8 v1+0     ; bin: heap_oob 66 0f 38 20 12
+    [-,%xmm2]    v4 = sload8x8 v1+20    ; bin: heap_oob 66 0f 38 20 52 14
+    [-,%xmm2]    v5 = sload8x8 v1+256   ; bin: heap_oob 66 0f 38 20 92 00000100
+    [-,%xmm10]   v6 = sload16x4 v1+0    ; bin: heap_oob 66 44 0f 38 23 12
+    [-,%xmm10]   v7 = sload16x4 v1+20   ; bin: heap_oob 66 44 0f 38 23 52 14
+    [-,%xmm10]   v8 = sload16x4 v1+256  ; bin: heap_oob 66 44 0f 38 23 92 00000100
+    [-,%xmm2]    v9 = sload32x2 v1+0    ; bin: heap_oob 66 0f 38 25 12
+    [-,%xmm2]    v10 = sload32x2 v1+20  ; bin: heap_oob 66 0f 38 25 52 14
+    [-,%xmm2]    v11 = sload32x2 v1+256 ; bin: heap_oob 66 0f 38 25 92 00000100
     return
 }


### PR DESCRIPTION
As described in #1421, REX prefixes should only be inferred for 64-bit mode instructions; 32-bit mode instructions can't have a REX prefix. Also, this adds the ability for some additional SIMD instructions to use `infer_rex`.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
