### PR TITLE
Use appropriate rustup profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+    - run: rustup component add rustfmt
     - run: cargo fmt --all -- --check
 
   # Build `mdBook` documentation for `wasmtime`, and upload it as a temporary


### PR DESCRIPTION
This PR adds `profile` input to `install-rust` action. As I can see, the current intention is to use `minimal` profile, however [it doesn't include rustfmt](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html). Maybe it works now, because some servers have preinstalled rust using default profile.

I'm submitting this PR, because in some other project I work on the CI was not installing clippy with nightly rust and I fixed it this way.

I'm not sure what profile is required for cargo doc. I'm guessing `minimal` is enough.

CC @alexcrichton 
