### PR TITLE
Fix value label ranges resolution

### DIFF
--- a/cranelift/codegen/src/value_label.rs
+++ b/cranelift/codegen/src/value_label.rs
@@ -18,9 +18,9 @@ use serde::{Deserialize, Serialize};
 pub struct ValueLocRange {
     /// The ValueLoc containing a ValueLabel during this range.
     pub loc: ValueLoc,
-    /// The start of the range.
+    /// The start of the range. It is an offset in the generated code.
     pub start: u32,
-    /// The end of the range.
+    /// The end of the range. It is an offset in the generated code.
     pub end: u32,
 }
 

--- a/crates/debug/src/transform/address_transform.rs
+++ b/crates/debug/src/transform/address_transform.rs
@@ -597,20 +597,6 @@ impl AddressTransform {
         let map = &self.map[index];
         (map.wasm_start, map.wasm_end)
     }
-
-    pub fn convert_to_code_range(
-        &self,
-        addr: write::Address,
-        len: u64,
-    ) -> (GeneratedAddress, GeneratedAddress) {
-        let start = if let write::Address::Symbol { addend, .. } = addr {
-            // TODO subtract self.map[symbol].offset ?
-            addend as GeneratedAddress
-        } else {
-            unreachable!();
-        };
-        (start, start + len as GeneratedAddress)
-    }
 }
 
 #[cfg(test)]

--- a/crates/debug/src/transform/attr.rs
+++ b/crates/debug/src/transform/attr.rs
@@ -51,8 +51,6 @@ pub(crate) fn clone_die_attributes<'a, R>(
 where
     R: Reader,
 {
-    let _tag = &entry.tag();
-    let endian = gimli::RunTimeEndian::Little;
     let unit_encoding = unit.encoding();
 
     let range_info = if let Some(subprogram_range_builder) = subprogram_range_builder {
@@ -161,7 +159,6 @@ where
                             &[(loc.range.begin, loc.range.end)],
                             addr_tr,
                             frame_info,
-                            endian,
                             isa,
                         )? {
                             if len == 0 {
@@ -202,13 +199,8 @@ where
                     } else {
                         // Conversion to loclist is required.
                         if let Some(scope_ranges) = scope_ranges {
-                            let exprs = expr.build_with_locals(
-                                scope_ranges,
-                                addr_tr,
-                                frame_info,
-                                endian,
-                                isa,
-                            )?;
+                            let exprs =
+                                expr.build_with_locals(scope_ranges, addr_tr, frame_info, isa)?;
                             if exprs.is_empty() {
                                 continue;
                             }

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -267,13 +267,9 @@ impl CompiledExpression {
         // the scope ranges.
         if let [CompiledExpressionPart::Code(code)] = self.parts.as_slice() {
             return BuildWithLocalsResult::Simple(
-                Box::new(
-                    scope
-                        .iter()
-                        .flat_map(move |(wasm_start, wasm_end)| {
-                            addr_tr.translate_ranges(*wasm_start, *wasm_end)
-                        })
-                ),
+                Box::new(scope.iter().flat_map(move |(wasm_start, wasm_end)| {
+                    addr_tr.translate_ranges(*wasm_start, *wasm_end)
+                })),
                 code.clone(),
             );
         }

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -270,10 +270,9 @@ impl CompiledExpression {
                 Box::new(
                     scope
                         .iter()
-                        .map(move |(wasm_start, wasm_end)| {
+                        .flat_map(move |(wasm_start, wasm_end)| {
                             addr_tr.translate_ranges(*wasm_start, *wasm_end)
                         })
-                        .flatten(),
                 ),
                 code.clone(),
             );
@@ -560,7 +559,7 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
             let j = match ranges.binary_search_by(|s| s.start.cmp(&range_end)) {
                 Ok(i) | Err(i) => i,
             };
-            // Starting for the end, intersect (range_start..range_end) with
+            // Starting from the end, intersect (range_start..range_end) with
             // self.ranges array.
             for i in (i..j).rev() {
                 if range_end <= ranges[i].start || ranges[i].end <= range_start {

--- a/crates/debug/src/transform/simulate.rs
+++ b/crates/debug/src/transform/simulate.rs
@@ -230,10 +230,10 @@ fn generate_vars(
             let loc_list_id = {
                 let endian = gimli::RunTimeEndian::Little;
 
-                let expr = CompiledExpression::from_label(*label, isa);
+                let expr = CompiledExpression::from_label(*label);
                 let mut locs = Vec::new();
                 for (begin, length, data) in
-                    expr.build_with_locals(scope_ranges, addr_tr, Some(frame_info), endian)?
+                    expr.build_with_locals(scope_ranges, addr_tr, Some(frame_info), endian, isa)?
                 {
                     locs.push(write::Location::StartLength {
                         begin,

--- a/crates/debug/src/transform/simulate.rs
+++ b/crates/debug/src/transform/simulate.rs
@@ -228,12 +228,10 @@ fn generate_vars(
                 };
 
             let loc_list_id = {
-                let endian = gimli::RunTimeEndian::Little;
-
                 let expr = CompiledExpression::from_label(*label);
                 let mut locs = Vec::new();
                 for (begin, length, data) in
-                    expr.build_with_locals(scope_ranges, addr_tr, Some(frame_info), endian, isa)?
+                    expr.build_with_locals(scope_ranges, addr_tr, Some(frame_info), isa)?
                 {
                     locs.push(write::Location::StartLength {
                         begin,

--- a/crates/debug/src/transform/simulate.rs
+++ b/crates/debug/src/transform/simulate.rs
@@ -228,17 +228,16 @@ fn generate_vars(
                 };
 
             let loc_list_id = {
-                let expr = CompiledExpression::from_label(*label);
-                let mut locs = Vec::new();
-                for (begin, length, data) in
-                    expr.build_with_locals(scope_ranges, addr_tr, Some(frame_info), isa)?
-                {
-                    locs.push(write::Location::StartLength {
-                        begin,
-                        length,
-                        data,
-                    });
-                }
+                let locs = CompiledExpression::from_label(*label)
+                    .build_with_locals(scope_ranges, addr_tr, Some(frame_info), isa)
+                    .map(|i| {
+                        i.map(|(begin, length, data)| write::Location::StartLength {
+                            begin,
+                            length,
+                            data,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
                 unit.locations.add(write::LocationList(locs))
             };
 

--- a/crates/debug/src/transform/unit.rs
+++ b/crates/debug/src/transform/unit.rs
@@ -432,7 +432,11 @@ where
             out_strings,
             &mut pending_die_refs,
             &mut pending_di_refs,
-            FileAttributeContext::Children(&file_map, file_index_base, current_frame_base.top()),
+            FileAttributeContext::Children {
+                file_map: &file_map,
+                file_index_base,
+                frame_base: current_frame_base.top(),
+            },
             isa,
         )?;
 

--- a/crates/debug/src/transform/unit.rs
+++ b/crates/debug/src/transform/unit.rs
@@ -386,7 +386,7 @@ where
         }
 
         if let Some(AttributeValue::Exprloc(expr)) = entry.attr_value(gimli::DW_AT_frame_base)? {
-            if let Some(expr) = compile_expression(&expr, unit.encoding(), None, isa)? {
+            if let Some(expr) = compile_expression(&expr, unit.encoding(), None)? {
                 current_frame_base.push(new_stack_len, expr);
             }
         }

--- a/crates/debug/src/transform/utils.rs
+++ b/crates/debug/src/transform/utils.rs
@@ -135,16 +135,16 @@ pub(crate) fn append_vmctx_info(
 ) -> Result<(), Error> {
     let loc = {
         let expr = CompiledExpression::vmctx();
-        let mut locs = Vec::new();
-        for (begin, length, data) in
-            expr.build_with_locals(scope_ranges, addr_tr, frame_info, isa)?
-        {
-            locs.push(write::Location::StartLength {
-                begin,
-                length,
-                data,
-            });
-        }
+        let locs = expr
+            .build_with_locals(scope_ranges, addr_tr, frame_info, isa)
+            .map(|i| {
+                i.map(|(begin, length, data)| write::Location::StartLength {
+                    begin,
+                    length,
+                    data,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         let list_id = comp_unit.locations.add(write::LocationList(locs));
         write::AttributeValue::LocationListRef(list_id)
     };

--- a/crates/debug/src/transform/utils.rs
+++ b/crates/debug/src/transform/utils.rs
@@ -136,10 +136,10 @@ pub(crate) fn append_vmctx_info(
     let loc = {
         let endian = gimli::RunTimeEndian::Little;
 
-        let expr = CompiledExpression::vmctx(isa);
+        let expr = CompiledExpression::vmctx();
         let mut locs = Vec::new();
         for (begin, length, data) in
-            expr.build_with_locals(scope_ranges, addr_tr, frame_info, endian)?
+            expr.build_with_locals(scope_ranges, addr_tr, frame_info, endian, isa)?
         {
             locs.push(write::Location::StartLength {
                 begin,

--- a/crates/debug/src/transform/utils.rs
+++ b/crates/debug/src/transform/utils.rs
@@ -134,12 +134,10 @@ pub(crate) fn append_vmctx_info(
     isa: &dyn TargetIsa,
 ) -> Result<(), Error> {
     let loc = {
-        let endian = gimli::RunTimeEndian::Little;
-
         let expr = CompiledExpression::vmctx();
         let mut locs = Vec::new();
         for (begin, length, data) in
-            expr.build_with_locals(scope_ranges, addr_tr, frame_info, endian, isa)?
+            expr.build_with_locals(scope_ranges, addr_tr, frame_info, isa)?
         {
             locs.push(write::Location::StartLength {
                 begin,

--- a/crates/environ/src/data_structures.rs
+++ b/crates/environ/src/data_structures.rs
@@ -5,7 +5,7 @@ pub mod ir {
         types, AbiParam, ArgumentPurpose, Signature, SourceLoc, StackSlots, TrapCode, Type,
         ValueLabel, ValueLoc,
     };
-    pub use cranelift_codegen::ValueLabelsRanges;
+    pub use cranelift_codegen::{ValueLabelsRanges, ValueLocRange};
 }
 
 pub mod settings {


### PR DESCRIPTION
There was a bug how value labels were resolved, which caused some DWARF expressions not be transformed, e.g. those are in the registers.

* Implements FIXME in expression.rs
* Move `TargetIsa` from `CompiledExpression` structure
* Fix expression format for GDB
* Add tests for parsing
* Proper logic in `ValueLabelRangesBuilder::process_label`
* Tests for `ValueLabelRangesBuilder`
* Refactor `build_with_locals` to return `Iterator` instead of `Vec<_>`
* Misc comments and magical numbers
