### PR TITLE
Correct version of region dependency of simplejit

### DIFF
--- a/cranelift/simplejit/Cargo.toml
+++ b/cranelift/simplejit/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 cranelift-module = { path = "../module", version = "0.64.0" }
 cranelift-native = { path = "../native", version = "0.64.0" }
 cranelift-codegen = { path = "../codegen", version = "0.64.0", default-features = false, features = ["std"] }
-region = "2.0.0"
+region = "2.1.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
 target-lexicon = "0.10"


### PR DESCRIPTION
Using `region 2.0.0` fails with:

```
error[E0599]: no associated item named `READ_WRITE` found for struct `region::protect::Protection` in the current scope
   --> /home/bjorn/.cargo/git/checkouts/wasmtime-41807828cb3a7a7e/00abfcd/cranelift/simplejit/src/memory.rs:114:73
    |
114 |                 region::protect(self.ptr, self.len, region::Protection::READ_WRITE)
    |                                                                         ^^^^^^^^^^ associated item not found in `region::protect::Protection`

error[E0599]: no associated item named `READ_EXECUTE` found for struct `region::protect::Protection` in the current scope
   --> /home/bjorn/.cargo/git/checkouts/wasmtime-41807828cb3a7a7e/00abfcd/cranelift/simplejit/src/memory.rs:194:71
    |
194 |                         region::protect(ptr, len, region::Protection::READ_EXECUTE)
    |                                                                       ^^^^^^^^^^^^ associated item not found in `region::protect::Protection`

error[E0599]: no associated item named `READ` found for struct `region::protect::Protection` in the current scope
   --> /home/bjorn/.cargo/git/checkouts/wasmtime-41807828cb3a7a7e/00abfcd/cranelift/simplejit/src/memory.rs:223:71
    |
223 |                         region::protect(ptr, len, region::Protection::READ)
    |                                                                       ^^^^ associated item not found in `region::protect::Protection`

error: aborting due to 3 previous errors
```