### PR TITLE
Remove `--nocapture` test argument on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,12 +225,12 @@ jobs:
     - run: cargo run -p run-examples
 
     # Build and test all features except for lightbeam
-    - run: cargo test --features test-programs/test_programs --all --exclude lightbeam -- --nocapture
+    - run: cargo test --features test-programs/test_programs --all --exclude lightbeam
       env:
         RUST_BACKTRACE: 1
 
     # Test debug (DWARF) related functionality.
-    - run: cargo test test_debug_dwarf_ -- --ignored --nocapture --test-threads 1
+    - run: cargo test test_debug_dwarf_ -- --ignored --test-threads 1
       if: matrix.os == 'ubuntu-latest'
       env:
         RUST_BACKTRACE: 1
@@ -239,7 +239,7 @@ jobs:
     # Lightbeam tests fail right now, but we don't want to block on that.
     - run: cargo build --package lightbeam
       if: matrix.rust == 'nightly'
-    - run: cargo test --package lightbeam -- --nocapture
+    - run: cargo test --package lightbeam
       if: matrix.rust == 'nightly'
       continue-on-error: true
       env:


### PR DESCRIPTION
This removes the `--nocapture` argument from Rust tests which enables
capturing the output of tests by default, only printing the output if
the test fails. I've seen that this otherwise seems to largely just dump
a very large amount of information to CI and makes it difficult to
diagnose a failure quickly from CI logs since you have to search
backwards to find the reason something failed.
