### PR TITLE
wiggle-generate: paramaterize library on module path to runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ dependencies = [
 name = "wiggle-macro"
 version = "0.15.0"
 dependencies = [
+ "quote",
  "syn",
  "wiggle",
  "wiggle-generate",

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -12,7 +12,6 @@ use syn::{
 pub struct Config {
     pub witx: WitxConf,
     pub ctx: CtxConf,
-    pub emit_metadata: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -60,7 +59,6 @@ impl Config {
             ctx: ctx
                 .take()
                 .ok_or_else(|| Error::new(err_loc, "`ctx` field required"))?,
-            emit_metadata: false,
         })
     }
 }

--- a/crates/wiggle/generate/src/types/handle.rs
+++ b/crates/wiggle/generate/src/types/handle.rs
@@ -9,6 +9,7 @@ pub(super) fn define_handle(
     name: &witx::Id,
     h: &witx::HandleDatatype,
 ) -> TokenStream {
+    let rt = names.runtime_mod();
     let ident = names.type_(name);
     let size = h.mem_size_align().size as u32;
     let align = h.mem_size_align().align as usize;
@@ -52,7 +53,7 @@ pub(super) fn define_handle(
             }
         }
 
-        impl<'a> wiggle::GuestType<'a> for #ident {
+        impl<'a> #rt::GuestType<'a> for #ident {
             fn guest_size() -> u32 {
                 #size
             }
@@ -61,18 +62,18 @@ pub(super) fn define_handle(
                 #align
             }
 
-            fn read(location: &wiggle::GuestPtr<'a, #ident>) -> Result<#ident, wiggle::GuestError> {
+            fn read(location: &#rt::GuestPtr<'a, #ident>) -> Result<#ident, #rt::GuestError> {
                 Ok(#ident(u32::read(&location.cast())?))
             }
 
-            fn write(location: &wiggle::GuestPtr<'_, Self>, val: Self) -> Result<(), wiggle::GuestError> {
+            fn write(location: &#rt::GuestPtr<'_, Self>, val: Self) -> Result<(), #rt::GuestError> {
                 u32::write(&location.cast(), val.0)
             }
         }
 
-        unsafe impl<'a> wiggle::GuestTypeTransparent<'a> for #ident {
+        unsafe impl<'a> #rt::GuestTypeTransparent<'a> for #ident {
             #[inline]
-            fn validate(_location: *mut #ident) -> Result<(), wiggle::GuestError> {
+            fn validate(_location: *mut #ident) -> Result<(), #rt::GuestError> {
                 // All bit patterns accepted
                 Ok(())
             }

--- a/crates/wiggle/generate/src/types/mod.rs
+++ b/crates/wiggle/generate/src/types/mod.rs
@@ -23,10 +23,12 @@ pub fn define_datatype(names: &Names, namedtype: &witx::NamedType) -> TokenStrea
             witx::Type::Handle(h) => handle::define_handle(names, &namedtype.name, &h),
             witx::Type::Builtin(b) => define_builtin(names, &namedtype.name, *b),
             witx::Type::Pointer(p) => {
-                define_witx_pointer(names, &namedtype.name, quote!(wiggle::GuestPtr), p)
+                let rt = names.runtime_mod();
+                define_witx_pointer(names, &namedtype.name, quote!(#rt::GuestPtr), p)
             }
             witx::Type::ConstPointer(p) => {
-                define_witx_pointer(names, &namedtype.name, quote!(wiggle::GuestPtr), p)
+                let rt = names.runtime_mod();
+                define_witx_pointer(names, &namedtype.name, quote!(#rt::GuestPtr), p)
             }
             witx::Type::Array(arr) => define_witx_array(names, &namedtype.name, &arr),
         },
@@ -67,8 +69,9 @@ fn define_witx_pointer(
 
 fn define_witx_array(names: &Names, name: &witx::Id, arr_raw: &witx::TypeRef) -> TokenStream {
     let ident = names.type_(name);
+    let rt = names.runtime_mod();
     let pointee_type = names.type_ref(arr_raw, quote!('a));
-    quote!(pub type #ident<'a> = wiggle::GuestPtr<'a, [#pointee_type]>;)
+    quote!(pub type #ident<'a> = #rt::GuestPtr<'a, [#pointee_type]>;)
 }
 
 fn int_repr_tokens(int_repr: witx::IntRepr) -> TokenStream {

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 [dependencies]
 wiggle-generate = { path = "../generate", version = "0.15.0" }
 witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.5" }
+quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This change makes no functional difference to users who only use the
wiggle crate.

Add a parameter to the `Names` constructor that determines the module
that runtime components (e.g. GuestPtr, GuestError etc) of wiggle come
from. For `wiggle` users this is just `quote!(wiggle)`, but other
libraries which consume wiggle-generate may wrap and re-export wiggle
under some other path, and not want their consumers to have to know
about the wiggle dependency, e.g. `quote!(my_crate::some_path::wiggle)`.

Then, we moved a small amount of logic from the generator into the macro
crate, which makes the generator code more reusable.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
