### PR TITLE
add the _set suffix to static_memory_guard_size and dynamic_memory_guard_size properties in c-api

### DIFF
--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -153,11 +153,11 @@ pub extern "C" fn wasmtime_config_static_memory_maximum_size_set(c: &mut wasm_co
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_static_memory_guard_size(c: &mut wasm_config_t, size: u64) {
+pub extern "C" fn wasmtime_config_static_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
     c.config.static_memory_guard_size(size);
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_dynamic_memory_guard_size(c: &mut wasm_config_t, size: u64) {
+pub extern "C" fn wasmtime_config_dynamic_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
     c.config.dynamic_memory_guard_size(size);
 }


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [x] This has been discussed in issue #1501
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.  The original feature didn't have tests either
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
This relates to #1501 and #1513.  I think that the _set suffix was missing from these two declarations.  I'm calling from Perl using FFI, but my read of the `wasmtime.h` header file is that they macros create function prototypes with the names in this patch.  @alexcrichton wrote the original PR and I am assuming could review.