### PR TITLE
Multi-value return support on aarch64/Wasmtime.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1311,7 +1311,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(32768),
+            mem: MemArg::FPOffset(32768, I8),
             srcloc: None,
         },
         "100090D2B063308B010240F9",
@@ -1320,7 +1320,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(-32768),
+            mem: MemArg::FPOffset(-32768, I8),
             srcloc: None,
         },
         "F0FF8F92B063308B010240F9",
@@ -1329,7 +1329,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(1048576), // 2^20
+            mem: MemArg::FPOffset(1048576, I8), // 2^20
             srcloc: None,
         },
         "1002A0D2B063308B010240F9",
@@ -1338,11 +1338,41 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(1048576 + 1), // 2^20 + 1
+            mem: MemArg::FPOffset(1048576 + 1, I8), // 2^20 + 1
             srcloc: None,
         },
         "300080D21002A0F2B063308B010240F9",
         "movz x16, #1 ; movk x16, #16, LSL #16 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
+    ));
+
+    insns.push((
+        Inst::ULoad64 {
+            rd: writable_xreg(1),
+            mem: MemArg::RegOffset(xreg(7), 8, I64),
+            srcloc: None,
+        },
+        "E18040F8",
+        "ldur x1, [x7, #8]",
+    ));
+
+    insns.push((
+        Inst::ULoad64 {
+            rd: writable_xreg(1),
+            mem: MemArg::RegOffset(xreg(7), 1024, I64),
+            srcloc: None,
+        },
+        "E10042F9",
+        "ldr x1, [x7, #1024]",
+    ));
+
+    insns.push((
+        Inst::ULoad64 {
+            rd: writable_xreg(1),
+            mem: MemArg::RegOffset(xreg(7), 1048576, I64),
+            srcloc: None,
+        },
+        "1002A0D2F060308B010240F9",
+        "movz x16, #16, LSL #16 ; add x16, x7, x16, UXTX ; ldr x1, [x16]",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -259,7 +259,12 @@ impl UImm12Scaled {
 
     /// Value after scaling.
     pub fn value(&self) -> u32 {
-        self.value as u32 * self.scale_ty.bytes()
+        self.value as u32
+    }
+
+    /// The value type which is the scaling base.
+    pub fn scale_ty(&self) -> Type {
+        self.scale_ty
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1004,6 +1004,9 @@ fn memarg_regs(memarg: &MemArg, collector: &mut RegUsageCollector) {
         &MemArg::SPOffset(..) | &MemArg::NominalSPOffset(..) => {
             collector.add_use(stack_reg());
         }
+        &MemArg::RegOffset(r, ..) => {
+            collector.add_use(r);
+        }
     }
 }
 
@@ -1318,6 +1321,7 @@ fn aarch64_map_regs<RUM: RegUsageMapper>(inst: &mut Inst, mapper: &RUM) {
             &mut MemArg::FPOffset(..)
             | &mut MemArg::SPOffset(..)
             | &mut MemArg::NominalSPOffset(..) => {}
+            &mut MemArg::RegOffset(ref mut r, ..) => map_use(m, r),
         };
     }
 

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -539,12 +539,10 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
     // TODO: support base_reg + scale * index_reg. For this, we would need to pattern-match shl or
     // mul instructions (Load/StoreComplex don't include scale factors).
 
-    // Handle one reg and offset that fits in immediate, if possible.
+    // Handle one reg and offset.
     if addends.len() == 1 {
         let reg = input_to_reg(ctx, addends[0], NarrowValueMode::ZeroExtend64);
-        if let Some(memarg) = MemArg::reg_maybe_offset(reg, offset as i64, elem_ty) {
-            return memarg;
-        }
+        return MemArg::RegOffset(reg, offset as i64, elem_ty);
     }
 
     // Handle two regs and a zero offset, if possible.

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1335,7 +1335,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert!(inputs.len() == sig.params.len());
                     assert!(outputs.len() == sig.returns.len());
                     (
-                        AArch64ABICall::from_func(sig, &extname, dist, loc),
+                        AArch64ABICall::from_func(sig, &extname, dist, loc)?,
                         &inputs[..],
                     )
                 }
@@ -1344,7 +1344,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     let sig = ctx.call_sig(insn).unwrap();
                     assert!(inputs.len() - 1 == sig.params.len());
                     assert!(outputs.len() == sig.returns.len());
-                    (AArch64ABICall::from_ptr(sig, ptr, loc, op), &inputs[1..])
+                    (AArch64ABICall::from_ptr(sig, ptr, loc, op)?, &inputs[1..])
                 }
                 _ => unreachable!(),
             };

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -46,7 +46,7 @@ impl AArch64Backend {
         func: &Function,
         flags: settings::Flags,
     ) -> CodegenResult<VCode<inst::Inst>> {
-        let abi = Box::new(abi::AArch64ABIBody::new(func, flags));
+        let abi = Box::new(abi::AArch64ABIBody::new(func, flags)?);
         compile::compile::<AArch64Backend>(func, self, abi)
     }
 }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -184,6 +184,12 @@ impl X64ABIBody {
 impl ABIBody for X64ABIBody {
     type I = Inst;
 
+    fn needed_tmps(&self) -> usize {
+        0
+    }
+
+    fn init_with_tmps(&mut self, _: &[Writable<Reg>]) {}
+
     fn flags(&self) -> &settings::Flags {
         &self.flags
     }
@@ -231,6 +237,10 @@ impl ABIBody for X64ABIBody {
             }
             ABIArg::_Stack => unimplemented!("moving from stack arg to vreg"),
         }
+    }
+
+    fn gen_retval_area_setup(&self) -> Vec<Inst> {
+        vec![]
     }
 
     fn gen_copy_reg_to_retval(

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -184,11 +184,11 @@ impl X64ABIBody {
 impl ABIBody for X64ABIBody {
     type I = Inst;
 
-    fn needed_tmps(&self) -> usize {
-        0
+    fn temp_needed(&self) -> bool {
+        false
     }
 
-    fn init_with_tmps(&mut self, _: &[Writable<Reg>]) {}
+    fn init(&mut self, _: Option<Writable<Reg>>) {}
 
     fn flags(&self) -> &settings::Flags {
         &self.flags
@@ -239,8 +239,8 @@ impl ABIBody for X64ABIBody {
         }
     }
 
-    fn gen_retval_area_setup(&self) -> Vec<Inst> {
-        vec![]
+    fn gen_retval_area_setup(&self) -> Option<Inst> {
+        None
     }
 
     fn gen_copy_reg_to_retval(

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -12,11 +12,14 @@ pub trait ABIBody {
     /// The instruction type for the ISA associated with this ABI.
     type I: VCodeInst;
 
-    /// How many temps are needed?
-    fn needed_tmps(&self) -> usize;
+    /// Does the ABI-body code need a temp reg? One will be provided to `init()`
+    /// as the `maybe_tmp` arg if so.
+    fn temp_needed(&self) -> bool;
 
-    /// Initialize, providing the requersted temps.
-    fn init_with_tmps(&mut self, tmps: &[Writable<Reg>]);
+    /// Initialize. This is called after the ABIBody is constructed because it
+    /// may be provided with a temp vreg, which can only be allocated once the
+    /// lowering context exists.
+    fn init(&mut self, maybe_tmp: Option<Writable<Reg>>);
 
     /// Get the settings controlling this function's compilation.
     fn flags(&self) -> &settings::Flags;
@@ -40,12 +43,12 @@ pub trait ABIBody {
     /// register.
     fn gen_copy_arg_to_reg(&self, idx: usize, into_reg: Writable<Reg>) -> Self::I;
 
-    /// Generate any setup instructions needed to save values to the
+    /// Generate any setup instruction needed to save values to the
     /// return-value area. This is usually used when were are multiple return
     /// values or an otherwise large return value that must be passed on the
     /// stack; typically the ABI specifies an extra hidden argument that is a
     /// pointer to that memory.
-    fn gen_retval_area_setup(&self) -> Vec<Self::I>;
+    fn gen_retval_area_setup(&self) -> Option<Self::I>;
 
     /// Generate an instruction which copies a source register to a return value slot.
     fn gen_copy_reg_to_retval(

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -12,6 +12,12 @@ pub trait ABIBody {
     /// The instruction type for the ISA associated with this ABI.
     type I: VCodeInst;
 
+    /// How many temps are needed?
+    fn needed_tmps(&self) -> usize;
+
+    /// Initialize, providing the requersted temps.
+    fn init_with_tmps(&mut self, tmps: &[Writable<Reg>]);
+
     /// Get the settings controlling this function's compilation.
     fn flags(&self) -> &settings::Flags;
 
@@ -33,6 +39,13 @@ pub trait ABIBody {
     /// Generate an instruction which copies an argument to a destination
     /// register.
     fn gen_copy_arg_to_reg(&self, idx: usize, into_reg: Writable<Reg>) -> Self::I;
+
+    /// Generate any setup instructions needed to save values to the
+    /// return-value area. This is usually used when were are multiple return
+    /// values or an otherwise large return value that must be passed on the
+    /// stack; typically the ABI specifies an extra hidden argument that is a
+    /// pointer to that memory.
+    fn gen_retval_area_setup(&self) -> Vec<Self::I>;
 
     /// Generate an instruction which copies a source register to a return value slot.
     fn gen_copy_reg_to_retval(

--- a/cranelift/filetests/filetests/vcode/aarch64/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/multivalue-ret.clif
@@ -1,0 +1,18 @@
+test compile
+target aarch64
+
+;; Test default (non-SpiderMonkey) ABI.
+function %f() -> i64, i64 {
+block1:
+  v0 = iconst.i64 1
+  v1 = iconst.i64 2
+  return v0, v1
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  movz x0, #1
+; nextln:  movz x1, #2
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret

--- a/cranelift/filetests/filetests/vcode/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/stack-limit.clif
@@ -64,8 +64,8 @@ block0(v0: i64):
 
 ; check:      stp fp, lr, [sp, #-16]!
 ; nextln:     mov fp, sp
-; nextln:     ldr x16, [x0]
-; nextln:     ldr x16, [x16, #4]
+; nextln:     ldur x16, [x0]
+; nextln:     ldur x16, [x16, #4]
 ; nextln:     subs xzr, sp, x16
 ; nextln:     b.hs 8
 ; nextln:     udf
@@ -128,8 +128,8 @@ block0(v0: i64):
 
 ; check:      stp fp, lr, [sp, #-16]!
 ; nextln:     mov fp, sp
-; nextln:     ldr x16, [x0]
-; nextln:     ldr x16, [x16, #4]
+; nextln:     ldur x16, [x0]
+; nextln:     ldur x16, [x16, #4]
 ; nextln:     add x16, x16, #32
 ; nextln:     subs xzr, sp, x16
 ; nextln:     b.hs 8
@@ -151,8 +151,8 @@ block0(v0: i64):
 
 ; check:      stp fp, lr, [sp, #-16]!
 ; nextln:     mov fp, sp
-; nextln:     ldr x16, [x0]
-; nextln:     ldr x16, [x16, #4]
+; nextln:     ldur x16, [x0]
+; nextln:     ldur x16, [x16, #4]
 ; nextln:     subs xzr, sp, x16
 ; nextln:     b.hs 8
 ; nextln:     udf
@@ -179,9 +179,7 @@ block0(v0: i64):
 
 ; check:      stp fp, lr, [sp, #-16]!
 ; nextln:     mov fp, sp
-; nextln:     movz x16, #6784
-; nextln:     movk x16, #6, LSL #16
-; nextln:     ldr x16, [x0, x16]
+; nextln:     movz x16, #6784 ; movk x16, #6, LSL #16 ; add x16, x0, x16, UXTX ; ldr x16, [x16]
 ; nextln:     add x16, x16, #32
 ; nextln:     subs xzr, sp, x16
 ; nextln:     b.hs 8

--- a/cranelift/filetests/filetests/wasm/multi-val-f32.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-f32.clif
@@ -1,5 +1,6 @@
 test compile
 target x86_64 haswell
+target aarch64
 
 ;; Returning many f32s
 

--- a/cranelift/filetests/filetests/wasm/multi-val-f64.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-f64.clif
@@ -1,5 +1,6 @@
 test compile
 target x86_64 haswell
+target aarch64
 
 ;; Returning many f64s
 

--- a/cranelift/filetests/filetests/wasm/multi-val-i32.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-i32.clif
@@ -1,5 +1,6 @@
 test compile
 target x86_64 haswell
+target aarch64
 
 ;; Returning many i32s
 

--- a/cranelift/filetests/filetests/wasm/multi-val-i64.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-i64.clif
@@ -1,5 +1,6 @@
 test compile
 target x86_64 haswell
+target aarch64
 
 ;; Returning many i64s
 

--- a/cranelift/filetests/filetests/wasm/multi-val-tons-of-results.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-tons-of-results.clif
@@ -1,5 +1,6 @@
 test compile
 target x86_64 haswell
+target aarch64
 
 function %return_20_i32s() -> i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 {
 block0:


### PR DESCRIPTION
This PR adds support for multi-value returns to the new aarch64 backend's ABI implementation, using an ABI that should match that of SpiderMonkey's Wasm baseline compiler on aarch64.

The existing multivalue Wasm spec-tests pass; curiously, these did not seem to actually be disabled before, so the rudimentary "return values in x0..x7" ABI that was previously implemented actually was sufficient. Nevertheless, it seems most reasonable to standardize on the SpiderMonkey-style struct-return-area ABI so that we don't need to maintain two different schemes.

I have not yet been able to test this in SpiderMonkey; we first need to resolve the newly-failing tests on an Cranelift version bump on the SM side, and then I need to work out how to cross-compile SM, since I'm back to working on an x86 host for now. Putting this up for review now in any case, and can tweak if need be as we work out the above.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
