### PR TITLE
Add TargetIsa::map_dwarf_register; fixes #1471

### DIFF
--- a/cranelift/codegen/src/isa/fde.rs
+++ b/cranelift/codegen/src/isa/fde.rs
@@ -1,0 +1,14 @@
+//! Support for FDE data generation.
+use thiserror::Error;
+
+/// Enumerate the errors possible in mapping Cranelift registers to their DWARF equivalent.
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum RegisterMappingError {
+    #[error("unable to find bank for register info")]
+    MissingBank,
+    #[error("register mapping is currently only implemented for x86_64")]
+    UnsupportedArchitecture,
+    #[error("unsupported register bank: {0}")]
+    UnsupportedRegisterBank(&'static str),
+}

--- a/cranelift/codegen/src/isa/x86/fde.rs
+++ b/cranelift/codegen/src/isa/x86/fde.rs
@@ -2,6 +2,7 @@
 
 use crate::binemit::{FrameUnwindOffset, FrameUnwindSink, Reloc};
 use crate::ir::{FrameLayoutChange, Function};
+use crate::isa::fde::RegisterMappingError;
 use crate::isa::{CallConv, RegUnit, TargetIsa};
 use alloc::vec::Vec;
 use core::convert::TryInto;
@@ -10,7 +11,6 @@ use gimli::write::{
     FrameDescriptionEntry, FrameTable, Result, Writer,
 };
 use gimli::{Encoding, Format, LittleEndian, Register, X86_64};
-use thiserror::Error;
 
 pub type FDERelocEntry = (FrameUnwindOffset, Reloc);
 
@@ -135,16 +135,6 @@ pub fn map_reg(
         "FloatRegs" => Ok(X86_XMM_REG_MAP[(reg - bank.first_unit) as usize]),
         _ => Err(RegisterMappingError::UnsupportedRegisterBank(bank.name)),
     }
-}
-
-#[derive(Error, Debug)]
-pub enum RegisterMappingError {
-    #[error("unable to find bank for register info")]
-    MissingBank,
-    #[error("register mapping is currently only implemented for x86_64")]
-    UnsupportedArchitecture,
-    #[error("unsupported register bank: {0}")]
-    UnsupportedRegisterBank(&'static str),
 }
 
 fn to_cfi(

--- a/cranelift/codegen/src/isa/x86/mod.rs
+++ b/cranelift/codegen/src/isa/x86/mod.rs
@@ -22,6 +22,8 @@ use crate::binemit::{FrameUnwindKind, FrameUnwindSink};
 use crate::ir;
 use crate::isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encodings};
 use crate::isa::Builder as IsaBuilder;
+#[cfg(feature = "unwind")]
+use crate::isa::{fde::RegisterMappingError, RegUnit};
 use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use crate::result::CodegenResult;
@@ -89,6 +91,11 @@ impl TargetIsa for Isa {
 
     fn register_info(&self) -> RegInfo {
         registers::INFO.clone()
+    }
+
+    #[cfg(feature = "unwind")]
+    fn map_dwarf_register(&self, reg: RegUnit) -> Result<u16, RegisterMappingError> {
+        map_reg(self, reg).map(|r| r.0)
     }
 
     fn encoding_info(&self) -> EncInfo {

--- a/crates/debug/src/frame.rs
+++ b/crates/debug/src/frame.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use wasmtime_environ::entity::EntityRef;
-use wasmtime_environ::isa::fde::map_reg;
 use wasmtime_environ::isa::{CallConv, TargetIsa};
 use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::{FrameLayoutChange, FrameLayouts};
@@ -19,8 +18,8 @@ fn to_cfi(
 ) -> Option<CallFrameInstruction> {
     Some(match change {
         FrameLayoutChange::CallFrameAddressAt { reg, offset } => {
-            let mapped = match map_reg(isa, *reg) {
-                Ok(r) => r,
+            let mapped = match isa.map_dwarf_register(*reg) {
+                Ok(r) => Register(r),
                 Err(_) => return None,
             };
             let offset = (*offset) as i32;
@@ -41,8 +40,8 @@ fn to_cfi(
         FrameLayoutChange::RegAt { reg, cfa_offset } => {
             assert!(cfa_offset % -8 == 0);
             let cfa_offset = *cfa_offset as i32;
-            let mapped = match map_reg(isa, *reg) {
-                Ok(r) => r,
+            let mapped = match isa.map_dwarf_register(*reg) {
+                Ok(r) => Register(r),
                 Err(_) => return None,
             };
             CallFrameInstruction::Offset(mapped, cfa_offset)

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -5,7 +5,6 @@ use more_asserts::{assert_le, assert_lt};
 use std::collections::{HashMap, HashSet};
 use wasmtime_environ::entity::EntityRef;
 use wasmtime_environ::ir::{StackSlots, ValueLabel, ValueLabelsRanges, ValueLoc};
-use wasmtime_environ::isa::fde::map_reg;
 use wasmtime_environ::isa::TargetIsa;
 use wasmtime_environ::wasm::{get_vmctx_value_label, DefinedFuncIndex};
 use wasmtime_environ::ModuleMemoryOffset;
@@ -79,7 +78,7 @@ fn translate_loc(
     use gimli::write::Writer;
     Ok(match loc {
         ValueLoc::Reg(reg) => {
-            let machine_reg = map_reg(isa, reg)?.0 as u8;
+            let machine_reg = isa.map_dwarf_register(reg)? as u8;
             Some(if machine_reg < 32 {
                 vec![gimli::constants::DW_OP_reg0.0 + machine_reg]
             } else {
@@ -120,8 +119,8 @@ fn append_memory_deref(
     // FIXME for imported memory
     match vmctx_loc {
         ValueLoc::Reg(vmctx_reg) => {
-            let reg = map_reg(isa, vmctx_reg)?;
-            writer.write_u8(gimli::constants::DW_OP_breg0.0 + reg.0 as u8)?;
+            let reg = isa.map_dwarf_register(vmctx_reg)? as u8;
+            writer.write_u8(gimli::constants::DW_OP_breg0.0 + reg)?;
             let memory_offset = match frame_info.vmctx_memory_offset() {
                 Some(offset) => offset,
                 None => {

--- a/crates/environ/src/data_structures.rs
+++ b/crates/environ/src/data_structures.rs
@@ -14,9 +14,6 @@ pub mod settings {
 
 pub mod isa {
     pub use cranelift_codegen::isa::{CallConv, RegUnit, TargetFrontendConfig, TargetIsa};
-    pub mod fde {
-        pub use cranelift_codegen::isa::fde::map_reg;
-    }
 }
 
 pub mod entity {


### PR DESCRIPTION
This exposes the functionality of `fde::map_reg` on the `TargetIsa` trait, avoiding compilation errors on architectures where register mapping is not yet supported. The change is conditially compiled under the `unwind` feature.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
