### PR TITLE
Update to using `wasmparser` 0.55.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,12 +11,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0989268a37e128d4d7a8028f1c60099430113fdbc70419010601ce51a228e4fe"
-dependencies = [
- "const-random",
-]
+checksum = "35b909d1c126f78ace756fc337133356c499eebeefcce930fa5fb018823f2b2d"
 
 [[package]]
 name = "aho-corasick"
@@ -44,9 +41,9 @@ checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
 name = "arbitrary"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75153c95fdedd7db9732dfbfc3702324a1627eec91ba56e37cd0ac78314ab2ed"
+checksum = "c5eb01a9ab8a3369f2f7632b9461c34f5920bd454774bab5b9fc6744f21d6143"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -100,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 dependencies = [
  "cc",
  "libc",
@@ -206,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
 
 [[package]]
 name = "byte-tools"
@@ -242,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 dependencies = [
  "jobserver",
 ]
@@ -271,18 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clicolors-control"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
-dependencies = [
- "atty",
- "lazy_static",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,18 +287,19 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
+checksum = "dea0f3e2e8d7dba335e913b97f9e1992c86c4399d54f8be1d31c8727d0652064"
 dependencies = [
- "clicolors-control",
  "encode_unicode",
  "lazy_static",
  "libc",
  "regex",
+ "terminal_size",
  "termios",
  "unicode-width",
  "winapi",
+ "winapi-util",
 ]
 
 [[package]]
@@ -377,7 +363,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "gimli",
- "hashbrown 0.7.1",
+ "hashbrown 0.7.2",
  "log",
  "peepmatic",
  "peepmatic-runtime",
@@ -446,7 +432,7 @@ name = "cranelift-frontend"
 version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
- "hashbrown 0.7.1",
+ "hashbrown 0.7.2",
  "log",
  "smallvec",
  "target-lexicon",
@@ -460,7 +446,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-reader",
- "hashbrown 0.7.1",
+ "hashbrown 0.7.2",
  "log",
  "pretty_env_logger",
  "thiserror",
@@ -588,12 +574,12 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "hashbrown 0.7.1",
+ "hashbrown 0.7.2",
  "log",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.52.2",
+ "wasmparser",
  "wat",
 ]
 
@@ -664,13 +650,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caedd6a71b6d00bdc458ec8ffbfd12689c1ee7ffa69ad9933310aaf2f08f18d8"
+checksum = "5cee758ebd1c79a9c6fb95f242dcc30bdbf555c28369ae908d21fdaf81537496"
 dependencies = [
  "proc-macro2",
+ "quote",
  "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -980,11 +966,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479e9d9a1a3f8c489868a935b557ab5710e3e223836da2ecd52901d88935cb56"
+checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
 dependencies = [
- "ahash 0.3.2",
+ "ahash 0.3.3",
  "autocfg 1.0.0",
 ]
 
@@ -999,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -1128,7 +1114,7 @@ dependencies = [
  "staticvec",
  "thiserror",
  "typemap",
- "wasmparser 0.52.2",
+ "wasmparser",
  "wat",
 ]
 
@@ -1198,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1389,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6147d103a7c9d7598f4105cf049b15c99e2ecd93179bf024f0fd349be5ada4"
+checksum = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -1665,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1756,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "same-file"
@@ -1832,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1855,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1888,9 +1874,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
+checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1899,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
+checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1912,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1930,18 +1916,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1984,6 +1958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "termios"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,18 +2003,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2072,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2163,24 +2147,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.51.4"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
-
-[[package]]
-name = "wasmparser"
-version = "0.52.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733954023c0b39602439e60a65126fd31b003196d3a1e8e4531b055165a79b31"
+checksum = "af931e2e1960c53f4a28b063fec4cacd036f35acbec8ff3a4739125b17382a87"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd423d45b95fcee11775472bfdce66c63c45ada23c1b338e0a63d623a6c475b"
+checksum = "c93ba310101ec5ee980db66b47b3d276577c8310df1570e19994347137650454"
 dependencies = [
  "anyhow",
- "wasmparser 0.51.4",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2196,7 +2174,7 @@ dependencies = [
  "rustc-demangle",
  "target-lexicon",
  "tempfile",
- "wasmparser 0.52.2",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-profiling",
@@ -2266,7 +2244,7 @@ dependencies = [
  "more-asserts",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.52.2",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -2297,7 +2275,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "wasmparser 0.52.2",
+ "wasmparser",
  "winapi",
  "zstd",
 ]
@@ -2326,7 +2304,7 @@ dependencies = [
  "env_logger 0.7.1",
  "log",
  "rayon",
- "wasmparser 0.52.2",
+ "wasmparser",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -2350,7 +2328,7 @@ dependencies = [
  "region",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.52.2",
+ "wasmparser",
  "wasmtime-debug",
  "wasmtime-environ",
  "wasmtime-profiling",
@@ -2441,7 +2419,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 15.0.0",
+ "wast 17.0.0",
 ]
 
 [[package]]
@@ -2463,12 +2441,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.0.16"
+name = "wast"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526d28df6c047d9f9a92d4925b98afd8d8d95b1b3aa4f13eb1306f17d1da56c4"
+checksum = "5a0e1c36b928fca33dbaf96235188f5fad22ee87100e26cc606bd0fbabdf1932"
 dependencies = [
- "wast 15.0.0",
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b50f9e5e5c81e6fd987ae6997a9f4bbb751df2dec1d8cadb0b5778f1ec13bbe"
+dependencies = [
+ "wast 17.0.0",
 ]
 
 [[package]]
@@ -2541,9 +2528,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ anyhow = "1.0.19"
 target-lexicon = { version = "0.10.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.10"
+wat = "1.0.18"
 libc = "0.2.60"
 rayon = "1.2.1"
 humantime = "1.3.0"

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4.8"
 serde = "1.0.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
-wat = { version = "1.0.7", optional = true }
+wat = { version = "1.0.18", optional = true }
 target-lexicon = "0.10"
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.2"

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition = "2018"
 
+[package.metadata.docs.rs]
+rustdoc-args = [ "--document-private-items" ]
+
 [dependencies]
 cranelift-codegen-shared = { path = "../shared", version = "0.63.0" }
 cranelift-entity = { path = "../../entity", version = "0.63.0" }
 
 [badges]
 maintenance = { status = "experimental" }
-
-[package.metadata.docs.rs]
-rustdoc-args = [ "--document-private-items" ]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.52.0", default-features = false }
+wasmparser = { version = "0.55.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.63.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.63.0" }
 cranelift-frontend = { path = "../frontend", version = "0.63.0", default-features = false }
@@ -22,7 +22,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 thiserror = "1.0.4"
 
 [dev-dependencies]
-wat = "1.0.9"
+wat = "1.0.18"
 target-lexicon = "0.10"
 # Enable the riscv feature for cranelift-codegen, as some tests require it
 cranelift-codegen = { path = "../codegen", version = "0.63.0", default-features = false, features = ["riscv"] }

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -196,9 +196,8 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
             let constant_handle = builder.func.dfg.constants.insert([0; 16].to_vec().into());
             builder.ins().vconst(ir::types::I8X16, constant_handle)
         }
-        NullRef => builder.ins().null(environ.reference_type()),
-        AnyRef => builder.ins().null(environ.reference_type()),
-        AnyFunc => builder.ins().null(environ.reference_type()),
+        ExternRef => builder.ins().null(environ.reference_type()),
+        FuncRef => builder.ins().null(environ.reference_type()),
         ty => return Err(wasm_unsupported!("unsupported local type {:?}", ty)),
     };
 

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -224,7 +224,7 @@ pub fn parse_global_section(
             Operator::V128Const { value } => {
                 GlobalInit::V128Const(V128Imm::from(value.bytes().to_vec().as_slice()))
             }
-            Operator::RefNull => GlobalInit::RefNullConst,
+            Operator::RefNull { ty: _ } => GlobalInit::RefNullConst,
             Operator::RefFunc { function_index } => {
                 GlobalInit::RefFunc(FuncIndex::from_u32(function_index))
             }
@@ -294,7 +294,7 @@ fn read_elems(items: &ElementItems) -> WasmResult<Box<[FuncIndex]>> {
     let mut elems = Vec::with_capacity(usize::try_from(items_reader.get_count()).unwrap());
     for item in items_reader {
         let elem = match item? {
-            ElementItem::Null => FuncIndex::reserved_value(),
+            ElementItem::Null(_ty) => FuncIndex::reserved_value(),
             ElementItem::Func(index) => FuncIndex::from_u32(index),
         };
         elems.push(elem);
@@ -311,7 +311,7 @@ pub fn parse_element_section<'data>(
 
     for (index, entry) in elements.into_iter().enumerate() {
         let Element { kind, items, ty } = entry?;
-        if ty != Type::AnyFunc {
+        if ty != Type::FuncRef {
             return Err(wasm_unsupported!(
                 "unsupported table element type: {:?}",
                 ty

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -143,9 +143,7 @@ pub fn type_to_type<PE: TargetEnvironment + ?Sized>(
         wasmparser::Type::F32 => Ok(ir::types::F32),
         wasmparser::Type::F64 => Ok(ir::types::F64),
         wasmparser::Type::V128 => Ok(ir::types::I8X16),
-        wasmparser::Type::AnyRef | wasmparser::Type::AnyFunc | wasmparser::Type::NullRef => {
-            Ok(environ.reference_type())
-        }
+        wasmparser::Type::ExternRef | wasmparser::Type::FuncRef => Ok(environ.reference_type()),
         ty => Err(wasm_unsupported!("type_to_type: wasm type {:?}", ty)),
     }
 }
@@ -162,8 +160,8 @@ pub fn tabletype_to_type<PE: TargetEnvironment + ?Sized>(
         wasmparser::Type::F32 => Ok(Some(ir::types::F32)),
         wasmparser::Type::F64 => Ok(Some(ir::types::F64)),
         wasmparser::Type::V128 => Ok(Some(ir::types::I8X16)),
-        wasmparser::Type::AnyRef => Ok(Some(environ.reference_type())),
-        wasmparser::Type::AnyFunc => Ok(None),
+        wasmparser::Type::ExternRef => Ok(Some(environ.reference_type())),
+        wasmparser::Type::FuncRef => Ok(None),
         ty => Err(wasm_unsupported!(
             "tabletype_to_type: table wasm type {:?}",
             ty
@@ -183,9 +181,8 @@ pub fn blocktype_params_results(
             wasmparser::Type::F32 => (&[], &[wasmparser::Type::F32]),
             wasmparser::Type::F64 => (&[], &[wasmparser::Type::F64]),
             wasmparser::Type::V128 => (&[], &[wasmparser::Type::V128]),
-            wasmparser::Type::AnyRef => (&[], &[wasmparser::Type::AnyRef]),
-            wasmparser::Type::AnyFunc => (&[], &[wasmparser::Type::AnyFunc]),
-            wasmparser::Type::NullRef => (&[], &[wasmparser::Type::NullRef]),
+            wasmparser::Type::ExternRef => (&[], &[wasmparser::Type::ExternRef]),
+            wasmparser::Type::FuncRef => (&[], &[wasmparser::Type::FuncRef]),
             wasmparser::Type::EmptyBlockType => (&[], &[]),
             ty => return Err(wasm_unsupported!("blocktype_params_results: type {:?}", ty)),
         },
@@ -218,7 +215,7 @@ pub fn block_with_params<PE: TargetEnvironment + ?Sized>(
             wasmparser::Type::F64 => {
                 builder.append_block_param(block, ir::types::F64);
             }
-            wasmparser::Type::AnyRef | wasmparser::Type::AnyFunc | wasmparser::Type::NullRef => {
+            wasmparser::Type::ExternRef | wasmparser::Type::FuncRef => {
                 builder.append_block_param(block, environ.reference_type());
             }
             wasmparser::Type::V128 => {

--- a/cranelift/wasm/tests/wasm_testsuite.rs
+++ b/cranelift/wasm/tests/wasm_testsuite.rs
@@ -83,7 +83,9 @@ fn read_module(path: &Path) -> Vec<u8> {
         }
         Some(ext) => match ext.to_str() {
             Some("wasm") => read_file(path).expect("error reading wasm file"),
-            Some("wat") => wat::parse_file(path).expect("failed to parse wat"),
+            Some("wat") => wat::parse_file(path)
+                .map_err(|e| e.to_string())
+                .expect("failed to parse wat"),
             None | Some(&_) => panic!("the file extension for {:?} is not wasm or wat", path),
         },
     }

--- a/cranelift/wasmtests/nullref.wat
+++ b/cranelift/wasmtests/nullref.wat
@@ -1,11 +1,11 @@
 (module
-	(func (result nullref)
-		ref.null
+	(func (result externref)
+		(ref.null extern)
 	)
 
-	(func (result nullref)
-		(block (result nullref)
-			ref.null
+	(func (result externref)
+		(block (result externref)
+			(ref.null extern)
 		)
 	)
 )

--- a/cranelift/wasmtests/ref-func-0.wat
+++ b/cranelift/wasmtests/ref-func-0.wat
@@ -1,12 +1,12 @@
 (module
   (func $imported (import "env" "f") (param i32) (result i32))
-  (func $local (result anyref anyref funcref funcref)
+  (func $local (result externref externref funcref funcref)
     global.get 0
     global.get 1
     global.get 2
     global.get 3)
 
-  (global (export "anyref-imported") anyref (ref.func $imported))
-  (global (export "anyref-local") anyref (ref.func $local))
+  (global (export "externref-imported") externref (ref.func $imported))
+  (global (export "externref-local") externref (ref.func $local))
   (global (export "funcref-imported") funcref (ref.func $imported))
   (global (export "funcref-local") funcref (ref.func $local)))

--- a/cranelift/wasmtests/select.wat
+++ b/cranelift/wasmtests/select.wat
@@ -5,15 +5,15 @@
   	i32.const 1
   	select)
 
-  (func $typed-select-1 (result anyref)
-  	ref.null
-  	ref.null
+  (func $typed-select-1 (result externref)
+  	ref.null extern
+  	ref.null extern
   	i32.const 1
-  	select (result anyref))
+  	select (result externref))
 
-  (func $typed-select-2 (param anyref) (result anyref)
-    ref.null
+  (func $typed-select-2 (param externref) (result externref)
+    ref.null extern
     local.get 0
     i32.const 1
-    select (result anyref))
+    select (result externref))
 )

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -23,7 +23,7 @@ wasmtime = { path = "../wasmtime", default-features = false }
 wasmtime-c-api-macros = { path = "macros" }
 
 # Optional dependency for the `wat2wasm` API
-wat = { version = "1.0", optional = true }
+wat = { version = "1.0.18", optional = true }
 
 # Optional dependencies for the `wasi` feature
 wasi-common = { path = "../wasi-common", optional = true }

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.20.0"
-wasmparser = "0.52.0"
+wasmparser = "0.55.0"
 faerie = "0.15.0"
 wasmtime-environ = { path = "../environ", version = "0.16.0" }
 target-lexicon = { version = "0.10.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.63.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.63.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.63.0", features = ["enable-serde"] }
-wasmparser = "0.52.0"
+wasmparser = "0.55.0"
 lightbeam = { path = "../lightbeam", optional = true, version = "0.16.0" }
 indexmap = "1.0.2"
 rayon = "1.2.1"

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,10 +13,10 @@ binaryen = { version = "0.10.0", optional = true }
 env_logger = "0.7.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.52.0"
-wasmprinter = "0.2.1"
+wasmparser = "0.55.0"
+wasmprinter = "0.2.5"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 
 [dev-dependencies]
-wat = "1.0.10"
+wat = "1.0.18"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime-profiling = { path = "../profiling", version = "0.16.0" }
 region = "2.0.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.10.0", default-features = false }
-wasmparser = "0.52.0"
+wasmparser = "0.55.0"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "0.1.9"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,11 +24,11 @@ smallvec = "1.0.0"
 staticvec = "0.9"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.52.0"
+wasmparser = "0.55.0"
 
 [dev-dependencies]
 lazy_static = "1.2"
-wat = "1.0.9"
+wat = "1.0.18"
 quickcheck = "0.9.0"
 anyhow = "1.0"
 

--- a/crates/lightbeam/src/microwasm.rs
+++ b/crates/lightbeam/src/microwasm.rs
@@ -2127,8 +2127,10 @@ where
             WasmOperator::I64Const { value } => one(Operator::Const(Value::I64(value))),
             WasmOperator::F32Const { value } => one(Operator::Const(Value::F32(value.into()))),
             WasmOperator::F64Const { value } => one(Operator::Const(Value::F64(value.into()))),
-            WasmOperator::RefNull => return Err(Error::Microwasm("RefNull unimplemented".into())),
-            WasmOperator::RefIsNull => {
+            WasmOperator::RefNull { ty: _ } => {
+                return Err(Error::Microwasm("RefNull unimplemented".into()))
+            }
+            WasmOperator::RefIsNull { ty: _ } => {
                 return Err(Error::Microwasm("RefIsNull unimplemented".into()))
             }
             WasmOperator::I32Eqz => one(Operator::Eqz(Size::_32)),

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -18,7 +18,7 @@ pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
-wat = "1.0.10"
+wat = "1.0.18"
 
 [features]
 test_programs = []

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -14,7 +14,7 @@ wasmtime-runtime = { path = "../runtime", version = "0.16.0" }
 wasmtime-environ = { path = "../environ", version = "0.16.0" }
 wasmtime-jit = { path = "../jit", version = "0.16.0" }
 wasmtime-profiling = { path = "../profiling", version = "0.16.0" }
-wasmparser = "0.52.0"
+wasmparser = "0.55.0"
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0.19"
 region = "2.0.0"
@@ -23,7 +23,7 @@ cfg-if = "0.1.9"
 backtrace = "0.3.42"
 rustc-demangle = "0.1.16"
 lazy_static = "1.4"
-wat = { version = "1.0.10", optional = true }
+wat = { version = "1.0.18", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.16.0", default-features = false }
-wast = "15.0.0"
+wast = "17.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/tests/misc_testsuite/bulk-memory-operations/elem-ref-null.wast
+++ b/tests/misc_testsuite/bulk-memory-operations/elem-ref-null.wast
@@ -1,2 +1,2 @@
 (module
-  (elem funcref (ref.null)))
+  (elem funcref (ref.null func)))

--- a/tests/misc_testsuite/threads.wast
+++ b/tests/misc_testsuite/threads.wast
@@ -1,1 +1,1 @@
-(assert_invalid (module (memory 1 1 shared)) "Unsupported feature: shared memories")
+(assert_invalid (module (memory 1 1 shared)) "threads must be enabled for shared memories")


### PR DESCRIPTION
This includes some SIMD opcode changes and the `AnyRef` to `ExternRef` changes
from the reference types proposal.