### PR TITLE
Turn down debuginfo level on CI

### DIFF
--- a/.github/actions/install-rust/main.js
+++ b/.github/actions/install-rust/main.js
@@ -12,4 +12,10 @@ child_process.execFileSync('rustup', ['set', 'profile', 'minimal']);
 child_process.execFileSync('rustup', ['update', toolchain, '--no-self-update']);
 child_process.execFileSync('rustup', ['default', toolchain]);
 
+// Save disk space by avoiding incremental compilation, and also we don't use
+// any caching so incremental wouldn't help anyway.
 console.log(`::set-env name=CARGO_INCREMENTAL::0`);
+
+// Turn down debuginfo from 2 to 1 to help save disk space
+console.log(`::set-env name=CARGO_PROFILE_DEV_DEBUG::1`);
+console.log(`::set-env name=CARGO_PROFILE_TEST_DEBUG::1`);


### PR DESCRIPTION
We don't need full debug information but rather line tables
(debuginfo=1) should suffice for backtraces if truly necessary. Note
that this doesn't actually work on stable Rust just yet due to it being
an unrelease feature of Cargo. With the Rust release next week though
this'll work on all of stable/beta/nightly.
