### PR TITLE
Enable optimizations for SIMD spec tests

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1601,8 +1601,11 @@ fn define_simd(
     let sadd_sat = shared.by_name("sadd_sat");
     let scalar_to_vector = shared.by_name("scalar_to_vector");
     let sload8x8 = shared.by_name("sload8x8");
+    let sload8x8_complex = shared.by_name("sload8x8_complex");
     let sload16x4 = shared.by_name("sload16x4");
+    let sload16x4_complex = shared.by_name("sload16x4_complex");
     let sload32x2 = shared.by_name("sload32x2");
+    let sload32x2_complex = shared.by_name("sload32x2_complex");
     let spill = shared.by_name("spill");
     let sqrt = shared.by_name("sqrt");
     let sshr_imm = shared.by_name("sshr_imm");
@@ -1611,8 +1614,11 @@ fn define_simd(
     let store_complex = shared.by_name("store_complex");
     let uadd_sat = shared.by_name("uadd_sat");
     let uload8x8 = shared.by_name("uload8x8");
+    let uload8x8_complex = shared.by_name("uload8x8_complex");
     let uload16x4 = shared.by_name("uload16x4");
+    let uload16x4_complex = shared.by_name("uload16x4_complex");
     let uload32x2 = shared.by_name("uload32x2");
+    let uload32x2_complex = shared.by_name("uload32x2_complex");
     let ushr_imm = shared.by_name("ushr_imm");
     let usub_sat = shared.by_name("usub_sat");
     let vconst = shared.by_name("vconst");
@@ -1974,6 +1980,35 @@ fn define_simd(
             let template = recipe.opcodes(*opcodes);
             e.enc_both_inferred_maybe_isap(inst.clone().bind(I32), template.clone(), isap);
             e.enc64_maybe_isap(inst.bind(I64), template.infer_rex(), isap);
+        }
+    }
+
+    // SIMD load extend (complex addressing)
+    let is_load_complex_length_two =
+        InstructionPredicate::new_length_equals(&*formats.load_complex, 2);
+    for (inst, opcodes) in &[
+        (uload8x8_complex, &PMOVZXBW),
+        (uload16x4_complex, &PMOVZXWD),
+        (uload32x2_complex, &PMOVZXDQ),
+        (sload8x8_complex, &PMOVSXBW),
+        (sload16x4_complex, &PMOVSXWD),
+        (sload32x2_complex, &PMOVSXDQ),
+    ] {
+        for recipe in &[
+            rec_fldWithIndex,
+            rec_fldWithIndexDisp8,
+            rec_fldWithIndexDisp32,
+        ] {
+            let template = recipe.opcodes(*opcodes);
+            let predicate = |encoding: EncodingBuilder| {
+                encoding
+                    .isa_predicate(use_sse41_simd)
+                    .inst_predicate(is_load_complex_length_two.clone())
+            };
+            e.enc32_func(inst.clone(), template.clone(), predicate);
+            // No infer_rex calculator for these recipes; place REX version first as in enc_x86_64.
+            e.enc64_func(inst.clone(), template.rex(), predicate);
+            e.enc64_func(inst.clone(), template, predicate);
         }
     }
 

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1174,6 +1174,20 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
+            "uload8x8_complex",
+            r#"
+        Load an 8x8 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an 
+        i16x8 vector.
+        "#,
+            &formats.load_complex,
+        )
+        .operands_in(vec![MemFlags, args, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
             "sload8x8",
             r#"
         Load an 8x8 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i16x8 
@@ -1182,6 +1196,20 @@ pub(crate) fn define(
             &formats.load,
         )
         .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "sload8x8_complex",
+            r#"
+        Load an 8x8 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an 
+        i16x8 vector.
+        "#,
+            &formats.load_complex,
+        )
+        .operands_in(vec![MemFlags, args, Offset])
         .operands_out(vec![a])
         .can_load(true),
     );
@@ -1201,12 +1229,26 @@ pub(crate) fn define(
         Inst::new(
             "uload16x4",
             r#"
-        Load an 16x4 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i32x4 
+        Load a 16x4 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i32x4 
         vector.
         "#,
             &formats.load,
         )
         .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "uload16x4_complex",
+            r#"
+        Load a 16x4 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an 
+        i32x4 vector.
+        "#,
+            &formats.load_complex,
+        )
+        .operands_in(vec![MemFlags, args, Offset])
         .operands_out(vec![a])
         .can_load(true),
     );
@@ -1221,6 +1263,20 @@ pub(crate) fn define(
             &formats.load,
         )
         .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "sload16x4_complex",
+            r#"
+        Load a 16x4 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an 
+        i32x4 vector.
+        "#,
+            &formats.load_complex,
+        )
+        .operands_in(vec![MemFlags, args, Offset])
         .operands_out(vec![a])
         .can_load(true),
     );
@@ -1252,6 +1308,20 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
+            "uload32x2_complex",
+            r#"
+        Load a 32x2 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an 
+        i64x2 vector.
+        "#,
+            &formats.load_complex,
+        )
+        .operands_in(vec![MemFlags, args, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
             "sload32x2",
             r#"
         Load a 32x2 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i64x2 
@@ -1260,6 +1330,20 @@ pub(crate) fn define(
             &formats.load,
         )
         .operands_in(vec![MemFlags, p, Offset])
+        .operands_out(vec![a])
+        .can_load(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "sload32x2_complex",
+            r#"
+        Load a 32x2 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an 
+        i64x2 vector.
+        "#,
+            &formats.load_complex,
+        )
+        .operands_in(vec![MemFlags, args, Offset])
         .operands_out(vec![a])
         .can_load(true),
     );

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1354,11 +1354,17 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRIns
         | Opcode::ScalarToVector
         | Opcode::Swizzle
         | Opcode::Uload8x8
+        | Opcode::Uload8x8Complex
         | Opcode::Sload8x8
+        | Opcode::Sload8x8Complex
         | Opcode::Uload16x4
+        | Opcode::Uload16x4Complex
         | Opcode::Sload16x4
+        | Opcode::Sload16x4Complex
         | Opcode::Uload32x2
-        | Opcode::Sload32x2 => {
+        | Opcode::Uload32x2Complex
+        | Opcode::Sload32x2
+        | Opcode::Sload32x2Complex => {
             // TODO
             panic!("Vector ops not implemented.");
         }

--- a/cranelift/codegen/src/postopt.rs
+++ b/cranelift/codegen/src/postopt.rs
@@ -271,6 +271,42 @@ fn optimize_complex_addresses(pos: &mut EncCursor, inst: Inst, isa: &dyn TargetI
                         .replace(inst)
                         .sload32_complex(info.flags, &args, info.offset);
                 }
+                Opcode::Uload8x8 => {
+                    pos.func
+                        .dfg
+                        .replace(inst)
+                        .uload8x8_complex(info.flags, &args, info.offset);
+                }
+                Opcode::Sload8x8 => {
+                    pos.func
+                        .dfg
+                        .replace(inst)
+                        .sload8x8_complex(info.flags, &args, info.offset);
+                }
+                Opcode::Uload16x4 => {
+                    pos.func
+                        .dfg
+                        .replace(inst)
+                        .uload16x4_complex(info.flags, &args, info.offset);
+                }
+                Opcode::Sload16x4 => {
+                    pos.func
+                        .dfg
+                        .replace(inst)
+                        .sload16x4_complex(info.flags, &args, info.offset);
+                }
+                Opcode::Uload32x2 => {
+                    pos.func
+                        .dfg
+                        .replace(inst)
+                        .uload32x2_complex(info.flags, &args, info.offset);
+                }
+                Opcode::Sload32x2 => {
+                    pos.func
+                        .dfg
+                        .replace(inst)
+                        .sload32x2_complex(info.flags, &args, info.offset);
+                }
                 Opcode::Store => {
                     pos.func.dfg.replace(inst).store_complex(
                         info.flags,

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use wasmtime::{Config, Engine, OptLevel, Store, Strategy};
+use wasmtime::{Config, Engine, Store, Strategy};
 use wasmtime_wast::WastContext;
 
 include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
@@ -27,11 +27,6 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
         .wasm_multi_value(multi_val)
         .strategy(strategy)?
         .cranelift_debug_verifier(true);
-
-    // FIXME: https://github.com/bytecodealliance/wasmtime/issues/1186
-    if simd {
-        cfg.cranelift_opt_level(OptLevel::None);
-    }
 
     let store = Store::new(&Engine::new(&cfg));
     let mut wast_context = WastContext::new(store);


### PR DESCRIPTION
@peterhuene discovered in #1186 that the SIMD spec tests failed when enabling Cranelift's optimizations. After looking into this, the issue was in the `optimize_complex_addresses`, an optimization function that replaces an `iadd + load*` with a single `load_complex` instruction. Since the SIMD load-extend instructions did not have complex encodings, the function would panic. This PR adds the necessary Cranelift instructions and x86 encodings to avoid this failure and re-enable optimizations for the SIMD spec tests.

@julian-seward1, @bnjbvr, @jlb6740: hopefully the new backend can somehow avoid the duplication involved with the Cranelift IR: every load-extend instruction is repeated over the load size (e.g. 8, 16, ..., 8x8, 16x4, ...) and is duplicated for its complex version (e.g. load8x8 and load8x8_complex).