### PR TITLE
arm64: Support bool constants

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -183,6 +183,7 @@ fn output_to_const<C: LowerCtx<I = Inst>>(ctx: &mut C, out: InsnOutput) -> Optio
                     let imm: i64 = imm.into();
                     Some(imm as u64)
                 }
+                &InstructionData::UnaryBool { opcode: _, imm } => Some(u64::from(imm)),
                 &InstructionData::UnaryIeee32 { opcode: _, imm } => Some(u64::from(imm.bits())),
                 &InstructionData::UnaryIeee64 { opcode: _, imm } => Some(imm.bits()),
                 _ => None,

--- a/cranelift/filetests/filetests/vcode/aarch64/constants.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/constants.clif
@@ -1,6 +1,32 @@
 test vcode
 target aarch64
 
+function %f() -> b8 {
+block0:
+  v0 = bconst.b8 true
+  return v0
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: movz x0, #1
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f() -> b16 {
+block0:
+  v0 = bconst.b16 false
+  return v0
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: movz x0, #0
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
 function %f() -> i64 {
 block0:
   v0 = iconst.i64 0


### PR DESCRIPTION
This is a rebase of `c81ec0c280eb5f20d7f9a994509bb0f031577b34` from the `arm64` dev branch that happened during review of the main merge.

Contributed by Joey Gouly @jgouly, and "Copyright (c) 2020, Arm Limited."

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
