### PR TITLE
Temporarily fix wasmtime on aarch64 by not constructing per-inst address map.

### DIFF
--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -125,15 +125,19 @@ fn get_function_address_map<'data>(
     let mut blocks = func.layout.blocks().collect::<Vec<_>>();
     blocks.sort_by_key(|block| func.offsets[*block]); // Ensure inst offsets always increase
 
-    let encinfo = isa.encoding_info();
-    for block in blocks {
-        for (offset, inst, size) in func.inst_offsets(block, &encinfo) {
-            let srcloc = func.srclocs[inst];
-            instructions.push(InstructionAddressMap {
-                srcloc,
-                code_offset: offset as usize,
-                code_len: size as usize,
-            });
+    // FIXME(#1523): New backend does not support debug info or instruction-address mapping
+    // yet.
+    if !isa.get_mach_backend().is_some() {
+        let encinfo = isa.encoding_info();
+        for block in blocks {
+            for (offset, inst, size) in func.inst_offsets(block, &encinfo) {
+                let srcloc = func.srclocs[inst];
+                instructions.push(InstructionAddressMap {
+                    srcloc,
+                    code_offset: offset as usize,
+                    code_len: size as usize,
+                });
+            }
         }
     }
 


### PR DESCRIPTION
The current build of wasmtime on aarch64 panics immediately because the
debug infrastructure constructs an address-to-instruction map
unconditionally now, and the new backend does not yet support debug info
generally (#1523). In this particular case, the address-map construction
consults the encoding info, which is not implemented by the new backend
and causes the panic.

This fix simply avoids generating per-instruction entries in the address
map; it at least gets us going until we plumb SourceLocs all the way
through the new pipeline.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
