### PR TITLE
Wiggle: tweaks to internal interfaces

### DIFF
--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -5,7 +5,11 @@ use crate::lifetimes::anon_lifetime;
 use crate::module_trait::passed_by_reference;
 use crate::names::Names;
 
-pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
+pub fn define_func(
+    names: &Names,
+    func: &witx::InterfaceFunc,
+    trait_name: TokenStream,
+) -> TokenStream {
     let funcname = func.name.as_str();
 
     let ident = names.func(&func.name);
@@ -166,7 +170,7 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
         {
             log::trace!(#trace_fmt, #(#args),*);
         }
-        let #trait_bindings  = match ctx.#ident(#(#trait_args),*) {
+        let #trait_bindings  = match #trait_name::#ident(ctx, #(#trait_args),*) {
             Ok(#trait_bindings) => { #trait_rets },
             Err(e) => { #ret_err },
         };

--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -15,7 +15,9 @@ pub use names::Names;
 pub use types::define_datatype;
 
 pub fn generate(doc: &witx::Document, config: &Config) -> TokenStream {
-    let names = Names::new(config); // TODO parse the names from the invocation of the macro, or from a file?
+    // TODO at some point config should grow more ability to configure name
+    // overrides.
+    let names = Names::new(&config.ctx.name);
 
     let types = doc.typenames().map(|t| define_datatype(&names, &t));
 

--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -23,7 +23,10 @@ pub fn generate(doc: &witx::Document, config: &Config) -> TokenStream {
 
     let modules = doc.modules().map(|module| {
         let modname = names.module(&module.name);
-        let fs = module.funcs().map(|f| define_func(&names, &f));
+        let trait_name = names.trait_name(&module.name);
+        let fs = module
+            .funcs()
+            .map(|f| define_func(&names, &f, quote!(#trait_name)));
         let modtrait = define_module_trait(&names, &module);
         let ctx_type = names.ctx_type();
         quote!(

--- a/crates/wiggle/generate/src/names.rs
+++ b/crates/wiggle/generate/src/names.rs
@@ -4,21 +4,19 @@ use quote::{format_ident, quote};
 use witx::{AtomType, BuiltinType, Id, TypeRef};
 
 use crate::lifetimes::LifetimeExt;
-use crate::Config;
 
-#[derive(Debug, Clone)]
 pub struct Names {
-    config: Config,
+    ctx_type: Ident,
 }
 
 impl Names {
-    pub fn new(config: &Config) -> Names {
+    pub fn new(ctx_type: &Ident) -> Names {
         Names {
-            config: config.clone(),
+            ctx_type: ctx_type.clone(),
         }
     }
     pub fn ctx_type(&self) -> Ident {
-        self.config.ctx.name.clone()
+        self.ctx_type.clone()
     }
     pub fn type_(&self, id: &Id) -> TokenStream {
         let ident = format_ident!("{}", id.as_str().to_camel_case());


### PR DESCRIPTION
These minor changes are required for downstream use in Lucet. No functional change for users of wiggle in this tree.

* `define_func` is given trait name explicitly, so that method dispatch is unambiguous
* `Names::new` doesn't require a whole `Config` struct, it just requires the name of the Ctx type.


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
