### PR TITLE
Perform lldb DWARF-5 test too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,7 +230,7 @@ jobs:
         RUST_BACKTRACE: 1
 
     # Test debug (DWARF) related functionality.
-    - run: cargo test test_debug_dwarf_ -- --ignored --test-threads 1
+    - run: cargo test test_debug_dwarf -- --ignored --test-threads 1
       if: matrix.os == 'ubuntu-latest'
       env:
         RUST_BACKTRACE: 1

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -99,6 +99,46 @@ check: exited with status
     any(target_os = "linux", target_os = "macos"),
     target_pointer_width = "64"
 ))]
+pub fn test_debug_dwarf5_lldb() -> Result<()> {
+    let output = lldb_with_script(
+        &[
+            "-g",
+            "tests/all/debug/testsuite/fib-wasm-dwarf5.wasm",
+            "--invoke",
+            "fib",
+            "3",
+        ],
+        r#"b fib
+r
+fr v
+c"#,
+    )?;
+
+    check_lldb_output(
+        &output,
+        r#"
+check: Breakpoint 1: no locations (pending)
+check: Unable to resolve breakpoint to any actual locations.
+check: 1 location added to breakpoint 1
+check: stop reason = breakpoint 1.1
+check: frame #0
+sameln: JIT
+sameln: fib(n=3)
+check: n = 3
+check: a = 0
+check: resuming
+check: exited with status
+"#,
+    )?;
+    Ok(())
+}
+
+#[test]
+#[ignore]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    target_pointer_width = "64"
+))]
 pub fn test_debug_dwarf_ptr() -> Result<()> {
     let output = lldb_with_script(
         &[


### PR DESCRIPTION
This is basically a copy of `test_debug_dwarf5_lldb`, only loading a different Wasm file. Please indicate whether it is worth refactoring.

Also unlocks `test_debug_dwarf5_translate` test, which was present, but not selected.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
