### PR TITLE
Re-enable ignored unreachable_wat CLI test

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -84,7 +84,6 @@ fn run_wasmtime_simple_wat() -> Result<()> {
 
 // Running a wat that traps.
 #[test]
-#[ignore] // FIXME(#1298)
 fn run_wasmtime_unreachable_wat() -> Result<()> {
     let wasm = build_wasm("tests/wasm/unreachable.wat")?;
     let output = run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;


### PR DESCRIPTION
This PR re-enables the `run_wasmtime_unreachable_wat` test initially ignored in #1302.
