### PR TITLE
Legalize imul.i64x2 for both AVX and non-AVX x86 CPUs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -186,13 +186,12 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             // to be a big chunk of work to implement them all there!
             ("simd", _) if target.contains("aarch64") => return true,
 
-            ("simd", "simd_conversions") => return true, // FIXME Unsupported feature: proposed SIMD operator I16x8NarrowI32x4S
+            ("simd", "simd_conversions") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
             ("simd", "simd_f32x4") => return true, // FIXME expected V128(F32x4([CanonicalNan, CanonicalNan, Value(Float32 { bits: 0 }), Value(Float32 { bits: 0 })])), got V128(18428729675200069632)
             ("simd", "simd_f64x2") => return true, // FIXME expected V128(F64x2([Value(Float64 { bits: 9221120237041090560 }), Value(Float64 { bits: 0 })])), got V128(0)
             ("simd", "simd_f64x2_arith") => return true, // FIXME expected V128(F64x2([Value(Float64 { bits: 9221120237041090560 }), Value(Float64 { bits: 13835058055282163712 })])), got V128(255211775190703847615975447847722024960)
-            ("simd", "simd_i64x2_arith") => return true, // FIXME Unsupported feature: proposed SIMD operator I64x2Mul
-            ("simd", "simd_load") => return true, // FIXME Unsupported feature: proposed SIMD operator I8x16Shl
-            ("simd", "simd_splat") => return true, // FIXME Unsupported feature: proposed SIMD operator I8x16ShrS
+            ("simd", "simd_load") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
+            ("simd", "simd_splat") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
 
             // not parsed in wasmparser yet
             ("simd", "simd_i32x4_arith2") => return true,

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -2108,7 +2108,7 @@ fn define_simd(
     {
         e.enc_32_64_maybe_isap(
             x86_pmullq,
-            rec_evex_reg_vvvv_rm_128.opcodes(&PMULLQ).w(),
+            rec_evex_reg_vvvv_rm_128.opcodes(&VPMULLQ).w(),
             Some(use_avx512dq_simd), // TODO need an OR predicate to join with AVX512VL
         );
     }

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -2184,8 +2184,11 @@ fn define_simd(
         let ushr_imm = ushr_imm.bind(vector(*ty, sse_vector_size));
         e.enc_both_inferred(ushr_imm, rec_f_ib.opcodes(*opcodes).rrr(2));
 
-        let sshr_imm = sshr_imm.bind(vector(*ty, sse_vector_size));
-        e.enc_both_inferred(sshr_imm, rec_f_ib.opcodes(*opcodes).rrr(4));
+        // One exception: PSRAQ does not exist in for 64x2 in SSE2, it requires a higher CPU feature set.
+        if *ty != I64 {
+            let sshr_imm = sshr_imm.bind(vector(*ty, sse_vector_size));
+            e.enc_both_inferred(sshr_imm, rec_f_ib.opcodes(*opcodes).rrr(4));
+        }
     }
 
     // SIMD integer comparisons

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1646,6 +1646,7 @@ fn define_simd(
     let x86_pmins = x86.by_name("x86_pmins");
     let x86_pminu = x86.by_name("x86_pminu");
     let x86_pmullq = x86.by_name("x86_pmullq");
+    let x86_pmuludq = x86.by_name("x86_pmuludq");
     let x86_pshufb = x86.by_name("x86_pshufb");
     let x86_pshufd = x86.by_name("x86_pshufd");
     let x86_psll = x86.by_name("x86_psll");
@@ -2099,6 +2100,9 @@ fn define_simd(
         let imul = imul.bind(vector(*ty, sse_vector_size));
         e.enc_both_inferred_maybe_isap(imul, rec_fa.opcodes(opcodes), *isap);
     }
+
+    // SIMD multiplication with lane expansion.
+    e.enc_both_inferred(x86_pmuludq, rec_fa.opcodes(&PMULUDQ));
 
     // SIMD integer multiplication for I64x2 using a AVX512.
     {

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1645,6 +1645,7 @@ fn define_simd(
     let x86_pmaxu = x86.by_name("x86_pmaxu");
     let x86_pmins = x86.by_name("x86_pmins");
     let x86_pminu = x86.by_name("x86_pminu");
+    let x86_pmullq = x86.by_name("x86_pmullq");
     let x86_pshufb = x86.by_name("x86_pshufb");
     let x86_pshufd = x86.by_name("x86_pshufd");
     let x86_psll = x86.by_name("x86_psll");
@@ -2101,9 +2102,8 @@ fn define_simd(
 
     // SIMD integer multiplication for I64x2 using a AVX512.
     {
-        let imul = imul.bind(vector(I64, sse_vector_size));
         e.enc_32_64_maybe_isap(
-            imul,
+            x86_pmullq,
             rec_evex_reg_vvvv_rm_128.opcodes(&PMULLQ).w(),
             Some(use_avx512dq_simd), // TODO need an OR predicate to join with AVX512VL
         );

--- a/cranelift/codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift/codegen/meta/src/isa/x86/instructions.rs
@@ -532,6 +532,23 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    let x = &Operand::new("x", I64x2);
+    let y = &Operand::new("y", I64x2);
+    let a = &Operand::new("a", I64x2);
+    ig.push(
+        Inst::new(
+            "x86_pmullq",
+            r#"
+        Multiply Packed Integers -- Multiply two 64x2 integers and receive a 64x2 result with
+        lane-wise wrapping if the result overflows. This instruction is necessary to add distinct
+        encodings for CPUs with newer vector features.
+        "#,
+            &formats.binary,
+        )
+        .operands_in(vec![x, y])
+        .operands_out(vec![a]),
+    );
+
     let x = &Operand::new("x", TxN);
     let y = &Operand::new("y", TxN);
     let f = &Operand::new("f", iflags);

--- a/cranelift/codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift/codegen/meta/src/isa/x86/legalize.rs
@@ -359,6 +359,7 @@ fn define_simd(shared: &mut SharedDefinitions, x86_instructions: &InstructionGro
     let icmp = insts.by_name("icmp");
     let imax = insts.by_name("imax");
     let imin = insts.by_name("imin");
+    let imul = insts.by_name("imul");
     let ineg = insts.by_name("ineg");
     let insertlane = insts.by_name("insertlane");
     let ishl = insts.by_name("ishl");
@@ -761,6 +762,12 @@ fn define_simd(shared: &mut SharedDefinitions, x86_instructions: &InstructionGro
                 def!(b = band(a, e)),             // Unset the MSB.
             ],
         );
+    }
+
+    // SIMD imul
+    {
+        let imul = imul.bind(vector(I64, sse_vector_size));
+        narrow.legalize(def!(c = imul(a, b)), vec![def!(c = x86_pmullq(a, b))]);
     }
 
     narrow.custom_legalize(shuffle, "convert_shuffle");

--- a/cranelift/codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift/codegen/meta/src/isa/x86/mod.rs
@@ -1,6 +1,6 @@
 use crate::cdsl::cpu_modes::CpuMode;
 use crate::cdsl::isa::TargetIsa;
-use crate::cdsl::types::ReferenceType;
+use crate::cdsl::types::{ReferenceType, VectorType};
 
 use crate::shared::types::Bool::B1;
 use crate::shared::types::Float::{F32, F64};
@@ -35,6 +35,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let expand_flags = shared_defs.transform_groups.by_name("expand_flags");
     let x86_widen = shared_defs.transform_groups.by_name("x86_widen");
     let x86_narrow = shared_defs.transform_groups.by_name("x86_narrow");
+    let x86_narrow_avx = shared_defs.transform_groups.by_name("x86_narrow_avx");
     let x86_expand = shared_defs.transform_groups.by_name("x86_expand");
 
     x86_32.legalize_monomorphic(expand_flags);
@@ -46,6 +47,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_32.legalize_value_type(ReferenceType(R32), x86_expand);
     x86_32.legalize_type(F32, x86_expand);
     x86_32.legalize_type(F64, x86_expand);
+    x86_32.legalize_value_type(VectorType::new(I64.into(), 2), x86_narrow_avx);
 
     x86_64.legalize_monomorphic(expand_flags);
     x86_64.legalize_default(x86_narrow);
@@ -57,6 +59,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_64.legalize_value_type(ReferenceType(R64), x86_expand);
     x86_64.legalize_type(F32, x86_expand);
     x86_64.legalize_type(F64, x86_expand);
+    x86_64.legalize_value_type(VectorType::new(I64.into(), 2), x86_narrow_avx);
 
     let recipes = recipes::define(shared_defs, &settings, &regs);
 

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -471,7 +471,7 @@ pub static PMULLD: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
 
 /// Multiply the packed quadword signed integers in xmm2 and xmm3/m128 and store the low 64
 /// bits of each product in xmm1 (AVX512VL/DQ). Requires an EVEX encoding.
-pub static PMULLQ: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
+pub static VPMULLQ: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
 
 /// Multiply packed unsigned doubleword integers in xmm1 by packed unsigned doubleword integers
 /// in xmm2/m128, and store the quadword results in xmm1 (SSE2).

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -473,6 +473,10 @@ pub static PMULLD: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
 /// bits of each product in xmm1 (AVX512VL/DQ). Requires an EVEX encoding.
 pub static PMULLQ: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
 
+/// Multiply packed unsigned doubleword integers in xmm1 by packed unsigned doubleword integers
+/// in xmm2/m128, and store the quadword results in xmm1 (SSE2).
+pub static PMULUDQ: [u8; 3] = [0x66, 0x0f, 0xf4];
+
 /// Pop top of stack into r{16,32,64}; increment stack pointer.
 pub static POP_REG: [u8; 1] = [0x58];
 

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1911,6 +1911,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::X86Pmaxu
         | Opcode::X86Pmins
         | Opcode::X86Pminu
+        | Opcode::X86Pmullq
         | Opcode::X86Packss
         | Opcode::X86Punpckh
         | Opcode::X86Punpckl

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1912,6 +1912,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::X86Pmins
         | Opcode::X86Pminu
         | Opcode::X86Pmullq
+        | Opcode::X86Pmuludq
         | Opcode::X86Packss
         | Opcode::X86Punpckh
         | Opcode::X86Punpckl

--- a/cranelift/codegen/src/isa/arm32/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/mod.rs
@@ -17,6 +17,7 @@ use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use core::any::Any;
 use core::fmt;
 use target_lexicon::{Architecture, Triple};
 
@@ -134,6 +135,10 @@ impl TargetIsa for Isa {
 
     fn unsigned_sub_overflow_condition(&self) -> ir::condcodes::IntCC {
         ir::condcodes::IntCC::UnsignedGreaterThanOrEqual
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
     }
 }
 

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -66,6 +66,7 @@ use crate::settings::SetResult;
 use crate::timing;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use core::any::Any;
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use target_lexicon::{triple, Architecture, PointerWidth, Triple};
@@ -422,6 +423,10 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     fn get_mach_backend(&self) -> Option<&dyn MachBackend> {
         None
     }
+
+    /// Return an [Any] reference for downcasting to the ISA-specific implementation of this trait
+    /// with `isa.as_any().downcast_ref::<isa::foo::Isa>()`.
+    fn as_any(&self) -> &dyn Any;
 }
 
 impl Debug for &dyn TargetIsa {

--- a/cranelift/codegen/src/isa/riscv/mod.rs
+++ b/cranelift/codegen/src/isa/riscv/mod.rs
@@ -17,6 +17,7 @@ use crate::isa::{EncInfo, RegClass, RegInfo, TargetIsa};
 use crate::regalloc;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use core::any::Any;
 use core::fmt;
 use target_lexicon::{PointerWidth, Triple};
 
@@ -129,6 +130,10 @@ impl TargetIsa for Isa {
 
     fn unsigned_sub_overflow_condition(&self) -> ir::condcodes::IntCC {
         unimplemented!()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
     }
 }
 

--- a/cranelift/codegen/src/isa/x86/mod.rs
+++ b/cranelift/codegen/src/isa/x86/mod.rs
@@ -23,6 +23,7 @@ use crate::result::CodegenResult;
 use crate::timing;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use core::any::Any;
 use core::fmt;
 use target_lexicon::{PointerWidth, Triple};
 
@@ -183,6 +184,10 @@ impl TargetIsa for Isa {
     #[cfg(feature = "unwind")]
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {
         Some(unwind::systemv::create_cie())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
     }
 }
 

--- a/cranelift/codegen/src/machinst/adapter.rs
+++ b/cranelift/codegen/src/machinst/adapter.rs
@@ -10,6 +10,7 @@ use crate::settings::Flags;
 #[cfg(feature = "testing_hooks")]
 use crate::regalloc::RegDiversions;
 
+use core::any::Any;
 use std::borrow::Cow;
 use std::fmt;
 use target_lexicon::Triple;
@@ -126,5 +127,9 @@ impl TargetIsa for TargetIsaAdapter {
 
     fn unsigned_sub_overflow_condition(&self) -> ir::condcodes::IntCC {
         self.backend.unsigned_sub_overflow_condition()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
     }
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
@@ -99,3 +99,9 @@ block0(v0: f64x2 [%xmm11], v1: f64x2 [%xmm13]):
 [-, %xmm11]    v8 = sqrt v0          ; bin: 66 45 0f 51 db
     return
 }
+
+function %pmuludq(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2 [%xmm3], v1: i64x2 [%xmm5]):
+[-, %xmm3]    v2 = x86_pmuludq v0, v1      ; bin: 66 0f f4 dd
+    return v2
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
@@ -70,9 +70,16 @@ block0:
     return
 }
 
-function %imul(i64x2, i64x2) {
+function %imul_i64x2(i64x2, i64x2) {
 block0(v0:i64x2, v1:i64x2):
     v2 = imul v0, v1
-    ; check: v2 = x86_pmullq v0, v1
+    ; check: v3 = ushr_imm v0, 32
+    ; nextln: v4 = x86_pmuludq v3, v1
+    ; nextln: v5 = ushr_imm v1, 32
+    ; nextln: v6 = x86_pmuludq v5, v0
+    ; nextln: v7 = iadd v4, v6
+    ; nextln: v8 = ishl_imm v7, 32
+    ; nextln: v9 = x86_pmuludq v0, v1
+    ; nextln: v2 = iadd v9, v8
     return
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
@@ -69,3 +69,10 @@ block0:
     ; nextln: v1 = band v0, v4
     return
 }
+
+function %imul(i64x2, i64x2) {
+block0(v0:i64x2, v1:i64x2):
+    v2 = imul v0, v1
+    ; check: v2 = x86_pmullq v0, v1
+    return
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
@@ -49,6 +49,13 @@ block0:
 }
 ; run
 
+function %imul_i64x2(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = imul v0, v1
+    return v2
+}
+; run: %imul_i64x2([0 2], [0 2]) == [0 4]
+
 function %imul_i32x4() -> b1 {
 block0:
     v0 = vconst.i32x4 [-1 0 1 0x80_00_00_01]

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-binemit.clif
@@ -6,7 +6,7 @@ function %imul_i64x2() {
 block0:
     [-, %xmm1]    v0 = vconst.i64x2 [1 2]
     [-, %xmm2]    v1 = vconst.i64x2 [2 2]
-    [-, %xmm14]   v2 = imul v0, v1 ; bin: 62 72 f5 08 40 f2
+    [-, %xmm14]   v2 = x86_pmullq v0, v1 ; bin: 62 72 f5 08 40 f2
     ; 62, mandatory EVEX prefix
     ; 72 = 0111 0010, R is set (MSB in %xmm14) while X, B, and R' are unset (note these are all inverted); mm is set to 0F38
     ; f5 = 1111 0101, W is set (64-bit op), vvvv set to 1 (inverted), bit 2 always set, pp set to 01

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-legalize.clif
@@ -1,0 +1,10 @@
+test legalizer
+set enable_simd
+target x86_64 skylake has_avx512dq=true
+
+function %imul_i64x2(i64x2, i64x2) {
+block0(v0:i64x2, v1:i64x2):
+    v2 = imul v0, v1
+    ; check: v2 = x86_pmullq v0, v1
+    return
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-bitwise-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitwise-binemit.clif
@@ -97,9 +97,3 @@ block0(v0: i32x4 [%xmm4]):
 [-, %xmm4]  v2 = sshr_imm v0, 10     ; bin: 66 0f 72 e4 0a
             return v2
 }
-
-function %sshr_imm_i64x2(i64x2) -> i64x2 {
-block0(v0: i64x2 [%xmm6]):
-[-, %xmm6]  v2 = sshr_imm v0, 42     ; bin: 66 0f 73 e6 2a
-            return v2
-}

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1383,7 +1383,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().ineg(a))
         }
-        Operator::I16x8Mul | Operator::I32x4Mul => {
+        Operator::I16x8Mul | Operator::I32x4Mul | Operator::I64x2Mul => {
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().imul(a, b))
         }
@@ -1544,8 +1544,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, I32X4, builder);
             state.push1(builder.ins().fcvt_from_sint(F32X4, a))
         }
-        Operator::I64x2Mul
-        | Operator::I32x4TruncSatF32x4S
+        Operator::I32x4TruncSatF32x4S
         | Operator::I32x4TruncSatF32x4U
         | Operator::F32x4ConvertI32x4U
         | Operator::I8x16Abs
@@ -2069,7 +2068,8 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I64x2ShrS
         | Operator::I64x2ShrU
         | Operator::I64x2Add
-        | Operator::I64x2Sub => I64X2,
+        | Operator::I64x2Sub
+        | Operator::I64x2Mul => I64X2,
 
         Operator::F32x4Splat
         | Operator::F32x4ExtractLane { .. }


### PR DESCRIPTION
The `convert_i64x2_imul` custom legalization checks the ISA flags for AVX512DQ or AVX512VL support and legalizes `imul.i64x2` to an `x86_pmullq` in this case; if not, it uses a lengthy SSE2-compatible instruction sequence. For this logic to work, we need:
 - the AVX512 instruction to be defined as a separate Cranelift instruction, `x86_pmullq` (this additional instruction would go away in the new backend)
 - a mechanism for accessing the x86 `TargetIsa` so that we can inspect its flags during legalization
 - a new SSE2 instruction, `x86_pmuludq` for implementing the SSE2-compatible instruction sequence