### PR TITLE
Cranelift: Module data apis should allow specifying the object file section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
 name = "cranelift-object"
 version = "0.64.0"
 dependencies = [
+ "anyhow",
  "cranelift-codegen",
  "cranelift-module",
  "object",

--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -215,7 +215,11 @@ impl Backend for FaerieBackend {
         } = data_ctx.description();
 
         if let Some((segment, section)) = custom_segment_section {
-            return Err(cranelift_module::ModuleError::Backend(anyhow::anyhow!("Custom section not supported by cranelift-faerie: `{}:{}`", segment, section)));
+            return Err(cranelift_module::ModuleError::Backend(anyhow::anyhow!(
+                "Custom section not supported by cranelift-faerie: `{}:{}`",
+                segment,
+                section
+            )));
         }
 
         for &(offset, id) in function_relocs {

--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -211,7 +211,10 @@ impl Backend for FaerieBackend {
             ref data_decls,
             ref function_relocs,
             ref data_relocs,
+            section: ref datasection
         } = data_ctx.description();
+
+        assert!(datasection.is_none(), "Custom sections not supported");
 
         for &(offset, id) in function_relocs {
             let to = &namespace.get_function_decl(&function_decls[id]).name;

--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -211,7 +211,7 @@ impl Backend for FaerieBackend {
             ref data_decls,
             ref function_relocs,
             ref data_relocs,
-            section: ref datasection
+            section: ref datasection,
         } = data_ctx.description();
 
         assert!(datasection.is_none(), "Custom sections not supported");

--- a/cranelift/faerie/src/backend.rs
+++ b/cranelift/faerie/src/backend.rs
@@ -211,10 +211,12 @@ impl Backend for FaerieBackend {
             ref data_decls,
             ref function_relocs,
             ref data_relocs,
-            section: ref datasection,
+            ref custom_segment_section,
         } = data_ctx.description();
 
-        assert!(datasection.is_none(), "Custom sections not supported");
+        if let Some((segment, section)) = custom_segment_section {
+            return Err(cranelift_module::ModuleError::Backend(anyhow::anyhow!("Custom section not supported by cranelift-faerie: `{}:{}`", segment, section)));
+        }
 
         for &(offset, id) in function_relocs {
             let to = &namespace.get_function_decl(&function_decls[id]).name;

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -3,7 +3,9 @@
 use cranelift_codegen::binemit::{Addend, CodeOffset};
 use cranelift_codegen::entity::PrimaryMap;
 use cranelift_codegen::ir;
+use std::borrow::ToOwned;
 use std::boxed::Box;
+use std::string::String;
 use std::vec::Vec;
 
 /// This specifies how data is to be initialized.
@@ -47,7 +49,7 @@ pub struct DataDescription {
     /// Data addresses to write at specified offsets.
     pub data_relocs: Vec<(CodeOffset, ir::GlobalValue, Addend)>,
     /// Object file section
-    pub section: Option<(std::string::String, std::string::String)>,
+    pub custom_segment_section: Option<(String, String)>,
 }
 
 /// This is to data objects what cranelift_codegen::Context is to functions.
@@ -65,7 +67,7 @@ impl DataContext {
                 data_decls: PrimaryMap::new(),
                 function_relocs: vec![],
                 data_relocs: vec![],
-                section: None,
+                custom_segment_section: None,
             },
         }
     }
@@ -94,10 +96,10 @@ impl DataContext {
     }
 
     /// Override the segment/section for data, only supported on Object backend
-    pub fn set_section(&mut self, seg: &str, sec: &str) {
-        self.description.section = Some((
-            std::string::String::from(seg),
-            std::string::String::from(sec),
+    pub fn set_segment_section(&mut self, seg: &str, sec: &str) {
+        self.description.custom_segment_section = Some((
+            seg.to_owned(),
+            sec.to_owned(),
         ))
     }
 

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -97,10 +97,7 @@ impl DataContext {
 
     /// Override the segment/section for data, only supported on Object backend
     pub fn set_segment_section(&mut self, seg: &str, sec: &str) {
-        self.description.custom_segment_section = Some((
-            seg.to_owned(),
-            sec.to_owned(),
-        ))
+        self.description.custom_segment_section = Some((seg.to_owned(), sec.to_owned()))
     }
 
     /// Declare an external function import.

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -46,6 +46,8 @@ pub struct DataDescription {
     pub function_relocs: Vec<(CodeOffset, ir::FuncRef)>,
     /// Data addresses to write at specified offsets.
     pub data_relocs: Vec<(CodeOffset, ir::GlobalValue, Addend)>,
+    /// Object file section
+    pub section: Option<(std::string::String, std::string::String)>
 }
 
 /// This is to data objects what cranelift_codegen::Context is to functions.
@@ -63,6 +65,7 @@ impl DataContext {
                 data_decls: PrimaryMap::new(),
                 function_relocs: vec![],
                 data_relocs: vec![],
+                section: None
             },
         }
     }
@@ -88,6 +91,11 @@ impl DataContext {
     pub fn define(&mut self, contents: Box<[u8]>) {
         debug_assert_eq!(self.description.init, Init::Uninitialized);
         self.description.init = Init::Bytes { contents };
+    }
+
+    /// Override the segment/section for data, only supported on Object backend
+    pub fn set_section(&mut self, seg: &str, sec: &str) {
+        self.description.section = Some((std::string::String::from(seg), std::string::String::from(sec)))
     }
 
     /// Declare an external function import.

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -47,7 +47,7 @@ pub struct DataDescription {
     /// Data addresses to write at specified offsets.
     pub data_relocs: Vec<(CodeOffset, ir::GlobalValue, Addend)>,
     /// Object file section
-    pub section: Option<(std::string::String, std::string::String)>
+    pub section: Option<(std::string::String, std::string::String)>,
 }
 
 /// This is to data objects what cranelift_codegen::Context is to functions.
@@ -65,7 +65,7 @@ impl DataContext {
                 data_decls: PrimaryMap::new(),
                 function_relocs: vec![],
                 data_relocs: vec![],
-                section: None
+                section: None,
             },
         }
     }
@@ -95,7 +95,10 @@ impl DataContext {
 
     /// Override the segment/section for data, only supported on Object backend
     pub fn set_section(&mut self, seg: &str, sec: &str) {
-        self.description.section = Some((std::string::String::from(seg), std::string::String::from(sec)))
+        self.description.section = Some((
+            std::string::String::from(seg),
+            std::string::String::from(sec),
+        ))
     }
 
     /// Declare an external function import.

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -14,6 +14,7 @@ cranelift-module = { path = "../module", version = "0.64.0" }
 cranelift-codegen = { path = "../codegen", version = "0.64.0", default-features = false, features = ["std"] }
 object = { version = "0.18", default-features = false, features = ["write"] }
 target-lexicon = "0.10"
+anyhow = "1.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -234,6 +234,7 @@ impl Backend for ObjectBackend {
             ref data_decls,
             ref function_relocs,
             ref data_relocs,
+            section: ref datasection
         } = data_ctx.description();
 
         let reloc_size = match self.isa.triple().pointer_width().unwrap() {
@@ -264,22 +265,30 @@ impl Backend for ObjectBackend {
         }
 
         let symbol = self.data_objects[data_id].unwrap();
-        let section_kind = if let Init::Zeros { .. } = *init {
-            if tls {
-                StandardSection::UninitializedTls
+        let section = 
+            if datasection.is_none() {
+                let section_kind = if let Init::Zeros { .. } = *init {
+                    if tls {
+                        StandardSection::UninitializedTls
+                    } else {
+                        StandardSection::UninitializedData
+                    }
+                } else if tls {
+                    StandardSection::Tls
+                } else if writable {
+                    StandardSection::Data
+                } else if relocs.is_empty() {
+                    StandardSection::ReadOnlyData
+                } else {
+                    StandardSection::ReadOnlyDataWithRel
+                };
+                self.object.section_id(section_kind)
             } else {
-                StandardSection::UninitializedData
-            }
-        } else if tls {
-            StandardSection::Tls
-        } else if writable {
-            StandardSection::Data
-        } else if relocs.is_empty() {
-            StandardSection::ReadOnlyData
-        } else {
-            StandardSection::ReadOnlyDataWithRel
-        };
-        let section = self.object.section_id(section_kind);
+                let (seg, sec) = &datasection.as_ref().unwrap();
+                self.object.add_section(seg.clone().into_bytes(), sec.clone().into_bytes(), 
+                    if writable { SectionKind::Data } else { SectionKind::ReadOnlyData }
+                )
+            };
 
         let align = u64::from(align.unwrap_or(1));
         let offset = match *init {

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -284,6 +284,7 @@ impl Backend for ObjectBackend {
                 };
                 self.object.section_id(section_kind)
             } else {
+                assert!(!tls, "Tls data cannot be in named section");
                 let (seg, sec) = &datasection.as_ref().unwrap();
                 self.object.add_section(seg.clone().into_bytes(), sec.clone().into_bytes(), 
                     if writable { SectionKind::Data } else { SectionKind::ReadOnlyData }

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -284,7 +284,9 @@ impl Backend for ObjectBackend {
             self.object.section_id(section_kind)
         } else {
             if tls {
-                return Err(cranelift_module::ModuleError::Backend(anyhow::anyhow!("Custom section not supported for TLS")));
+                return Err(cranelift_module::ModuleError::Backend(anyhow::anyhow!(
+                    "Custom section not supported for TLS"
+                )));
             }
             let (seg, sec) = &custom_segment_section.as_ref().unwrap();
             self.object.add_section(

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -361,7 +361,10 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             ref data_decls,
             ref function_relocs,
             ref data_relocs,
+            section: ref datasection,
         } = data.description();
+
+        assert!(datasection.is_none(), "Custom sections not supported");
 
         let size = init.size();
         let storage = if writable {

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -361,10 +361,8 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             ref data_decls,
             ref function_relocs,
             ref data_relocs,
-            section: ref datasection,
+            custom_segment_section: _,
         } = data.description();
-
-        assert!(datasection.is_none(), "Custom sections not supported");
 
         let size = init.size();
         let storage = if writable {


### PR DESCRIPTION
This fixes #1640.

What it does is two things:
* Expose a new api on the data context type to set the section of the current data item
* Emit it in the Object backend

I have no idea how to write a testcase for this or if it's meaningful at all.
I don't know who can review this.
