### PR TITLE
Always check if struct-return parameter is needed

### DIFF
--- a/cranelift/filetests/filetests/isa/x86/abi64.clif
+++ b/cranelift/filetests/filetests/isa/x86/abi64.clif
@@ -14,6 +14,12 @@ function %f() {
     sig2 = (f32, i64) -> f64 system_v
     ; check: sig2 = (f32 [%xmm0], i64 [%rdi]) -> f64 [%xmm0] system_v
 
+    sig3 = () -> i128 system_v
+    ; check: sig3 = () -> i64 [%rax], i64 [%rdx] system_v
+
+    sig4 = (i128) -> i128 system_v
+    ; check: sig4 = (i64 [%rdi], i64 [%rsi]) -> i64 [%rax], i64 [%rdx] system_v
+
 block0:
     return
 }

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -110,6 +110,13 @@ block0(v0: f32, v1: f64, v2: i64, v3: i64):
 ; nextln: return v1, v5
 ; nextln: }
 
+function %ret_val_i128(i64, i64) -> i128 windows_fastcall {
+block0(v0: i64, v1: i64):
+    v2 = iconcat v0, v1
+    return v2
+}
+; check: function %ret_val_i128(i64 [%rdx], i64 [%r8], i64 sret [%rcx], i64 fp [%rbp]) -> i64 sret [%rax], i64 fp [%rbp] windows_fastcall {
+
 function %internal_stack_arg_function_call(i64) -> i64 windows_fastcall {
   fn0 = %foo(i64, i64, i64, i64) -> i64 windows_fastcall
   fn1 = %foo2(i64, i64, i64, i64) -> i64 windows_fastcall

--- a/cranelift/filetests/filetests/legalizer/popcnt-i128.clif
+++ b/cranelift/filetests/filetests/legalizer/popcnt-i128.clif
@@ -1,5 +1,5 @@
 test legalizer
-target i686
+target x86_64 haswell
 
 function %foo() -> i128 {
 block0:
@@ -10,22 +10,12 @@ block0:
     return v4
 }
 
-; check: v5 = iconst.i32 66
-; check: v6 = iconst.i32 100
-; check: v1 = iconcat v5, v6
-; check: v7 = iconst.i32 0x1010_0042
-; check: v8 = iconst.i32 127
-; check: v2 = iconcat v7, v8
+; check: v1 = iconst.i64 0x0064_0000_0042
+; check: v2 = iconst.i64 0x007f_1010_0042
 ; check: v3 = iconcat v1, v2
-; check: v9 = popcnt v1
-; check: v10 = popcnt v2
-; check: v12, v13 = isplit v9
-; check: v14, v15 = isplit v10
-; check: v16, v17 = iadd_ifcout v12, v14
-; check: v18 = iadd_ifcin v13, v15, v17
-; check: v11 = iconcat v16, v18
-; check: v20 = iconst.i32 0
-; check: v21 = iconst.i32 0
-; check: v19 = iconcat v20, v21
-; check: v4 = iconcat v11, v19
-; check: return v16, v18, v20, v21
+; check: v5 = popcnt v1
+; check: v6 = popcnt v2
+; check: v7 = iadd v5, v6
+; check: v8 = iconst.i64 0
+; check: v4 = iconcat v7, v8
+; check: return v7, v8

--- a/cranelift/filetests/filetests/wasm/multi-val-call-legalize-args.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-call-legalize-args.clif
@@ -1,0 +1,24 @@
+test legalizer
+target x86_64 haswell
+
+;; Test if arguments are legalized if function uses sret
+
+function %call_indirect_with_split_arg(i64, i64, i64) {
+    ; check: ss0 = sret_slot 32
+    sig0 = (i128) -> i64, i64, i64, i64
+    ; check: sig0 = (i64 [%rsi], i64 [%rdx], i64 sret [%rdi]) -> i64 sret [%rax] fast
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4, v5, v6, v7 = call_indirect sig0, v0(v3)
+    ; check: v8 = stack_addr.i64 ss0
+    ; check: v9 = call_indirect sig0, v0(v1, v2, v8)
+    ; check: v10 = load.i64 notrap aligned v9
+    ; check: v4 -> v10
+    ; check: v11 = load.i64 notrap aligned v9+8
+    ; check: v5 -> v11
+    ; check: v12 = load.i64 notrap aligned v9+16
+    ; check: v6 -> v12
+    ; check: v13 = load.i64 notrap aligned v9+24
+    ; check: v7 -> v13
+    return
+}


### PR DESCRIPTION
Current implementation of `legalize_signature` for x86 ABI assumes struct-return parameters can be generated only for multi-return functions. This is incorrect: functions can become multi-return after splitting return values in `legalize_args` - for example functions that return `i128`. This PR removes this assumption. Fixes #1162.

---
- [x] This has been discussed in issue #1162
- [x] This PR contains test cases, if meaningful.
- [x] I'm new to the project, I don't know who could review this.
