### PR TITLE
Enable `env_logger` in the C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ name = "wasmtime-c-api"
 version = "0.16.0"
 dependencies = [
  "anyhow",
+ "env_logger 0.7.1",
  "once_cell",
  "wasi-common",
  "wasmtime",

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -17,6 +17,7 @@ test = false
 doctest = false
 
 [dependencies]
+env_logger = "0.7"
 anyhow = "1.0"
 once_cell = "1.3"
 wasmtime = { path = "../wasmtime", default-features = false }

--- a/crates/c-api/src/engine.rs
+++ b/crates/c-api/src/engine.rs
@@ -11,6 +11,16 @@ wasmtime_c_api_macros::declare_own!(wasm_engine_t);
 
 #[no_mangle]
 pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
+    // Enable the `env_logger` crate since this is as good a place as any to
+    // support some "top level initialization" for the C API. Almost all support
+    // should go through this one way or another, so this ensures that
+    // `RUST_LOG` should work reasonably well.
+    //
+    // Note that we `drop` the result here since this fails after the first
+    // initialization attempt. We don't mind that though because this function
+    // can be called multiple times, so we just ignore the result.
+    drop(env_logger::try_init());
+
     Box::new(wasm_engine_t {
         engine: HostRef::new(Engine::default()),
     })


### PR DESCRIPTION
This commit ensures that `env_logger` and `RUST_LOG` are configured to
work with the C API.
