### PR TITLE
Limit the size of automaton keys in the `peepmatic_fst_diff` fuzz target

### DIFF
--- a/cranelift/peepmatic/crates/fuzzing/src/automata.rs
+++ b/cranelift/peepmatic/crates/fuzzing/src/automata.rs
@@ -109,7 +109,11 @@ pub fn simple_automata(input_output_pairs: Vec<Vec<(u8, Vec<u8>)>>) {
 pub fn fst_differential(map: HashMap<Vec<u8>, u64>) {
     let _ = env_logger::try_init();
 
-    let mut inputs: Vec<_> = map.keys().filter(|i| !i.is_empty()).cloned().collect();
+    let mut inputs: Vec<_> = map
+        .keys()
+        .filter(|k| !k.is_empty() && k.len() < 256)
+        .cloned()
+        .collect();
     inputs.sort();
     inputs.dedup();
     if inputs.is_empty() {


### PR DESCRIPTION
This should avoid timeouts caused by large keys.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22251