### PR TITLE
Remove Eq bound of ReservedValue trait

### DIFF
--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -85,6 +85,10 @@ macro_rules! entity_impl {
             fn reserved_value() -> $entity {
                 $entity($crate::__core::u32::MAX)
             }
+
+            fn is_reserved_value(&self) -> bool {
+                self.0 == $crate::__core::u32::MAX
+            }
         }
 
         impl $entity {

--- a/cranelift/entity/src/packed_option.rs
+++ b/cranelift/entity/src/packed_option.rs
@@ -11,9 +11,11 @@ use core::fmt;
 use core::mem;
 
 /// Types that have a reserved value which can't be created any other way.
-pub trait ReservedValue: Eq {
+pub trait ReservedValue {
     /// Create an instance of the reserved value.
     fn reserved_value() -> Self;
+    /// Checks whether value is the reserved one.
+    fn is_reserved_value(&self) -> bool;
 }
 
 /// Packed representation of `Option<T>`.
@@ -23,12 +25,12 @@ pub struct PackedOption<T: ReservedValue>(T);
 impl<T: ReservedValue> PackedOption<T> {
     /// Returns `true` if the packed option is a `None` value.
     pub fn is_none(&self) -> bool {
-        self.0 == T::reserved_value()
+        self.0.is_reserved_value()
     }
 
     /// Returns `true` if the packed option is a `Some` value.
     pub fn is_some(&self) -> bool {
-        self.0 != T::reserved_value()
+        !self.0.is_reserved_value()
     }
 
     /// Expand the packed option into a normal `Option`.
@@ -75,7 +77,7 @@ impl<T: ReservedValue> From<T> for PackedOption<T> {
     /// Convert `t` into a packed `Some(x)`.
     fn from(t: T) -> Self {
         debug_assert!(
-            t != T::reserved_value(),
+            !t.is_reserved_value(),
             "Can't make a PackedOption from the reserved value."
         );
         Self(t)
@@ -123,6 +125,10 @@ mod tests {
         fn reserved_value() -> Self {
             NoC(13)
         }
+
+        fn is_reserved_value(&self) -> bool {
+            self.0 == 13
+        }
     }
 
     #[test]
@@ -144,6 +150,10 @@ mod tests {
     impl ReservedValue for Ent {
         fn reserved_value() -> Self {
             Ent(13)
+        }
+
+        fn is_reserved_value(&self) -> bool {
+            self.0 == 13
         }
     }
 


### PR DESCRIPTION
A full Eq implementation is no needed for ReservedValue, as we only need
to check whether a value is the reserved one. For entities (defined with
`entity_impl!`) this doesn't make much difference, but for more
complicated types this avoids generating redundant `Eq`s.