### PR TITLE
Properly bubble up errors when seeing an unexpected type during lowering

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -7,7 +7,7 @@ use crate::binemit::CodeOffset;
 use crate::ir::types::{B1, B16, B32, B64, B8, F32, F64, FFLAGS, I16, I32, I64, I8, IFLAGS};
 use crate::ir::{ExternalName, Opcode, SourceLoc, TrapCode, Type};
 use crate::machinst::*;
-use crate::settings;
+use crate::{settings, CodegenError, CodegenResult};
 
 use regalloc::Map as RegallocMap;
 use regalloc::{RealReg, RealRegUniverse, Reg, RegClass, SpillSlot, VirtualReg, Writable};
@@ -1787,12 +1787,15 @@ impl MachInst for Inst {
         None
     }
 
-    fn rc_for_type(ty: Type) -> RegClass {
+    fn rc_for_type(ty: Type) -> CodegenResult<RegClass> {
         match ty {
-            I8 | I16 | I32 | I64 | B1 | B8 | B16 | B32 | B64 => RegClass::I64,
-            F32 | F64 => RegClass::V128,
-            IFLAGS | FFLAGS => RegClass::I64,
-            _ => panic!("Unexpected SSA-value type: {}", ty),
+            I8 | I16 | I32 | I64 | B1 | B8 | B16 | B32 | B64 => Ok(RegClass::I64),
+            F32 | F64 => Ok(RegClass::V128),
+            IFLAGS | FFLAGS => Ok(RegClass::I64),
+            _ => Err(CodegenError::Unsupported(format!(
+                "Unexpected SSA-value type: {}",
+                ty
+            ))),
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -34,7 +34,11 @@ impl AArch64Backend {
 
     /// This performs lowering to VCode, register-allocates the code, computes block layout and
     /// finalizes branches. The result is ready for binary emission.
-    fn compile_vcode(&self, func: &Function, flags: settings::Flags) -> VCode<inst::Inst> {
+    fn compile_vcode(
+        &self,
+        func: &Function,
+        flags: settings::Flags,
+    ) -> CodegenResult<VCode<inst::Inst>> {
         let abi = Box::new(abi::AArch64ABIBody::new(func, flags));
         compile::compile::<AArch64Backend>(func, self, abi)
     }
@@ -47,7 +51,7 @@ impl MachBackend for AArch64Backend {
         want_disasm: bool,
     ) -> CodegenResult<MachCompileResult> {
         let flags = self.flags();
-        let vcode = self.compile_vcode(func, flags.clone());
+        let vcode = self.compile_vcode(func, flags.clone())?;
         let sections = vcode.emit();
         let frame_size = vcode.frame_size();
 

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -14,12 +14,12 @@ pub fn compile<B: LowerBackend>(
     f: &Function,
     b: &B,
     abi: Box<dyn ABIBody<I = B::MInst>>,
-) -> VCode<B::MInst>
+) -> CodegenResult<VCode<B::MInst>>
 where
     B::MInst: ShowWithRRU,
 {
     // This lowers the CL IR.
-    let mut vcode = Lower::new(f, abi).lower(b);
+    let mut vcode = Lower::new(f, abi)?.lower(b)?;
 
     let universe = &B::MInst::reg_universe(vcode.flags());
 
@@ -62,5 +62,5 @@ where
         vcode.show_rru(Some(universe))
     );
 
-    vcode
+    Ok(vcode)
 }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -163,8 +163,9 @@ pub trait MachInst: Clone + Debug {
     /// (e.g., add directly from or directly to memory), like x86.
     fn maybe_direct_reload(&self, reg: VirtualReg, slot: SpillSlot) -> Option<Self>;
 
-    /// Determine a register class to store the given CraneLift type.
-    fn rc_for_type(ty: Type) -> RegClass;
+    /// Determine a register class to store the given Cranelift type.
+    /// May return an error if the type isn't supported by this backend.
+    fn rc_for_type(ty: Type) -> CodegenResult<RegClass>;
 
     /// Generate a jump to another target. Used during lowering of
     /// control flow.

--- a/cranelift/codegen/src/result.rs
+++ b/cranelift/codegen/src/result.rs
@@ -1,6 +1,7 @@
 //! Result and error types representing the outcome of compiling a function.
 
 use crate::verifier::VerifierErrors;
+use std::string::String;
 use thiserror::Error;
 
 /// A compilation error.
@@ -30,6 +31,12 @@ pub enum CodegenError {
     /// is exceeded, compilation fails.
     #[error("Code for function is too large")]
     CodeTooLarge,
+
+    /// Something is not supported by the code generator. This might be an indication that a
+    /// feature is used without explicitly enabling it, or that something is temporarily
+    /// unsupported by a given target backend.
+    #[error("Unsupported feature: {0}")]
+    Unsupported(String),
 
     /// A failure to map Cranelift register representation to a DWARF register representation.
     #[cfg(feature = "unwind")]


### PR DESCRIPTION
Pretty straightforward. Having a Result means we can't use as many iterators as we want, and one iterator was changed into a loop as a matter of fact.