### PR TITLE
Add some debugging assistance to spectest oracle

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -393,6 +393,8 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
 ///
 /// Ensures that spec tests pass regardless of the `Config`.
 pub fn spectest(config: crate::generators::Config, test: crate::generators::SpecTest) {
+    crate::init_fuzzing();
+    log::debug!("running {:?} with {:?}", test.file, config);
     let store = Store::new(&Engine::new(&config.to_wasmtime()));
     let mut wast_context = WastContext::new(store);
     wast_context.register_spectest().unwrap();


### PR DESCRIPTION
Basically just log what's happening so if you're running the fuzzer you
can see what test is being run.

