### PR TITLE
Fix aarch64 load trap info: HeapOutOfBounds, not OutOfBounds.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -607,7 +607,7 @@ impl<O: MachSectionOutput> MachInstEmit<O> for Inst {
 
                 if let Some(srcloc) = srcloc {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(srcloc, TrapCode::OutOfBounds);
+                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
                 }
 
                 match &mem {
@@ -741,7 +741,7 @@ impl<O: MachSectionOutput> MachInstEmit<O> for Inst {
 
                 if let Some(srcloc) = srcloc {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(srcloc, TrapCode::OutOfBounds);
+                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
                 }
 
                 match &mem {


### PR DESCRIPTION
This halfway solves a test failure: when temporarily disabling another
assert that is triggered by lack of debug info, this causes the
`custom_trap_handler` test to pass.

Validated that the `HeapOutOfBounds` trapcode is passed to the `TrapSink` by the x86 backend's lowering of memory accesses as well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
