### PR TITLE
Clarify wording in command error messages.

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -284,9 +284,9 @@ impl RunCommand {
                 Some(s) => s,
                 None => {
                     if let Some(name) = name {
-                        bail!("not enough arguments for `{}`", name)
+                        bail!("not enough arguments for command function `{}`", name)
                     } else {
-                        bail!("not enough arguments for command default")
+                        bail!("not enough arguments for command")
                     }
                 }
             };
@@ -306,9 +306,9 @@ impl RunCommand {
         // out, if there are any.
         let results = func.call(&values).with_context(|| {
             if let Some(name) = name {
-                format!("failed to invoke `{}`", name)
+                format!("failed to invoke command function `{}`", name)
             } else {
-                format!("failed to invoke command default")
+                format!("failed to invoke command")
             }
         })?;
         if !results.is_empty() {


### PR DESCRIPTION
This tweaks the wording in some of the error message related to commands to hopefully be a little clearer.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
