### PR TITLE
Refactor

### DIFF
--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -68,7 +68,7 @@ pub struct ElemIndex(u32);
 entity_impl!(ElemIndex);
 
 /// WebAssembly global.
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct Global {
     /// The type of the value stored in the global.
     pub ty: ir::Type,
@@ -79,7 +79,7 @@ pub struct Global {
 }
 
 /// Globals are initialized via the `const` operators or by referring to another import.
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum GlobalInit {
     /// An `i32.const`.
     I32Const(i32),
@@ -102,7 +102,7 @@ pub enum GlobalInit {
 }
 
 /// WebAssembly table.
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct Table {
     /// The type of data stored in elements of the table.
     pub ty: TableElementType,
@@ -113,7 +113,7 @@ pub struct Table {
 }
 
 /// WebAssembly table element. Can be a function or a scalar type.
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum TableElementType {
     /// A scalar type.
     Val(ir::Type),
@@ -122,7 +122,7 @@ pub enum TableElementType {
 }
 
 /// WebAssembly linear memory.
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct Memory {
     /// The minimum number of pages in the memory.
     pub minimum: u32,

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -34,7 +34,7 @@ impl Extern {
     /// Returns the underlying `Func`, if this external is a function.
     ///
     /// Returns `None` if this is not a function.
-    pub fn func(self) -> Option<Func> {
+    pub fn into_func(self) -> Option<Func> {
         match self {
             Extern::Func(func) => Some(func),
             _ => None,
@@ -44,7 +44,7 @@ impl Extern {
     /// Returns the underlying `Global`, if this external is a global.
     ///
     /// Returns `None` if this is not a global.
-    pub fn global(self) -> Option<Global> {
+    pub fn into_global(self) -> Option<Global> {
         match self {
             Extern::Global(global) => Some(global),
             _ => None,
@@ -54,7 +54,7 @@ impl Extern {
     /// Returns the underlying `Table`, if this external is a table.
     ///
     /// Returns `None` if this is not a table.
-    pub fn table(self) -> Option<Table> {
+    pub fn into_table(self) -> Option<Table> {
         match self {
             Extern::Table(table) => Some(table),
             _ => None,
@@ -64,7 +64,7 @@ impl Extern {
     /// Returns the underlying `Memory`, if this external is a memory.
     ///
     /// Returns `None` if this is not a memory.
-    pub fn memory(self) -> Option<Memory> {
+    pub fn into_memory(self) -> Option<Memory> {
         match self {
             Extern::Memory(memory) => Some(memory),
             _ => None,
@@ -702,7 +702,7 @@ impl Memory {
     /// let store = Store::default();
     /// let module = Module::new(&store, "(module (memory (export \"mem\") 1))")?;
     /// let instance = Instance::new(&module, &[])?;
-    /// let memory = instance.get_export("mem").unwrap().memory().unwrap();
+    /// let memory = instance.get_export("mem").unwrap().into_memory().unwrap();
     /// let ty = memory.ty();
     /// assert_eq!(ty.limits().min(), 1);
     /// # Ok(())
@@ -814,7 +814,7 @@ impl Memory {
     /// let store = Store::default();
     /// let module = Module::new(&store, "(module (memory (export \"mem\") 1 2))")?;
     /// let instance = Instance::new(&module, &[])?;
-    /// let memory = instance.get_export("mem").unwrap().memory().unwrap();
+    /// let memory = instance.get_export("mem").unwrap().into_memory().unwrap();
     ///
     /// assert_eq!(memory.size(), 1);
     /// assert_eq!(memory.grow(1)?, 1);
@@ -908,24 +908,24 @@ pub struct Export<'instance> {
 }
 
 impl<'instance> Export<'instance> {
-    /// Shorthand for `self.external.func()`.
-    pub fn func(self) -> Option<Func> {
-        self.external.func()
+    /// Shorthand for `self.external.into_func()`.
+    pub fn into_func(self) -> Option<Func> {
+        self.external.into_func()
     }
 
-    /// Shorthand for `self.external.table()`.
-    pub fn table(self) -> Option<Table> {
-        self.external.table()
+    /// Shorthand for `self.external.into_table()`.
+    pub fn into_table(self) -> Option<Table> {
+        self.external.into_table()
     }
 
-    /// Shorthand for `self.external.memory()`.
-    pub fn memory(self) -> Option<Memory> {
-        self.external.memory()
+    /// Shorthand for `self.external.into_memory()`.
+    pub fn into_memory(self) -> Option<Memory> {
+        self.external.into_memory()
     }
 
-    /// Shorthand for `self.external.global()`.
-    pub fn global(self) -> Option<Global> {
-        self.external.global()
+    /// Shorthand for `self.external.into_global()`.
+    pub fn into_global(self) -> Option<Global> {
+        self.external.into_global()
     }
 
     /// Shorthand for `self.external.ty()`.

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -374,7 +374,7 @@ impl Table {
 
     /// Returns the current size of this table.
     pub fn size(&self) -> u32 {
-        unsafe { (&*self.wasmtime_export.definition).current_elements }
+        unsafe { (*self.wasmtime_export.definition).current_elements }
     }
 
     /// Grows the size of this table by `delta` more elements, initialization

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -34,7 +34,7 @@ impl Extern {
     /// Returns the underlying `Func`, if this external is a function.
     ///
     /// Returns `None` if this is not a function.
-    pub fn func(&self) -> Option<&Func> {
+    pub fn func(self) -> Option<Func> {
         match self {
             Extern::Func(func) => Some(func),
             _ => None,
@@ -44,7 +44,7 @@ impl Extern {
     /// Returns the underlying `Global`, if this external is a global.
     ///
     /// Returns `None` if this is not a global.
-    pub fn global(&self) -> Option<&Global> {
+    pub fn global(self) -> Option<Global> {
         match self {
             Extern::Global(global) => Some(global),
             _ => None,
@@ -54,7 +54,7 @@ impl Extern {
     /// Returns the underlying `Table`, if this external is a table.
     ///
     /// Returns `None` if this is not a table.
-    pub fn table(&self) -> Option<&Table> {
+    pub fn table(self) -> Option<Table> {
         match self {
             Extern::Table(table) => Some(table),
             _ => None,
@@ -64,7 +64,7 @@ impl Extern {
     /// Returns the underlying `Memory`, if this external is a memory.
     ///
     /// Returns `None` if this is not a memory.
-    pub fn memory(&self) -> Option<&Memory> {
+    pub fn memory(self) -> Option<Memory> {
         match self {
             Extern::Memory(memory) => Some(memory),
             _ => None,

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -890,3 +890,46 @@ pub unsafe trait MemoryCreator: Send + Sync {
     /// Create new LinearMemory
     fn new_memory(&self, ty: MemoryType) -> Result<Box<dyn LinearMemory>, String>;
 }
+
+// Exports
+
+/// An exported WebAssembly value.
+///
+/// This type is primarily accessed from the
+/// [`Instance::exports`](crate::Instance::exports) accessor and describes what
+/// names and items are exported from a wasm instance.
+#[derive(Clone)]
+pub struct Export<'instance> {
+    /// The name of the export.
+    pub name: &'instance str,
+
+    /// The value of the export.
+    pub external: Extern,
+}
+
+impl<'instance> Export<'instance> {
+    /// Shorthand for `self.external.func()`.
+    pub fn func(self) -> Option<Func> {
+        self.external.func()
+    }
+
+    /// Shorthand for `self.external.table()`.
+    pub fn table(self) -> Option<Table> {
+        self.external.table()
+    }
+
+    /// Shorthand for `self.external.memory()`.
+    pub fn memory(self) -> Option<Memory> {
+        self.external.memory()
+    }
+
+    /// Shorthand for `self.external.global()`.
+    pub fn global(self) -> Option<Global> {
+        self.external.global()
+    }
+
+    /// Shorthand for `self.external.ty()`.
+    pub fn ty(&self) -> ExternType {
+        self.external.ty()
+    }
+}

--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -702,7 +702,7 @@ impl Memory {
     /// let store = Store::default();
     /// let module = Module::new(&store, "(module (memory (export \"mem\") 1))")?;
     /// let instance = Instance::new(&module, &[])?;
-    /// let memory = instance.get_export("mem").unwrap().into_memory().unwrap();
+    /// let memory = instance.get_memory("mem").unwrap();
     /// let ty = memory.ty();
     /// assert_eq!(ty.limits().min(), 1);
     /// # Ok(())
@@ -814,7 +814,7 @@ impl Memory {
     /// let store = Store::default();
     /// let module = Module::new(&store, "(module (memory (export \"mem\") 1 2))")?;
     /// let instance = Instance::new(&module, &[])?;
-    /// let memory = instance.get_export("mem").unwrap().into_memory().unwrap();
+    /// let memory = instance.get_memory("mem").unwrap();
     ///
     /// assert_eq!(memory.size(), 1);
     /// assert_eq!(memory.grow(1)?, 1);

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -138,7 +138,6 @@ pub struct Func {
     store: Store,
     instance: InstanceHandle,
     export: ExportFunction,
-    ty: FuncType,
     trampoline: VMTrampoline,
 }
 
@@ -157,7 +156,8 @@ macro_rules! getters {
         {
             // Verify all the paramers match the expected parameters, and that
             // there are no extra parameters...
-            let mut params = self.ty().params().iter().cloned();
+            let ty = self.ty();
+            let mut params = ty.params().iter().cloned();
             let n = 0;
             $(
                 let n = n + 1;
@@ -167,7 +167,7 @@ macro_rules! getters {
             ensure!(params.next().is_none(), "Type mismatch: too many arguments (expected {})", n);
 
             // ... then do the same for the results...
-            let mut results = self.ty().results().iter().cloned();
+            let mut results = ty.results().iter().cloned();
             R::matches(&mut results)
                 .context("Type mismatch in return type")?;
             ensure!(results.next().is_none(), "Type mismatch: too many return values (expected 1)");
@@ -271,7 +271,6 @@ impl Func {
             crate::trampoline::generate_func_export(&ty, func, store).expect("generated func");
         Func {
             store: store.clone(),
-            ty,
             instance,
             export,
             trampoline,
@@ -469,18 +468,42 @@ impl Func {
     }
 
     /// Returns the underlying wasm type that this `Func` has.
-    pub fn ty(&self) -> &FuncType {
-        &self.ty
+    pub fn ty(&self) -> FuncType {
+        // Signatures should always be registered in the store's registry of
+        // shared signatures, so we should be able to unwrap safely here.
+        let sig = self
+            .store
+            .compiler()
+            .signatures()
+            .lookup(self.export.signature)
+            .expect("failed to lookup signature");
+
+        // This is only called with `Export::Function`, and since it's coming
+        // from wasmtime_runtime itself we should support all the types coming
+        // out of it, so assert such here.
+        FuncType::from_wasmtime_signature(&sig).expect("core wasm signature should be supported")
     }
 
     /// Returns the number of parameters that this function takes.
     pub fn param_arity(&self) -> usize {
-        self.ty.params().len()
+        let sig = self
+            .store
+            .compiler()
+            .signatures()
+            .lookup(self.export.signature)
+            .expect("failed to lookup signature");
+        sig.params.len()
     }
 
     /// Returns the number of results this function produces.
     pub fn result_arity(&self) -> usize {
-        self.ty.results().len()
+        let sig = self
+            .store
+            .compiler()
+            .signatures()
+            .lookup(self.export.signature)
+            .expect("failed to lookup signature");
+        sig.returns.len()
     }
 
     /// Invokes this function with the `params` given, returning the results and
@@ -498,18 +521,19 @@ impl Func {
         // this function. This involves checking to make sure we have the right
         // number and types of arguments as well as making sure everything is
         // from the same `Store`.
-        if self.ty.params().len() != params.len() {
+        let my_ty = self.ty();
+        if my_ty.params().len() != params.len() {
             bail!(
                 "expected {} arguments, got {}",
-                self.ty.params().len(),
+                my_ty.params().len(),
                 params.len()
             );
         }
 
-        let mut values_vec = vec![0; max(params.len(), self.ty.results().len())];
+        let mut values_vec = vec![0; max(params.len(), my_ty.results().len())];
 
         // Store the argument values into `values_vec`.
-        let param_tys = self.ty.params().iter();
+        let param_tys = my_ty.params().iter();
         for ((arg, slot), ty) in params.iter().zip(&mut values_vec).zip(param_tys) {
             if arg.ty() != *ty {
                 bail!("argument type mismatch");
@@ -537,8 +561,8 @@ impl Func {
         }
 
         // Load the return values out of `values_vec`.
-        let mut results = Vec::with_capacity(self.ty.results().len());
-        for (index, ty) in self.ty.results().iter().enumerate() {
+        let mut results = Vec::with_capacity(my_ty.results().len());
+        for (index, ty) in my_ty.results().iter().enumerate() {
             unsafe {
                 let ptr = values_vec.as_ptr().add(index);
                 results.push(Val::read_value_from(ptr, ty));
@@ -557,20 +581,6 @@ impl Func {
         store: &Store,
         instance: InstanceHandle,
     ) -> Self {
-        // Signatures should always be registered in the store's registry of
-        // shared signatures, so we should be able to unwrap safely here.
-        let sig = store
-            .compiler()
-            .signatures()
-            .lookup(export.signature)
-            .expect("failed to lookup signature");
-
-        // This is only called with `Export::Function`, and since it's coming
-        // from wasmtime_runtime itself we should support all the types coming
-        // out of it, so assert such here.
-        let ty = FuncType::from_wasmtime_signature(sig)
-            .expect("core wasm signature should be supported");
-
         // Each function signature in a module should have a trampoline stored
         // on that module as well, so unwrap the result here since otherwise
         // it's a bug in wasmtime.
@@ -582,7 +592,6 @@ impl Func {
             instance,
             export,
             trampoline,
-            ty,
             store: store.clone(),
         }
     }
@@ -1094,7 +1103,6 @@ macro_rules! impl_into_func {
                     .expect("failed to generate export");
                     Func {
                         store: store.clone(),
-                        ty,
                         instance,
                         export,
                         trampoline,

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -38,7 +38,7 @@ use wasmtime_runtime::{ExportFunction, VMTrampoline};
 /// let store = Store::default();
 /// let module = Module::new(&store, r#"(module (func (export "foo")))"#)?;
 /// let instance = Instance::new(&module, &[])?;
-/// let foo = instance.exports().next().unwrap().func().expect("export wasn't a function");
+/// let foo = instance.exports().next().unwrap().into_func().expect("export wasn't a function");
 ///
 /// // Work with `foo` as a `Func` at this point, such as calling it
 /// // dynamically...
@@ -88,7 +88,7 @@ use wasmtime_runtime::{ExportFunction, VMTrampoline};
 ///     "#,
 /// )?;
 /// let instance = Instance::new(&module, &[add.into()])?;
-/// let call_add_twice = instance.exports().next().unwrap().func().expect("export wasn't a function");
+/// let call_add_twice = instance.exports().next().unwrap().into_func().expect("export wasn't a function");
 /// let call_add_twice = call_add_twice.get0::<i32>()?;
 ///
 /// assert_eq!(call_add_twice()?, 10);
@@ -349,7 +349,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[add.into()])?;
-    /// let foo = instance.exports().next().unwrap().func().unwrap().get2::<i32, i32, i32>()?;
+    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get2::<i32, i32, i32>()?;
     /// assert_eq!(foo(1, 2)?, 3);
     /// # Ok(())
     /// # }
@@ -380,7 +380,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[add.into()])?;
-    /// let foo = instance.exports().next().unwrap().func().unwrap().get2::<i32, i32, i32>()?;
+    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get2::<i32, i32, i32>()?;
     /// assert_eq!(foo(1, 2)?, 3);
     /// assert!(foo(i32::max_value(), 1).is_err());
     /// # Ok(())
@@ -413,7 +413,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[debug.into()])?;
-    /// let foo = instance.exports().next().unwrap().func().unwrap().get0::<()>()?;
+    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get0::<()>()?;
     /// foo()?;
     /// # Ok(())
     /// # }
@@ -469,7 +469,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[log_str.into()])?;
-    /// let foo = instance.exports().next().unwrap().func().unwrap().get0::<()>()?;
+    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get0::<()>()?;
     /// foo()?;
     /// # Ok(())
     /// # }

--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -38,7 +38,7 @@ use wasmtime_runtime::{ExportFunction, VMTrampoline};
 /// let store = Store::default();
 /// let module = Module::new(&store, r#"(module (func (export "foo")))"#)?;
 /// let instance = Instance::new(&module, &[])?;
-/// let foo = instance.exports().next().unwrap().into_func().expect("export wasn't a function");
+/// let foo = instance.get_func("foo").expect("export wasn't a function");
 ///
 /// // Work with `foo` as a `Func` at this point, such as calling it
 /// // dynamically...
@@ -88,7 +88,7 @@ use wasmtime_runtime::{ExportFunction, VMTrampoline};
 ///     "#,
 /// )?;
 /// let instance = Instance::new(&module, &[add.into()])?;
-/// let call_add_twice = instance.exports().next().unwrap().into_func().expect("export wasn't a function");
+/// let call_add_twice = instance.get_func("call_add_twice").expect("export wasn't a function");
 /// let call_add_twice = call_add_twice.get0::<i32>()?;
 ///
 /// assert_eq!(call_add_twice()?, 10);
@@ -349,7 +349,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[add.into()])?;
-    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get2::<i32, i32, i32>()?;
+    /// let foo = instance.get_func("foo").unwrap().get2::<i32, i32, i32>()?;
     /// assert_eq!(foo(1, 2)?, 3);
     /// # Ok(())
     /// # }
@@ -380,7 +380,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[add.into()])?;
-    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get2::<i32, i32, i32>()?;
+    /// let foo = instance.get_func("foo").unwrap().get2::<i32, i32, i32>()?;
     /// assert_eq!(foo(1, 2)?, 3);
     /// assert!(foo(i32::max_value(), 1).is_err());
     /// # Ok(())
@@ -413,7 +413,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[debug.into()])?;
-    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get0::<()>()?;
+    /// let foo = instance.get_func("foo").unwrap().get0::<()>()?;
     /// foo()?;
     /// # Ok(())
     /// # }
@@ -469,7 +469,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&module, &[log_str.into()])?;
-    /// let foo = instance.exports().next().unwrap().into_func().unwrap().get0::<()>()?;
+    /// let foo = instance.get_func("foo").unwrap().get0::<()>()?;
     /// foo()?;
     /// # Ok(())
     /// # }

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -126,11 +126,11 @@ impl Instance {
             }
         }
 
-        if imports.len() != module.imports().len() {
+        if imports.len() != module.num_imports() {
             bail!(
                 "wrong number of imports provided, {} != {}",
                 imports.len(),
-                module.imports().len()
+                module.num_imports()
             );
         }
 

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -167,10 +167,8 @@ impl Instance {
             .exports()
             .map(move |(name, entity_index)| {
                 let export = instance_handle.lookup_by_declaration(entity_index);
-                Export {
-                    name,
-                    external: Extern::from_wasmtime_export(store, instance_handle.clone(), export),
-                }
+                let extern_ = Extern::from_wasmtime_export(export, store, instance_handle.clone());
+                Export::new(name, extern_)
             })
     }
 
@@ -183,9 +181,9 @@ impl Instance {
     pub fn get_export(&self, name: &str) -> Option<Extern> {
         let export = self.instance_handle.lookup(&name)?;
         Some(Extern::from_wasmtime_export(
+            export,
             self.module.store(),
             self.instance_handle.clone(),
-            export,
         ))
     }
 

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -160,7 +160,9 @@ impl Instance {
     }
 
     /// Returns the list of exported items from this [`Instance`].
-    pub fn exports<'me>(&'me self) -> impl ExactSizeIterator<Item = Export> + 'me {
+    pub fn exports<'instance>(
+        &'instance self,
+    ) -> impl ExactSizeIterator<Item = Export<'instance>> + 'instance {
         let instance_handle = &self.instance_handle;
         let store = self.module.store();
         self.instance_handle

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -158,15 +158,6 @@ impl Instance {
         self.module.store()
     }
 
-    /// Returns the associated [`Module`] that this `Instance` instantiated.
-    ///
-    /// The corresponding [`Module`] here is a static version of this `Instance`
-    /// which can be used to learn information such as naming information about
-    /// various functions.
-    pub fn module(&self) -> &Module {
-        &self.module
-    }
-
     /// Returns the list of exported items from this [`Instance`].
     ///
     /// The actual returned value is a tuple containing the name of an export and

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -126,11 +126,11 @@ impl Instance {
             }
         }
 
-        if imports.len() != module.num_imports() {
+        if imports.len() != module.imports().len() {
             bail!(
                 "wrong number of imports provided, {} != {}",
                 imports.len(),
-                module.num_imports()
+                module.imports().len()
             );
         }
 
@@ -164,7 +164,7 @@ impl Instance {
     /// information about the export itself. The list returned here maps 1:1 with
     /// the list that [`Module::exports`] returns, and [`ExportType`](crate::ExportType)
     /// contains the name of each export.
-    pub fn exports<'me>(&'me self) -> impl Iterator<Item = Export> + 'me {
+    pub fn exports<'me>(&'me self) -> impl ExactSizeIterator<Item = Export> + 'me {
         let instance_handle = &self.instance_handle;
         let store = self.module.store();
         self.instance_handle

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -1,4 +1,5 @@
-use crate::externals::{Export, Extern};
+use crate::externals::{Export, Extern, Global, Memory, Table};
+use crate::func::Func;
 use crate::module::Module;
 use crate::runtime::{Config, Store};
 use crate::trap::Trap;
@@ -186,6 +187,38 @@ impl Instance {
             self.instance_handle.clone(),
             export,
         ))
+    }
+
+    /// Looks up an exported [`Func`] value by name.
+    ///
+    /// Returns `None` if there was no export named `name`, or if there was but
+    /// it wasn't a function.
+    pub fn get_func(&self, name: &str) -> Option<Func> {
+        self.get_export(name)?.into_func()
+    }
+
+    /// Looks up an exported [`Table`] value by name.
+    ///
+    /// Returns `None` if there was no export named `name`, or if there was but
+    /// it wasn't a table.
+    pub fn get_table(&self, name: &str) -> Option<Table> {
+        self.get_export(name)?.into_table()
+    }
+
+    /// Looks up an exported [`Memory`] value by name.
+    ///
+    /// Returns `None` if there was no export named `name`, or if there was but
+    /// it wasn't a memory.
+    pub fn get_memory(&self, name: &str) -> Option<Memory> {
+        self.get_export(name)?.into_memory()
+    }
+
+    /// Looks up an exported [`Global`] value by name.
+    ///
+    /// Returns `None` if there was no export named `name`, or if there was but
+    /// it wasn't a global.
+    pub fn get_global(&self, name: &str) -> Option<Global> {
+        self.get_export(name)?.into_global()
     }
 
     #[doc(hidden)]

--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -159,11 +159,6 @@ impl Instance {
     }
 
     /// Returns the list of exported items from this [`Instance`].
-    ///
-    /// The actual returned value is a tuple containing the name of an export and
-    /// information about the export itself. The list returned here maps 1:1 with
-    /// the list that [`Module::exports`] returns, and [`ExportType`](crate::ExportType)
-    /// contains the name of each export.
     pub fn exports<'me>(&'me self) -> impl ExactSizeIterator<Item = Export> + 'me {
         let instance_handle = &self.instance_handle;
         let store = self.module.store();

--- a/crates/api/src/linker.rs
+++ b/crates/api/src/linker.rs
@@ -166,7 +166,7 @@ impl Linker {
         if !item.comes_from_same_store(&self.store) {
             bail!("all linker items must be from the same store");
         }
-        self.insert(module, name, item.ty(), item)?;
+        self.insert(module, name, item)?;
         Ok(self)
     }
 
@@ -265,7 +265,7 @@ impl Linker {
             bail!("all linker items must be from the same store");
         }
         for export in instance.exports() {
-            self.insert(module_name, export.name, export.ty(), export.external)?;
+            self.insert(module_name, export.name(), export.into_extern())?;
         }
         Ok(self)
     }
@@ -291,8 +291,8 @@ impl Linker {
         Ok(())
     }
 
-    fn insert(&mut self, module: &str, name: &str, ty: ExternType, item: Extern) -> Result<()> {
-        let key = self.import_key(module, name, ty);
+    fn insert(&mut self, module: &str, name: &str, item: Extern) -> Result<()> {
+        let key = self.import_key(module, name, item.ty());
         match self.map.entry(key) {
             Entry::Occupied(o) if !self.allow_shadowing => bail!(
                 "import of `{}::{}` with kind {:?} defined twice",

--- a/crates/api/src/linker.rs
+++ b/crates/api/src/linker.rs
@@ -166,7 +166,7 @@ impl Linker {
         if !item.comes_from_same_store(&self.store) {
             bail!("all linker items must be from the same store");
         }
-        self.insert(module, name, &item.ty(), item)?;
+        self.insert(module, name, item.ty(), item)?;
         Ok(self)
     }
 
@@ -264,8 +264,8 @@ impl Linker {
         if !Store::same(&self.store, instance.store()) {
             bail!("all linker items must be from the same store");
         }
-        for (export, item) in instance.module().exports().iter().zip(instance.exports()) {
-            self.insert(module_name, export.name(), export.ty(), item.clone())?;
+        for (export, item) in instance.module().exports().zip(instance.exports()) {
+            self.insert(module_name, export.name(), export.ty().clone(), item)?;
         }
         Ok(self)
     }
@@ -291,7 +291,7 @@ impl Linker {
         Ok(())
     }
 
-    fn insert(&mut self, module: &str, name: &str, ty: &ExternType, item: Extern) -> Result<()> {
+    fn insert(&mut self, module: &str, name: &str, ty: ExternType, item: Extern) -> Result<()> {
         let key = self.import_key(module, name, ty);
         match self.map.entry(key) {
             Entry::Occupied(o) if !self.allow_shadowing => bail!(
@@ -310,7 +310,7 @@ impl Linker {
         Ok(())
     }
 
-    fn import_key(&mut self, module: &str, name: &str, ty: &ExternType) -> ImportKey {
+    fn import_key(&mut self, module: &str, name: &str, ty: ExternType) -> ImportKey {
         ImportKey {
             module: self.intern_str(module),
             name: self.intern_str(name),
@@ -318,10 +318,10 @@ impl Linker {
         }
     }
 
-    fn import_kind(&self, ty: &ExternType) -> ImportKind {
+    fn import_kind(&self, ty: ExternType) -> ImportKind {
         match ty {
-            ExternType::Func(f) => ImportKind::Func(f.clone()),
-            ExternType::Global(f) => ImportKind::Global(f.clone()),
+            ExternType::Func(f) => ImportKind::Func(f),
+            ExternType::Global(f) => ImportKind::Global(f),
             ExternType::Memory(_) => ImportKind::Memory,
             ExternType::Table(_) => ImportKind::Table,
         }
@@ -378,8 +378,8 @@ impl Linker {
     pub fn instantiate(&self, module: &Module) -> Result<Instance> {
         let mut imports = Vec::new();
         for import in module.imports() {
-            if let Some(item) = self.get(import) {
-                imports.push(item.clone());
+            if let Some(item) = self.get(&import) {
+                imports.push(item);
                 continue;
             }
 
@@ -429,23 +429,27 @@ impl Linker {
     ///
     /// Note that multiple `Extern` items may be defined for the same
     /// module/name pair.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &Extern)> {
-        self.map
-            .iter()
-            .map(move |(key, item)| (&*self.strings[key.module], &*self.strings[key.name], item))
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, Extern)> {
+        self.map.iter().map(move |(key, item)| {
+            (
+                &*self.strings[key.module],
+                &*self.strings[key.name],
+                item.clone(),
+            )
+        })
     }
 
     /// Looks up a value in this `Linker` which matches the `import` type
     /// provided.
     ///
     /// Returns `None` if no match was found.
-    pub fn get(&self, import: &ImportType) -> Option<&Extern> {
+    pub fn get(&self, import: &ImportType) -> Option<Extern> {
         let key = ImportKey {
             module: *self.string2idx.get(import.module())?,
             name: *self.string2idx.get(import.name())?,
-            kind: self.import_kind(import.ty()),
+            kind: self.import_kind(import.ty().clone()),
         };
-        self.map.get(&key)
+        self.map.get(&key).cloned()
     }
 
     /// Returns all items defined for the `module` and `name` pair.
@@ -468,10 +472,10 @@ impl Linker {
     /// Returns the single item defined for the `module` and `name` pair.
     ///
     /// Unlike the similar [`Linker::get_by_name`] method this function returns
-    /// a single `&Extern` item. If the `module` and `name` pair isn't defined
+    /// a single `Extern` item. If the `module` and `name` pair isn't defined
     /// in this linker then an error is returned. If more than one value exists
     /// for the `module` and `name` pairs, then an error is returned as well.
-    pub fn get_one_by_name(&self, module: &str, name: &str) -> Result<&Extern> {
+    pub fn get_one_by_name(&self, module: &str, name: &str) -> Result<Extern> {
         let mut items = self.get_by_name(module, name);
         let ret = items
             .next()
@@ -479,6 +483,6 @@ impl Linker {
         if items.next().is_some() {
             bail!("too many items named `{}` in `{}`", name, module);
         }
-        Ok(ret)
+        Ok(ret.clone())
     }
 }

--- a/crates/api/src/linker.rs
+++ b/crates/api/src/linker.rs
@@ -283,7 +283,7 @@ impl Linker {
         let items = self
             .iter()
             .filter(|(m, _, _)| *m == module)
-            .map(|(_, name, item)| (name.to_string(), item.clone()))
+            .map(|(_, name, item)| (name.to_string(), item))
             .collect::<Vec<_>>();
         for (name, item) in items {
             self.define(as_module, &name, item)?;

--- a/crates/api/src/linker.rs
+++ b/crates/api/src/linker.rs
@@ -264,8 +264,8 @@ impl Linker {
         if !Store::same(&self.store, instance.store()) {
             bail!("all linker items must be from the same store");
         }
-        for (export, item) in instance.module().exports().zip(instance.exports()) {
-            self.insert(module_name, export.name(), export.ty().clone(), item)?;
+        for export in instance.exports() {
+            self.insert(module_name, &export.name, export.ty(), export.external)?;
         }
         Ok(self)
     }
@@ -385,8 +385,8 @@ impl Linker {
 
             let mut options = String::new();
             for i in self.map.keys() {
-                if &*self.strings[i.module] != import.module()
-                    || &*self.strings[i.name] != import.name()
+                if &*self.strings[i.module] != import.module
+                    || &*self.strings[i.name] != import.name
                 {
                     continue;
                 }
@@ -397,8 +397,8 @@ impl Linker {
             if options.len() == 0 {
                 bail!(
                     "unknown import: `{}::{}` has not been defined",
-                    import.module(),
-                    import.name()
+                    import.module,
+                    import.name
                 )
             }
 
@@ -406,9 +406,9 @@ impl Linker {
                 "incompatible import type for `{}::{}` specified\n\
                  desired signature was: {:?}\n\
                  signatures available:\n\n{}",
-                import.module(),
-                import.name(),
-                import.ty(),
+                import.module,
+                import.name,
+                import.ty,
                 options,
             )
         }
@@ -445,9 +445,9 @@ impl Linker {
     /// Returns `None` if no match was found.
     pub fn get(&self, import: &ImportType) -> Option<Extern> {
         let key = ImportKey {
-            module: *self.string2idx.get(import.module())?,
-            name: *self.string2idx.get(import.name())?,
-            kind: self.import_kind(import.ty().clone()),
+            module: *self.string2idx.get(import.module.as_str())?,
+            name: *self.string2idx.get(import.name.as_str())?,
+            kind: self.import_kind(import.ty.clone()),
         };
         self.map.get(&key).cloned()
     }

--- a/crates/api/src/linker.rs
+++ b/crates/api/src/linker.rs
@@ -265,7 +265,7 @@ impl Linker {
             bail!("all linker items must be from the same store");
         }
         for export in instance.exports() {
-            self.insert(module_name, &export.name, export.ty(), export.external)?;
+            self.insert(module_name, export.name, export.ty(), export.external)?;
         }
         Ok(self)
     }
@@ -385,8 +385,8 @@ impl Linker {
 
             let mut options = String::new();
             for i in self.map.keys() {
-                if &*self.strings[i.module] != import.module
-                    || &*self.strings[i.name] != import.name
+                if &*self.strings[i.module] != import.module()
+                    || &*self.strings[i.name] != import.name()
                 {
                     continue;
                 }
@@ -397,8 +397,8 @@ impl Linker {
             if options.len() == 0 {
                 bail!(
                     "unknown import: `{}::{}` has not been defined",
-                    import.module,
-                    import.name
+                    import.module(),
+                    import.name()
                 )
             }
 
@@ -406,9 +406,9 @@ impl Linker {
                 "incompatible import type for `{}::{}` specified\n\
                  desired signature was: {:?}\n\
                  signatures available:\n\n{}",
-                import.module,
-                import.name,
-                import.ty,
+                import.module(),
+                import.name(),
+                import.ty(),
                 options,
             )
         }
@@ -445,9 +445,9 @@ impl Linker {
     /// Returns `None` if no match was found.
     pub fn get(&self, import: &ImportType) -> Option<Extern> {
         let key = ImportKey {
-            module: *self.string2idx.get(import.module.as_str())?,
-            name: *self.string2idx.get(import.name.as_str())?,
-            kind: self.import_kind(import.ty.clone()),
+            module: *self.string2idx.get(import.module())?,
+            name: *self.string2idx.get(import.name())?,
+            kind: self.import_kind(import.ty()),
         };
         self.map.get(&key).cloned()
     }

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -376,7 +376,7 @@ impl Module {
     /// # fn main() -> anyhow::Result<()> {
     /// # let store = Store::default();
     /// let module = Module::new(&store, "(module)")?;
-    /// assert_eq!(module.num_imports(), 0);
+    /// assert_eq!(module.imports().len(), 0);
     /// # Ok(())
     /// # }
     /// ```
@@ -393,7 +393,7 @@ impl Module {
     ///     )
     /// "#;
     /// let module = Module::new(&store, wat)?;
-    /// assert_eq!(module.num_imports(), 1);
+    /// assert_eq!(module.imports().len(), 1);
     /// let import = module.imports().next().unwrap();
     /// assert_eq!(import.module, "host");
     /// assert_eq!(import.name, "foo");
@@ -404,7 +404,7 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn imports<'me>(&'me self) -> impl Iterator<Item = ImportType> + 'me {
+    pub fn imports<'me>(&'me self) -> impl ExactSizeIterator<Item = ImportType> + 'me {
         let module = self.inner.compiled.module_ref();
         module
             .imports
@@ -417,11 +417,6 @@ impl Module {
                     ty: r#type,
                 }
             })
-    }
-
-    /// Return the number of imports in this module.
-    pub fn num_imports(&self) -> usize {
-        self.inner.compiled.module_ref().imports.len()
     }
 
     /// Returns the list of exports that this [`Module`] has and will be
@@ -459,7 +454,7 @@ impl Module {
     ///     )
     /// "#;
     /// let module = Module::new(&store, wat)?;
-    /// assert_eq!(module.num_exports(), 2);
+    /// assert_eq!(module.exports().len(), 2);
     ///
     /// let foo = module.exports().next().unwrap();
     /// assert_eq!(foo.name, "foo");
@@ -477,7 +472,7 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn exports<'me>(&'me self) -> impl Iterator<Item = ExportType> + 'me {
+    pub fn exports<'me>(&'me self) -> impl ExactSizeIterator<Item = ExportType> + 'me {
         let module = self.inner.compiled.module_ref();
         module.exports.iter().map(move |(name, entity_index)| {
             let r#type = entity_type(entity_index, module);
@@ -486,11 +481,6 @@ impl Module {
                 ty: r#type,
             }
         })
-    }
-
-    /// Return the number of exports in this module.
-    pub fn num_exports(&self) -> usize {
-        self.inner.compiled.module_ref().exports.len()
     }
 
     /// Returns the [`Store`] that this [`Module`] was compiled into.

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -513,8 +513,7 @@ impl Module {
 fn entity_type(entity_index: &EntityIndex, module: &wasmtime_environ::Module) -> ExternType {
     match entity_index {
         EntityIndex::Function(func_index) => {
-            let sig_index = module.local.functions[*func_index];
-            let sig = &module.local.signatures[sig_index];
+            let sig = module.local.func_signature(*func_index);
             FuncType::from_wasmtime_signature(sig)
                 .expect("core wasm function type should be supported")
                 .into()

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -405,13 +405,14 @@ impl Module {
     /// # }
     /// ```
     pub fn imports<'me>(&'me self) -> impl Iterator<Item = ImportType> + 'me {
-        let inner = self.inner.clone();
-        self.inner.compiled.module_ref().imports.iter().map(
-            move |(module_name, name, entity_index)| {
-                let r#type = entity_type(entity_index, inner.compiled.module_ref());
+        let module = self.inner.compiled.module_ref();
+        module
+            .imports
+            .iter()
+            .map(move |(module_name, name, entity_index)| {
+                let r#type = entity_type(entity_index, module);
                 ImportType::new(module_name, name, r#type)
-            },
-        )
+            })
     }
 
     /// Return the number of imports in this module.
@@ -473,16 +474,11 @@ impl Module {
     /// # }
     /// ```
     pub fn exports<'me>(&'me self) -> impl Iterator<Item = ExportType> + 'me {
-        let inner = self.inner.clone();
-        self.inner
-            .compiled
-            .module_ref()
-            .exports
-            .iter()
-            .map(move |(name, entity_index)| {
-                let r#type = entity_type(entity_index, inner.compiled.module_ref());
-                ExportType::new(name, r#type)
-            })
+        let module = self.inner.compiled.module_ref();
+        module.exports.iter().map(move |(name, entity_index)| {
+            let r#type = entity_type(entity_index, module);
+            ExportType::new(name, r#type)
+        })
     }
 
     /// Return the number of exports in this module.

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -401,7 +401,9 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn imports<'me>(&'me self) -> impl ExactSizeIterator<Item = ImportType<'me>> + 'me {
+    pub fn imports<'module>(
+        &'module self,
+    ) -> impl ExactSizeIterator<Item = ImportType<'module>> + 'module {
         let module = self.inner.compiled.module_ref();
         module
             .imports
@@ -466,7 +468,9 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn exports<'me>(&'me self) -> impl ExactSizeIterator<Item = ExportType<'me>> + 'me {
+    pub fn exports<'module>(
+        &'module self,
+    ) -> impl ExactSizeIterator<Item = ExportType<'module>> + 'module {
         let module = self.inner.compiled.module_ref();
         module.exports.iter().map(move |(name, entity_index)| {
             let r#type = EntityType::new(entity_index, module);

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -456,14 +456,15 @@ impl Module {
     /// let module = Module::new(&store, wat)?;
     /// assert_eq!(module.exports().len(), 2);
     ///
-    /// let foo = module.exports().next().unwrap();
+    /// let mut exports = module.exports();
+    /// let foo = exports.next().unwrap();
     /// assert_eq!(foo.name, "foo");
     /// match foo.ty {
     ///     ExternType::Func(_) => { /* ... */ }
     ///     _ => panic!("unexpected export type!"),
     /// }
     ///
-    /// let memory = module.exports().nth(1).unwrap();
+    /// let memory = exports.next().unwrap();
     /// assert_eq!(memory.name, "memory");
     /// match memory.ty {
     ///     ExternType::Memory(_) => { /* ... */ }

--- a/crates/api/src/module.rs
+++ b/crates/api/src/module.rs
@@ -395,9 +395,9 @@ impl Module {
     /// let module = Module::new(&store, wat)?;
     /// assert_eq!(module.num_imports(), 1);
     /// let import = module.imports().next().unwrap();
-    /// assert_eq!(import.module(), "host");
-    /// assert_eq!(import.name(), "foo");
-    /// match import.ty() {
+    /// assert_eq!(import.module, "host");
+    /// assert_eq!(import.name, "foo");
+    /// match import.ty {
     ///     ExternType::Func(_) => { /* ... */ }
     ///     _ => panic!("unexpected import type!"),
     /// }
@@ -411,7 +411,11 @@ impl Module {
             .iter()
             .map(move |(module_name, name, entity_index)| {
                 let r#type = entity_type(entity_index, module);
-                ImportType::new(module_name, name, r#type)
+                ImportType {
+                    module: module_name.to_owned(),
+                    name: name.to_owned(),
+                    ty: r#type,
+                }
             })
     }
 
@@ -458,15 +462,15 @@ impl Module {
     /// assert_eq!(module.num_exports(), 2);
     ///
     /// let foo = module.exports().next().unwrap();
-    /// assert_eq!(foo.name(), "foo");
-    /// match foo.ty() {
+    /// assert_eq!(foo.name, "foo");
+    /// match foo.ty {
     ///     ExternType::Func(_) => { /* ... */ }
     ///     _ => panic!("unexpected export type!"),
     /// }
     ///
     /// let memory = module.exports().nth(1).unwrap();
-    /// assert_eq!(memory.name(), "memory");
-    /// match memory.ty() {
+    /// assert_eq!(memory.name, "memory");
+    /// match memory.ty {
     ///     ExternType::Memory(_) => { /* ... */ }
     ///     _ => panic!("unexpected export type!"),
     /// }
@@ -477,7 +481,10 @@ impl Module {
         let module = self.inner.compiled.module_ref();
         module.exports.iter().map(move |(name, entity_index)| {
             let r#type = entity_type(entity_index, module);
-            ExportType::new(name, r#type)
+            ExportType {
+                name: name.to_owned(),
+                ty: r#type,
+            }
         })
     }
 

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -212,7 +212,7 @@ pub fn create_handle_with_function(
 
     let pointer_type = isa.pointer_type();
     let sig = match ft.get_wasmtime_signature(pointer_type) {
-        Some(sig) => sig.clone(),
+        Some(sig) => sig,
         None => bail!("not a supported core wasm signature {:?}", ft),
     };
 
@@ -276,7 +276,7 @@ pub unsafe fn create_handle_with_raw_function(
 
     let pointer_type = isa.pointer_type();
     let sig = match ft.get_wasmtime_signature(pointer_type) {
-        Some(sig) => sig.clone(),
+        Some(sig) => sig,
         None => bail!("not a supported core wasm signature {:?}", ft),
     };
 

--- a/crates/api/src/trampoline/func.rs
+++ b/crates/api/src/trampoline/func.rs
@@ -10,7 +10,7 @@ use std::mem;
 use std::panic::{self, AssertUnwindSafe};
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::isa::TargetIsa;
-use wasmtime_environ::{ir, settings, CompiledFunction, Export, Module};
+use wasmtime_environ::{ir, settings, CompiledFunction, EntityIndex, Module};
 use wasmtime_jit::trampoline::ir::{
     ExternalName, Function, InstBuilder, MemFlags, StackSlotData, StackSlotKind,
 };
@@ -228,7 +228,7 @@ pub fn create_handle_with_function(
     let func_id = module.local.functions.push(sig_id);
     module
         .exports
-        .insert("trampoline".to_string(), Export::Function(func_id));
+        .insert("trampoline".to_string(), EntityIndex::Function(func_id));
     let trampoline = make_trampoline(isa.as_ref(), &mut code_memory, &mut fn_builder_ctx, &sig);
     finished_functions.push(trampoline);
 
@@ -288,7 +288,7 @@ pub unsafe fn create_handle_with_raw_function(
     let func_id = module.local.functions.push(sig_id);
     module
         .exports
-        .insert("trampoline".to_string(), Export::Function(func_id));
+        .insert("trampoline".to_string(), EntityIndex::Function(func_id));
     finished_functions.push(func);
     let sig_id = store.compiler().signatures().register(&sig);
     trampolines.insert(sig_id, trampoline);

--- a/crates/api/src/trampoline/global.rs
+++ b/crates/api/src/trampoline/global.rs
@@ -3,7 +3,7 @@ use crate::Store;
 use crate::{GlobalType, Mutability, Val};
 use anyhow::{bail, Result};
 use wasmtime_environ::entity::PrimaryMap;
-use wasmtime_environ::{wasm, Module};
+use wasmtime_environ::{wasm, EntityIndex, Module};
 use wasmtime_runtime::InstanceHandle;
 
 pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<InstanceHandle> {
@@ -26,10 +26,9 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<Instanc
     };
     let mut module = Module::new();
     let global_id = module.local.globals.push(global);
-    module.exports.insert(
-        "global".to_string(),
-        wasmtime_environ::Export::Global(global_id),
-    );
+    module
+        .exports
+        .insert("global".to_string(), EntityIndex::Global(global_id));
     let handle = create_handle(
         module,
         store,

--- a/crates/api/src/trampoline/memory.rs
+++ b/crates/api/src/trampoline/memory.rs
@@ -4,7 +4,7 @@ use crate::Store;
 use crate::{Limits, MemoryType};
 use anyhow::Result;
 use wasmtime_environ::entity::PrimaryMap;
-use wasmtime_environ::{wasm, MemoryPlan, Module, WASM_PAGE_SIZE};
+use wasmtime_environ::{wasm, EntityIndex, MemoryPlan, Module, WASM_PAGE_SIZE};
 use wasmtime_runtime::{
     InstanceHandle, RuntimeLinearMemory, RuntimeMemoryCreator, VMMemoryDefinition,
 };
@@ -23,10 +23,9 @@ pub fn create_handle_with_memory(store: &Store, memory: &MemoryType) -> Result<I
 
     let memory_plan = wasmtime_environ::MemoryPlan::for_memory(memory, &tunable);
     let memory_id = module.local.memory_plans.push(memory_plan);
-    module.exports.insert(
-        "memory".to_string(),
-        wasmtime_environ::Export::Memory(memory_id),
-    );
+    module
+        .exports
+        .insert("memory".to_string(), EntityIndex::Memory(memory_id));
 
     create_handle(
         module,

--- a/crates/api/src/trampoline/table.rs
+++ b/crates/api/src/trampoline/table.rs
@@ -3,7 +3,7 @@ use crate::Store;
 use crate::{TableType, ValType};
 use anyhow::{bail, Result};
 use wasmtime_environ::entity::PrimaryMap;
-use wasmtime_environ::{wasm, Module};
+use wasmtime_environ::{wasm, EntityIndex, Module};
 use wasmtime_runtime::InstanceHandle;
 
 pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<InstanceHandle> {
@@ -21,10 +21,9 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Inst
 
     let table_plan = wasmtime_environ::TablePlan::for_table(table, &tunable);
     let table_id = module.local.table_plans.push(table_plan);
-    module.exports.insert(
-        "table".to_string(),
-        wasmtime_environ::Export::Table(table_id),
-    );
+    module
+        .exports
+        .insert("table".to_string(), EntityIndex::Table(table_id));
 
     create_handle(
         module,

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -247,7 +247,7 @@ impl FuncType {
     /// Returns `None` if any types in the signature can't be converted to the
     /// types in this crate, but that should very rarely happen and largely only
     /// indicate a bug in our cranelift integration.
-    pub(crate) fn from_wasmtime_signature(signature: ir::Signature) -> Option<FuncType> {
+    pub(crate) fn from_wasmtime_signature(signature: &ir::Signature) -> Option<FuncType> {
         let params = signature
             .params
             .iter()

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -1,4 +1,5 @@
-use wasmtime_environ::{ir, wasm};
+use std::fmt;
+use wasmtime_environ::{ir, wasm, EntityIndex};
 
 // Type Representations
 
@@ -382,6 +383,53 @@ impl MemoryType {
     }
 }
 
+// Entity Types
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub(crate) enum EntityType<'module> {
+    Function(&'module ir::Signature),
+    Table(&'module wasm::Table),
+    Memory(&'module wasm::Memory),
+    Global(&'module wasm::Global),
+}
+
+impl<'module> EntityType<'module> {
+    /// Translate from a `EntityIndex` into an `ExternType`.
+    pub(crate) fn new(
+        entity_index: &EntityIndex,
+        module: &'module wasmtime_environ::Module,
+    ) -> EntityType<'module> {
+        match entity_index {
+            EntityIndex::Function(func_index) => {
+                let sig = module.local.func_signature(*func_index);
+                EntityType::Function(&sig)
+            }
+            EntityIndex::Table(table_index) => {
+                EntityType::Table(&module.local.table_plans[*table_index].table)
+            }
+            EntityIndex::Memory(memory_index) => {
+                EntityType::Memory(&module.local.memory_plans[*memory_index].memory)
+            }
+            EntityIndex::Global(global_index) => {
+                EntityType::Global(&module.local.globals[*global_index])
+            }
+        }
+    }
+
+    fn extern_type(&self) -> ExternType {
+        match self {
+            EntityType::Function(sig) => FuncType::from_wasmtime_signature(sig)
+                .expect("core wasm function type should be supported")
+                .into(),
+            EntityType::Table(table) => TableType::from_wasmtime_table(table).into(),
+            EntityType::Memory(memory) => MemoryType::from_wasmtime_memory(memory).into(),
+            EntityType::Global(global) => GlobalType::from_wasmtime_global(global)
+                .expect("core wasm global type should be supported")
+                .into(),
+        }
+    }
+}
+
 // Import Types
 
 /// A descriptor for an imported value into a wasm module.
@@ -390,16 +438,54 @@ impl MemoryType {
 /// [`Module::imports`](crate::Module::imports) API. Each [`ImportType`]
 /// describes an import into the wasm module with the module/name that it's
 /// imported from as well as the type of item that's being imported.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct ImportType {
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub struct ImportType<'module> {
     /// The module of the import.
-    pub module: String,
+    module: &'module str,
 
     /// The field of the import.
-    pub name: String,
+    name: &'module str,
 
     /// The type of the import.
-    pub ty: ExternType,
+    ty: EntityType<'module>,
+}
+
+impl<'module> ImportType<'module> {
+    /// Creates a new import descriptor which comes from `module` and `name` and
+    /// is of type `ty`.
+    pub(crate) fn new(
+        module: &'module str,
+        name: &'module str,
+        ty: EntityType<'module>,
+    ) -> ImportType<'module> {
+        ImportType { module, name, ty }
+    }
+
+    /// Returns the module name that this import is expected to come from.
+    pub fn module(&'module self) -> &'module str {
+        self.module
+    }
+
+    /// Returns the field name of the module that this import is expected to
+    /// come from.
+    pub fn name(&'module self) -> &'module str {
+        self.name
+    }
+
+    /// Returns the expected type of this import.
+    pub fn ty(&'module self) -> ExternType {
+        self.ty.extern_type()
+    }
+}
+
+impl<'module> fmt::Debug for ImportType<'module> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ImportType")
+            .field("module", &self.module().to_owned())
+            .field("name", &self.name().to_owned())
+            .field("ty", &self.ty())
+            .finish()
+    }
 }
 
 // Export Types
@@ -410,11 +496,38 @@ pub struct ImportType {
 /// [`Module::exports`](crate::Module::exports) accessor and describes what
 /// names are exported from a wasm module and the type of the item that is
 /// exported.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct ExportType {
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub struct ExportType<'module> {
     /// The name of the export.
-    pub name: String,
+    name: &'module str,
 
     /// The type of the export.
-    pub ty: ExternType,
+    ty: EntityType<'module>,
+}
+
+impl<'module> ExportType<'module> {
+    /// Creates a new export which is exported with the given `name` and has the
+    /// given `ty`.
+    pub(crate) fn new(name: &'module str, ty: EntityType<'module>) -> ExportType<'module> {
+        ExportType { name, ty }
+    }
+
+    /// Returns the name by which this export is known by.
+    pub fn name(&'module self) -> &'module str {
+        self.name
+    }
+
+    /// Returns the type of this export.
+    pub fn ty(&'module self) -> ExternType {
+        self.ty.extern_type()
+    }
+}
+
+impl<'module> fmt::Debug for ExportType<'module> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExportType")
+            .field("name", &self.name().to_owned())
+            .field("ty", &self.ty())
+            .finish()
+    }
 }

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -462,18 +462,18 @@ impl<'module> ImportType<'module> {
     }
 
     /// Returns the module name that this import is expected to come from.
-    pub fn module(&'module self) -> &'module str {
+    pub fn module(&self) -> &'module str {
         self.module
     }
 
     /// Returns the field name of the module that this import is expected to
     /// come from.
-    pub fn name(&'module self) -> &'module str {
+    pub fn name(&self) -> &'module str {
         self.name
     }
 
     /// Returns the expected type of this import.
-    pub fn ty(&'module self) -> ExternType {
+    pub fn ty(&self) -> ExternType {
         self.ty.extern_type()
     }
 }
@@ -512,13 +512,13 @@ impl<'module> ExportType<'module> {
         ExportType { name, ty }
     }
 
-    /// Returns the name by which this export is known by.
-    pub fn name(&'module self) -> &'module str {
+    /// Returns the name by which this export is known.
+    pub fn name(&self) -> &'module str {
         self.name
     }
 
     /// Returns the type of this export.
-    pub fn ty(&'module self) -> ExternType {
+    pub fn ty(&self) -> ExternType {
         self.ty.extern_type()
     }
 }

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -392,37 +392,14 @@ impl MemoryType {
 /// imported from as well as the type of item that's being imported.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ImportType {
-    module: String,
-    name: String,
-    ty: ExternType,
-}
+    /// The module of the import.
+    pub module: String,
 
-impl ImportType {
-    /// Creates a new import descriptor which comes from `module` and `name` and
-    /// is of type `ty`.
-    pub fn new(module: &str, name: &str, ty: ExternType) -> ImportType {
-        ImportType {
-            module: module.to_string(),
-            name: name.to_string(),
-            ty,
-        }
-    }
+    /// The field of the import.
+    pub name: String,
 
-    /// Returns the module name that this import is expected to come from.
-    pub fn module(&self) -> &str {
-        &self.module
-    }
-
-    /// Returns the field name of the module that this import is expected to
-    /// come from.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Returns the expected type of this import.
-    pub fn ty(&self) -> &ExternType {
-        &self.ty
-    }
+    /// The type of the import.
+    pub ty: ExternType,
 }
 
 // Export Types
@@ -435,27 +412,9 @@ impl ImportType {
 /// exported.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ExportType {
-    name: String,
-    ty: ExternType,
-}
+    /// The name of the export.
+    pub name: String,
 
-impl ExportType {
-    /// Creates a new export which is exported with the given `name` and has the
-    /// given `ty`.
-    pub fn new(name: &str, ty: ExternType) -> ExportType {
-        ExportType {
-            name: name.to_string(),
-            ty,
-        }
-    }
-
-    /// Returns the name by which this export is known by.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Returns the type of this export.
-    pub fn ty(&self) -> &ExternType {
-        &self.ty
-    }
+    /// The type of the export.
+    pub ty: ExternType,
 }

--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -41,10 +41,10 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
 #[no_mangle]
 pub extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
     let ty = match &e.which {
-        ExternHost::Func(f) => ExternType::Func(f.borrow().ty().clone()),
-        ExternHost::Global(f) => ExternType::Global(f.borrow().ty().clone()),
-        ExternHost::Table(f) => ExternType::Table(f.borrow().ty().clone()),
-        ExternHost::Memory(f) => ExternType::Memory(f.borrow().ty().clone()),
+        ExternHost::Func(f) => ExternType::Func(f.borrow().ty()),
+        ExternHost::Global(f) => ExternType::Global(f.borrow().ty()),
+        ExternHost::Table(f) => ExternType::Table(f.borrow().ty()),
+        ExternHost::Memory(f) => ExternType::Memory(f.borrow().ty()),
     };
     Box::new(wasm_externtype_t::new(ty))
 }

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -246,7 +246,7 @@ fn _wasmtime_func_call(
 
 #[no_mangle]
 pub extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t> {
-    Box::new(wasm_functype_t::new(f.func().borrow().ty().clone()))
+    Box::new(wasm_functype_t::new(f.func().borrow().ty()))
 }
 
 #[no_mangle]
@@ -272,10 +272,10 @@ pub unsafe extern "C" fn wasmtime_caller_export_get(
     let name = str::from_utf8(name.as_slice()).ok()?;
     let export = caller.caller.get_export(name)?;
     let which = match export {
-        Extern::Func(f) => ExternHost::Func(HostRef::new(f.clone())),
-        Extern::Global(g) => ExternHost::Global(HostRef::new(g.clone())),
-        Extern::Memory(m) => ExternHost::Memory(HostRef::new(m.clone())),
-        Extern::Table(t) => ExternHost::Table(HostRef::new(t.clone())),
+        Extern::Func(f) => ExternHost::Func(HostRef::new(f)),
+        Extern::Global(g) => ExternHost::Global(HostRef::new(g)),
+        Extern::Memory(m) => ExternHost::Memory(HostRef::new(m)),
+        Extern::Table(t) => ExternHost::Table(HostRef::new(t)),
     };
     Some(Box::new(wasm_extern_t { which }))
 }

--- a/crates/c-api/src/global.rs
+++ b/crates/c-api/src/global.rs
@@ -71,7 +71,7 @@ pub extern "C" fn wasm_global_as_extern(g: &wasm_global_t) -> &wasm_extern_t {
 
 #[no_mangle]
 pub extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globaltype_t> {
-    let globaltype = g.global().borrow().ty().clone();
+    let globaltype = g.global().borrow().ty();
     Box::new(wasm_globaltype_t::new(globaltype))
 }
 

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -145,7 +145,7 @@ pub extern "C" fn wasm_instance_exports(instance: &wasm_instance_t, out: &mut wa
         let instance = &instance.instance.borrow();
         instance
             .exports()
-            .map(|e| match e {
+            .map(|e| match e.external {
                 Extern::Func(f) => ExternHost::Func(HostRef::new(f.clone())),
                 Extern::Global(f) => ExternHost::Global(HostRef::new(f.clone())),
                 Extern::Memory(f) => ExternHost::Memory(HostRef::new(f.clone())),

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -145,7 +145,6 @@ pub extern "C" fn wasm_instance_exports(instance: &wasm_instance_t, out: &mut wa
         let instance = &instance.instance.borrow();
         instance
             .exports()
-            .iter()
             .map(|e| match e {
                 Extern::Func(f) => ExternHost::Func(HostRef::new(f.clone())),
                 Extern::Global(f) => ExternHost::Global(HostRef::new(f.clone())),

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -146,10 +146,10 @@ pub extern "C" fn wasm_instance_exports(instance: &wasm_instance_t, out: &mut wa
         instance
             .exports()
             .map(|e| match e.external {
-                Extern::Func(f) => ExternHost::Func(HostRef::new(f.clone())),
-                Extern::Global(f) => ExternHost::Global(HostRef::new(f.clone())),
-                Extern::Memory(f) => ExternHost::Memory(HostRef::new(f.clone())),
-                Extern::Table(f) => ExternHost::Table(HostRef::new(f.clone())),
+                Extern::Func(f) => ExternHost::Func(HostRef::new(f)),
+                Extern::Global(f) => ExternHost::Global(HostRef::new(f)),
+                Extern::Memory(f) => ExternHost::Memory(HostRef::new(f)),
+                Extern::Table(f) => ExternHost::Table(HostRef::new(f)),
             })
             .collect()
     });

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -145,7 +145,7 @@ pub extern "C" fn wasm_instance_exports(instance: &wasm_instance_t, out: &mut wa
         let instance = &instance.instance.borrow();
         instance
             .exports()
-            .map(|e| match e.external {
+            .map(|e| match e.into_extern() {
                 Extern::Func(f) => ExternHost::Func(HostRef::new(f)),
                 Extern::Global(f) => ExternHost::Global(HostRef::new(f)),
                 Extern::Memory(f) => ExternHost::Memory(HostRef::new(f)),

--- a/crates/c-api/src/memory.rs
+++ b/crates/c-api/src/memory.rs
@@ -51,7 +51,7 @@ pub extern "C" fn wasm_memory_as_extern(m: &wasm_memory_t) -> &wasm_extern_t {
 
 #[no_mangle]
 pub extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memorytype_t> {
-    let ty = m.memory().borrow().ty().clone();
+    let ty = m.memory().borrow().ty();
     Box::new(wasm_memorytype_t::new(ty))
 }
 

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -46,12 +46,10 @@ pub extern "C" fn wasmtime_module_new(
     handle_result(Module::from_binary(store, binary), |module| {
         let imports = module
             .imports()
-            .iter()
             .map(|i| wasm_importtype_t::new(i.clone()))
             .collect::<Vec<_>>();
         let exports = module
             .exports()
-            .iter()
             .map(|e| wasm_exporttype_t::new(e.clone()))
             .collect::<Vec<_>>();
         let module = Box::new(wasm_module_t {

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -46,11 +46,11 @@ pub extern "C" fn wasmtime_module_new(
     handle_result(Module::from_binary(store, binary), |module| {
         let imports = module
             .imports()
-            .map(|i| wasm_importtype_t::new(i.clone()))
+            .map(|i| wasm_importtype_t::new(i.module().to_owned(), i.name().to_owned(), i.ty()))
             .collect::<Vec<_>>();
         let exports = module
             .exports()
-            .map(|e| wasm_exporttype_t::new(e.clone()))
+            .map(|e| wasm_exporttype_t::new(e.name().to_owned(), e.ty()))
             .collect::<Vec<_>>();
         let module = Box::new(wasm_module_t {
             module: HostRef::new(module),

--- a/crates/c-api/src/table.rs
+++ b/crates/c-api/src/table.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn wasm_table_new(
 
 #[no_mangle]
 pub extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype_t> {
-    let ty = t.table().borrow().ty().clone();
+    let ty = t.table().borrow().ty();
     Box::new(wasm_tabletype_t::new(ty))
 }
 

--- a/crates/c-api/src/types/export.rs
+++ b/crates/c-api/src/types/export.rs
@@ -30,18 +30,21 @@ pub extern "C" fn wasm_exporttype_new(
 ) -> Option<Box<wasm_exporttype_t>> {
     let name = name.take();
     let name = str::from_utf8(&name).ok()?;
-    let ty = ExportType::new(name, ty.ty());
+    let ty = ExportType {
+        name: name.to_string(),
+        ty: ty.ty(),
+    };
     Some(Box::new(wasm_exporttype_t::new(ty)))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
     et.name_cache
-        .get_or_init(|| wasm_name_t::from_name(&et.ty.name()))
+        .get_or_init(|| wasm_name_t::from_name(et.ty.name.clone()))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     et.type_cache
-        .get_or_init(|| wasm_externtype_t::new(et.ty.ty().clone()))
+        .get_or_init(|| wasm_externtype_t::new(et.ty.ty.clone()))
 }

--- a/crates/c-api/src/types/export.rs
+++ b/crates/c-api/src/types/export.rs
@@ -1,12 +1,12 @@
 use crate::{wasm_externtype_t, wasm_name_t};
 use once_cell::unsync::OnceCell;
-use std::str;
-use wasmtime::ExportType;
+use wasmtime::ExternType;
 
 #[repr(C)]
 #[derive(Clone)]
 pub struct wasm_exporttype_t {
-    ty: ExportType,
+    name: String,
+    ty: ExternType,
     name_cache: OnceCell<wasm_name_t>,
     type_cache: OnceCell<wasm_externtype_t>,
 }
@@ -14,8 +14,9 @@ pub struct wasm_exporttype_t {
 wasmtime_c_api_macros::declare_ty!(wasm_exporttype_t);
 
 impl wasm_exporttype_t {
-    pub(crate) fn new(ty: ExportType) -> wasm_exporttype_t {
+    pub(crate) fn new(name: String, ty: ExternType) -> wasm_exporttype_t {
         wasm_exporttype_t {
+            name,
             ty,
             name_cache: OnceCell::new(),
             type_cache: OnceCell::new(),
@@ -29,22 +30,18 @@ pub extern "C" fn wasm_exporttype_new(
     ty: Box<wasm_externtype_t>,
 ) -> Option<Box<wasm_exporttype_t>> {
     let name = name.take();
-    let name = str::from_utf8(&name).ok()?;
-    let ty = ExportType {
-        name: name.to_string(),
-        ty: ty.ty(),
-    };
-    Some(Box::new(wasm_exporttype_t::new(ty)))
+    let name = String::from_utf8(name).ok()?;
+    Some(Box::new(wasm_exporttype_t::new(name, ty.ty())))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
     et.name_cache
-        .get_or_init(|| wasm_name_t::from_name(et.ty.name.clone()))
+        .get_or_init(|| wasm_name_t::from_name(et.name.clone()))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     et.type_cache
-        .get_or_init(|| wasm_externtype_t::new(et.ty.ty.clone()))
+        .get_or_init(|| wasm_externtype_t::new(et.ty.clone()))
 }

--- a/crates/c-api/src/types/import.rs
+++ b/crates/c-api/src/types/import.rs
@@ -35,24 +35,28 @@ pub extern "C" fn wasm_importtype_new(
     let name = name.take();
     let module = str::from_utf8(&module).ok()?;
     let name = str::from_utf8(&name).ok()?;
-    let ty = ImportType::new(module, name, ty.ty());
+    let ty = ImportType {
+        module: module.to_owned(),
+        name: name.to_owned(),
+        ty: ty.ty(),
+    };
     Some(Box::new(wasm_importtype_t::new(ty)))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t {
     it.module_cache
-        .get_or_init(|| wasm_name_t::from_name(&it.ty.module()))
+        .get_or_init(|| wasm_name_t::from_name(it.ty.module.clone()))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
     it.name_cache
-        .get_or_init(|| wasm_name_t::from_name(&it.ty.name()))
+        .get_or_init(|| wasm_name_t::from_name(it.ty.name.clone()))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     it.type_cache
-        .get_or_init(|| wasm_externtype_t::new(it.ty.ty().clone()))
+        .get_or_init(|| wasm_externtype_t::new(it.ty.ty.clone()))
 }

--- a/crates/c-api/src/types/import.rs
+++ b/crates/c-api/src/types/import.rs
@@ -1,12 +1,13 @@
 use crate::{wasm_externtype_t, wasm_name_t};
 use once_cell::unsync::OnceCell;
-use std::str;
-use wasmtime::ImportType;
+use wasmtime::ExternType;
 
 #[repr(C)]
 #[derive(Clone)]
 pub struct wasm_importtype_t {
-    pub(crate) ty: ImportType,
+    pub(crate) module: String,
+    pub(crate) name: String,
+    pub(crate) ty: ExternType,
     module_cache: OnceCell<wasm_name_t>,
     name_cache: OnceCell<wasm_name_t>,
     type_cache: OnceCell<wasm_externtype_t>,
@@ -15,8 +16,10 @@ pub struct wasm_importtype_t {
 wasmtime_c_api_macros::declare_ty!(wasm_importtype_t);
 
 impl wasm_importtype_t {
-    pub(crate) fn new(ty: ImportType) -> wasm_importtype_t {
+    pub(crate) fn new(module: String, name: String, ty: ExternType) -> wasm_importtype_t {
         wasm_importtype_t {
+            module,
+            name,
             ty,
             module_cache: OnceCell::new(),
             name_cache: OnceCell::new(),
@@ -33,30 +36,25 @@ pub extern "C" fn wasm_importtype_new(
 ) -> Option<Box<wasm_importtype_t>> {
     let module = module.take();
     let name = name.take();
-    let module = str::from_utf8(&module).ok()?;
-    let name = str::from_utf8(&name).ok()?;
-    let ty = ImportType {
-        module: module.to_owned(),
-        name: name.to_owned(),
-        ty: ty.ty(),
-    };
-    Some(Box::new(wasm_importtype_t::new(ty)))
+    let module = String::from_utf8(module).ok()?;
+    let name = String::from_utf8(name).ok()?;
+    Some(Box::new(wasm_importtype_t::new(module, name, ty.ty())))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t {
     it.module_cache
-        .get_or_init(|| wasm_name_t::from_name(it.ty.module.clone()))
+        .get_or_init(|| wasm_name_t::from_name(it.module.clone()))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
     it.name_cache
-        .get_or_init(|| wasm_name_t::from_name(it.ty.name.clone()))
+        .get_or_init(|| wasm_name_t::from_name(it.name.clone()))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     it.type_cache
-        .get_or_init(|| wasm_externtype_t::new(it.ty.ty.clone()))
+        .get_or_init(|| wasm_externtype_t::new(it.ty.clone()))
 }

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -9,8 +9,8 @@ use std::slice;
 pub type wasm_name_t = wasm_byte_vec_t;
 
 impl wasm_name_t {
-    pub(crate) fn from_name(name: &str) -> wasm_name_t {
-        name.to_string().into_bytes().into()
+    pub(crate) fn from_name(name: String) -> wasm_name_t {
+        name.into_bytes().into()
     }
 }
 

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -313,8 +313,8 @@ pub extern "C" fn wasi_instance_bind_import<'a>(
     instance: &'a mut wasi_instance_t,
     import: &wasm_importtype_t,
 ) -> Option<&'a wasm_extern_t> {
-    let module = &import.ty.module;
-    let name = str::from_utf8(import.ty.name.as_bytes()).ok()?;
+    let module = &import.module;
+    let name = str::from_utf8(import.name.as_bytes()).ok()?;
 
     let export = match &instance.wasi {
         WasiInstance::Preview1(wasi) => {
@@ -332,7 +332,7 @@ pub extern "C" fn wasi_instance_bind_import<'a>(
         }
     };
 
-    if &export.ty() != import.ty.ty.func()? {
+    if &export.ty() != import.ty.func()? {
         return None;
     }
 

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::os::raw::{c_char, c_int};
 use std::path::{Path, PathBuf};
 use std::slice;
+use std::str;
 use wasi_common::{
     old::snapshot_0::WasiCtxBuilder as WasiSnapshot0CtxBuilder, preopen_dir,
     WasiCtxBuilder as WasiPreview1CtxBuilder,
@@ -312,26 +313,26 @@ pub extern "C" fn wasi_instance_bind_import<'a>(
     instance: &'a mut wasi_instance_t,
     import: &wasm_importtype_t,
 ) -> Option<&'a wasm_extern_t> {
-    let module = import.ty.module();
-    let name = import.ty.name();
+    let module = &import.ty.module;
+    let name = str::from_utf8(import.ty.name.as_bytes()).ok()?;
 
     let export = match &instance.wasi {
         WasiInstance::Preview1(wasi) => {
             if module != "wasi_snapshot_preview1" {
                 return None;
             }
-            wasi.get_export(name)?
+            wasi.get_export(&name)?
         }
         WasiInstance::Snapshot0(wasi) => {
             if module != "wasi_unstable" {
                 return None;
             }
 
-            wasi.get_export(name)?
+            wasi.get_export(&name)?
         }
     };
 
-    if &export.ty() != import.ty.ty().func()? {
+    if &export.ty() != import.ty.ty.func()? {
         return None;
     }
 

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -331,7 +331,7 @@ pub extern "C" fn wasi_instance_bind_import<'a>(
         }
     };
 
-    if export.ty() != import.ty.ty().func()? {
+    if &export.ty() != import.ty.ty().func()? {
         return None;
     }
 

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -297,7 +297,7 @@ pub unsafe extern "C" fn wasi_instance_new(
         })),
         Err(e) => {
             *trap = Box::into_raw(Box::new(wasm_trap_t {
-                trap: HostRef::new(Trap::new(e.to_string())),
+                trap: HostRef::new(Trap::new(e)),
             }));
 
             None

--- a/crates/c-api/src/wat2wasm.rs
+++ b/crates/c-api/src/wat2wasm.rs
@@ -10,6 +10,6 @@ pub extern "C" fn wasmtime_wat2wasm(
         Err(_) => return bad_utf8(),
     };
     handle_result(wat::parse_str(wat).map_err(|e| e.into()), |bytes| {
-        ret.set_buffer(bytes.into())
+        ret.set_buffer(bytes)
     })
 }

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -203,7 +203,7 @@ fn compile(env: CompileEnv<'_>) -> Result<ModuleCacheDataTupleType, CompileError
             let func_index = env.local.func_index(*i);
             let mut context = Context::new();
             context.func.name = get_func_name(func_index);
-            context.func.signature = env.local.signatures[env.local.functions[func_index]].clone();
+            context.func.signature = env.local.func_signature(func_index).clone();
             if env.tunables.debug_info {
                 context.func.collect_debug_info();
             }

--- a/crates/environ/src/func_environ.rs
+++ b/crates/environ/src/func_environ.rs
@@ -906,8 +906,8 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         func: &mut ir::Function,
         index: FuncIndex,
     ) -> WasmResult<ir::FuncRef> {
-        let sigidx = self.module.functions[index];
-        let signature = func.import_signature(self.module.signatures[sigidx].clone());
+        let sig = self.module.func_signature(index);
+        let signature = func.import_signature(sig.clone());
         let name = get_func_name(index);
         Ok(func.import_function(ir::ExtFuncData {
             name,

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::func_environ::BuiltinFunctionIndex;
 #[cfg(feature = "lightbeam")]
 pub use crate::lightbeam::Lightbeam;
 pub use crate::module::{
-    Export, MemoryPlan, MemoryStyle, Module, ModuleLocal, TableElements, TablePlan, TableStyle,
+    EntityIndex, MemoryPlan, MemoryStyle, Module, ModuleLocal, TableElements, TablePlan, TableStyle,
 };
 pub use crate::module_environ::{
     translate_signature, DataInitializer, DataInitializerLocation, FunctionBodyData,

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -150,18 +150,8 @@ pub struct Module {
     /// function.
     pub local: ModuleLocal,
 
-    /// Names of imported functions, as well as the index of the import that
-    /// performed this import.
-    pub imported_funcs: PrimaryMap<FuncIndex, (String, String, u32)>,
-
-    /// Names of imported tables.
-    pub imported_tables: PrimaryMap<TableIndex, (String, String, u32)>,
-
-    /// Names of imported memories.
-    pub imported_memories: PrimaryMap<MemoryIndex, (String, String, u32)>,
-
-    /// Names of imported globals.
-    pub imported_globals: PrimaryMap<GlobalIndex, (String, String, u32)>,
+    /// All import records, in the order they are declared in the module.
+    pub imports: Vec<(String, String, Export)>,
 
     /// Exported entities.
     pub exports: IndexMap<String, Export>,
@@ -226,10 +216,7 @@ impl Module {
         Self {
             id: NEXT_ID.fetch_add(1, SeqCst),
             name: None,
-            imported_funcs: PrimaryMap::new(),
-            imported_tables: PrimaryMap::new(),
-            imported_memories: PrimaryMap::new(),
-            imported_globals: PrimaryMap::new(),
+            imports: Vec::new(),
             exports: IndexMap::new(),
             start_func: None,
             table_elements: Vec::new(),

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -331,4 +331,9 @@ impl ModuleLocal {
     pub fn is_imported_global(&self, index: GlobalIndex) -> bool {
         index.index() < self.num_imported_globals
     }
+
+    /// Convenience method for looking up the signature of a function.
+    pub fn func_signature(&self, func_index: FuncIndex) -> &ir::Signature {
+        &self.signatures[self.functions[func_index]]
+    }
 }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -30,16 +30,16 @@ pub struct TableElements {
     pub elements: Box<[FuncIndex]>,
 }
 
-/// An entity to export.
+/// An index of an entity.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Export {
-    /// Function export.
+pub enum EntityIndex {
+    /// Function index.
     Function(FuncIndex),
-    /// Table export.
+    /// Table index.
     Table(TableIndex),
-    /// Memory export.
+    /// Memory index.
     Memory(MemoryIndex),
-    /// Global export.
+    /// Global index.
     Global(GlobalIndex),
 }
 
@@ -151,10 +151,10 @@ pub struct Module {
     pub local: ModuleLocal,
 
     /// All import records, in the order they are declared in the module.
-    pub imports: Vec<(String, String, Export)>,
+    pub imports: Vec<(String, String, EntityIndex)>,
 
     /// Exported entities.
-    pub exports: IndexMap<String, Export>,
+    pub exports: IndexMap<String, EntityIndex>,
 
     /// The module "start" function, if present.
     pub start_func: Option<FuncIndex>,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -1,5 +1,5 @@
 use crate::func_environ::FuncEnvironment;
-use crate::module::{Export, MemoryPlan, Module, TableElements, TablePlan};
+use crate::module::{EntityIndex, MemoryPlan, Module, TableElements, TablePlan};
 use crate::tunables::Tunables;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::{AbiParam, ArgumentPurpose};
@@ -87,7 +87,7 @@ impl<'data> ModuleEnvironment<'data> {
         Ok(self.result)
     }
 
-    fn declare_export(&mut self, export: Export, name: &str) -> WasmResult<()> {
+    fn declare_export(&mut self, export: EntityIndex, name: &str) -> WasmResult<()> {
         self.result
             .module
             .exports
@@ -144,7 +144,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result.module.imports.push((
             module.to_owned(),
             field.to_owned(),
-            Export::Function(func_index),
+            EntityIndex::Function(func_index),
         ));
         self.result.module.local.num_imported_funcs += 1;
         Ok(())
@@ -161,7 +161,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result.module.imports.push((
             module.to_owned(),
             field.to_owned(),
-            Export::Table(table_index),
+            EntityIndex::Table(table_index),
         ));
         self.result.module.local.num_imported_tables += 1;
         Ok(())
@@ -186,7 +186,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result.module.imports.push((
             module.to_owned(),
             field.to_owned(),
-            Export::Memory(memory_index),
+            EntityIndex::Memory(memory_index),
         ));
         self.result.module.local.num_imported_memories += 1;
         Ok(())
@@ -207,7 +207,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result.module.imports.push((
             module.to_owned(),
             field.to_owned(),
-            Export::Global(global_index),
+            EntityIndex::Global(global_index),
         ));
         self.result.module.local.num_imported_globals += 1;
         Ok(())
@@ -286,19 +286,19 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn declare_func_export(&mut self, func_index: FuncIndex, name: &str) -> WasmResult<()> {
-        self.declare_export(Export::Function(func_index), name)
+        self.declare_export(EntityIndex::Function(func_index), name)
     }
 
     fn declare_table_export(&mut self, table_index: TableIndex, name: &str) -> WasmResult<()> {
-        self.declare_export(Export::Table(table_index), name)
+        self.declare_export(EntityIndex::Table(table_index), name)
     }
 
     fn declare_memory_export(&mut self, memory_index: MemoryIndex, name: &str) -> WasmResult<()> {
-        self.declare_export(Export::Memory(memory_index), name)
+        self.declare_export(EntityIndex::Memory(memory_index), name)
     }
 
     fn declare_global_export(&mut self, global_index: GlobalIndex, name: &str) -> WasmResult<()> {
-        self.declare_export(Export::Global(global_index), name)
+        self.declare_export(EntityIndex::Global(global_index), name)
     }
 
     fn declare_start_func(&mut self, func_index: FuncIndex) -> WasmResult<()> {

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -8,7 +8,7 @@ use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{
     self, translate_module, DataIndex, DefinedFuncIndex, ElemIndex, FuncIndex, Global, GlobalIndex,
     Memory, MemoryIndex, ModuleTranslationState, SignatureIndex, Table, TableIndex,
-    TargetEnvironment, WasmResult,
+    TargetEnvironment, WasmError, WasmResult,
 };
 use std::convert::TryFrom;
 use std::sync::Arc;
@@ -57,7 +57,6 @@ impl<'data> ModuleTranslation<'data> {
 pub struct ModuleEnvironment<'data> {
     /// The result to be filled in.
     result: ModuleTranslation<'data>,
-    imports: u32,
 }
 
 impl<'data> ModuleEnvironment<'data> {
@@ -72,7 +71,6 @@ impl<'data> ModuleEnvironment<'data> {
                 tunables: tunables.clone(),
                 module_translation: None,
             },
-            imports: 0,
         }
     }
 
@@ -123,6 +121,14 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         Ok(())
     }
 
+    fn reserve_imports(&mut self, num: u32) -> WasmResult<()> {
+        Ok(self
+            .result
+            .module
+            .imports
+            .reserve_exact(usize::try_from(num).unwrap()))
+    }
+
     fn declare_func_import(
         &mut self,
         sig_index: SignatureIndex,
@@ -131,37 +137,33 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     ) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.functions.len(),
-            self.result.module.imported_funcs.len(),
+            self.result.module.local.num_imported_funcs,
             "Imported functions must be declared first"
         );
-        self.result.module.local.functions.push(sig_index);
-
-        self.result.module.imported_funcs.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let func_index = self.result.module.local.functions.push(sig_index);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Function(func_index),
         ));
         self.result.module.local.num_imported_funcs += 1;
-        self.imports += 1;
         Ok(())
     }
 
     fn declare_table_import(&mut self, table: Table, module: &str, field: &str) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.table_plans.len(),
-            self.result.module.imported_tables.len(),
+            self.result.module.local.num_imported_tables,
             "Imported tables must be declared first"
         );
         let plan = TablePlan::for_table(table, &self.result.tunables);
-        self.result.module.local.table_plans.push(plan);
-
-        self.result.module.imported_tables.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let table_index = self.result.module.local.table_plans.push(plan);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Table(table_index),
         ));
         self.result.module.local.num_imported_tables += 1;
-        self.imports += 1;
         Ok(())
     }
 
@@ -173,19 +175,20 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     ) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.memory_plans.len(),
-            self.result.module.imported_memories.len(),
+            self.result.module.local.num_imported_memories,
             "Imported memories must be declared first"
         );
+        if memory.shared {
+            return Err(WasmError::Unsupported("shared memories".to_owned()));
+        }
         let plan = MemoryPlan::for_memory(memory, &self.result.tunables);
-        self.result.module.local.memory_plans.push(plan);
-
-        self.result.module.imported_memories.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let memory_index = self.result.module.local.memory_plans.push(plan);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Memory(memory_index),
         ));
         self.result.module.local.num_imported_memories += 1;
-        self.imports += 1;
         Ok(())
     }
 
@@ -197,26 +200,16 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     ) -> WasmResult<()> {
         debug_assert_eq!(
             self.result.module.local.globals.len(),
-            self.result.module.imported_globals.len(),
+            self.result.module.local.num_imported_globals,
             "Imported globals must be declared first"
         );
-        self.result.module.local.globals.push(global);
-
-        self.result.module.imported_globals.push((
-            String::from(module),
-            String::from(field),
-            self.imports,
+        let global_index = self.result.module.local.globals.push(global);
+        self.result.module.imports.push((
+            module.to_owned(),
+            field.to_owned(),
+            Export::Global(global_index),
         ));
         self.result.module.local.num_imported_globals += 1;
-        self.imports += 1;
-        Ok(())
-    }
-
-    fn finish_imports(&mut self) -> WasmResult<()> {
-        self.result.module.imported_funcs.shrink_to_fit();
-        self.result.module.imported_tables.shrink_to_fit();
-        self.result.module.imported_memories.shrink_to_fit();
-        self.result.module.imported_globals.shrink_to_fit();
         Ok(())
     }
 
@@ -262,6 +255,9 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn declare_memory(&mut self, memory: Memory) -> WasmResult<()> {
+        if memory.shared {
+            return Err(WasmError::Unsupported("shared memories".to_owned()));
+        }
         let plan = MemoryPlan::for_memory(memory, &self.result.tunables);
         self.result.module.local.memory_plans.push(plan);
         Ok(())
@@ -420,6 +416,27 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
             .func_names
             .insert(func_index, name.to_string());
         Ok(())
+    }
+
+    fn custom_section(&mut self, name: &'data str, _data: &'data [u8]) -> WasmResult<()> {
+        match name {
+            "webidl-bindings" | "wasm-interface-types" => Err(WasmError::Unsupported(
+                "\
+Support for interface types has temporarily been removed from `wasmtime`.
+
+For more information about this temoprary you can read on the issue online:
+
+    https://github.com/bytecodealliance/wasmtime/issues/1271
+
+and for re-adding support for interface types you can see this issue:
+
+    https://github.com/bytecodealliance/wasmtime/issues/677
+"
+                .to_owned(),
+            )),
+            // skip other sections
+            _ => Ok(()),
+        }
     }
 }
 

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -185,13 +185,11 @@ pub fn differential_execution(
             // infinite loop when calling another export.
             init_hang_limit(&instance);
 
-            let f = match instance
+            let f = instance
                 .get_export(&name)
                 .expect("instance should have export from module")
-            {
-                Extern::Func(f) => f.clone(),
-                _ => panic!("export should be a function"),
-            };
+                .into_func()
+                .expect("export should be a function");
 
             let ty = f.ty();
             let params = match dummy::dummy_values(ty.params()) {

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -169,27 +169,13 @@ pub fn differential_execution(
             }
         };
 
-        let funcs = module
-            .exports()
-            .filter_map(|e| {
-                if let ExternType::Func(_) = e.ty() {
-                    Some(e.name())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        for name in funcs {
+        for (name, f) in instance.exports().filter_map(|e| {
+            let name = e.name();
+            e.into_func().map(|f| (name, f))
+        }) {
             // Always call the hang limit initializer first, so that we don't
             // infinite loop when calling another export.
             init_hang_limit(&instance);
-
-            let f = instance
-                .get_export(&name)
-                .expect("instance should have export from module")
-                .into_func()
-                .expect("export should be a function");
 
             let ty = f.ty();
             let params = match dummy::dummy_values(ty.params()) {
@@ -375,7 +361,7 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
 
                 let funcs = instance
                     .exports()
-                    .filter_map(|e| match e {
+                    .filter_map(|e| match e.into_extern() {
                         Extern::Func(f) => Some(f.clone()),
                         _ => None,
                     })

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -171,7 +171,6 @@ pub fn differential_execution(
 
         let funcs = module
             .exports()
-            .iter()
             .filter_map(|e| {
                 if let ExternType::Func(_) = e.ty() {
                     Some(e.name())
@@ -378,7 +377,6 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
 
                 let funcs = instance
                     .exports()
-                    .iter()
                     .filter_map(|e| match e {
                         Extern::Func(f) => Some(f.clone()),
                         _ => None,

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -12,7 +12,7 @@ pub fn dummy_imports(
 ) -> Result<Vec<Extern>, Trap> {
     import_tys
         .map(|imp| {
-            Ok(match imp.ty() {
+            Ok(match imp.ty {
                 ExternType::Func(func_ty) => Extern::Func(dummy_func(&store, func_ty.clone())),
                 ExternType::Global(global_ty) => {
                     Extern::Global(dummy_global(&store, global_ty.clone())?)

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -6,19 +6,24 @@ use wasmtime::{
 };
 
 /// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_imports(store: &Store, import_tys: &[ImportType]) -> Result<Vec<Extern>, Trap> {
-    let mut imports = Vec::with_capacity(import_tys.len());
-    for imp in import_tys {
-        imports.push(match imp.ty() {
-            ExternType::Func(func_ty) => Extern::Func(dummy_func(&store, func_ty.clone())),
-            ExternType::Global(global_ty) => {
-                Extern::Global(dummy_global(&store, global_ty.clone())?)
-            }
-            ExternType::Table(table_ty) => Extern::Table(dummy_table(&store, table_ty.clone())?),
-            ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(&store, mem_ty.clone())),
-        });
-    }
-    Ok(imports)
+pub fn dummy_imports(
+    store: &Store,
+    import_tys: impl Iterator<Item = ImportType>,
+) -> Result<Vec<Extern>, Trap> {
+    import_tys
+        .map(|imp| {
+            Ok(match imp.ty() {
+                ExternType::Func(func_ty) => Extern::Func(dummy_func(&store, func_ty.clone())),
+                ExternType::Global(global_ty) => {
+                    Extern::Global(dummy_global(&store, global_ty.clone())?)
+                }
+                ExternType::Table(table_ty) => {
+                    Extern::Table(dummy_table(&store, table_ty.clone())?)
+                }
+                ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(&store, mem_ty.clone())),
+            })
+        })
+        .collect()
 }
 
 /// Construct a dummy function for the given function type

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -6,21 +6,17 @@ use wasmtime::{
 };
 
 /// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_imports(
+pub fn dummy_imports<'module>(
     store: &Store,
-    import_tys: impl Iterator<Item = ImportType>,
+    import_tys: impl Iterator<Item = ImportType<'module>>,
 ) -> Result<Vec<Extern>, Trap> {
     import_tys
         .map(|imp| {
-            Ok(match imp.ty {
-                ExternType::Func(func_ty) => Extern::Func(dummy_func(&store, func_ty.clone())),
-                ExternType::Global(global_ty) => {
-                    Extern::Global(dummy_global(&store, global_ty.clone())?)
-                }
-                ExternType::Table(table_ty) => {
-                    Extern::Table(dummy_table(&store, table_ty.clone())?)
-                }
-                ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(&store, mem_ty.clone())),
+            Ok(match imp.ty() {
+                ExternType::Func(func_ty) => Extern::Func(dummy_func(&store, func_ty)),
+                ExternType::Global(global_ty) => Extern::Global(dummy_global(&store, global_ty)?),
+                ExternType::Table(table_ty) => Extern::Table(dummy_table(&store, table_ty)?),
+                ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(&store, mem_ty)),
             })
         })
         .collect()

--- a/crates/jit/src/imports.rs
+++ b/crates/jit/src/imports.rs
@@ -34,8 +34,7 @@ pub fn resolve_imports(
 
         match (import, &export) {
             (EntityIndex::Function(func_index), Some(Export::Function(f))) => {
-                let import_signature =
-                    &module.local.signatures[module.local.functions[*func_index]];
+                let import_signature = module.local.func_signature(*func_index);
                 let signature = signatures.lookup(f.signature).unwrap();
                 if signature != *import_signature {
                     // TODO: If the difference is in the calling convention,

--- a/crates/jit/src/imports.rs
+++ b/crates/jit/src/imports.rs
@@ -3,6 +3,7 @@
 use crate::resolver::Resolver;
 use more_asserts::assert_ge;
 use std::collections::HashSet;
+use std::convert::TryInto;
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::wasm::{Global, GlobalInit, Memory, Table, TableElementType};
 use wasmtime_environ::{MemoryPlan, MemoryStyle, Module, TablePlan};
@@ -22,156 +23,140 @@ pub fn resolve_imports(
 ) -> Result<Imports, LinkError> {
     let mut dependencies = HashSet::new();
 
-    let mut function_imports = PrimaryMap::with_capacity(module.imported_funcs.len());
-    for (index, (module_name, field, import_idx)) in module.imported_funcs.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Function(f) => {
-                    let import_signature = &module.local.signatures[module.local.functions[index]];
-                    let signature = signatures.lookup(f.signature).unwrap();
-                    if signature != *import_signature {
-                        // TODO: If the difference is in the calling convention,
-                        // we could emit a wrapper function to fix it up.
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported function with signature {} \
-                             incompatible with function import with signature {}",
-                            module_name, field, signature, import_signature
-                        )));
-                    }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(f.vmctx) });
-                    function_imports.push(VMFunctionImport {
-                        body: f.address,
-                        vmctx: f.vmctx,
-                    });
-                }
-                Export::Table(_) | Export::Memory(_) | Export::Global(_) => {
+    let mut function_imports = PrimaryMap::with_capacity(module.local.num_imported_funcs);
+    let mut table_imports = PrimaryMap::with_capacity(module.local.num_imported_tables);
+    let mut memory_imports = PrimaryMap::with_capacity(module.local.num_imported_memories);
+    let mut global_imports = PrimaryMap::with_capacity(module.local.num_imported_globals);
+
+    for (import_idx, (module_name, field_name, import)) in module.imports.iter().enumerate() {
+        let import_idx = import_idx.try_into().unwrap();
+        let export = resolver.resolve(import_idx, module_name, field_name);
+
+        match (import, &export) {
+            (wasmtime_environ::Export::Function(func_index), Some(Export::Function(f))) => {
+                let import_signature =
+                    &module.local.signatures[module.local.functions[*func_index]];
+                let signature = signatures.lookup(f.signature).unwrap();
+                if signature != *import_signature {
+                    // TODO: If the difference is in the calling convention,
+                    // we could emit a wrapper function to fix it up.
                     return Err(LinkError(format!(
-                        "{}/{}: incompatible import type: export incompatible with function import",
-                        module_name, field
+                        "{}/{}: incompatible import type: exported function with signature {} \
+                         incompatible with function import with signature {}",
+                        module_name, field_name, signature, import_signature
                     )));
                 }
-            },
-            None => {
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(f.vmctx) });
+                function_imports.push(VMFunctionImport {
+                    body: f.address,
+                    vmctx: f.vmctx,
+                });
+            }
+            (wasmtime_environ::Export::Function(_), Some(_)) => {
+                return Err(LinkError(format!(
+                    "{}/{}: incompatible import type: export incompatible with function import",
+                    module_name, field_name
+                )));
+            }
+            (wasmtime_environ::Export::Function(_), None) => {
                 return Err(LinkError(format!(
                     "{}/{}: unknown import function: function not provided",
-                    module_name, field
+                    module_name, field_name
                 )));
             }
-        }
-    }
 
-    let mut table_imports = PrimaryMap::with_capacity(module.imported_tables.len());
-    for (index, (module_name, field, import_idx)) in module.imported_tables.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Table(t) => {
-                    let import_table = &module.local.table_plans[index];
-                    if !is_table_compatible(&t.table, import_table) {
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported table incompatible with \
+            (wasmtime_environ::Export::Table(table_index), Some(Export::Table(t))) => {
+                let import_table = &module.local.table_plans[*table_index];
+                if !is_table_compatible(&t.table, import_table) {
+                    return Err(LinkError(format!(
+                        "{}/{}: incompatible import type: exported table incompatible with \
                              table import",
-                            module_name, field,
-                        )));
-                    }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(t.vmctx) });
-                    table_imports.push(VMTableImport {
-                        from: t.definition,
-                        vmctx: t.vmctx,
-                    });
-                }
-                Export::Global(_) | Export::Memory(_) | Export::Function(_) => {
-                    return Err(LinkError(format!(
-                        "{}/{}: incompatible import type: export incompatible with table import",
-                        module_name, field
+                        module_name, field_name,
                     )));
                 }
-            },
-            None => {
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(t.vmctx) });
+                table_imports.push(VMTableImport {
+                    from: t.definition,
+                    vmctx: t.vmctx,
+                });
+            }
+            (wasmtime_environ::Export::Table(_), Some(_)) => {
                 return Err(LinkError(format!(
-                    "unknown import: no provided import table for {}/{}",
-                    module_name, field
+                    "{}/{}: incompatible import type: export incompatible with table import",
+                    module_name, field_name
                 )));
             }
-        }
-    }
+            (wasmtime_environ::Export::Table(_), None) => {
+                return Err(LinkError(format!(
+                    "{}/{}: unknown import table: table not provided",
+                    module_name, field_name
+                )));
+            }
 
-    let mut memory_imports = PrimaryMap::with_capacity(module.imported_memories.len());
-    for (index, (module_name, field, import_idx)) in module.imported_memories.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Memory(m) => {
-                    let import_memory = &module.local.memory_plans[index];
-                    if !is_memory_compatible(&m.memory, import_memory) {
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported memory incompatible with \
+            (wasmtime_environ::Export::Memory(memory_index), Some(Export::Memory(m))) => {
+                let import_memory = &module.local.memory_plans[*memory_index];
+                if !is_memory_compatible(&m.memory, import_memory) {
+                    return Err(LinkError(format!(
+                        "{}/{}: incompatible import type: exported memory incompatible with \
                              memory import",
-                            module_name, field
-                        )));
-                    }
-
-                    // Sanity-check: Ensure that the imported memory has at least
-                    // guard-page protections the importing module expects it to have.
-                    if let (
-                        MemoryStyle::Static { bound },
-                        MemoryStyle::Static {
-                            bound: import_bound,
-                        },
-                    ) = (m.memory.style, &import_memory.style)
-                    {
-                        assert_ge!(bound, *import_bound);
-                    }
-                    assert_ge!(m.memory.offset_guard_size, import_memory.offset_guard_size);
-
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(m.vmctx) });
-                    memory_imports.push(VMMemoryImport {
-                        from: m.definition,
-                        vmctx: m.vmctx,
-                    });
-                }
-                Export::Table(_) | Export::Global(_) | Export::Function(_) => {
-                    return Err(LinkError(format!(
-                        "{}/{}: incompatible import type: export incompatible with memory import",
-                        module_name, field
+                        module_name, field_name
                     )));
                 }
-            },
-            None => {
+
+                // Sanity-check: Ensure that the imported memory has at least
+                // guard-page protections the importing module expects it to have.
+                if let (
+                    MemoryStyle::Static { bound },
+                    MemoryStyle::Static {
+                        bound: import_bound,
+                    },
+                ) = (&m.memory.style, &import_memory.style)
+                {
+                    assert_ge!(*bound, *import_bound);
+                }
+                assert_ge!(m.memory.offset_guard_size, import_memory.offset_guard_size);
+
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(m.vmctx) });
+                memory_imports.push(VMMemoryImport {
+                    from: m.definition,
+                    vmctx: m.vmctx,
+                });
+            }
+            (wasmtime_environ::Export::Memory(_), Some(_)) => {
                 return Err(LinkError(format!(
-                    "unknown import: no provided import memory for {}/{}",
-                    module_name, field
+                    "{}/{}: incompatible import type: export incompatible with memory import",
+                    module_name, field_name
                 )));
             }
-        }
-    }
+            (wasmtime_environ::Export::Memory(_), None) => {
+                return Err(LinkError(format!(
+                    "{}/{}: unknown import memory: memory not provided",
+                    module_name, field_name
+                )));
+            }
 
-    let mut global_imports = PrimaryMap::with_capacity(module.imported_globals.len());
-    for (index, (module_name, field, import_idx)) in module.imported_globals.iter() {
-        match resolver.resolve(*import_idx, module_name, field) {
-            Some(export_value) => match export_value {
-                Export::Table(_) | Export::Memory(_) | Export::Function(_) => {
+            (wasmtime_environ::Export::Global(global_index), Some(Export::Global(g))) => {
+                let imported_global = module.local.globals[*global_index];
+                if !is_global_compatible(&g.global, &imported_global) {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: exported global incompatible with \
-                         global import",
-                        module_name, field
+                             global import",
+                        module_name, field_name
                     )));
                 }
-                Export::Global(g) => {
-                    let imported_global = module.local.globals[index];
-                    if !is_global_compatible(&g.global, &imported_global) {
-                        return Err(LinkError(format!(
-                            "{}/{}: incompatible import type: exported global incompatible with \
-                             global import",
-                            module_name, field
-                        )));
-                    }
-                    dependencies.insert(unsafe { InstanceHandle::from_vmctx(g.vmctx) });
-                    global_imports.push(VMGlobalImport { from: g.definition });
-                }
-            },
-            None => {
+                dependencies.insert(unsafe { InstanceHandle::from_vmctx(g.vmctx) });
+                global_imports.push(VMGlobalImport { from: g.definition });
+            }
+            (wasmtime_environ::Export::Global(_), Some(_)) => {
                 return Err(LinkError(format!(
-                    "unknown import: no provided import global for {}/{}",
-                    module_name, field
+                    "{}/{}: incompatible import type: export incompatible with global import",
+                    module_name, field_name
+                )));
+            }
+            (wasmtime_environ::Export::Global(_), None) => {
+                return Err(LinkError(format!(
+                    "{}/{}: unknown import global: global not provided",
+                    module_name, field_name
                 )));
             }
         }

--- a/crates/obj/src/context.rs
+++ b/crates/obj/src/context.rs
@@ -42,7 +42,7 @@ pub fn layout_vmcontext(
         }
     }
 
-    let num_tables_imports = module.imported_tables.len();
+    let num_tables_imports = module.local.num_imported_tables;
     let mut table_relocs = Vec::with_capacity(module.local.table_plans.len() - num_tables_imports);
     for (index, table) in module.local.table_plans.iter().skip(num_tables_imports) {
         let def_index = module.local.defined_table_index(index).unwrap();
@@ -66,7 +66,7 @@ pub fn layout_vmcontext(
         });
     }
 
-    let num_globals_imports = module.imported_globals.len();
+    let num_globals_imports = module.local.num_imported_globals;
     for (index, global) in module.local.globals.iter().skip(num_globals_imports) {
         let def_index = module.local.defined_global_index(index).unwrap();
         let offset = ofs.vmctx_vmglobal_definition(def_index) as usize;

--- a/crates/obj/src/function.rs
+++ b/crates/obj/src/function.rs
@@ -11,7 +11,7 @@ pub fn declare_functions(
     module: &Module,
     relocations: &Relocations,
 ) -> Result<()> {
-    for i in 0..module.imported_funcs.len() {
+    for i in 0..module.local.num_imported_funcs {
         let string_name = format!("_wasm_function_{}", i);
         obj.declare(string_name, Decl::function_import())?;
     }
@@ -32,7 +32,7 @@ pub fn emit_functions(
 ) -> Result<()> {
     debug_assert!(
         module.start_func.is_none()
-            || module.start_func.unwrap().index() >= module.imported_funcs.len(),
+            || module.start_func.unwrap().index() >= module.local.num_imported_funcs,
         "imported start functions not supported yet"
     );
 

--- a/crates/runtime/src/debug_builtins.rs
+++ b/crates/runtime/src/debug_builtins.rs
@@ -16,7 +16,7 @@ pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
     );
     let handle = InstanceHandle::from_vmctx(VMCTX_AND_MEMORY.0);
     assert!(
-        VMCTX_AND_MEMORY.1 < handle.instance().module().local.memory_plans.len(),
+        VMCTX_AND_MEMORY.1 < handle.module().local.memory_plans.len(),
         "memory index for debugger is out of bounds"
     );
     let index = MemoryIndex::new(VMCTX_AND_MEMORY.1);

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -31,7 +31,7 @@ use wasmtime_environ::wasm::{
     DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
     ElemIndex, FuncIndex, GlobalIndex, GlobalInit, MemoryIndex, SignatureIndex, TableIndex,
 };
-use wasmtime_environ::{ir, DataInitializer, Module, TableElements, VMOffsets};
+use wasmtime_environ::{ir, DataInitializer, EntityIndex, Module, TableElements, VMOffsets};
 
 cfg_if::cfg_if! {
     if #[cfg(unix)] {
@@ -296,9 +296,9 @@ impl Instance {
     }
 
     /// Lookup an export with the given export declaration.
-    pub fn lookup_by_declaration(&self, export: &wasmtime_environ::Export) -> Export {
+    pub fn lookup_by_declaration(&self, export: &EntityIndex) -> Export {
         match export {
-            wasmtime_environ::Export::Function(index) => {
+            EntityIndex::Function(index) => {
                 let signature = self.signature_id(self.module.local.functions[*index]);
                 let (address, vmctx) =
                     if let Some(def_index) = self.module.local.defined_func_index(*index) {
@@ -317,7 +317,7 @@ impl Instance {
                 }
                 .into()
             }
-            wasmtime_environ::Export::Table(index) => {
+            EntityIndex::Table(index) => {
                 let (definition, vmctx) =
                     if let Some(def_index) = self.module.local.defined_table_index(*index) {
                         (self.table_ptr(def_index), self.vmctx_ptr())
@@ -332,7 +332,7 @@ impl Instance {
                 }
                 .into()
             }
-            wasmtime_environ::Export::Memory(index) => {
+            EntityIndex::Memory(index) => {
                 let (definition, vmctx) =
                     if let Some(def_index) = self.module.local.defined_memory_index(*index) {
                         (self.memory_ptr(def_index), self.vmctx_ptr())
@@ -347,7 +347,7 @@ impl Instance {
                 }
                 .into()
             }
-            wasmtime_environ::Export::Global(index) => ExportGlobal {
+            EntityIndex::Global(index) => ExportGlobal {
                 definition: if let Some(def_index) = self.module.local.defined_global_index(*index)
                 {
                     self.global_ptr(def_index)
@@ -366,7 +366,7 @@ impl Instance {
     /// Specifically, it provides access to the key-value pairs, where they keys
     /// are export names, and the values are export declarations which can be
     /// resolved `lookup_by_declaration`.
-    pub fn exports(&self) -> indexmap::map::Iter<String, wasmtime_environ::Export> {
+    pub fn exports(&self) -> indexmap::map::Iter<String, EntityIndex> {
         self.module.exports.iter()
     }
 
@@ -1031,7 +1031,7 @@ impl InstanceHandle {
     }
 
     /// Lookup an export with the given export declaration.
-    pub fn lookup_by_declaration(&self, export: &wasmtime_environ::Export) -> Export {
+    pub fn lookup_by_declaration(&self, export: &EntityIndex) -> Export {
         self.instance().lookup_by_declaration(export)
     }
 
@@ -1040,7 +1040,7 @@ impl InstanceHandle {
     /// Specifically, it provides access to the key-value pairs, where the keys
     /// are export names, and the values are export declarations which can be
     /// resolved `lookup_by_declaration`.
-    pub fn exports(&self) -> indexmap::map::Iter<String, wasmtime_environ::Export> {
+    pub fn exports(&self) -> indexmap::map::Iter<String, EntityIndex> {
         self.instance().exports()
     }
 

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -363,7 +363,7 @@ impl Instance {
 
     /// Return an iterator over the exports of this instance.
     ///
-    /// Specifically, it provides access to the key-value pairs, where they keys
+    /// Specifically, it provides access to the key-value pairs, where the keys
     /// are export names, and the values are export declarations which can be
     /// resolved `lookup_by_declaration`.
     pub fn exports(&self) -> indexmap::map::Iter<String, EntityIndex> {

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -52,11 +52,15 @@ pub fn instantiate(
     let imports = module
         .imports()
         .map(|i| {
-            let field_name = &i.name;
+            let field_name = i.name();
             if let Some(export) = snapshot1.get_export(field_name) {
                 Ok(export.clone().into())
             } else {
-                bail!("import {} was not found in module {}", field_name, i.module,)
+                bail!(
+                    "import {} was not found in module {}",
+                    field_name,
+                    i.module()
+                )
             }
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -52,15 +52,11 @@ pub fn instantiate(
     let imports = module
         .imports()
         .map(|i| {
-            let field_name = i.name();
+            let field_name = &i.name;
             if let Some(export) = snapshot1.get_export(field_name) {
                 Ok(export.clone().into())
             } else {
-                bail!(
-                    "import {} was not found in module {}",
-                    field_name,
-                    i.module(),
-                )
+                bail!("import {} was not found in module {}", field_name, i.module,)
             }
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -66,12 +66,9 @@ pub fn instantiate(
         bin_name,
     ))?;
 
-    let export = instance
+    instance
         .get_export("_start")
         .context("expected a _start export")?
-        .clone();
-
-    export
         .into_func()
         .context("expected export to be a func")?
         .call(&[])?;

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -51,7 +51,6 @@ pub fn instantiate(
     let module = Module::new(&store, &data).context("failed to create wasm module")?;
     let imports = module
         .imports()
-        .iter()
         .map(|i| {
             let field_name = i.name();
             if let Some(export) = snapshot1.get_export(field_name) {

--- a/crates/test-programs/tests/wasm_tests/runtime.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime.rs
@@ -72,7 +72,7 @@ pub fn instantiate(
         .clone();
 
     export
-        .func()
+        .into_func()
         .context("expected export to be a func")?
         .call(&[])?;
 

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -68,7 +68,7 @@ impl WastContext {
 
     fn get_export(&self, module: Option<&str>, name: &str) -> Result<Extern> {
         match module {
-            Some(module) => self.linker.get_one_by_name(module, name).map(Extern::clone),
+            Some(module) => self.linker.get_one_by_name(module, name),
             None => self
                 .current
                 .as_ref()

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -156,7 +156,7 @@ impl WastContext {
     ) -> Result<Outcome> {
         let func = self
             .get_export(instance_name, field)?
-            .func()
+            .into_func()
             .ok_or_else(|| anyhow!("no function named `{}`", field))?;
         Ok(match func.call(args) {
             Ok(result) => Outcome::Ok(result.into()),
@@ -168,7 +168,7 @@ impl WastContext {
     fn get(&mut self, instance_name: Option<&str>, field: &str) -> Result<Outcome> {
         let global = self
             .get_export(instance_name, field)?
-            .global()
+            .into_global()
             .ok_or_else(|| anyhow!("no global named `{}`", field))?;
         Ok(Outcome::Ok(vec![global.get()]))
     }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -66,9 +66,9 @@ impl WastContext {
         }
     }
 
-    fn get_export(&self, module: Option<&str>, name: &str) -> Result<&Extern> {
+    fn get_export(&self, module: Option<&str>, name: &str) -> Result<Extern> {
         match module {
-            Some(module) => self.linker.get_one_by_name(module, name),
+            Some(module) => self.linker.get_one_by_name(module, name).map(Extern::clone),
             None => self
                 .current
                 .as_ref()

--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // run it.
     let answer = instance.get_export("answer")
         .expect("export named `answer` not found")
-        .func()
+        .into_func()
         .expect("export `answer` was not a function");
 
     // There's a few ways we can call the `answer` `Func` value. The easiest

--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -74,10 +74,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // The `Instance` gives us access to various exported functions and items,
     // which we access here to pull out our `answer` exported function and
     // run it.
-    let answer = instance.get_export("answer")
-        .expect("export named `answer` not found")
-        .into_func()
-        .expect("export `answer` was not a function");
+    let answer = instance.get_func("answer")
+        .expect("`answer` was not an exported function");
 
     // There's a few ways we can call the `answer` `Func` value. The easiest
     // is to statically assert its signature with `get0` (in this case asserting

--- a/docs/wasm-wat.md
+++ b/docs/wasm-wat.md
@@ -47,7 +47,7 @@ let wat = r#"
 "#;
 let module = Module::new(&store, wat)?;
 let instance = Instance::new(&module, &[])?;
-let add = instance.get_export("add").and_then(|f| f.into_func()).unwrap();
+let add = instance.get_func("add").unwrap();
 let add = add.get2::<i32, i32, i32>()?;
 println!("1 + 2 = {}", add(1, 2)?);
 # Ok(())

--- a/docs/wasm-wat.md
+++ b/docs/wasm-wat.md
@@ -47,7 +47,7 @@ let wat = r#"
 "#;
 let module = Module::new(&store, wat)?;
 let instance = Instance::new(&module, &[])?;
-let add = instance.get_export("add").and_then(|f| f.func()).unwrap();
+let add = instance.get_export("add").and_then(|f| f.into_func()).unwrap();
 let add = add.get2::<i32, i32, i32>()?;
 println!("1 + 2 = {}", add(1, 2)?);
 # Ok(())

--- a/examples/fib-debug/main.rs
+++ b/examples/fib-debug/main.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
     // Invoke `fib` export
     let fib = instance
         .get_export("fib")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(anyhow::format_err!("failed to find `fib` function export"))?
         .get1::<i32, i32>()?;
     println!("fib(6) = {}", fib(6)?);

--- a/examples/fib-debug/main.rs
+++ b/examples/fib-debug/main.rs
@@ -22,8 +22,7 @@ fn main() -> Result<()> {
 
     // Invoke `fib` export
     let fib = instance
-        .get_export("fib")
-        .and_then(|e| e.into_func())
+        .get_func("fib")
         .ok_or(anyhow::format_err!("failed to find `fib` function export"))?
         .get1::<i32, i32>()?;
     println!("fib(6) = {}", fib(6)?);

--- a/examples/gcd.rs
+++ b/examples/gcd.rs
@@ -16,8 +16,7 @@ fn main() -> Result<()> {
 
     // Invoke `gcd` export
     let gcd = instance
-        .get_export("gcd")
-        .and_then(|e| e.into_func())
+        .get_func("gcd")
         .ok_or(anyhow::format_err!("failed to find `gcd` function export"))?
         .get2::<i32, i32, i32>()?;
 

--- a/examples/gcd.rs
+++ b/examples/gcd.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
     // Invoke `gcd` export
     let gcd = instance
         .get_export("gcd")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(anyhow::format_err!("failed to find `gcd` function export"))?
         .get2::<i32, i32, i32>()?;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -35,8 +35,7 @@ fn main() -> Result<()> {
     // Next we poke around a bit to extract the `run` function from the module.
     println!("Extracting export...");
     let run = instance
-        .get_export("run")
-        .and_then(|e| e.into_func())
+        .get_func("run")
         .ok_or(anyhow::format_err!("failed to find `run` function export"))?
         .get0::<()>()?;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
     println!("Extracting export...");
     let run = instance
         .get_export("run")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(anyhow::format_err!("failed to find `run` function export"))?
         .get0::<()>()?;
 

--- a/examples/linking.rs
+++ b/examples/linking.rs
@@ -26,10 +26,7 @@ fn main() -> Result<()> {
 
     // And with that we can perform the final link and the execute the module.
     let linking1 = linker.instantiate(&linking1)?;
-    let run = linking1
-        .get_export("run")
-        .and_then(|e| e.into_func())
-        .unwrap();
+    let run = linking1.get_func("run").unwrap();
     let run = run.get0::<()>()?;
     run()?;
     Ok(())

--- a/examples/linking.rs
+++ b/examples/linking.rs
@@ -26,7 +26,10 @@ fn main() -> Result<()> {
 
     // And with that we can perform the final link and the execute the module.
     let linking1 = linker.instantiate(&linking1)?;
-    let run = linking1.get_export("run").and_then(|e| e.func()).unwrap();
+    let run = linking1
+        .get_export("run")
+        .and_then(|e| e.into_func())
+        .unwrap();
     let run = run.get0::<()>()?;
     run()?;
     Ok(())

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -18,22 +18,18 @@ fn main() -> Result<()> {
 
     // Load up our exports from the instance
     let memory = instance
-        .get_export("memory")
-        .and_then(|e| e.into_memory())
+        .get_memory("memory")
         .ok_or(anyhow::format_err!("failed to find `memory` export"))?;
     let size = instance
-        .get_export("size")
-        .and_then(|e| e.into_func())
+        .get_func("size")
         .ok_or(anyhow::format_err!("failed to find `size` export"))?
         .get0::<i32>()?;
     let load = instance
-        .get_export("load")
-        .and_then(|e| e.into_func())
+        .get_func("load")
         .ok_or(anyhow::format_err!("failed to find `load` export"))?
         .get1::<i32, i32>()?;
     let store = instance
-        .get_export("store")
-        .and_then(|e| e.into_func())
+        .get_func("store")
         .ok_or(anyhow::format_err!("failed to find `store` export"))?
         .get2::<i32, i32, ()>()?;
 

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -19,21 +19,21 @@ fn main() -> Result<()> {
     // Load up our exports from the instance
     let memory = instance
         .get_export("memory")
-        .and_then(|e| e.memory())
+        .and_then(|e| e.into_memory())
         .ok_or(anyhow::format_err!("failed to find `memory` export"))?;
     let size = instance
         .get_export("size")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(anyhow::format_err!("failed to find `size` export"))?
         .get0::<i32>()?;
     let load = instance
         .get_export("load")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(anyhow::format_err!("failed to find `load` export"))?
         .get1::<i32, i32>()?;
     let store = instance
         .get_export("store")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(anyhow::format_err!("failed to find `store` export"))?
         .get2::<i32, i32, ()>()?;
 

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     println!("Extracting export...");
     let g = instance
         .get_export("g")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(format_err!("failed to find export `g`"))?;
 
     // Call `$g`.
@@ -61,7 +61,7 @@ fn main() -> Result<()> {
     println!("Calling export \"round_trip_many\"...");
     let round_trip_many = instance
         .get_export("round_trip_many")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .ok_or(format_err!("failed to find export `round_trip_many`"))?;
     let args = vec![
         Val::I64(0),

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -43,8 +43,7 @@ fn main() -> Result<()> {
     // Extract exports.
     println!("Extracting export...");
     let g = instance
-        .get_export("g")
-        .and_then(|e| e.into_func())
+        .get_func("g")
         .ok_or(format_err!("failed to find export `g`"))?;
 
     // Call `$g`.
@@ -60,8 +59,7 @@ fn main() -> Result<()> {
     // Call `$round_trip_many`.
     println!("Calling export \"round_trip_many\"...");
     let round_trip_many = instance
-        .get_export("round_trip_many")
-        .and_then(|e| e.into_func())
+        .get_func("round_trip_many")
         .ok_or(format_err!("failed to find export `round_trip_many`"))?;
     let args = vec![
         Val::I64(0),

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -32,10 +32,7 @@ fn main() -> Result<()> {
     // Instance our module with the imports we've created, then we can run the
     // standard wasi `_start` function.
     let instance = Instance::new(&module, &imports)?;
-    let start = instance
-        .get_export("_start")
-        .and_then(|e| e.into_func())
-        .unwrap();
+    let start = instance.get_func("_start").unwrap();
     let start = start.get0::<()>()?;
     start()?;
     Ok(())

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -17,15 +17,16 @@ fn main() -> Result<()> {
     let wasi = Wasi::new(&store, WasiCtx::new(std::env::args())?);
     let mut imports = Vec::new();
     for import in module.imports() {
-        if import.module == "wasi_snapshot_preview1" {
-            if let Some(export) = wasi.get_export(&import.name) {
+        if import.module() == "wasi_snapshot_preview1" {
+            if let Some(export) = wasi.get_export(import.name()) {
                 imports.push(Extern::from(export.clone()));
                 continue;
             }
         }
         panic!(
             "couldn't find import for `{}::{}`",
-            import.module, import.name
+            import.module(),
+            import.name()
         );
     }
 

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -17,16 +17,15 @@ fn main() -> Result<()> {
     let wasi = Wasi::new(&store, WasiCtx::new(std::env::args())?);
     let mut imports = Vec::new();
     for import in module.imports() {
-        if import.module() == "wasi_snapshot_preview1" {
-            if let Some(export) = wasi.get_export(import.name()) {
+        if import.module == "wasi_snapshot_preview1" {
+            if let Some(export) = wasi.get_export(&import.name) {
                 imports.push(Extern::from(export.clone()));
                 continue;
             }
         }
         panic!(
             "couldn't find import for `{}::{}`",
-            import.module(),
-            import.name()
+            import.module, import.name
         );
     }
 

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
     let instance = Instance::new(&module, &imports)?;
     let start = instance
         .get_export("_start")
-        .and_then(|e| e.func())
+        .and_then(|e| e.into_func())
         .unwrap();
     let start = start.get0::<()>()?;
     start()?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -240,7 +240,7 @@ impl RunCommand {
 
     fn invoke_export(&self, instance: Instance, name: &str) -> Result<()> {
         let func = if let Some(export) = instance.get_export(name) {
-            if let Some(func) = export.func() {
+            if let Some(func) = export.into_func() {
                 func
             } else {
                 bail!("export of `{}` wasn't a function", name)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -200,16 +200,20 @@ impl RunCommand {
         let imports = module
             .imports()
             .map(|i| {
-                let export = match i.module.as_str() {
+                let export = match i.module() {
                     "wasi_snapshot_preview1" => {
-                        module_registry.wasi_snapshot_preview1.get_export(&i.name)
+                        module_registry.wasi_snapshot_preview1.get_export(i.name())
                     }
-                    "wasi_unstable" => module_registry.wasi_unstable.get_export(&i.name),
+                    "wasi_unstable" => module_registry.wasi_unstable.get_export(i.name()),
                     other => bail!("import module `{}` was not found", other),
                 };
                 match export {
                     Some(export) => Ok(export.clone().into()),
-                    None => bail!("import `{}` was not found in module `{}`", i.name, i.module),
+                    None => bail!(
+                        "import `{}` was not found in module `{}`",
+                        i.name(),
+                        i.module()
+                    ),
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -199,7 +199,6 @@ impl RunCommand {
         // Resolve import using module_registry.
         let imports = module
             .imports()
-            .iter()
             .map(|i| {
                 let export = match i.module() {
                     "wasi_snapshot_preview1" => {
@@ -231,11 +230,7 @@ impl RunCommand {
         // If a function to invoke was given, invoke it.
         if let Some(name) = self.invoke.as_ref() {
             self.invoke_export(instance, name)?;
-        } else if module
-            .exports()
-            .iter()
-            .any(|export| export.name().is_empty())
-        {
+        } else if module.exports().any(|export| export.name().is_empty()) {
             // Launch the default command export.
             self.invoke_export(instance, "")?;
         } else {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -230,7 +230,7 @@ impl RunCommand {
         // If a function to invoke was given, invoke it.
         if let Some(name) = self.invoke.as_ref() {
             self.invoke_export(instance, name)?;
-        } else if instance.exports().any(|export| export.name.is_empty()) {
+        } else if instance.exports().any(|export| export.name().is_empty()) {
             // Launch the default command export.
             self.invoke_export(instance, "")?;
         } else {

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -100,8 +100,6 @@ mod tests {
             });
         }
 
-        let mut exports = instance.exports();
-
         // these invoke wasmtime_call_trampoline from action.rs
         {
             println!("calling read...");
@@ -124,10 +122,8 @@ mod tests {
 
         // these invoke wasmtime_call_trampoline from callable.rs
         {
-            let read_func = exports
-                .next()
-                .unwrap()
-                .into_func()
+            let read_func = instance
+                .get_func("read")
                 .expect("expected a 'read' func in the module");
             println!("calling read...");
             let result = read_func.call(&[]).expect("expected function not to trap");
@@ -135,10 +131,8 @@ mod tests {
         }
 
         {
-            let read_out_of_bounds_func = exports
-                .next()
-                .unwrap()
-                .into_func()
+            let read_out_of_bounds_func = instance
+                .get_func("read_out_of_bounds")
                 .expect("expected a 'read_out_of_bounds' func in the module");
             println!("calling read_out_of_bounds...");
             let trap = read_out_of_bounds_func

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -38,22 +38,13 @@ mod tests {
 "#;
 
     fn invoke_export(instance: &Instance, func_name: &str) -> Result<Box<[Val]>> {
-        let ret = instance
-            .get_export(func_name)
-            .unwrap()
-            .into_func()
-            .unwrap()
-            .call(&[])?;
+        let ret = instance.get_func(func_name).unwrap().call(&[])?;
         Ok(ret)
     }
 
     // Locate "memory" export, get base address and size and set memory protection to PROT_NONE
     fn set_up_memory(instance: &Instance) -> (*mut u8, usize) {
-        let mem_export = instance
-            .get_export("memory")
-            .unwrap()
-            .into_memory()
-            .unwrap();
+        let mem_export = instance.get_memory("memory").unwrap();
         let base = mem_export.data_ptr();
         let length = mem_export.data_size();
 

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -41,7 +41,7 @@ mod tests {
         let ret = instance
             .get_export(func_name)
             .unwrap()
-            .func()
+            .into_func()
             .unwrap()
             .call(&[])?;
         Ok(ret)
@@ -49,7 +49,11 @@ mod tests {
 
     // Locate "memory" export, get base address and size and set memory protection to PROT_NONE
     fn set_up_memory(instance: &Instance) -> (*mut u8, usize) {
-        let mem_export = instance.get_export("memory").unwrap().memory().unwrap();
+        let mem_export = instance
+            .get_export("memory")
+            .unwrap()
+            .into_memory()
+            .unwrap();
         let base = mem_export.data_ptr();
         let length = mem_export.data_size();
 
@@ -132,7 +136,7 @@ mod tests {
             let read_func = exports
                 .next()
                 .unwrap()
-                .func()
+                .into_func()
                 .expect("expected a 'read' func in the module");
             println!("calling read...");
             let result = read_func.call(&[]).expect("expected function not to trap");
@@ -143,7 +147,7 @@ mod tests {
             let read_out_of_bounds_func = exports
                 .next()
                 .unwrap()
-                .func()
+                .into_func()
                 .expect("expected a 'read_out_of_bounds' func in the module");
             println!("calling read_out_of_bounds...");
             let trap = read_out_of_bounds_func

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -259,7 +259,7 @@ mod tests {
 
         // instance2 which calls 'instance1.read'
         let module2 = Module::new(&store, WAT2)?;
-        let instance2 = Instance::new(&module2, &[instance1_read.external])?;
+        let instance2 = Instance::new(&module2, &[instance1_read.into_extern()])?;
         // since 'instance2.run' calls 'instance1.read' we need to set up the signal handler to handle
         // SIGSEGV originating from within the memory of instance1
         unsafe {

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -270,7 +270,7 @@ mod tests {
 
         // instance2 which calls 'instance1.read'
         let module2 = Module::new(&store, WAT2)?;
-        let instance2 = Instance::new(&module2, &[instance1_read])?;
+        let instance2 = Instance::new(&module2, &[instance1_read.external])?;
         // since 'instance2.run' calls 'instance1.read' we need to set up the signal handler to handle
         // SIGSEGV originating from within the memory of instance1
         unsafe {

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -105,8 +105,7 @@ mod tests {
             });
         }
 
-        let exports = instance.exports();
-        assert!(!exports.is_empty());
+        let mut exports = instance.exports();
 
         // these invoke wasmtime_call_trampoline from action.rs
         {
@@ -130,7 +129,9 @@ mod tests {
 
         // these invoke wasmtime_call_trampoline from callable.rs
         {
-            let read_func = exports[0]
+            let read_func = exports
+                .next()
+                .unwrap()
                 .func()
                 .expect("expected a 'read' func in the module");
             println!("calling read...");
@@ -139,7 +140,9 @@ mod tests {
         }
 
         {
-            let read_out_of_bounds_func = exports[1]
+            let read_out_of_bounds_func = exports
+                .next()
+                .unwrap()
                 .func()
                 .expect("expected a 'read_out_of_bounds' func in the module");
             println!("calling read_out_of_bounds...");
@@ -216,8 +219,8 @@ mod tests {
 
         // First instance1
         {
-            let exports1 = instance1.exports();
-            assert!(!exports1.is_empty());
+            let mut exports1 = instance1.exports();
+            assert!(exports1.next().is_some());
 
             println!("calling instance1.read...");
             let result = invoke_export(&instance1, "read").expect("read succeeded");
@@ -231,8 +234,8 @@ mod tests {
 
         // And then instance2
         {
-            let exports2 = instance2.exports();
-            assert!(!exports2.is_empty());
+            let mut exports2 = instance2.exports();
+            assert!(exports2.next().is_some());
 
             println!("calling instance2.read...");
             let result = invoke_export(&instance2, "read").expect("read succeeded");
@@ -262,11 +265,10 @@ mod tests {
             });
         }
 
-        let instance1_exports = instance1.exports();
-        assert!(!instance1_exports.is_empty());
-        let instance1_read = instance1_exports[0].clone();
+        let mut instance1_exports = instance1.exports();
+        let instance1_read = instance1_exports.next().unwrap();
 
-        // instance2 wich calls 'instance1.read'
+        // instance2 which calls 'instance1.read'
         let module2 = Module::new(&store, WAT2)?;
         let instance2 = Instance::new(&module2, &[instance1_read])?;
         // since 'instance2.run' calls 'instance1.read' we need to set up the signal handler to handle

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -207,33 +207,33 @@ fn trap_import() -> Result<()> {
 fn get_from_wrapper() {
     let store = Store::default();
     let f = Func::wrap(&store, || {});
-    assert!(f.clone().get0::<()>().is_ok());
-    assert!(f.clone().get0::<i32>().is_err());
-    assert!(f.clone().get1::<(), ()>().is_ok());
-    assert!(f.clone().get1::<i32, ()>().is_err());
-    assert!(f.clone().get1::<i32, i32>().is_err());
-    assert!(f.clone().get2::<(), (), ()>().is_ok());
-    assert!(f.clone().get2::<i32, i32, ()>().is_err());
-    assert!(f.clone().get2::<i32, i32, i32>().is_err());
+    assert!(f.get0::<()>().is_ok());
+    assert!(f.get0::<i32>().is_err());
+    assert!(f.get1::<(), ()>().is_ok());
+    assert!(f.get1::<i32, ()>().is_err());
+    assert!(f.get1::<i32, i32>().is_err());
+    assert!(f.get2::<(), (), ()>().is_ok());
+    assert!(f.get2::<i32, i32, ()>().is_err());
+    assert!(f.get2::<i32, i32, i32>().is_err());
 
     let f = Func::wrap(&store, || -> i32 { loop {} });
-    assert!(f.clone().get0::<i32>().is_ok());
+    assert!(f.get0::<i32>().is_ok());
     let f = Func::wrap(&store, || -> f32 { loop {} });
-    assert!(f.clone().get0::<f32>().is_ok());
+    assert!(f.get0::<f32>().is_ok());
     let f = Func::wrap(&store, || -> f64 { loop {} });
-    assert!(f.clone().get0::<f64>().is_ok());
+    assert!(f.get0::<f64>().is_ok());
 
     let f = Func::wrap(&store, |_: i32| {});
-    assert!(f.clone().get1::<i32, ()>().is_ok());
-    assert!(f.clone().get1::<i64, ()>().is_err());
-    assert!(f.clone().get1::<f32, ()>().is_err());
-    assert!(f.clone().get1::<f64, ()>().is_err());
+    assert!(f.get1::<i32, ()>().is_ok());
+    assert!(f.get1::<i64, ()>().is_err());
+    assert!(f.get1::<f32, ()>().is_err());
+    assert!(f.get1::<f64, ()>().is_err());
     let f = Func::wrap(&store, |_: i64| {});
-    assert!(f.clone().get1::<i64, ()>().is_ok());
+    assert!(f.get1::<i64, ()>().is_ok());
     let f = Func::wrap(&store, |_: f32| {});
-    assert!(f.clone().get1::<f32, ()>().is_ok());
+    assert!(f.get1::<f32, ()>().is_ok());
     let f = Func::wrap(&store, |_: f64| {});
-    assert!(f.clone().get1::<f64, ()>().is_ok());
+    assert!(f.get1::<f64, ()>().is_ok());
 }
 
 #[test]
@@ -241,16 +241,16 @@ fn get_from_signature() {
     let store = Store::default();
     let ty = FuncType::new(Box::new([]), Box::new([]));
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.clone().get0::<()>().is_ok());
-    assert!(f.clone().get0::<i32>().is_err());
-    assert!(f.clone().get1::<i32, ()>().is_err());
+    assert!(f.get0::<()>().is_ok());
+    assert!(f.get0::<i32>().is_err());
+    assert!(f.get1::<i32, ()>().is_err());
 
     let ty = FuncType::new(Box::new([ValType::I32]), Box::new([ValType::F64]));
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.clone().get0::<()>().is_err());
-    assert!(f.clone().get0::<i32>().is_err());
-    assert!(f.clone().get1::<i32, ()>().is_err());
-    assert!(f.clone().get1::<i32, f64>().is_ok());
+    assert!(f.get0::<()>().is_err());
+    assert!(f.get0::<i32>().is_err());
+    assert!(f.get1::<i32, ()>().is_err());
+    assert!(f.get1::<i32, f64>().is_ok());
 }
 
 #[test]
@@ -270,17 +270,17 @@ fn get_from_module() -> anyhow::Result<()> {
     )?;
     let instance = Instance::new(&module, &[])?;
     let f0 = instance.get_export("f0").unwrap().func().unwrap();
-    assert!(f0.clone().get0::<()>().is_ok());
-    assert!(f0.clone().get0::<i32>().is_err());
+    assert!(f0.get0::<()>().is_ok());
+    assert!(f0.get0::<i32>().is_err());
     let f1 = instance.get_export("f1").unwrap().func().unwrap();
-    assert!(f1.clone().get0::<()>().is_err());
-    assert!(f1.clone().get1::<i32, ()>().is_ok());
-    assert!(f1.clone().get1::<i32, f32>().is_err());
+    assert!(f1.get0::<()>().is_err());
+    assert!(f1.get1::<i32, ()>().is_ok());
+    assert!(f1.get1::<i32, f32>().is_err());
     let f2 = instance.get_export("f2").unwrap().func().unwrap();
-    assert!(f2.clone().get0::<()>().is_err());
-    assert!(f2.clone().get0::<i32>().is_ok());
-    assert!(f2.clone().get1::<i32, ()>().is_err());
-    assert!(f2.clone().get1::<i32, f32>().is_err());
+    assert!(f2.get0::<()>().is_err());
+    assert!(f2.get0::<i32>().is_ok());
+    assert!(f2.get1::<i32, ()>().is_err());
+    assert!(f2.get1::<i32, f32>().is_err());
     Ok(())
 }
 

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -269,14 +269,14 @@ fn get_from_module() -> anyhow::Result<()> {
         "#,
     )?;
     let instance = Instance::new(&module, &[])?;
-    let f0 = instance.get_export("f0").unwrap().func().unwrap();
+    let f0 = instance.get_export("f0").unwrap().into_func().unwrap();
     assert!(f0.get0::<()>().is_ok());
     assert!(f0.get0::<i32>().is_err());
-    let f1 = instance.get_export("f1").unwrap().func().unwrap();
+    let f1 = instance.get_export("f1").unwrap().into_func().unwrap();
     assert!(f1.get0::<()>().is_err());
     assert!(f1.get1::<i32, ()>().is_ok());
     assert!(f1.get1::<i32, f32>().is_err());
-    let f2 = instance.get_export("f2").unwrap().func().unwrap();
+    let f2 = instance.get_export("f2").unwrap().into_func().unwrap();
     assert!(f2.get0::<()>().is_err());
     assert!(f2.get0::<i32>().is_ok());
     assert!(f2.get1::<i32, ()>().is_err());

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -207,33 +207,33 @@ fn trap_import() -> Result<()> {
 fn get_from_wrapper() {
     let store = Store::default();
     let f = Func::wrap(&store, || {});
-    assert!(f.get0::<()>().is_ok());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<(), ()>().is_ok());
-    assert!(f.get1::<i32, ()>().is_err());
-    assert!(f.get1::<i32, i32>().is_err());
-    assert!(f.get2::<(), (), ()>().is_ok());
-    assert!(f.get2::<i32, i32, ()>().is_err());
-    assert!(f.get2::<i32, i32, i32>().is_err());
+    assert!(f.clone().get0::<()>().is_ok());
+    assert!(f.clone().get0::<i32>().is_err());
+    assert!(f.clone().get1::<(), ()>().is_ok());
+    assert!(f.clone().get1::<i32, ()>().is_err());
+    assert!(f.clone().get1::<i32, i32>().is_err());
+    assert!(f.clone().get2::<(), (), ()>().is_ok());
+    assert!(f.clone().get2::<i32, i32, ()>().is_err());
+    assert!(f.clone().get2::<i32, i32, i32>().is_err());
 
     let f = Func::wrap(&store, || -> i32 { loop {} });
-    assert!(f.get0::<i32>().is_ok());
+    assert!(f.clone().get0::<i32>().is_ok());
     let f = Func::wrap(&store, || -> f32 { loop {} });
-    assert!(f.get0::<f32>().is_ok());
+    assert!(f.clone().get0::<f32>().is_ok());
     let f = Func::wrap(&store, || -> f64 { loop {} });
-    assert!(f.get0::<f64>().is_ok());
+    assert!(f.clone().get0::<f64>().is_ok());
 
     let f = Func::wrap(&store, |_: i32| {});
-    assert!(f.get1::<i32, ()>().is_ok());
-    assert!(f.get1::<i64, ()>().is_err());
-    assert!(f.get1::<f32, ()>().is_err());
-    assert!(f.get1::<f64, ()>().is_err());
+    assert!(f.clone().get1::<i32, ()>().is_ok());
+    assert!(f.clone().get1::<i64, ()>().is_err());
+    assert!(f.clone().get1::<f32, ()>().is_err());
+    assert!(f.clone().get1::<f64, ()>().is_err());
     let f = Func::wrap(&store, |_: i64| {});
-    assert!(f.get1::<i64, ()>().is_ok());
+    assert!(f.clone().get1::<i64, ()>().is_ok());
     let f = Func::wrap(&store, |_: f32| {});
-    assert!(f.get1::<f32, ()>().is_ok());
+    assert!(f.clone().get1::<f32, ()>().is_ok());
     let f = Func::wrap(&store, |_: f64| {});
-    assert!(f.get1::<f64, ()>().is_ok());
+    assert!(f.clone().get1::<f64, ()>().is_ok());
 }
 
 #[test]
@@ -241,16 +241,16 @@ fn get_from_signature() {
     let store = Store::default();
     let ty = FuncType::new(Box::new([]), Box::new([]));
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.get0::<()>().is_ok());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<i32, ()>().is_err());
+    assert!(f.clone().get0::<()>().is_ok());
+    assert!(f.clone().get0::<i32>().is_err());
+    assert!(f.clone().get1::<i32, ()>().is_err());
 
     let ty = FuncType::new(Box::new([ValType::I32]), Box::new([ValType::F64]));
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.get0::<()>().is_err());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<i32, ()>().is_err());
-    assert!(f.get1::<i32, f64>().is_ok());
+    assert!(f.clone().get0::<()>().is_err());
+    assert!(f.clone().get0::<i32>().is_err());
+    assert!(f.clone().get1::<i32, ()>().is_err());
+    assert!(f.clone().get1::<i32, f64>().is_ok());
 }
 
 #[test]
@@ -270,17 +270,17 @@ fn get_from_module() -> anyhow::Result<()> {
     )?;
     let instance = Instance::new(&module, &[])?;
     let f0 = instance.get_export("f0").unwrap().func().unwrap();
-    assert!(f0.get0::<()>().is_ok());
-    assert!(f0.get0::<i32>().is_err());
+    assert!(f0.clone().get0::<()>().is_ok());
+    assert!(f0.clone().get0::<i32>().is_err());
     let f1 = instance.get_export("f1").unwrap().func().unwrap();
-    assert!(f1.get0::<()>().is_err());
-    assert!(f1.get1::<i32, ()>().is_ok());
-    assert!(f1.get1::<i32, f32>().is_err());
+    assert!(f1.clone().get0::<()>().is_err());
+    assert!(f1.clone().get1::<i32, ()>().is_ok());
+    assert!(f1.clone().get1::<i32, f32>().is_err());
     let f2 = instance.get_export("f2").unwrap().func().unwrap();
-    assert!(f2.get0::<()>().is_err());
-    assert!(f2.get0::<i32>().is_ok());
-    assert!(f2.get1::<i32, ()>().is_err());
-    assert!(f2.get1::<i32, f32>().is_err());
+    assert!(f2.clone().get0::<()>().is_err());
+    assert!(f2.clone().get0::<i32>().is_ok());
+    assert!(f2.clone().get1::<i32, ()>().is_err());
+    assert!(f2.clone().get1::<i32, f32>().is_err());
     Ok(())
 }
 

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -269,14 +269,14 @@ fn get_from_module() -> anyhow::Result<()> {
         "#,
     )?;
     let instance = Instance::new(&module, &[])?;
-    let f0 = instance.get_export("f0").unwrap().into_func().unwrap();
+    let f0 = instance.get_func("f0").unwrap();
     assert!(f0.get0::<()>().is_ok());
     assert!(f0.get0::<i32>().is_err());
-    let f1 = instance.get_export("f1").unwrap().into_func().unwrap();
+    let f1 = instance.get_func("f1").unwrap();
     assert!(f1.get0::<()>().is_err());
     assert!(f1.get1::<i32, ()>().is_ok());
     assert!(f1.get1::<i32, f32>().is_err());
-    let f2 = instance.get_export("f2").unwrap().into_func().unwrap();
+    let f2 = instance.get_func("f2").unwrap();
     assert!(f2.get0::<()>().is_err());
     assert!(f2.get0::<i32>().is_ok());
     assert!(f2.get1::<i32, ()>().is_err());

--- a/tests/all/globals.rs
+++ b/tests/all/globals.rs
@@ -70,7 +70,7 @@ fn use_after_drop() -> anyhow::Result<()> {
         "#,
     )?;
     let instance = Instance::new(&module, &[])?;
-    let g = instance.exports().next().unwrap().global().unwrap();
+    let g = instance.exports().next().unwrap().into_global().unwrap();
     assert_eq!(g.get().i32(), Some(100));
     g.set(101.into())?;
     drop(instance);

--- a/tests/all/globals.rs
+++ b/tests/all/globals.rs
@@ -70,7 +70,7 @@ fn use_after_drop() -> anyhow::Result<()> {
         "#,
     )?;
     let instance = Instance::new(&module, &[])?;
-    let g = instance.exports().next().unwrap().into_global().unwrap();
+    let g = instance.get_global("foo").unwrap();
     assert_eq!(g.get().i32(), Some(100));
     g.set(101.into())?;
     drop(instance);

--- a/tests/all/globals.rs
+++ b/tests/all/globals.rs
@@ -70,7 +70,7 @@ fn use_after_drop() -> anyhow::Result<()> {
         "#,
     )?;
     let instance = Instance::new(&module, &[])?;
-    let g = instance.exports()[0].global().unwrap().clone();
+    let g = instance.exports().next().unwrap().global().unwrap();
     assert_eq!(g.get().i32(), Some(100));
     g.set(101.into())?;
     drop(instance);

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -40,18 +40,20 @@ fn test_import_calling_export() {
     let instance =
         Instance::new(&module, imports.as_slice()).expect("failed to instantiate module");
 
-    let exports = instance.exports();
-    assert!(!exports.is_empty());
+    let mut exports = instance.exports();
 
-    let run_func = exports[0]
+    let run_func = exports
+        .next()
+        .unwrap()
         .func()
         .expect("expected a run func in the module");
 
     *other.borrow_mut() = Some(
-        exports[1]
+        exports
+            .next()
+            .unwrap()
             .func()
-            .expect("expected an other func in the module")
-            .clone(),
+            .expect("expected an other func in the module"),
     );
 
     run_func.call(&[]).expect("expected function not to trap");
@@ -84,10 +86,11 @@ fn test_returns_incorrect_type() -> Result<()> {
     let imports = vec![callback_func.into()];
     let instance = Instance::new(&module, imports.as_slice())?;
 
-    let exports = instance.exports();
-    assert!(!exports.is_empty());
+    let mut exports = instance.exports();
 
-    let run_func = exports[0]
+    let run_func = exports
+        .next()
+        .unwrap()
         .func()
         .expect("expected a run func in the module");
 

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -40,8 +40,6 @@ fn test_import_calling_export() {
     let instance =
         Instance::new(&module, imports.as_slice()).expect("failed to instantiate module");
 
-    let mut exports = instance.exports();
-
     let run_func = instance
         .get_func("run")
         .expect("expected a run func in the module");

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -42,17 +42,13 @@ fn test_import_calling_export() {
 
     let mut exports = instance.exports();
 
-    let run_func = exports
-        .next()
-        .unwrap()
-        .into_func()
+    let run_func = instance
+        .get_func("run")
         .expect("expected a run func in the module");
 
     *other.borrow_mut() = Some(
-        exports
-            .next()
-            .unwrap()
-            .into_func()
+        instance
+            .get_func("other")
             .expect("expected an other func in the module"),
     );
 
@@ -86,12 +82,8 @@ fn test_returns_incorrect_type() -> Result<()> {
     let imports = vec![callback_func.into()];
     let instance = Instance::new(&module, imports.as_slice())?;
 
-    let mut exports = instance.exports();
-
-    let run_func = exports
-        .next()
-        .unwrap()
-        .into_func()
+    let run_func = instance
+        .get_func("run")
         .expect("expected a run func in the module");
 
     let trap = run_func

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -45,14 +45,14 @@ fn test_import_calling_export() {
     let run_func = exports
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected a run func in the module");
 
     *other.borrow_mut() = Some(
         exports
             .next()
             .unwrap()
-            .func()
+            .into_func()
             .expect("expected an other func in the module"),
     );
 
@@ -91,7 +91,7 @@ fn test_returns_incorrect_type() -> Result<()> {
     let run_func = exports
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected a run func in the module");
 
     let trap = run_func

--- a/tests/all/import_indexes.rs
+++ b/tests/all/import_indexes.rs
@@ -43,7 +43,7 @@ fn same_import_names_still_distinct() -> anyhow::Result<()> {
     ];
     let instance = Instance::new(&module, &imports)?;
 
-    let func = instance.get_export("foo").unwrap().func().unwrap();
+    let func = instance.get_export("foo").unwrap().into_func().unwrap();
     let results = func.call(&[])?;
     assert_eq!(results.len(), 1);
     match results[0] {

--- a/tests/all/import_indexes.rs
+++ b/tests/all/import_indexes.rs
@@ -43,7 +43,7 @@ fn same_import_names_still_distinct() -> anyhow::Result<()> {
     ];
     let instance = Instance::new(&module, &imports)?;
 
-    let func = instance.get_export("foo").unwrap().into_func().unwrap();
+    let func = instance.get_func("foo").unwrap();
     let results = func.call(&[])?;
     assert_eq!(results.len(), 1);
     match results[0] {

--- a/tests/all/invoke_func_via_table.rs
+++ b/tests/all/invoke_func_via_table.rs
@@ -19,7 +19,7 @@ fn test_invoke_func_via_table() -> Result<()> {
     let f = instance
         .get_export("table")
         .unwrap()
-        .table()
+        .into_table()
         .unwrap()
         .get(0)
         .unwrap()

--- a/tests/all/invoke_func_via_table.rs
+++ b/tests/all/invoke_func_via_table.rs
@@ -17,9 +17,7 @@ fn test_invoke_func_via_table() -> Result<()> {
     let instance = Instance::new(&module, &[]).context("> Error instantiating module!")?;
 
     let f = instance
-        .get_export("table")
-        .unwrap()
-        .into_table()
+        .get_table("table")
         .unwrap()
         .get(0)
         .unwrap()

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -90,7 +90,7 @@ fn interposition() -> Result<()> {
         )?;
     }
     let instance = linker.instantiate(&module)?;
-    let func = instance.get_export("export").unwrap().func().unwrap();
+    let func = instance.get_export("export").unwrap().into_func().unwrap();
     let func = func.get0::<i32>()?;
     assert_eq!(func()?, 112);
     Ok(())

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -90,7 +90,7 @@ fn interposition() -> Result<()> {
         )?;
     }
     let instance = linker.instantiate(&module)?;
-    let func = instance.get_export("export").unwrap().into_func().unwrap();
+    let func = instance.get_func("export").unwrap();
     let func = func.get0::<i32>()?;
     assert_eq!(func()?, 112);
     Ok(())

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -173,7 +173,7 @@ mod not_for_windows {
             instance2
                 .get_export("memory")
                 .unwrap()
-                .memory()
+                .into_memory()
                 .unwrap()
                 .size(),
             2

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -169,15 +169,7 @@ mod not_for_windows {
 
         assert_eq!(*mem_creator.num_created_memories.lock().unwrap(), 2);
 
-        assert_eq!(
-            instance2
-                .get_export("memory")
-                .unwrap()
-                .into_memory()
-                .unwrap()
-                .size(),
-            2
-        );
+        assert_eq!(instance2.get_memory("memory").unwrap().size(), 2);
 
         // we take the lock outside the assert, so it won't get poisoned on assert failure
         let tot_pages = *mem_creator.num_total_pages.lock().unwrap();

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -17,7 +17,10 @@ fn test_trap_return() -> Result<()> {
     let hello_func = Func::new(&store, hello_type, |_, _, _| Err(Trap::new("test 123")));
 
     let instance = Instance::new(&module, &[hello_func.into()])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -44,7 +47,10 @@ fn test_trap_trace() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -91,7 +97,10 @@ fn test_trap_trace_cb() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[fn_func.into()])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -123,7 +132,10 @@ fn test_trap_stack_overflow() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -159,7 +171,10 @@ fn trap_display_pretty() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance.exports()[0]
+    let run_func = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -192,7 +207,7 @@ fn trap_display_multi_module() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let bar = instance.exports()[0].clone();
+    let bar = instance.exports().next().unwrap();
 
     let wat = r#"
         (module $b
@@ -203,7 +218,10 @@ fn trap_display_multi_module() -> Result<()> {
     "#;
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[bar])?;
-    let bar2 = instance.exports()[0]
+    let bar2 = instance
+        .exports()
+        .next()
+        .unwrap()
         .func()
         .expect("expected function export");
 
@@ -268,14 +286,14 @@ fn rust_panic_import() -> Result<()> {
             Func::wrap(&store, || panic!("this is another panic")).into(),
         ],
     )?;
-    let func = instance.exports()[0].func().unwrap().clone();
+    let func = instance.exports().next().unwrap().func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
     .unwrap_err();
     assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
 
-    let func = instance.exports()[1].func().unwrap().clone();
+    let func = instance.exports().nth(1).unwrap().func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
@@ -333,7 +351,7 @@ fn mismatched_arguments() -> Result<()> {
 
     let module = Module::new(&store, &binary)?;
     let instance = Instance::new(&module, &[])?;
-    let func = instance.exports()[0].func().unwrap().clone();
+    let func = instance.exports().next().unwrap().func().unwrap();
     assert_eq!(
         func.call(&[]).unwrap_err().to_string(),
         "expected 1 arguments, got 0"

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -17,12 +17,7 @@ fn test_trap_return() -> Result<()> {
     let hello_func = Func::new(&store, hello_type, |_, _, _| Err(Trap::new("test 123")));
 
     let instance = Instance::new(&module, &[hello_func.into()])?;
-    let run_func = instance
-        .exports()
-        .next()
-        .unwrap()
-        .into_func()
-        .expect("expected function export");
+    let run_func = instance.get_func("run").expect("expected function export");
 
     let e = run_func
         .call(&[])
@@ -47,12 +42,7 @@ fn test_trap_trace() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance
-        .exports()
-        .next()
-        .unwrap()
-        .into_func()
-        .expect("expected function export");
+    let run_func = instance.get_func("run").expect("expected function export");
 
     let e = run_func
         .call(&[])
@@ -97,12 +87,7 @@ fn test_trap_trace_cb() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[fn_func.into()])?;
-    let run_func = instance
-        .exports()
-        .next()
-        .unwrap()
-        .into_func()
-        .expect("expected function export");
+    let run_func = instance.get_func("run").expect("expected function export");
 
     let e = run_func
         .call(&[])
@@ -132,12 +117,7 @@ fn test_trap_stack_overflow() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance
-        .exports()
-        .next()
-        .unwrap()
-        .into_func()
-        .expect("expected function export");
+    let run_func = instance.get_func("run").expect("expected function export");
 
     let e = run_func
         .call(&[])
@@ -171,12 +151,7 @@ fn trap_display_pretty() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let run_func = instance
-        .exports()
-        .next()
-        .unwrap()
-        .into_func()
-        .expect("expected function export");
+    let run_func = instance.get_func("bar").expect("expected function export");
 
     let e = run_func.call(&[]).err().expect("error calling function");
     assert_eq!(
@@ -207,7 +182,7 @@ fn trap_display_multi_module() -> Result<()> {
 
     let module = Module::new(&store, wat)?;
     let instance = Instance::new(&module, &[])?;
-    let bar = instance.exports().next().unwrap();
+    let bar = instance.get_export("bar").unwrap();
 
     let wat = r#"
         (module $b
@@ -217,13 +192,8 @@ fn trap_display_multi_module() -> Result<()> {
         )
     "#;
     let module = Module::new(&store, wat)?;
-    let instance = Instance::new(&module, &[bar.external])?;
-    let bar2 = instance
-        .exports()
-        .next()
-        .unwrap()
-        .into_func()
-        .expect("expected function export");
+    let instance = Instance::new(&module, &[bar])?;
+    let bar2 = instance.get_func("bar2").expect("expected function export");
 
     let e = bar2.call(&[]).err().expect("error calling function");
     assert_eq!(
@@ -286,15 +256,14 @@ fn rust_panic_import() -> Result<()> {
             Func::wrap(&store, || panic!("this is another panic")).into(),
         ],
     )?;
-    let mut exports = instance.exports();
-    let func = exports.next().unwrap().into_func().unwrap();
+    let func = instance.get_func("foo").unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
     .unwrap_err();
     assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
 
-    let func = exports.next().unwrap().into_func().unwrap();
+    let func = instance.get_func("bar").unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
@@ -352,7 +321,7 @@ fn mismatched_arguments() -> Result<()> {
 
     let module = Module::new(&store, &binary)?;
     let instance = Instance::new(&module, &[])?;
-    let func = instance.exports().next().unwrap().into_func().unwrap();
+    let func = instance.get_func("foo").unwrap();
     assert_eq!(
         func.call(&[]).unwrap_err().to_string(),
         "expected 1 arguments, got 0"
@@ -436,7 +405,7 @@ fn present_after_module_drop() -> Result<()> {
     let store = Store::default();
     let module = Module::new(&store, r#"(func (export "foo") unreachable)"#)?;
     let instance = Instance::new(&module, &[])?;
-    let func = instance.exports().next().unwrap().into_func().unwrap();
+    let func = instance.get_func("foo").unwrap();
 
     println!("asserting before we drop modules");
     assert_trap(func.call(&[]).unwrap_err().downcast()?);

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -286,14 +286,15 @@ fn rust_panic_import() -> Result<()> {
             Func::wrap(&store, || panic!("this is another panic")).into(),
         ],
     )?;
-    let func = instance.exports().next().unwrap().into_func().unwrap();
+    let mut exports = instance.exports();
+    let func = exports.next().unwrap().into_func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
     .unwrap_err();
     assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
 
-    let func = instance.exports().nth(1).unwrap().into_func().unwrap();
+    let func = exports.next().unwrap().into_func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -217,7 +217,7 @@ fn trap_display_multi_module() -> Result<()> {
         )
     "#;
     let module = Module::new(&store, wat)?;
-    let instance = Instance::new(&module, &[bar])?;
+    let instance = Instance::new(&module, &[bar.external])?;
     let bar2 = instance
         .exports()
         .next()

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -21,7 +21,7 @@ fn test_trap_return() -> Result<()> {
         .exports()
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected function export");
 
     let e = run_func
@@ -51,7 +51,7 @@ fn test_trap_trace() -> Result<()> {
         .exports()
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected function export");
 
     let e = run_func
@@ -101,7 +101,7 @@ fn test_trap_trace_cb() -> Result<()> {
         .exports()
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected function export");
 
     let e = run_func
@@ -136,7 +136,7 @@ fn test_trap_stack_overflow() -> Result<()> {
         .exports()
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected function export");
 
     let e = run_func
@@ -175,7 +175,7 @@ fn trap_display_pretty() -> Result<()> {
         .exports()
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected function export");
 
     let e = run_func.call(&[]).err().expect("error calling function");
@@ -222,7 +222,7 @@ fn trap_display_multi_module() -> Result<()> {
         .exports()
         .next()
         .unwrap()
-        .func()
+        .into_func()
         .expect("expected function export");
 
     let e = bar2.call(&[]).err().expect("error calling function");
@@ -286,14 +286,14 @@ fn rust_panic_import() -> Result<()> {
             Func::wrap(&store, || panic!("this is another panic")).into(),
         ],
     )?;
-    let func = instance.exports().next().unwrap().func().unwrap();
+    let func = instance.exports().next().unwrap().into_func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
     .unwrap_err();
     assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
 
-    let func = instance.exports().nth(1).unwrap().func().unwrap();
+    let func = instance.exports().nth(1).unwrap().into_func().unwrap();
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(func.call(&[]));
     }))
@@ -351,7 +351,7 @@ fn mismatched_arguments() -> Result<()> {
 
     let module = Module::new(&store, &binary)?;
     let instance = Instance::new(&module, &[])?;
-    let func = instance.exports().next().unwrap().func().unwrap();
+    let func = instance.exports().next().unwrap().into_func().unwrap();
     assert_eq!(
         func.call(&[]).unwrap_err().to_string(),
         "expected 1 arguments, got 0"
@@ -435,7 +435,7 @@ fn present_after_module_drop() -> Result<()> {
     let store = Store::default();
     let module = Module::new(&store, r#"(func (export "foo") unreachable)"#)?;
     let instance = Instance::new(&module, &[])?;
-    let func = instance.exports()[0].func().unwrap().clone();
+    let func = instance.exports().next().unwrap().into_func().unwrap();
 
     println!("asserting before we drop modules");
     assert_trap(func.call(&[]).unwrap_err().downcast()?);

--- a/tests/misc_testsuite/threads.wast
+++ b/tests/misc_testsuite/threads.wast
@@ -1,1 +1,1 @@
-(assert_invalid (module (memory 1 1 shared)) "not supported")
+(assert_invalid (module (memory 1 1 shared)) "Unsupported feature: shared memories")


### PR DESCRIPTION
This contains refactorings and API changes split off from #1516.

The main public-facing change here is that `Instance` and `Module` now compute their imports and exports on demand rather than holding precomputed arrays, and `Func::get*` return closures which capture an `InstanceHandle` so that they hold the instance live dynamically.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
