### PR TITLE
wasmtime-c-api: Don't create slices with null pointers

### DIFF
--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -42,7 +42,15 @@ macro_rules! declare_vecs {
             }
 
             pub fn as_slice(&self) -> &[$elem_ty] {
-                unsafe { slice::from_raw_parts(self.data, self.size) }
+                // Note that we're careful to not create a slice with a null
+                // pointer as the data pointer, since that isn't defined
+                // behavior in Rust.
+                if self.size == 0 {
+                    &[]
+                } else {
+                    assert!(!self.data.is_null());
+                    unsafe { slice::from_raw_parts(self.data, self.size) }
+                }
             }
 
             pub fn take(&mut self) -> Vec<$elem_ty> {


### PR DESCRIPTION
It's a common idiom to pass in `NULL` for slices of zero-length in the C
API, but it's not safe to create a Rust `&[T]` slice with this `NULL`
pointer. Special-case this in the `as_slice()` method of incoming
vectors to return an empty slice so we don't violate Rust's invariants.
