### PR TITLE
Add a spec test fuzzer for Config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,7 +2229,6 @@ dependencies = [
 name = "wasmtime-fuzz"
 version = "0.0.0"
 dependencies = [
- "arbitrary",
  "cranelift-codegen",
  "cranelift-reader",
  "cranelift-wasm",
@@ -2237,7 +2236,6 @@ dependencies = [
  "target-lexicon",
  "wasmtime",
  "wasmtime-fuzzing",
- "wasmtime-wast",
 ]
 
 [[package]]
@@ -2253,6 +2251,7 @@ dependencies = [
  "wasmparser",
  "wasmprinter",
  "wasmtime",
+ "wasmtime-wast",
  "wat",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,6 +2229,7 @@ dependencies = [
 name = "wasmtime-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "cranelift-codegen",
  "cranelift-reader",
  "cranelift-wasm",
@@ -2236,6 +2237,7 @@ dependencies = [
  "target-lexicon",
  "wasmtime",
  "wasmtime-fuzzing",
+ "wasmtime-wast",
 ]
 
 [[package]]

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -15,7 +15,8 @@ log = "0.4.8"
 rayon = "1.2.1"
 wasmparser = "0.51.2"
 wasmprinter = "0.2.1"
-wasmtime = { path = "../api", version = "0.15.0" }
+wasmtime = { path = "../api" }
+wasmtime-wast = { path = "../wast" }
 
 [dev-dependencies]
 wat = "1.0.10"

--- a/crates/fuzzing/build.rs
+++ b/crates/fuzzing/build.rs
@@ -9,8 +9,10 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let dir = env::current_dir().unwrap().join("../tests/spec_testsuite");
-    let mut code = format!("pub static FILES: &[(&str, &str)] = &[\n");
+    let dir = env::current_dir()
+        .unwrap()
+        .join("../../tests/spec_testsuite");
+    let mut code = format!("static FILES: &[(&str, &str)] = &[\n");
     for entry in dir.read_dir().unwrap() {
         let entry = entry.unwrap();
         let path = entry.path().display().to_string();

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -60,7 +60,7 @@ impl Arbitrary for WasmOptTtf {
 #[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DifferentialConfig {
     strategy: DifferentialStrategy,
-    opt_level: DifferentialOptLevel,
+    opt_level: OptLevel,
 }
 
 impl DifferentialConfig {
@@ -70,11 +70,7 @@ impl DifferentialConfig {
             DifferentialStrategy::Cranelift => wasmtime::Strategy::Cranelift,
             DifferentialStrategy::Lightbeam => wasmtime::Strategy::Lightbeam,
         })?;
-        config.cranelift_opt_level(match self.opt_level {
-            DifferentialOptLevel::None => wasmtime::OptLevel::None,
-            DifferentialOptLevel::Speed => wasmtime::OptLevel::Speed,
-            DifferentialOptLevel::SpeedAndSize => wasmtime::OptLevel::SpeedAndSize,
-        });
+        config.cranelift_opt_level(self.opt_level.to_wasmtime());
         Ok(config)
     }
 }
@@ -85,9 +81,21 @@ enum DifferentialStrategy {
     Lightbeam,
 }
 
+#[allow(missing_docs)]
 #[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Hash)]
-enum DifferentialOptLevel {
+pub enum OptLevel {
     None,
     Speed,
     SpeedAndSize,
+}
+
+impl OptLevel {
+    /// Converts to the native wasmtime optimization level for cranelift
+    pub fn to_wasmtime(&self) -> wasmtime::OptLevel {
+        match self {
+            OptLevel::None => wasmtime::OptLevel::None,
+            OptLevel::Speed => wasmtime::OptLevel::Speed,
+            OptLevel::SpeedAndSize => wasmtime::OptLevel::SpeedAndSize,
+        }
+    }
 }

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -11,7 +11,7 @@
 #[cfg(feature = "binaryen")]
 pub mod api;
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Unstructured};
 
 /// A Wasm test case generator that is powered by Binaryen's `wasm-opt -ttf`.
 #[derive(Clone)]
@@ -81,21 +81,66 @@ enum DifferentialStrategy {
     Lightbeam,
 }
 
-#[allow(missing_docs)]
 #[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum OptLevel {
+enum OptLevel {
     None,
     Speed,
     SpeedAndSize,
 }
 
 impl OptLevel {
-    /// Converts to the native wasmtime optimization level for cranelift
-    pub fn to_wasmtime(&self) -> wasmtime::OptLevel {
+    fn to_wasmtime(&self) -> wasmtime::OptLevel {
         match self {
             OptLevel::None => wasmtime::OptLevel::None,
             OptLevel::Speed => wasmtime::OptLevel::Speed,
             OptLevel::SpeedAndSize => wasmtime::OptLevel::SpeedAndSize,
         }
+    }
+}
+
+/// Implementation of generating a `wasmtime::Config` arbitrarily
+#[derive(Arbitrary, Debug)]
+pub struct Config {
+    opt_level: OptLevel,
+    debug_verifier: bool,
+    debug_info: bool,
+    canonicalize_nans: bool,
+    spectest: usize,
+}
+
+impl Config {
+    /// Converts this to a `wasmtime::Config` object
+    pub fn to_wasmtime(&self) -> wasmtime::Config {
+        let mut cfg = wasmtime::Config::new();
+        cfg.debug_info(self.debug_info)
+            .cranelift_nan_canonicalization(self.canonicalize_nans)
+            .cranelift_debug_verifier(self.debug_verifier)
+            .cranelift_opt_level(self.opt_level.to_wasmtime());
+        return cfg;
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/spectests.rs"));
+
+/// A spec test from the upstream wast testsuite, arbitrarily chosen from the
+/// list of known spec tests.
+#[derive(Debug)]
+pub struct SpecTest {
+    /// The filename of the spec test
+    pub file: &'static str,
+    /// The `*.wast` contents of the spec test
+    pub contents: &'static str,
+}
+
+impl Arbitrary for SpecTest {
+    fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
+        // NB: this does get a uniform value in the provided range.
+        let i = u.int_in_range(0..=FILES.len() - 1)?;
+        let (file, contents) = FILES[i];
+        Ok(SpecTest { file, contents })
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (1, Some(std::mem::size_of::<usize>()))
     }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -15,6 +15,7 @@ pub mod dummy;
 use dummy::dummy_imports;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;
+use wasmtime_wast::WastContext;
 
 fn log_wasm(wasm: &[u8]) {
     static CNT: AtomicUsize = AtomicUsize::new(0);
@@ -399,4 +400,16 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
             }
         }
     }
+}
+
+/// Executes the wast `test` spectest with the `config` specified.
+///
+/// Ensures that spec tests pass regardless of the `Config`.
+pub fn spectest(config: crate::generators::Config, test: crate::generators::SpecTest) {
+    let store = Store::new(&Engine::new(&config.to_wasmtime()));
+    let mut wast_context = WastContext::new(store);
+    wast_context.register_spectest().unwrap();
+    wast_context
+        .run_buffer(test.file, test.contents.as_bytes())
+        .unwrap();
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,8 @@ libfuzzer-sys = "0.3.2"
 target-lexicon = "0.10"
 wasmtime = { path = "../crates/api" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }
+wasmtime-wast = { path = "../crates/wast" }
+arbitrary = { version = "0.4.1", features = ["derive"] }
 
 [[bin]]
 name = "compile"
@@ -49,6 +51,12 @@ path = "fuzz_targets/differential.rs"
 test = false
 doc = false
 required-features = ['binaryen']
+
+[[bin]]
+name = "spectests"
+path = "fuzz_targets/spectests.rs"
+test = false
+doc = false
 
 [features]
 binaryen = ['wasmtime-fuzzing/binaryen']

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,8 +16,6 @@ libfuzzer-sys = "0.3.2"
 target-lexicon = "0.10"
 wasmtime = { path = "../crates/api" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }
-wasmtime-wast = { path = "../crates/wast" }
-arbitrary = { version = "0.4.1", features = ["derive"] }
 
 [[bin]]
 name = "compile"

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -1,0 +1,24 @@
+// A small build script to include the contents of the spec test suite into the
+// final fuzzing binary so the fuzzing binary can be run elsewhere and doesn't
+// rely on the original source tree.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let dir = env::current_dir().unwrap().join("../tests/spec_testsuite");
+    let mut code = format!("pub static FILES: &[(&str, &str)] = &[\n");
+    for entry in dir.read_dir().unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path().display().to_string();
+        if !path.ends_with(".wast") {
+            continue;
+        }
+        code.push_str(&format!("({:?}, include_str!({0:?})),\n", path));
+    }
+    code.push_str("];\n");
+    std::fs::write(out_dir.join("spectests.rs"), code).unwrap();
+}

--- a/fuzz/fuzz_targets/spectests.rs
+++ b/fuzz/fuzz_targets/spectests.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use wasmtime::{Config, Engine, Store};
+use wasmtime_fuzzing::generators::OptLevel;
+use wasmtime_wast::WastContext;
+
+include!(concat!(env!("OUT_DIR"), "/spectests.rs"));
+
+#[derive(Arbitrary, Debug)]
+pub struct SpecCompliantConfig {
+    opt_level: OptLevel,
+    debug_verifier: bool,
+    debug_info: bool,
+    canonicalize_nans: bool,
+    spectest: usize,
+}
+
+fuzz_target!(|config: SpecCompliantConfig| {
+    let mut cfg = Config::new();
+    cfg.debug_info(config.debug_info)
+        .cranelift_nan_canonicalization(config.canonicalize_nans)
+        .cranelift_debug_verifier(config.debug_verifier)
+        .cranelift_opt_level(config.opt_level.to_wasmtime());
+
+    let (file, contents) = FILES[config.spectest % FILES.len()];
+    println!("run test {:?}", file);
+    let store = Store::new(&Engine::new(&cfg));
+    let mut wast_context = WastContext::new(store);
+    wast_context.register_spectest().unwrap();
+    wast_context.run_buffer(file, contents.as_bytes()).unwrap();
+});

--- a/fuzz/fuzz_targets/spectests.rs
+++ b/fuzz/fuzz_targets/spectests.rs
@@ -1,33 +1,9 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use wasmtime::{Config, Engine, Store};
-use wasmtime_fuzzing::generators::OptLevel;
-use wasmtime_wast::WastContext;
+use wasmtime_fuzzing::generators::{Config, SpecTest};
 
-include!(concat!(env!("OUT_DIR"), "/spectests.rs"));
-
-#[derive(Arbitrary, Debug)]
-pub struct SpecCompliantConfig {
-    opt_level: OptLevel,
-    debug_verifier: bool,
-    debug_info: bool,
-    canonicalize_nans: bool,
-    spectest: usize,
-}
-
-fuzz_target!(|config: SpecCompliantConfig| {
-    let mut cfg = Config::new();
-    cfg.debug_info(config.debug_info)
-        .cranelift_nan_canonicalization(config.canonicalize_nans)
-        .cranelift_debug_verifier(config.debug_verifier)
-        .cranelift_opt_level(config.opt_level.to_wasmtime());
-
-    let (file, contents) = FILES[config.spectest % FILES.len()];
-    println!("run test {:?}", file);
-    let store = Store::new(&Engine::new(&cfg));
-    let mut wast_context = WastContext::new(store);
-    wast_context.register_spectest().unwrap();
-    wast_context.run_buffer(file, contents.as_bytes()).unwrap();
+fuzz_target!(|pair: (Config, SpecTest)| {
+    let (config, test) = pair;
+    wasmtime_fuzzing::oracles::spectest(config, test);
 });


### PR DESCRIPTION
This commit adds a new fuzzer which is intended to run on oss-fuzz. This
fuzzer creates and arbitrary `Config` which *should* pass spec tests and
then asserts that it does so. The goal here is to weed out any
accidental bugs in global configuration which could cause
non-spec-compliant behavior.
