### PR TITLE
Move SingleFunctionCompiler into its own crate, cranelift-simplecompiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-preopt",
  "cranelift-reader",
+ "cranelift-simplecompiler",
  "file-per-thread-logger",
  "filecheck",
  "gimli",
@@ -515,6 +516,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-simplecompiler"
+version = "0.63.0"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-reader",
+ "log",
+ "memmap",
+ "thiserror",
+]
+
+[[package]]
 name = "cranelift-simplejit"
 version = "0.63.0"
 dependencies = [
@@ -552,6 +566,7 @@ dependencies = [
  "cranelift-preopt",
  "cranelift-reader",
  "cranelift-serde",
+ "cranelift-simplecompiler",
  "cranelift-simplejit",
  "cranelift-wasm",
  "file-per-thread-logger",

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -27,6 +27,7 @@ cranelift-filetests = { path = "filetests", version = "0.63.0" }
 cranelift-module = { path = "module", version = "0.63.0" }
 cranelift-faerie = { path = "faerie", version = "0.63.0" }
 cranelift-object = { path = "object", version = "0.63.0" }
+cranelift-simplecompiler = { path = "simplecompiler", version = "0.63.0" }
 cranelift-simplejit = { path = "simplejit", version = "0.63.0" }
 cranelift-preopt = { path = "preopt", version = "0.63.0" }
 cranelift = { path = "umbrella", version = "0.63.0" }

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -16,6 +16,7 @@ cranelift-interpreter = { path = "../interpreter", version = "*" }
 cranelift-native = { path = "../native", version = "0.63.0" }
 cranelift-reader = { path = "../reader", version = "0.63.0" }
 cranelift-preopt = { path = "../preopt", version = "0.63.0" }
+cranelift-simplecompiler = { path = "../simplecompiler", version = "0.63.0" }
 byteorder = { version = "1.3.2", default-features = false }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -23,7 +23,6 @@
     )
 )]
 
-pub use crate::function_runner::SingleFunctionCompiler;
 use crate::runner::TestRunner;
 use cranelift_codegen::timing;
 use cranelift_reader::TestCommand;
@@ -31,7 +30,6 @@ use std::path::Path;
 use std::time;
 
 mod concurrent;
-mod function_runner;
 mod match_directive;
 mod runner;
 mod runone;

--- a/cranelift/filetests/src/test_run.rs
+++ b/cranelift/filetests/src/test_run.rs
@@ -2,11 +2,11 @@
 //!
 //! The `run` test command compiles each function on the host machine and executes it
 
-use crate::function_runner::SingleFunctionCompiler;
 use crate::subtest::{Context, SubTest, SubtestResult};
 use cranelift_codegen::ir;
 use cranelift_reader::parse_run_command;
 use cranelift_reader::TestCommand;
+use cranelift_simplecompiler::SingleFunctionCompiler;
 use log::trace;
 use std::borrow::Cow;
 use target_lexicon::Architecture;

--- a/cranelift/simplecompiler/Cargo.toml
+++ b/cranelift/simplecompiler/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "cranelift-simplecompiler"
+version = "0.63.0"
+authors = ["The Cranelift Project Developers"]
+description = "A single function compiler for Cranelift"
+repository = "https://github.com/bytecodealliance/wasmtime"
+documentation = "https://docs.rs/cranelift-simplejit"
+license = "Apache-2.0 WITH LLVM-exception"
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+cranelift-codegen = { path = "../codegen", version = "0.63.0" }
+cranelift-frontend = { path = "../frontend", version = "0.63.0" }
+cranelift-native = { path = "../native", version = "0.63.0" }
+cranelift-reader = { path = "../reader", version = "0.63.0" }
+memmap = "0.7.0"
+log = "0.4.8"
+thiserror = "1.0.16"
+

--- a/cranelift/simplecompiler/src/lib.rs
+++ b/cranelift/simplecompiler/src/lib.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 /// "outside-of-function" functionality, see `cranelift_simplejit::backend::SimpleJITBackend`.
 ///
 /// ```
-/// use cranelift_filetests::SingleFunctionCompiler;
+/// use cranelift_simplecompiler::SingleFunctionCompiler;
 /// use cranelift_reader::parse_functions;
 ///
 /// let code = "test run \n function %add(i32, i32) -> i32 {  block0(v0:i32, v1:i32):  v2 = iadd v0, v1  return v2 }".into();
@@ -124,7 +124,7 @@ impl Trampoline {
 /// function through the use of a [Trampoline].
 ///
 /// ```
-/// use cranelift_filetests::SingleFunctionCompiler;
+/// use cranelift_simplecompiler::SingleFunctionCompiler;
 /// use cranelift_reader::{parse_functions, DataValue};
 ///
 /// let code = "test run \n function %add(i32, i32) -> i32 {  block0(v0:i32, v1:i32):  v2 = iadd v0, v1  return v2 }".into();

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -2,9 +2,9 @@
 
 use crate::utils::{iterate_files, read_to_string};
 use cranelift_codegen::isa::{CallConv, TargetIsa};
-use cranelift_filetests::SingleFunctionCompiler;
 use cranelift_native::builder as host_isa_builder;
 use cranelift_reader::{parse_run_command, parse_test, Details, IsaSpec, ParseOptions};
+use cranelift_simplecompiler::SingleFunctionCompiler;
 use std::path::PathBuf;
 use target_lexicon::Triple;
 


### PR DESCRIPTION
While experimenting with using this together with `cranelift-interpreter`, I realized that having `SingleFunctionCompiler` in `cranelift-filetests` creates a circular dependency. Moving this functionality out to its own crate breaks that cycle. I am quite open to other approaches (merge together with simplejit somehow?) or crate name suggestions.