### PR TITLE
Pin nightly rust toolchain to 2020-04-07

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2020-04-07
     - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
     - run: cargo doc --package cranelift-codegen-meta --document-private-items
     - uses: actions/upload-artifact@v1
@@ -72,7 +72,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2020-04-07
 
     # Check some feature combinations of the `wasmtime` crate
     - run: cargo check --manifest-path crates/api/Cargo.toml --no-default-features
@@ -121,7 +121,7 @@ jobs:
         ref: refs/heads/master
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2020-04-07
     - run: cargo install cargo-fuzz --vers "^0.7"
     - run: cargo fetch
       working-directory: ./fuzz
@@ -182,7 +182,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2020-04-07
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
I rebased #1377 and started seeing weird errors compiling `proptest` for `wiggle`. @pchickey thinks it might be a nightly regression so I am trying to pin the nightly version to something we know works.