### PR TITLE
Optimize codegen in `Func::wrap`

### DIFF
--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -1030,8 +1030,12 @@ macro_rules! impl_into_func {
                     R: WasmRet,
                 {
                     let ret = {
-                        let instance = InstanceHandle::from_vmctx(vmctx);
-                        let (func, store) = instance.host_state().downcast_ref::<(F, Store)>().expect("state");
+                        let state = (*vmctx).host_state();
+                        // Double-check ourselves in debug mode, but we control
+                        // the `Any` here so an unsafe downcast should also
+                        // work.
+                        debug_assert!(state.is::<(F, Store)>());
+                        let (func, store) = &*(state as *const _ as *const (F, Store));
                         panic::catch_unwind(AssertUnwindSafe(|| {
                             func(
                                 Caller { store, caller_vmctx },

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -376,6 +376,7 @@ impl Instance {
     }
 
     /// Return a reference to the custom state attached to this instance.
+    #[inline]
     pub fn host_state(&self) -> &dyn Any {
         &*self.host_state
     }
@@ -416,6 +417,7 @@ impl Instance {
     }
 
     /// Return the offset from the vmctx pointer to its containing Instance.
+    #[inline]
     pub(crate) fn vmctx_offset() -> isize {
         offset_of!(Self, vmctx) as isize
     }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -632,6 +632,7 @@ impl VMContext {
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
     /// be a `VMContext` allocated as part of an `Instance`.
     #[allow(clippy::cast_ptr_alignment)]
+    #[inline]
     pub(crate) unsafe fn instance(&self) -> &Instance {
         &*((self as *const Self as *mut u8).offset(-Instance::vmctx_offset()) as *const Instance)
     }
@@ -641,6 +642,7 @@ impl VMContext {
     /// # Safety
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
     /// be a `VMContext` allocated as part of an `Instance`.
+    #[inline]
     pub unsafe fn host_state(&self) -> &dyn Any {
         self.instance().host_state()
     }


### PR DESCRIPTION
This commit optimizes the codegen of `Func::wrap` such that if you do
something like `Func::wrap(&store, || {})` then the shim generated
contains zero code (as expected). In general this means that the extra
tidbits generated by wasmtime are all eligible to be entirely optimized
away so long as you don't actually rely on something.
