### PR TITLE
runtime: handle traps on Windows x32

### DIFF
--- a/crates/jit/src/unwind.rs
+++ b/crates/jit/src/unwind.rs
@@ -2,6 +2,9 @@ cfg_if::cfg_if! {
     if #[cfg(all(windows, target_arch = "x86_64"))] {
         mod winx64;
         pub use self::winx64::*;
+    } else if #[cfg(all(windows, target_arch = "x86"))] {
+        mod winx32;
+        pub use self::winx32::*;
     } else if #[cfg(unix)] {
         mod systemv;
         pub use self::systemv::*;

--- a/crates/jit/src/unwind/winx32.rs
+++ b/crates/jit/src/unwind/winx32.rs
@@ -1,0 +1,20 @@
+//! Stub unwind registry for Windows x32.
+
+use anyhow::{bail, Result};
+use cranelift_codegen::isa::{unwind::UnwindInfo, TargetIsa};
+
+pub struct UnwindRegistry {}
+
+impl UnwindRegistry {
+    pub fn new(_base_address: usize) -> Self {
+        Self {}
+    }
+
+    pub fn register(&mut self, _func_start: u32, _func_len: u32, _info: &UnwindInfo) -> Result<()> {
+        bail!("winx32 has no unwind registry")
+    }
+
+    pub fn publish(&mut self, _isa: &dyn TargetIsa) -> Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR is a small incremental step towards a working Windows x32 backend. It implements what I believe is the correct approach to handling traps on x86_32 Windows, which is based on my understanding of x32 SEH: there is no global unwind registry at all, and instead SEH frames are pushed onto stack. Therefore no registration is needed. However I am by no means a Windows expert and my understanding might be incorrect.

There is no way to actually run code on Windows x32 yet because the fastcall ABI isn't implemented. I'll add that in a follow-up PR. I have a working prototype that can print `Hello, World` but it has some missing parts and requires major cleanup to be upstreamed.