### PR TITLE
Legalize 64 bit shifts on x86_32 using PSLLQ/PSRLQ

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1493,8 +1493,13 @@ fn define_alu(
     for &(inst, rrr) in &[(rotl, 0), (rotr, 1), (ishl, 4), (ushr, 5), (sshr, 7)] {
         // Cannot use enc_i32_i64 for this pattern because instructions require
         // to bind any.
+        e.enc32(inst.bind(I32).bind(I8), rec_rc.opcodes(&ROTATE_CL).rrr(rrr));
         e.enc32(
-            inst.bind(I32).bind(Any),
+            inst.bind(I32).bind(I16),
+            rec_rc.opcodes(&ROTATE_CL).rrr(rrr),
+        );
+        e.enc32(
+            inst.bind(I32).bind(I32),
             rec_rc.opcodes(&ROTATE_CL).rrr(rrr),
         );
         e.enc64(

--- a/cranelift/filetests/filetests/isa/x86/legalize-x86_32-shifts.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-x86_32-shifts.clif
@@ -1,0 +1,51 @@
+test compile
+set enable_simd
+target i686 haswell
+
+function u0:1(i32) -> i64 system_v {
+    block1(v0: i32):
+        v1 = load.i64 notrap aligned v0+0
+        v2 = load.i32 notrap aligned v0+16
+        v3 = ishl v1, v2
+        return v3
+}
+
+function u0:2(i32) -> i64 system_v {
+    block1(v0: i32):
+        v1 = load.i64 notrap aligned v0+0
+        v2 = load.i64 notrap aligned v0+16
+        v3 = ishl v1, v2
+        return v3
+}
+
+function u0:3(i32) -> i32 system_v {
+    block1(v0: i32):
+        v1 = load.i32 notrap aligned v0+0
+        v2 = load.i64 notrap aligned v0+16
+        v3 = ishl v1, v2
+        return v3
+}
+
+function u0:4(i32) -> i64 system_v {
+    block1(v0: i32):
+        v1 = load.i64 notrap aligned v0+0
+        v2 = load.i32 notrap aligned v0+16
+        v3 = ushr v1, v2
+        return v3
+}
+
+function u0:5(i32) -> i64 system_v {
+    block1(v0: i32):
+        v1 = load.i64 notrap aligned v0+0
+        v2 = load.i64 notrap aligned v0+16
+        v3 = ushr v1, v2
+        return v3
+}
+
+function u0:6(i32) -> i32 system_v {
+    block1(v0: i32):
+        v1 = load.i32 notrap aligned v0+0
+        v2 = load.i64 notrap aligned v0+16
+        v3 = ushr v1, v2
+        return v3
+}


### PR DESCRIPTION
I tried to run some WASI binary with wasmtime targeting i686-unknown-linux-gnu (as part of #1089) and immediately ran into a codegen crash. I believe the cause of the crash is the fact that something is emitting shifts with 64-bit value and amount (both 64-bit, in the testcase I reduced), which are not legal on x86_32. 

I think I managed to fix 2/3 of the problematic cases, although not in an elegant way. Let me know what you think.

<details>
<summary>Testcase</summary>

```
test compile
set enable_simd
target i686 haswell

function u0:1(i32) -> i64 system_v {
    block1(v0: i32):
        v1 = load.i64 notrap aligned v0+0
        v2 = load.i32 notrap aligned v0+16
        v3 = ishl v1, v2
        return v3
}

function u0:2(i32) -> i64 system_v {
    block1(v0: i32):
        v1 = load.i64 notrap aligned v0+0
        v2 = load.i64 notrap aligned v0+16
        v3 = ishl v1, v2
        return v3
}

; this doesn't work
;function u0:3(i32) -> i32 system_v {
;    block1(v0: i32):
;        v1 = load.i32 notrap aligned v0+0
;        v2 = load.i64 notrap aligned v0+16
;        v3 = ishl v1, v2
;        return v3
;}

function u0:4(i32) -> i64 system_v {
    block1(v0: i32):
        v1 = load.i64 notrap aligned v0+0
        v2 = load.i32 notrap aligned v0+16
        v3 = ishl v1, v2
        return v3
}

function u0:5(i32) -> i64 system_v {
    block1(v0: i32):
        v1 = load.i64 notrap aligned v0+0
        v2 = load.i64 notrap aligned v0+16
        v3 = ishl v1, v2
        return v3
}

; this doesn't work
;function u0:6(i32) -> i32 system_v {
;    block1(v0: i32):
;        v1 = load.i32 notrap aligned v0+0
;        v2 = load.i64 notrap aligned v0+16
;        v3 = ishl v1, v2
;        return v3
;}
```

</details>