### PR TITLE
Add logging to frame operations

### DIFF
--- a/cranelift/interpreter/src/frame.rs
+++ b/cranelift/interpreter/src/frame.rs
@@ -2,6 +2,7 @@
 
 use cranelift_codegen::ir::{Function, Value as ValueRef};
 use cranelift_reader::DataValue;
+use log::trace;
 use std::collections::HashMap;
 
 /// Holds the mutable elements of an interpretation. At some point I thought about using
@@ -22,6 +23,7 @@ impl<'a> Frame<'a> {
     /// `Value` (renamed to `ValueRef` here) which should mean that no additional allocations are
     /// needed while interpreting the frame.
     pub fn new(function: &'a Function) -> Self {
+        trace!("Create new frame for function: {}", function.signature);
         Self {
             function,
             registers: HashMap::with_capacity(function.dfg.num_values()),
@@ -41,6 +43,7 @@ impl<'a> Frame<'a> {
     /// Retrieve the actual value associated with an SSA reference.
     #[inline]
     pub fn get(&self, name: &ValueRef) -> &DataValue {
+        trace!("Get {}", name);
         self.registers
             .get(name)
             .unwrap_or_else(|| panic!("unknown value: {}", name))
@@ -54,6 +57,7 @@ impl<'a> Frame<'a> {
     /// Assign `value` to the SSA reference `name`.
     #[inline]
     pub fn set(&mut self, name: ValueRef, value: DataValue) -> Option<DataValue> {
+        trace!("Set {} -> {}", name, value);
         self.registers.insert(name, value)
     }
 
@@ -70,6 +74,7 @@ impl<'a> Frame<'a> {
     /// could be removed if we copied the values in the right order (i.e. when modifying in place,
     /// we need to avoid changing a value before it is referenced).
     pub fn rename(&mut self, old_names: &[ValueRef], new_names: &[ValueRef]) {
+        trace!("Renaming {:?} -> {:?}", old_names, new_names);
         assert_eq!(old_names.len(), new_names.len());
         let mut registers = HashMap::with_capacity(self.registers.len());
         for (on, nn) in old_names.iter().zip(new_names) {

--- a/cranelift/interpreter/src/frame.rs
+++ b/cranelift/interpreter/src/frame.rs
@@ -30,16 +30,6 @@ impl<'a> Frame<'a> {
         }
     }
 
-    /// Construct a new [Frame] with the given `values` assigned to their corresponding slot
-    /// (from the SSA references in `parameters`) in the [Frame].
-    pub fn with_parameters(mut self, parameters: &[ValueRef], values: &[DataValue]) -> Self {
-        assert_eq!(parameters.len(), values.len());
-        for (n, v) in parameters.iter().zip(values) {
-            self.registers.insert(*n, v.clone());
-        }
-        self
-    }
-
     /// Retrieve the actual value associated with an SSA reference.
     #[inline]
     pub fn get(&self, name: &ValueRef) -> &DataValue {

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -112,7 +112,8 @@ impl Interpreter {
             .next()
             .expect("to have a first block");
         let parameters = function.dfg.block_params(first_block);
-        let mut frame = Frame::new(function).with_parameters(parameters, arguments);
+        let mut frame = Frame::new(function);
+        frame.set_all(parameters, arguments.to_vec());
         self.block(&mut frame, first_block)
     }
 


### PR DESCRIPTION
Adding `trace!`-level logging makes it significantly easier to debug what the interpreter is doing. Also removes a function that had a single use to simplify the API.