### PR TITLE
Use `[u8; 16]` instead of `u128` for representing `Val::V128`

### DIFF
--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -34,7 +34,7 @@ pub enum Val {
     FuncRef(Func),
 
     /// A 128-bit number
-    V128(u128),
+    V128([u8; 16]),
 }
 
 macro_rules! accessors {
@@ -86,7 +86,7 @@ impl Val {
             Val::I64(i) => ptr::write(p as *mut i64, *i),
             Val::F32(u) => ptr::write(p as *mut u32, *u),
             Val::F64(u) => ptr::write(p as *mut u64, *u),
-            Val::V128(b) => ptr::write(p as *mut u128, *b),
+            Val::V128(b) => ptr::write(p as *mut [u8; 16], *b),
             _ => unimplemented!("Val::write_value_to"),
         }
     }
@@ -97,7 +97,7 @@ impl Val {
             ValType::I64 => Val::I64(ptr::read(p as *const i64)),
             ValType::F32 => Val::F32(ptr::read(p as *const u32)),
             ValType::F64 => Val::F64(ptr::read(p as *const u64)),
-            ValType::V128 => Val::V128(ptr::read(p as *const u128)),
+            ValType::V128 => Val::V128(ptr::read(p as *const [u8; 16])),
             _ => unimplemented!("Val::read_value_from"),
         }
     }
@@ -109,7 +109,7 @@ impl Val {
         (F32(f32) f32 unwrap_f32 f32::from_bits(*e))
         (F64(f64) f64 unwrap_f64 f64::from_bits(*e))
         (FuncRef(&Func) funcref unwrap_funcref e)
-        (V128(u128) v128 unwrap_v128 *e)
+        (V128([u8; 16]) v128 unwrap_v128 *e)
     }
 
     /// Attempt to access the underlying value of this `Val`, returning

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -328,7 +328,7 @@ impl RunCommand {
                 Val::F64(f) => println!("{}", f),
                 Val::AnyRef(_) => println!("<anyref>"),
                 Val::FuncRef(_) => println!("<anyref>"),
-                Val::V128(i) => println!("{}", i),
+                Val::V128(i) => println!("{:?}", i),
             }
         }
 


### PR DESCRIPTION
When troubleshooting WAST test failures, it was difficult to determine what was different between the expected V128 pattern (e.g. `[0, 1, 2...]`) and the giant integer contained in `Val::V128`. There are multiple ways to make this more user-friendly, but this change does so by changing the contained type of `Val::V128` to the easier to read `[u8; 16]`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
