### PR TITLE
machinst: Avoid a full instructions traversal of all the blocks when computing final block ordering

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -317,6 +317,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                     GenerateReturn::Yes
                 } else {
                     debug_assert!(last_insn_opcode == Opcode::FallthroughReturn);
+                    self.vcode.set_fallthrough_return_block(*bb);
                     GenerateReturn::No
                 };
                 self.gen_retval_setup(gen_ret);


### PR DESCRIPTION
Fixing a temporary hack to put the block containing the `fallthrough_return` at the end. This doesn't show any noticeable improvement in wallclock compile time, but it's a 10M (~0.1% total) instructions reduction (according to the imprecise `perf stat`) when compiling `regex-rs.wasm` on my machine.