### PR TITLE
aarch64: emit SP copies when SP is involved in an explicit add during address lowering

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -237,11 +237,7 @@ fn should_panic(testsuite: &str, testname: &str) -> bool {
     }
     match (testsuite, testname) {
         // FIXME(#1521)
-        ("misc_testsuite", "func_400_params")
-        | ("simd", _)
-        | ("multi_value", "call")
-        | ("spec_testsuite", "call") => true,
-
+        ("simd", _) => true,
         _ => false,
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1719,6 +1719,9 @@ impl MachInst for Inst {
 
     fn is_move(&self) -> Option<(Writable<Reg>, Reg)> {
         match self {
+            // TODO a regalloc assertion is triggered if we don't have this, see also #1586 on
+            // wasmtime, as well as https://github.com/bytecodealliance/regalloc.rs/issues/52.
+            &Inst::Mov { rm, .. } if rm == stack_reg() => None,
             &Inst::Mov { rd, rm } => Some((rd, rm)),
             &Inst::FpuMove64 { rd, rn } => Some((rd, rn)),
             _ => None,

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2297,35 +2297,41 @@ impl ShowWithRRU for Inst {
             }
             &Inst::FpuLoad32 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd.to_reg(), mb_rru, InstSize::Size32);
-                let mem = mem.show_rru_sized(mb_rru, /* size = */ 4);
-                format!("ldr {}, {}", rd, mem)
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let mem = mem.show_rru(mb_rru);
+                format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuLoad64 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd.to_reg(), mb_rru, InstSize::Size64);
-                let mem = mem.show_rru_sized(mb_rru, /* size = */ 8);
-                format!("ldr {}, {}", rd, mem)
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let mem = mem.show_rru(mb_rru);
+                format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuLoad128 { rd, ref mem, .. } => {
                 let rd = rd.to_reg().show_rru(mb_rru);
                 let rd = "q".to_string() + &rd[1..];
-                let mem = mem.show_rru_sized(mb_rru, /* size = */ 8);
-                format!("ldr {}, {}", rd, mem)
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let mem = mem.show_rru(mb_rru);
+                format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore32 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd, mb_rru, InstSize::Size32);
-                let mem = mem.show_rru_sized(mb_rru, /* size = */ 4);
-                format!("str {}, {}", rd, mem)
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let mem = mem.show_rru(mb_rru);
+                format!("{}str {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore64 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd, mb_rru, InstSize::Size64);
-                let mem = mem.show_rru_sized(mb_rru, /* size = */ 8);
-                format!("str {}, {}", rd, mem)
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let mem = mem.show_rru(mb_rru);
+                format!("{}str {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore128 { rd, ref mem, .. } => {
                 let rd = rd.show_rru(mb_rru);
                 let rd = "q".to_string() + &rd[1..];
-                let mem = mem.show_rru_sized(mb_rru, /* size = */ 8);
-                format!("str {}, {}", rd, mem)
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let mem = mem.show_rru(mb_rru);
+                format!("{}str {}, {}", mem_str, rd, mem)
             }
             &Inst::LoadFpuConst32 { rd, const_data } => {
                 let rd = show_freg_sized(rd.to_reg(), mb_rru, InstSize::Size32);

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -1982,11 +1982,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) {
                 ctx.emit(inst);
             }
             assert!(inputs.len() == abi.num_args());
-            let tmp1 = ctx.tmp(RegClass::I64, I64);
-            let tmp2 = ctx.tmp(RegClass::I64, I64);
             for (i, input) in inputs.iter().enumerate() {
                 let arg_reg = input_to_reg(ctx, *input, NarrowValueMode::None);
-                for inst in abi.gen_copy_reg_to_arg(i, arg_reg, tmp1, tmp2) {
+                for inst in abi.gen_copy_reg_to_arg(ctx, i, arg_reg) {
                     ctx.emit(inst);
                 }
             }

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -132,9 +132,14 @@ pub trait ABICall {
     /// Get the number of arguments expected.
     fn num_args(&self) -> usize;
 
-    /// Save the clobbered registers.
     /// Copy an argument value from a source register, prior to the call.
-    fn gen_copy_reg_to_arg(&self, idx: usize, from_reg: Reg) -> Self::I;
+    fn gen_copy_reg_to_arg(
+        &self,
+        idx: usize,
+        from_reg: Reg,
+        tmp1: Writable<Reg>,
+        tmp2: Writable<Reg>,
+    ) -> Vec<Self::I>;
 
     /// Copy a return value into a destination register, after the call returns.
     fn gen_copy_retval_to_reg(&self, idx: usize, into_reg: Writable<Reg>) -> Self::I;

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -133,12 +133,11 @@ pub trait ABICall {
     fn num_args(&self) -> usize;
 
     /// Copy an argument value from a source register, prior to the call.
-    fn gen_copy_reg_to_arg(
+    fn gen_copy_reg_to_arg<C: LowerCtx<I = Self::I>>(
         &self,
+        ctx: &mut C,
         idx: usize,
         from_reg: Reg,
-        tmp1: Writable<Reg>,
-        tmp2: Writable<Reg>,
     ) -> Vec<Self::I>;
 
     /// Copy a return value into a destination register, after the call returns.


### PR DESCRIPTION
and use explicit address lowering for passing stack arguments to calls, when the offset is large.

One question is: what `Inst` should cause a move from SP to another register? I preferred to keep the "high-level" semantics of `Inst::Mov`, instead of relying on every producer to produce an `Inst::Add { rd, sp, 0 }`. This means we have to modify the codegen of `Inst::Mov` when SP is involved, but it seemed like fine blackboxing.

The PR as a whole is a bit messy. I was wondering if `gen_copy_reg_to_arg` shouldn't just take the `ctx` argument, but then type parameters were involved, making the trait more contrived. I didn't look into it, it might be the right thing to do in the future (otherwise this aarch64 impl detail leaks into the general interface, which is bad).

Good thing is that thanks to many new assertions, error like this one should be more easily caught in the future.

cc @julian-seward1 because I was hitting an assertion in regalloc if I didn't include the change in `is_move`: `assert!(iix_bounds.uses_len == 1);` (backtracking.rs:572). That happens during coalescing; I checked and the value was 0, instead of the expected 1. I don't think the change in `is_move` ought to be correct, so it'd be nice to see if there's something else to do to fix this.