### PR TITLE
Add a MinGW release to our CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,10 +269,17 @@ jobs:
         include:
         - build: x86_64-linux
           os: ubuntu-latest
+          rust: stable
         - build: x86_64-macos
           os: macos-latest
+          rust: stable
         - build: x86_64-windows
           os: windows-latest
+          rust: stable
+        - build: x86_64-mingw
+          os: windows-latest
+          target: x86_64-pc-windows-gnu
+          rust: nightly     # needs rust-lang/rust#69351 to ride to stable
         - build: aarch64-linux
           os: ubuntu-latest
           rust: stable
@@ -286,8 +293,17 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
     - uses: ./.github/actions/binary-compatible-builds
       if: matrix.target == ''
+
+    - name: Configure Cargo target
+      run: |
+        echo ::set-env name=CARGO_BUILD_TARGET::${{ matrix.target }}
+        rustup target add ${{ matrix.target }}
+      shell: bash
+      if: matrix.target != ''
 
     - name: Install cross-compilation tools
       run: |
@@ -309,9 +325,7 @@ jobs:
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo ::set-env name=CARGO_TARGET_${upcase}_RUNNER::$HOME/qemu/bin/${{ matrix.qemu }}
         echo ::set-env name=CARGO_TARGET_${upcase}_LINKER::${{ matrix.gcc }}
-        echo ::set-env name=CARGO_BUILD_TARGET::${{ matrix.target }}
-        rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
+      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
 
     # Install wasm32-wasi target in order to build wasi-common's integration
     # tests
@@ -348,7 +362,10 @@ jobs:
       if: matrix.os != 'windows-latest' && matrix.target != ''
     - run: cp target/release/wasmtime.exe dist
       shell: bash
-      if: matrix.os == 'windows-latest'
+      if: matrix.build == 'x86_64-windows'
+    - run: cp target/x86_64-pc-windows-gnu/release/wasmtime.exe dist
+      shell: bash
+      if: matrix.build == 'x86_64-mingw'
 
     # Move libwasmtime dylib to dist folder
     - run: cp target/release/libwasmtime.{so,a} dist
@@ -359,7 +376,10 @@ jobs:
       if: matrix.os == 'macos-latest'
     - run: cp target/release/wasmtime.{dll,lib,dll.lib} dist
       shell: bash
-      if: matrix.os == 'windows-latest'
+      if: matrix.build == 'x86_64-windows'
+    - run: cp target/x86_64-pc-windows-gnu/release/{wasmtime.dll,libwasmtime.a} dist
+      shell: bash
+      if: matrix.build == 'x86_64-mingw'
 
     # Make a Windows MSI installer if we're on Windows
     - run: |
@@ -368,7 +388,7 @@ jobs:
         "$WIX/bin/light" -out dist/installer.msi target/wasmtime.wixobj -ext WixUtilExtension
         rm dist/installer.wixpdb
       shell: bash
-      if: matrix.os == 'windows-latest'
+      if: matrix.build == 'x86_64-windows'
 
     - uses: actions/upload-artifact@v1
       with:
@@ -416,6 +436,10 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: bins-x86_64-windows
+    - name: Download x86_64 Windows MinGW binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: bins-x86_64-mingw
 
     - name: Assemble gh-pages
       run: |
@@ -449,6 +473,7 @@ jobs:
       run: |
         ./ci/build-tarballs.sh x86_64-linux
         ./ci/build-tarballs.sh x86_64-windows .exe
+        ./ci/build-tarballs.sh x86_64-mingw .exe
         ./ci/build-tarballs.sh x86_64-macos
         ./ci/build-tarballs.sh aarch64-linux
 

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -40,7 +40,7 @@ mv bins-$platform/wasmtime$exe tmp/$bin_pkgname
 chmod +x tmp/$bin_pkgname/wasmtime$exe
 mktarball $bin_pkgname
 
-if [ "$exe" = ".exe" ]; then
+if [ -f bins-$platform/installer.msi ]; then
   mv bins-$platform/installer.msi dist/$bin_pkgname.msi
 fi
 


### PR DESCRIPTION
This commit extends our CI to produce release artifacts for the
x86_64-pc-windows-gnu target. This was originally motivate by the [go
extension] where it looks like the Go toolchain primarily interoperates
with MinGW, not with MSVC natively.

The support here turned out to be quite trivial, largely just adding the
configuration to make the release. I don't think we should necessarily
commit to this being a primary platform for Wasmtime at this time
though. If the support here regresses in the future for a
difficult-to-fix reason I think it would be fine to back out the
platform at least temporarily.

Note that this does not add a full test suite for the MinGW target, only
a release builder. This release builder does run tests, but not with
full debug assertions enabled.

[go extension]: https://github.com/bytecodealliance/wasmtime-go/issues/3

Closes #1535
