### PR TITLE
Bump regalloc to 0.0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.18"
+version = "0.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d7df180ed313488abdbeec2e3398f16cbf5ea6ce20db968c8cd6fc410400a9"
+checksum = "75d8659dfee0d5b4c06022ab25e3efda0737a2a1798f9c33d0c0a147a740db86"
 dependencies = [
  "log",
  "rustc-hash",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -24,7 +24,7 @@ gimli = { version = "0.20.0", default-features = false, features = ["write"], op
 smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }
-regalloc = "0.0.18"
+regalloc = "0.0.20"
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1721,9 +1721,6 @@ impl MachInst for Inst {
 
     fn is_move(&self) -> Option<(Writable<Reg>, Reg)> {
         match self {
-            // TODO a regalloc assertion is triggered if we don't have this, see also #1586 on
-            // wasmtime, as well as https://github.com/bytecodealliance/regalloc.rs/issues/52.
-            &Inst::Mov { rm, .. } if rm == stack_reg() => None,
             &Inst::Mov { rd, rm } => Some((rd, rm)),
             &Inst::FpuMove64 { rd, rn } => Some((rd, rn)),
             _ => None,


### PR DESCRIPTION
And fix the `is_move` bug, now that https://github.com/bytecodealliance/regalloc.rs/issues/52 has been fixed.