### PR TITLE
peepmatic: remove unused member from `PeepholeOptimizer`

### DIFF
--- a/cranelift/peepmatic/crates/runtime/src/optimizations.rs
+++ b/cranelift/peepmatic/crates/runtime/src/optimizations.rs
@@ -65,7 +65,6 @@ impl PeepholeOptimizations {
         PeepholeOptimizer {
             peep_opt: self,
             instr_set,
-            left_hand_sides: vec![],
             right_hand_sides: vec![],
             actions: vec![],
             backtracking_states: vec![],

--- a/cranelift/peepmatic/crates/runtime/src/optimizer.rs
+++ b/cranelift/peepmatic/crates/runtime/src/optimizer.rs
@@ -27,7 +27,6 @@ where
 {
     pub(crate) peep_opt: &'peep PeepholeOptimizations,
     pub(crate) instr_set: I,
-    pub(crate) left_hand_sides: Vec<Part<I::Instruction>>,
     pub(crate) right_hand_sides: Vec<Part<I::Instruction>>,
     pub(crate) actions: Vec<Action>,
     pub(crate) backtracking_states: Vec<(State, usize)>,
@@ -41,7 +40,6 @@ where
         let PeepholeOptimizer {
             peep_opt,
             instr_set: _,
-            left_hand_sides,
             right_hand_sides,
             actions,
             backtracking_states,
@@ -49,7 +47,6 @@ where
         f.debug_struct("PeepholeOptimizer")
             .field("peep_opt", peep_opt)
             .field("instr_set", &"_")
-            .field("left_hand_sides", left_hand_sides)
             .field("right_hand_sides", right_hand_sides)
             .field("actions", actions)
             .field("backtracking_states", backtracking_states)
@@ -485,7 +482,6 @@ where
 
         self.backtracking_states.clear();
         self.actions.clear();
-        self.left_hand_sides.clear();
         self.right_hand_sides.clear();
 
         let mut r#final = None;


### PR DESCRIPTION
This is dead code, left over from an earlier design.