### PR TITLE
Implement basic support for the Linux i686 target

### DIFF
--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -222,7 +222,7 @@ impl FuncType {
     /// or `None` if one of the types/results wasn't supported or compatible
     /// with cranelift.
     pub(crate) fn get_wasmtime_signature(&self, pointer_type: ir::Type) -> Option<ir::Signature> {
-        use wasmtime_environ::ir::{types, AbiParam, ArgumentPurpose, Signature};
+        use wasmtime_environ::ir::{AbiParam, ArgumentPurpose, Signature};
         use wasmtime_jit::native;
         let call_conv = native::call_conv();
         let mut params = self
@@ -235,7 +235,10 @@ impl FuncType {
             .iter()
             .map(|p| p.get_wasmtime_type().map(AbiParam::new))
             .collect::<Option<Vec<_>>>()?;
-        params.insert(0, AbiParam::special(types::I64, ArgumentPurpose::VMContext));
+        params.insert(
+            0,
+            AbiParam::special(pointer_type, ArgumentPurpose::VMContext),
+        );
         params.insert(1, AbiParam::new(pointer_type));
 
         Some(Signature {

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -94,9 +94,14 @@ fn apply_reloc(
             write_unaligned(reloc_address as *mut u32, reloc_delta_u32);
         },
         #[cfg(target_pointer_width = "32")]
-        Reloc::X86CallPCRel4 => {
-            // ignore
-        }
+        Reloc::X86CallPCRel4 => unsafe {
+            let reloc_address = body.add(r.offset as usize) as usize;
+            let reloc_addend = r.addend as isize;
+            let reloc_delta_u32 = (target_func_address as u32)
+                .wrapping_sub(reloc_address as u32)
+                .wrapping_add(reloc_addend as u32);
+            write_unaligned(reloc_address as *mut u32, reloc_delta_u32);
+        },
         Reloc::X86PCRelRodata4 => {
             // ignore
         }

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -156,6 +156,9 @@ cfg_if::cfg_if! {
                 if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
                     let cx = &*(cx as *const libc::ucontext_t);
                     cx.uc_mcontext.gregs[libc::REG_RIP as usize] as *const u8
+                } else if #[cfg(all(target_os = "linux", target_arch = "x86"))] {
+                    let cx = &*(cx as *const libc::ucontext_t);
+                    cx.uc_mcontext.gregs[libc::REG_EIP as usize] as *const u8
                 } else if #[cfg(all(target_os = "linux", target_arch = "aarch64"))] {
                     // libc doesn't seem to support Linux/aarch64 at the moment?
                     extern "C" {


### PR DESCRIPTION
This PR, together with #1612, #1615 and #1616 makes it possible to run simple WASI binaries on x86_32 Linux. There are some caveats:

  * Because of the approach taken in #1612, it is necessary to always use `--enable-simd`.
  * There are still some issues in the 32-bit legalizer that prevent complex applications from running.
  * Debug information is not generated.

Other than that it should be fully functional, or at least I don't see anything obviously broken.