### PR TITLE
MachInst backend: don't reallocate RealRegUniverses for each function compilation.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1903,10 +1903,6 @@ impl MachInst for Inst {
             _ => {}
         }
     }
-
-    fn reg_universe(flags: &settings::Flags) -> RealRegUniverse {
-        create_reg_universe(flags)
-    }
 }
 
 //=============================================================================

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -25,12 +25,18 @@ use inst::create_reg_universe;
 pub struct AArch64Backend {
     triple: Triple,
     flags: settings::Flags,
+    reg_universe: RealRegUniverse,
 }
 
 impl AArch64Backend {
     /// Create a new AArch64 backend with the given (shared) flags.
     pub fn new_with_flags(triple: Triple, flags: settings::Flags) -> AArch64Backend {
-        AArch64Backend { triple, flags }
+        let reg_universe = create_reg_universe(&flags);
+        AArch64Backend {
+            triple,
+            flags,
+            reg_universe,
+        }
     }
 
     /// This performs lowering to VCode, register-allocates the code, computes block layout and
@@ -81,8 +87,8 @@ impl MachBackend for AArch64Backend {
         &self.flags
     }
 
-    fn reg_universe(&self) -> RealRegUniverse {
-        create_reg_universe(&self.flags)
+    fn reg_universe(&self) -> &RealRegUniverse {
+        &self.reg_universe
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -25,7 +25,7 @@ mod emit_tests;
 pub mod regs;
 
 use args::*;
-use regs::{create_reg_universe_systemv, show_ireg_sized};
+use regs::show_ireg_sized;
 
 //=============================================================================
 // Instructions (top level): definition
@@ -942,10 +942,6 @@ impl MachInst for Inst {
             }
             _ => {}
         }
-    }
-
-    fn reg_universe(flags: &settings::Flags) -> RealRegUniverse {
-        create_reg_universe_systemv(flags)
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -22,12 +22,18 @@ mod lower;
 pub(crate) struct X64Backend {
     triple: Triple,
     flags: Flags,
+    reg_universe: RealRegUniverse,
 }
 
 impl X64Backend {
     /// Create a new X64 backend with the given (shared) flags.
     fn new_with_flags(triple: Triple, flags: Flags) -> Self {
-        Self { triple, flags }
+        let reg_universe = create_reg_universe_systemv(&flags);
+        Self {
+            triple,
+            flags,
+            reg_universe,
+        }
     }
 
     fn compile_vcode(&self, func: &Function, flags: Flags) -> CodegenResult<VCode<inst::Inst>> {
@@ -74,8 +80,8 @@ impl MachBackend for X64Backend {
         self.triple.clone()
     }
 
-    fn reg_universe(&self) -> RealRegUniverse {
-        create_reg_universe_systemv(&self.flags)
+    fn reg_universe(&self) -> &RealRegUniverse {
+        &self.reg_universe
     }
 }
 

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -186,9 +186,6 @@ pub trait MachInst: Clone + Debug {
     /// BlockIndex.
     fn with_block_offsets(&mut self, my_offset: CodeOffset, targets: &[CodeOffset]);
 
-    /// Get the register universe for this backend.
-    fn reg_universe(flags: &Flags) -> RealRegUniverse;
-
     /// Align a basic block offset (from start of function).  By default, no
     /// alignment occurs.
     fn align_basic_block(offset: CodeOffset) -> CodeOffset {
@@ -264,7 +261,7 @@ pub trait MachBackend {
     fn name(&self) -> &'static str;
 
     /// Return the register universe for this backend.
-    fn reg_universe(&self) -> RealRegUniverse;
+    fn reg_universe(&self) -> &RealRegUniverse;
 
     /// Machine-specific condcode info needed by TargetIsa.
     fn unsigned_add_overflow_condition(&self) -> IntCC {


### PR DESCRIPTION
There's no good reason for the current behavior; we just happened to build the `RealRegUniverse` each time it was needed. This involves allocating a `Vec` and pushing a bunch (on AArch64, O(64)) of register-info structs onto it. We should share this work across the backend instance as long as it exists; and we can, because the flags (which might affect which registers we use) remain constant for one backend instance.

This saves ~0.14% instruction count, ~0.18% allocated bytes, and ~1.5%
allocated blocks on a `clif-util wasm` compilation of `bz2.wasm` for
aarch64.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
