### PR TITLE
arm64: Add support for CCmp

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -525,4 +525,11 @@ impl InstSize {
             InstSize::Size64
         }
     }
+
+    pub fn sf_bit(&self) -> u32 {
+        match self {
+            InstSize::Size32 => 0,
+            InstSize::Size64 => 1,
+        }
+    }
 }


### PR DESCRIPTION
Also add a test for SUBS/ADDS with XZR, as CMP/CMN are aliases.

Copyright (c) 2020, Arm Limited.