### PR TITLE
aarch64: implement correct float-to-int conversion semantics

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -242,7 +242,6 @@ fn should_panic(testsuite: &str, testname: &str) -> bool {
         | ("simd", _)
         | ("multi_value", "call")
         | ("spec_testsuite", "call")
-        | ("spec_testsuite", "conversions")
         | ("spec_testsuite", "i32")
         | ("spec_testsuite", "i64")
         | ("spec_testsuite", "int_exprs")

--- a/cranelift/filetests/filetests/vcode/aarch64/floating-point.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/floating-point.clif
@@ -433,6 +433,17 @@ block0(v0: f32):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp s0, s0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 -1
+; nextln:  fcmp s0, s1
+; nextln:  b.gt 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 4294967300
+; nextln:  fcmp s0, s1
+; nextln:  b.mi 8
+; nextln:  udf
 ; nextln:  fcvtzu w0, s0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
@@ -446,6 +457,17 @@ block0(v0: f32):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp s0, s0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 -2147483600
+; nextln:  fcmp s0, s1
+; nextln:  b.ge 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 2147483600
+; nextln:  fcmp s0, s1
+; nextln:  b.mi
+; nextln:  udf
 ; nextln:  fcvtzs w0, s0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
@@ -459,6 +481,17 @@ block0(v0: f32):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp s0, s0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 -1
+; nextln:  fcmp s0, s1
+; nextln:  b.gt 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 18446744000000000000
+; nextln:  fcmp s0, s1
+; nextln:  b.mi 8
+; nextln:  udf
 ; nextln:  fcvtzu x0, s0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
@@ -472,6 +505,17 @@ block0(v0: f32):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp s0, s0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 -9223372000000000000
+; nextln:  fcmp s0, s1
+; nextln:  b.ge 8
+; nextln:  udf
+; nextln:  ldr s1, pc+8 ; b 8 ; data.f32 9223372000000000000
+; nextln:  fcmp s0, s1
+; nextln:  b.mi 8
+; nextln:  udf
 ; nextln:  fcvtzs x0, s0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
@@ -485,6 +529,17 @@ block0(v0: f64):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp d0, d0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 -1
+; nextln:  fcmp d0, d1
+; nextln:  b.gt 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 4294967296
+; nextln:  fcmp d0, d1
+; nextln:  b.mi 8
+; nextln:  udf
 ; nextln:  fcvtzu w0, d0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
@@ -498,6 +553,17 @@ block0(v0: f64):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp d0, d0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 -2147483649
+; nextln:  fcmp d0, d1
+; nextln:  b.gt 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 2147483648
+; nextln:  fcmp d0, d1
+; nextln:  b.mi 8
+; nextln:  udf
 ; nextln:  fcvtzs w0, d0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
@@ -511,6 +577,17 @@ block0(v0: f64):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp d0, d0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 -1
+; nextln:  fcmp d0, d1
+; nextln:  b.gt 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 18446744073709552000
+; nextln:  fcmp d0, d1
+; nextln:  b.mi 8
+; nextln:  udf
 ; nextln:  fcvtzu x0, d0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
@@ -524,6 +601,17 @@ block0(v0: f64):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
+; nextln:  fcmp d0, d0
+; nextln:  b.vc 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 -9223372036854776000
+; nextln:  fcmp d0, d1
+; nextln:  b.ge 8
+; nextln:  udf
+; nextln:  ldr d1, pc+8 ; b 12 ; data.f64 9223372036854776000
+; nextln:  fcmp d0, d1
+; nextln:  b.mi 8
+; nextln:  udf
 ; nextln:  fcvtzs x0, d0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16

--- a/crates/lightbeam/src/backend.rs
+++ b/crates/lightbeam/src/backend.rs
@@ -5533,7 +5533,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
             slice = rest;
         }
 
-        mem::replace(&mut self.block_state.stack, stack);
+        let _ = mem::replace(&mut self.block_state.stack, stack);
         Ok(())
     }
 

--- a/crates/lightbeam/src/function_body.rs
+++ b/crates/lightbeam/src/function_body.rs
@@ -876,7 +876,7 @@ where
 
     ctx.epilogue();
 
-    mem::replace(&mut session.op_offset_map, op_offset_map);
+    let _ = mem::replace(&mut session.op_offset_map, op_offset_map);
 
     Ok(())
 }


### PR DESCRIPTION
These are inherited from wasm semantics:

- if the input is a NaN, early trap
- if the input is out of bounds, trap
- truncating has towards-0 semantics, e.g. all the values in ]-1, 0] are possible inputs for unsigned truncate.

This makes Spidermonkey pass one more test entirely.

@cfallin PTAL!