### PR TITLE
cranelift/reader/src/parser.rs: fn parse_inst_resuts: produce the res…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ name = "cranelift-reader"
 version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
+ "smallvec",
  "target-lexicon",
  "thiserror",
 ]

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../codegen", version = "0.63.0" }
+smallvec = "1.0.0"
 target-lexicon = "0.10"
 thiserror = "1.0.15"
 

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -23,6 +23,7 @@ use cranelift_codegen::ir::{
 use cranelift_codegen::isa::{self, CallConv, Encoding, RegUnit, TargetIsa};
 use cranelift_codegen::packed_option::ReservedValue;
 use cranelift_codegen::{settings, timing};
+use smallvec::SmallVec;
 use std::mem;
 use std::str::FromStr;
 use std::{u16, u32};
@@ -2223,9 +2224,9 @@ impl<'a> Parser<'a> {
     //
     // inst-results ::= Value(v) { "," Value(v) }
     //
-    fn parse_inst_results(&mut self) -> ParseResult<Vec<Value>> {
+    fn parse_inst_results(&mut self) -> ParseResult<SmallVec<[Value; 1]>> {
         // Result value numbers.
-        let mut results = Vec::new();
+        let mut results = SmallVec::new();
 
         // instruction  ::=  * [inst-results "="] Opcode(opc) ["." Type] ...
         // inst-results ::= * Value(v) { "," Value(v) }


### PR DESCRIPTION
…ults as a

SmallVec<[Value; 1]>, not as a Vec<Value>.  This isn't a useful change for any
non-developer use of Cranelift, but it does significantly reduce the amount of
allocation "noise" seen when tuning the new backend pipeline as driven by
clif-util reading .clif files.  In one case the number of malloc calls
declined by about 20% with this change.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
