### PR TITLE
Use debug! logging instead of info! for verbose logging

### DIFF
--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -11,7 +11,7 @@ use crate::Backend;
 use cranelift_codegen::binemit::{self, CodeInfo};
 use cranelift_codegen::entity::{entity_impl, PrimaryMap};
 use cranelift_codegen::{ir, isa, CodegenError, Context};
-use log::info;
+use log::debug;
 use std::borrow::ToOwned;
 use std::convert::TryInto;
 use std::string::String;
@@ -576,7 +576,7 @@ where
     where
         TS: binemit::TrapSink,
     {
-        info!(
+        debug!(
             "defining function {}: {}",
             func,
             ctx.func.display(self.backend.isa())
@@ -618,7 +618,7 @@ where
         func: FuncId,
         bytes: &[u8],
     ) -> ModuleResult<ModuleCompiledFunction> {
-        info!("defining function {} with bytes", func);
+        debug!("defining function {} with bytes", func);
         let info = &self.contents.functions[func];
         if info.compiled.is_some() {
             return Err(ModuleError::DuplicateDefinition(info.decl.name.clone()));

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -13,7 +13,7 @@ use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, Block, InstBuilder, ValueLabel};
 use cranelift_codegen::timing;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
-use log::info;
+use log::debug;
 use wasmparser::{self, BinaryReader};
 
 /// WebAssembly to Cranelift IR function translator.
@@ -78,7 +78,7 @@ impl FuncTranslator {
         environ: &mut FE,
     ) -> WasmResult<()> {
         let _tt = timing::wasm_translate_function();
-        info!(
+        debug!(
             "translate({} bytes, {}{})",
             reader.bytes_remaining(),
             func.name,

--- a/crates/environ/src/cache/worker.rs
+++ b/crates/environ/src/cache/worker.rs
@@ -100,7 +100,7 @@ impl Worker {
         let sent_event = self.sender.try_send(event.clone());
 
         if let Err(ref err) = sent_event {
-            debug!(
+            warn!(
                 "Failed to send asynchronously message to worker thread, \
                  event: {:?}, error: {}",
                 event, err

--- a/crates/environ/src/cache/worker.rs
+++ b/crates/environ/src/cache/worker.rs
@@ -6,7 +6,7 @@
 //! Background tasks can be CPU intensive, but the worker thread has low priority.
 
 use super::{fs_write_atomic, CacheConfig};
-use log::{debug, info, trace, warn};
+use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::collections::HashMap;
@@ -100,7 +100,7 @@ impl Worker {
         let sent_event = self.sender.try_send(event.clone());
 
         if let Err(ref err) = sent_event {
-            info!(
+            debug!(
                 "Failed to send asynchronously message to worker thread, \
                  event: {:?}, error: {}",
                 event, err

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -167,7 +167,7 @@ impl Compiler {
             // show up be sure to log it in case anyone's listening and there's
             // an accidental bug.
             if relocations.len() > 0 {
-                log::debug!("relocations found in trampoline for {:?}", sig);
+                log::warn!("relocations found in trampoline for {:?}", sig);
                 trampoline_relocations.insert(index, relocations);
             }
         }

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -167,7 +167,7 @@ impl Compiler {
             // show up be sure to log it in case anyone's listening and there's
             // an accidental bug.
             if relocations.len() > 0 {
-                log::info!("relocations found in trampoline for {:?}", sig);
+                log::debug!("relocations found in trampoline for {:?}", sig);
                 trampoline_relocations.insert(index, relocations);
             }
         }


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

This issue has not been discussed, but I believe it simple enough that a discussion wasn't needed.  The `info!` log is meant for high level logs that are relevant to every invocation. The logs in this PR are only relevant when debugging so they should use the `debug!` logging macro.

I'm not sure who should look at this, but perhaps @peterhuene can take a look. 
