### PR TITLE
Add FreeBSD x86-64 support to runtime trap handler

### DIFF
--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -27,6 +27,15 @@ void* GetPcFromUContext(ucontext_t *cx) {
 }
 #endif
 
+#if defined(__FreeBSD__) && defined(__x86_64__)
+#include <sys/ucontext.h>
+
+void* GetPcFromUContext(ucontext_t *cx) {
+  return (void*) cx->uc_mcontext.mc_rip;
+}
+#endif
+
+
 #if defined(__linux__) && defined(__aarch64__)
 #include <sys/ucontext.h>
 

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -164,7 +164,7 @@ cfg_if::cfg_if! {
                         fn GetPcFromUContext(cx: *mut libc::c_void) -> *const u8;
                     }
                     GetPcFromUContext(cx)
-                } else if #[cfg(target_os = "macos")] {
+                } else if #[cfg(any(target_os = "macos", target_os = "freebsd"))] {
                     // FIXME(rust-lang/libc#1702) - once that lands and is
                     // released we should inline the definition here
                     extern "C" {


### PR DESCRIPTION
This patch was not discussed in a PR.  This is a small change implement support for FreeBSD x86-64.