### PR TITLE
Add an instance API for invoking the WASI start functions.

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -34,7 +34,7 @@ impl Extern {
     /// Returns the underlying `Func`, if this external is a function.
     ///
     /// Returns `None` if this is not a function.
-    pub fn func(&self) -> Option<&Func> {
+    pub fn func(self) -> Option<Func> {
         match self {
             Extern::Func(func) => Some(func),
             _ => None,
@@ -44,7 +44,7 @@ impl Extern {
     /// Returns the underlying `Global`, if this external is a global.
     ///
     /// Returns `None` if this is not a global.
-    pub fn global(&self) -> Option<&Global> {
+    pub fn global(self) -> Option<Global> {
         match self {
             Extern::Global(global) => Some(global),
             _ => None,
@@ -54,7 +54,7 @@ impl Extern {
     /// Returns the underlying `Table`, if this external is a table.
     ///
     /// Returns `None` if this is not a table.
-    pub fn table(&self) -> Option<&Table> {
+    pub fn table(self) -> Option<Table> {
         match self {
             Extern::Table(table) => Some(table),
             _ => None,
@@ -64,7 +64,7 @@ impl Extern {
     /// Returns the underlying `Memory`, if this external is a memory.
     ///
     /// Returns `None` if this is not a memory.
-    pub fn memory(&self) -> Option<&Memory> {
+    pub fn memory(self) -> Option<Memory> {
         match self {
             Extern::Memory(memory) => Some(memory),
             _ => None,

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -481,7 +481,7 @@ impl Func {
         // This is only called with `Export::Function`, and since it's coming
         // from wasmtime_runtime itself we should support all the types coming
         // out of it, so assert such here.
-        FuncType::from_wasmtime_signature(sig).expect("core wasm signature should be supported")
+        FuncType::from_wasmtime_signature(&sig).expect("core wasm signature should be supported")
     }
 
     /// Returns the number of parameters that this function takes.

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -123,11 +123,11 @@ impl Instance {
             }
         }
 
-        if imports.len() != module.imports().len() {
+        if imports.len() != module.num_imports() {
             bail!(
                 "wrong number of imports provided, {} != {}",
                 imports.len(),
-                module.imports().len()
+                module.num_imports()
             );
         }
 
@@ -173,7 +173,7 @@ impl Instance {
     pub fn exports<'me>(&'me self) -> impl Iterator<Item = Extern> + 'me {
         let instance_handle = self.instance_handle.clone();
         let module = self.module.clone();
-        self.module.exports().iter().map(move |export| {
+        self.module.exports().map(move |export| {
             let name = export.name();
             let export = instance_handle.lookup(&name).expect("export");
             Extern::from_wasmtime_export(module.store(), instance_handle.clone(), export)
@@ -187,7 +187,7 @@ impl Instance {
     ///
     /// Returns `None` if there was no export named `name`.
     pub fn get_export(&self, name: &str) -> Option<Extern> {
-        let export = self.module.exports().iter().find(|e| e.name() == name)?;
+        let export = self.module.exports().find(|e| e.name() == name)?;
         let name = export.name();
         let export = self.instance_handle.lookup(&name).expect("export");
         Some(Extern::from_wasmtime_export(

--- a/crates/api/src/linker.rs
+++ b/crates/api/src/linker.rs
@@ -264,8 +264,8 @@ impl Linker {
         if !Store::same(&self.store, instance.store()) {
             bail!("all linker items must be from the same store");
         }
-        for (export, item) in instance.module().exports().iter().zip(instance.exports()) {
-            self.insert(module_name, export.name(), export.ty(), item.clone())?;
+        for (export, item) in instance.module().exports().zip(instance.exports()) {
+            self.insert(module_name, export.name(), export.ty().clone(), item)?;
         }
         Ok(self)
     }
@@ -378,8 +378,8 @@ impl Linker {
     pub fn instantiate(&self, module: &Module) -> Result<Instance> {
         let mut imports = Vec::new();
         for import in module.imports() {
-            if let Some(item) = self.get(import) {
-                imports.push(item.clone());
+            if let Some(item) = self.get(&import) {
+                imports.push(item);
                 continue;
             }
 
@@ -447,7 +447,7 @@ impl Linker {
         let key = ImportKey {
             module: *self.string2idx.get(import.module())?,
             name: *self.string2idx.get(import.name())?,
-            kind: self.import_kind(import.ty()),
+            kind: self.import_kind(import.ty().clone()),
         };
         self.map.get(&key).cloned()
     }

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -1,65 +1,13 @@
 use crate::frame_info::GlobalFrameInfoRegistration;
 use crate::runtime::Store;
 use crate::types::{
-    ExportType, ExternType, FuncType, GlobalType, ImportType, Limits, MemoryType, Mutability,
-    TableType, ValType,
+    ExportType, ExternType, FuncType, GlobalType, ImportType, MemoryType, TableType,
 };
-use anyhow::{bail, Error, Result};
+use anyhow::{Error, Result};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use wasmparser::{validate, ExternalKind, ImportSectionEntryType, ModuleReader, SectionCode};
+use wasmparser::validate;
 use wasmtime_jit::CompiledModule;
-
-fn into_memory_type(mt: wasmparser::MemoryType) -> Result<MemoryType> {
-    if mt.shared {
-        bail!("shared memories are not supported yet");
-    }
-    Ok(MemoryType::new(Limits::new(
-        mt.limits.initial,
-        mt.limits.maximum,
-    )))
-}
-
-fn into_global_type(gt: wasmparser::GlobalType) -> GlobalType {
-    let mutability = if gt.mutable {
-        Mutability::Var
-    } else {
-        Mutability::Const
-    };
-    GlobalType::new(into_valtype(&gt.content_type), mutability)
-}
-
-// `into_valtype` is used for `map` which requires `&T`.
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn into_valtype(ty: &wasmparser::Type) -> ValType {
-    use wasmparser::Type::*;
-    match ty {
-        I32 => ValType::I32,
-        I64 => ValType::I64,
-        F32 => ValType::F32,
-        F64 => ValType::F64,
-        V128 => ValType::V128,
-        AnyFunc => ValType::FuncRef,
-        AnyRef => ValType::AnyRef,
-        _ => unimplemented!("types in into_valtype"),
-    }
-}
-
-fn into_func_type(mt: wasmparser::FuncType) -> FuncType {
-    assert_eq!(mt.form, wasmparser::Type::Func);
-    let params = mt.params.iter().map(into_valtype).collect::<Vec<_>>();
-    let returns = mt.returns.iter().map(into_valtype).collect::<Vec<_>>();
-    FuncType::new(params.into_boxed_slice(), returns.into_boxed_slice())
-}
-
-fn into_table_type(tt: wasmparser::TableType) -> TableType {
-    assert!(
-        tt.element_type == wasmparser::Type::AnyFunc || tt.element_type == wasmparser::Type::AnyRef
-    );
-    let ty = into_valtype(&tt.element_type);
-    let limits = Limits::new(tt.limits.initial, tt.limits.maximum);
-    TableType::new(ty, limits)
-}
 
 /// A compiled WebAssembly module, ready to be instantiated.
 ///
@@ -134,8 +82,6 @@ pub struct Module {
 
 struct ModuleInner {
     store: Store,
-    imports: Box<[ImportType]>,
-    exports: Box<[ExportType]>,
     compiled: CompiledModule,
     frame_info_registration: Mutex<Option<Option<GlobalFrameInfoRegistration>>>,
 }
@@ -332,9 +278,7 @@ impl Module {
     /// be somewhat valid for decoding purposes, and the basics of decoding can
     /// still fail.
     pub unsafe fn from_binary_unchecked(store: &Store, binary: &[u8]) -> Result<Module> {
-        let mut ret = Module::compile(store, binary)?;
-        ret.read_imports_and_exports(binary)?;
-        Ok(ret)
+        Module::compile(store, binary)
     }
 
     /// Validates `binary` input data as a WebAssembly binary given the
@@ -372,8 +316,6 @@ impl Module {
         Ok(Module {
             inner: Arc::new(ModuleInner {
                 store: store.clone(),
-                imports: Box::new([]),
-                exports: Box::new([]),
                 compiled,
                 frame_info_registration: Mutex::new(None),
             }),
@@ -433,7 +375,7 @@ impl Module {
     /// # fn main() -> anyhow::Result<()> {
     /// # let store = Store::default();
     /// let module = Module::new(&store, "(module)")?;
-    /// assert_eq!(module.imports().len(), 0);
+    /// assert_eq!(module.num_imports(), 0);
     /// # Ok(())
     /// # }
     /// ```
@@ -450,8 +392,8 @@ impl Module {
     ///     )
     /// "#;
     /// let module = Module::new(&store, wat)?;
-    /// assert_eq!(module.imports().len(), 1);
-    /// let import = &module.imports()[0];
+    /// assert_eq!(module.num_imports(), 1);
+    /// let import = module.imports().next().unwrap();
     /// assert_eq!(import.module(), "host");
     /// assert_eq!(import.name(), "foo");
     /// match import.ty() {
@@ -461,8 +403,49 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn imports(&self) -> &[ImportType] {
-        &self.inner.imports
+    pub fn imports<'me>(&'me self) -> impl Iterator<Item = ImportType> + 'me {
+        let inner = self.inner.clone();
+        self.inner.compiled.module_ref().imports.iter().map(
+            move |(module_name, field_name, import)| {
+                let module = inner.compiled.module_ref();
+                match import {
+                    wasmtime_environ::Export::Function(func_index) => {
+                        let sig_index = module.local.functions[*func_index];
+                        let sig = &module.local.signatures[sig_index];
+                        let ty = FuncType::from_wasmtime_signature(sig)
+                            .expect("core wasm function type should be supported")
+                            .into();
+                        ImportType::new(module_name, field_name, ty)
+                    }
+                    wasmtime_environ::Export::Table(table_index) => {
+                        let ty = TableType::from_wasmtime_table(
+                            &module.local.table_plans[*table_index].table,
+                        )
+                        .into();
+                        ImportType::new(module_name, field_name, ty)
+                    }
+                    wasmtime_environ::Export::Memory(memory_index) => {
+                        let ty = MemoryType::from_wasmtime_memory(
+                            &module.local.memory_plans[*memory_index].memory,
+                        )
+                        .into();
+                        ImportType::new(module_name, field_name, ty)
+                    }
+                    wasmtime_environ::Export::Global(global_index) => {
+                        let ty =
+                            GlobalType::from_wasmtime_global(&module.local.globals[*global_index])
+                                .expect("core wasm global type should be supported")
+                                .into();
+                        ImportType::new(module_name, field_name, ty)
+                    }
+                }
+            },
+        )
+    }
+
+    /// Return the number of imports in this module.
+    pub fn num_imports(&self) -> usize {
+        self.inner.compiled.module_ref().imports.len()
     }
 
     /// Returns the list of exports that this [`Module`] has and will be
@@ -482,7 +465,7 @@ impl Module {
     /// # fn main() -> anyhow::Result<()> {
     /// # let store = Store::default();
     /// let module = Module::new(&store, "(module)")?;
-    /// assert!(module.exports().is_empty());
+    /// assert!(module.exports().next().is_none());
     /// # Ok(())
     /// # }
     /// ```
@@ -500,16 +483,16 @@ impl Module {
     ///     )
     /// "#;
     /// let module = Module::new(&store, wat)?;
-    /// assert_eq!(module.exports().len(), 2);
+    /// assert_eq!(module.num_exports(), 2);
     ///
-    /// let foo = &module.exports()[0];
+    /// let foo = module.exports().next().unwrap();
     /// assert_eq!(foo.name(), "foo");
     /// match foo.ty() {
     ///     ExternType::Func(_) => { /* ... */ }
     ///     _ => panic!("unexpected export type!"),
     /// }
     ///
-    /// let memory = &module.exports()[1];
+    /// let memory = module.exports().nth(1).unwrap();
     /// assert_eq!(memory.name(), "memory");
     /// match memory.ty() {
     ///     ExternType::Memory(_) => { /* ... */ }
@@ -518,148 +501,51 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn exports(&self) -> &[ExportType] {
-        &self.inner.exports
+    pub fn exports<'me>(&'me self) -> impl Iterator<Item = ExportType> + 'me {
+        let inner = self.inner.clone();
+        self.inner
+            .compiled
+            .module_ref()
+            .exports
+            .iter()
+            .map(move |(name, ty)| {
+                let module = inner.compiled.module_ref();
+                let r#type = match ty {
+                    wasmtime_environ::Export::Function(func_index) => {
+                        let sig_index = module.local.functions[*func_index];
+                        let sig = &module.local.signatures[sig_index];
+                        ExternType::Func(
+                            FuncType::from_wasmtime_signature(sig)
+                                .expect("core wasm function type should be supported"),
+                        )
+                    }
+                    wasmtime_environ::Export::Table(table_index) => {
+                        ExternType::Table(TableType::from_wasmtime_table(
+                            &module.local.table_plans[*table_index].table,
+                        ))
+                    }
+                    wasmtime_environ::Export::Memory(memory_index) => {
+                        ExternType::Memory(MemoryType::from_wasmtime_memory(
+                            &module.local.memory_plans[*memory_index].memory,
+                        ))
+                    }
+                    wasmtime_environ::Export::Global(global_index) => ExternType::Global(
+                        GlobalType::from_wasmtime_global(&module.local.globals[*global_index])
+                            .expect("core wasm global type should be supported"),
+                    ),
+                };
+                ExportType::new(name, r#type)
+            })
+    }
+
+    /// Return the number of exports in this module.
+    pub fn num_exports(&self) -> usize {
+        self.inner.compiled.module_ref().exports.len()
     }
 
     /// Returns the [`Store`] that this [`Module`] was compiled into.
     pub fn store(&self) -> &Store {
         &self.inner.store
-    }
-
-    fn read_imports_and_exports(&mut self, binary: &[u8]) -> Result<()> {
-        let inner = Arc::get_mut(&mut self.inner).unwrap();
-        let mut reader = ModuleReader::new(binary)?;
-        let mut imports = Vec::new();
-        let mut exports = Vec::new();
-        let mut memories = Vec::new();
-        let mut tables = Vec::new();
-        let mut func_sig = Vec::new();
-        let mut sigs = Vec::new();
-        let mut globals = Vec::new();
-        while !reader.eof() {
-            let section = reader.read()?;
-            match section.code {
-                SectionCode::Memory => {
-                    let section = section.get_memory_section_reader()?;
-                    memories.reserve_exact(section.get_count() as usize);
-                    for entry in section {
-                        memories.push(into_memory_type(entry?)?);
-                    }
-                }
-                SectionCode::Type => {
-                    let section = section.get_type_section_reader()?;
-                    sigs.reserve_exact(section.get_count() as usize);
-                    for entry in section {
-                        sigs.push(into_func_type(entry?));
-                    }
-                }
-                SectionCode::Function => {
-                    let section = section.get_function_section_reader()?;
-                    func_sig.reserve_exact(section.get_count() as usize);
-                    for entry in section {
-                        func_sig.push(entry?);
-                    }
-                }
-                SectionCode::Global => {
-                    let section = section.get_global_section_reader()?;
-                    globals.reserve_exact(section.get_count() as usize);
-                    for entry in section {
-                        globals.push(into_global_type(entry?.ty));
-                    }
-                }
-                SectionCode::Table => {
-                    let section = section.get_table_section_reader()?;
-                    tables.reserve_exact(section.get_count() as usize);
-                    for entry in section {
-                        tables.push(into_table_type(entry?))
-                    }
-                }
-                SectionCode::Import => {
-                    let section = section.get_import_section_reader()?;
-                    imports.reserve_exact(section.get_count() as usize);
-                    for entry in section {
-                        let entry = entry?;
-                        let r#type = match entry.ty {
-                            ImportSectionEntryType::Function(index) => {
-                                func_sig.push(index);
-                                let sig = &sigs[index as usize];
-                                ExternType::Func(sig.clone())
-                            }
-                            ImportSectionEntryType::Table(tt) => {
-                                let table = into_table_type(tt);
-                                tables.push(table.clone());
-                                ExternType::Table(table)
-                            }
-                            ImportSectionEntryType::Memory(mt) => {
-                                let memory = into_memory_type(mt)?;
-                                memories.push(memory.clone());
-                                ExternType::Memory(memory)
-                            }
-                            ImportSectionEntryType::Global(gt) => {
-                                let global = into_global_type(gt);
-                                globals.push(global.clone());
-                                ExternType::Global(global)
-                            }
-                        };
-                        imports.push(ImportType::new(entry.module, entry.field, r#type));
-                    }
-                }
-                SectionCode::Export => {
-                    let section = section.get_export_section_reader()?;
-                    exports.reserve_exact(section.get_count() as usize);
-                    for entry in section {
-                        let entry = entry?;
-                        let r#type = match entry.kind {
-                            ExternalKind::Function => {
-                                let sig_index = func_sig[entry.index as usize] as usize;
-                                let sig = &sigs[sig_index];
-                                ExternType::Func(sig.clone())
-                            }
-                            ExternalKind::Table => {
-                                ExternType::Table(tables[entry.index as usize].clone())
-                            }
-                            ExternalKind::Memory => {
-                                ExternType::Memory(memories[entry.index as usize].clone())
-                            }
-                            ExternalKind::Global => {
-                                ExternType::Global(globals[entry.index as usize].clone())
-                            }
-                        };
-                        exports.push(ExportType::new(entry.field, r#type));
-                    }
-                }
-                SectionCode::Custom {
-                    name: "webidl-bindings",
-                    ..
-                }
-                | SectionCode::Custom {
-                    name: "wasm-interface-types",
-                    ..
-                } => {
-                    bail!(
-                        "\
-support for interface types has temporarily been removed from `wasmtime`
-
-for more information about this temoprary you can read on the issue online:
-
-    https://github.com/bytecodealliance/wasmtime/issues/1271
-
-and for re-adding support for interface types you can see this issue:
-
-    https://github.com/bytecodealliance/wasmtime/issues/677
-"
-                    );
-                }
-                _ => {
-                    // skip other sections
-                }
-            }
-        }
-
-        inner.imports = imports.into();
-        inner.exports = exports.into();
-        Ok(())
     }
 
     /// Register this module's stack frame information into the global scope.

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -247,7 +247,7 @@ impl FuncType {
     /// Returns `None` if any types in the signature can't be converted to the
     /// types in this crate, but that should very rarely happen and largely only
     /// indicate a bug in our cranelift integration.
-    pub(crate) fn from_wasmtime_signature(signature: ir::Signature) -> Option<FuncType> {
+    pub(crate) fn from_wasmtime_signature(signature: &ir::Signature) -> Option<FuncType> {
         let params = signature
             .params
             .iter()

--- a/crates/api/tests/func.rs
+++ b/crates/api/tests/func.rs
@@ -207,33 +207,33 @@ fn trap_import() -> Result<()> {
 fn get_from_wrapper() {
     let store = Store::default();
     let f = Func::wrap(&store, || {});
-    assert!(f.get0::<()>().is_ok());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<(), ()>().is_ok());
-    assert!(f.get1::<i32, ()>().is_err());
-    assert!(f.get1::<i32, i32>().is_err());
-    assert!(f.get2::<(), (), ()>().is_ok());
-    assert!(f.get2::<i32, i32, ()>().is_err());
-    assert!(f.get2::<i32, i32, i32>().is_err());
+    assert!(f.clone().get0::<()>().is_ok());
+    assert!(f.clone().get0::<i32>().is_err());
+    assert!(f.clone().get1::<(), ()>().is_ok());
+    assert!(f.clone().get1::<i32, ()>().is_err());
+    assert!(f.clone().get1::<i32, i32>().is_err());
+    assert!(f.clone().get2::<(), (), ()>().is_ok());
+    assert!(f.clone().get2::<i32, i32, ()>().is_err());
+    assert!(f.clone().get2::<i32, i32, i32>().is_err());
 
     let f = Func::wrap(&store, || -> i32 { loop {} });
-    assert!(f.get0::<i32>().is_ok());
+    assert!(f.clone().get0::<i32>().is_ok());
     let f = Func::wrap(&store, || -> f32 { loop {} });
-    assert!(f.get0::<f32>().is_ok());
+    assert!(f.clone().get0::<f32>().is_ok());
     let f = Func::wrap(&store, || -> f64 { loop {} });
-    assert!(f.get0::<f64>().is_ok());
+    assert!(f.clone().get0::<f64>().is_ok());
 
     let f = Func::wrap(&store, |_: i32| {});
-    assert!(f.get1::<i32, ()>().is_ok());
-    assert!(f.get1::<i64, ()>().is_err());
-    assert!(f.get1::<f32, ()>().is_err());
-    assert!(f.get1::<f64, ()>().is_err());
+    assert!(f.clone().get1::<i32, ()>().is_ok());
+    assert!(f.clone().get1::<i64, ()>().is_err());
+    assert!(f.clone().get1::<f32, ()>().is_err());
+    assert!(f.clone().get1::<f64, ()>().is_err());
     let f = Func::wrap(&store, |_: i64| {});
-    assert!(f.get1::<i64, ()>().is_ok());
+    assert!(f.clone().get1::<i64, ()>().is_ok());
     let f = Func::wrap(&store, |_: f32| {});
-    assert!(f.get1::<f32, ()>().is_ok());
+    assert!(f.clone().get1::<f32, ()>().is_ok());
     let f = Func::wrap(&store, |_: f64| {});
-    assert!(f.get1::<f64, ()>().is_ok());
+    assert!(f.clone().get1::<f64, ()>().is_ok());
 }
 
 #[test]
@@ -241,16 +241,16 @@ fn get_from_signature() {
     let store = Store::default();
     let ty = FuncType::new(Box::new([]), Box::new([]));
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.get0::<()>().is_ok());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<i32, ()>().is_err());
+    assert!(f.clone().get0::<()>().is_ok());
+    assert!(f.clone().get0::<i32>().is_err());
+    assert!(f.clone().get1::<i32, ()>().is_err());
 
     let ty = FuncType::new(Box::new([ValType::I32]), Box::new([ValType::F64]));
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.get0::<()>().is_err());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<i32, ()>().is_err());
-    assert!(f.get1::<i32, f64>().is_ok());
+    assert!(f.clone().get0::<()>().is_err());
+    assert!(f.clone().get0::<i32>().is_err());
+    assert!(f.clone().get1::<i32, ()>().is_err());
+    assert!(f.clone().get1::<i32, f64>().is_ok());
 }
 
 #[test]
@@ -270,17 +270,17 @@ fn get_from_module() -> anyhow::Result<()> {
     )?;
     let instance = Instance::new(&module, &[])?;
     let f0 = instance.get_export("f0").unwrap().func().unwrap();
-    assert!(f0.get0::<()>().is_ok());
-    assert!(f0.get0::<i32>().is_err());
+    assert!(f0.clone().get0::<()>().is_ok());
+    assert!(f0.clone().get0::<i32>().is_err());
     let f1 = instance.get_export("f1").unwrap().func().unwrap();
-    assert!(f1.get0::<()>().is_err());
-    assert!(f1.get1::<i32, ()>().is_ok());
-    assert!(f1.get1::<i32, f32>().is_err());
+    assert!(f1.clone().get0::<()>().is_err());
+    assert!(f1.clone().get1::<i32, ()>().is_ok());
+    assert!(f1.clone().get1::<i32, f32>().is_err());
     let f2 = instance.get_export("f2").unwrap().func().unwrap();
-    assert!(f2.get0::<()>().is_err());
-    assert!(f2.get0::<i32>().is_ok());
-    assert!(f2.get1::<i32, ()>().is_err());
-    assert!(f2.get1::<i32, f32>().is_err());
+    assert!(f2.clone().get0::<()>().is_err());
+    assert!(f2.clone().get0::<i32>().is_ok());
+    assert!(f2.clone().get1::<i32, ()>().is_err());
+    assert!(f2.clone().get1::<i32, f32>().is_err());
     Ok(())
 }
 

--- a/crates/api/tests/globals.rs
+++ b/crates/api/tests/globals.rs
@@ -70,7 +70,7 @@ fn use_after_drop() -> anyhow::Result<()> {
         "#,
     )?;
     let instance = Instance::new(&module, &[])?;
-    let g = instance.exports()[0].global().unwrap().clone();
+    let g = instance.exports().next().unwrap().global().unwrap();
     assert_eq!(g.get().i32(), Some(100));
     g.set(101.into())?;
     drop(instance);

--- a/crates/api/tests/import_calling_export.rs
+++ b/crates/api/tests/import_calling_export.rs
@@ -40,18 +40,20 @@ fn test_import_calling_export() {
     let instance =
         Instance::new(&module, imports.as_slice()).expect("failed to instantiate module");
 
-    let exports = instance.exports();
-    assert!(!exports.is_empty());
+    let mut exports = instance.exports();
 
-    let run_func = exports[0]
+    let run_func = exports
+        .next()
+        .unwrap()
         .func()
         .expect("expected a run func in the module");
 
     *other.borrow_mut() = Some(
-        exports[1]
+        exports
+            .next()
+            .unwrap()
             .func()
-            .expect("expected an other func in the module")
-            .clone(),
+            .expect("expected an other func in the module"),
     );
 
     run_func.call(&[]).expect("expected function not to trap");
@@ -84,10 +86,11 @@ fn test_returns_incorrect_type() -> Result<()> {
     let imports = vec![callback_func.into()];
     let instance = Instance::new(&module, imports.as_slice())?;
 
-    let exports = instance.exports();
-    assert!(!exports.is_empty());
+    let mut exports = instance.exports();
 
-    let run_func = exports[0]
+    let run_func = exports
+        .next()
+        .unwrap()
         .func()
         .expect("expected a run func in the module");
 

--- a/crates/api/tests/traps.rs
+++ b/crates/api/tests/traps.rs
@@ -17,7 +17,10 @@ fn test_trap_return() -> Result<()> {
     let hello_func = Func::new(&store, hello_type, |_, _, _| Err(Trap::new("test 123")));
 
     let instance = Instance::new(&module, &[hello_func.into()])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -44,7 +47,10 @@ fn test_trap_trace() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -91,7 +97,10 @@ fn test_trap_trace_cb() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[fn_func.into()])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -123,7 +132,10 @@ fn test_trap_stack_overflow() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -159,7 +171,10 @@ fn trap_display_pretty() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -192,7 +207,7 @@ fn trap_display_multi_module() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let bar = instance.exports()[0].clone();
+    let bar = instance.exports().next().unwrap();
 
     let wat = r#"
         (module $b
@@ -203,7 +218,10 @@ fn trap_display_multi_module() -> Result<()> {
     "#;
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[bar])?;
-    let bar2 = instance.exports()[0]
+    let bar2 = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -268,14 +286,14 @@ fn rust_panic_import() -> Result<()> {
             Func::wrap(&store, || panic!("this is another panic")).into(),
         ],
     )?;
-    let func = instance.exports()[0].func().unwrap().clone();
+    let func = instance.exports().next().unwrap().func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
     .unwrap_err();
     assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
 
-    let func = instance.exports()[1].func().unwrap().clone();
+    let func = instance.exports().nth(1).unwrap().func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
@@ -333,7 +351,7 @@ fn mismatched_arguments() -> Result<()> {
 
     let module = Module::new(&store, &binary)?;
     let instance = Instance::new(&module, &[])?;
-    let func = instance.exports()[0].func().unwrap().clone();
+    let func = instance.exports().next().unwrap().func().unwrap();
     assert_eq!(
         func.call(&[]).unwrap_err().to_string(),
         "expected 1 arguments, got 0"

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -145,7 +145,6 @@ pub extern "C" fn wasm_instance_exports(instance: &wasm_instance_t, out: &mut wa
         let instance = &instance.instance.borrow();
         instance
             .exports()
-            .iter()
             .map(|e| match e {
                 Extern::Func(f) => ExternHost::Func(HostRef::new(f.clone())),
                 Extern::Global(f) => ExternHost::Global(HostRef::new(f.clone())),

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -46,12 +46,10 @@ pub extern "C" fn wasmtime_module_new(
     handle_result(Module::from_binary(store, binary), |module| {
         let imports = module
             .imports()
-            .iter()
             .map(|i| wasm_importtype_t::new(i.clone()))
             .collect::<Vec<_>>();
         let exports = module
             .exports()
-            .iter()
             .map(|e| wasm_exporttype_t::new(e.clone()))
             .collect::<Vec<_>>();
         let module = Box::new(wasm_module_t {

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -331,7 +331,7 @@ pub extern "C" fn wasi_instance_bind_import<'a>(
         }
     };
 
-    if export.ty() != import.ty.ty().func()? {
+    if &export.ty() != import.ty.ty().func()? {
         return None;
     }
 

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -150,18 +150,8 @@ pub struct Module {
     /// function.
     pub local: ModuleLocal,
 
-    /// Names of imported functions, as well as the index of the import that
-    /// performed this import.
-    pub imported_funcs: PrimaryMap<FuncIndex, (String, String, u32)>,
-
-    /// Names of imported tables.
-    pub imported_tables: PrimaryMap<TableIndex, (String, String, u32)>,
-
-    /// Names of imported memories.
-    pub imported_memories: PrimaryMap<MemoryIndex, (String, String, u32)>,
-
-    /// Names of imported globals.
-    pub imported_globals: PrimaryMap<GlobalIndex, (String, String, u32)>,
+    /// All import records, in the order they are declared in the module.
+    pub imports: Vec<(String, String, Export)>,
 
     /// Exported entities.
     pub exports: IndexMap<String, Export>,
@@ -226,10 +216,7 @@ impl Module {
         Self {
             id: NEXT_ID.fetch_add(1, SeqCst),
             name: None,
-            imported_funcs: PrimaryMap::new(),
-            imported_tables: PrimaryMap::new(),
-            imported_memories: PrimaryMap::new(),
-            imported_globals: PrimaryMap::new(),
+            imports: Vec::new(),
             exports: IndexMap::new(),
             start_func: None,
             table_elements: Vec::new(),

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -8,7 +8,7 @@ use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{
     self, translate_module, DataIndex, DefinedFuncIndex, ElemIndex, FuncIndex, Global, GlobalIndex,
     Memory, MemoryIndex, ModuleTranslationState, SignatureIndex, Table, TableIndex,
-    TargetEnvironment, WasmResult,
+    TargetEnvironment, WasmError, WasmResult,
 };
 use std::convert::TryFrom;
 use std::sync::Arc;
@@ -57,7 +57,6 @@ impl<'data> ModuleTranslation<'data> {
 pub struct ModuleEnvironment<'data> {
     /// The result to be filled in.
     result: ModuleTranslation<'data>,
-    imports: u32,
 }
 
 impl<'data> ModuleEnvironment<'data> {
@@ -72,7 +71,6 @@ impl<'data> ModuleEnvironment<'data> {
                 tunables: tunables.clone(),
                 module_translation: None,
             },
-            imports: 0,
         }
     }
 
@@ -123,6 +121,14 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         Ok(())
     }
 
+    fn reserve_imports(&mut self, num: u32) -> WasmResult<()> {
+        Ok(self
+            .result
+            .module
+            .imports
+            .reserve_exact(usize::try_from(num).unwrap()))
+    }
+
     fn declare_func_import(
         &mut self,
         sig_index: SignatureIndex,
@@ -131,37 +137,33 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     ) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.functions.len(),
-            self.result.module.imported_funcs.len(),
+            self.result.module.local.num_imported_funcs,
             "Imported functions must be declared first"
         );
-        self.result.module.local.functions.push(sig_index);
-
-        self.result.module.imported_funcs.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let func_index = self.result.module.local.functions.push(sig_index);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Function(func_index),
         ));
         self.result.module.local.num_imported_funcs += 1;
-        self.imports += 1;
         Ok(())
     }
 
     fn declare_table_import(&mut self, table: Table, module: &str, field: &str) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.table_plans.len(),
-            self.result.module.imported_tables.len(),
+            self.result.module.local.num_imported_tables,
             "Imported tables must be declared first"
         );
         let plan = TablePlan::for_table(table, &self.result.tunables);
-        self.result.module.local.table_plans.push(plan);
-
-        self.result.module.imported_tables.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let table_index = self.result.module.local.table_plans.push(plan);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Table(table_index),
         ));
         self.result.module.local.num_imported_tables += 1;
-        self.imports += 1;
         Ok(())
     }
 
@@ -173,19 +175,20 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     ) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.memory_plans.len(),
-            self.result.module.imported_memories.len(),
+            self.result.module.local.num_imported_memories,
             "Imported memories must be declared first"
         );
+        if memory.shared {
+            return Err(WasmError::Unsupported("shared memories".to_owned()));
+        }
         let plan = MemoryPlan::for_memory(memory, &self.result.tunables);
-        self.result.module.local.memory_plans.push(plan);
-
-        self.result.module.imported_memories.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let memory_index = self.result.module.local.memory_plans.push(plan);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Memory(memory_index),
         ));
         self.result.module.local.num_imported_memories += 1;
-        self.imports += 1;
         Ok(())
     }
 
@@ -197,26 +200,16 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     ) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.globals.len(),
-            self.result.module.imported_globals.len(),
+            self.result.module.local.num_imported_globals,
             "Imported globals must be declared first"
         );
-        self.result.module.local.globals.push(global);
-
-        self.result.module.imported_globals.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let global_index = self.result.module.local.globals.push(global);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Global(global_index),
         ));
         self.result.module.local.num_imported_globals += 1;
-        self.imports += 1;
-        Ok(())
-    }
-
-    fn finish_imports(&mut self) -> WasmResult<()> {
-        self.result.module.imported_funcs.shrink_to_fit();
-        self.result.module.imported_tables.shrink_to_fit();
-        self.result.module.imported_memories.shrink_to_fit();
-        self.result.module.imported_globals.shrink_to_fit();
         Ok(())
     }
 
@@ -262,6 +255,9 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn declare_memory(&mut self, memory: Memory) -> WasmResult<()> {
+        if memory.shared {
+            return Err(WasmError::Unsupported("shared memories".to_owned()));
+        }
         let plan = MemoryPlan::for_memory(memory, &self.result.tunables);
         self.result.module.local.memory_plans.push(plan);
         Ok(())
@@ -420,6 +416,27 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
             .func_names
             .insert(func_index, name.to_string());
         Ok(())
+    }
+
+    fn custom_section(&mut self, name: &'data str, _data: &'data [u8]) -> WasmResult<()> {
+        match name {
+            "webidl-bindings" | "wasm-interface-types" => Err(WasmError::Unsupported(
+                "\
+Support for interface types has temporarily been removed from `wasmtime`.
+
+For more information about this temoprary you can read on the issue online:
+
+    https://github.com/bytecodealliance/wasmtime/issues/1271
+
+and for re-adding support for interface types you can see this issue:
+
+    https://github.com/bytecodealliance/wasmtime/issues/677
+"
+                .to_owned(),
+            )),
+            // skip other sections
+            _ => Ok(()),
+        }
     }
 }
 

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -6,19 +6,24 @@ use wasmtime::{
 };
 
 /// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_imports(store: &Store, import_tys: &[ImportType]) -> Result<Vec<Extern>, Trap> {
-    let mut imports = Vec::with_capacity(import_tys.len());
-    for imp in import_tys {
-        imports.push(match imp.ty() {
-            ExternType::Func(func_ty) => Extern::Func(dummy_func(&store, func_ty.clone())),
-            ExternType::Global(global_ty) => {
-                Extern::Global(dummy_global(&store, global_ty.clone())?)
-            }
-            ExternType::Table(table_ty) => Extern::Table(dummy_table(&store, table_ty.clone())?),
-            ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(&store, mem_ty.clone())),
-        });
-    }
-    Ok(imports)
+pub fn dummy_imports(
+    store: &Store,
+    import_tys: impl Iterator<Item = ImportType>,
+) -> Result<Vec<Extern>, Trap> {
+    import_tys
+        .map(|imp| {
+            Ok(match imp.ty() {
+                ExternType::Func(func_ty) => Extern::Func(dummy_func(&store, func_ty.clone())),
+                ExternType::Global(global_ty) => {
+                    Extern::Global(dummy_global(&store, global_ty.clone())?)
+                }
+                ExternType::Table(table_ty) => {
+                    Extern::Table(dummy_table(&store, table_ty.clone())?)
+                }
+                ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(&store, mem_ty.clone())),
+            })
+        })
+        .collect()
 }
 
 /// Construct a dummy function for the given function type

--- a/crates/jit/src/imports.rs
+++ b/crates/jit/src/imports.rs
@@ -3,6 +3,7 @@
 use crate::resolver::Resolver;
 use more_asserts::assert_ge;
 use std::collections::HashSet;
+use std::convert::TryInto;
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::wasm::{Global, GlobalInit, Memory, Table, TableElementType};
 use wasmtime_environ::{MemoryPlan, MemoryStyle, Module, TablePlan};
@@ -22,156 +23,140 @@ pub fn resolve_imports(
 ) -> Result<Imports, LinkError> {
     let mut dependencies = HashSet::new();
 
-    let mut function_imports = PrimaryMap::with_capacity(module.imported_funcs.len());
-    for (index, (module_name, field, import_idx)) in module.imported_funcs.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Function(f) => {
-                    let import_signature = &module.local.signatures[module.local.functions[index]];
-                    let signature = signatures.lookup(f.signature).unwrap();
-                    if signature != *import_signature {
-                        // TODO: If the difference is in the calling convention,
-                        // we could emit a wrapper function to fix it up.
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported function with signature {} \
-                             incompatible with function import with signature {}",
-                            module_name, field, signature, import_signature
-                        )));
-                    }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(f.vmctx) });
-                    function_imports.push(VMFunctionImport {
-                        body: f.address,
-                        vmctx: f.vmctx,
-                    });
-                }
-                Export::Table(_) | Export::Memory(_) | Export::Global(_) => {
+    let mut function_imports = PrimaryMap::with_capacity(module.local.num_imported_funcs);
+    let mut table_imports = PrimaryMap::with_capacity(module.local.num_imported_tables);
+    let mut memory_imports = PrimaryMap::with_capacity(module.local.num_imported_memories);
+    let mut global_imports = PrimaryMap::with_capacity(module.local.num_imported_globals);
+
+    for (import_idx, (module_name, field_name, import)) in module.imports.iter().enumerate() {
+        let import_idx = import_idx.try_into().unwrap();
+        let export = resolver.resolve(import_idx, module_name, field_name);
+
+        match (import, &export) {
+            (wasmtime_environ::Export::Function(func_index), Some(Export::Function(f))) => {
+                let import_signature =
+                    &module.local.signatures[module.local.functions[*func_index]];
+                let signature = signatures.lookup(f.signature).unwrap();
+                if signature != *import_signature {
+                    // TODO: If the difference is in the calling convention,
+                    // we could emit a wrapper function to fix it up.
                     return Err(LinkError(format!(
-                        "{}/{}: incompatible import type: export incompatible with function import",
-                        module_name, field
+                        "{}/{}: incompatible import type: exported function with signature {} \
+                         incompatible with function import with signature {}",
+                        module_name, field_name, signature, import_signature
                     )));
                 }
-            },
-            None => {
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(f.vmctx) });
+                function_imports.push(VMFunctionImport {
+                    body: f.address,
+                    vmctx: f.vmctx,
+                });
+            }
+            (wasmtime_environ::Export::Function(_), Some(_)) => {
+                return Err(LinkError(format!(
+                    "{}/{}: incompatible import type: export incompatible with function import",
+                    module_name, field_name
+                )));
+            }
+            (wasmtime_environ::Export::Function(_), None) => {
                 return Err(LinkError(format!(
                     "{}/{}: unknown import function: function not provided",
-                    module_name, field
+                    module_name, field_name
                 )));
             }
-        }
-    }
 
-    let mut table_imports = PrimaryMap::with_capacity(module.imported_tables.len());
-    for (index, (module_name, field, import_idx)) in module.imported_tables.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Table(t) => {
-                    let import_table = &module.local.table_plans[index];
-                    if !is_table_compatible(&t.table, import_table) {
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported table incompatible with \
+            (wasmtime_environ::Export::Table(table_index), Some(Export::Table(t))) => {
+                let import_table = &module.local.table_plans[*table_index];
+                if !is_table_compatible(&t.table, import_table) {
+                    return Err(LinkError(format!(
+                        "{}/{}: incompatible import type: exported table incompatible with \
                              table import",
-                            module_name, field,
-                        )));
-                    }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(t.vmctx) });
-                    table_imports.push(VMTableImport {
-                        from: t.definition,
-                        vmctx: t.vmctx,
-                    });
-                }
-                Export::Global(_) | Export::Memory(_) | Export::Function(_) => {
-                    return Err(LinkError(format!(
-                        "{}/{}: incompatible import type: export incompatible with table import",
-                        module_name, field
+                        module_name, field_name,
                     )));
                 }
-            },
-            None => {
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(t.vmctx) });
+                table_imports.push(VMTableImport {
+                    from: t.definition,
+                    vmctx: t.vmctx,
+                });
+            }
+            (wasmtime_environ::Export::Table(_), Some(_)) => {
                 return Err(LinkError(format!(
-                    "unknown import: no provided import table for {}/{}",
-                    module_name, field
+                    "{}/{}: incompatible import type: export incompatible with table import",
+                    module_name, field_name
                 )));
             }
-        }
-    }
+            (wasmtime_environ::Export::Table(_), None) => {
+                return Err(LinkError(format!(
+                    "{}/{}: unknown import table: table not provided",
+                    module_name, field_name
+                )));
+            }
 
-    let mut memory_imports = PrimaryMap::with_capacity(module.imported_memories.len());
-    for (index, (module_name, field, import_idx)) in module.imported_memories.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Memory(m) => {
-                    let import_memory = &module.local.memory_plans[index];
-                    if !is_memory_compatible(&m.memory, import_memory) {
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported memory incompatible with \
+            (wasmtime_environ::Export::Memory(memory_index), Some(Export::Memory(m))) => {
+                let import_memory = &module.local.memory_plans[*memory_index];
+                if !is_memory_compatible(&m.memory, import_memory) {
+                    return Err(LinkError(format!(
+                        "{}/{}: incompatible import type: exported memory incompatible with \
                              memory import",
-                            module_name, field
-                        )));
-                    }
-
-                    // Sanity-check: Ensure that the imported memory has at least
-                    // guard-page protections the importing module expects it to have.
-                    if let (
-                        MemoryStyle::Static { bound },
-                        MemoryStyle::Static {
-                            bound: import_bound,
-                        },
-                    ) = (m.memory.style, &import_memory.style)
-                    {
-                        assert_ge!(bound, *import_bound);
-                    }
-                    assert_ge!(m.memory.offset_guard_size, import_memory.offset_guard_size);
-
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(m.vmctx) });
-                    memory_imports.push(VMMemoryImport {
-                        from: m.definition,
-                        vmctx: m.vmctx,
-                    });
-                }
-                Export::Table(_) | Export::Global(_) | Export::Function(_) => {
-                    return Err(LinkError(format!(
-                        "{}/{}: incompatible import type: export incompatible with memory import",
-                        module_name, field
+                        module_name, field_name
                     )));
                 }
-            },
-            None => {
+
+                // Sanity-check: Ensure that the imported memory has at least
+                // guard-page protections the importing module expects it to have.
+                if let (
+                    MemoryStyle::Static { bound },
+                    MemoryStyle::Static {
+                        bound: import_bound,
+                    },
+                ) = (&m.memory.style, &import_memory.style)
+                {
+                    assert_ge!(*bound, *import_bound);
+                }
+                assert_ge!(m.memory.offset_guard_size, import_memory.offset_guard_size);
+
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(m.vmctx) });
+                memory_imports.push(VMMemoryImport {
+                    from: m.definition,
+                    vmctx: m.vmctx,
+                });
+            }
+            (wasmtime_environ::Export::Memory(_), Some(_)) => {
                 return Err(LinkError(format!(
-                    "unknown import: no provided import memory for {}/{}",
-                    module_name, field
+                    "{}/{}: incompatible import type: export incompatible with memory import",
+                    module_name, field_name
                 )));
             }
-        }
-    }
+            (wasmtime_environ::Export::Memory(_), None) => {
+                return Err(LinkError(format!(
+                    "{}/{}: unknown import memory: memory not provided",
+                    module_name, field_name
+                )));
+            }
 
-    let mut global_imports = PrimaryMap::with_capacity(module.imported_globals.len());
-    for (index, (module_name, field, import_idx)) in module.imported_globals.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Table(_) | Export::Memory(_) | Export::Function(_) => {
+            (wasmtime_environ::Export::Global(global_index), Some(Export::Global(g))) => {
+                let imported_global = module.local.globals[*global_index];
+                if !is_global_compatible(&g.global, &imported_global) {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: exported global incompatible with \
-                         global import",
-                        module_name, field
+                             global import",
+                        module_name, field_name
                     )));
                 }
-                Export::Global(g) => {
-                    let imported_global = module.local.globals[index];
-                    if !is_global_compatible(&g.global, &imported_global) {
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported global incompatible with \
-                             global import",
-                            module_name, field
-                        )));
-                    }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(g.vmctx) });
-                    global_imports.push(VMGlobalImport { from: g.definition });
-                }
-            },
-            None => {
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(g.vmctx) });
+                global_imports.push(VMGlobalImport { from: g.definition });
+            }
+            (wasmtime_environ::Export::Global(_), Some(_)) => {
                 return Err(LinkError(format!(
-                    "unknown import: no provided import global for {}/{}",
-                    module_name, field
+                    "{}/{}: incompatible import type: export incompatible with global import",
+                    module_name, field_name
+                )));
+            }
+            (wasmtime_environ::Export::Global(_), None) => {
+                return Err(LinkError(format!(
+                    "{}/{}: unknown import global: global not provided",
+                    module_name, field_name
                 )));
             }
         }

--- a/crates/obj/src/context.rs
+++ b/crates/obj/src/context.rs
@@ -42,7 +42,7 @@ pub fn layout_vmcontext(
         }
     }
 
-    let num_tables_imports = module.imported_tables.len();
+    let num_tables_imports = module.local.num_imported_tables;
     let mut table_relocs = Vec::with_capacity(module.local.table_plans.len() - num_tables_imports);
     for (index, table) in module.local.table_plans.iter().skip(num_tables_imports) {
         let def_index = module.local.defined_table_index(index).unwrap();
@@ -66,7 +66,7 @@ pub fn layout_vmcontext(
         });
     }
 
-    let num_globals_imports = module.imported_globals.len();
+    let num_globals_imports = module.local.num_imported_globals;
     for (index, global) in module.local.globals.iter().skip(num_globals_imports) {
         let def_index = module.local.defined_global_index(index).unwrap();
         let offset = ofs.vmctx_vmglobal_definition(def_index) as usize;

--- a/crates/obj/src/function.rs
+++ b/crates/obj/src/function.rs
@@ -11,7 +11,7 @@ pub fn declare_functions(
     module: &Module,
     relocations: &Relocations,
 ) -> Result<()> {
-    for i in 0..module.imported_funcs.len() {
+    for i in 0..module.local.num_imported_funcs {
         let string_name = format!("_wasm_function_{}", i);
         obj.declare(string_name, Decl::function_import())?;
     }
@@ -32,7 +32,7 @@ pub fn emit_functions(
 ) -> Result<()> {
     debug_assert!(
         module.start_func.is_none()
-            || module.start_func.unwrap().index() >= module.imported_funcs.len(),
+            || module.start_func.unwrap().index() >= module.local.num_imported_funcs,
         "imported start functions not supported yet"
     );
 

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1138,7 +1138,7 @@ impl InstanceHandle {
                     Ok(None)
                 } else {
                     Err(InstantiationError::WASIInvalid(
-                        "Must be a function".to_owned(),
+                        "_start must be a function".to_owned(),
                     ))
                 }
             }
@@ -1161,7 +1161,7 @@ impl InstanceHandle {
                     Ok(Some(self))
                 } else {
                     Err(InstantiationError::WASIInvalid(
-                        "Must be a function".to_owned(),
+                        "_initialize must be a function".to_owned(),
                     ))
                 }
             }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -398,7 +398,7 @@ impl Instance {
                     (body as *const _, self.vmctx_ptr())
                 }
                 None => {
-                    assert_lt!(callee_index.index(), self.module.imported_funcs.len());
+                    assert_lt!(callee_index.index(), self.module.local.num_imported_funcs);
                     let import = self.imported_function(callee_index);
                     (import.body, import.vmctx)
                 }
@@ -1287,7 +1287,7 @@ fn check_memory_init_bounds(
 
 /// Allocate memory for just the tables of the current module.
 fn create_tables(module: &Module) -> BoxedSlice<DefinedTableIndex, Table> {
-    let num_imports = module.imported_tables.len();
+    let num_imports = module.local.num_imported_tables;
     let mut tables: PrimaryMap<DefinedTableIndex, _> =
         PrimaryMap::with_capacity(module.local.table_plans.len() - num_imports);
     for table in &module.local.table_plans.values().as_slice()[num_imports..] {
@@ -1374,7 +1374,7 @@ fn create_memories(
     module: &Module,
     mem_creator: &dyn RuntimeMemoryCreator,
 ) -> Result<BoxedSlice<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>, InstantiationError> {
-    let num_imports = module.imported_memories.len();
+    let num_imports = module.local.num_imported_memories;
     let mut memories: PrimaryMap<DefinedMemoryIndex, _> =
         PrimaryMap::with_capacity(module.local.memory_plans.len() - num_imports);
     for plan in &module.local.memory_plans.values().as_slice()[num_imports..] {
@@ -1419,7 +1419,7 @@ fn initialize_memories(
 /// Allocate memory for just the globals of the current module,
 /// with initializers applied.
 fn create_globals(module: &Module) -> BoxedSlice<DefinedGlobalIndex, VMGlobalDefinition> {
-    let num_imports = module.imported_globals.len();
+    let num_imports = module.local.num_imported_globals;
     let mut vmctx_globals = PrimaryMap::with_capacity(module.local.globals.len() - num_imports);
 
     for _ in &module.local.globals.values().as_slice()[num_imports..] {
@@ -1431,7 +1431,7 @@ fn create_globals(module: &Module) -> BoxedSlice<DefinedGlobalIndex, VMGlobalDef
 
 fn initialize_globals(instance: &Instance) {
     let module = Arc::clone(&instance.module);
-    let num_imports = module.imported_globals.len();
+    let num_imports = module.local.num_imported_globals;
     for (index, global) in module.local.globals.iter().skip(num_imports) {
         let def_index = module.local.defined_global_index(index).unwrap();
         unsafe {

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -71,15 +71,11 @@ pub fn instantiate(
         bin_name,
     ))?;
 
-    let export = instance
-        .get_export("_start")
-        .context("expected a _start export")?
-        .clone();
+    let result = instance.invoke_wasi_start_function()?;
 
-    export
-        .func()
-        .context("expected export to be a func")?
-        .call(&[])?;
+    if result.is_some() {
+        bail!("expected module to be a command with a \"_start\" function")
+    }
 
     Ok(())
 }

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -51,7 +51,6 @@ pub fn instantiate(
     let module = Module::new(&store, &data).context("failed to create wasm module")?;
     let imports = module
         .imports()
-        .iter()
         .map(|i| {
             let field_name = i.name();
             if let Some(export) = snapshot1.get_export(field_name) {

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -68,7 +68,7 @@ impl WastContext {
 
     fn get_export(&self, module: Option<&str>, name: &str) -> Result<Extern> {
         match module {
-            Some(module) => self.linker.get_one_by_name(module, name).map(Extern::clone),
+            Some(module) => self.linker.get_one_by_name(module, name),
             None => self
                 .current
                 .as_ref()

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -66,9 +66,9 @@ impl WastContext {
         }
     }
 
-    fn get_export(&self, module: Option<&str>, name: &str) -> Result<&Extern> {
+    fn get_export(&self, module: Option<&str>, name: &str) -> Result<Extern> {
         match module {
-            Some(module) => self.linker.get_one_by_name(module, name),
+            Some(module) => self.linker.get_one_by_name(module, name).map(Extern::clone),
             None => self
                 .current
                 .as_ref()

--- a/examples/wasi/main.c
+++ b/examples/wasi/main.c
@@ -96,6 +96,7 @@ int main() {
   wasm_importtype_vec_delete(&import_types);
 
   // Lookup our `_start` export function
+  // TODO: Add API for this to call invoke_wasi_start_function.
   wasm_extern_vec_t externs;
   wasm_instance_exports(instance, &externs);
   wasm_exporttype_vec_t exports;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -199,7 +199,6 @@ impl RunCommand {
         // Resolve import using module_registry.
         let imports = module
             .imports()
-            .iter()
             .map(|i| {
                 let export = match i.module() {
                     "wasi_snapshot_preview1" => {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -122,3 +122,54 @@ fn hello_wasi_snapshot1() -> Result<()> {
     assert_eq!(stdout, "Hello, world!\n");
     Ok(())
 }
+
+// Run a command which does nothing.
+#[test]
+fn minimal_command() -> Result<()> {
+    let wasm = build_wasm("tests/wasm/minimal-command.wat")?;
+    let stdout = run_wasmtime(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+// Attempt to invoke an export on a command.
+#[test]
+fn minimal_command_with_invoke() -> Result<()> {
+    let wasm = build_wasm("tests/wasm/minimal-command.wat")?;
+    assert!(
+        run_wasmtime(&[
+            "run",
+            wasm.path().to_str().unwrap(),
+            "--invoke",
+            "_start",
+            "--disable-cache",
+        ])
+        .is_err(),
+        "shall fail"
+    );
+    Ok(())
+}
+
+// Run a reactor which does nothing.
+#[test]
+fn minimal_reactor() -> Result<()> {
+    let wasm = build_wasm("tests/wasm/minimal-reactor.wat")?;
+    let stdout = run_wasmtime(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+// Invoke an export on a reactor.
+#[test]
+fn minimal_reactor_with_invoke() -> Result<()> {
+    let wasm = build_wasm("tests/wasm/minimal-reactor.wat")?;
+    let output = run_wasmtime(&[
+        "run",
+        wasm.path().to_str().unwrap(),
+        "--invoke",
+        "_initialize",
+        "--disable-cache",
+    ])?;
+    assert!(output.is_empty());
+    Ok(())
+}

--- a/tests/custom_signal_handler.rs
+++ b/tests/custom_signal_handler.rs
@@ -105,8 +105,7 @@ mod tests {
             });
         }
 
-        let exports = instance.exports();
-        assert!(!exports.is_empty());
+        let mut exports = instance.exports();
 
         // these invoke wasmtime_call_trampoline from action.rs
         {
@@ -130,7 +129,9 @@ mod tests {
 
         // these invoke wasmtime_call_trampoline from callable.rs
         {
-            let read_func = exports[0]
+            let read_func = exports
+                .next()
+                .unwrap()
                 .func()
                 .expect("expected a 'read' func in the module");
             println!("calling read...");
@@ -139,7 +140,9 @@ mod tests {
         }
 
         {
-            let read_out_of_bounds_func = exports[1]
+            let read_out_of_bounds_func = exports
+                .next()
+                .unwrap()
                 .func()
                 .expect("expected a 'read_out_of_bounds' func in the module");
             println!("calling read_out_of_bounds...");
@@ -216,8 +219,8 @@ mod tests {
 
         // First instance1
         {
-            let exports1 = instance1.exports();
-            assert!(!exports1.is_empty());
+            let mut exports1 = instance1.exports();
+            assert!(exports1.next().is_some());
 
             println!("calling instance1.read...");
             let result = invoke_export(&instance1, "read").expect("read succeeded");
@@ -231,8 +234,8 @@ mod tests {
 
         // And then instance2
         {
-            let exports2 = instance2.exports();
-            assert!(!exports2.is_empty());
+            let mut exports2 = instance2.exports();
+            assert!(exports2.next().is_some());
 
             println!("calling instance2.read...");
             let result = invoke_export(&instance2, "read").expect("read succeeded");
@@ -262,11 +265,10 @@ mod tests {
             });
         }
 
-        let instance1_exports = instance1.exports();
-        assert!(!instance1_exports.is_empty());
-        let instance1_read = instance1_exports[0].clone();
+        let mut instance1_exports = instance1.exports();
+        let instance1_read = instance1_exports.next().unwrap();
 
-        // instance2 wich calls 'instance1.read'
+        // instance2 which calls 'instance1.read'
         let module2 = Module::new(&store, WAT2)?;
         let instance2 = Instance::new(&module2, &[instance1_read])?;
         // since 'instance2.run' calls 'instance1.read' we need to set up the signal handler to handle

--- a/tests/misc_testsuite/threads.wast
+++ b/tests/misc_testsuite/threads.wast
@@ -1,1 +1,1 @@
-(assert_invalid (module (memory 1 1 shared)) "not supported")
+(assert_invalid (module (memory 1 1 shared)) "Unsupported feature: shared memories")

--- a/tests/wasm/minimal-command.wat
+++ b/tests/wasm/minimal-command.wat
@@ -1,0 +1,3 @@
+(module
+    (func (export "_start"))
+)

--- a/tests/wasm/minimal-reactor.wat
+++ b/tests/wasm/minimal-reactor.wat
@@ -1,0 +1,3 @@
+(module
+    (func (export "_initialize"))
+)


### PR DESCRIPTION
This adds support for the WASI reactor ABI proposed in
https://github.com/WebAssembly/WASI/pull/256, as well as the existing
_start ABI for commands.

This also implements the semantics that command instances should not
persist after their _start function is called. As a safety measure,
this includes a check that the instance refcount is 1, so that other
references to the instance don't hold it live.

Implementing that prompted a change to how the main Instance API works.
Instead having instances eagerly compute a Vec of Externs, and bumping
the refcount for each Extern, compute Externs on demand.

This also means that the closure returned by `get0` and friends now
holds an `InstanceHandle` to dynamically hold the instance live rather
than being scoped to a lifetime.

This is a draft PR for now while I think more about whether this is a good
approach.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
