### PR TITLE
Legalize [su]extend.i64 to iconst/sshr_imm + iconcat

### DIFF
--- a/cranelift/codegen/meta/src/shared/legalize.rs
+++ b/cranelift/codegen/meta/src/shared/legalize.rs
@@ -212,8 +212,8 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     // embedded as part of arguments), so use a custom legalization for now.
     narrow.custom_legalize(iconst, "narrow_iconst");
 
-    {
-        let inst = uextend.bind(I128).bind(I64);
+    for &(ty, ty_half) in &[(I128, I64), (I64, I32)] {
+        let inst = uextend.bind(ty).bind(ty_half);
         narrow.legalize(
             def!(a = inst(x)),
             vec![
@@ -223,12 +223,12 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         );
     }
 
-    {
-        let inst = sextend.bind(I128).bind(I64);
+    for &(ty, ty_half, shift) in &[(I128, I64, 63), (I64, I32, 31)] {
+        let inst = sextend.bind(ty).bind(ty_half);
         narrow.legalize(
             def!(a = inst(x)),
             vec![
-                def!(ah = sshr_imm(x, Literal::constant(&imm.imm64, 63))), // splat sign bit to whole number
+                def!(ah = sshr_imm(x, Literal::constant(&imm.imm64, shift))), // splat sign bit to whole number
                 def!(a = iconcat(x, ah)),
             ],
         );

--- a/cranelift/filetests/filetests/isa/riscv/legalize-abi.clif
+++ b/cranelift/filetests/filetests/isa/riscv/legalize-abi.clif
@@ -22,8 +22,8 @@ function %split_call_arg(i32) {
 block0(v0: i32):
     v1 = uextend.i64 v0
     call fn1(v1)
-    ; check: $(v1l=$V), $(v1h=$V) = isplit v1
-    ; check: call fn1($v1l, $v1h)
+    ; check: $(v1h=$V) = iconst.i32 0
+    ; check: call fn1(v0, $v1h)
     call fn2(v0, v1)
     ; check: call fn2(v0, $V, $V)
     return

--- a/cranelift/filetests/filetests/isa/x86/extend-i64-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/extend-i64-run.clif
@@ -1,0 +1,26 @@
+test run
+target i686
+
+function u0:0() -> b1 {
+block0:
+    v0 = iconst.i32 0xffff_ee00
+    v1 = uextend.i64 v0
+    v2, v3 = isplit v1
+    v4 = icmp_imm eq v2, 0xffff_ee00
+    v5 = icmp_imm eq v3, 0
+    v6 = band v4, v5
+    return v6
+}
+; run
+
+function u0:1() -> b1 {
+block0:
+    v0 = iconst.i32 0xffff_ee00
+    v1 = sextend.i64 v0
+    v2, v3 = isplit v1
+    v4 = icmp_imm eq v2, 0xffff_ee00
+    v5 = icmp_imm eq v3, 0xffff_ffff
+    v6 = band v4, v5
+    return v6
+}
+; run

--- a/cranelift/filetests/filetests/isa/x86/extend-i64.clif
+++ b/cranelift/filetests/filetests/isa/x86/extend-i64.clif
@@ -1,0 +1,37 @@
+test compile
+target i686
+
+function u0:0() -> b1 {
+block0:
+    v0 = iconst.i32 0xffff_ee00
+    ; check: v0 = iconst.i32 0xffff_ee00
+    ; nextln: v2 -> v0
+    v1 = uextend.i64 v0
+    ; nextln: v7 = iconst.i32 0
+    ; nextln: v3 -> v7
+    ; nextln: v1 = iconcat v0, v7
+
+    v2, v3 = isplit v1
+    v4 = icmp_imm eq v2, 0xffff_ee00
+    v5 = icmp_imm eq v3, 0
+
+    v6 = band v4, v5
+    return v6
+}
+
+function u0:1() -> b1 {
+block0:
+    v0 = iconst.i32 0xffff_ee00
+    ; check: v0 = iconst.i32 0xffff_ee00
+    ; nextln: v2 -> v0
+    v1 = sextend.i64 v0
+    ; nextln: v10 = copy v0
+    ; nextln: v7 = sshr_imm v10, 31
+    ; nextln: v3 -> v7
+
+    v2, v3 = isplit v1
+    v4 = icmp_imm eq v2, 0xffff_ee00
+    v5 = icmp_imm eq v3, 0xffff_ffff
+    v6 = band v4, v5
+    return v6
+}


### PR DESCRIPTION
This was already done for `[su]extend.i128`, and is necessary for codegen for 32-bit x86 (#1089).