### PR TITLE
Correct the WASM location expression opcode

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -322,7 +322,7 @@ where
     while !pc.is_empty() {
         let next = buf[pc.offset_from(&expr.0).into_u64() as usize];
         need_deref = true;
-        if next == 0xED {
+        if next == 0xEB {
             // WebAssembly DWARF extension
             pc.read_u8()?;
             let ty = pc.read_uleb128()?;


### PR DESCRIPTION
... to be in sync with https://yurydelendik.github.io/webassembly-dwarf

This was presumably a typo committed with
https://github.com/bytecodealliance/wasmtime/commit/4f04d7d8732484b96fd46a489990e2f25c4b1c9e#diff-9c791366cbfff00136acf7eb05de91e9R309

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
