### PR TITLE
Move trap handler initialization to per-`Store`

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -743,6 +743,13 @@ pub(crate) struct StoreInner {
 impl Store {
     /// Creates a new store to be associated with the given [`Engine`].
     pub fn new(engine: &Engine) -> Store {
+        // Ensure that wasmtime_runtime's signal handlers are configured. Note
+        // that at the `Store` level it means we should perform this
+        // once-per-thread. Platforms like Unix, however, only require this
+        // once-per-program. In any case this is safe to call many times and
+        // each one that's not relevant just won't do anything.
+        wasmtime_runtime::init_traps();
+
         let isa = native::builder().finish(settings::Flags::new(engine.config.flags.clone()));
         let compiler = Compiler::new(
             isa,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -7,7 +7,6 @@ use crate::imports::Imports;
 use crate::jit_int::GdbJitImageRegistration;
 use crate::memory::{DefaultMemoryCreator, RuntimeLinearMemory, RuntimeMemoryCreator};
 use crate::table::Table;
-use crate::traphandlers;
 use crate::traphandlers::Trap;
 use crate::vmcontext::{
     VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport,
@@ -885,10 +884,6 @@ impl InstanceHandle {
             VMBuiltinFunctionsArray::initialized(),
         );
         *instance.interrupts() = &*instance.interrupts;
-
-        // Ensure that our signal handlers are ready for action.
-        // TODO: Move these calls out of `InstanceHandle`.
-        traphandlers::init();
 
         // Perform infallible initialization in this constructor, while fallible
         // initialization is deferred to the `initialize` method.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -44,7 +44,7 @@ pub use crate::mmap::Mmap;
 pub use crate::sig_registry::SignatureRegistry;
 pub use crate::table::Table;
 pub use crate::traphandlers::{
-    catch_traps, raise_lib_trap, raise_user_trap, resume_panic, SignalHandler, Trap,
+    catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, SignalHandler, Trap,
 };
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -253,7 +253,7 @@ cfg_if::cfg_if! {
 /// function needs to be called at the end of the startup process, after other
 /// handlers have been installed. This function can thus be called multiple
 /// times, having no effect after the first call.
-pub fn init() {
+pub fn init_traps() {
     static INIT: Once = Once::new();
     INIT.call_once(real_init);
 }


### PR DESCRIPTION
Previously we initialized trap handling (signals/etc) once-per-instance
but that's a bit too granular since we only need to do this as
one-time per-program initialization. This moves the initialization to
`Store` instead which means that we'll call this at least once per
thread, which some platforms may need (none currently do, they all only
need per-program initialization, but Fuchsia will need per-thread
initialization).
