### PR TITLE
[WIP] Add support for Windows x32 ABI

### DIFF
--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -2,7 +2,7 @@ use crate::isa::TargetIsa;
 use crate::settings::LibcallCallConv;
 use core::fmt;
 use core::str;
-use target_lexicon::{CallingConvention, Triple};
+use target_lexicon::{CallingConvention, OperatingSystem, PointerWidth, Triple};
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -30,6 +30,10 @@ pub enum CallConv {
 impl CallConv {
     /// Return the default calling convention for the given target triple.
     pub fn triple_default(triple: &Triple) -> Self {
+        match (triple.operating_system, triple.pointer_width()) {
+            (OperatingSystem::Windows, Ok(PointerWidth::U32)) => return Self::SystemV,
+            _ => ()
+        }
         match triple.default_calling_convention() {
             // Default to System V for unknown targets because most everything
             // uses System V.


### PR DESCRIPTION
As it stands the patch in this PR is as minimal as it is hair-raising, and it's really not going to be merged in the current state. However, with it and #1740 I can actually run simple programs on x32! 
![Screenshot_20200521_193835](https://user-images.githubusercontent.com/54771/82598768-a98bc600-9b9a-11ea-861e-7ad54ef5c350.png)

(The `-Cpanic=abort`, plus a dummy `#[no_mangle] pub extern fn _Unwind_Resume() { unimplemented!() }`, are there to work around the fact that Linux distributions all build MinGW with SjLj exceptions, but Rust expects a MinGW toolchain with DWARF exceptions.)

Let me explain the reasons this PR looks like it does. 

First, currently target-lexicon considers Windows as [always using `fastcall`](https://github.com/bytecodealliance/target-lexicon/blob/0f50c382befc9f7f13349299f3ca77cabcc4b163/src/triple.rs#L124). However that's not the case on x32, where C code uses `cdecl` by default, and Win32 APIs use `stdcall` by default.  This is why Windows x32 is special-cased in cranelift in this PR. To fix this, I believe that `default_calling_convention` for Windows x32 should return `cdecl` so that it matches the behavior of the Rust `c` calling convention, but that's where we get to the second issue...

Second, there is actually no way to express "Windows `cdecl`" in either target-lexicon or cranelift. AFAICT this calling convention is functionally identical to the System V one; LLVM calls it `ccc` to avoid naming it in either a *nix-specific way ("System V") or a Windows-specific way ("`cdecl`"). The way this should be handled is purely subjective though (the options being "rename SystemV to Ccc", "rename SystemV to Cdecl", "add Cdecl as an alias of SystemV for Windows alone", and "do nothing and just use SystemV on Windows x32") so I'm going to implement whatever the maintainers ask me to.