### PR TITLE
machinst: reduce the number of memory allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.22"
+version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993953f6481fe355c490a0bdc2d488e354cd28728da36cd4156e2cfb74fd6de"
+checksum = "b36727ea09f6e363ddebb29b2d2620052267cc1fc6e0da7da63317938eb4104c"
 dependencies = [
  "log",
  "rustc-hash",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -24,7 +24,7 @@ gimli = { version = "0.20.0", default-features = false, features = ["write"], op
 smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }
-regalloc = "0.0.22"
+regalloc = "0.0.23"
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -72,6 +72,7 @@ use alloc::vec::Vec;
 
 use regalloc::{RealReg, Reg, RegClass, Set, SpillSlot, Writable};
 
+use core::mem;
 use log::{debug, trace};
 
 /// A location for an argument or return value.
@@ -1267,8 +1268,11 @@ impl ABICall for AArch64ABICall {
         }
     }
 
-    fn emit_call<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
-        let (uses, defs) = (self.uses.clone(), self.defs.clone());
+    fn emit_call<C: LowerCtx<I = Self::I>>(&mut self, ctx: &mut C) {
+        let (uses, defs) = (
+            mem::replace(&mut self.uses, Set::empty()),
+            mem::replace(&mut self.defs, Set::empty()),
+        );
         match &self.dest {
             &CallDest::ExtName(ref name, RelocDistance::Near) => ctx.emit(Inst::Call {
                 dest: name.clone(),

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1285,26 +1285,18 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRIns
                 _ => unreachable!(),
             };
 
-            for inst in abi.gen_stack_pre_adjust().into_iter() {
-                ctx.emit(inst);
-            }
+            abi.emit_stack_pre_adjust(ctx);
             assert!(inputs.len() == abi.num_args());
             for (i, input) in inputs.iter().enumerate() {
                 let arg_reg = input_to_reg(ctx, *input, NarrowValueMode::None);
-                for inst in abi.gen_copy_reg_to_arg(i, arg_reg) {
-                    ctx.emit(inst);
-                }
+                abi.emit_copy_reg_to_arg(ctx, i, arg_reg);
             }
-            for inst in abi.gen_call().into_iter() {
-                ctx.emit(inst);
-            }
+            abi.emit_call(ctx);
             for (i, output) in outputs.iter().enumerate() {
                 let retval_reg = output_to_reg(ctx, *output);
-                ctx.emit(abi.gen_copy_retval_to_reg(i, retval_reg));
+                abi.emit_copy_retval_to_reg(ctx, i, retval_reg);
             }
-            for inst in abi.gen_stack_post_adjust().into_iter() {
-                ctx.emit(inst);
-            }
+            abi.emit_stack_post_adjust(ctx);
         }
 
         Opcode::GetPinnedReg => {

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1263,7 +1263,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRIns
 
         Opcode::Call | Opcode::CallIndirect => {
             let loc = ctx.srcloc(insn);
-            let (abi, inputs) = match op {
+            let (mut abi, inputs) = match op {
                 Opcode::Call => {
                     let (extname, dist) = ctx.call_target(insn).unwrap();
                     let extname = extname.clone();

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -135,19 +135,29 @@ pub trait ABICall {
     /// Get the number of arguments expected.
     fn num_args(&self) -> usize;
 
-    /// Copy an argument value from a source register, prior to the call.
-    fn gen_copy_reg_to_arg(&self, idx: usize, from_reg: Reg) -> Vec<Self::I>;
+    /// Emit a copy of an argument value from a source register, prior to the call.
+    fn emit_copy_reg_to_arg<C: LowerCtx<I = Self::I>>(
+        &self,
+        ctx: &mut C,
+        idx: usize,
+        from_reg: Reg,
+    );
 
-    /// Copy a return value into a destination register, after the call returns.
-    fn gen_copy_retval_to_reg(&self, idx: usize, into_reg: Writable<Reg>) -> Self::I;
+    /// Emit a copy a return value into a destination register, after the call returns.
+    fn emit_copy_retval_to_reg<C: LowerCtx<I = Self::I>>(
+        &self,
+        ctx: &mut C,
+        idx: usize,
+        into_reg: Writable<Reg>,
+    );
 
-    /// Pre-adjust the stack, prior to argument copies and call.
-    fn gen_stack_pre_adjust(&self) -> Vec<Self::I>;
+    /// Emit code to pre-adjust the stack, prior to argument copies and call.
+    fn emit_stack_pre_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C);
 
-    /// Post-adjust the satck, after call return and return-value copies.
-    fn gen_stack_post_adjust(&self) -> Vec<Self::I>;
+    /// Emit code to post-adjust the satck, after call return and return-value copies.
+    fn emit_stack_post_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C);
 
-    /// Generate the call itself.
+    /// Emit the call itself.
     ///
     /// The returned instruction should have proper use- and def-sets according
     /// to the argument registers, return-value registers, and clobbered
@@ -157,5 +167,5 @@ pub trait ABICall {
     /// registers are also logically defs, but should never be read; their
     /// values are "defined" (to the regalloc) but "undefined" in every other
     /// sense.)
-    fn gen_call(&self) -> Vec<Self::I>;
+    fn emit_call<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C);
 }

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -167,5 +167,5 @@ pub trait ABICall {
     /// registers are also logically defs, but should never be read; their
     /// values are "defined" (to the regalloc) but "undefined" in every other
     /// sense.)
-    fn emit_call<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C);
+    fn emit_call<C: LowerCtx<I = Self::I>>(&mut self, ctx: &mut C);
 }

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -22,8 +22,8 @@ impl BlockRPO {
     fn visit<I: VCodeInst>(&mut self, vcode: &VCode<I>, block: BlockIndex) {
         self.visited[block as usize] = true;
         for succ in vcode.succs(block) {
-            if !self.visited[*succ as usize] {
-                self.visit(vcode, *succ);
+            if !self.visited[succ.get() as usize] {
+                self.visit(vcode, succ.get());
             }
         }
         if Some(block) != vcode.fallthrough_return_block {


### PR DESCRIPTION
This set of small changes in the code helps reducing the number of memory allocations, as reported by DHAT, during compilation of `regex-rs.wasm` with aarch64:

| | #bytes allocated | #blocks allocated | avg size of block |
|-|-|-|-|
| Before | 1 086 592 728 | 2 734 386 | 397,38 |
| After | 1 078 766 780 | 2 516 317 | 428,71 |

So this represents an 8% reduction of the number of allocated memory blocks. This doesn't seem to show any compiler runtime performance improvement, but the whole programs compiles in less than 1.2 seconds on my machine, so it's a bit hard to distinguish what's noise and what's not.

Will need a regalloc.rs bump for https://github.com/bytecodealliance/regalloc.rs/pull/59, so CI will fail.