### PR TITLE
Print more detailed `test run` failures

### DIFF
--- a/cranelift/filetests/src/test_run.rs
+++ b/cranelift/filetests/src/test_run.rs
@@ -58,7 +58,7 @@ impl SubTest for TestRun {
                 // running x86_64 code on aarch64 platforms.
                 let compiled_fn = compiler
                     .compile(func.clone().into_owned())
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| format!("{:?}", e))?;
                 command.run(|_, args| Ok(compiled_fn.call(args)))?;
             }
         }


### PR DESCRIPTION
I noticed while run `test run` filetests that the errors printed were less than meaningful. This makes them more meaningful (in a very `Debug`-like way) but perhaps there is a better way to use `thiserror` to print better messages?