### PR TITLE
Legalize ireduce.iN.i2N to isplit

### DIFF
--- a/cranelift/codegen/meta/src/shared/legalize.rs
+++ b/cranelift/codegen/meta/src/shared/legalize.rs
@@ -61,6 +61,7 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     let cls = insts.by_name("cls");
     let clz = insts.by_name("clz");
     let ctz = insts.by_name("ctz");
+    let copy = insts.by_name("copy");
     let fabs = insts.by_name("fabs");
     let f32const = insts.by_name("f32const");
     let f64const = insts.by_name("f64const");
@@ -626,6 +627,14 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         widen.legalize(
             def!(brnz.ty(x, block, vararg)),
             vec![def!(a = uextend.I32(x)), def!(brnz(a, block, vararg))],
+        );
+    }
+
+    for &(ty_half, ty) in &[(I64, I128), (I32, I64)] {
+        let inst = ireduce.bind(ty_half).bind(ty);
+        expand.legalize(
+            def!(a = inst(x)),
+            vec![def!((b, c) = isplit(x)), def!(a = copy(b))],
         );
     }
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i128.clif
@@ -1,0 +1,11 @@
+test compile
+target x86_64
+
+function u0:0(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = iconcat v0, v1
+    v3 = ireduce.i64 v2
+    ; check: v3 = copy v0
+    ; check: return v3
+    return v3
+}

--- a/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i64.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i64.clif
@@ -1,0 +1,11 @@
+test compile
+target i686
+
+function u0:0(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconcat v0, v1
+    v3 = ireduce.i32 v2
+    ; check: v3 = fill v0
+    ; check: return v3
+    return v3
+}


### PR DESCRIPTION
Although the transformation seems a bit suspicious to me, it seems to work reliably, and this was the only way I could prevent some 64-bit iconcats from crashing codegen for 32-bit targets (#1089).

With this PR, #1615, #1612, pinning VMContext to `%esi` and a small patch that corrects wasmtime's 64-bit assumptions in two places, I can successfully build reasonably looking 32-bit machine code and run it! Of course, it crashes immediately.