### PR TITLE
SystemV struct arguments

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/types.rs
+++ b/cranelift/codegen/meta/src/cdsl/types.rs
@@ -424,7 +424,7 @@ impl SpecialType {
                 flags can be tested with a :type:`floatcc` condition code.",
             ),
             SpecialType::StructArgument => {
-                String::from("After legalization sarg__ arguments will get this type.")
+                String::from("After legalization sarg_t arguments will get this type.")
             }
         }
     }
@@ -452,7 +452,7 @@ impl fmt::Display for SpecialType {
         match *self {
             SpecialType::Flag(shared_types::Flag::IFlags) => write!(f, "iflags"),
             SpecialType::Flag(shared_types::Flag::FFlags) => write!(f, "fflags"),
-            SpecialType::StructArgument => write!(f, "sarg__"),
+            SpecialType::StructArgument => write!(f, "sarg_t"),
         }
     }
 }

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -439,6 +439,7 @@ fn define_moves(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions, r:
     let sextend = shared.by_name("sextend");
     let set_pinned_reg = shared.by_name("set_pinned_reg");
     let uextend = shared.by_name("uextend");
+    let dummy_sarg__ = shared.by_name("dummy_sarg__");
 
     // Shorthands for recipes.
     let rec_copysp = r.template("copysp");
@@ -456,6 +457,7 @@ fn define_moves(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions, r:
     let rec_umr_reg_to_ssa = r.template("umr_reg_to_ssa");
     let rec_urm_noflags = r.template("urm_noflags");
     let rec_urm_noflags_abcd = r.template("urm_noflags_abcd");
+    let rec_dummy_sarg__ = r.recipe("dummy_sarg__");
 
     // The pinned reg is fixed to a certain value entirely user-controlled, so it generates nothing!
     e.enc64_rec(get_pinned_reg.bind(I64), rec_get_pinned_reg, 0);
@@ -721,6 +723,8 @@ fn define_moves(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions, r:
         copy_to_ssa.bind(F32),
         rec_furm_reg_to_ssa.opcodes(&MOVSS_LOAD),
     );
+
+    e.enc_32_64_rec(dummy_sarg__, rec_dummy_sarg__, 0);
 }
 
 #[inline(never)]

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -439,7 +439,7 @@ fn define_moves(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions, r:
     let sextend = shared.by_name("sextend");
     let set_pinned_reg = shared.by_name("set_pinned_reg");
     let uextend = shared.by_name("uextend");
-    let dummy_sarg__ = shared.by_name("dummy_sarg__");
+    let dummy_sarg_t = shared.by_name("dummy_sarg_t");
 
     // Shorthands for recipes.
     let rec_copysp = r.template("copysp");
@@ -457,7 +457,7 @@ fn define_moves(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions, r:
     let rec_umr_reg_to_ssa = r.template("umr_reg_to_ssa");
     let rec_urm_noflags = r.template("urm_noflags");
     let rec_urm_noflags_abcd = r.template("urm_noflags_abcd");
-    let rec_dummy_sarg__ = r.recipe("dummy_sarg__");
+    let rec_dummy_sarg_t = r.recipe("dummy_sarg_t");
 
     // The pinned reg is fixed to a certain value entirely user-controlled, so it generates nothing!
     e.enc64_rec(get_pinned_reg.bind(I64), rec_get_pinned_reg, 0);
@@ -724,7 +724,7 @@ fn define_moves(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions, r:
         rec_furm_reg_to_ssa.opcodes(&MOVSS_LOAD),
     );
 
-    e.enc_32_64_rec(dummy_sarg__, rec_dummy_sarg__, 0);
+    e.enc_32_64_rec(dummy_sarg_t, rec_dummy_sarg_t, 0);
 }
 
 #[inline(never)]

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -1271,7 +1271,7 @@ pub(crate) fn define<'shared>(
     }
 
     recipes.add_recipe(
-        EncodingRecipeBuilder::new("dummy_sarg__", &formats.nullary, 0)
+        EncodingRecipeBuilder::new("dummy_sarg_t", &formats.nullary, 0)
             .operands_out(vec![Stack::new(gpr)])
             .emit(""),
     );

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -1270,6 +1270,12 @@ pub(crate) fn define<'shared>(
         );
     }
 
+    recipes.add_recipe(
+        EncodingRecipeBuilder::new("dummy_sarg__", &formats.nullary, 0)
+            .operands_out(vec![Stack::new(gpr)])
+            .emit(""),
+    );
+
     // XX+rd id with Abs4 function relocation.
     recipes.add_template_recipe(
         EncodingRecipeBuilder::new("fnaddr4", &formats.func_addr, 4)

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1837,7 +1837,7 @@ pub(crate) fn define(
 
     let Sarg = &TypeVar::new(
         "Sarg",
-        "Any scalar or vector type with as most 128 lanes",
+        "Any scalar or vector type with at most 128 lanes",
         TypeSetBuilder::new()
             .specials(vec![crate::cdsl::types::SpecialType::StructArgument])
             .build(),

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1835,6 +1835,31 @@ pub(crate) fn define(
         .can_load(true),
     );
 
+    let Sarg = &TypeVar::new(
+        "Sarg",
+        "Any scalar or vector type with as most 128 lanes",
+        TypeSetBuilder::new()
+            .specials(vec![crate::cdsl::types::SpecialType::StructArgument])
+            .build(),
+    );
+    let sarg__ = &Operand::new("sarg__", Sarg);
+
+    // FIXME remove once the old style codegen backends are removed.
+    ig.push(
+        Inst::new(
+            "dummy_sarg__",
+            r#"
+        This creates a sarg__
+
+        This instruction is internal and should not be created by
+        Cranelift users.
+        "#,
+            &formats.nullary,
+        )
+        .operands_in(vec![])
+        .operands_out(vec![sarg__]),
+    );
+
     let src = &Operand::new("src", &imm.regunit);
     let dst = &Operand::new("dst", &imm.regunit);
 

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1842,14 +1842,14 @@ pub(crate) fn define(
             .specials(vec![crate::cdsl::types::SpecialType::StructArgument])
             .build(),
     );
-    let sarg__ = &Operand::new("sarg__", Sarg);
+    let sarg_t = &Operand::new("sarg_t", Sarg);
 
     // FIXME remove once the old style codegen backends are removed.
     ig.push(
         Inst::new(
-            "dummy_sarg__",
+            "dummy_sarg_t",
             r#"
-        This creates a sarg__
+        This creates a sarg_t
 
         This instruction is internal and should not be created by
         Cranelift users.
@@ -1857,7 +1857,7 @@ pub(crate) fn define(
             &formats.nullary,
         )
         .operands_in(vec![])
-        .operands_out(vec![sarg__]),
+        .operands_out(vec![sarg_t]),
     );
 
     let src = &Operand::new("src", &imm.regunit);

--- a/cranelift/codegen/src/abi.rs
+++ b/cranelift/codegen/src/abi.rs
@@ -123,7 +123,8 @@ pub fn legalize_args<AA: ArgAssigner>(args: &[AbiParam], aa: &mut AA) -> Option<
                 args.to_mut()[argno].location = loc;
                 argno += 1;
             }
-            // Assign argument to a location, change type to `INVALID` and move on to the next one.
+            // Assign argument to a location, change type to the requested one and move on to the
+            // next one.
             ArgAction::AssignAndChangeType(loc, ty) => {
                 let arg = &mut args.to_mut()[argno];
                 arg.location = loc;

--- a/cranelift/codegen/src/abi.rs
+++ b/cranelift/codegen/src/abi.rs
@@ -18,6 +18,10 @@ pub enum ArgAction {
     /// Assign the argument to the given location.
     Assign(ArgumentLoc),
 
+    /// Assign the argument to the given location and change the type to the specified type.
+    /// This is used by [`ArgumentPurpose::StructArgument`].
+    AssignAndChangeType(ArgumentLoc, Type),
+
     /// Convert the argument, then call again.
     ///
     /// This action can split an integer type into two smaller integer arguments, or it can split a
@@ -117,6 +121,13 @@ pub fn legalize_args<AA: ArgAssigner>(args: &[AbiParam], aa: &mut AA) -> Option<
             // Assign argument to a location and move on to the next one.
             ArgAction::Assign(loc) => {
                 args.to_mut()[argno].location = loc;
+                argno += 1;
+            }
+            // Assign argument to a location, change type to `INVALID` and move on to the next one.
+            ArgAction::AssignAndChangeType(loc, ty) => {
+                let arg = &mut args.to_mut()[argno];
+                arg.location = loc;
+                arg.value_type = ty;
                 argno += 1;
             }
             // Split this argument into two smaller ones. Then revisit both.

--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -363,6 +363,7 @@ impl FromStr for ArgumentPurpose {
                 if !s.ends_with(")") {
                     return Err(());
                 }
+                // Parse 'sarg(size)'
                 let size: u32 = s["sarg(".len()..s.len() - 1].parse().map_err(|_| ())?;
                 Ok(Self::StructArgument(size))
             }

--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -276,6 +276,9 @@ pub enum ArgumentPurpose {
     /// A normal user program value passed to or from a function.
     Normal,
 
+    /// A C struct passed as argument.
+    StructArgument(u32),
+
     /// Struct return pointer.
     ///
     /// When a function needs to return more data than will fit in registers, the caller passes a
@@ -328,21 +331,19 @@ pub enum ArgumentPurpose {
     StackLimit,
 }
 
-/// Text format names of the `ArgumentPurpose` variants.
-static PURPOSE_NAMES: [&str; 8] = [
-    "normal",
-    "sret",
-    "link",
-    "fp",
-    "csr",
-    "vmctx",
-    "sigid",
-    "stack_limit",
-];
-
 impl fmt::Display for ArgumentPurpose {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(PURPOSE_NAMES[*self as usize])
+        f.write_str(match self {
+            Self::Normal => "normal",
+            Self::StructArgument(size) => return write!(f, "sarg({})", size),
+            Self::StructReturn => "sret",
+            Self::Link => "link",
+            Self::FramePointer => "fp",
+            Self::CalleeSaved => "csr",
+            Self::VMContext => "vmctx",
+            Self::SignatureId => "sigid",
+            Self::StackLimit => "stack_limit",
+        })
     }
 }
 
@@ -358,6 +359,13 @@ impl FromStr for ArgumentPurpose {
             "vmctx" => Ok(Self::VMContext),
             "sigid" => Ok(Self::SignatureId),
             "stack_limit" => Ok(Self::StackLimit),
+            _ if s.starts_with("sarg(") => {
+                if !s.ends_with(")") {
+                    return Err(());
+                }
+                let size: u32 = s["sarg(".len()..s.len() - 1].parse().map_err(|_| ())?;
+                Ok(Self::StructArgument(size))
+            }
             _ => Err(()),
         }
     }
@@ -430,16 +438,17 @@ mod tests {
     #[test]
     fn argument_purpose() {
         let all_purpose = [
-            ArgumentPurpose::Normal,
-            ArgumentPurpose::StructReturn,
-            ArgumentPurpose::Link,
-            ArgumentPurpose::FramePointer,
-            ArgumentPurpose::CalleeSaved,
-            ArgumentPurpose::VMContext,
-            ArgumentPurpose::SignatureId,
-            ArgumentPurpose::StackLimit,
+            (ArgumentPurpose::Normal, "normal"),
+            (ArgumentPurpose::StructReturn, "sret"),
+            (ArgumentPurpose::Link, "link"),
+            (ArgumentPurpose::FramePointer, "fp"),
+            (ArgumentPurpose::CalleeSaved, "csr"),
+            (ArgumentPurpose::VMContext, "vmctx"),
+            (ArgumentPurpose::SignatureId, "sigid"),
+            (ArgumentPurpose::StackLimit, "stack_limit"),
+            (ArgumentPurpose::StructArgument(42), "sarg(42)"),
         ];
-        for (&e, &n) in all_purpose.iter().zip(PURPOSE_NAMES.iter()) {
+        for &(e, n) in &all_purpose {
             assert_eq!(e.to_string(), n);
             assert_eq!(Ok(e), n.parse());
         }

--- a/cranelift/codegen/src/ir/stackslot.rs
+++ b/cranelift/codegen/src/ir/stackslot.rs
@@ -286,12 +286,7 @@ impl StackSlots {
     }
 
     /// Create a stack slot representing an incoming function argument.
-    pub fn make_incoming_arg(&mut self, ty: Type, offset: StackOffset) -> StackSlot {
-        self.make_incoming_struct_arg(ty.bytes(), offset)
-    }
-
-    /// Create a stack slot representing an incoming struct function argument.
-    pub fn make_incoming_struct_arg(&mut self, size: u32, offset: StackOffset) -> StackSlot {
+    pub fn make_incoming_arg(&mut self, size: u32, offset: StackOffset) -> StackSlot {
         let mut data = StackSlotData::new(StackSlotKind::IncomingArg, size);
         debug_assert!(offset <= StackOffset::max_value() - data.size as StackOffset);
         data.offset = Some(offset);
@@ -305,12 +300,7 @@ impl StackSlots {
     ///
     /// The requested offset is relative to this function's stack pointer immediately before making
     /// the call.
-    pub fn get_outgoing_arg(&mut self, ty: Type, offset: StackOffset) -> StackSlot {
-        self.get_outgoing_struct_arg(ty.bytes(), offset)
-    }
-
-    /// FIXME
-    pub fn get_outgoing_struct_arg(&mut self, size: u32, offset: StackOffset) -> StackSlot {
+    pub fn get_outgoing_arg(&mut self, size: u32, offset: StackOffset) -> StackSlot {
         // Look for an existing outgoing stack slot with the same offset and size.
         let inspos = match self.outgoing.binary_search_by_key(&(offset, size), |&ss| {
             (self[ss].offset.unwrap(), self[ss].size)
@@ -395,9 +385,9 @@ mod tests {
     fn outgoing() {
         let mut sss = StackSlots::new();
 
-        let ss0 = sss.get_outgoing_arg(types::I32, 8);
-        let ss1 = sss.get_outgoing_arg(types::I32, 4);
-        let ss2 = sss.get_outgoing_arg(types::I64, 8);
+        let ss0 = sss.get_outgoing_arg(4, 8);
+        let ss1 = sss.get_outgoing_arg(4, 4);
+        let ss2 = sss.get_outgoing_arg(8, 8);
 
         assert_eq!(sss[ss0].offset, Some(8));
         assert_eq!(sss[ss0].size, 4);
@@ -408,9 +398,9 @@ mod tests {
         assert_eq!(sss[ss2].offset, Some(8));
         assert_eq!(sss[ss2].size, 8);
 
-        assert_eq!(sss.get_outgoing_arg(types::I32, 8), ss0);
-        assert_eq!(sss.get_outgoing_arg(types::I32, 4), ss1);
-        assert_eq!(sss.get_outgoing_arg(types::I64, 8), ss2);
+        assert_eq!(sss.get_outgoing_arg(4, 8), ss0);
+        assert_eq!(sss.get_outgoing_arg(4, 4), ss1);
+        assert_eq!(sss.get_outgoing_arg(8, 8), ss2);
     }
 
     #[test]

--- a/cranelift/codegen/src/ir/stackslot.rs
+++ b/cranelift/codegen/src/ir/stackslot.rs
@@ -287,7 +287,12 @@ impl StackSlots {
 
     /// Create a stack slot representing an incoming function argument.
     pub fn make_incoming_arg(&mut self, ty: Type, offset: StackOffset) -> StackSlot {
-        let mut data = StackSlotData::new(StackSlotKind::IncomingArg, ty.bytes());
+        self.make_incoming_struct_arg(ty.bytes(), offset)
+    }
+
+    /// Create a stack slot representing an incoming struct function argument.
+    pub fn make_incoming_struct_arg(&mut self, size: u32, offset: StackOffset) -> StackSlot {
+        let mut data = StackSlotData::new(StackSlotKind::IncomingArg, size);
         debug_assert!(offset <= StackOffset::max_value() - data.size as StackOffset);
         data.offset = Some(offset);
         self.push(data)
@@ -301,8 +306,11 @@ impl StackSlots {
     /// The requested offset is relative to this function's stack pointer immediately before making
     /// the call.
     pub fn get_outgoing_arg(&mut self, ty: Type, offset: StackOffset) -> StackSlot {
-        let size = ty.bytes();
+        self.get_outgoing_struct_arg(ty.bytes(), offset)
+    }
 
+    /// FIXME
+    pub fn get_outgoing_struct_arg(&mut self, size: u32, offset: StackOffset) -> StackSlot {
         // Look for an existing outgoing stack slot with the same offset and size.
         let inspos = match self.outgoing.binary_search_by_key(&(offset, size), |&ss| {
             (self[ss].offset.unwrap(), self[ss].size)

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -329,6 +329,7 @@ impl Display for Type {
             f.write_str(match *self {
                 IFLAGS => "iflags",
                 FFLAGS => "fflags",
+                SARG__ => "sarg__",
                 INVALID => panic!("INVALID encountered"),
                 _ => panic!("Unknown Type(0x{:x})", self.0),
             })

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -329,7 +329,7 @@ impl Display for Type {
             f.write_str(match *self {
                 IFLAGS => "iflags",
                 FFLAGS => "fflags",
-                SARG__ => "sarg__",
+                SARG_T => "sarg_t",
                 INVALID => panic!("INVALID encountered"),
                 _ => panic!("Unknown Type(0x{:x})", self.0),
             })

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -2069,7 +2069,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             panic!("x86-specific opcode in supposedly arch-neutral IR!");
         }
 
-        Opcode::DummySarg => unreachable!(),
+        Opcode::DummySargT => unreachable!(),
 
         Opcode::AvgRound => unimplemented!(),
         Opcode::TlsValue => unimplemented!(),

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -2069,6 +2069,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             panic!("x86-specific opcode in supposedly arch-neutral IR!");
         }
 
+        Opcode::DummySarg => unreachable!(),
+
         Opcode::AvgRound => unimplemented!(),
         Opcode::TlsValue => unimplemented!(),
     }

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -108,6 +108,19 @@ impl Args {
 
 impl ArgAssigner for Args {
     fn assign(&mut self, arg: &AbiParam) -> ArgAction {
+        if let ArgumentPurpose::StructArgument(size) = arg.purpose {
+            if self.call_conv != CallConv::SystemV {
+                panic!(
+                    "The sarg argument purpose is not yet implemented for non-systemv call conv {:?}",
+                    self.call_conv,
+                );
+            }
+            let loc = ArgumentLoc::Stack(self.offset as i32);
+            self.offset += size;
+            debug_assert!(self.offset <= i32::MAX as u32);
+            return ArgAction::AssignAndChangeType(loc, types::SARG__);
+        }
+
         let ty = arg.value_type;
 
         if ty.bits() > u16::from(self.pointer_bits) {

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -118,7 +118,7 @@ impl ArgAssigner for Args {
             let loc = ArgumentLoc::Stack(self.offset as i32);
             self.offset += size;
             debug_assert!(self.offset <= i32::MAX as u32);
-            return ArgAction::AssignAndChangeType(loc, types::SARG__);
+            return ArgAction::AssignAndChangeType(loc, types::SARG_T);
         }
 
         let ty = arg.value_type;

--- a/cranelift/codegen/src/legalizer/boundary.rs
+++ b/cranelift/codegen/src/legalizer/boundary.rs
@@ -22,8 +22,9 @@ use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::instructions::CallInfo;
 use crate::ir::{
-    AbiParam, ArgumentLoc, ArgumentPurpose, Block, DataFlowGraph, Function, Inst, InstBuilder,
-    MemFlags, SigRef, Signature, StackSlotData, StackSlotKind, Type, Value, ValueLoc,
+    AbiParam, ArgumentLoc, ArgumentPurpose, Block, DataFlowGraph, ExtFuncData, ExternalName,
+    Function, Inst, InstBuilder, LibCall, MemFlags, SigRef, Signature, StackSlotData,
+    StackSlotKind, Type, Value, ValueLoc,
 };
 use crate::isa::TargetIsa;
 use crate::legalizer::split::{isplit, vsplit};
@@ -113,12 +114,33 @@ fn legalize_entry_params(func: &mut Function, entry: Block) {
 
         let abi_type = pos.func.signature.params[abi_arg];
         let arg_type = pos.func.dfg.value_type(arg);
+        match abi_type.purpose {
+            ArgumentPurpose::StructArgument(size) => {
+                let offset = if let ArgumentLoc::Stack(offset) = abi_type.location {
+                    offset
+                } else {
+                    unreachable!("StructArgument must already have a Stack ArgumentLoc assigned");
+                };
+                let ss = pos.func.stack_slots.make_incoming_struct_arg(size, offset);
+                let struct_arg = pos.ins().stack_addr(arg_type, ss, 0);
+                pos.func.dfg.change_to_alias(arg, struct_arg);
+                let dummy = pos
+                    .func
+                    .dfg
+                    .append_block_param(entry, crate::ir::types::SARG__);
+                pos.func.locations[dummy] = ValueLoc::Stack(ss);
+                abi_arg += 1;
+                continue;
+            }
+            _ => {}
+        }
         if arg_type == abi_type.value_type {
             // No value translation is necessary, this argument matches the ABI type.
             // Just use the original block argument value. This is the most common case.
             pos.func.dfg.attach_block_param(entry, arg);
             match abi_type.purpose {
                 ArgumentPurpose::Normal => {}
+                ArgumentPurpose::StructArgument(_) => unreachable!("Handled above"),
                 ArgumentPurpose::FramePointer => {}
                 ArgumentPurpose::CalleeSaved => {}
                 ArgumentPurpose::StructReturn => {
@@ -137,7 +159,7 @@ fn legalize_entry_params(func: &mut Function, entry: Block) {
                     debug_assert!(!has_stack_limit, "Multiple stack_limit arguments found");
                     has_stack_limit = true;
                 }
-                _ => panic!("Unexpected special-purpose arg {}", abi_type),
+                ArgumentPurpose::Link => panic!("Unexpected link arg {}", abi_type),
             }
             abi_arg += 1;
         } else {
@@ -168,7 +190,7 @@ fn legalize_entry_params(func: &mut Function, entry: Block) {
     for &arg in &pos.func.signature.params[abi_arg..] {
         match arg.purpose {
             // Any normal parameters should have been processed above.
-            ArgumentPurpose::Normal => {
+            ArgumentPurpose::Normal | ArgumentPurpose::StructArgument(_) => {
                 panic!("Leftover arg: {}", arg);
             }
             // The callee-save parameters should not appear until after register allocation is
@@ -587,9 +609,20 @@ fn convert_to_abi<PutArg>(
 
 /// Check if a sequence of arguments match a desired sequence of argument types.
 fn check_arg_types(dfg: &DataFlowGraph, args: &[Value], types: &[AbiParam]) -> bool {
-    let arg_types = args.iter().map(|&v| dfg.value_type(v));
-    let sig_types = types.iter().map(|&at| at.value_type);
-    arg_types.eq(sig_types)
+    let mut args = args.iter();
+    let mut types = types.iter();
+    loop {
+        match (args.next(), types.next()) {
+            (Some(&v), Some(at)) => {
+                if let ArgumentPurpose::StructArgument(_) = at.purpose {
+                } else if dfg.value_type(v) != at.value_type {
+                    return false;
+                }
+            }
+            (Some(_), None) | (None, Some(_)) => return false,
+            (None, None) => return true,
+        }
+    }
 }
 
 /// Check if the arguments of the call `inst` match the signature.
@@ -699,7 +732,12 @@ fn legalize_inst_arguments<ArgType>(
             .unwrap();
         let mut put_arg = |func: &mut Function, arg| {
             let abi_type = get_abi_type(func, abi_arg);
-            if func.dfg.value_type(arg) == abi_type.value_type {
+            let struct_argument = if let ArgumentPurpose::StructArgument(_) = abi_type.purpose {
+                true
+            } else {
+                false
+            };
+            if func.dfg.value_type(arg) == abi_type.value_type || struct_argument {
                 // This is the argument type we need.
                 vlist.as_mut_slice(&mut func.dfg.value_lists)[num_fixed_values + abi_arg] = arg;
                 abi_arg += 1;
@@ -762,7 +800,7 @@ pub fn handle_call_abi(
 
     // Start by checking if the argument types already match the signature.
     let sig_ref = match check_call_signature(&pos.func.dfg, inst) {
-        Ok(_) => return spill_call_arguments(pos),
+        Ok(_) => return spill_call_arguments(pos, isa),
         Err(s) => s,
     };
 
@@ -800,7 +838,7 @@ pub fn handle_call_abi(
 
     // Go back and insert spills for any stack arguments.
     pos.goto_inst(inst);
-    spill_call_arguments(pos);
+    spill_call_arguments(pos, isa);
 
     // Yes, we changed stuff.
     true
@@ -990,7 +1028,8 @@ fn spill_entry_params(func: &mut Function, entry: Block) {
         .iter()
         .zip(func.dfg.block_params(entry))
     {
-        if let ArgumentLoc::Stack(offset) = abi.location {
+        if let ArgumentPurpose::StructArgument(_) = abi.purpose {
+        } else if let ArgumentLoc::Stack(offset) = abi.location {
             let ss = func.stack_slots.make_incoming_arg(abi.value_type, offset);
             func.locations[arg] = ValueLoc::Stack(ss);
         }
@@ -1005,7 +1044,7 @@ fn spill_entry_params(func: &mut Function, entry: Block) {
 /// TODO: The outgoing stack slots can be written a bit earlier, as long as there are no branches
 /// or calls between writing the stack slots and the call instruction. Writing the slots earlier
 /// could help reduce register pressure before the call.
-fn spill_call_arguments(pos: &mut FuncCursor) -> bool {
+fn spill_call_arguments(pos: &mut FuncCursor, isa: &dyn TargetIsa) -> bool {
     let inst = pos
         .current_inst()
         .expect("Cursor must point to a call instruction");
@@ -1032,9 +1071,15 @@ fn spill_call_arguments(pos: &mut FuncCursor) -> bool {
                         // Assign `arg` to a new stack slot, unless it's already in the correct
                         // slot. The legalization needs to be idempotent, so we should see a
                         // correct outgoing slot on the second pass.
-                        let ss = stack_slots.get_outgoing_arg(abi.value_type, offset);
+                        let (ss, size) = match abi.purpose {
+                            ArgumentPurpose::StructArgument(size) => (
+                                stack_slots.get_outgoing_struct_arg(size, offset),
+                                Some(size),
+                            ),
+                            _ => (stack_slots.get_outgoing_arg(abi.value_type, offset), None),
+                        };
                         if locations[arg] != ValueLoc::Stack(ss) {
-                            Some((idx, arg, ss))
+                            Some((idx, arg, ss, size))
                         } else {
                             None
                         }
@@ -1050,8 +1095,34 @@ fn spill_call_arguments(pos: &mut FuncCursor) -> bool {
     }
 
     // Insert the spill instructions and rewrite call arguments.
-    for (idx, arg, ss) in arglist {
-        let stack_val = pos.ins().spill(arg);
+    for (idx, arg, ss, size) in arglist {
+        let stack_val = if let Some(size) = size {
+            // Struct argument
+            let pointer_type = pos.func.dfg.value_type(arg);
+            let src = arg;
+            let dest = pos.ins().stack_addr(pointer_type, ss, 0);
+            let size = pos.ins().iconst(pointer_type, i64::from(size));
+            let signature = {
+                let mut s = Signature::new(isa.default_call_conv());
+                s.params.push(AbiParam::new(pointer_type));
+                s.params.push(AbiParam::new(pointer_type));
+                s.params.push(AbiParam::new(pointer_type));
+                legalize_libcall_signature(&mut s, isa);
+                pos.func.import_signature(s)
+            };
+
+            let libc_memcpy = pos.func.import_function(ExtFuncData {
+                name: ExternalName::LibCall(LibCall::Memcpy),
+                signature,
+                colocated: false,
+            });
+
+            pos.ins().call(libc_memcpy, &[dest, src, size]);
+            pos.ins().dummy_sarg__()
+        } else {
+            // Non struct argument
+            pos.ins().spill(arg)
+        };
         pos.func.locations[stack_val] = ValueLoc::Stack(ss);
         pos.func.dfg.inst_variable_args_mut(inst)[idx] = stack_val;
     }

--- a/cranelift/codegen/src/legalizer/boundary.rs
+++ b/cranelift/codegen/src/legalizer/boundary.rs
@@ -127,7 +127,7 @@ fn legalize_entry_params(func: &mut Function, entry: Block) {
                 let dummy = pos
                     .func
                     .dfg
-                    .append_block_param(entry, crate::ir::types::SARG__);
+                    .append_block_param(entry, crate::ir::types::SARG_T);
                 pos.func.locations[dummy] = ValueLoc::Stack(ss);
                 abi_arg += 1;
                 continue;
@@ -1127,7 +1127,7 @@ fn spill_call_arguments(pos: &mut FuncCursor, isa: &dyn TargetIsa) -> bool {
 
             let libc_memcpy = import_memcpy(pos.func, pointer_type);
             pos.ins().call(libc_memcpy, &[dest, src, size]);
-            pos.ins().dummy_sarg__()
+            pos.ins().dummy_sarg_t()
         } else {
             // Non struct argument
             pos.ins().spill(arg)

--- a/cranelift/codegen/src/stack_layout.rs
+++ b/cranelift/codegen/src/stack_layout.rs
@@ -152,8 +152,8 @@ mod tests {
         assert_eq!(layout_stack(sss, is_leaf, 16), Ok(0));
 
         // Same for incoming arguments with non-negative offsets.
-        let in0 = sss.make_incoming_arg(types::I64, 0);
-        let in1 = sss.make_incoming_arg(types::I64, 8);
+        let in0 = sss.make_incoming_arg(8, 0);
+        let in1 = sss.make_incoming_arg(8, 8);
 
         assert_eq!(layout_stack(sss, is_leaf, 1), Ok(0));
         assert_eq!(layout_stack(sss, is_leaf, 16), Ok(0));
@@ -178,7 +178,7 @@ mod tests {
 
         // An incoming argument with negative offset counts towards the total frame size, but it
         // should still pack nicely with the spill slots.
-        let in2 = sss.make_incoming_arg(types::I32, -4);
+        let in2 = sss.make_incoming_arg(4, -4);
 
         assert_eq!(layout_stack(sss, is_leaf, 1), Ok(16));
         assert_eq!(sss[in0].offset, Some(0));
@@ -195,7 +195,7 @@ mod tests {
         assert_eq!(sss[ss1].offset, Some(-8));
 
         // Finally, make sure there is room for the outgoing args.
-        let out0 = sss.get_outgoing_arg(types::I32, 0);
+        let out0 = sss.get_outgoing_arg(4, 0);
 
         assert_eq!(layout_stack(sss, is_leaf, 1), Ok(20));
         assert_eq!(sss[in0].offset, Some(0));
@@ -214,7 +214,7 @@ mod tests {
         assert_eq!(sss[out0].offset, Some(0));
 
         // Also test that an unsupported offset is rejected.
-        sss.get_outgoing_arg(types::I8, StackOffset::max_value() - 1);
+        sss.get_outgoing_arg(1, StackOffset::max_value() - 1);
         assert_eq!(
             layout_stack(sss, is_leaf, 1),
             Err(CodegenError::ImplLimitExceeded)

--- a/cranelift/filetests/filetests/isa/x86/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x86/struct-arg.clif
@@ -23,7 +23,29 @@ block0(v0: i64):
 ; nextln:  [Op1ret#c3]                         return v1, v6
 ; nextln:  }
 
-function u0:1(i64) -> i8 system_v {
+function u0:1(i64, i64 sarg(64)) -> i8 system_v {
+block0(v0: i64, v1: i64):
+    v2 = load.i8 v1
+    return v2
+}
+
+; check: function u0:1(i64 [%rdi], sarg_t sarg(64) [0], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
+; nextln:      ss0 = incoming_arg 64, offset 0
+; nextln:      ss1 = incoming_arg 16, offset -16
+
+; check:                                  block0(v0: i64 [%rdi], v4: sarg_t [ss0], v6: i64 [%rbp]):
+; nextln: [RexOp1pushq#50]                    x86_push v6
+; nextln: [RexOp1copysp#8089]                 copy_special %rsp -> %rbp
+; nextln: [RexOp1spaddr_id#808d,%rax]         v3 = stack_addr.i64 ss0
+; nextln:                                     v1 -> v3
+; nextln: [RexOp2ld#4b6,%rax]                 v5 = uload8.i32 v3
+; nextln: [null#00,%rax]                      v2 = ireduce.i8 v5
+; nextln: [RexOp1popq#58,%rbp]                v7 = x86_pop.i64
+; nextln: [Op1ret#c3]                         return v2, v7
+; nextln: }
+
+
+function u0:2(i64) -> i8 system_v {
 fn1 = u0:0(i64 sarg(64)) -> i8 system_v
 
 block0(v0: i64):
@@ -31,7 +53,7 @@ block0(v0: i64):
     return v1
 }
 
-; check: function u0:1(i64 [%rdi], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
+; check: function u0:2(i64 [%rdi], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
 ; nextln:     ss0 = outgoing_arg 64, offset 0
 ; nextln:     ss1 = incoming_arg 16, offset -16
 ; nextln:     sig0 = (sarg_t sarg(64) [0]) -> i8 [%rax] system_v
@@ -54,4 +76,42 @@ block0(v0: i64):
 ; nextln: [RexOp1adjustsp_ib#8083]            adjust_sp_up_imm 64
 ; nextln: [RexOp1popq#58,%rbp]                v6 = x86_pop.i64
 ; nextln: [Op1ret#c3]                         return v1, v6
+; nextln: }
+
+function u0:3(i64, i64) -> i8 system_v {
+fn1 = u0:0(i64, i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64, v1: i64):
+    v2 = call fn1(v0, v1)
+    return v2
+}
+
+; check: function u0:3(i64 [%rdi], i64 [%rsi], i64 fp [%rbp], i64 csr [%r15]) -> i8 [%rax], i64 fp [%rbp], i64 csr [%r15] system_v {
+; nextln:     ss0 = outgoing_arg 64, offset 0
+; nextln:     ss1 = spill_slot 8, offset -32
+; nextln:     ss2 = incoming_arg 24, offset -24
+; nextln:     sig0 = (i64 [%rdi], sarg_t sarg(64) [0]) -> i8 [%rax] system_v
+; nextln:     sig1 = (i64 [%rdi], i64 [%rsi], i64 [%rdx]) system_v
+; nextln:     fn1 = u0:0 sig0
+; nextln:     fn2 = %Memcpy sig1
+
+; check:                                  block0(v6: i64 [%rdi], v1: i64 [%rsi], v8: i64 [%rbp], v9: i64 [%r15]):
+; nextln: [RexOp1pushq#50]                    x86_push v8
+; nextln: [RexOp1copysp#8089]                 copy_special %rsp -> %rbp
+; nextln: [RexOp1pushq#50]                    x86_push v9
+; nextln: [RexOp1adjustsp_ib#d083]            adjust_sp_down_imm 72
+; nextln: [RexOp1spillSib32#8089,ss1]         v0 = spill v6
+; nextln: [RexOp1spaddr_id#808d,%rax]         v3 = stack_addr.i64 ss0
+; nextln: [RexOp1pu_id#b8,%rcx]               v4 = iconst.i64 64
+; nextln: [RexOp1rmov#8089]                   regmove v3, %rax -> %rdi
+; nextln: [RexOp1rmov#8089]                   regmove v4, %rcx -> %rdx
+; nextln: [Op1call_plt_id#e8]                 call fn2(v3, v1, v4)
+; nextln: [dummy_sarg_t#00,ss0]               v5 = dummy_sarg_t
+; nextln: [RexOp1fillSib32#808b,%r15]         v7 = fill v0
+; nextln: [RexOp1rmov#8089]                   regmove v7, %r15 -> %rdi
+; nextln: [Op1call_plt_id#e8,%rax]            v2 = call fn1(v7, v5)
+; nextln: [RexOp1adjustsp_ib#8083]            adjust_sp_up_imm 72
+; nextln: [RexOp1popq#58,%r15]                v11 = x86_pop.i64
+; nextln: [RexOp1popq#58,%rbp]                v10 = x86_pop.i64
+; nextln: [Op1ret#c3]                         return v2, v10, v11
 ; nextln: }

--- a/cranelift/filetests/filetests/isa/x86/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x86/struct-arg.clif
@@ -1,0 +1,57 @@
+test compile
+set is_pic
+target x86_64
+
+function u0:0(i64 sarg(64)) -> i8 system_v {
+block0(v0: i64):
+    v1 = load.i8 v0
+    return v1
+}
+
+; check: function u0:0(sarg__ sarg(64) [0], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
+; nextln:      ss0 = incoming_arg 64, offset 0
+; nextln:      ss1 = incoming_arg 16, offset -16
+
+; check:                                  block0(v3: sarg__ [ss0], v5: i64 [%rbp]):
+; nextln:  [RexOp1pushq#50]                    x86_push v5
+; nextln:  [RexOp1copysp#8089]                 copy_special %rsp -> %rbp
+; nextln:  [RexOp1spaddr_id#808d,%rax]         v2 = stack_addr.i64 ss0
+; nextln:                                      v0 -> v2
+; nextln:  [RexOp2ld#4b6,%rax]                 v4 = uload8.i32 v2
+; nextln:  [null#00,%rax]                      v1 = ireduce.i8 v4
+; nextln:  [RexOp1popq#58,%rbp]                v6 = x86_pop.i64
+; nextln:  [Op1ret#c3]                         return v1, v6
+; nextln:  }
+
+function u0:1(i64) -> i8 system_v {
+fn1 = u0:0(i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64):
+    v1 = call fn1(v0)
+    return v1
+}
+
+; check: function u0:1(i64 [%rdi], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
+; nextln:     ss0 = outgoing_arg 64, offset 0
+; nextln:     ss1 = incoming_arg 16, offset -16
+; nextln:     sig0 = (sarg__ sarg(64) [0]) -> i8 [%rax] system_v
+; nextln:     sig1 = (i64 [%rdi], i64 [%rsi], i64 [%rdx]) system_v
+; nextln:     fn1 = u0:0 sig0
+; nextln:     fn2 = %Memcpy sig1
+
+; check:                                 block0(v0: i64 [%rdi], v5: i64 [%rbp]):
+; nextln: [RexOp1pushq#50]                    x86_push v5
+; nextln: [RexOp1copysp#8089]                 copy_special %rsp -> %rbp
+; nextln: [RexOp1adjustsp_ib#d083]            adjust_sp_down_imm 64
+; nextln: [RexOp1spaddr_id#808d,%rax]         v2 = stack_addr.i64 ss0
+; nextln: [RexOp1pu_id#b8,%rcx]               v3 = iconst.i64 64
+; nextln: [RexOp1rmov#8089]                   regmove v0, %rdi -> %rsi
+; nextln: [RexOp1rmov#8089]                   regmove v2, %rax -> %rdi
+; nextln: [RexOp1rmov#8089]                   regmove v3, %rcx -> %rdx
+; nextln: [Op1call_plt_id#e8]                 call fn2(v2, v0, v3)
+; nextln: [dummy_sarg__#00,ss0]               v4 = dummy_sarg__
+; nextln: [Op1call_plt_id#e8,%rax]            v1 = call fn1(v4)
+; nextln: [RexOp1adjustsp_ib#8083]            adjust_sp_up_imm 64
+; nextln: [RexOp1popq#58,%rbp]                v6 = x86_pop.i64
+; nextln: [Op1ret#c3]                         return v1, v6
+; nextln: }

--- a/cranelift/filetests/filetests/isa/x86/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x86/struct-arg.clif
@@ -8,11 +8,11 @@ block0(v0: i64):
     return v1
 }
 
-; check: function u0:0(sarg__ sarg(64) [0], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
+; check: function u0:0(sarg_t sarg(64) [0], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
 ; nextln:      ss0 = incoming_arg 64, offset 0
 ; nextln:      ss1 = incoming_arg 16, offset -16
 
-; check:                                  block0(v3: sarg__ [ss0], v5: i64 [%rbp]):
+; check:                                  block0(v3: sarg_t [ss0], v5: i64 [%rbp]):
 ; nextln:  [RexOp1pushq#50]                    x86_push v5
 ; nextln:  [RexOp1copysp#8089]                 copy_special %rsp -> %rbp
 ; nextln:  [RexOp1spaddr_id#808d,%rax]         v2 = stack_addr.i64 ss0
@@ -34,7 +34,7 @@ block0(v0: i64):
 ; check: function u0:1(i64 [%rdi], i64 fp [%rbp]) -> i8 [%rax], i64 fp [%rbp] system_v {
 ; nextln:     ss0 = outgoing_arg 64, offset 0
 ; nextln:     ss1 = incoming_arg 16, offset -16
-; nextln:     sig0 = (sarg__ sarg(64) [0]) -> i8 [%rax] system_v
+; nextln:     sig0 = (sarg_t sarg(64) [0]) -> i8 [%rax] system_v
 ; nextln:     sig1 = (i64 [%rdi], i64 [%rsi], i64 [%rdx]) system_v
 ; nextln:     fn1 = u0:0 sig0
 ; nextln:     fn2 = %Memcpy sig1
@@ -49,7 +49,7 @@ block0(v0: i64):
 ; nextln: [RexOp1rmov#8089]                   regmove v2, %rax -> %rdi
 ; nextln: [RexOp1rmov#8089]                   regmove v3, %rcx -> %rdx
 ; nextln: [Op1call_plt_id#e8]                 call fn2(v2, v0, v3)
-; nextln: [dummy_sarg__#00,ss0]               v4 = dummy_sarg__
+; nextln: [dummy_sarg_t#00,ss0]               v4 = dummy_sarg_t
 ; nextln: [Op1call_plt_id#e8,%rax]            v1 = call fn1(v4)
 ; nextln: [RexOp1adjustsp_ib#8083]            adjust_sp_up_imm 64
 ; nextln: [RexOp1popq#58,%rbp]                v6 = x86_pop.i64

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -329,6 +329,7 @@ impl<'a> Lexer<'a> {
                 .unwrap_or_else(|| match text {
                     "iflags" => Token::Type(types::IFLAGS),
                     "fflags" => Token::Type(types::FFLAGS),
+                    "sarg__" => Token::Type(types::SARG__),
                     _ => Token::Identifier(text),
                 }),
             loc,
@@ -620,7 +621,7 @@ mod tests {
         let mut lex = Lexer::new(
             "v0 v00 vx01 block1234567890 block5234567890 v1x vx1 vxvx4 \
              function0 function b1 i32x4 f32x5 \
-             iflags fflags iflagss",
+             iflags fflags sarg__ iflagss",
         );
         assert_eq!(
             lex.next(),
@@ -643,6 +644,7 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Identifier("f32x5"), 1));
         assert_eq!(lex.next(), token(Token::Type(types::IFLAGS), 1));
         assert_eq!(lex.next(), token(Token::Type(types::FFLAGS), 1));
+        assert_eq!(lex.next(), token(Token::Type(types::SARG__), 1));
         assert_eq!(lex.next(), token(Token::Identifier("iflagss"), 1));
         assert_eq!(lex.next(), None);
     }

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -329,7 +329,7 @@ impl<'a> Lexer<'a> {
                 .unwrap_or_else(|| match text {
                     "iflags" => Token::Type(types::IFLAGS),
                     "fflags" => Token::Type(types::FFLAGS),
-                    "sarg__" => Token::Type(types::SARG__),
+                    "sarg_t" => Token::Type(types::SARG_T),
                     _ => Token::Identifier(text),
                 }),
             loc,
@@ -621,7 +621,7 @@ mod tests {
         let mut lex = Lexer::new(
             "v0 v00 vx01 block1234567890 block5234567890 v1x vx1 vxvx4 \
              function0 function b1 i32x4 f32x5 \
-             iflags fflags sarg__ iflagss",
+             iflags fflags sarg_t iflagss",
         );
         assert_eq!(
             lex.next(),
@@ -644,7 +644,7 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Identifier("f32x5"), 1));
         assert_eq!(lex.next(), token(Token::Type(types::IFLAGS), 1));
         assert_eq!(lex.next(), token(Token::Type(types::FFLAGS), 1));
-        assert_eq!(lex.next(), token(Token::Type(types::SARG__), 1));
+        assert_eq!(lex.next(), token(Token::Type(types::SARG_T), 1));
         assert_eq!(lex.next(), token(Token::Identifier("iflagss"), 1));
         assert_eq!(lex.next(), None);
     }

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -15,10 +15,10 @@ use cranelift_codegen::ir::instructions::{InstructionData, InstructionFormat, Va
 use cranelift_codegen::ir::types::INVALID;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{
-    AbiParam, ArgumentExtension, ArgumentLoc, Block, Constant, ConstantData, ExtFuncData,
-    ExternalName, FuncRef, Function, GlobalValue, GlobalValueData, Heap, HeapData, HeapStyle,
-    JumpTable, JumpTableData, MemFlags, Opcode, SigRef, Signature, StackSlot, StackSlotData,
-    StackSlotKind, Table, TableData, Type, Value, ValueLoc,
+    AbiParam, ArgumentExtension, ArgumentLoc, ArgumentPurpose, Block, Constant, ConstantData,
+    ExtFuncData, ExternalName, FuncRef, Function, GlobalValue, GlobalValueData, Heap, HeapData,
+    HeapStyle, JumpTable, JumpTableData, MemFlags, Opcode, SigRef, Signature, StackSlot,
+    StackSlotData, StackSlotKind, Table, TableData, Type, Value, ValueLoc,
 };
 use cranelift_codegen::isa::{self, CallConv, Encoding, RegUnit, TargetIsa};
 use cranelift_codegen::packed_option::ReservedValue;
@@ -1423,6 +1423,14 @@ impl<'a> Parser<'a> {
             match s {
                 "uext" => arg.extension = ArgumentExtension::Uext,
                 "sext" => arg.extension = ArgumentExtension::Sext,
+                "sarg" => {
+                    self.consume();
+                    self.match_token(Token::LPar, "expected '(' to begin sarg size")?;
+                    let size = self.match_uimm32("expected byte-size in sarg decl")?;
+                    self.match_token(Token::RPar, "expected ')' to end sarg size")?;
+                    arg.purpose = ArgumentPurpose::StructArgument(size.into());
+                    continue;
+                }
                 _ => {
                     if let Ok(purpose) = s.parse() {
                         arg.purpose = purpose;


### PR DESCRIPTION
According to the SystemV abi, struct arguments must be passed at a fixed stack offset. Cranelift didn't have any way to implement this before. This is necessary to compile proc-macros using cg_clif: https://github.com/bjorn3/rustc_codegen_cranelift/issues/905#issuecomment-616173297

Fixes #1108

# TODO

* [x] Don't misuse `INVALID`, but introduce a proper type.
* [x] Implement this correctly for WindowsFastcall or give an error.