### PR TITLE
Fix ImmLogic.invert(), and with it, `fcopysign` and `float_misc` test.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -243,8 +243,6 @@ fn should_panic(testsuite: &str, testname: &str) -> bool {
         | ("multi_value", "call")
         | ("spec_testsuite", "call")
         | ("spec_testsuite", "conversions")
-        | ("spec_testsuite", "f32_bitwise")
-        | ("spec_testsuite", "float_misc")
         | ("spec_testsuite", "i32")
         | ("spec_testsuite", "i64")
         | ("spec_testsuite", "int_exprs")

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -6,6 +6,7 @@
 use crate::binemit::CodeOffset;
 use crate::ir::Type;
 use crate::isa::aarch64::inst::*;
+use crate::isa::aarch64::lower::ty_bits;
 
 use regalloc::{RealRegUniverse, Reg, Writable};
 
@@ -523,6 +524,19 @@ impl InstSize {
             InstSize::Size32
         } else {
             InstSize::Size64
+        }
+    }
+
+    /// Convert from an integer type into the smallest size that fits.
+    pub fn from_ty(ty: Type) -> InstSize {
+        Self::from_bits(ty_bits(ty))
+    }
+
+    /// Convert to I32 or I64.
+    pub fn to_ty(self) -> Type {
+        match self {
+            InstSize::Size32 => I32,
+            InstSize::Size64 => I64,
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -2105,19 +2105,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) {
             ctx.emit(Inst::MovFromVec64 { rd: tmp1, rn: rn });
             ctx.emit(Inst::MovFromVec64 { rd: tmp2, rn: rm });
             let imml = if bits == 32 {
-                ImmLogic::from_raw(
-                    /* value = */ 0x8000_0000,
-                    /* n = */ false,
-                    /* r = */ 1,
-                    /* s = */ 0,
-                )
+                ImmLogic::maybe_from_u64(0x8000_0000, I32).unwrap()
             } else {
-                ImmLogic::from_raw(
-                    /* value = */ 0x8000_0000_0000_0000,
-                    /* n = */ true,
-                    /* r = */ 1,
-                    /* s = */ 0,
-                )
+                ImmLogic::maybe_from_u64(0x8000_0000_0000_0000, I64).unwrap()
             };
             let alu_op = choose_32_64(ty, ALUOp::And32, ALUOp::And64);
             ctx.emit(Inst::AluRRImmLogic {


### PR DESCRIPTION
Previously, `fcopysign` was mysteriously failing to pass the
`float_misc` spec test. This was tracked down to bad logical-immediate
masks used to separate the sign and not-sign bits. In particular, the
masks for the and-not operations were wrong. The `invert()` function on
an `ImmLogic` immediate, it turns out, assumed every immediate would be
used by a 64-bit instruction; `ImmLogic` immediates are subtly different
for 32-bit instructions. This change tracks the instruction size (32 or
64 bits) intended for use with each such immediate, and passes it back
into `maybe_from_u64` when computing the inverted immediate.

Addresses one of the failures (`float_misc`) for #1521 (test failures)
and presumably helps #1519 (SpiderMonkey integration).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
