### PR TITLE
Remove no-longer-needed C shims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,9 +1066,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 wasmtime-environ = { path = "../environ", version = "0.16.0" }
 region = "2.0.0"
-libc = { version = "0.2.60", default-features = false }
+libc = { version = "0.2.70", default-features = false }
 memoffset = "0.5.3"
 indexmap = "1.0.2"
 thiserror = "1.0.4"

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -17,21 +17,3 @@ void Unwind(void *JmpBuf) {
   jmp_buf *buf = (jmp_buf*) JmpBuf;
   longjmp(*buf, 1);
 }
-
-
-#ifdef __APPLE__
-#include <sys/ucontext.h>
-
-void* GetPcFromUContext(ucontext_t *cx) {
-  return (void*) cx->uc_mcontext->__ss.__rip;
-}
-#endif
-
-#if defined(__linux__) && defined(__aarch64__)
-#include <sys/ucontext.h>
-
-void* GetPcFromUContext(ucontext_t *cx) {
-    return (void*) cx->uc_mcontext.pc;
-}
-
-#endif  // __linux__ && __aarch64__

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -162,18 +162,11 @@ cfg_if::cfg_if! {
                     let cx = &*(cx as *const libc::ucontext_t);
                     cx.uc_mcontext.gregs[libc::REG_EIP as usize] as *const u8
                 } else if #[cfg(all(target_os = "linux", target_arch = "aarch64"))] {
-                    // libc doesn't seem to support Linux/aarch64 at the moment?
-                    extern "C" {
-                        fn GetPcFromUContext(cx: *mut libc::c_void) -> *const u8;
-                    }
-                    GetPcFromUContext(cx)
+                    let cx = &*(cx as *const libc::ucontext_t);
+                    cx.uc_mcontext.pc as *const u8
                 } else if #[cfg(target_os = "macos")] {
-                    // FIXME(rust-lang/libc#1702) - once that lands and is
-                    // released we should inline the definition here
-                    extern "C" {
-                        fn GetPcFromUContext(cx: *mut libc::c_void) -> *const u8;
-                    }
-                    GetPcFromUContext(cx)
+                    let cx = &*(cx as *const libc::ucontext_t);
+                    (*cx.uc_mcontext).__ss.__rip as *const u8
                 } else {
                     compile_error!("unsupported platform");
                 }


### PR DESCRIPTION
The published version of `libc` now has all that's necessary to natively
read these fields!
