### PR TITLE
MachInst: a few memory enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.24"
+version = "0.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5842bece8a4b1690ffa6d9d959081c1d5d851ee4337a36c0a121fafe8c16add2"
+checksum = "cca5b48c9db66c5ba084e4660b4c0cfe8b551a96074bc04b7c11de86ad0bf1f9"
 dependencies = [
  "log",
  "rustc-hash",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -25,7 +25,7 @@ smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true }
-regalloc = "0.0.24"
+regalloc = "0.0.25"
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1276,33 +1276,39 @@ impl ABICall for AArch64ABICall {
         );
         match &self.dest {
             &CallDest::ExtName(ref name, RelocDistance::Near) => ctx.emit(Inst::Call {
-                dest: Box::new(name.clone()),
-                uses: uses.into_boxed_slice(),
-                defs: defs.into_boxed_slice(),
-                loc: self.loc,
-                opcode: self.opcode,
+                info: Box::new(CallInfo {
+                    dest: name.clone(),
+                    uses,
+                    defs,
+                    loc: self.loc,
+                    opcode: self.opcode,
+                }),
             }),
             &CallDest::ExtName(ref name, RelocDistance::Far) => {
                 ctx.emit(Inst::LoadExtName {
                     rd: writable_spilltmp_reg(),
-                    name: name.clone(),
+                    name: Box::new(name.clone()),
                     offset: 0,
                     srcloc: self.loc,
                 });
                 ctx.emit(Inst::CallInd {
-                    rn: spilltmp_reg(),
-                    uses: uses.into_boxed_slice(),
-                    defs: defs.into_boxed_slice(),
-                    loc: self.loc,
-                    opcode: self.opcode,
+                    info: Box::new(CallIndInfo {
+                        rn: spilltmp_reg(),
+                        uses,
+                        defs,
+                        loc: self.loc,
+                        opcode: self.opcode,
+                    }),
                 });
             }
             &CallDest::Reg(reg) => ctx.emit(Inst::CallInd {
-                rn: reg,
-                uses: uses.into_boxed_slice(),
-                defs: defs.into_boxed_slice(),
-                loc: self.loc,
-                opcode: self.opcode,
+                info: Box::new(CallIndInfo {
+                    rn: reg,
+                    uses,
+                    defs,
+                    loc: self.loc,
+                    opcode: self.opcode,
+                }),
             }),
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -309,7 +309,7 @@ pub enum BranchTarget {
     /// `lower_branch_group()`.
     Label(MachLabel),
     /// A fixed PC offset.
-    ResolvedOffset(isize),
+    ResolvedOffset(i32),
 }
 
 impl BranchTarget {

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -2114,8 +2114,8 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Call {
             dest: Box::new(ExternalName::testcase("test0")),
-            uses: Box::new(Set::empty()),
-            defs: Box::new(Set::empty()),
+            uses: Vec::new().into_boxed_slice(),
+            defs: Vec::new().into_boxed_slice(),
             loc: SourceLoc::default(),
             opcode: Opcode::Call,
         },
@@ -2126,8 +2126,8 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::CallInd {
             rn: xreg(10),
-            uses: Box::new(Set::empty()),
-            defs: Box::new(Set::empty()),
+            uses: Vec::new().into_boxed_slice(),
+            defs: Vec::new().into_boxed_slice(),
             loc: SourceLoc::default(),
             opcode: Opcode::CallIndirect,
         },

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -2113,11 +2113,13 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::Call {
-            dest: Box::new(ExternalName::testcase("test0")),
-            uses: Vec::new().into_boxed_slice(),
-            defs: Vec::new().into_boxed_slice(),
-            loc: SourceLoc::default(),
-            opcode: Opcode::Call,
+            info: Box::new(CallInfo {
+                dest: ExternalName::testcase("test0"),
+                uses: Vec::new(),
+                defs: Vec::new(),
+                loc: SourceLoc::default(),
+                opcode: Opcode::Call,
+            }),
         },
         "00000094",
         "bl 0",
@@ -2125,11 +2127,13 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::CallInd {
-            rn: xreg(10),
-            uses: Vec::new().into_boxed_slice(),
-            defs: Vec::new().into_boxed_slice(),
-            loc: SourceLoc::default(),
-            opcode: Opcode::CallIndirect,
+            info: Box::new(CallIndInfo {
+                rn: xreg(10),
+                uses: Vec::new(),
+                defs: Vec::new(),
+                loc: SourceLoc::default(),
+                opcode: Opcode::CallIndirect,
+            }),
         },
         "40013FD6",
         "blr x10",

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -14,6 +14,7 @@ use crate::isa::aarch64::inst::*;
 
 use regalloc::RegClass;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use smallvec::SmallVec;
@@ -1245,7 +1246,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let loc = ctx.srcloc(insn);
             ctx.emit(Inst::LoadExtName {
                 rd,
-                name: extname,
+                name: Box::new(extname),
                 srcloc: loc,
                 offset: 0,
             });
@@ -1262,7 +1263,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let loc = ctx.srcloc(insn);
             ctx.emit(Inst::LoadExtName {
                 rd,
-                name: extname,
+                name: Box::new(extname),
                 srcloc: loc,
                 offset,
             });
@@ -2140,8 +2141,10 @@ pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
                     ridx,
                     rtmp1,
                     rtmp2,
-                    targets: jt_targets.into_boxed_slice(),
-                    targets_for_term: targets_for_term.into_boxed_slice(),
+                    info: Box::new(JTSequenceInfo {
+                        targets: jt_targets,
+                        targets_for_term: targets_for_term,
+                    }),
                 });
             }
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -167,5 +167,8 @@ pub trait ABICall {
     /// registers are also logically defs, but should never be read; their
     /// values are "defined" (to the regalloc) but "undefined" in every other
     /// sense.)
+    ///
+    /// This function should only be called once, as it is allowed to re-use
+    /// parts of the ABICall object in emitting instructions.
     fn emit_call<C: LowerCtx<I = Self::I>>(&mut self, ctx: &mut C);
 }


### PR DESCRIPTION
This series of commits (which will have to land with a version bump of regalloc.rs to accommodate the API changes) reduces the number of memory allocations during compilation.

- First commit changes the return type of mem_finalize so it's a SmallVec, avoiding short-lived a SmallVec allocation that was convered into a Vec.
- Second commit adapts to changes in regalloc.rs brought by https://github.com/bytecodealliance/regalloc.rs/pull/71, reducing the need for short-lived Sets. Also avoids hashing computations, etc.
- Third commit makes an effort to reduce the size of the `Inst` enum down to 32 bytes. Unfortunately this means more pointer chasing for Call/JTSequence instructions (their members are now living in a *Info data structures) so not sure it's something we'd take as is. Maybe we could mitigate the indirection effects by reversing some of the attributes moves, putting them back next to the box; it's unclear which are most often accessed, and thus should be prioritized.

All in all, with all the changes from https://github.com/bytecodealliance/regalloc.rs/pull/71 too, the results are the following:

| benchmark | bytes allocs | block allocs | inst count |
| - | - | - | - |
| big.clif before | 389M | 458K | 4966M |
| big.clif after | 317M | 424K | 4798M |
| medium.clif before | 17.9M | 33K | 173M |
| medium.clif after | 14.8M | 22K | 155M |
| regex-rs.wasm before | 700M |  1.942M | 5030M |
| regex-rs.wasm after | 586M | 1.619M | 4582M |

It's hard to measure the wallclock effect, because my machine is quite noisy (despite setting CPU governance to perf, etc.) and the benchmarks run for really short. Instruction counts are pretty stable, though, and for a final measure I performed them with Cachegrind, just to be sure about those.

cc @julian-seward1 