### PR TITLE
Wasm translator multi-value bugfix: handle branch to loop with loop parameters.

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -361,7 +361,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 // We signal that all the code that follows until the next End is unreachable
                 frame.set_branched_to_exit();
                 let return_count = if frame.is_loop() {
-                    0
+                    frame.num_param_values()
                 } else {
                     frame.num_return_values()
                 };

--- a/tests/wasm/loop-params.wat
+++ b/tests/wasm/loop-params.wat
@@ -1,0 +1,13 @@
+  (module
+    (func (export "run") (result i32)
+      (local $i i32)
+      (i32.const 0) ;; sum
+      (i32.const 10) ;; i
+      (loop $loop (param i32 i32) (result i32)
+        (local.tee $i)
+        (i32.add) ;; sum = i + sum
+        (i32.sub (local.get $i) (i32.const 1))
+        (i32.eqz (local.tee $i))
+        (if (param i32) (result i32)
+            (then)
+            (else (local.get $i) (br $loop))))))


### PR DESCRIPTION
It appears that the CLIF generation for a branch to a loop label did not taken into account the possibility of loop-block parameters. I believe the correct semantics here (at least as far as I understood the spec) are to pop new versions of the loop params off the stack at the point of the branch.

This PR fixes `spec/multi-value/block-run.wast` in the *newer* version of `spec_testsuite`, which we aren't yet using in the wasmtime tree but which SpiderMonkey is. This bug was caught during integration of the multivalue work with SpiderMonkey.

(The `loop-params.wast` test added in this PR is the one particular failing case from `block-run.wast`.)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
