### PR TITLE
Fix stdin/stdout/stderr not being replaceable

### DIFF
--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -2,6 +2,7 @@ use crate::entry::{Entry, EntryHandle};
 use crate::fdpool::FdPool;
 use crate::handle::Handle;
 use crate::sys::osdir::OsDir;
+use crate::sys::osfile::OsFile;
 use crate::sys::osother::{OsOther, OsOtherExt};
 use crate::sys::stdio::{Stderr, StderrExt, Stdin, StdinExt, Stdout, StdoutExt};
 use crate::virtfs::{VirtualDir, VirtualDirEntry};
@@ -369,7 +370,7 @@ impl WasiCtxBuilder {
                         .ok_or(WasiCtxBuilderError::TooManyFilesOpen)?
                 }
                 PendingEntry::OsHandle(f) => {
-                    let handle = OsOther::try_from(f)?;
+                    let handle = OsFile::try_from(f)?;
                     let handle = EntryHandle::new(handle);
                     let entry = Entry::new(handle);
                     entries


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

OsOther cannot be used for file descriptors representing a file or a directory.
https://github.com/bytecodealliance/wasmtime/blob/4bb58940c74c37bdba8630810645cbd41dd0ff7e/crates/wasi-common/src/sys/unix/osother.rs#L16

As such, an OsFile should instead directly be used.

Before this PR, and since #1561, it was not possible to replace stdin/stdout/stderr with an user-provided File.