### PR TITLE
cranelift-wasm: fix dev-dependencies so that `cargo test` passes

### DIFF
--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -24,6 +24,8 @@ thiserror = "1.0.4"
 [dev-dependencies]
 wat = "1.0.9"
 target-lexicon = "0.10"
+# Enable the riscv feature for cranelift-codegen, as some tests require it
+cranelift-codegen = { path = "../codegen", version = "0.62.0", default-features = false, features = ["riscv"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Fixes #1595; see there for more discussion.

Before this PR, running `cargo test` locally in the `cranelift/wasm` directory fails.  This PR ensures that the correct dependency features are enabled for tests, so that `cargo test` succeeds.  Note that `cargo +nightly test --workspace` works both before and after this PR, because it enables the feature in question; this PR ensures that `cargo test` works locally in the `cranelift/wasm` directory.