### PR TITLE
wasi-common: export `WasiCtxBuilderError`

### DIFF
--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -36,6 +36,6 @@ mod sys;
 mod virtfs;
 pub mod wasi;
 
-pub use ctx::{WasiCtx, WasiCtxBuilder};
+pub use ctx::{WasiCtx, WasiCtxBuilder, WasiCtxBuilderError};
 pub use sys::preopen_dir;
 pub use virtfs::{FileContents, VirtualDirEntry};


### PR DESCRIPTION
This type is exposed as part of the `WasiCtxBuilder` methods, and should be exported as well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
