### PR TITLE
machinst: add a checked variant of LSRA + suggest another scratch GPR

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -25,11 +25,14 @@ pub(crate) fn define() -> SettingGroup {
         - `experimental_linear_scan` is an experimental linear scan allocator. It may take less
         time to allocate registers, but generated code's quality may be inferior. As of
         2020-04-17, it is still experimental and it should not be used in production settings.
+        - `experimental_linear_scan_checked` is the linear scan allocator with additional self
+        checks that may take some time to run, and thus these checks are disabled by default.
     "#,
         vec![
             "backtracking",
             "backtracking_checked",
             "experimental_linear_scan",
+            "experimental_linear_scan_checked",
         ],
     );
 

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -206,7 +206,7 @@ pub fn create_reg_universe(flags: &settings::Flags) -> RealRegUniverse {
     allocable_by_class[RegClass::I64.rc_to_usize()] = Some(RegClassInfo {
         first: x_reg_base as usize,
         last: x_reg_last as usize,
-        suggested_scratch: Some(XREG_INDICES[13] as usize),
+        suggested_scratch: Some(XREG_INDICES[19] as usize),
     });
     allocable_by_class[RegClass::V128.rc_to_usize()] = Some(RegClassInfo {
         first: v_reg_base as usize,

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -35,6 +35,9 @@ where
         settings::Regalloc::ExperimentalLinearScan => {
             (false, Algorithm::LinearScan(Default::default()))
         }
+        settings::Regalloc::ExperimentalLinearScanChecked => {
+            (true, Algorithm::LinearScan(Default::default()))
+        }
     };
 
     let result = {


### PR DESCRIPTION
- add the checked variant of LSRA back in the choice of possible regalloc algorithms,
- defines another scratch register for LSRA (see commit message for reasoning).