### PR TITLE
Legalize fmin/fmax with NaN quieting semantics

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -187,9 +187,8 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", _) if target.contains("aarch64") => return true,
 
             ("simd", "simd_conversions") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
-            ("simd", "simd_f32x4") => return true, // FIXME expected V128(F32x4([CanonicalNan, CanonicalNan, Value(Float32 { bits: 0 }), Value(Float32 { bits: 0 })])), got V128(18428729675200069632)
-            ("simd", "simd_f64x2") => return true, // FIXME expected V128(F64x2([Value(Float64 { bits: 9221120237041090560 }), Value(Float64 { bits: 0 })])), got V128(0)
-            ("simd", "simd_f64x2_arith") => return true, // FIXME expected V128(F64x2([Value(Float64 { bits: 9221120237041090560 }), Value(Float64 { bits: 13835058055282163712 })])), got V128(255211775190703847615975447847722024960)
+            ("simd", "simd_f64x2") => return true, // FIXME pending change in https://github.com/WebAssembly/simd/pull/239; then update tests/spec_testuite
+            ("simd", "simd_f64x2_arith") => return true, // FIXME pending change in https://github.com/WebAssembly/simd/pull/239; then update tests/spec_testuite
             ("simd", "simd_load") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
             ("simd", "simd_splat") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
 

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1635,6 +1635,7 @@ fn define_simd(
     let usub_sat = shared.by_name("usub_sat");
     let vconst = shared.by_name("vconst");
     let vselect = shared.by_name("vselect");
+    let x86_cvtt2si = x86.by_name("x86_cvtt2si");
     let x86_insertps = x86.by_name("x86_insertps");
     let x86_movlhps = x86.by_name("x86_movlhps");
     let x86_movsd = x86.by_name("x86_movsd");
@@ -1901,6 +1902,13 @@ fn define_simd(
             x86_vcvtudq2ps,
             rec_evex_reg_rm_128.opcodes(&VCVTUDQ2PS),
             Some(use_avx512vl_simd), // TODO need an OR predicate to join with AVX512F
+        );
+
+        e.enc_both_inferred(
+            x86_cvtt2si
+                .bind(vector(I32, sse_vector_size))
+                .bind(vector(F32, sse_vector_size)),
+            rec_furm.opcodes(&CVTTPS2DQ),
         );
     }
 

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1596,8 +1596,6 @@ fn define_simd(
     let fdiv = shared.by_name("fdiv");
     let fill = shared.by_name("fill");
     let fill_nop = shared.by_name("fill_nop");
-    let fmax = shared.by_name("fmax");
-    let fmin = shared.by_name("fmin");
     let fmul = shared.by_name("fmul");
     let fsub = shared.by_name("fsub");
     let iadd = shared.by_name("iadd");
@@ -1637,6 +1635,8 @@ fn define_simd(
     let vselect = shared.by_name("vselect");
     let x86_cvtt2si = x86.by_name("x86_cvtt2si");
     let x86_insertps = x86.by_name("x86_insertps");
+    let x86_fmax = x86.by_name("x86_fmax");
+    let x86_fmin = x86.by_name("x86_fmin");
     let x86_movlhps = x86.by_name("x86_movlhps");
     let x86_movsd = x86.by_name("x86_movsd");
     let x86_packss = x86.by_name("x86_packss");
@@ -2276,10 +2276,10 @@ fn define_simd(
         (F64, fmul, &MULPD[..]),
         (F32, fdiv, &DIVPS[..]),
         (F64, fdiv, &DIVPD[..]),
-        (F32, fmin, &MINPS[..]),
-        (F64, fmin, &MINPD[..]),
-        (F32, fmax, &MAXPS[..]),
-        (F64, fmax, &MAXPD[..]),
+        (F32, x86_fmin, &MINPS[..]),
+        (F64, x86_fmin, &MINPD[..]),
+        (F32, x86_fmax, &MAXPS[..]),
+        (F64, x86_fmax, &MAXPD[..]),
     ] {
         let inst = inst.bind(vector(*ty, sse_vector_size));
         e.enc_both_inferred(inst, rec_fa.opcodes(opcodes));

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1639,6 +1639,7 @@ fn define_simd(
     let x86_movlhps = x86.by_name("x86_movlhps");
     let x86_movsd = x86.by_name("x86_movsd");
     let x86_packss = x86.by_name("x86_packss");
+    let x86_pblendw = x86.by_name("x86_pblendw");
     let x86_pextr = x86.by_name("x86_pextr");
     let x86_pinsr = x86.by_name("x86_pinsr");
     let x86_pmaxs = x86.by_name("x86_pmaxs");
@@ -1741,6 +1742,13 @@ fn define_simd(
         };
         let instruction = vselect.bind(vector(ty, sse_vector_size));
         let template = rec_blend.opcodes(opcode);
+        e.enc_both_inferred_maybe_isap(instruction, template, Some(use_sse41_simd));
+    }
+
+    // PBLENDW, select lanes using a u8 immediate.
+    for ty in ValueType::all_lane_types().filter(|t| t.lane_bits() == 16) {
+        let instruction = x86_pblendw.bind(vector(ty, sse_vector_size));
+        let template = rec_fa_ib.opcodes(&PBLENDW);
         e.enc_both_inferred_maybe_isap(instruction, template, Some(use_sse41_simd));
     }
 

--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1655,10 +1655,12 @@ fn define_simd(
     let x86_ptest = x86.by_name("x86_ptest");
     let x86_punpckh = x86.by_name("x86_punpckh");
     let x86_punpckl = x86.by_name("x86_punpckl");
+    let x86_vcvtudq2ps = x86.by_name("x86_vcvtudq2ps");
 
     // Shorthands for recipes.
     let rec_blend = r.template("blend");
     let rec_evex_reg_vvvv_rm_128 = r.template("evex_reg_vvvv_rm_128");
+    let rec_evex_reg_rm_128 = r.template("evex_reg_rm_128");
     let rec_f_ib = r.template("f_ib");
     let rec_fa = r.template("fa");
     let rec_fa_ib = r.template("fa_ib");
@@ -1702,6 +1704,7 @@ fn define_simd(
     let use_sse41_simd = settings.predicate_by_name("use_sse41_simd");
     let use_sse42_simd = settings.predicate_by_name("use_sse42_simd");
     let use_avx512dq_simd = settings.predicate_by_name("use_avx512dq_simd");
+    let use_avx512vl_simd = settings.predicate_by_name("use_avx512vl_simd");
 
     // SIMD vector size: eventually multiple vector sizes may be supported but for now only
     // SSE-sized vectors are available.
@@ -1885,6 +1888,12 @@ fn define_simd(
             .bind(vector(F32, sse_vector_size))
             .bind(vector(I32, sse_vector_size));
         e.enc_both(fcvt_from_sint_32, rec_furm.opcodes(&CVTDQ2PS));
+
+        e.enc_32_64_maybe_isap(
+            x86_vcvtudq2ps,
+            rec_evex_reg_rm_128.opcodes(&VCVTUDQ2PS),
+            Some(use_avx512vl_simd), // TODO need an OR predicate to join with AVX512F
+        );
     }
 
     // SIMD vconst for special cases (all zeroes, all ones)

--- a/cranelift/codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift/codegen/meta/src/isa/x86/instructions.rs
@@ -333,6 +333,20 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    let mask = &Operand::new("mask", uimm8).with_doc("mask to select lanes from b");
+    ig.push(
+        Inst::new(
+            "x86_pblendw",
+            r#"
+    Blend packed words using an immediate mask. Each bit of the 8-bit immediate corresponds to a 
+    lane in ``b``: if the bit is set, the lane is copied into ``a``.
+    "#,
+            &formats.ternary_imm8,
+        )
+        .operands_in(vec![a, b, mask])
+        .operands_out(vec![a]),
+    );
+
     let Idx = &Operand::new("Idx", uimm8).with_doc("Lane index");
     let x = &Operand::new("x", TxN);
     let a = &Operand::new("a", &TxN.lane_of());

--- a/cranelift/codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift/codegen/meta/src/isa/x86/instructions.rs
@@ -145,6 +145,37 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    let f32x4 = &TypeVar::new(
+        "f32x4",
+        "A floating point number",
+        TypeSetBuilder::new()
+            .floats(32..32)
+            .simd_lanes(4..4)
+            .build(),
+    );
+    let i32x4 = &TypeVar::new(
+        "i32x4",
+        "An integer type with the same number of lanes",
+        TypeSetBuilder::new().ints(32..32).simd_lanes(4..4).build(),
+    );
+    let x = &Operand::new("x", i32x4);
+    let a = &Operand::new("a", f32x4);
+
+    ig.push(
+        Inst::new(
+            "x86_vcvtudq2ps",
+            r#"
+        Convert unsigned integer to floating point.
+
+        Convert packed doubleword unsigned integers to packed single-precision floating-point 
+        values. This instruction does not trap.
+        "#,
+            &formats.unary,
+        )
+        .operands_in(vec![x])
+        .operands_out(vec![a]),
+    );
+
     let x = &Operand::new("x", Float);
     let a = &Operand::new("a", Float);
     let y = &Operand::new("y", Float);

--- a/cranelift/codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift/codegen/meta/src/isa/x86/legalize.rs
@@ -379,10 +379,12 @@ fn define_simd(
     let bnot = insts.by_name("bnot");
     let bxor = insts.by_name("bxor");
     let extractlane = insts.by_name("extractlane");
+    let fabs = insts.by_name("fabs");
     let fcmp = insts.by_name("fcmp");
     let fcvt_from_uint = insts.by_name("fcvt_from_uint");
     let fcvt_to_sint_sat = insts.by_name("fcvt_to_sint_sat");
-    let fabs = insts.by_name("fabs");
+    let fmax = insts.by_name("fmax");
+    let fmin = insts.by_name("fmin");
     let fneg = insts.by_name("fneg");
     let iadd_imm = insts.by_name("iadd_imm");
     let icmp = insts.by_name("icmp");
@@ -790,6 +792,8 @@ fn define_simd(
     narrow.custom_legalize(ushr, "convert_ushr");
     narrow.custom_legalize(ishl, "convert_ishl");
     narrow.custom_legalize(fcvt_to_sint_sat, "expand_fcvt_to_sint_sat_vector");
+    narrow.custom_legalize(fmin, "expand_minmax_vector");
+    narrow.custom_legalize(fmax, "expand_minmax_vector");
 
     narrow_avx.custom_legalize(imul, "convert_i64x2_imul");
     narrow_avx.custom_legalize(fcvt_from_uint, "expand_fcvt_from_uint_vector");

--- a/cranelift/codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift/codegen/meta/src/isa/x86/legalize.rs
@@ -381,6 +381,7 @@ fn define_simd(
     let extractlane = insts.by_name("extractlane");
     let fcmp = insts.by_name("fcmp");
     let fcvt_from_uint = insts.by_name("fcvt_from_uint");
+    let fcvt_to_sint_sat = insts.by_name("fcvt_to_sint_sat");
     let fabs = insts.by_name("fabs");
     let fneg = insts.by_name("fneg");
     let iadd_imm = insts.by_name("iadd_imm");
@@ -788,6 +789,7 @@ fn define_simd(
     narrow.custom_legalize(ineg, "convert_ineg");
     narrow.custom_legalize(ushr, "convert_ushr");
     narrow.custom_legalize(ishl, "convert_ishl");
+    narrow.custom_legalize(fcvt_to_sint_sat, "expand_fcvt_to_sint_sat_vector");
 
     narrow_avx.custom_legalize(imul, "convert_i64x2_imul");
     narrow_avx.custom_legalize(fcvt_from_uint, "expand_fcvt_from_uint_vector");

--- a/cranelift/codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift/codegen/meta/src/isa/x86/legalize.rs
@@ -380,6 +380,7 @@ fn define_simd(
     let bxor = insts.by_name("bxor");
     let extractlane = insts.by_name("extractlane");
     let fcmp = insts.by_name("fcmp");
+    let fcvt_from_uint = insts.by_name("fcvt_from_uint");
     let fabs = insts.by_name("fabs");
     let fneg = insts.by_name("fneg");
     let iadd_imm = insts.by_name("iadd_imm");
@@ -788,6 +789,6 @@ fn define_simd(
     narrow.custom_legalize(ushr, "convert_ushr");
     narrow.custom_legalize(ishl, "convert_ishl");
 
-    // This lives in the expand group to avoid conflicting with, e.g., i128 legalizations.
     narrow_avx.custom_legalize(imul, "convert_i64x2_imul");
+    narrow_avx.custom_legalize(fcvt_from_uint, "expand_fcvt_from_uint_vector");
 }

--- a/cranelift/codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift/codegen/meta/src/isa/x86/mod.rs
@@ -48,6 +48,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_32.legalize_type(F32, x86_expand);
     x86_32.legalize_type(F64, x86_expand);
     x86_32.legalize_value_type(VectorType::new(I64.into(), 2), x86_narrow_avx);
+    x86_32.legalize_value_type(VectorType::new(F32.into(), 4), x86_narrow_avx);
 
     x86_64.legalize_monomorphic(expand_flags);
     x86_64.legalize_default(x86_narrow);
@@ -60,6 +61,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_64.legalize_type(F32, x86_expand);
     x86_64.legalize_type(F64, x86_expand);
     x86_64.legalize_value_type(VectorType::new(I64.into(), 2), x86_narrow_avx);
+    x86_64.legalize_value_type(VectorType::new(F32.into(), 4), x86_narrow_avx);
 
     let recipes = recipes::define(shared_defs, &settings, &regs);
 

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -347,6 +347,10 @@ pub static PAVGW: [u8; 3] = [0x66, 0x0f, 0xE3];
 /// in XMM0 and store the values into xmm1 (SSE4.1).
 pub static PBLENDVB: [u8; 4] = [0x66, 0x0f, 0x38, 0x10];
 
+/// Select words from xmm1 and xmm2/m128 from mask specified in imm8 and store the values into xmm1
+/// (SSE4.1).
+pub static PBLENDW: [u8; 4] = [0x66, 0x0f, 0x3a, 0x0e];
+
 /// Compare packed data for equal (SSE2).
 pub static PCMPEQB: [u8; 3] = [0x66, 0x0f, 0x74];
 

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -103,6 +103,10 @@ pub static CVTSI2SS: [u8; 3] = [0xf3, 0x0f, 0x2a];
 /// float-point value.
 pub static CVTSS2SD: [u8; 3] = [0xf3, 0x0f, 0x5a];
 
+/// Convert four packed single-precision floating-point values from xmm2/mem to four packed signed
+/// doubleword values in xmm1 using truncation (SSE2).
+pub static CVTTPS2DQ: [u8; 3] = [0xf3, 0x0f, 0x5b];
+
 /// Convert with truncation scalar double-precision floating-point value to signed
 /// integer.
 pub static CVTTSD2SI: [u8; 3] = [0xf2, 0x0f, 0x2c];

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -665,6 +665,10 @@ pub static UCOMISS: [u8; 2] = [0x0f, 0x2e];
 /// Raise invalid opcode instruction.
 pub static UNDEFINED2: [u8; 2] = [0x0f, 0x0b];
 
+/// Convert four packed unsigned doubleword integers from xmm2/m128/m32bcst to packed
+/// single-precision floating-point values in xmm1 with writemask k1 (AVX512VL, AVX512F).
+pub static VCVTUDQ2PS: [u8; 3] = [0xf2, 0x0f, 0x7a];
+
 /// imm{16,32} XOR r/m{16,32,64}, possibly sign-extended.
 pub static XOR_IMM: [u8; 1] = [0x81];
 

--- a/cranelift/codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/recipes.rs
@@ -3417,5 +3417,23 @@ pub(crate) fn define<'shared>(
         regs).rex_kind(RecipePrefixKind::Evex)
     );
 
+    recipes.add_template(
+        Template::new(
+            EncodingRecipeBuilder::new("evex_reg_rm_128", &formats.unary, 1)
+                .operands_in(vec![fpr])
+                .operands_out(vec![fpr])
+                .emit(
+                    r#"
+                // instruction encoding operands: reg (op1, w), rm (op2, r)
+                // this maps to:                  out_reg0,     in_reg0
+                let context = EvexContext::Other { length: EvexVectorLength::V128 };
+                let masking = EvexMasking::None;
+                put_evex(bits, out_reg0, 0, in_reg0, context, masking, sink); // params: reg, vvvv, rm
+                modrm_rr(in_reg0, out_reg0, sink); // params: rm, reg
+                "#,
+                ),
+            regs).rex_kind(RecipePrefixKind::Evex)
+    );
+
     recipes
 }

--- a/cranelift/codegen/meta/src/isa/x86/settings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/settings.rs
@@ -23,7 +23,12 @@ pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
     );
     let has_avx512vl = settings.add_bool(
         "has_avx512vl",
-        "AVX512DQ: CPUID.07H:EBX.AVX512VL[bit 31]",
+        "AVX512VL: CPUID.07H:EBX.AVX512VL[bit 31]",
+        false,
+    );
+    let has_avx512f = settings.add_bool(
+        "has_avx512f",
+        "AVX512F: CPUID.07H:EBX.AVX512F[bit 16]",
         false,
     );
     let has_popcnt = settings.add_bool("has_popcnt", "POPCNT: CPUID.01H:ECX.POPCNT[bit 23]", false);
@@ -75,6 +80,10 @@ pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
     settings.add_predicate(
         "use_avx512vl_simd",
         predicate!(shared_enable_simd && has_avx512vl),
+    );
+    settings.add_predicate(
+        "use_avx512f_simd",
+        predicate!(shared_enable_simd && has_avx512f),
     );
 
     settings.add_predicate("use_popcnt", predicate!(has_popcnt && has_sse42));

--- a/cranelift/codegen/meta/src/isa/x86/settings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/settings.rs
@@ -16,6 +16,14 @@ pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
         false,
     );
 
+    settings.add_bool(
+        "assert_in_bounds",
+        "If set, Cranelift will assume that operations with bounds are in bounds (e.g. \
+        float/integers conversions, dynamic lane indices); in certain cases, Cranelift can use \
+        this information to produce faster code.",
+        false,
+    );
+
     // CPUID.01H:ECX
     let has_sse3 = settings.add_bool("has_sse3", "SSE3: CPUID.01H:ECX.SSE3[bit 0]", false);
     let has_ssse3 = settings.add_bool("has_ssse3", "SSSE3: CPUID.01H:ECX.SSSE3[bit 9]", false);

--- a/cranelift/codegen/meta/src/isa/x86/settings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/settings.rs
@@ -9,6 +9,13 @@ pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
         false,
     );
 
+    settings.add_bool(
+        "assert_no_nans",
+        "If set, Cranelift will assume that floating-point operations will not produce \
+        NaNs; in certain cases, Cranelift can use this information to produce faster code.",
+        false,
+    );
+
     // CPUID.01H:ECX
     let has_sse3 = settings.add_bool("has_sse3", "SSE3: CPUID.01H:ECX.SSE3[bit 0]", false);
     let has_ssse3 = settings.add_bool("has_ssse3", "SSSE3: CPUID.01H:ECX.SSSE3[bit 9]", false);

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1916,6 +1916,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::X86Packss
         | Opcode::X86Punpckh
         | Opcode::X86Punpckl
+        | Opcode::X86Vcvtudq2ps
         | Opcode::X86ElfTlsGetAddr
         | Opcode::X86MachoTlsGetAddr => {
             panic!("x86-specific opcode in supposedly arch-neutral IR!");

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1896,6 +1896,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::X86Pop
         | Opcode::X86Bsr
         | Opcode::X86Bsf
+        | Opcode::X86Pblendw
         | Opcode::X86Pshufd
         | Opcode::X86Pshufb
         | Opcode::X86Pextr

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -597,6 +597,9 @@ fn expand_minmax(
 
 /// x86 has no unsigned-to-float conversions. We handle the easy case of zero-extending i32 to
 /// i64 with a pattern, the rest needs more code.
+///
+/// Note that this is the scalar implementation; for the vector implemenation see
+/// [expand_fcvt_from_uint_vector].
 fn expand_fcvt_from_uint(
     inst: ir::Inst,
     func: &mut ir::Function,
@@ -676,6 +679,55 @@ fn expand_fcvt_from_uint(
     cfg.recompute_block(pos.func, poszero_block);
     cfg.recompute_block(pos.func, neg_block);
     cfg.recompute_block(pos.func, done);
+}
+
+/// To convert packed unsigned integers to their float equivalents, we must legalize to a special
+/// AVX512 instruction or use a long sequence of instructions. This logic is separate from
+/// [expand_fcvt_from_uint] above (the scalar version), only due to how the transform groups are
+/// set up; TODO if we change the SIMD legalization groups, then this logic could be merged into
+/// [expand_fcvt_from_uint] (see https://github.com/bytecodealliance/wasmtime/issues/1745).
+fn expand_fcvt_from_uint_vector(
+    inst: ir::Inst,
+    func: &mut ir::Function,
+    _cfg: &mut ControlFlowGraph,
+    isa: &dyn TargetIsa,
+) {
+    let mut pos = FuncCursor::new(func).at_inst(inst);
+    pos.use_srcloc(inst);
+
+    if let ir::InstructionData::Unary {
+        opcode: ir::Opcode::FcvtFromUint,
+        arg,
+    } = pos.func.dfg[inst]
+    {
+        let controlling_type = pos.func.dfg.ctrl_typevar(inst);
+        if controlling_type == F32X4 {
+            debug_assert_eq!(pos.func.dfg.value_type(arg), I32X4);
+            let x86_isa = isa
+                .as_any()
+                .downcast_ref::<isa::x86::Isa>()
+                .expect("the target ISA must be x86 at this point");
+            if x86_isa.isa_flags.use_avx512vl_simd() || x86_isa.isa_flags.use_avx512f_simd() {
+                // If we have certain AVX512 features, we can lower this instruction simply.
+                pos.func.dfg.replace(inst).x86_vcvtudq2ps(arg);
+            } else {
+                // Otherwise, we default to a very lengthy SSE4.1-compatible sequence.
+                let bitcast_arg = pos.ins().raw_bitcast(I16X8, arg);
+                let zero_constant = pos.func.dfg.constants.insert(vec![0; 16].into());
+                let zero = pos.ins().vconst(I16X8, zero_constant);
+                let low = pos.ins().x86_pblendw(zero, bitcast_arg, 0x55);
+                let bitcast_low = pos.ins().raw_bitcast(I32X4, low);
+                let high = pos.ins().isub(arg, bitcast_low);
+                let convert_low = pos.ins().fcvt_from_sint(F32X4, bitcast_low);
+                let shift_high = pos.ins().ushr_imm(high, 1);
+                let convert_high = pos.ins().fcvt_from_sint(F32X4, shift_high);
+                let double_high = pos.ins().fadd(convert_high, convert_high);
+                pos.func.dfg.replace(inst).fadd(double_high, convert_low);
+            }
+        } else {
+            unimplemented!("cannot legalize {}", pos.func.dfg.display_inst(inst, None))
+        }
+    }
 }
 
 fn expand_fcvt_to_sint(

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -595,6 +595,113 @@ fn expand_minmax(
     cfg.recompute_block(pos.func, done);
 }
 
+/// This legalization converts a minimum/maximum operation into a sequence that matches the
+/// non-x86-friendly WebAssembly semantics of NaN handling. It also provides the option to avoid
+/// this overhead with an ISA flag, `assert_no_nans`. This logic is separate from [expand_minmax]
+/// above (the scalar version), only due to how the transform groups are set up; TODO if we change
+/// the SIMD legalization groups, then this logic could be merged into [expand_minmax]
+/// (see https://github.com/bytecodealliance/wasmtime/issues/1745).
+fn expand_minmax_vector(
+    inst: ir::Inst,
+    func: &mut ir::Function,
+    _cfg: &mut ControlFlowGraph,
+    isa: &dyn TargetIsa,
+) {
+    let ty = func.dfg.ctrl_typevar(inst);
+    debug_assert!(ty.is_vector());
+    let (x, y, x86_opcode, is_max) = match func.dfg[inst] {
+        ir::InstructionData::Binary {
+            opcode: ir::Opcode::Fmin,
+            args,
+        } => (args[0], args[1], ir::Opcode::X86Fmin, false),
+        ir::InstructionData::Binary {
+            opcode: ir::Opcode::Fmax,
+            args,
+        } => (args[0], args[1], ir::Opcode::X86Fmax, true),
+        _ => panic!("Expected fmin/fmax: {}", func.dfg.display_inst(inst, None)),
+    };
+
+    let x86_isa = isa
+        .as_any()
+        .downcast_ref::<isa::x86::Isa>()
+        .expect("the target ISA must be x86 at this point");
+
+    if x86_isa.isa_flags.assert_no_nans() {
+        // If we are assured by the user that neither operand can be a NaN, we can lower this
+        // operation with a single instructions. This currently ignores the inconsistency with +0.0
+        // and -0.0 (x86 will return the second operand always)--TODO.
+        func.dfg.replace(inst).Binary(x86_opcode, ty, x, y);
+    } else {
+        let mut pos = FuncCursor::new(func).at_inst(inst);
+        pos.use_srcloc(inst);
+
+        // During this lowering we will need to know how many bits to shift by and what type to
+        // convert to when using an integer shift. Recall that an IEEE754 number looks like:
+        // `[sign bit] [exponent bits] [significand bits]`
+        // A quiet NaN has all exponent bits set to 1 and the most significant bit of the
+        // significand set to 1; a signaling NaN has the same exponent but the MSB of the
+        // significand is set to 0. The payload of the NaN is the remaining significand bits, and
+        // WebAssembly assumes a canonical NaN is quiet and has 0s in its payload. To compute this
+        // canonical NaN, we create a mask for the top 10 bits on F32X4 (1 sign + 8 exp. + 1 MSB
+        // sig.) and the top 13 bits on F64X2 (1 sign + 11 exp. + 1 MSB sig.).
+        let (shift_by, ty_as_int) = match ty {
+            F32X4 => (10, I32X4),
+            F64X2 => (13, I64X2),
+            _ => panic!("TODO"),
+        };
+
+        // This sequence is complex due to how x86 handles NaNs and +0/-0. If x86 finds a NaN in
+        // either lane it returns the second operand; likewise, if both operands are in {+0.0, -0.0}
+        // it returns the second operand. To match the behavior of "return the minimum of the
+        // operands or a canonical NaN if either operand is NaN," we must compare in both
+        // directions.
+        let (forward_inst, dfg) = pos.ins().Binary(x86_opcode, ty, x, y);
+        let forward = dfg.first_result(forward_inst);
+        let (backward_inst, dfg) = pos.ins().Binary(x86_opcode, ty, y, x);
+        let backward = dfg.first_result(backward_inst);
+
+        let (value, mask) = if is_max {
+            // For maximum:
+            // Find any differences between the forward and backward `max` operation.
+            let difference = pos.ins().bxor(forward, backward);
+            // Merge in the differences. TODO could this be done as in min?
+            let propagate_nans_and_plus_zero = pos.ins().bor(backward, difference);
+            let value = pos.ins().fsub(propagate_nans_and_plus_zero, difference);
+            // Discover which lanes have NaNs in them.
+            let find_nan_lanes_mask = pos.ins().fcmp(FloatCC::Unordered, difference, value);
+            (value, find_nan_lanes_mask)
+        } else {
+            // For minimum:
+            // If either lane is a NaN, we want to use these bits, not the second operand bits.
+            let propagate_nans = pos.ins().bor(backward, forward);
+            // Find which lanes contain a NaN with an unordered comparison, filling the mask with
+            // 1s.
+            let find_nan_lanes_mask = pos.ins().fcmp(FloatCC::Unordered, forward, propagate_nans);
+            let bitcast_find_nan_lanes_mask = pos.ins().raw_bitcast(ty, find_nan_lanes_mask);
+            // Then flood the value lane with all 1s if that lane is a NaN. This causes all NaNs
+            // along this code path to be quieted and negative: after the upcoming shift and and_not,
+            // all upper bits (sign, exponent, and payload MSB) will be 1s.
+            let tmp = pos.ins().bor(propagate_nans, bitcast_find_nan_lanes_mask);
+            (tmp, bitcast_find_nan_lanes_mask)
+        };
+
+        // In order to clear the NaN payload for canonical NaNs, we shift right the NaN lanes (all
+        // 1s) leaving 0s in the top bits. Remember that non-NaN lanes are all 0s so this has
+        // little effect.
+        let mask_as_int = pos.ins().raw_bitcast(ty_as_int, mask);
+        let shift_mask = pos.ins().ushr_imm(mask_as_int, shift_by);
+        let shift_mask_as_float = pos.ins().raw_bitcast(ty, shift_mask);
+
+        // Finally, we replace the value with `value & ~shift_mask`. For non-NaN lanes, this is
+        // equivalent to `... & 1111...` but for NaN lanes this will only have 1s in the top bits,
+        // clearing the payload.
+        pos.func
+            .dfg
+            .replace(inst)
+            .band_not(value, shift_mask_as_float);
+    }
+}
+
 /// x86 has no unsigned-to-float conversions. We handle the easy case of zero-extending i32 to
 /// i64 with a pattern, the rest needs more code.
 ///

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
@@ -58,8 +58,8 @@ block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm5]):
 [-, %xmm3]    v3 = fsub v0, v1      ; bin: 0f 5c dd
 [-, %xmm3]    v4 = fmul v0, v1      ; bin: 0f 59 dd
 [-, %xmm3]    v5 = fdiv v0, v1      ; bin: 0f 5e dd
-[-, %xmm3]    v6 = fmin v0, v1      ; bin: 0f 5d dd
-[-, %xmm3]    v7 = fmax v0, v1      ; bin: 0f 5f dd
+[-, %xmm3]    v6 = x86_fmin v0, v1  ; bin: 0f 5d dd
+[-, %xmm3]    v7 = x86_fmax v0, v1  ; bin: 0f 5f dd
 [-, %xmm3]    v8 = sqrt v0          ; bin: 0f 51 db
     return
 }
@@ -70,8 +70,8 @@ block0(v0: f32x4 [%xmm3], v1: f32x4 [%xmm10]):
 [-, %xmm3]    v3 = fsub v0, v1      ; bin: 41 0f 5c da
 [-, %xmm3]    v4 = fmul v0, v1      ; bin: 41 0f 59 da
 [-, %xmm3]    v5 = fdiv v0, v1      ; bin: 41 0f 5e da
-[-, %xmm3]    v6 = fmin v0, v1      ; bin: 41 0f 5d da
-[-, %xmm3]    v7 = fmax v0, v1      ; bin: 41 0f 5f da
+[-, %xmm3]    v6 = x86_fmin v0, v1  ; bin: 41 0f 5d da
+[-, %xmm3]    v7 = x86_fmax v0, v1  ; bin: 41 0f 5f da
 [-, %xmm3]    v8 = sqrt v1          ; bin: 41 0f 51 da
     return
 }
@@ -82,8 +82,8 @@ block0(v0: f64x2 [%xmm3], v1: f64x2 [%xmm5]):
 [-, %xmm3]    v3 = fsub v0, v1      ; bin: 66 0f 5c dd
 [-, %xmm3]    v4 = fmul v0, v1      ; bin: 66 0f 59 dd
 [-, %xmm3]    v5 = fdiv v0, v1      ; bin: 66 0f 5e dd
-[-, %xmm3]    v6 = fmin v0, v1      ; bin: 66 0f 5d dd
-[-, %xmm3]    v7 = fmax v0, v1      ; bin: 66 0f 5f dd
+[-, %xmm3]    v6 = x86_fmin v0, v1  ; bin: 66 0f 5d dd
+[-, %xmm3]    v7 = x86_fmax v0, v1  ; bin: 66 0f 5f dd
 [-, %xmm3]    v8 = sqrt v0          ; bin: 66 0f 51 db
     return
 }
@@ -94,8 +94,8 @@ block0(v0: f64x2 [%xmm11], v1: f64x2 [%xmm13]):
 [-, %xmm11]    v3 = fsub v0, v1      ; bin: 66 45 0f 5c dd
 [-, %xmm11]    v4 = fmul v0, v1      ; bin: 66 45 0f 59 dd
 [-, %xmm11]    v5 = fdiv v0, v1      ; bin: 66 45 0f 5e dd
-[-, %xmm11]    v6 = fmin v0, v1      ; bin: 66 45 0f 5d dd
-[-, %xmm11]    v7 = fmax v0, v1      ; bin: 66 45 0f 5f dd
+[-, %xmm11]    v6 = x86_fmin v0, v1  ; bin: 66 45 0f 5d dd
+[-, %xmm11]    v7 = x86_fmax v0, v1  ; bin: 66 45 0f 5f dd
 [-, %xmm11]    v8 = sqrt v0          ; bin: 66 45 0f 51 db
     return
 }

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
@@ -83,3 +83,35 @@ block0(v0:i64x2, v1:i64x2):
     ; nextln: v2 = iadd v9, v8
     return
 }
+
+function %fmin_f32x4(f32x4, f32x4) {
+block0(v0:f32x4, v1:f32x4):
+    v2 = fmin v0, v1
+    ; check: v3 = x86_fmin v0, v1
+    ; nextln: v4 = x86_fmin v1, v0
+    ; nextln: v5 = bor v4, v3
+    ; nextln: v6 = fcmp uno v3, v5
+    ; nextln: v7 = raw_bitcast.f32x4 v6
+    ; nextln: v8 = bor v5, v7
+    ; nextln: v9 = raw_bitcast.i32x4 v7
+    ; nextln: v10 = ushr_imm v9, 10
+    ; nextln: v11 = raw_bitcast.f32x4 v10
+    ; nextln: v2 = band_not v8, v11
+    return
+}
+
+function %fmax_f64x2(f64x2, f64x2) {
+block0(v0:f64x2, v1:f64x2):
+    v2 = fmax v0, v1
+    ; check: v3 = x86_fmax v0, v1
+    ; nextln: v4 = x86_fmax v1, v0
+    ; nextln: v5 = bxor v3, v4
+    ; nextln: v6 = bor v4, v5
+    ; nextln: v7 = fsub v6, v5
+    ; nextln: v8 = fcmp uno v5, v7
+    ; nextln: v9 = raw_bitcast.i64x2 v8
+    ; nextln: v10 = ushr_imm v9, 13
+    ; nextln: v11 = raw_bitcast.f64x2 v10
+    ; nextln: v2 = band_not v7, v11
+    return
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
@@ -192,31 +192,22 @@ block0:
 }
 ; run
 
-function %fmax_f64x2() -> b1 {
-block0:
-    v0 = vconst.f64x2 [-0.0 -0x1.0]
-    v1 = vconst.f64x2 [+0.0 +0x1.0]
-
+function %fmax_f64x2(f64x2, f64x2) -> f64x2 {
+block0(v0: f64x2, v1: f64x2):
     v2 = fmax v0, v1
-    v3 = fcmp eq v2, v1
-    v4 = vall_true v3
-
-    return v4
+    return v2
 }
-; run
+; run: %fmax_f64x2([-0x0.0 -0x1.0], [+0x0.0 0x1.0]) == [+0x0.0 0x1.0]
+; run: %fmax_f64x2([-NaN NaN], [0x0.0 0x100.0]) == [-NaN NaN]
 
-function %fmin_f64x2() -> b1 {
-block0:
-    v0 = vconst.f64x2 [-0x1.0 -0x1.0]
-    v1 = vconst.f64x2 [+0.0 +0x1.0]
-
+function %fmin_f64x2(f64x2, f64x2) -> f64x2 {
+block0(v0: f64x2, v1: f64x2):
     v2 = fmin v0, v1
-    v3 = fcmp eq v2, v0
-    v4 = vall_true v3
-
-    return v4
+    return v2
 }
-; run
+; run: %fmin_f64x2([-0x0.0 -0x1.0], [+0x0.0 0x1.0]) == [-0x0.0 -0x1.0]
+; run: %fmin_f64x2([-NaN 0x100.0], [0x0.0 NaN]) == [-NaN -NaN]  ; note how the second NaN is now quieted and negative:
+; this is due to non-determinism in the NaN sequence.
 
 function %fneg_f64x2() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-binemit.clif
@@ -1,0 +1,9 @@
+test binemit
+set enable_simd
+target x86_64 has_avx512vl=true
+
+function %fcvt_from_uint(i32x4) {
+block0(v0: i32x4 [%xmm2]):
+[-, %xmm6]  v1 = x86_vcvtudq2ps v0 ; bin: 62 f1 7f 08 7a f2
+    return
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-legalize.clif
@@ -1,0 +1,10 @@
+test legalizer
+set enable_simd
+target x86_64 skylake has_avx512f=true
+
+function %fcvt_from_uint(i32x4) -> f32x4 {
+block0(v0:i32x4):
+    v1 = fcvt_from_uint.f32x4 v0
+    ; check: v1 = x86_vcvtudq2ps v0
+    return v1
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize-fast.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize-fast.clif
@@ -1,0 +1,12 @@
+test legalizer
+set enable_simd
+target x86_64 skylake assert_no_nans=true assert_in_bounds=true
+
+; When we assert that no NaNs are possible and the conversion will not overflow, we can emit a shorter legalization
+; sequence.
+function %fcvt_to_sint_sat(f32x4) -> i32x4 {
+block0(v0:f32x4):
+    v1 = fcvt_to_sint_sat.i32x4 v0
+    ; check: v1 = x86_cvtt2si.i32x4 v0
+    return v1
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
@@ -1,0 +1,19 @@
+test legalizer
+set enable_simd
+target x86_64 skylake
+
+function %fcvt_from_uint(i32x4) -> f32x4 {
+block0(v0:i32x4):
+    v1 = fcvt_from_uint.f32x4 v0
+    ; check: v2 = raw_bitcast.i16x8 v0
+    ; nextln: v3 = vconst.i16x8 const0
+    ; nextln: v4 = x86_pblendw v3, v2, 85
+    ; nextln: v5 = raw_bitcast.i32x4 v4
+    ; nextln: v6 = isub v0, v5
+    ; nextln: v7 = fcvt_from_sint.f32x4 v5
+    ; nextln: v8 = ushr_imm v6, 1
+    ; nextln: v9 = fcvt_from_sint.f32x4 v8
+    ; nextln: v10 = fadd v9, v9
+    ; nextln: v1 = fadd v10, v7
+    return v1
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
@@ -17,3 +17,17 @@ block0(v0:i32x4):
     ; nextln: v1 = fadd v10, v7
     return v1
 }
+
+function %fcvt_to_sint_sat(f32x4) -> i32x4 {
+block0(v0:f32x4):
+    v1 = fcvt_to_sint_sat.i32x4 v0
+    ; check: v2 = vconst.f32x4 const0
+    ; nextln: v3 = band v0, v2
+    ; nextln: v4 = bxor v2, v0
+    ; nextln: v5 = x86_cvtt2si.i32x4 v3
+    ; nextln: v6 = raw_bitcast.i32x4 v4
+    ; nextln: v7 = band v6, v5
+    ; nextln: v8 = sshr_imm v7, 31
+    ; nextln: v1 = bxor v5, v8
+    return v1
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
@@ -13,3 +13,10 @@ block0:
     return v4
 }
 ; run
+
+function %fcvt_from_uint(i32x4) -> f32x4 {
+block0(v0:i32x4):
+    v1 = fcvt_from_uint.f32x4 v0
+    return v1
+}
+; run: %fcvt_from_uint([0 0 0 0]) == [0x0.0 0x0.0 0x0.0 0x0.0]

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
@@ -20,3 +20,10 @@ block0(v0:i32x4):
     return v1
 }
 ; run: %fcvt_from_uint([0 0 0 0]) == [0x0.0 0x0.0 0x0.0 0x0.0]
+
+function %fcvt_to_sint_sat(f32x4) -> i32x4 {
+block0(v0:f32x4):
+    v1 = fcvt_to_sint_sat.i32x4 v0
+    return v1
+}
+; run: %fcvt_to_sint_sat([0x0.0 -0x1.0 0x1.0 0x1.0p100]) == [0 -1 1 0x7FFFFFFF]

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit.clif
@@ -96,6 +96,14 @@ block0:
             return
 }
 
+;; blend
+
+function %pblendw(b16x8, b16x8) {
+block0(v0: b16x8 [%xmm10], v1: b16x8 [%xmm2]):
+[-, %xmm10] v2 = x86_pblendw v0, v1, 0x55   ; bin: 66 44 0f 3a 0e d2 55
+            return
+}
+
 ;; pack/unpack
 
 function %unpack_high_i8x16(i8x16, i8x16) {

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -91,6 +91,9 @@ fn parse_x86_cpuid(isa_builder: &mut isa::Builder) -> Result<(), &'static str> {
         if info.has_avx512vl() {
             isa_builder.enable("has_avx512vl").unwrap();
         }
+        if info.has_avx512f() {
+            isa_builder.enable("has_avx512f").unwrap();
+        }
     }
     if let Some(info) = cpuid.get_extended_function_info() {
         if info.has_lzcnt() {

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1548,8 +1548,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, I32X4, builder);
             state.push1(builder.ins().fcvt_from_uint(F32X4, a))
         }
-        Operator::I32x4TruncSatF32x4S
-        | Operator::I32x4TruncSatF32x4U
+        Operator::I32x4TruncSatF32x4S => {
+            let a = pop1_with_bitcast(state, F32X4, builder);
+            state.push1(builder.ins().fcvt_to_sint_sat(I32X4, a))
+        }
+        Operator::I32x4TruncSatF32x4U
         | Operator::I8x16Abs
         | Operator::I16x8Abs
         | Operator::I32x4Abs

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1544,9 +1544,12 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, I32X4, builder);
             state.push1(builder.ins().fcvt_from_sint(F32X4, a))
         }
+        Operator::F32x4ConvertI32x4U => {
+            let a = pop1_with_bitcast(state, I32X4, builder);
+            state.push1(builder.ins().fcvt_from_uint(F32X4, a))
+        }
         Operator::I32x4TruncSatF32x4S
         | Operator::I32x4TruncSatF32x4U
-        | Operator::F32x4ConvertI32x4U
         | Operator::I8x16Abs
         | Operator::I16x8Abs
         | Operator::I32x4Abs


### PR DESCRIPTION
This builds on #1820 and should be merged after that PR.

The Wasm SIMD spec defines semantics for [`fmin` and `fmax`](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#floating-point-min-and-max) that require runtimes to produce long sequences of instructions. This change adds these long sequences through legalization but also provides an alternate mechansim, using the `assert_no_nans` flag, for guaranteeing that special NaN handling is not required, thus resulting in a much shorter legalization.