### PR TITLE
Update test ignore annotations for aarch64

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -970,7 +970,6 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
     fn cache_accounts_for_opt_level() -> Result<()> {
         let td = TempDir::new()?;
         let config_path = td.path().join("config.toml");
@@ -1018,15 +1017,18 @@ mod tests {
         assert_eq!(store.engine().config.cache_config.cache_hits(), 1);
         assert_eq!(store.engine().config.cache_config.cache_misses(), 1);
 
-        let mut cfg = Config::new();
-        cfg.debug_info(true).cache_config_load(&config_path)?;
-        let store = Store::new(&Engine::new(&cfg));
-        Module::new(&store, "(module (func))")?;
-        assert_eq!(store.engine().config.cache_config.cache_hits(), 0);
-        assert_eq!(store.engine().config.cache_config.cache_misses(), 1);
-        Module::new(&store, "(module (func))")?;
-        assert_eq!(store.engine().config.cache_config.cache_hits(), 1);
-        assert_eq!(store.engine().config.cache_config.cache_misses(), 1);
+        // FIXME(#1523) need debuginfo on aarch64 before we run this test there
+        if !cfg!(target_arch = "aarch64") {
+            let mut cfg = Config::new();
+            cfg.debug_info(true).cache_config_load(&config_path)?;
+            let store = Store::new(&Engine::new(&cfg));
+            Module::new(&store, "(module (func))")?;
+            assert_eq!(store.engine().config.cache_config.cache_hits(), 0);
+            assert_eq!(store.engine().config.cache_config.cache_misses(), 1);
+            Module::new(&store, "(module (func))")?;
+            assert_eq!(store.engine().config.cache_config.cache_hits(), 1);
+            assert_eq!(store.engine().config.cache_config.cache_misses(), 1);
+        }
 
         Ok(())
     }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -102,7 +102,6 @@ fn run_wasmtime_simple_wat() -> Result<()> {
 
 // Running a wat that traps.
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
 fn run_wasmtime_unreachable_wat() -> Result<()> {
     let wasm = build_wasm("tests/wasm/unreachable.wat")?;
     let output = run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -87,7 +87,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
     fn test_custom_signal_handler_single_instance() -> Result<()> {
         let engine = Engine::new(&Config::default());
         let store = Store::new(&engine);

--- a/tests/all/fuzzing.rs
+++ b/tests/all/fuzzing.rs
@@ -21,7 +21,7 @@ fn instantiate_empty_module_with_memory() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", should_panic)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", should_panic)] // FIXME(#1523)
 fn instantiate_module_that_compiled_to_x64_has_register_32() {
     let mut config = Config::new();
     config.debug_info(true);

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -31,7 +31,7 @@ fn test_trap_return() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn test_trap_trace() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -73,7 +73,7 @@ fn test_trap_trace() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn test_trap_trace_cb() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -109,7 +109,7 @@ fn test_trap_trace_cb() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn test_trap_stack_overflow() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -141,7 +141,7 @@ fn test_trap_stack_overflow() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn trap_display_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -173,7 +173,7 @@ wasm backtrace:
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn trap_display_multi_module() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -218,7 +218,7 @@ wasm backtrace:
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn trap_start_function_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -239,7 +239,7 @@ fn trap_start_function_import() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn rust_panic_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -283,7 +283,7 @@ fn rust_panic_import() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn rust_panic_start_function() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -317,7 +317,7 @@ fn rust_panic_start_function() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn mismatched_arguments() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -349,7 +349,7 @@ fn mismatched_arguments() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn call_signature_mismatch() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -378,7 +378,7 @@ fn call_signature_mismatch() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1521)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
 fn start_trap_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"


### PR DESCRIPTION
Looks like everything is in general passing now so it's probably time to
close #1521 and all other remaining tests that are failing are
classified under new more focused issues.

Closes #1521
