### PR TITLE
Fix a missing early-return in `Table::get`

### DIFF
--- a/crates/api/src/values.rs
+++ b/crates/api/src/values.rs
@@ -216,7 +216,7 @@ pub(crate) fn from_checked_anyfunc(
     store: &Store,
 ) -> Val {
     if item.type_index == wasmtime_runtime::VMSharedSignatureIndex::default() {
-        Val::AnyRef(AnyRef::Null);
+        return Val::AnyRef(AnyRef::Null);
     }
     let instance_handle = unsafe { wasmtime_runtime::InstanceHandle::from_vmctx(item.vmctx) };
     let export = wasmtime_runtime::ExportFunction {

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -14,6 +14,7 @@ mod linker;
 mod memory_creator;
 mod name;
 mod stack_overflow;
+mod table;
 mod traps;
 mod use_after_drop;
 mod wast;

--- a/tests/all/table.rs
+++ b/tests/all/table.rs
@@ -1,0 +1,13 @@
+use wasmtime::*;
+
+#[test]
+fn get_none() {
+    let store = Store::default();
+    let ty = TableType::new(ValType::FuncRef, Limits::new(1, None));
+    let table = Table::new(&store, ty, Val::AnyRef(AnyRef::Null)).unwrap();
+    match table.get(0) {
+        Some(Val::AnyRef(AnyRef::Null)) => {}
+        _ => panic!(),
+    }
+    assert!(table.get(1).is_none());
+}


### PR DESCRIPTION
Turns out this was a typo from #1016!
