### PR TITLE
Wiggle: reject null (linear memory location 0) pointers

### DIFF
--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -31,6 +31,7 @@ impl From<wiggle::GuestError> for Errno {
         match err {
             InvalidFlagValue { .. } => Self::Inval,
             InvalidEnumValue { .. } => Self::Inval,
+            NullPtr { .. } => Self::Inval,
             PtrOverflow { .. } => Self::Fault,
             PtrOutOfBounds { .. } => Self::Fault,
             PtrNotAligned { .. } => Self::Inval,

--- a/crates/wiggle/src/error.rs
+++ b/crates/wiggle/src/error.rs
@@ -7,6 +7,8 @@ pub enum GuestError {
     InvalidFlagValue(&'static str),
     #[error("Invalid enum value {0}")]
     InvalidEnumValue(&'static str),
+    #[error("Null pointer")]
+    NullPtr,
     #[error("Pointer overflow")]
     PtrOverflow,
     #[error("Pointer out of bounds: {0:?}")]

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -121,6 +121,12 @@ pub unsafe trait GuestMemory {
         align: usize,
         len: u32,
     ) -> Result<*mut u8, GuestError> {
+        // Even though the 0-offset location of linear memory is a valid
+        // location, toolchains use it for the null pointer.
+        if offset == 0 {
+            return Err(GuestError::NullPtr);
+        }
+
         let (base_ptr, base_len) = self.base();
         let region = Region { start: offset, len };
 

--- a/tests/wasm/hello_wasi_snapshot0.wat
+++ b/tests/wasm/hello_wasi_snapshot0.wat
@@ -5,7 +5,7 @@
     (func $__wasi_fd_write (param i32 i32 i32 i32) (result i32)))
   (func $_start
     (i32.store (i32.const 24) (i32.const 14))
-    (i32.store (i32.const 20) (i32.const 0))
+    (i32.store (i32.const 20) (i32.const 4))
     (block
       (br_if 0
         (call $__wasi_fd_write
@@ -21,5 +21,5 @@
   (memory 1)
   (export "memory" (memory 0))
   (export "_start" (func $_start))
-  (data (i32.const 0) "Hello, world!\0a")
+  (data (i32.const 4) "Hello, world!\0a")
 )

--- a/tests/wasm/hello_wasi_snapshot1.wat
+++ b/tests/wasm/hello_wasi_snapshot1.wat
@@ -5,7 +5,7 @@
     (func $__wasi_fd_write (param i32 i32 i32 i32) (result i32)))
   (func $_start
     (i32.store (i32.const 24) (i32.const 14))
-    (i32.store (i32.const 20) (i32.const 0))
+    (i32.store (i32.const 20) (i32.const 4))
     (block
       (br_if 0
         (call $__wasi_fd_write
@@ -21,5 +21,5 @@
   (memory 1)
   (export "memory" (memory 0))
   (export "_start" (func $_start))
-  (data (i32.const 0) "Hello, world!\0a")
+  (data (i32.const 4) "Hello, world!\0a")
 )


### PR DESCRIPTION
Linear memory location 0 is valid to access, but many toolchains we care about use it for null pointers. If a pointer to 0 is passed to wiggle, we should reject it with a new `GuestError::NullPtr` error, rather than permit a `GuestPtr` to dereference it.

One nice thing about this patch is that, if you don't apply the changes to the test crate, the proptests will quickly find that all test cases they generate using linear memory location 0 will fail. I added filters to the two memory location generator functions to ensure they don't produce location 0 anymore.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
