### PR TITLE
Resolve CI failures related to ConstAddr and Aarch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -1515,6 +1515,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) {
             panic!("table_addr should have been removed by legalization!");
         }
 
+        Opcode::ConstAddr => unimplemented!(),
+
         Opcode::Nop => {
             // Nothing.
         }


### PR DESCRIPTION
@alexcrichton, initially I am going to try this out as `unimplemented!` but it wouldn't be difficult to implement: it's a single `LEA` in x86. @cfallin, is there a quick fix for this? Where do you legalize `HeapAddr` and `TableAddr`?