### PR TITLE
Three fixes to various SpiderMonkey-related issues

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -212,9 +212,14 @@ pub(crate) fn input_to_reg<C: LowerCtx<I = Inst>>(
     let from_bits = ty_bits(ty) as u8;
     let inputs = ctx.get_input(input.insn, input.input);
     let in_reg = if let Some(c) = inputs.constant {
+        let masked = if from_bits < 64 {
+            c & ((1u64 << from_bits) - 1)
+        } else {
+            c
+        };
         // Generate constants fresh at each use to minimize long-range register pressure.
         let to_reg = ctx.alloc_tmp(Inst::rc_for_type(ty).unwrap(), ty);
-        for inst in Inst::gen_constant(to_reg, c, ty).into_iter() {
+        for inst in Inst::gen_constant(to_reg, masked, ty).into_iter() {
             ctx.emit(inst);
         }
         to_reg.to_reg()

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -1,5 +1,6 @@
 //! ARM 64-bit Instruction Set Architecture.
 
+use crate::ir::condcodes::IntCC;
 use crate::ir::Function;
 use crate::isa::Builder as IsaBuilder;
 use crate::machinst::{
@@ -91,6 +92,19 @@ impl MachBackend for AArch64Backend {
 
     fn reg_universe(&self) -> &RealRegUniverse {
         &self.reg_universe
+    }
+
+    fn unsigned_add_overflow_condition(&self) -> IntCC {
+        // Unsigned `>=`; this corresponds to the carry flag set on aarch64, which happens on
+        // overflow of an add.
+        IntCC::UnsignedGreaterThanOrEqual
+    }
+
+    fn unsigned_sub_overflow_condition(&self) -> IntCC {
+        // unsigned `<`; this corresponds to the carry flag cleared on aarch64, which happens on
+        // underflow of a subtract (aarch64 follows a carry-cleared-on-borrow convention, the
+        // opposite of x86).
+        IntCC::UnsignedLessThan
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -5,6 +5,7 @@ use alloc::boxed::Box;
 use regalloc::RealRegUniverse;
 use target_lexicon::Triple;
 
+use crate::ir::condcodes::IntCC;
 use crate::ir::Function;
 use crate::isa::Builder as IsaBuilder;
 use crate::machinst::pretty_print::ShowWithRRU;
@@ -83,6 +84,18 @@ impl MachBackend for X64Backend {
 
     fn reg_universe(&self) -> &RealRegUniverse {
         &self.reg_universe
+    }
+
+    fn unsigned_add_overflow_condition(&self) -> IntCC {
+        // Unsigned `>=`; this corresponds to the carry flag set on x86, which happens on
+        // overflow of an add.
+        IntCC::UnsignedGreaterThanOrEqual
+    }
+
+    fn unsigned_sub_overflow_condition(&self) -> IntCC {
+        // unsigned `>=`; this corresponds to the carry flag set on x86, which happens on
+        // underflow of a subtract (carry is borrow for subtract).
+        IntCC::UnsignedGreaterThanOrEqual
     }
 }
 

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -308,14 +308,10 @@ pub trait MachBackend {
     fn reg_universe(&self) -> &RealRegUniverse;
 
     /// Machine-specific condcode info needed by TargetIsa.
-    fn unsigned_add_overflow_condition(&self) -> IntCC {
-        // TODO: this is what x86 specifies. Is this right for arm64?
-        IntCC::UnsignedLessThan
-    }
+    /// Condition that will be true when an IaddIfcout overflows.
+    fn unsigned_add_overflow_condition(&self) -> IntCC;
 
     /// Machine-specific condcode info needed by TargetIsa.
-    fn unsigned_sub_overflow_condition(&self) -> IntCC {
-        // TODO: this is what x86 specifies. Is this right for arm64?
-        IntCC::UnsignedLessThan
-    }
+    /// Condition that will be true when an IsubIfcout overflows.
+    fn unsigned_sub_overflow_condition(&self) -> IntCC;
 }

--- a/cranelift/codegen/src/value_label.rs
+++ b/cranelift/codegen/src/value_label.rs
@@ -91,6 +91,11 @@ pub fn build_value_labels_ranges<T>(
 where
     T: From<SourceLoc> + Deref<Target = SourceLoc> + Ord + Copy,
 {
+    // FIXME(#1523): New-style backend does not yet have debug info.
+    if isa.get_mach_backend().is_some() {
+        return HashMap::new();
+    }
+
     let values_labels = build_value_labels_index::<T>(func);
 
     let mut blocks = func.layout.blocks().collect::<Vec<_>>();

--- a/cranelift/filetests/filetests/vcode/aarch64/constants.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/constants.clif
@@ -200,3 +200,16 @@ block0:
 ; nextln: mov sp, fp
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
+
+function %f() -> i32 {
+block0:
+  v0 = iconst.i32 -1
+  return v0
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: orr x0, xzr, #4294967295
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret

--- a/cranelift/filetests/filetests/vcode/aarch64/heap_addr.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/heap_addr.clif
@@ -1,0 +1,49 @@
+test compile
+target aarch64
+
+function %dynamic_heap_check(i64 vmctx, i32) -> i64 {
+    gv0 = vmctx
+    gv1 = load.i32 notrap aligned gv0
+    heap0 = dynamic gv0, bound gv1, offset_guard 0x1000, index_type i32
+
+block0(v0: i64, v1: i32):
+    v2 = heap_addr.i64 heap0, v1, 0
+    return v2
+}
+
+; check:   stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  ldur w2, [x0]
+; nextln:  add w2, w2, #0
+; nextln:  subs wzr, w1, w2
+; nextln:  b.ls label1 ; b label2
+; nextln:  Block 1:
+; check:   add x0, x0, x1, UXTW
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret
+; nextln:  Block 2:
+; check:  udf
+
+
+function %static_heap_check(i64 vmctx, i32) -> i64 {
+    gv0 = vmctx
+    heap0 = static gv0, bound 0x1_0000, offset_guard 0x1000, index_type i32
+
+block0(v0: i64, v1: i32):
+    v2 = heap_addr.i64 heap0, v1, 0
+    return v2
+}
+
+; check:   stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  subs wzr, w1, #65536
+; nextln:  b.ls label1 ; b label2
+; nextln:  Block 1:
+; check:   add x0, x0, x1, UXTW
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret
+; nextln:  Block 2:
+; check:   udf
+

--- a/tests/all/fuzzing.rs
+++ b/tests/all/fuzzing.rs
@@ -21,7 +21,7 @@ fn instantiate_empty_module_with_memory() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", should_panic)] // FIXME(#1523)
+#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1523)
 fn instantiate_module_that_compiled_to_x64_has_register_32() {
     let mut config = Config::new();
     config.debug_info(true);


### PR DESCRIPTION
- Properly mask constant values down to appropriate width when
  generating a constant value directly in aarch64 backend. This was a
  miscompilation introduced in the new-isel refactor. In combination
  with failure to respect NarrowValueMode, this resulted in a very
  subtle bug when an `i32` constant was used in bit-twiddling logic.

- Add support for `iadd_ifcout` in aarch64 backend as used in explicit
  heap-check mode. With this change, we no longer fail heap-related
  tests with the huge-heap-region mode disabled.

- Remove a panic that was occurring in some tests that are currently
  ignored on aarch64, by simply returning empty/default information in
  `value_label` functionality rather than touching unimplemented APIs.
  This is not a bugfix per-se, but removes confusing panic messages from
  `cargo test` output that might otherwise mislead.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
