### PR TITLE
Fix interpreter semantics of 'irsub_imm'

### DIFF
--- a/cranelift/filetests/filetests/interpreter/fibonacci.clif
+++ b/cranelift/filetests/filetests/interpreter/fibonacci.clif
@@ -10,12 +10,12 @@ block0(v0: i32):
 
 block1(v4: i32, v5:i32):
     v6 = iconst.i32 1
-    v7 = irsub_imm v4, 2
+    v7 = iadd_imm v4, -2
     fallthrough block2(v7, v5, v6)
 
 block2(v10: i32, v11: i32, v12: i32): ; params: n, fib(n-1), fib(n-2)
     v13 = iadd v11, v12
-    v14 = irsub_imm v10, 1
+    v14 = iadd_imm v10, -1
     v15 = icmp_imm eq v14, 0
     brnz v15, block3(v13)
     jump block2(v14, v13, v11)
@@ -43,9 +43,9 @@ block0(v0: i32):
     fallthrough block1(v0)
 
 block1(v10: i32):
-    v11 = irsub_imm v10, 1
+    v11 = iadd_imm v10, -1
     v12 = call fn0(v11)
-    v13 = irsub_imm v10, 2
+    v13 = iadd_imm v10, -2
     v14 = call fn0(v13)
     v15 = iadd v12, v14
     return v15

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -163,7 +163,7 @@ impl Interpreter {
                 let arg = frame.get(&arg);
                 let result = match opcode {
                     IaddImm => binary_op!(Add::add[arg, imm]; [I8, I16, I32, I64, F32, F64]; inst),
-                    IrsubImm => binary_op!(Sub::sub[arg, imm]; [I8, I16, I32, I64, F32, F64]; inst),
+                    IrsubImm => binary_op!(Sub::sub[imm, arg]; [I8, I16, I32, I64, F32, F64]; inst),
                     _ => unimplemented!("interpreter does not support opcode yet: {}", opcode),
                 }?;
                 frame.set(first_result(frame.function, inst), result);
@@ -349,9 +349,9 @@ mod tests {
     fn sanity() {
         let code = "function %test() -> b1 {
         block0:
-            v0 = iconst.i32 40
-            v1 = iadd_imm v0, 3
-            v2 = irsub_imm v1, 1
+            v0 = iconst.i32 1
+            v1 = iadd_imm v0, 1
+            v2 = irsub_imm v1, 44  ; 44 - 2 == 42 (see irsub_imm's semantics)
             v3 = icmp_imm eq v2, 42
             return v3
         }";


### PR DESCRIPTION
Previously the interpreter used `arg - imm` but the functionality should be a wrapping `imm - arg` (see `cranelift/codegen/meta/src/shared/instructions.rs`).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
