### PR TITLE
Make too many imports an instantiation error

### DIFF
--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -124,6 +124,14 @@ impl Instance {
             }
         }
 
+        if imports.len() != module.imports().len() {
+            bail!(
+                "wrong number of imports provided, {} != {}",
+                imports.len(),
+                module.imports().len()
+            );
+        }
+
         module.register_frame_info();
         let config = store.engine().config();
         let instance_handle = instantiate(

--- a/crates/api/tests/instance.rs
+++ b/crates/api/tests/instance.rs
@@ -1,5 +1,5 @@
-use wasmtime::*;
 use anyhow::Result;
+use wasmtime::*;
 
 #[test]
 fn wrong_import_numbers() -> Result<()> {

--- a/crates/api/tests/instance.rs
+++ b/crates/api/tests/instance.rs
@@ -1,0 +1,13 @@
+use wasmtime::*;
+use anyhow::Result;
+
+#[test]
+fn wrong_import_numbers() -> Result<()> {
+    let store = Store::default();
+    let module = Module::new(&store, r#"(module (import "" "" (func)))"#)?;
+
+    assert!(Instance::new(&module, &[]).is_err());
+    let func = Func::wrap(&store, || {});
+    assert!(Instance::new(&module, &[func.clone().into(), func.into()]).is_err());
+    Ok(())
+}


### PR DESCRIPTION
Previously we'd accidentally only take the head of the list when
instantiating, but instead this changes the API to require exactly the
right number of imports.

