### PR TITLE
[bugpoint] Few improvements

### DIFF
--- a/cranelift/tests/bugpoint_consts.clif
+++ b/cranelift/tests/bugpoint_consts.clif
@@ -1,0 +1,14 @@
+test compile
+target x86_64
+
+function u0:0() {
+    sig0 = (f32, f64, i8, i16, i32, i64, i128, b1, b8, b128, r32, r64, b8x16, i16x4, f32x16)
+    fn0 = u0:1 sig0
+
+block0:
+    trap user0
+
+block1(v0: f32, v1: f64, v2: i8, v3: i16, v4: i32, v5: i64, v6: i128, v7: b1, v8: b8, v9: b128, v10: r32, v11: r64, v12: b8x16, v13: i16x4, v14: f32x16):
+    call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14)
+    trap user0
+}

--- a/cranelift/tests/bugpoint_consts_expected.clif
+++ b/cranelift/tests/bugpoint_consts_expected.clif
@@ -1,0 +1,26 @@
+function u0:0() fast {
+    sig0 = (f32, f64, i8, i16, i32, i64, i128, b1, b8, b128, r32, r64, b8x16, i16x4, f32x16) fast
+    fn0 = u0:1 sig0
+    const0 = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    const1 = 0x0000000000000000
+    const2 = 0x00000000000000000000000000000000
+
+block1:
+    v0 = f32const 0.0
+    v1 = f64const 0.0
+    v2 = iconst.i8 0
+    v3 = iconst.i16 0
+    v4 = iconst.i32 0
+    v5 = iconst.i64 0
+    v6 = iconst.i128 0
+    v7 = bconst.b1 false
+    v8 = bconst.b8 false
+    v9 = bconst.b128 false
+    v10 = null.r32 
+    v11 = null.r64 
+    v12 = vconst.b8x16 const2
+    v13 = vconst.i16x4 const1
+    v14 = vconst.f32x16 const0
+    call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14)
+    trap user0
+}

--- a/cranelift/tests/bugpoint_test_expected.clif
+++ b/cranelift/tests/bugpoint_test_expected.clif
@@ -5,49 +5,31 @@ function u0:0() system_v {
 block0:
     v0 = iconst.i64 0
     v105 = iconst.i64 0
-    trap user0
-
-block101:
     v829 = iconst.i64 0
     v935 -> v829
     v962 -> v829
     v992 -> v829
     v1036 -> v829
     v1049 -> v829
-    trap user0
-
-block102:
     v842 = iconst.i64 0
     v976 -> v842
     v989 -> v842
     v1038 -> v842
     v1061 -> v842
-    trap user0
-
-block105:
     v883 = iconst.i64 0
     v934 -> v883
     v961 -> v883
     v991 -> v883
     v1005 -> v883
     v1048 -> v883
-    trap user0
-
-block114:
     v951 = iconst.i64 0
     v988 -> v951
-    trap user0
-
-block117:
     v987 = iconst.i64 0
-    call fn0(v0, v105, v1052, v883, v829, v987, v951, v842)
-    trap user0
-
-block120:
     v1052 = iconst.i16 0
     v960 -> v1052
     v990 -> v1052
     v1051 -> v1052
     v1055 -> v1052
+    call fn0(v0, v105, v1052, v883, v829, v987, v951, v842)
     trap user0
 }


### PR DESCRIPTION
This PR contains few improvements for bugpoint:

- New mutator that tries to move instructions to the entry block (closes #1540)
- Missing conversion to constants for vector and reference types (closes #1633)
- Aliases are now resolved after reduction, ~~not before~~ (some mutators may create aliases)

r? @abrown 