### PR TITLE
Fix assertion about length/capacity in C API

### DIFF
--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -67,8 +67,8 @@ macro_rules! declare_vecs {
         }
 
         impl From<Vec<$elem_ty>> for $name {
-            fn from(mut vec: Vec<$elem_ty>) -> Self {
-                assert_eq!(vec.len(), vec.capacity());
+            fn from(vec: Vec<$elem_ty>) -> Self {
+                let mut vec = vec.into_boxed_slice();
                 let result = $name {
                     size: vec.len(),
                     data: vec.as_mut_ptr(),


### PR DESCRIPTION
I recently saw some [errors] crop up in wasmtime-go's CI, so let's be
sure to convert to `Box<[T]>` which guarantees the length/capacity of
the vector are equal.

[errors]: https://github.com/bytecodealliance/wasmtime-go/runs/694744570
