### PR TITLE
Fix return value of `Func::param_arity`

### DIFF
--- a/crates/api/src/func.rs
+++ b/crates/api/src/func.rs
@@ -502,7 +502,7 @@ impl Func {
             .signatures()
             .lookup(self.export.signature)
             .expect("failed to lookup signature");
-        sig.params.len()
+        sig.params.len() - 2 // skip the two vmctx leading parameters
     }
 
     /// Returns the number of results this function produces.

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -74,7 +74,9 @@ fn signatures_match() {
 
     let f = Func::wrap(&store, || {});
     assert_eq!(f.ty().params(), &[]);
+    assert_eq!(f.param_arity(), 0);
     assert_eq!(f.ty().results(), &[]);
+    assert_eq!(f.result_arity(), 0);
 
     let f = Func::wrap(&store, || -> i32 { loop {} });
     assert_eq!(f.ty().params(), &[]);


### PR DESCRIPTION
Accidentally forgot to subtract 2 to account for the two vmctx
parameters, so let's add a test here nad adjust it appropriately.
