### PR TITLE
Implement 128bit legalizations for AArch64

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -19,7 +19,6 @@ use crate::flowgraph::ControlFlowGraph;
 use crate::ir::Function;
 use crate::isa::TargetIsa;
 use crate::legalize_function;
-use crate::legalizer::simple_legalize;
 use crate::licm::do_licm;
 use crate::loop_analysis::LoopAnalysis;
 use crate::machinst::MachCompileResult;
@@ -311,15 +310,10 @@ impl Context {
         // TODO: Avoid doing this when legalization doesn't actually mutate the CFG.
         self.domtree.clear();
         self.loop_analysis.clear();
-        if isa.get_mach_backend().is_some() {
-            // Run some specific legalizations only.
-            simple_legalize(&mut self.func, &mut self.cfg, isa);
-            self.verify_if(isa)
-        } else {
-            legalize_function(&mut self.func, &mut self.cfg, isa);
-            debug!("Legalized:\n{}", self.func.display(isa));
-            self.verify_if(isa)
-        }
+
+        legalize_function(&mut self.func, &mut self.cfg, isa);
+        debug!("Legalized:\n{}", self.func.display(isa));
+        self.verify_if(isa)
     }
 
     /// Perform post-legalization rewrites on the function.

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -1988,7 +1988,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) {
             panic!("Vector ops not implemented.");
         }
 
-        Opcode::Isplit | Opcode::Iconcat => panic!("Vector ops not supported."),
+        Opcode::Isplit => panic!("isplit should have been removed by legalization!"),
+        Opcode::Iconcat => panic!("iconcat result users should have been removed by legalization!"),
+
         Opcode::Imax | Opcode::Imin | Opcode::Umin | Opcode::Umax => {
             panic!("Vector ops not supported.")
         }

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -171,6 +171,9 @@ impl<'a, I: VCodeInst> Lower<'a, I> {
                 vcode.set_vreg_type(vreg, f.dfg.value_type(*param));
             }
             for inst in f.layout.block_insts(bb) {
+                if f.dfg[inst].opcode() == Opcode::Iconcat {
+                    continue; // iconcat results are never used after legalization
+                }
                 for result in f.dfg.inst_results(inst) {
                     let vreg = alloc_vreg(
                         &mut value_regs,


### PR DESCRIPTION
This works by always using `legalize_function`, but skipping the steps that are not necessary for the AArch64 backend.

While `iadd` is not yet legalized, as they it depends on `iadd_ifcout` and `iadd_ifcin`, this does legalize many other 128bit integer operations and it supports function signatures with 128bit integers, making it much easier to support 128bit integers in cg_clif for the AArch64 backend.