### PR TITLE
Minor fixes to release scripts

### DIFF
--- a/scripts/publish-cranelift.sh
+++ b/scripts/publish-cranelift.sh
@@ -36,7 +36,7 @@ do
 
     # Sleep for a few seconds to allow the server to update the index.
     # https://internals.rust-lang.org/t/changes-to-how-crates-io-handles-index-updates/9608
-    echo sleep 20
+    echo sleep 30
 done
 
 echo git tag cranelift-v$(grep version cranelift/Cargo.toml | head -n 1 | cut -d '"' -f 2)

--- a/scripts/publish-wasmtime.sh
+++ b/scripts/publish-wasmtime.sh
@@ -35,7 +35,6 @@ for cargo_toml in \
     crates/api/Cargo.toml \
     crates/wasi/Cargo.toml \
     crates/wast/Cargo.toml \
-    crates/misc/py/Cargo.toml \
     crates/misc/rust/macro/Cargo.toml \
     crates/misc/rust/Cargo.toml \
     Cargo.toml \
@@ -50,7 +49,7 @@ for cargo_toml in \
 
     # Sleep for a few seconds to allow the server to update the index.
     # https://internals.rust-lang.org/t/changes-to-how-crates-io-handles-index-updates/9608
-    echo sleep 20
+    echo sleep 30
 done
 
 echo git tag v$(grep "version =" Cargo.toml | head -n 1 | cut -d '"' -f 2)


### PR DESCRIPTION
 - We still saw a timeout with 20 second pauses; bump to 30 seconds.
 - wasmtime-py is now in a separate repository

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
