### PR TITLE
Make vconst BxN match specification

### DIFF
--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
@@ -16,7 +16,7 @@ block0:
     return v0
 }
 
-; sameln: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0]
+; sameln: [FF, FF, 0, 0, FF, FF, 0, 0, FF, FF, 0, 0, FF, FF, FF, FF]
 
 
 ; Since both jump tables and constants are emitted after the function body, it is important that they do not interfere.

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -1075,9 +1075,8 @@ impl<'a> Parser<'a> {
             if lane_size < 1 {
                 panic!("The boolean lane must have a byte size greater than zero.");
             }
-            let mut buffer = vec![0; lane_size as usize];
-            buffer[0] = if value { 1 } else { 0 };
-            buffer
+            let value = if value { 0xFF } else { 0 };
+            vec![value; lane_size as usize]
         }
 
         if !ty.is_vector() {
@@ -3824,7 +3823,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             c.into_vec(),
-            [1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]
+            [0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0]
         )
     }
 


### PR DESCRIPTION
 [Cranelift IR docs](https://github.com/bytecodealliance/wasmtime/blob/master/cranelift/docs/ir.md#boolean-types) for boolean types say:

> Several larger boolean types are also defined, primarily to be used as SIMD element types. They can be stored in memory, and are represented as **either all zero bits or all one bits**.

According to [Zulip conversation](https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/general/near/198816881), this applies only to boolean vector types, and it matches the [WASM SIMD spec](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#comparisons):

> The comparison operations all compare two vectors lane-wise, and produce a mask vector with the same number of lanes as the input interpretation where the bits in each lane are 0 for false and all ones for true.

The `vconst.BxN` instruction currently produces vector with values `0` or `1` instead of masks. This PR changes it to produce masks.

r? @abrown 