### PR TITLE
Don't try to handle non-wasmtime segfaults

### DIFF
--- a/crates/api/src/unix.rs
+++ b/crates/api/src/unix.rs
@@ -9,10 +9,10 @@
 //! throughout the `wasmtime` crate with extra functionality that's only
 //! available on Unix.
 
-use crate::Instance;
+use crate::Store;
 
-/// Extensions for the [`Instance`] type only available on Unix.
-pub trait InstanceExt {
+/// Extensions for the [`Store`] type only available on Unix.
+pub trait StoreExt {
     // TODO: needs more docs?
     /// The signal handler must be
     /// [async-signal-safe](http://man7.org/linux/man-pages/man7/signal-safety.7.html).
@@ -21,11 +21,11 @@ pub trait InstanceExt {
         H: 'static + Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool;
 }
 
-impl InstanceExt for Instance {
+impl StoreExt for Store {
     unsafe fn set_signal_handler<H>(&self, handler: H)
     where
         H: 'static + Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool,
     {
-        self.handle.set_signal_handler(handler);
+        *self.signal_handler_mut() = Some(Box::new(handler));
     }
 }

--- a/crates/api/src/windows.rs
+++ b/crates/api/src/windows.rs
@@ -9,10 +9,10 @@
 //! throughout the `wasmtime` crate with extra functionality that's only
 //! available on Windows.
 
-use crate::Instance;
+use crate::Store;
 
-/// Extensions for the [`Instance`] type only available on Windows.
-pub trait InstanceExt {
+/// Extensions for the [`Store`] type only available on Windows.
+pub trait StoreExt {
     /// Configures a custom signal handler to execute.
     ///
     /// TODO: needs more documentation.
@@ -21,11 +21,11 @@ pub trait InstanceExt {
         H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool;
 }
 
-impl InstanceExt for Instance {
+impl StoreExt for Store {
     unsafe fn set_signal_handler<H>(&self, handler: H)
     where
         H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool,
     {
-        self.handle.set_signal_handler(handler);
+        *self.signal_handler_mut() = Some(Box::new(handler));
     }
 }

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -21,6 +21,12 @@ impl CodeMemoryEntry {
         let registry = ManuallyDrop::new(UnwindRegistry::new(mmap.as_ptr() as usize));
         Ok(Self { mmap, registry })
     }
+
+    fn contains(&self, addr: usize) -> bool {
+        let start = self.mmap.as_ptr() as usize;
+        let end = start + self.mmap.len();
+        start <= addr && addr < end
+    }
 }
 
 impl Drop for CodeMemoryEntry {
@@ -235,5 +241,13 @@ impl CodeMemory {
         self.position = 0;
 
         Ok(())
+    }
+
+    /// Returns whether any published segment of this code memory contains
+    /// `addr`.
+    pub fn published_contains(&self, addr: usize) -> bool {
+        self.entries[..self.published]
+            .iter()
+            .any(|entry| entry.contains(addr))
     }
 }

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -235,6 +235,12 @@ impl Compiler {
     pub fn signatures(&self) -> &SignatureRegistry {
         &self.signatures
     }
+
+    /// Returns whether or not the given address falls within the JIT code
+    /// managed by the compiler
+    pub fn is_in_jit_code(&self, addr: usize) -> bool {
+        self.code_memory.published_contains(addr)
+    }
 }
 
 /// Create a trampoline for invoking a function.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -43,8 +43,9 @@ pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
 pub use crate::sig_registry::SignatureRegistry;
 pub use crate::table::Table;
-pub use crate::traphandlers::resume_panic;
-pub use crate::traphandlers::{catch_traps, raise_lib_trap, raise_user_trap, Trap};
+pub use crate::traphandlers::{
+    catch_traps, raise_lib_trap, raise_user_trap, resume_panic, SignalHandler, Trap,
+};
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
     VMGlobalImport, VMInterrupts, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport,

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -59,6 +59,12 @@ fn main() {
             let _instance = Instance::new(&module, &[]).unwrap();
             println!("stack overrun: {}", overrun_the_stack());
         }),
+        ("segfault in a host function", || {
+            let store = Store::default();
+            let module = Module::new(&store, r#"(import "" "" (func)) (start 0)"#).unwrap();
+            let segfault = Func::wrap(&store, || segfault());
+            Instance::new(&module, &[segfault.into()]).unwrap();
+        }),
     ];
     match env::var(VAR_NAME) {
         Ok(s) => {


### PR DESCRIPTION
This commit fixes an issue in Wasmtime where Wasmtime would accidentally
"handle" non-wasm segfaults while executing host imports of wasm
modules. If a host import segfaulted then Wasmtime would recognize that
wasm code is on the stack, so it'd longjmp out of the wasm code. This
papers over real bugs though in host code and erroneously classified
segfaults as wasm traps.

The fix here was to add a check to our wasm signal handler for if the
faulting address falls in JIT code itself. Actually threading through
all the right information for that check to happen is a bit tricky,
though, so this involved some refactoring:

* A closure parameter to `catch_traps` was added. This closure is
  responsible for classifying addresses as whether or not they fall in
  JIT code. Anything returning `false` means that the trap won't get
  handled and we'll forward to the next signal handler.

* To avoid passing tons of context all over the place, the start
  function is now no longer automatically invoked by `InstanceHandle`.
  This avoids the need for passing all sorts of trap-handling contextual
  information like the maximum stack size and "is this a jit address"
  closure. Instead creators of `InstanceHandle` (like wasmtime) are now
  responsible for invoking the start function.

* To avoid excessive use of `transmute` with lifetimes since the
  traphandler state now has a lifetime the per-instance custom signal
  handler is now replaced with a per-store custom signal handler. I'm
  not entirely certain the purpose of the custom signal handler, though,
  so I'd look for feedback on this part.

A new test has been added which ensures that if a host function
segfaults we don't accidentally try to handle it, and instead we
correctly report the segfault.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
