### PR TITLE
MachInst backend: attach SourceLoc span information to all ranges.

### DIFF
--- a/crates/api/src/frame_info.rs
+++ b/crates/api/src/frame_info.rs
@@ -94,11 +94,7 @@ impl GlobalFrameInfo {
         // the function, because otherwise something is buggy along the way and
         // not accounting for all the instructions. This isn't super critical
         // though so we can omit this check in release mode.
-        //
-        // FIXME(#1521) aarch64 instruction info isn't quite up-to-par yet.
-        if !cfg!(target_arch = "aarch64") {
-            debug_assert!(pos.is_some(), "failed to find instruction for {:x}", pc);
-        }
+        debug_assert!(pos.is_some(), "failed to find instruction for {:x}", pc);
 
         let instr = match pos {
             Some(pos) => func.instr_map.instructions[pos].srcloc,


### PR DESCRIPTION
Previously, the SourceLoc information transferred in `VCode` only
included PC-spans for non-default SourceLocs. I realized that the
invariant we're supposed to keep here is that every PC is covered; if no
source information, just use `SourceLoc::default()`.

This was spurred by @bjorn3's comment in #1575 (thanks!): [link](https://github.com/bytecodealliance/wasmtime/pull/1575#pullrequestreview-400385205).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
