### PR TITLE
Keep frame info registered until internal instance is gone

### DIFF
--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -34,7 +34,7 @@ pub mod trampoline;
 
 pub use crate::code_memory::CodeMemory;
 pub use crate::compiler::{make_trampoline, Compilation, CompilationStrategy, Compiler};
-pub use crate::instantiate::{instantiate, CompiledModule, SetupError};
+pub use crate::instantiate::{CompiledModule, SetupError};
 pub use crate::link::link_module;
 pub use crate::resolver::{NullResolver, Resolver};
 


### PR DESCRIPTION
This commit fixes an issue where the global registration of frame data
goes away once the `wasmtime::Module` has been dropped. Even after this
has been dropped, though, there may still be `wasmtime::Func` instances
which reference the original module, so it's only once the underlying
`wasmtime_runtime::Instance` has gone away that we can drop everything.

Closes #1479

