### PR TITLE
MachInst backends: sink constants to use-sites to avoid long live-ranges.

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -31,6 +31,7 @@ use crate::result::CodegenResult;
 use crate::settings::{FlagsOrIsa, OptLevel};
 use crate::simple_gvn::do_simple_gvn;
 use crate::simple_preopt::do_preopt;
+use crate::sink_constants::do_sink_constants;
 use crate::timing;
 use crate::unreachable_code::eliminate_unreachable_code;
 use crate::value_label::{build_value_labels_ranges, ComparableSourceLoc, ValueLabelsRanges};
@@ -180,6 +181,8 @@ impl Context {
         }
 
         if let Some(backend) = isa.get_mach_backend() {
+            // New backend/regalloc has better codegen if constants are def'd right at use.
+            do_sink_constants(&mut self.func);
             let result = backend.compile_function(&self.func, self.want_disasm)?;
             let info = result.code_info();
             self.mach_compile_result = Some(result);

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -109,6 +109,7 @@ mod result;
 mod scoped_hash_map;
 mod simple_gvn;
 mod simple_preopt;
+mod sink_constants;
 mod stack_layout;
 mod topo_order;
 mod unreachable_code;

--- a/cranelift/codegen/src/sink_constants.rs
+++ b/cranelift/codegen/src/sink_constants.rs
@@ -1,0 +1,58 @@
+use crate::entity::SecondaryMap;
+use crate::ir::{Function, Inst, InstructionData, Opcode, Type, ValueDef};
+
+use smallvec::SmallVec;
+
+use log::debug;
+
+/// Sink constants in `func` to just before uses.
+pub fn do_sink_constants(func: &mut Function) {
+    // Const instructions to remove.
+    let mut remove = SecondaryMap::with_default(false);
+    let mut remove_list: SmallVec<[Inst; 16]> = SmallVec::new();
+    // Insertions: (before_this_inst, replace_this_arg, const_data, type).
+    let mut insert: SmallVec<[(Inst, usize, InstructionData, Type); 16]> = SmallVec::new();
+
+    debug!("do_sink_constants: function {:?}", func);
+
+    for bb in func.layout.blocks() {
+        for inst in func.layout.block_insts(bb) {
+            if is_const(func, inst) && !remove[inst] {
+                remove[inst] = true;
+                remove_list.push(inst);
+            }
+            for (i, arg) in func.dfg.inst_args(inst).iter().enumerate() {
+                let v = func.dfg.resolve_aliases(*arg);
+                if let ValueDef::Result(src_inst, _) = func.dfg.value_def(v) {
+                    if is_const(func, src_inst) {
+                        let data = func.dfg[src_inst].clone();
+                        let ty = func.dfg.ctrl_typevar(src_inst);
+                        insert.push((inst, i, data, ty));
+                    }
+                }
+            }
+        }
+    }
+
+    for (inst, arg, data, ty) in insert.into_iter() {
+        let const_inst = func.dfg.make_inst(data);
+        func.dfg.make_inst_results(const_inst, ty);
+        func.layout.insert_inst(const_inst, inst);
+        let const_val = func.dfg.inst_results(const_inst)[0];
+        func.dfg.inst_args_mut(inst)[arg] = const_val;
+    }
+    for inst in remove_list.into_iter() {
+        func.layout.remove_inst(inst);
+    }
+
+    debug!("do_sink_constants: resulting function {:?}", func);
+}
+
+fn is_const(func: &Function, inst: Inst) -> bool {
+    match func.dfg[inst].opcode() {
+        Opcode::Iconst | Opcode::Bconst | Opcode::F32const | Opcode::F64const | Opcode::Vconst => {
+            true
+        }
+        _ => false,
+    }
+}

--- a/cranelift/filetests/filetests/vcode/aarch64/constant-sinking.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/constant-sinking.clif
@@ -1,0 +1,52 @@
+test vcode
+target aarch64
+
+function %f(b1) {
+block0(v0: b1):
+  v1 = iconst.i64 0
+  v2 = f32const 0x2.0
+  v3 = f64const 0x3.0
+  v4 = bconst.b1 true
+  brnz v0, block1
+  jump block2
+
+block1:
+  v5 = iconst.i32 4
+  jump block3(v5)
+
+block2:
+  v6 = iconst.i32 5
+  jump block3(v6)
+
+block3(v7: i32):
+  store.f32 v2, v1
+  store.f64 v3, v1
+  v8 = bint.i64 v4
+  store.i64 v8, v1
+  store.i32 v7, v1
+  return
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: and w0, w0, #1
+; nextln: cbnz x0, 12
+; check: movz x0, #5
+; nextln: b 8
+; check: movz x0, #4
+; nextln: nop-zero-len
+; check: ldr s0, pc+8 ; b 8 ; data.f32 2
+; nextln: movz x1, #0
+; nextln: str s0, [x1]
+; nextln: ldr d0, pc+8 ; b 12 ; data.f64 3
+; nextln: movz x1, #0
+; nextln: str d0, [x1]
+; nextln: movz x1, #1
+; nextln: and w1, w1, #1
+; nextln: movz x2, #0
+; nextln: stur x1, [x2]
+; nextln: movz x1, #0
+; nextln: stur w0, [x1]
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret


### PR DESCRIPTION
We've observed that there is sometimes significant wasted work in the generated
code due to spills/reloads when constants that have been CSE'd are codegen'd
once and then used much later. Because we don't support constant
rematerialization yet (bytecodealliance/regalloc.rs#19), it seems best to clone
and sink `iconst`-and-friends to just before their uses; this should avoid many
spills/reloads.

Stats on `bz2.wasm` under wasmtime on aarch64 hardware, before and
after:

Before:

```
 Performance counter stats for 'target/release/wasmtime run --disable-cache /home/cfallin/wasm-tests/bz2.wasm':

       3841.058300      task-clock (msec)         #    1.996 CPUs utilized
            31,786      context-switches          #    0.008 M/sec
               503      cpu-migrations            #    0.131 K/sec
            23,709      page-faults               #    0.006 M/sec
     9,803,413,280      cycles                    #    2.552 GHz
     9,470,301,612      instructions              #    0.97  insn per cycle
   <not supported>      branches
        49,773,064      branch-misses

       1.924119736 seconds time elapsed
```

After:

```
 Performance counter stats for 'target/release/wasmtime run --disable-cache /home/cfallin/wasm-tests/bz2.wasm':

       3390.286950      task-clock (msec)         #    1.962 CPUs utilized
            16,780      context-switches          #    0.005 M/sec
               157      cpu-migrations            #    0.046 K/sec
            20,398      page-faults               #    0.006 M/sec
     8,336,868,801      cycles                    #    2.459 GHz
     7,867,825,316      instructions              #    0.94  insn per cycle
   <not supported>      branches
        44,435,002      branch-misses

       1.728082422 seconds time elapsed
```

Compile time, as measured by `clif-util wasm`, went up very slightly (1.02s ->
1.07s, but 2635M insns to 2628M insns), but this is more than offset by the
runtime decrease: total wallclock time decreased by ~10% and instruction count
by ~17%.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
