### PR TITLE
Fix Wasm from rust docs

### DIFF
--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -43,7 +43,7 @@ dependency in `Cargo.toml`:
 
 ```toml
 [dependencies]
-wasmtime = "0.12.0"
+wasmtime = "0.16.0"
 ```
 
 Next up let's write the code that we need to execute this wasm file. The
@@ -120,7 +120,7 @@ some simple arithmetic from the environment.
 (module
   (import "" "log" (func $log (param i32)))
   (import "" "double" (func $double (param i32) (result i32)))
-  (func (export "run") (result i32)
+  (func (export "run")
     i32.const 0
     call $log
     i32.const 1
@@ -138,29 +138,37 @@ looks like this:
 
 ```rust,no_run
 # extern crate wasmtime;
-# use std::error::Error;
-# use wasmtime::*;
-# fn main() -> Result<(), Box<dyn Error>> {
-# let store = Store::default();
-# let module = Module::new(&store, r#"
-# (module
-# (import "" "log" (func $log (param i32)))
-# (import "" "double" (func $double (param i32) (result i32))))"#)?;
-// First we can create our `log` function, which will simply print out the
-// parameter it receives.
-let log = Func::wrap(&store, |param: i32| {
-    println!("log: {}", param);
-});
+use std::error::Error;
+use wasmtime::*;
 
-// Next we can create our double function which doubles the input it receives.
-let double = Func::wrap(&store, |param: i32| param * 2);
+fn main() -> Result<(), Box<dyn Error>> {
+    let store = Store::default();
+    let module = Module::from_file(&store, "hello.wat")?;
 
-// When instantiating the module we now need to provide the imports to the
-// instantiation process. This is the second slice argument, where each
-// entry in the slice must line up with the imports in the module.
-let instance = Instance::new(&module, &[log.into(), double.into()])?;
-# Ok(())
-# }
+    // First we can create our `log` function, which will simply print out the
+    // parameter it receives.
+    let log = Func::wrap(&store, |param: i32| {
+        println!("log: {}", param);
+    });
+
+    // Next we can create our double function which doubles the input it receives.
+    let double = Func::wrap(&store, |param: i32| param * 2);
+
+    // When instantiating the module we now need to provide the imports to the
+    // instantiation process. This is the second slice argument, where each
+    // entry in the slice must line up with the imports in the module.
+    let instance = Instance::new(&module, &[log.into(), double.into()])?;
+
+    let run = instance
+        .get_func("run")
+        .expect("`run` was not an exported function");
+
+    let run = run.get0::<()>()?;
+
+    Ok(run()?)
+}
+
+}
 ```
 
 Note that there's a number of ways to define a `Func`, be sure to [consult its

--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -143,7 +143,10 @@ use wasmtime::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let store = Store::default();
+# if false {
     let module = Module::from_file(&store, "hello.wat")?;
+# }
+# let module = Module::new(&store, r#"(module (import "" "log" (func $log (param i32))) (import "" "double" (func $double (param i32) (result i32))) (func (export "run") i32.const 0 call $log i32.const 1 call $log i32.const 2 call $double call $log))"#)?;
 
     // First we can create our `log` function, which will simply print out the
     // parameter it receives.

--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -170,8 +170,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(run()?)
 }
-
-}
 ```
 
 Note that there's a number of ways to define a `Func`, be sure to [consult its


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Hello!

I was playing around with this and noticed the docs are a bit broken. Here are my changes:

- Update wasmtime version in docs to 0.16.0
  - Breaking API changes from #1524 were made in the docs, but the old version was kept
- Change second code `wat` example.
  - The run function does not return anything (I guess another option would be to return some value to keep the function call the same signature as previous but I think this may help some)
- Expose the whole file code for the updated usage on the second example
  - Expanding from the previous example, it is confusing how the code is setup for this, as there is the other changes needed for this to run successfully
  - Open to suggestions or reverting this, as this is more opinionated

Link to docs for reference, if it helps: https://bytecodealliance.github.io/wasmtime/lang-rust.html
