### PR TITLE
x86_32: legalize {istore,sload,uload}32.i64

### DIFF
--- a/cranelift/filetests/filetests/isa/x86/legalize-x86_32-loadstore32.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-x86_32-loadstore32.clif
@@ -1,0 +1,34 @@
+; Test the legalization of load32/store32.i64 instructions on x86_32.
+
+test compile
+target i686
+
+function u0:0(i32, i32, i32) {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = iconcat v1, v2
+    ; check:  v4 = fill v1
+    ; nextln: v5 = fill v0
+    ; nextln: store v4, v5
+    istore32.i64 v3, v0
+    return
+}
+
+function u0:1(i32) -> i32 {
+block0(v0: i32):
+    ; check: v7 = fill v0
+    ; nextln: v4 = load.i32 v7
+    v1 = sload32.i32 v0
+    v2, v3 = isplit v1
+    ; check: return v4
+    return v2
+}
+
+function u0:2(i32) -> i32 {
+block0(v0: i32):
+    ; check: v6 = fill v0
+    ; nextln: v4 = load.i32 v6
+    v1 = uload32.i32 v0
+    v2, v3 = isplit v1
+    ; check: return v4
+    return v2
+}


### PR DESCRIPTION
Fixes #1747.

Co-authored-by: bjorn3