### PR TITLE
print TrapReason::Error causes

### DIFF
--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -30,7 +30,7 @@ impl fmt::Display for TrapReason {
         match self {
             TrapReason::Message(s) => write!(f, "{}", s),
             TrapReason::I32Exit(status) => write!(f, "Exited with i32 exit status {}", status),
-            TrapReason::Error(e) => write!(f, "{}", e),
+            TrapReason::Error(e) => write!(f, "{:#}", e),
         }
     }
 }


### PR DESCRIPTION
Fixing an oversight in #1753, we probably want to include the causes when printing this.