### PR TITLE
Fix warning

### DIFF
--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -120,7 +120,7 @@ impl CodeMemory {
 
             if !m.is_empty() {
                 unsafe {
-                    region::protect(m.as_mut_ptr(), m.len(), region::Protection::ReadExecute)
+                    region::protect(m.as_mut_ptr(), m.len(), region::Protection::READ_EXECUTE)
                 }
                 .expect("unable to make memory readonly and executable");
             }

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -182,7 +182,7 @@ impl Mmap {
 
         // Commit the accessible size.
         let ptr = self.ptr as *const u8;
-        unsafe { region::protect(ptr.add(start), len, region::Protection::ReadWrite) }
+        unsafe { region::protect(ptr.add(start), len, region::Protection::READ_WRITE) }
             .map_err(|e| e.to_string())
     }
 


### PR DESCRIPTION
The Wasmtime publishing scripts run `cargo update`, which upgraded Wasmtime's `region` dependency from 2.1.0 to 2.2.0. In 2.2.0, `region` deprecated `region::Protection::ReadExecute` and added `region::Protection::READ_EXECUTE`. Adding new things is compatible with a minor version bump, and my local build and `cargo publish` verifiation didn't get errors, however since our CI builds with warnings-as-errors, the CI is now red.

This PR fixes the warning, which should fix error.