### PR TITLE
Fuchsia port

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::types::*;
 pub use crate::values::*;
 
 cfg_if::cfg_if! {
-    if #[cfg(unix)] {
+    if #[cfg(all(unix, not(target_os = "fuchsia")))] {
         pub mod unix;
     } else if #[cfg(windows)] {
         pub mod windows;


### PR DESCRIPTION
This is an MVP port for Fuchsia. 

There are at least two things that need to be cleaned up in the future:
* Currently we spawn one exception handling thread per runtime thread. In the future we'll want to `zx_object_wait_async`/ports and register with a global exception handling thread
* The convention for registering a fault handler

I know that these syscalls are super unfamiliar so I'm happy to provide context. I've also unfortunately chosen to use the lowest level bindings since they are our most stable interface for out-of-tree Rust code.


cc/ @leecam