### PR TITLE
Add AArch64 tests to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,13 +266,52 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+        - build: x86_64-linux
+          os: ubuntu-latest
+        - build: x86_64-macos
+          os: macos-latest
+        - build: x86_64-windows
+          os: windows-latest
+        - build: aarch64-linux
+          os: ubuntu-latest
+          rust: stable
+          target: aarch64-unknown-linux-gnu
+          gcc_package: gcc-aarch64-linux-gnu
+          gcc: aarch64-linux-gnu-gcc
+          qemu: qemu-aarch64 -L /usr/aarch64-linux-gnu
+          qemu_target: aarch64-linux-user
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
     - uses: ./.github/actions/binary-compatible-builds
+      if: matrix.target == ''
+
+    - name: Install cross-compilation tools
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.gcc_package }}
+
+        # Download and build qemu from source since the most recent release is
+        # way faster at arm emulation than the current version github actions'
+        # ubuntu image uses. Disable as much as we can to get it to build
+        # quickly.
+        curl https://download.qemu.org/qemu-4.2.0.tar.xz | tar xJf -
+        cd qemu-4.2.0
+        ./configure --target-list=${{ matrix.qemu_target }} --prefix=$HOME/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
+        make -j$(nproc) install
+
+        # Configure Cargo for cross compilation and tell it how it can run
+        # cross executables
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo ::set-env name=CARGO_TARGET_${upcase}_RUNNER::$HOME/qemu/bin/${{ matrix.qemu }}
+        echo ::set-env name=CARGO_TARGET_${upcase}_LINKER::${{ matrix.gcc }}
+        echo ::set-env name=CARGO_BUILD_TARGET::${{ matrix.target }}
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
 
     # Install wasm32-wasi target in order to build wasi-common's integration
     # tests
@@ -285,7 +324,7 @@ jobs:
     - run: $CENTOS cargo build --release --manifest-path crates/c-api/Cargo.toml
       shell: bash
     # Test what we just built
-    - run: $CENTOS cargo test --features test-programs/test_programs --release --all --exclude lightbeam --exclude wasmtime --exclude wasmtime-c-api --exclude wasmtime-fuzzing
+    - run: $CENTOS cargo test --features test-programs/test_programs --release --all --exclude lightbeam
       shell: bash
       env:
         RUST_BACKTRACE: 1
@@ -304,14 +343,18 @@ jobs:
 
     # Move binaries to dist folder
     - run: cp target/release/wasmtime dist
-      if: matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-latest' && matrix.target == ''
+    - run: cp target/${{ matrix.target }}/release/wasmtime dist
+      if: matrix.os != 'windows-latest' && matrix.target != ''
     - run: cp target/release/wasmtime.exe dist
       shell: bash
       if: matrix.os == 'windows-latest'
 
     # Move libwasmtime dylib to dist folder
     - run: cp target/release/libwasmtime.{so,a} dist
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.target == ''
+    - run: cp target/${{ matrix.target }}/release/libwasmtime.{so,a} dist
+      if: matrix.os == 'ubuntu-latest' && matrix.target != ''
     - run: cp target/release/libwasmtime.{dylib,a} dist
       if: matrix.os == 'macos-latest'
     - run: cp target/release/wasmtime.{dll,lib,dll.lib} dist
@@ -329,7 +372,7 @@ jobs:
 
     - uses: actions/upload-artifact@v1
       with:
-        name: bins-${{ matrix.os }}
+        name: bins-${{ matrix.build }}
         path: dist
 
   # Consumes all published artifacts from all the previous build steps, creates
@@ -357,18 +400,22 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: doc-api
-    - name: Download macOS binaries
+    - name: Download x86_64 macOS binaries
       uses: actions/download-artifact@v1
       with:
-        name: bins-macos-latest
-    - name: Download Linux binaries
+        name: bins-x86_64-macos
+    - name: Download x86_64 Linux binaries
       uses: actions/download-artifact@v1
       with:
-        name: bins-ubuntu-latest
-    - name: Download Windows binaries
+        name: bins-x86_64-linux
+    - name: Download AArch64 Linux binaries
       uses: actions/download-artifact@v1
       with:
-        name: bins-windows-latest
+        name: bins-aarch64-linux
+    - name: Download x86_64 Windows binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: bins-x86_64-windows
 
     - name: Assemble gh-pages
       run: |
@@ -400,9 +447,10 @@ jobs:
     # Assemble all the build artifacts into tarballs and zip archives.
     - name: Assemble tarballs
       run: |
-        ./ci/build-tarballs.sh x86_64-linux ubuntu-latest
-        ./ci/build-tarballs.sh x86_64-windows windows-latest .exe
-        ./ci/build-tarballs.sh x86_64-macos macos-latest
+        ./ci/build-tarballs.sh x86_64-linux
+        ./ci/build-tarballs.sh x86_64-windows .exe
+        ./ci/build-tarballs.sh x86_64-macos
+        ./ci/build-tarballs.sh aarch64-linux
 
     # Upload all assembled tarballs as an artifact of the github action run, so
     # that way even PRs can inspect the output.

--- a/build.rs
+++ b/build.rs
@@ -227,6 +227,9 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
     false
 }
 
+/// Determine whether to add a should_panic attribute. These tests currently
+/// panic because of unfinished backend implementation work; we will remove them
+/// from this list as we finish the implementation
 fn should_panic(testsuite: &str, testname: &str) -> bool {
     let target = env::var("TARGET").unwrap();
     if !target.contains("aarch64") {

--- a/build.rs
+++ b/build.rs
@@ -154,10 +154,13 @@ fn write_testsuite_tests(
     if ignore(testsuite, &testname, strategy) {
         writeln!(out, "#[ignore]")?;
     }
-    writeln!(out, "fn r#{}() -> anyhow::Result<()> {{", &testname)?;
+    if should_panic(testsuite, &testname) {
+        writeln!(out, "#[should_panic]")?;
+    }
+    writeln!(out, "fn r#{}() {{", &testname)?;
     writeln!(
         out,
-        "crate::wast::run_wast(r#\"{}\"#, crate::wast::Strategy::{})",
+        "crate::wast::run_wast(r#\"{}\"#, crate::wast::Strategy::{}).unwrap();",
         path.display(),
         strategy
     )?;
@@ -168,6 +171,7 @@ fn write_testsuite_tests(
 
 /// Ignore tests that aren't supported yet.
 fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
+    let target = env::var("TARGET").unwrap();
     match strategy {
         #[cfg(feature = "lightbeam")]
         "Lightbeam" => match (testsuite, testname) {
@@ -205,10 +209,50 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
                 return true;
             }
 
+            // FIXME(#1569) stack protection isn't implemented yet and these
+            // tests segfault.
+            ("spec_testsuite", "skip_stack_guard_page")
+            | ("spec_testsuite", "stack")
+            | ("misc_testsuite", "stack_overflow")
+                if target.contains("aarch64") =>
+            {
+                return true
+            }
+
             _ => {}
         },
         _ => panic!("unrecognized strategy"),
     }
 
     false
+}
+
+fn should_panic(testsuite: &str, testname: &str) -> bool {
+    let target = env::var("TARGET").unwrap();
+    if !target.contains("aarch64") {
+        return false;
+    }
+    match (testsuite, testname) {
+        // FIXME(#1521)
+        ("bulk_memory_operations", "imports")
+        | ("misc_testsuite", "func_400_params")
+        | ("misc_testsuite", "misc_traps")
+        | ("simd", _)
+        | ("multi_value", "call")
+        | ("spec_testsuite", "address")
+        | ("spec_testsuite", "align")
+        | ("spec_testsuite", "call")
+        | ("spec_testsuite", "conversions")
+        | ("spec_testsuite", "f32_bitwise")
+        | ("spec_testsuite", "float_misc")
+        | ("spec_testsuite", "i32")
+        | ("spec_testsuite", "i64")
+        | ("spec_testsuite", "imports")
+        | ("spec_testsuite", "int_exprs")
+        | ("spec_testsuite", "memory_grow")
+        | ("spec_testsuite", "memory_trap")
+        | ("spec_testsuite", "traps") => true,
+
+        _ => false,
+    }
 }

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -9,11 +9,14 @@
 # the second argument is the name of the github actions platform which is where
 # we source binaries from. The final third argument is ".exe" on Windows to
 # handle executable extensions right.
+#
+# Usage: build-tarballs.sh PLATFORM [.exe]
+
+# where PLATFORM is e.g. x86_64-linux, aarch64-linux, ...
 
 set -ex
 
 platform=$1
-src=$1
 exe=$2
 
 rm -rf tmp
@@ -33,12 +36,12 @@ mktarball() {
 bin_pkgname=wasmtime-$TAG-$platform
 mkdir tmp/$bin_pkgname
 cp LICENSE README.md tmp/$bin_pkgname
-mv bins-$src/wasmtime$exe tmp/$bin_pkgname
+mv bins-$platform/wasmtime$exe tmp/$bin_pkgname
 chmod +x tmp/$bin_pkgname/wasmtime$exe
 mktarball $bin_pkgname
 
 if [ "$exe" = ".exe" ]; then
-  mv bins-$src/installer.msi dist/$bin_pkgname.msi
+  mv bins-$platform/installer.msi dist/$bin_pkgname.msi
 fi
 
 # Create tarball of API libraries
@@ -47,7 +50,7 @@ mkdir tmp/$api_pkgname
 mkdir tmp/$api_pkgname/lib
 mkdir tmp/$api_pkgname/include
 cp LICENSE README.md tmp/$api_pkgname
-mv bins-$src/* tmp/$api_pkgname/lib
+mv bins-$platform/* tmp/$api_pkgname/lib
 cp crates/c-api/wasm-c-api/include/wasm.h tmp/$api_pkgname/include
 cp crates/c-api/include/{wasmtime,wasi}.h tmp/$api_pkgname/include
 mktarball $api_pkgname

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -13,8 +13,8 @@
 set -ex
 
 platform=$1
-src=$2
-exe=$3
+src=$1
+exe=$2
 
 rm -rf tmp
 mkdir tmp

--- a/cranelift/docs/testing.md
+++ b/cranelift/docs/testing.md
@@ -316,10 +316,15 @@ functions must have the signature `() -> bNN` where `bNN` is some sort of
 boolean, e.g. `b1` or `b32`. A `true` value is interpreted as a successful
 test execution, whereas a `false` value is interpreted as a failed test.
 
+Currently a `target` is required but is only used to indicate whether the host
+platform can run the test, and currently only the architecture is filtered. The
+host platform's native target will be used to actually compile the test.
+
 Example:
 
 ```
     test run
+    target x86_64
 
     function %trivial_test() -> b1 {
     ebb0:

--- a/cranelift/filetests/filetests/isa/x86/run-const.clif
+++ b/cranelift/filetests/filetests/isa/x86/run-const.clif
@@ -1,4 +1,5 @@
 test run
+target x86_64
 
 function %test_compare_i32() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-comparison-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-comparison-run.clif
@@ -1,5 +1,6 @@
 test run
 set enable_simd
+target x86_64
 
 function %icmp_eq_i8x16() -> b8 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
@@ -1,5 +1,6 @@
 test run
 set enable_simd
+target x86_64
 
 function %fcvt_from_sint() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-run.clif
@@ -1,5 +1,6 @@
 test run
 set enable_simd
+target x86_64
 
 function %shuffle_different_ssa_values() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-run.clif
@@ -1,5 +1,6 @@
 test run
 set enable_simd
+target x86_64
 
 function %vconst_syntax() -> b1 {
 block0:

--- a/cranelift/simplejit/tests/basic.rs
+++ b/cranelift/simplejit/tests/basic.rs
@@ -153,6 +153,7 @@ fn switch_error() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", should_panic)] // FIXME(#1521)
 fn libcall_function() {
     let mut module: Module<SimpleJITBackend> =
         Module::new(SimpleJITBuilder::new(default_libcall_names()));

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -723,6 +723,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
     fn cache_accounts_for_opt_level() -> Result<()> {
         let td = TempDir::new()?;
         let config_path = td.path().join("config.toml");

--- a/crates/c-api/macros/Cargo.toml
+++ b/crates/c-api/macros/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [lib]
 proc-macro = true
+test = false
 
 [dependencies]
 quote = "1.0"

--- a/crates/c-api/tests/wasm-c-examples.rs
+++ b/crates/c-api/tests/wasm-c-examples.rs
@@ -55,6 +55,7 @@ fn run_c_example(name: &'static str, expected_out: &str) {
         .arg("-lpthread")
         .arg("-ldl")
         .arg("-lm")
+        .arg("-lrt")
         .current_dir(&examples_dir)
         .arg("-o")
         .arg(c_examples_dir.join(name))

--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -200,6 +200,10 @@ mod wasi_tests {
         if #[cfg(not(windows))] {
             /// Ignore tests that aren't supported yet.
             fn ignore(testsuite: &str, name: &str) -> bool {
+                let target = env::var("TARGET").unwrap();
+                if target.contains("aarch64") {
+                    return true; // FIXME(#1521)
+                }
                 if testsuite == "wasi-tests" {
                     match name {
                         // TODO: virtfs files cannot be poll_oneoff'd yet

--- a/crates/wasi-common/wig/Cargo.toml
+++ b/crates/wasi-common/wig/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/**/*", "LICENSE", "WASI"]
 
 [lib]
 proc-macro = true
+test = false
 
 [dependencies]
 quote = "1.0.2"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/**/*", "LICENSE"]
 
 [lib]
 proc-macro = true
+test = false
 
 [dependencies]
 wiggle-generate = { path = "../generate", version = "0.15.0" }

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -87,6 +87,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
     fn test_custom_signal_handler_single_instance() -> Result<()> {
         let engine = Engine::new(&Config::default());
         let store = Store::new(&engine);

--- a/tests/all/fuzzing.rs
+++ b/tests/all/fuzzing.rs
@@ -21,6 +21,7 @@ fn instantiate_empty_module_with_memory() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", should_panic)] // FIXME(#1521)
 fn instantiate_module_that_compiled_to_x64_has_register_32() {
     let mut config = Config::new();
     config.debug_info(true);

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -99,6 +99,7 @@ fn loop_interrupt_from_afar() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1569)
 fn function_interrupt_from_afar() -> anyhow::Result<()> {
     // Create an instance which calls an imported function on each iteration of
     // the loop so we can count the number of loop iterations we've executed so

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1569)
 fn host_always_has_some_stack() -> anyhow::Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
     // assume hosts always have at least 512k of stack

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -31,6 +31,7 @@ fn test_trap_return() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn test_trap_trace() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -72,6 +73,7 @@ fn test_trap_trace() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn test_trap_trace_cb() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -107,6 +109,7 @@ fn test_trap_trace_cb() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn test_trap_stack_overflow() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -138,6 +141,7 @@ fn test_trap_stack_overflow() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn trap_display_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -169,6 +173,7 @@ wasm backtrace:
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn trap_display_multi_module() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -213,6 +218,7 @@ wasm backtrace:
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn trap_start_function_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -233,6 +239,7 @@ fn trap_start_function_import() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn rust_panic_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -276,6 +283,7 @@ fn rust_panic_import() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn rust_panic_start_function() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -309,6 +317,7 @@ fn rust_panic_start_function() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn mismatched_arguments() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -340,6 +349,7 @@ fn mismatched_arguments() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn call_signature_mismatch() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -368,6 +378,7 @@ fn call_signature_mismatch() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn start_trap_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -34,6 +34,17 @@ fn overrun_the_stack() -> usize {
 }
 
 fn main() {
+    // Skip this tests if it looks like we're in a cross-compiled situation and
+    // we're emulating this test for a different platform. In that scenario
+    // emulators (like QEMU) tend to not report signals the same way and such.
+    if std::env::vars()
+        .filter(|(k, _v)| k.starts_with("CARGO_TARGET") && k.ends_with("RUNNER"))
+        .count()
+        > 0
+    {
+        return;
+    }
+
     let tests: &[(&str, fn())] = &[
         ("normal segfault", || segfault()),
         ("make instance then segfault", || {


### PR DESCRIPTION
This commit enhances our CI with an AArch64 builder. Currently we have
no physical hardware to run on so for now we run all tests in an
emulator. The AArch64 build is cross-compiled from x86_64 from Linux.
Tests all happen in release mode with a recent version of QEMU (recent
version because it's so much faster, and in release mode because debug
mode tests take quite a long time in an emulator).

The goal here was not to get all tests passing on CI, but rather to get
AArch64 running on CI and get it green at the same time. To achieve that
goal many tests are now ignored on aarch64 platforms. Many tests fail
due to unimplemented functionality in the aarch64 backend (#1521), and
all wasmtime tests involving compilation are also disabled due to
panicking attempting to generate generate instruction offset information
for trap symbolication (#1523).

Despite this, though, all Cranelift tests and other wasmtime tests
should be runnin on AArch64 through QEMU with this PR. Additionally
we'll have an AArch64 binary release of Wasmtime for Linux, although it
won't be too useful just yet since it will panic on almost all wasm
modules.
