### PR TITLE
Enable the multi-value proposal by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.52.1"
+version = "0.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb8b596eb158e19625ddfe56a4e74bd176313a75f8d9c1b5159dccff9bb073"
+checksum = "733954023c0b39602439e60a65126fd31b003196d3a1e8e4531b055165a79b31"
 
 [[package]]
 name = "wasmprinter"

--- a/build.rs
+++ b/build.rs
@@ -192,6 +192,11 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", "simd_load") => return true, // FIXME Unsupported feature: proposed SIMD operator I8x16Shl
             ("simd", "simd_splat") => return true, // FIXME Unsupported feature: proposed SIMD operator I8x16ShrS
 
+            // not parsed in wasmparser yet
+            ("simd", "simd_i32x4_arith2") => return true,
+            ("simd", "simd_i16x8_arith2") => return true,
+            ("simd", "simd_i8x16_arith2") => return true,
+
             // waiting for the upstream spec to get updated with new binary
             // encodings of operations and for that to propagate to the
             // testsuite repo.
@@ -203,6 +208,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
 
             ("misc_testsuite", "export_large_signature")
             | ("spec_testsuite", "call")
+            | ("spec_testsuite", "func")
             | ("multi_value", "call")
             | ("multi_value", "func") => {
                 // FIXME These involves functions with very large stack frames that Cranelift currently

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -82,7 +82,7 @@ impl Config {
                     enable_reference_types: false,
                     enable_bulk_memory: false,
                     enable_simd: false,
-                    enable_multi_value: false,
+                    enable_multi_value: true,
                 },
             },
             flags,
@@ -247,16 +247,10 @@ impl Config {
     /// Configures whether the WebAssembly multi-value proposal will
     /// be enabled for compilation.
     ///
-    /// The [WebAssembly multi-value proposal][proposal] is not
-    /// currently fully standardized and is undergoing development.
-    /// Additionally the support in wasmtime itself is still being worked on.
-    /// Support for this feature can be enabled through this method for
-    /// appropriate wasm modules.
-    ///
     /// This feature gates functions and blocks returning multiple values in a
     /// module, for example.
     ///
-    /// This is `false` by default.
+    /// This is `true` by default.
     ///
     /// [proposal]: https://github.com/webassembly/multi-value
     pub fn wasm_multi_value(&mut self, enable: bool) -> &mut Self {

--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -39,7 +39,6 @@ pub(crate) fn fuzz_default_config(
     config
         .cranelift_debug_verifier(true)
         .cranelift_nan_canonicalization(true)
-        .wasm_multi_value(true)
         .wasm_bulk_memory(true)
         .strategy(strategy)?;
     Ok(config)

--- a/crates/misc/rust/macro/src/lib.rs
+++ b/crates/misc/rust/macro/src/lib.rs
@@ -53,8 +53,7 @@ fn generate_load(item: &syn::ItemTrait) -> syn::Result<TokenStream> {
             use #root::wasmtime::{Config, Extern, Engine, Store, Instance, Module};
             use #root::anyhow::{bail, format_err};
 
-            let engine = Engine::new(Config::new().wasm_multi_value(true));
-            let store = Store::new(&engine);
+            let store = Store::default();
 
             let data = #root::wasmtime_interface_types::ModuleData::new(bytes.as_ref())?;
 

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -356,6 +356,8 @@ fn is_matching_assert_invalid_error_message(expected: &str, actual: &str) -> boo
         // `elem.wast` and `proposals/bulk-memory-operations/elem.wast` disagree
         // on the expected error message for the same error.
         || (expected.contains("out of bounds") && actual.contains("does not fit"))
+        // slight difference in error messages
+        || (expected.contains("unknown elem segment") && actual.contains("unknown element segment"))
 }
 
 fn extract_lane_as_i8(bytes: u128, lane: usize) -> i8 {

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -61,10 +61,7 @@ wasm_trap_t* closure_callback(
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_config_t *config = wasm_config_new();
-  assert(config != NULL);
-  wasmtime_config_wasm_multi_value_set(config, true);
-  wasm_engine_t* engine = wasm_engine_new_with_config(config);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load our input file to parse it next

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -11,11 +11,8 @@ use anyhow::{format_err, Result};
 use wasmtime::*;
 
 fn main() -> Result<()> {
-    // Configure our `Store`, but be sure to use a `Config` that enables the
-    // wasm multi-value feature since it's not stable yet.
     println!("Initializing...");
-    let engine = Engine::new(Config::new().wasm_multi_value(true));
-    let store = Store::new(&engine);
+    let store = Store::default();
 
     // Compile.
     println!("Compiling module...");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ struct CommonOptions {
 
     /// Enable support for multi-value functions
     #[structopt(long)]
-    enable_multi_value: bool,
+    enable_multi_value: Option<bool>,
 
     /// Enable support for Wasm threads
     #[structopt(long)]
@@ -176,7 +176,7 @@ impl CommonOptions {
             .wasm_bulk_memory(self.enable_bulk_memory || self.enable_all)
             .wasm_simd(self.enable_simd || self.enable_all)
             .wasm_reference_types(self.enable_reference_types || self.enable_all)
-            .wasm_multi_value(self.enable_multi_value || self.enable_all)
+            .wasm_multi_value(self.enable_multi_value.unwrap_or(true) || self.enable_all)
             .wasm_threads(self.enable_threads || self.enable_all)
             .cranelift_opt_level(self.opt_level())
             .strategy(pick_compilation_strategy(self.cranelift, self.lightbeam)?)?

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -18,13 +18,10 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
     // by reference types.
     let reftypes = simd || wast.iter().any(|s| s == "reference-types");
 
-    let multi_val = wast.iter().any(|s| s == "multi-value");
-
     let mut cfg = Config::new();
     cfg.wasm_simd(simd)
         .wasm_bulk_memory(bulk_mem)
         .wasm_reference_types(reftypes)
-        .wasm_multi_value(multi_val)
         .strategy(strategy)?
         .cranelift_debug_verifier(true);
 


### PR DESCRIPTION
This was merged into the wasm spec upstream in WebAssembly/spec#1145, so
let's follow the spec and enable it by default here as well!

Some assorted updates happen here as well:

* The spec testsuite repo is updated to remove tests which assert that multi-value does not validate.
* The wasmparser dep is updated to bring in a few error message updates to pass the updated spec tests.