### PR TITLE
Remove mention of dead stores in comment for MemFlags::notrap

### DIFF
--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -65,8 +65,7 @@ impl MemFlags {
     /// also required to trap.
     ///
     /// The `notrap` flag tells Cranelift that the memory is *accessible*, which means that
-    /// accesses will not trap. This makes it possible to delete an unused load or a dead store
-    /// instruction.
+    /// accesses will not trap. This makes it possible to delete an unused load instruction.
     pub fn notrap(self) -> bool {
         self.read(FlagBit::Notrap)
     }


### PR DESCRIPTION
Claiming that `notrap` makes it possible to remove a dead store seems incorrect. This contradicts [inst_predicates.rs](https://github.com/bytecodealliance/wasmtime/blob/master/cranelift/codegen/src/inst_predicates.rs) which considers anything that stores as having side effects.