### PR TITLE
Reduce arm64 Inst enum size

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -68,6 +68,7 @@ use crate::isa::aarch64::{self, inst::*};
 use crate::machinst::*;
 use crate::settings;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use regalloc::{RealReg, Reg, RegClass, Set, SpillSlot, Writable};
@@ -1275,9 +1276,9 @@ impl ABICall for AArch64ABICall {
         );
         match &self.dest {
             &CallDest::ExtName(ref name, RelocDistance::Near) => ctx.emit(Inst::Call {
-                dest: name.clone(),
-                uses,
-                defs,
+                dest: Box::new(name.clone()),
+                uses: Box::new(uses),
+                defs: Box::new(defs),
                 loc: self.loc,
                 opcode: self.opcode,
             }),
@@ -1290,16 +1291,16 @@ impl ABICall for AArch64ABICall {
                 });
                 ctx.emit(Inst::CallInd {
                     rn: spilltmp_reg(),
-                    uses,
-                    defs,
+                    uses: Box::new(uses),
+                    defs: Box::new(defs),
                     loc: self.loc,
                     opcode: self.opcode,
                 });
             }
             &CallDest::Reg(reg) => ctx.emit(Inst::CallInd {
                 rn: reg,
-                uses,
-                defs,
+                uses: Box::new(uses),
+                defs: Box::new(defs),
                 loc: self.loc,
                 opcode: self.opcode,
             }),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -1303,7 +1303,7 @@ impl<O: MachSectionOutput> MachInstEmit<O> for Inst {
                 };
                 inst.emit(sink, flags, state);
                 // Emit jump table (table of 32-bit offsets).
-                for target in targets {
+                for target in targets.iter() {
                     let off = target.as_offset_words() * 4;
                     let off = i32::try_from(off).unwrap();
                     // cast i32 to u32 (two's-complement)

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -3,6 +3,7 @@ use crate::isa::aarch64::inst::*;
 use crate::isa::test_utils;
 use crate::settings;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 #[test]
@@ -2112,9 +2113,9 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::Call {
-            dest: ExternalName::testcase("test0"),
-            uses: Set::empty(),
-            defs: Set::empty(),
+            dest: Box::new(ExternalName::testcase("test0")),
+            uses: Box::new(Set::empty()),
+            defs: Box::new(Set::empty()),
             loc: SourceLoc::default(),
             opcode: Opcode::Call,
         },
@@ -2125,8 +2126,8 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::CallInd {
             rn: xreg(10),
-            uses: Set::empty(),
-            defs: Set::empty(),
+            uses: Box::new(Set::empty()),
+            defs: Box::new(Set::empty()),
             loc: SourceLoc::default(),
             opcode: Opcode::CallIndirect,
         },

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -2132,8 +2132,8 @@ pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
                     ridx,
                     rtmp1,
                     rtmp2,
-                    targets: jt_targets,
-                    targets_for_term,
+                    targets: jt_targets.into_boxed_slice(),
+                    targets_for_term: targets_for_term.into_boxed_slice(),
                 });
             }
 


### PR DESCRIPTION
This reduces the size of the Inst enum from 112 bytes to 48 bytes.

Using DHAT on a regex-rs.wasm benchmark, `valgrind --tool=dhat clif-util compile --target aarch64`

The total number of allocated bytes, drops by around 170 MB.
At t-gmax drops by 3 MB.

Using `perf stat clif-util compile --target aarch64`, the instructions count dropped by 0.6%. Cache misses dropped by 6%. Cycles dropped by 2.3%.

Suggestions (or help!) for measuring this further are welcomed.

Inspired by nnethercote's changes / articles about reducing enum sizes in rustc.