### PR TITLE
The index in DW_OP_WASM_location is ULEB128

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -331,7 +331,7 @@ where
                 // TODO support wasm globals?
                 return Ok(None);
             }
-            let index = pc.read_sleb128()?;
+            let index = pc.read_uleb128()?;
             if pc.read_u8()? != 159 {
                 // FIXME The following operator is not DW_OP_stack_value, e.g. :
                 // DW_AT_location  (0x00000ea5:


### PR DESCRIPTION
C.f. https://yurydelendik.github.io/webassembly-dwarf/#DWARF-expressions-and-location-descriptions

N.B.: This is probably a benign change even if tools in the wild use `sleb128` (contrary to the spec). Confusion might happen when there are more than 63 (or 127?, I'd have to check) locals/arguments.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
