### PR TITLE
Fix a memory leak in the test suite

### DIFF
--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -20,13 +20,15 @@ fn test_import_calling_export() {
     let module = Module::new(&store, WAT).expect("failed to create module");
 
     let other = Rc::new(RefCell::new(None::<Func>));
-    let other2 = other.clone();
+    let other2 = Rc::downgrade(&other);
 
     let callback_func = Func::new(
         &store,
         FuncType::new(Box::new([]), Box::new([])),
         move |_, _, _| {
             other2
+                .upgrade()
+                .unwrap()
                 .borrow()
                 .as_ref()
                 .expect("expected a function ref")


### PR DESCRIPTION
This test creates a cycle between two `Func` objects (and indirectly
through their instance) which prevents anything from being collected.
This was found when running tests locally with address sanitizer, and
using a `Weak<T>` breaks the cycle to allow collecting resources.
