### PR TITLE
Revert fstatat on *nix and test symlinks in path_filestat calls

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
@@ -124,22 +124,12 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
     let mut sym_stat = wasi::path_filestat_get(dir_fd, 0, "file").expect("reading file stats");
 
     let sym_new_mtim = sym_stat.mtim - 200;
-    wasi::path_filestat_set_times(
-        dir_fd,
-        0,
-        "symlink",
-        // on purpose: the syscall should not touch atim, because
-        // neither of the ATIM flags is set
-        sym_new_mtim,
-        sym_new_mtim,
-        wasi::FSTFLAGS_MTIM,
-    )
-    .expect("path_filestat_set_times should succeed on symlink");
+    wasi::path_filestat_set_times(dir_fd, 0, "symlink", 0, sym_new_mtim, wasi::FSTFLAGS_MTIM)
+        .expect("path_filestat_set_times should succeed on symlink");
 
     sym_stat = wasi::path_filestat_get(dir_fd, 0, "symlink")
         .expect("reading file stats after path_filestat_set_times");
-    assert_eq!(sym_stat.mtim, new_mtim, "mtim should change");
-    assert_eq!(sym_stat.atim, old_atim, "atim should not change");
+    assert_eq!(sym_stat.mtim, sym_new_mtim, "mtim should change");
 
     // Now, dereference the symlink
     sym_stat = wasi::path_filestat_get(dir_fd, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW, "symlink")

--- a/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
@@ -117,8 +117,61 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
     assert_eq!(stat.mtim, new_mtim, "mtim should not change");
     assert_eq!(stat.atim, old_atim, "atim should not change");
 
+    // Create a symlink
+    wasi::path_symlink("file", dir_fd, "symlink").expect("creating symlink to a file");
+
+    // Check path_filestat_set_times on the symlink itself
+    let mut sym_stat = wasi::path_filestat_get(dir_fd, 0, "file").expect("reading file stats");
+
+    let sym_new_mtim = sym_stat.mtim - 200;
+    wasi::path_filestat_set_times(
+        dir_fd,
+        0,
+        "symlink",
+        // on purpose: the syscall should not touch atim, because
+        // neither of the ATIM flags is set
+        sym_new_mtim,
+        sym_new_mtim,
+        wasi::FSTFLAGS_MTIM,
+    )
+    .expect("path_filestat_set_times should succeed on symlink");
+
+    sym_stat = wasi::path_filestat_get(dir_fd, 0, "symlink")
+        .expect("reading file stats after path_filestat_set_times");
+    assert_eq!(sym_stat.mtim, new_mtim, "mtim should change");
+    assert_eq!(sym_stat.atim, old_atim, "atim should not change");
+
+    // Now, dereference the symlink
+    sym_stat = wasi::path_filestat_get(dir_fd, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW, "symlink")
+        .expect("reading file stats on the dereferenced symlink");
+    assert_eq!(
+        sym_stat.mtim, stat.mtim,
+        "symlink mtim should be equal to pointee's when dereferenced"
+    );
+    assert_eq!(
+        sym_stat.atim, stat.atim,
+        "symlink atim should be equal to pointee's when dereferenced"
+    );
+
+    // Finally, change stat of the original file by dereferencing the symlink
+    wasi::path_filestat_set_times(
+        dir_fd,
+        wasi::LOOKUPFLAGS_SYMLINK_FOLLOW,
+        "symlink",
+        sym_stat.atim,
+        sym_stat.mtim,
+        wasi::FSTFLAGS_MTIM | wasi::FSTFLAGS_ATIM,
+    )
+    .expect("path_filestat_set_times should succeed on setting stat on original file");
+
+    stat = wasi::path_filestat_get(dir_fd, 0, "file")
+        .expect("reading file stats after path_filestat_set_times");
+    assert_eq!(stat.mtim, sym_stat.mtim, "mtim should change");
+    assert_eq!(stat.atim, sym_stat.atim, "atim should change");
+
     wasi::fd_close(file_fd).expect("closing a file");
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasi::path_unlink_file(dir_fd, "symlink").expect("removing a symlink");
 }
 fn main() {
     let mut args = env::args();

--- a/crates/wasi-common/src/handle.rs
+++ b/crates/wasi-common/src/handle.rs
@@ -135,7 +135,7 @@ pub(crate) trait Handle {
     fn create_directory(&self, _path: &str) -> Result<()> {
         Err(Errno::Acces)
     }
-    fn filestat_get_at(&self, _path: &str) -> Result<types::Filestat> {
+    fn filestat_get_at(&self, _path: &str, _follow: bool) -> Result<types::Filestat> {
         Err(Errno::Acces)
     }
     fn filestat_set_times_at(
@@ -144,6 +144,7 @@ pub(crate) trait Handle {
         _atim: types::Timestamp,
         _mtim: types::Timestamp,
         _fst_flags: types::Fstflags,
+        _follow: bool,
     ) -> Result<()> {
         Err(Errno::Acces)
     }

--- a/crates/wasi-common/src/handle.rs
+++ b/crates/wasi-common/src/handle.rs
@@ -135,6 +135,18 @@ pub(crate) trait Handle {
     fn create_directory(&self, _path: &str) -> Result<()> {
         Err(Errno::Acces)
     }
+    fn filestat_get_at(&self, _path: &str) -> Result<types::Filestat> {
+        Err(Errno::Acces)
+    }
+    fn filestat_set_times_at(
+        &self,
+        _path: &str,
+        _atim: types::Timestamp,
+        _mtim: types::Timestamp,
+        _fst_flags: types::Fstflags,
+    ) -> Result<()> {
+        Err(Errno::Acces)
+    }
     fn openat(
         &self,
         _path: &str,

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -469,15 +469,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         let required_rights = HandleRights::from_base(types::Rights::PATH_FILESTAT_GET);
         let entry = self.get_entry(dirfd)?;
         let (dirfd, path) = path::get(&entry, &required_rights, flags, path, false)?;
-        let host_filestat = dirfd
-            .openat(
-                &path,
-                false,
-                false,
-                types::Oflags::empty(),
-                types::Fdflags::empty(),
-            )?
-            .filestat_get()?;
+        let host_filestat = dirfd.filestat_get_at(&path)?;
         Ok(host_filestat)
     }
 
@@ -493,15 +485,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         let required_rights = HandleRights::from_base(types::Rights::PATH_FILESTAT_SET_TIMES);
         let entry = self.get_entry(dirfd)?;
         let (dirfd, path) = path::get(&entry, &required_rights, flags, path, false)?;
-        dirfd
-            .openat(
-                &path,
-                false,
-                false,
-                types::Oflags::empty(),
-                types::Fdflags::empty(),
-            )?
-            .filestat_set_times(atim, mtim, fst_flags)?;
+        dirfd.filestat_set_times_at(&path, atim, mtim, fst_flags)?;
         Ok(())
     }
 

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -469,7 +469,8 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         let required_rights = HandleRights::from_base(types::Rights::PATH_FILESTAT_GET);
         let entry = self.get_entry(dirfd)?;
         let (dirfd, path) = path::get(&entry, &required_rights, flags, path, false)?;
-        let host_filestat = dirfd.filestat_get_at(&path)?;
+        let host_filestat =
+            dirfd.filestat_get_at(&path, flags.contains(&types::Lookupflags::SYMLINK_FOLLOW))?;
         Ok(host_filestat)
     }
 
@@ -485,7 +486,13 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         let required_rights = HandleRights::from_base(types::Rights::PATH_FILESTAT_SET_TIMES);
         let entry = self.get_entry(dirfd)?;
         let (dirfd, path) = path::get(&entry, &required_rights, flags, path, false)?;
-        dirfd.filestat_set_times_at(&path, atim, mtim, fst_flags)?;
+        dirfd.filestat_set_times_at(
+            &path,
+            atim,
+            mtim,
+            fst_flags,
+            flags.contains(&types::Lookupflags::SYMLINK_FOLLOW),
+        )?;
         Ok(())
     }
 

--- a/crates/wasi-common/src/sys/osdir.rs
+++ b/crates/wasi-common/src/sys/osdir.rs
@@ -69,8 +69,8 @@ impl Handle for OsDir {
     fn create_directory(&self, path: &str) -> Result<()> {
         path::create_directory(self, path)
     }
-    fn filestat_get_at(&self, path: &str) -> Result<types::Filestat> {
-        path::filestat_get_at(self, path)
+    fn filestat_get_at(&self, path: &str, follow: bool) -> Result<types::Filestat> {
+        path::filestat_get_at(self, path, follow)
     }
     fn filestat_set_times_at(
         &self,
@@ -78,8 +78,9 @@ impl Handle for OsDir {
         atim: types::Timestamp,
         mtim: types::Timestamp,
         fst_flags: types::Fstflags,
+        follow: bool,
     ) -> Result<()> {
-        path::filestat_set_times_at(self, path, atim, mtim, fst_flags)
+        path::filestat_set_times_at(self, path, atim, mtim, fst_flags, follow)
     }
     fn openat(
         &self,

--- a/crates/wasi-common/src/sys/osdir.rs
+++ b/crates/wasi-common/src/sys/osdir.rs
@@ -69,6 +69,18 @@ impl Handle for OsDir {
     fn create_directory(&self, path: &str) -> Result<()> {
         path::create_directory(self, path)
     }
+    fn filestat_get_at(&self, path: &str) -> Result<types::Filestat> {
+        path::filestat_get_at(self, path)
+    }
+    fn filestat_set_times_at(
+        &self,
+        path: &str,
+        atim: types::Timestamp,
+        mtim: types::Timestamp,
+        fst_flags: types::Fstflags,
+    ) -> Result<()> {
+        path::filestat_set_times_at(self, path, atim, mtim, fst_flags)
+    }
     fn openat(
         &self,
         path: &str,

--- a/crates/wasi-common/src/sys/unix/path.rs
+++ b/crates/wasi-common/src/sys/unix/path.rs
@@ -257,4 +257,5 @@ pub(crate) fn filestat_set_times_at(
 
     utimensat(&*dirfd.as_file()?, path, atim, mtim, !follow)?;
 
-    Ok(()) }
+    Ok(())
+}

--- a/crates/wasi-common/src/sys/windows/path.rs
+++ b/crates/wasi-common/src/sys/windows/path.rs
@@ -501,7 +501,7 @@ pub(crate) fn filestat_get_at(dirfd: &OsDir, path: &str, follow: bool) -> Result
     let mut opts = OpenOptions::new();
 
     if !follow {
-        // by specifying FILE_FLAG_OPEN_REPARSE_POINT, we force Windows to *not* dereference symlinks
+        // By specifying FILE_FLAG_OPEN_REPARSE_POINT, we force Windows to *not* dereference symlinks.
         opts.custom_flags(Flags::FILE_FLAG_OPEN_REPARSE_POINT.bits());
     }
 
@@ -510,8 +510,6 @@ pub(crate) fn filestat_get_at(dirfd: &OsDir, path: &str, follow: bool) -> Result
     Ok(stat)
 }
 
-// We can safely ignore `follow` here as symlink expansion and any error throwing
-// should be done one layer above in `path::get`.
 pub(crate) fn filestat_set_times_at(
     dirfd: &OsDir,
     path: &str,
@@ -525,7 +523,7 @@ pub(crate) fn filestat_set_times_at(
     let mut opts = OpenOptions::new();
 
     if !follow {
-        // by specifying FILE_FLAG_OPEN_REPARSE_POINT, we force Windows to *not* dereference symlinks
+        // By specifying FILE_FLAG_OPEN_REPARSE_POINT, we force Windows to *not* dereference symlinks.
         opts.custom_flags(Flags::FILE_FLAG_OPEN_REPARSE_POINT.bits());
     }
 

--- a/crates/wasi-common/src/sys/windows/path.rs
+++ b/crates/wasi-common/src/sys/windows/path.rs
@@ -495,7 +495,11 @@ pub(crate) fn remove_directory(dirfd: &OsDir, path: &str) -> Result<()> {
     std::fs::remove_dir(&path).map_err(Into::into)
 }
 
-pub(crate) fn filestat_get_at(dirfd: &OsDir, path: &str) -> Result<types::Filestat> {
+pub(crate) fn filestat_get_at(
+    dirfd: &OsDir,
+    path: &str,
+    _symlink_follow: bool,
+) -> Result<types::Filestat> {
     let stat = dirfd
         .openat(
             path,
@@ -514,6 +518,7 @@ pub(crate) fn filestat_set_times_at(
     atim: types::Timestamp,
     mtim: types::Timestamp,
     fst_flags: types::Fstflags,
+    _symlink_follow: bool,
 ) -> Result<()> {
     dirfd
         .openat(

--- a/crates/wasi-common/src/sys/windows/path.rs
+++ b/crates/wasi-common/src/sys/windows/path.rs
@@ -494,3 +494,35 @@ pub(crate) fn remove_directory(dirfd: &OsDir, path: &str) -> Result<()> {
     let path = concatenate(dirfd, path)?;
     std::fs::remove_dir(&path).map_err(Into::into)
 }
+
+pub(crate) fn filestat_get_at(dirfd: &OsDir, path: &str) -> Result<types::Filestat> {
+    let stat = dirfd
+        .openat(
+            path,
+            false,
+            false,
+            types::Oflags::empty(),
+            types::Fdflags::empty(),
+        )?
+        .filestat_get()?;
+    Ok(stat)
+}
+
+pub(crate) fn filestat_set_times_at(
+    dirfd: &OsDir,
+    path: &str,
+    atim: types::Timestamp,
+    mtim: types::Timestamp,
+    fst_flags: types::Fstflags,
+) -> Result<()> {
+    dirfd
+        .openat(
+            path,
+            false,
+            false,
+            types::Oflags::empty(),
+            types::Fdflags::empty(),
+        )?
+        .filestat_set_times(atim, mtim, fst_flags)?;
+    Ok(())
+}

--- a/crates/wasi-common/src/sys/windows/path.rs
+++ b/crates/wasi-common/src/sys/windows/path.rs
@@ -495,13 +495,9 @@ pub(crate) fn remove_directory(dirfd: &OsDir, path: &str) -> Result<()> {
     std::fs::remove_dir(&path).map_err(Into::into)
 }
 
-pub(crate) fn filestat_get_at(
-    dirfd: &OsDir,
-    path: &str,
-    follow: bool,
-) -> Result<types::Filestat> {
+pub(crate) fn filestat_get_at(dirfd: &OsDir, path: &str, follow: bool) -> Result<types::Filestat> {
     let path = concatenate(dirfd, path)?;
-    
+
     // Expand symlinks if we're meant to follow.
     // TODO audit this: is it possible to expand outside of
     // `dirfd`? In a way, is it possible to "dirfd/.."?

--- a/crates/wasi-common/src/virtfs.rs
+++ b/crates/wasi-common/src/virtfs.rs
@@ -600,7 +600,7 @@ impl Handle for VirtualDir {
             }
         }
     }
-    fn filestat_get_at(&self, path: &str) -> Result<types::Filestat> {
+    fn filestat_get_at(&self, path: &str, _symlink_follow: bool) -> Result<types::Filestat> {
         let stat = self
             .openat(
                 path,
@@ -618,6 +618,7 @@ impl Handle for VirtualDir {
         atim: types::Timestamp,
         mtim: types::Timestamp,
         fst_flags: types::Fstflags,
+        _symlink_follow: bool,
     ) -> Result<()> {
         self.openat(
             path,

--- a/crates/wasi-common/src/virtfs.rs
+++ b/crates/wasi-common/src/virtfs.rs
@@ -600,7 +600,7 @@ impl Handle for VirtualDir {
             }
         }
     }
-    fn filestat_get_at(&self, path: &str, _symlink_follow: bool) -> Result<types::Filestat> {
+    fn filestat_get_at(&self, path: &str, _follow: bool) -> Result<types::Filestat> {
         let stat = self
             .openat(
                 path,
@@ -618,7 +618,7 @@ impl Handle for VirtualDir {
         atim: types::Timestamp,
         mtim: types::Timestamp,
         fst_flags: types::Fstflags,
-        _symlink_follow: bool,
+        _follow: bool,
     ) -> Result<()> {
         self.openat(
             path,

--- a/crates/wasi-common/src/virtfs.rs
+++ b/crates/wasi-common/src/virtfs.rs
@@ -600,6 +600,35 @@ impl Handle for VirtualDir {
             }
         }
     }
+    fn filestat_get_at(&self, path: &str) -> Result<types::Filestat> {
+        let stat = self
+            .openat(
+                path,
+                false,
+                false,
+                types::Oflags::empty(),
+                types::Fdflags::empty(),
+            )?
+            .filestat_get()?;
+        Ok(stat)
+    }
+    fn filestat_set_times_at(
+        &self,
+        path: &str,
+        atim: types::Timestamp,
+        mtim: types::Timestamp,
+        fst_flags: types::Fstflags,
+    ) -> Result<()> {
+        self.openat(
+            path,
+            false,
+            false,
+            types::Oflags::empty(),
+            types::Fdflags::empty(),
+        )?
+        .filestat_set_times(atim, mtim, fst_flags)?;
+        Ok(())
+    }
     fn openat(
         &self,
         path: &str,


### PR DESCRIPTION
This commit effectively reverts too eager refactoring on my part which
resulted in incorrect `path_filestat_{get, set_times}` behaviour on
*nix hosts. In the presence of symlinks, neither of the calls would
work properly.

In order to shield ourselves from similar errors in the future, I've
augmented the `path_filestat` test cases with symlink checks as well.