### PR TITLE
Put contributing guide link on text inside paragraph

### DIFF
--- a/cranelift/README.md
+++ b/cranelift/README.md
@@ -60,10 +60,8 @@ Contributing
 ------------
 
 If you're interested in contributing to Cranelift: thank you! We have a
-[contributing guide] which will help you getting involved in the Cranelift
-project.
+[contributing guide](https://bytecodealliance.github.io/wasmtime/contributing.html) which will help you getting involved in the Cranelift project.
 
-[contributing guide](https://bytecodealliance.github.io/wasmtime/contributing.html)
 
 Planned uses
 ------------


### PR DESCRIPTION
There was the text in [] in the para and a separate link outside, move the link into the paragraph