### PR TITLE
Add deprecation notice to cranelift-faerie README and FaerieBuilder.

### DIFF
--- a/cranelift/faerie/README.md
+++ b/cranelift/faerie/README.md
@@ -2,3 +2,8 @@ This crate contains a library that enables
 [Cranelift](https://crates.io/crates/cranelift)
 to emit native object (".o") files, using the
 [Faerie](https://crates.io/crates/faerie) library.
+
+DEPRECATION NOTICE: the Cranelift developer team intends to stop maintaining
+the `cranelift-faerie` crate and remove it from the `wasmtime` git repository
+on or after August 3, 2020. We recommend users use its successor, the
+`cranelift-object` crate.

--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -34,6 +34,12 @@ impl FaerieBuilder {
     /// enum to symbols. LibCalls are inserted in the IR as part of the legalization for certain
     /// floating point instructions, and for stack probes. If you don't know what to use for this
     /// argument, use `cranelift_module::default_libcall_names()`.
+    #[deprecated(
+        since = "0.65.0",
+        note = "the Cranelift developer team intends to stop maintaining the `cranelift-faerie`
+        crate and remove it from the `wasmtime` git repository on or after August 3, 2020. We
+        recommend users use its successor, the `cranelift-object` crate."
+    )]
     pub fn new(
         isa: Box<dyn TargetIsa>,
         name: String,


### PR DESCRIPTION
I put the following notice in both the README and as a `deprecated` attribute on the
FaerieBuilder::new method:
```
the Cranelift developer team intends to stop maintaining
the `cranelift-faerie` crate and remove it from the `wasmtime` git repository
on or after August 3, 2020. We recommend users use its successor, the
`cranelift-object` crate.
```
