### PR TITLE
Update `Table::grow`'s return to be the previous size

### DIFF
--- a/crates/api/src/externals.rs
+++ b/crates/api/src/externals.rs
@@ -371,6 +371,8 @@ impl Table {
     /// Grows the size of this table by `delta` more elements, initialization
     /// all new elements to `init`.
     ///
+    /// Returns the previous size of this table if successful.
+    ///
     /// # Errors
     ///
     /// Returns an error if the table cannot be grown by `delta`, for example
@@ -381,8 +383,7 @@ impl Table {
         let item = into_checked_anyfunc(init, &self.instance.store)?;
         if let Some(len) = self.instance.table_grow(index, delta) {
             for i in 0..delta {
-                let i = len - (delta - i);
-                set_table_item(&self.instance, index, i, item.clone())?;
+                set_table_item(&self.instance, index, len + i, item.clone())?;
             }
             Ok(len)
         } else {

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -44,7 +44,8 @@ impl Table {
     /// Grow table by the specified amount of elements.
     ///
     /// Returns `None` if table can't be grown by the specified amount
-    /// of elements.
+    /// of elements. Returns the previous size of the table if growth is
+    /// successful.
     pub fn grow(&self, delta: u32) -> Option<u32> {
         let size = self.size();
         let new_len = match size.checked_add(delta) {

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -46,7 +46,8 @@ impl Table {
     /// Returns `None` if table can't be grown by the specified amount
     /// of elements.
     pub fn grow(&self, delta: u32) -> Option<u32> {
-        let new_len = match self.size().checked_add(delta) {
+        let size = self.size();
+        let new_len = match size.checked_add(delta) {
             Some(len) => {
                 if let Some(max) = self.maximum {
                     if len > max {
@@ -63,7 +64,7 @@ impl Table {
             usize::try_from(new_len).unwrap(),
             VMCallerCheckedAnyfunc::default(),
         );
-        Some(new_len)
+        Some(size)
     }
 
     /// Get reference to the specified element.


### PR DESCRIPTION
This brings it in line with `Memory::grow` and the `table.grow`
instruction which return the size of the table previously, not the size
of the table currently.

