### PR TITLE
Update the `wat`/`wast` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 13.0.0",
+ "wast 14.0.0",
 ]
 
 [[package]]
@@ -2375,20 +2375,20 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b20abd8b4a26f7e0d4dd5e357e90a3d555ec190e94472c9b2b27c5b9777f9ae"
+checksum = "47b11c94c63d5365a76ea287f8e6e5b6050233fae4b2423aea2a1e126a385e17"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a615830ee3e7200b505c441fec09aac2f114deae69df52f215cb828ba112c4"
+checksum = "03db18bc33cff3859c296efbefdcc00763a644539feeadca3415a1cee8a2835d"
 dependencies = [
- "wast 13.0.0",
+ "wast 14.0.0",
 ]
 
 [[package]]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../api", version = "0.15.0", default-features = false }
-wast = "13.0.0"
+wast = "14.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Pulls in a fix for a fuzz bug found recently where `br_on_null` might
not resolve indices and could cause a panic.

