### PR TITLE
Fix missing modification of jump table in licm

### DIFF
--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -7,8 +7,9 @@ use crate::binemit::CodeOffset;
 use crate::entity::{PrimaryMap, SecondaryMap};
 use crate::ir;
 use crate::ir::{
-    Block, ExtFuncData, FuncRef, GlobalValue, GlobalValueData, Heap, HeapData, Inst, JumpTable,
-    JumpTableData, Opcode, SigRef, StackSlot, StackSlotData, Table, TableData,
+    instructions::BranchInfo, Block, ExtFuncData, FuncRef, GlobalValue, GlobalValueData, Heap,
+    HeapData, Inst, InstructionData, JumpTable, JumpTableData, Opcode, SigRef, StackSlot,
+    StackSlotData, Table, TableData,
 };
 use crate::ir::{BlockOffsets, InstEncodings, SourceLocs, StackSlots, ValueLocations};
 use crate::ir::{DataFlowGraph, ExternalName, Layout, Signature};
@@ -270,10 +271,49 @@ impl Function {
 
     /// Changes the destination of a jump or branch instruction.
     /// Does nothing if called with a non-jump or non-branch instruction.
+    ///
+    /// Note that this method ignores multi-destination branches like `br_table`.
     pub fn change_branch_destination(&mut self, inst: Inst, new_dest: Block) {
         match self.dfg[inst].branch_destination_mut() {
             None => (),
             Some(inst_dest) => *inst_dest = new_dest,
+        }
+    }
+
+    /// Rewrite the branch destination to `new_dest` if the destination matches `old_dest`.
+    /// Does nothing if called with a non-jump or non-branch instruction.
+    ///
+    /// Unlike [change_branch_destination](Function::change_branch_destination), this method rewrite the destinations of
+    /// multi-destination branches like `br_table`.
+    pub fn rewrite_branch_destination(&mut self, inst: Inst, old_dest: Block, new_dest: Block) {
+        match self.dfg.analyze_branch(inst) {
+            BranchInfo::SingleDest(dest, ..) => {
+                if dest == old_dest {
+                    self.change_branch_destination(inst, new_dest);
+                }
+            }
+
+            BranchInfo::Table(table, default_dest) => {
+                self.jump_tables[table].iter_mut().for_each(|entry| {
+                    if *entry == old_dest {
+                        *entry = new_dest;
+                    }
+                });
+
+                if default_dest == Some(old_dest) {
+                    match &mut self.dfg[inst] {
+                        InstructionData::BranchTable { destination, .. } => {
+                            *destination = new_dest;
+                        }
+                        _ => panic!(
+                            "Unexpected instruction {} having default destination",
+                            self.dfg.display_inst(inst, None)
+                        ),
+                    }
+                }
+            }
+
+            BranchInfo::NotABranch => {}
         }
     }
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -277,7 +277,7 @@ impl InstructionData {
                 ref mut destination,
                 ..
             } => Some(destination),
-            Self::BranchTable { .. } => None,
+            Self::BranchTable { .. } | Self::IndirectJump { .. } => None,
             _ => {
                 debug_assert!(!self.opcode().is_branch());
                 None

--- a/cranelift/filetests/filetests/licm/br-table.clif
+++ b/cranelift/filetests/filetests/licm/br-table.clif
@@ -1,0 +1,19 @@
+test compile
+set opt_level=speed_and_size
+target x86_64
+
+function %br_table_opt() {
+    jt0 = jump_table [block1, block2]
+
+    block0:
+        v0 = iconst.i32 1
+        br_table v0, block2, jt0
+
+    block1: 
+        return
+
+    block2:
+        v1 = iconst.i32 1
+        jump block2
+
+}

--- a/cranelift/filetests/filetests/licm/rewrite-jump-table.clif
+++ b/cranelift/filetests/filetests/licm/rewrite-jump-table.clif
@@ -1,0 +1,28 @@
+test licm
+target aarch64
+
+function %rewrite_jump_table() {
+    jt0 = jump_table [block1, block2]
+
+    block0:
+        v0 = iconst.i64 1
+        v1 = jump_table_base.i64 jt0
+        v2 = jump_table_entry.i64 v0, v1, 4, jt0
+        v3 = iadd v1, v2
+        indirect_jump_table_br v3, jt0
+
+    block1:
+        return
+
+    block2:
+        v4 = bconst.b1 false
+        jump block2
+}
+
+; sameln: function
+; nextln: jt0 = jump_table [block1, block3]
+; check: block3:
+; nextln: v4 = bconst.b1 false
+; nextln: jump block2
+; check: block2:
+; nextln: jump block2


### PR DESCRIPTION
Resolve #1648 and resolve #1080.
- [x] This has been discussed in issue #1648 and #1080
- [x] A short description of what this does, why it is needed;

1. Fix inconsistency between `branch_destination` and `branch_destination_mut` (Just adding `IndirectJump` case to `branch_destination_mut`).
2. Modify jump table entry if it points at loop header, and also modify destination if it points at loop header.

- [x] This PR contains test cases, if meaningful.

- [x] A reviewer from the core maintainer team has been assigned for this PR.
@iximeow Could you review this please?  I know you are aware of the issue, so please feel free to close this PR if you have started looking into.

