### PR TITLE
Disable tests for the peepmatic-macro crate

### DIFF
--- a/cranelift/peepmatic/crates/macro/Cargo.toml
+++ b/cranelift/peepmatic/crates/macro/Cargo.toml
@@ -13,3 +13,5 @@ syn = { version = "1.0.16", features = ['extra-traits'] }
 
 [lib]
 proc_macro = true
+test = false
+doctest = false


### PR DESCRIPTION
I'm not actually sure that it's possible to write `#[test]` in a
`proc-macro` crate. Regardless I don't think it's too too conventional,
so let's disable this for now.

Closes #1775
