### PR TITLE
Add add_call_site + pass SourceLoc in RelocSink

### DIFF
--- a/cranelift/codegen/meta/src/isa/riscv/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/riscv/recipes.rs
@@ -205,7 +205,8 @@ pub(crate) fn define(shared_defs: &SharedDefinitions, regs: &IsaRegs) -> RecipeG
 
     recipes.push(EncodingRecipeBuilder::new("UJcall", &formats.call, 4).emit(
         r#"
-                    sink.reloc_external(Reloc::RiscvCall,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::RiscvCall,
                                         &func.dfg.ext_funcs[func_ref].name,
                                         0);
                     // rd=%x1 is the standard link register.

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -1258,7 +1258,8 @@ pub(crate) fn define<'shared>(
             .emit(
                 r#"
                     {{PUT_OP}}(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-                    sink.reloc_external(Reloc::Abs4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::Abs4,
                                         &func.dfg.ext_funcs[func_ref].name,
                                         0);
                     sink.put4(0);
@@ -1273,7 +1274,8 @@ pub(crate) fn define<'shared>(
             .emit(
                 r#"
                     {{PUT_OP}}(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-                    sink.reloc_external(Reloc::Abs8,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::Abs8,
                                         &func.dfg.ext_funcs[func_ref].name,
                                         0);
                     sink.put8(0);
@@ -1288,7 +1290,8 @@ pub(crate) fn define<'shared>(
             .emit(
                 r#"
                     {{PUT_OP}}(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-                    sink.reloc_external(Reloc::Abs4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::Abs4,
                                         &func.dfg.ext_funcs[func_ref].name,
                                         0);
                     // Write the immediate as `!0` for the benefit of BaldrMonkey.
@@ -1304,7 +1307,8 @@ pub(crate) fn define<'shared>(
             .emit(
                 r#"
                     {{PUT_OP}}(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-                    sink.reloc_external(Reloc::Abs8,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::Abs8,
                                         &func.dfg.ext_funcs[func_ref].name,
                                         0);
                     // Write the immediate as `!0` for the benefit of BaldrMonkey.
@@ -1324,7 +1328,8 @@ pub(crate) fn define<'shared>(
                     modrm_riprel(out_reg0, sink);
                     // The addend adjusts for the difference between the end of the
                     // instruction and the beginning of the immediate field.
-                    sink.reloc_external(Reloc::X86PCRel4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::X86PCRel4,
                                         &func.dfg.ext_funcs[func_ref].name,
                                         -4);
                     sink.put4(0);
@@ -1343,7 +1348,8 @@ pub(crate) fn define<'shared>(
                     modrm_riprel(out_reg0, sink);
                     // The addend adjusts for the difference between the end of the
                     // instruction and the beginning of the immediate field.
-                    sink.reloc_external(Reloc::X86GOTPCRel4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::X86GOTPCRel4,
                                         &func.dfg.ext_funcs[func_ref].name,
                                         -4);
                     sink.put4(0);
@@ -1358,7 +1364,8 @@ pub(crate) fn define<'shared>(
             .emit(
                 r#"
                     {{PUT_OP}}(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-                    sink.reloc_external(Reloc::Abs4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::Abs4,
                                         &func.global_values[global_value].symbol_name(),
                                         0);
                     sink.put4(0);
@@ -1373,7 +1380,8 @@ pub(crate) fn define<'shared>(
             .emit(
                 r#"
                     {{PUT_OP}}(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-                    sink.reloc_external(Reloc::Abs8,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::Abs8,
                                         &func.global_values[global_value].symbol_name(),
                                         0);
                     sink.put8(0);
@@ -1391,7 +1399,8 @@ pub(crate) fn define<'shared>(
                     modrm_rm(5, out_reg0, sink);
                     // The addend adjusts for the difference between the end of the
                     // instruction and the beginning of the immediate field.
-                    sink.reloc_external(Reloc::X86PCRel4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::X86PCRel4,
                                         &func.global_values[global_value].symbol_name(),
                                         -4);
                     sink.put4(0);
@@ -1409,7 +1418,8 @@ pub(crate) fn define<'shared>(
                     modrm_rm(5, out_reg0, sink);
                     // The addend adjusts for the difference between the end of the
                     // instruction and the beginning of the immediate field.
-                    sink.reloc_external(Reloc::X86GOTPCRel4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::X86GOTPCRel4,
                                         &func.global_values[global_value].symbol_name(),
                                         -4);
                     sink.put4(0);
@@ -2402,7 +2412,8 @@ pub(crate) fn define<'shared>(
             {{PUT_OP}}(bits, BASE_REX, sink);
             // The addend adjusts for the difference between the end of the
             // instruction and the beginning of the immediate field.
-            sink.reloc_external(Reloc::X86CallPCRel4,
+            sink.reloc_external(func.srclocs[inst],
+                                Reloc::X86CallPCRel4,
                                 &func.dfg.ext_funcs[func_ref].name,
                                 -4);
             sink.put4(0);
@@ -2415,7 +2426,8 @@ pub(crate) fn define<'shared>(
             r#"
             sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
             {{PUT_OP}}(bits, BASE_REX, sink);
-            sink.reloc_external(Reloc::X86CallPLTRel4,
+            sink.reloc_external(func.srclocs[inst],
+                                Reloc::X86CallPLTRel4,
                                 &func.dfg.ext_funcs[func_ref].name,
                                 -4);
             sink.put4(0);
@@ -3320,7 +3332,8 @@ pub(crate) fn define<'shared>(
                     const LEA: u8 = 0x8d;
                     sink.put1(LEA); // lea
                     modrm_riprel(0b111/*out_reg0*/, sink); // 0x3d
-                    sink.reloc_external(Reloc::ElfX86_64TlsGd,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::ElfX86_64TlsGd,
                                         &func.global_values[global_value].symbol_name(),
                                         -4);
                     sink.put4(0);
@@ -3330,7 +3343,8 @@ pub(crate) fn define<'shared>(
                     sink.put1(0x66); // data16
                     sink.put1(0b01001000); // rex.w
                     sink.put1(0xe8); // call
-                    sink.reloc_external(Reloc::X86CallPLTRel4,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::X86CallPLTRel4,
                                         &ExternalName::LibCall(LibCall::ElfTlsGetAddr),
                                         -4);
                     sink.put4(0);
@@ -3351,7 +3365,8 @@ pub(crate) fn define<'shared>(
                     sink.put1(0x48); // rex
                     sink.put1(0x8b); // mov
                     modrm_riprel(0b111/*out_reg0*/, sink); // 0x3d
-                    sink.reloc_external(Reloc::MachOX86_64Tlv,
+                    sink.reloc_external(func.srclocs[inst],
+                                        Reloc::MachOX86_64Tlv,
                                         &func.global_values[global_value].symbol_name(),
                                         -4);
                     sink.put4(0);

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -2417,6 +2417,7 @@ pub(crate) fn define<'shared>(
                                 &func.dfg.ext_funcs[func_ref].name,
                                 -4);
             sink.put4(0);
+            sink.add_call_site(opcode, func.srclocs[inst]);
         "#,
         ),
     );
@@ -2431,6 +2432,7 @@ pub(crate) fn define<'shared>(
                                 &func.dfg.ext_funcs[func_ref].name,
                                 -4);
             sink.put4(0);
+            sink.add_call_site(opcode, func.srclocs[inst]);
         "#,
         ),
     );
@@ -2443,6 +2445,7 @@ pub(crate) fn define<'shared>(
                     sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
                     {{PUT_OP}}(bits, rex1(in_reg0), sink);
                     modrm_r_bits(in_reg0, bits, sink);
+                    sink.add_call_site(opcode, func.srclocs[inst]);
                 "#,
             ),
     );

--- a/cranelift/codegen/src/binemit/memorysink.rs
+++ b/cranelift/codegen/src/binemit/memorysink.rs
@@ -78,7 +78,14 @@ pub trait RelocSink {
     fn reloc_block(&mut self, _: CodeOffset, _: Reloc, _: CodeOffset);
 
     /// Add a relocation referencing an external symbol at the current offset.
-    fn reloc_external(&mut self, _: CodeOffset, _: Reloc, _: &ExternalName, _: Addend);
+    fn reloc_external(
+        &mut self,
+        _: CodeOffset,
+        _: SourceLoc,
+        _: Reloc,
+        _: &ExternalName,
+        _: Addend,
+    );
 
     /// Add a relocation referencing a constant.
     fn reloc_constant(&mut self, _: CodeOffset, _: Reloc, _: ConstantOffset);
@@ -132,9 +139,15 @@ impl<'a> CodeSink for MemoryCodeSink<'a> {
         self.relocs.reloc_block(ofs, rel, block_offset);
     }
 
-    fn reloc_external(&mut self, rel: Reloc, name: &ExternalName, addend: Addend) {
+    fn reloc_external(
+        &mut self,
+        srcloc: SourceLoc,
+        rel: Reloc,
+        name: &ExternalName,
+        addend: Addend,
+    ) {
         let ofs = self.offset();
-        self.relocs.reloc_external(ofs, rel, name, addend);
+        self.relocs.reloc_external(ofs, srcloc, rel, name, addend);
     }
 
     fn reloc_constant(&mut self, rel: Reloc, constant_offset: ConstantOffset) {
@@ -177,10 +190,18 @@ impl<'a> CodeSink for MemoryCodeSink<'a> {
 pub struct NullRelocSink {}
 
 impl RelocSink for NullRelocSink {
-    fn reloc_block(&mut self, _: u32, _: Reloc, _: u32) {}
-    fn reloc_external(&mut self, _: u32, _: Reloc, _: &ExternalName, _: i64) {}
+    fn reloc_block(&mut self, _: CodeOffset, _: Reloc, _: CodeOffset) {}
+    fn reloc_external(
+        &mut self,
+        _: CodeOffset,
+        _: SourceLoc,
+        _: Reloc,
+        _: &ExternalName,
+        _: Addend,
+    ) {
+    }
     fn reloc_constant(&mut self, _: CodeOffset, _: Reloc, _: ConstantOffset) {}
-    fn reloc_jt(&mut self, _: u32, _: Reloc, _: JumpTable) {}
+    fn reloc_jt(&mut self, _: CodeOffset, _: Reloc, _: JumpTable) {}
 }
 
 /// A `TrapSink` implementation that does nothing, which is convenient when

--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -16,7 +16,9 @@ pub use self::relaxation::relax_branches;
 pub use self::shrink::shrink_instructions;
 pub use self::stackmap::Stackmap;
 use crate::ir::entities::Value;
-use crate::ir::{ConstantOffset, ExternalName, Function, Inst, JumpTable, SourceLoc, TrapCode};
+use crate::ir::{
+    ConstantOffset, ExternalName, Function, Inst, JumpTable, Opcode, SourceLoc, TrapCode,
+};
 use crate::isa::TargetIsa;
 pub use crate::regalloc::RegDiversions;
 use core::fmt;
@@ -162,6 +164,11 @@ pub trait CodeSink {
 
     /// Add a stackmap at the current code offset.
     fn add_stackmap(&mut self, _: &[Value], _: &Function, _: &dyn TargetIsa);
+
+    /// Add a call site for a call with the given opcode, returning at the current offset.
+    fn add_call_site(&mut self, _: Opcode, _: SourceLoc) {
+        // Default implementation doesn't need to do anything.
+    }
 }
 
 /// Type of the frame unwind information.

--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -140,7 +140,7 @@ pub trait CodeSink {
     fn reloc_block(&mut self, _: Reloc, _: CodeOffset);
 
     /// Add a relocation referencing an external symbol plus the addend at the current offset.
-    fn reloc_external(&mut self, _: Reloc, _: &ExternalName, _: Addend);
+    fn reloc_external(&mut self, _: SourceLoc, _: Reloc, _: &ExternalName, _: Addend);
 
     /// Add a relocation referencing a constant.
     fn reloc_constant(&mut self, _: Reloc, _: ConstantOffset);

--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -386,6 +386,7 @@ impl<'a> RelocSink for FaerieRelocSink<'a> {
     fn reloc_external(
         &mut self,
         offset: CodeOffset,
+        _srcloc: ir::SourceLoc,
         reloc: Reloc,
         name: &ir::ExternalName,
         addend: Addend,

--- a/cranelift/filetests/src/test_binemit.rs
+++ b/cranelift/filetests/src/test_binemit.rs
@@ -79,6 +79,7 @@ impl binemit::CodeSink for TextSink {
 
     fn reloc_external(
         &mut self,
+        _srcloc: ir::SourceLoc,
         reloc: binemit::Reloc,
         name: &ir::ExternalName,
         addend: binemit::Addend,

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -101,6 +101,7 @@ impl binemit::CodeSink for SizeSink {
     fn reloc_block(&mut self, _reloc: binemit::Reloc, _block_offset: binemit::CodeOffset) {}
     fn reloc_external(
         &mut self,
+        _srcloc: ir::SourceLoc,
         _reloc: binemit::Reloc,
         _name: &ir::ExternalName,
         _addend: binemit::Addend,

--- a/cranelift/filetests/src/test_rodata.rs
+++ b/cranelift/filetests/src/test_rodata.rs
@@ -109,7 +109,14 @@ impl binemit::CodeSink for RodataSink {
     }
 
     fn reloc_block(&mut self, _reloc: binemit::Reloc, _block_offset: binemit::CodeOffset) {}
-    fn reloc_external(&mut self, _: binemit::Reloc, _: &ir::ExternalName, _: binemit::Addend) {}
+    fn reloc_external(
+        &mut self,
+        _: ir::SourceLoc,
+        _: binemit::Reloc,
+        _: &ir::ExternalName,
+        _: binemit::Addend,
+    ) {
+    }
     fn reloc_constant(&mut self, _: binemit::Reloc, _: ir::ConstantOffset) {}
     fn reloc_jt(&mut self, _reloc: binemit::Reloc, _jt: ir::JumpTable) {}
     fn trap(&mut self, _code: ir::TrapCode, _srcloc: ir::SourceLoc) {}

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -530,6 +530,7 @@ impl RelocSink for ObjectRelocSink {
     fn reloc_external(
         &mut self,
         offset: CodeOffset,
+        _srcloc: ir::SourceLoc,
         reloc: Reloc,
         name: &ir::ExternalName,
         mut addend: Addend,

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -631,6 +631,7 @@ impl RelocSink for SimpleJITRelocSink {
     fn reloc_external(
         &mut self,
         offset: CodeOffset,
+        _srcloc: ir::SourceLoc,
         reloc: Reloc,
         name: &ir::ExternalName,
         addend: Addend,

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -37,6 +37,7 @@ impl binemit::RelocSink for PrintRelocs {
     fn reloc_external(
         &mut self,
         where_: binemit::CodeOffset,
+        _srcloc: ir::SourceLoc,
         r: binemit::Reloc,
         name: &ir::ExternalName,
         addend: binemit::Addend,

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -41,6 +41,7 @@ impl binemit::RelocSink for RelocSink {
     fn reloc_external(
         &mut self,
         offset: binemit::CodeOffset,
+        _srcloc: ir::SourceLoc,
         reloc: binemit::Reloc,
         name: &ExternalName,
         addend: binemit::Addend,

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -434,6 +434,7 @@ impl binemit::RelocSink for RelocSink {
     fn reloc_external(
         &mut self,
         offset: binemit::CodeOffset,
+        _srcloc: ir::SourceLoc,
         reloc: binemit::Reloc,
         name: &ir::ExternalName,
         addend: binemit::Addend,

--- a/crates/jit/src/trampoline.rs
+++ b/crates/jit/src/trampoline.rs
@@ -31,6 +31,7 @@ pub mod binemit {
         fn reloc_external(
             &mut self,
             _offset: binemit::CodeOffset,
+            _srcloc: ir::SourceLoc,
             _reloc: binemit::Reloc,
             _name: &ir::ExternalName,
             _addend: binemit::Addend,

--- a/crates/lightbeam/src/backend.rs
+++ b/crates/lightbeam/src/backend.rs
@@ -5404,6 +5404,8 @@ impl<'this, M: ModuleContext> Context<'this, M> {
                     .unwrap()
                     .0) as u32
                 + 2,
+            // Passing a default location here, since until proven otherwise, it's not used.
+            ir::SourceLoc::default(),
             binemit::Reloc::Abs8,
             name,
             0,

--- a/crates/lightbeam/src/translate_sections.rs
+++ b/crates/lightbeam/src/translate_sections.rs
@@ -87,6 +87,7 @@ impl binemit::RelocSink for UnimplementedRelocSink {
     fn reloc_external(
         &mut self,
         _: binemit::CodeOffset,
+        _: ir::SourceLoc,
         _: binemit::Reloc,
         _: &ir::ExternalName,
         _: binemit::Addend,


### PR DESCRIPTION
This implements the two first bullet-points of #1453 (motivation of this PR is explained there). This is a separate refactoring that'll make the integration of the new backend easier in Spidermonkey.