### PR TITLE
Remove unnecessary braces around assigned value in simple_preopt

### DIFF
--- a/cranelift/codegen/src/simple_preopt.rs
+++ b/cranelift/codegen/src/simple_preopt.rs
@@ -902,8 +902,8 @@ fn branch_order(pos: &mut FuncCursor, cfg: &mut ControlFlowGraph, block: Block, 
             _ => return,
         };
 
-    let cond_args = { cond_inst_args.as_slice(&pos.func.dfg.value_lists).to_vec() };
-    let term_args = { term_inst_args.as_slice(&pos.func.dfg.value_lists).to_vec() };
+    let cond_args = cond_inst_args.as_slice(&pos.func.dfg.value_lists).to_vec();
+    let term_args = term_inst_args.as_slice(&pos.func.dfg.value_lists).to_vec();
 
     match kind {
         BranchOrderKind::BrnzToBrz(cond_arg) => {


### PR DESCRIPTION
Removes unnecessary braces that is causing compilation failure
in a test scenario.

Submitted to address a testing failure.

https://github.com/bytecodealliance/wasmtime/issues/1458

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
