### PR TITLE
Reference type support in MachInst backend and on AArch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.26"
+version = "0.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c03092d79e0fd610932d89ed53895a38c0dd3bcd317a0046e69940de32f1d95"
+checksum = "b9ba8aaf5fe7cf307c6dbdaeed85478961d29e25e3bee5169e11b92fa9f027a8"
 dependencies = [
  "log",
  "rustc-hash",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.2.0" }
-regalloc = "0.0.26"
+regalloc = { version = "0.0.27" }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -61,3 +61,10 @@ pub fn is_constant_64bit(func: &Function, inst: Inst) -> Option<u64> {
         _ => None,
     }
 }
+
+/// Is the given instruction a safepoint (i.e., potentially causes a GC, depending on the
+/// embedding, and so requires reftyped values to be enumerated with a stackmap)?
+pub fn is_safepoint(func: &Function, inst: Inst) -> bool {
+    let op = func.dfg[inst].opcode();
+    op.is_resumable_trap() || op.is_call()
+}

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -400,6 +400,7 @@ fn in_int_reg(ty: ir::Type) -> bool {
     match ty {
         types::I8 | types::I16 | types::I32 | types::I64 => true,
         types::B1 | types::B8 | types::B16 | types::B32 | types::B64 => true,
+        types::R32 | types::R64 => true,
         _ => false,
     }
 }
@@ -653,12 +654,12 @@ fn load_stack(mem: MemArg, into_reg: Writable<Reg>, ty: Type) -> Inst {
             mem,
             srcloc: None,
         },
-        types::B32 | types::I32 => Inst::ULoad32 {
+        types::B32 | types::I32 | types::R32 => Inst::ULoad32 {
             rd: into_reg,
             mem,
             srcloc: None,
         },
-        types::B64 | types::I64 => Inst::ULoad64 {
+        types::B64 | types::I64 | types::R64 => Inst::ULoad64 {
             rd: into_reg,
             mem,
             srcloc: None,
@@ -689,12 +690,12 @@ fn store_stack(mem: MemArg, from_reg: Reg, ty: Type) -> Inst {
             mem,
             srcloc: None,
         },
-        types::B32 | types::I32 => Inst::Store32 {
+        types::B32 | types::I32 | types::R32 => Inst::Store32 {
             rd: from_reg,
             mem,
             srcloc: None,
         },
-        types::B64 | types::I64 => Inst::Store64 {
+        types::B64 | types::I64 | types::R64 => Inst::Store64 {
             rd: from_reg,
             mem,
             srcloc: None,

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1346,11 +1346,11 @@ fn aarch64_get_regs(inst: &Inst, collector: &mut RegUsageCollector) {
             collector.add_use(rn);
         }
         &Inst::Jump { .. } | &Inst::Ret | &Inst::EpiloguePlaceholder => {}
-        &Inst::Call { ref info } => {
+        &Inst::Call { ref info, .. } => {
             collector.add_uses(&*info.uses);
             collector.add_defs(&*info.defs);
         }
-        &Inst::CallInd { ref info } => {
+        &Inst::CallInd { ref info, .. } => {
             collector.add_uses(&*info.uses);
             collector.add_defs(&*info.defs);
             collector.add_use(info.rn);
@@ -2137,13 +2137,21 @@ impl MachInst for Inst {
         // feasible for other reasons).
         44
     }
+
+    fn ref_type_rc(_: &settings::Flags) -> RegClass {
+        RegClass::I64
+    }
 }
 
 //=============================================================================
 // Pretty-printing of instructions.
 
-fn mem_finalize_for_show(mem: &MemArg, mb_rru: Option<&RealRegUniverse>) -> (String, MemArg) {
-    let (mem_insts, mem) = mem_finalize(0, mem, &mut Default::default());
+fn mem_finalize_for_show(
+    mem: &MemArg,
+    mb_rru: Option<&RealRegUniverse>,
+    state: &EmitState,
+) -> (String, MemArg) {
+    let (mem_insts, mem) = mem_finalize(0, mem, state);
     let mut mem_str = mem_insts
         .into_iter()
         .map(|inst| inst.show_rru(mb_rru))
@@ -2158,6 +2166,12 @@ fn mem_finalize_for_show(mem: &MemArg, mb_rru: Option<&RealRegUniverse>) -> (Str
 
 impl ShowWithRRU for Inst {
     fn show_rru(&self, mb_rru: Option<&RealRegUniverse>) -> String {
+        self.pretty_print(mb_rru, &mut EmitState::default())
+    }
+}
+
+impl Inst {
+    fn print_with_state(&self, mb_rru: Option<&RealRegUniverse>, state: &mut EmitState) -> String {
         fn op_name_size(alu_op: ALUOp) -> (&'static str, OperandSize) {
             match alu_op {
                 ALUOp::Add32 => ("add", OperandSize::Size32),
@@ -2344,7 +2358,7 @@ impl ShowWithRRU for Inst {
                 srcloc: _srcloc,
                 ..
             } => {
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
 
                 let is_unscaled = match &mem {
                     &MemArg::Unscaled(..) => true,
@@ -2392,7 +2406,7 @@ impl ShowWithRRU for Inst {
                 srcloc: _srcloc,
                 ..
             } => {
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
 
                 let is_unscaled = match &mem {
                     &MemArg::Unscaled(..) => true,
@@ -2576,39 +2590,39 @@ impl ShowWithRRU for Inst {
             }
             &Inst::FpuLoad32 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd.to_reg(), mb_rru, ScalarSize::Size32);
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
                 let mem = mem.show_rru(mb_rru);
                 format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuLoad64 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd.to_reg(), mb_rru, ScalarSize::Size64);
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
                 let mem = mem.show_rru(mb_rru);
                 format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuLoad128 { rd, ref mem, .. } => {
                 let rd = rd.to_reg().show_rru(mb_rru);
                 let rd = "q".to_string() + &rd[1..];
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
                 let mem = mem.show_rru(mb_rru);
                 format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore32 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd, mb_rru, ScalarSize::Size32);
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
                 let mem = mem.show_rru(mb_rru);
                 format!("{}str {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore64 { rd, ref mem, .. } => {
                 let rd = show_freg_sized(rd, mb_rru, ScalarSize::Size64);
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
                 let mem = mem.show_rru(mb_rru);
                 format!("{}str {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore128 { rd, ref mem, .. } => {
                 let rd = rd.show_rru(mb_rru);
                 let rd = "q".to_string() + &rd[1..];
-                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
+                let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru, state);
                 let mem = mem.show_rru(mb_rru);
                 format!("{}str {}, {}", mem_str, rd, mem)
             }
@@ -2978,7 +2992,7 @@ impl ShowWithRRU for Inst {
                 // this logic between `emit()` and `show_rru()` -- a separate 1-to-N
                 // expansion stage (i.e., legalization, but without the slow edit-in-place
                 // of the existing legalization framework).
-                let (mem_insts, mem) = mem_finalize(0, mem, &EmitState::default());
+                let (mem_insts, mem) = mem_finalize(0, mem, state);
                 let mut ret = String::new();
                 for inst in mem_insts.into_iter() {
                     ret.push_str(&inst.show_rru(mb_rru));
@@ -3025,7 +3039,10 @@ impl ShowWithRRU for Inst {
                 }
                 ret
             }
-            &Inst::VirtualSPOffsetAdj { offset } => format!("virtual_sp_offset_adjust {}", offset),
+            &Inst::VirtualSPOffsetAdj { offset } => {
+                state.virtual_sp_offset += offset;
+                format!("virtual_sp_offset_adjust {}", offset)
+            }
             &Inst::EmitIsland { needed_space } => format!("emit_island {}", needed_space),
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -6,7 +6,7 @@
 use crate::binemit::CodeOffset;
 use crate::ir::types::{
     B1, B16, B16X8, B32, B32X4, B64, B64X2, B8, B8X16, F32, F32X2, F32X4, F64, F64X2, FFLAGS, I16,
-    I16X4, I16X8, I32, I32X2, I32X4, I64, I64X2, I8, I8X16, I8X8, IFLAGS,
+    I16X4, I16X8, I32, I32X2, I32X4, I64, I64X2, I8, I8X16, I8X8, IFLAGS, R32, R64,
 };
 use crate::ir::{ExternalName, Opcode, SourceLoc, TrapCode, Type};
 use crate::machinst::*;
@@ -2081,6 +2081,8 @@ impl MachInst for Inst {
                     || ty == B32
                     || ty == I64
                     || ty == B64
+                    || ty == R32
+                    || ty == R64
             );
             Inst::load_constant(to_reg, value)
         }
@@ -2102,7 +2104,7 @@ impl MachInst for Inst {
 
     fn rc_for_type(ty: Type) -> CodegenResult<RegClass> {
         match ty {
-            I8 | I16 | I32 | I64 | B1 | B8 | B16 | B32 | B64 => Ok(RegClass::I64),
+            I8 | I16 | I32 | I64 | B1 | B8 | B16 | B32 | B64 | R32 | R64 => Ok(RegClass::I64),
             F32 | F64 => Ok(RegClass::V128),
             IFLAGS | FFLAGS => Ok(RegClass::I64),
             B8X16 | I8X16 | B16X8 | I16X8 | B32X4 | I32X4 | B64X2 | I64X2 | F32X4 | F64X2 => {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2138,7 +2138,7 @@ impl MachInst for Inst {
         44
     }
 
-    fn ref_type_rc(_: &settings::Flags) -> RegClass {
+    fn ref_type_regclass(_: &settings::Flags) -> RegClass {
         RegClass::I64
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -829,8 +829,8 @@ pub fn ty_bits(ty: Type) -> usize {
         B1 => 1,
         B8 | I8 => 8,
         B16 | I16 => 16,
-        B32 | I32 | F32 => 32,
-        B64 | I64 | F64 => 64,
+        B32 | I32 | F32 | R32 => 32,
+        B64 | I64 | F64 | R64 => 64,
         B128 | I128 => 128,
         IFLAGS | FFLAGS => 32,
         B8X8 | I8X8 | B16X4 | I16X4 | B32X2 | I32X2 => 64,
@@ -842,7 +842,7 @@ pub fn ty_bits(ty: Type) -> usize {
 
 pub(crate) fn ty_is_int(ty: Type) -> bool {
     match ty {
-        B1 | B8 | I8 | B16 | I16 | B32 | I32 | B64 | I64 => true,
+        B1 | B8 | I8 | B16 | I16 | B32 | I32 | B64 | I64 | R32 | R64 => true,
         F32 | F64 | B128 | I128 | I8X8 | I8X16 | I16X4 | I16X8 | I32X2 | I32X4 | I64X2 => false,
         IFLAGS | FFLAGS => panic!("Unexpected flags type"),
         _ => panic!("ty_is_int() on unknown type: {:?}", ty),

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1394,7 +1394,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Trap | Opcode::ResumableTrap => {
             let trap_info = (ctx.srcloc(insn), inst_trapcode(ctx.data(insn)).unwrap());
-            ctx.emit(Inst::Udf { trap_info })
+            ctx.emit_safepoint(Inst::Udf { trap_info });
         }
 
         Opcode::Trapif | Opcode::Trapff => {
@@ -1432,10 +1432,11 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 trap_info,
                 kind: CondBrKind::Cond(cond),
             });
+            ctx.emit_safepoint(Inst::Udf { trap_info })
         }
 
         Opcode::Safepoint => {
-            panic!("safepoint support not implemented!");
+            panic!("safepoint instructions not used by new backend's safepoints!");
         }
 
         Opcode::Trapz | Opcode::Trapnz | Opcode::ResumableTrapnz => {

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1204,7 +1204,26 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::IsNull | Opcode::IsInvalid => {
-            panic!("Reference types not supported");
+            // Null references are represented by the constant value 0; invalid references are
+            // represented by the constant value -1. See `define_reftypes()` in
+            // `meta/src/isa/x86/encodings.rs` to confirm.
+            let rd = get_output_reg(ctx, outputs[0]);
+            let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
+            let ty = ctx.input_ty(insn, 0);
+            let (alu_op, const_value) = match op {
+                Opcode::IsNull => {
+                    // cmp rn, #0
+                    (choose_32_64(ty, ALUOp::SubS32, ALUOp::SubS64), 0)
+                }
+                Opcode::IsInvalid => {
+                    // cmn rn, #1
+                    (choose_32_64(ty, ALUOp::AddS32, ALUOp::AddS64), 1)
+                }
+                _ => unreachable!(),
+            };
+            let const_value = ResultRSEImm12::Imm12(Imm12::maybe_from_u64(const_value).unwrap());
+            ctx.emit(alu_inst_imm12(alu_op, writable_zero_reg(), rn, const_value));
+            ctx.emit(Inst::CSet { rd, cond: Cond::Eq });
         }
 
         Opcode::Copy => {
@@ -1215,6 +1234,21 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Bint | Opcode::Breduce | Opcode::Bextend | Opcode::Ireduce => {
+            // If this is a Bint from a Trueif/Trueff/IsNull/IsInvalid, then the result is already
+            // 64-bit-zero-extended, even if the CLIF type doesn't say so, because it was produced
+            // by a CSet. In this case, we do not need to do any zero-extension.
+            let input_info = ctx.get_input(insn, 0);
+            let src_op = input_info
+                .inst
+                .map(|(src_inst, _)| ctx.data(src_inst).opcode());
+            let narrow_mode = match (src_op, op) {
+                (Some(Opcode::Trueif), Opcode::Bint)
+                | (Some(Opcode::Trueff), Opcode::Bint)
+                | (Some(Opcode::IsNull), Opcode::Bint)
+                | (Some(Opcode::IsInvalid), Opcode::Bint) => NarrowValueMode::None,
+                _ => NarrowValueMode::ZeroExtend64,
+            };
+
             // All of these ops are simply a move from a zero-extended source.
             // Here is why this works, in each case:
             //
@@ -1227,7 +1261,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // - Ireduce: changing width of an integer. Smaller ints are stored
             //   with undefined high-order bits, so we can simply do a copy.
 
-            let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::ZeroExtend64);
+            let rn = put_input_in_reg(ctx, inputs[0], narrow_mode);
             let rd = get_output_reg(ctx, outputs[0]);
             let ty = ctx.input_ty(insn, 0);
             ctx.emit(Inst::gen_move(rd, rn, ty));

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -5,6 +5,7 @@ use log::trace;
 use regalloc::{RealReg, Reg, RegClass, Set, SpillSlot, Writable};
 use std::mem;
 
+use crate::binemit::Stackmap;
 use crate::ir::{self, types, types::*, ArgumentExtension, StackSlot, Type};
 use crate::isa::{self, x64::inst::*};
 use crate::machinst::*;
@@ -415,6 +416,10 @@ impl ABIBody for X64ABIBody {
         )
     }
 
+    fn spillslots_to_stackmap(&self, _slots: &[SpillSlot], _state: &EmitState) -> Stackmap {
+        unimplemented!("spillslots_to_stackmap")
+    }
+
     fn gen_prologue(&mut self) -> Vec<Inst> {
         let r_rsp = regs::rsp();
 
@@ -553,6 +558,10 @@ impl ABIBody for X64ABIBody {
             .expect("frame size not computed before prologue generation") as u32
     }
 
+    fn stack_args_size(&self) -> u32 {
+        unimplemented!("I need to be computed!")
+    }
+
     fn get_spillslot_size(&self, rc: RegClass, ty: Type) -> u32 {
         // We allocate in terms of 8-byte slots.
         match (rc, ty) {
@@ -563,12 +572,27 @@ impl ABIBody for X64ABIBody {
         }
     }
 
-    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, ty: Type) -> Inst {
+    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, ty: Option<Type>) -> Inst {
+        let ty = ty_from_ty_hint_or_reg_class(from_reg.to_reg(), ty);
         self.store_spillslot(to_slot, ty, from_reg.to_reg())
     }
 
-    fn gen_reload(&self, to_reg: Writable<RealReg>, from_slot: SpillSlot, ty: Type) -> Inst {
+    fn gen_reload(
+        &self,
+        to_reg: Writable<RealReg>,
+        from_slot: SpillSlot,
+        ty: Option<Type>,
+    ) -> Inst {
+        let ty = ty_from_ty_hint_or_reg_class(to_reg.to_reg().to_reg(), ty);
         self.load_spillslot(from_slot, ty, to_reg.map(|r| r.to_reg()))
+    }
+}
+
+fn ty_from_ty_hint_or_reg_class(r: Reg, ty: Option<Type>) -> Type {
+    match (ty, r.get_class()) {
+        (Some(t), _) => t,
+        (None, RegClass::I64) => I64,
+        _ => panic!("Unexpected register class!"),
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1258,7 +1258,7 @@ impl MachInst for Inst {
         15
     }
 
-    fn ref_type_rc(_: &settings::Flags) -> RegClass {
+    fn ref_type_regclass(_: &settings::Flags) -> RegClass {
         RegClass::I64
     }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1258,6 +1258,10 @@ impl MachInst for Inst {
         15
     }
 
+    fn ref_type_rc(_: &settings::Flags) -> RegClass {
+        RegClass::I64
+    }
+
     type LabelUse = LabelUse;
 }
 
@@ -1272,6 +1276,18 @@ impl MachInstEmit for Inst {
 
     fn emit(&self, sink: &mut MachBuffer<Inst>, flags: &settings::Flags, state: &mut Self::State) {
         emit::emit(self, sink, flags, state);
+    }
+
+    fn pretty_print(&self, mb_rru: Option<&RealRegUniverse>, _: &mut Self::State) -> String {
+        self.show_rru(mb_rru)
+    }
+}
+
+impl MachInstEmitState<Inst> for EmitState {
+    fn new(_: &dyn ABIBody<I = Inst>) -> Self {
+        EmitState {
+            virtual_sp_offset: 0,
+        }
     }
 }
 

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1318,8 +1318,9 @@ pub struct MachSrcLoc {
 pub struct MachStackMap {
     /// The code offset at which this stackmap applies.
     pub offset: CodeOffset,
-    /// The code offset at the *end* of the instruction at which this stackmap
-    /// applies.
+    /// The code offset just past the "end" of the instruction: that is, the
+    /// offset of the first byte of the following instruction, or equivalently,
+    /// the start offset plus the instruction length.
     pub offset_end: CodeOffset,
     /// The Stackmap itself.
     pub stackmap: Stackmap,

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -23,7 +23,7 @@ where
     // Build the lowering context.
     let lower = Lower::new(f, abi, block_order)?;
     // Lower the IR.
-    let mut vcode = lower.lower(b)?;
+    let (mut vcode, stackmap_request_info) = lower.lower(b)?;
 
     debug!(
         "vcode from lowering: \n{}",
@@ -57,11 +57,23 @@ where
         }
     }
 
+    // If either there are no reference-typed values, or else there are
+    // but there are no safepoints at which we need to know about them,
+    // then we don't need stackmaps.
+    let sri = if stackmap_request_info.reftyped_vregs.len() > 0
+        && stackmap_request_info.safepoint_insns.len() > 0
+    {
+        Some(&stackmap_request_info)
+    } else {
+        None
+    };
+
     let result = {
         let _tt = timing::regalloc();
         allocate_registers_with_opts(
             &mut vcode,
             b.reg_universe(),
+            sri,
             Options {
                 run_checker,
                 algorithm,

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -4,7 +4,6 @@
 
 use crate::entity::SecondaryMap;
 use crate::fx::{FxHashMap, FxHashSet};
-use crate::inst_predicates::is_safepoint;
 use crate::inst_predicates::{has_side_effect_or_load, is_constant_64bit};
 use crate::ir::instructions::BranchInfo;
 use crate::ir::types::I64;
@@ -94,8 +93,6 @@ pub trait LowerCtx {
     /// every side-effecting op; the backend should not try to merge across
     /// side-effect colors unless the op being merged is known to be pure.
     fn inst_color(&self, ir_inst: Inst) -> InstColor;
-    /// Determine whether an instruction is a safepoint.
-    fn is_safepoint(&self, ir_inst: Inst) -> bool;
 
     // Instruction input/output queries:
 
@@ -897,13 +894,6 @@ impl<'func, I: VCodeInst> LowerCtx for Lower<'func, I> {
 
     fn inst_color(&self, ir_inst: Inst) -> InstColor {
         self.inst_colors[ir_inst]
-    }
-
-    fn is_safepoint(&self, ir_inst: Inst) -> bool {
-        // There is no safepoint metadata at all if we have no reftyped values
-        // in this function; lack of metadata implies "nothing to trace", and
-        // avoids overhead.
-        self.vcode.have_ref_values() && is_safepoint(self.f, ir_inst)
     }
 
     fn num_inputs(&self, ir_inst: Inst) -> usize {

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -96,7 +96,7 @@
 //!
 //! ```
 
-use crate::binemit::{CodeInfo, CodeOffset};
+use crate::binemit::{CodeInfo, CodeOffset, Stackmap};
 use crate::ir::condcodes::IntCC;
 use crate::ir::{Function, Type};
 use crate::result::CodegenResult;
@@ -191,6 +191,10 @@ pub trait MachInst: Clone + Debug {
     /// What is the worst-case instruction size emitted by this instruction type?
     fn worst_case_size() -> CodeOffset;
 
+    /// What is the register class used for reference types (GC-observable pointers)? Can
+    /// be dependent on compilation flags.
+    fn ref_type_rc(_flags: &Flags) -> RegClass;
+
     /// A label-use kind: a type that describes the types of label references that
     /// can occur in an instruction.
     type LabelUse: MachInstLabelUse;
@@ -256,9 +260,21 @@ pub enum MachTerminator<'a> {
 /// A trait describing the ability to encode a MachInst into binary machine code.
 pub trait MachInstEmit: MachInst {
     /// Persistent state carried across `emit` invocations.
-    type State: Default + Clone + Debug;
+    type State: MachInstEmitState<Self>;
     /// Emit the instruction.
     fn emit(&self, code: &mut MachBuffer<Self>, flags: &Flags, state: &mut Self::State);
+    /// Pretty-print the instruction.
+    fn pretty_print(&self, mb_rru: Option<&RealRegUniverse>, state: &mut Self::State) -> String;
+}
+
+/// A trait describing the emission state carried between MachInsts when
+/// emitting a function body.
+pub trait MachInstEmitState<I: MachInst>: Default + Clone + Debug {
+    /// Create a new emission state given the ABI object.
+    fn new(abi: &dyn ABIBody<I = I>) -> Self;
+    /// Update the emission state before emitting an instruction that is a
+    /// safepoint.
+    fn pre_safepoint(&mut self, _stackmap: Stackmap) {}
 }
 
 /// The result of a `MachBackend::compile_function()` call. Contains machine

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -193,7 +193,7 @@ pub trait MachInst: Clone + Debug {
 
     /// What is the register class used for reference types (GC-observable pointers)? Can
     /// be dependent on compilation flags.
-    fn ref_type_rc(_flags: &Flags) -> RegClass;
+    fn ref_type_regclass(_flags: &Flags) -> RegClass;
 
     /// A label-use kind: a type that describes the types of label references that
     /// can occur in an instruction.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -17,14 +17,15 @@
 //! See the main module comment in `mod.rs` for more details on the VCode-based
 //! backend pipeline.
 
-use crate::ir::{self, SourceLoc};
+use crate::ir::{self, types, SourceLoc};
 use crate::machinst::*;
 use crate::settings;
 
 use regalloc::Function as RegallocFunction;
 use regalloc::Set as RegallocSet;
 use regalloc::{
-    BlockIx, InstIx, Range, RegAllocResult, RegClass, RegUsageCollector, RegUsageMapper,
+    BlockIx, InstIx, Range, RegAllocResult, RegClass, RegUsageCollector, RegUsageMapper, SpillSlot,
+    StackmapRequestInfo,
 };
 
 use alloc::boxed::Box;
@@ -56,6 +57,9 @@ pub struct VCode<I: VCodeInst> {
     /// VReg IR-level types.
     vreg_types: Vec<Type>,
 
+    /// Do we have any ref values among our vregs?
+    have_ref_values: bool,
+
     /// Lowered machine instructions in order corresponding to the original IR.
     insts: Vec<I>,
 
@@ -82,6 +86,16 @@ pub struct VCode<I: VCodeInst> {
 
     /// ABI object.
     abi: Box<dyn ABIBody<I = I>>,
+
+    /// Safepoint instruction indices. Filled in post-regalloc. (Prior to
+    /// regalloc, the safepoint instructions are listed in the separate
+    /// `StackmapRequestInfo` held separate from the `VCode`.)
+    safepoint_insns: Vec<InsnIndex>,
+
+    /// For each safepoint entry in `safepoint_insns`, a list of `SpillSlot`s.
+    /// These are used to generate actual stackmaps at emission. Filled in
+    /// post-regalloc.
+    safepoint_slots: Vec<Vec<SpillSlot>>,
 }
 
 /// A builder for a VCode function body. This builder is designed for the
@@ -102,6 +116,9 @@ pub struct VCodeBuilder<I: VCodeInst> {
     /// In-progress VCode.
     vcode: VCode<I>,
 
+    /// In-progress stackmap-request info.
+    stackmap_info: StackmapRequestInfo,
+
     /// Index of the last block-start in the vcode.
     block_start: InsnIndex,
 
@@ -115,9 +132,17 @@ pub struct VCodeBuilder<I: VCodeInst> {
 impl<I: VCodeInst> VCodeBuilder<I> {
     /// Create a new VCodeBuilder.
     pub fn new(abi: Box<dyn ABIBody<I = I>>, block_order: BlockLoweringOrder) -> VCodeBuilder<I> {
+        let reftype_class = I::ref_type_rc(abi.flags());
         let vcode = VCode::new(abi, block_order);
+        let stackmap_info = StackmapRequestInfo {
+            reftype_class,
+            reftyped_vregs: vec![],
+            safepoint_insns: vec![],
+        };
+
         VCodeBuilder {
             vcode,
+            stackmap_info,
             block_start: 0,
             succ_start: 0,
             cur_srcloc: SourceLoc::default(),
@@ -142,6 +167,15 @@ impl<I: VCodeInst> VCodeBuilder<I> {
                 .resize(vreg.get_index() + 1, ir::types::I8);
         }
         self.vcode.vreg_types[vreg.get_index()] = ty;
+        if is_reftype(ty) {
+            self.stackmap_info.reftyped_vregs.push(vreg);
+            self.vcode.have_ref_values = true;
+        }
+    }
+
+    /// Are there any reference-typed values at all among the vregs?
+    pub fn have_ref_values(&self) -> bool {
+        self.vcode.have_ref_values()
     }
 
     /// Set the current block as the entry block.
@@ -166,7 +200,7 @@ impl<I: VCodeInst> VCodeBuilder<I> {
     }
 
     /// Push an instruction for the current BB and current IR inst within the BB.
-    pub fn push(&mut self, insn: I) {
+    pub fn push(&mut self, insn: I, is_safepoint: bool) {
         match insn.is_term() {
             MachTerminator::None | MachTerminator::Ret => {}
             MachTerminator::Uncond(target) => {
@@ -186,6 +220,11 @@ impl<I: VCodeInst> VCodeBuilder<I> {
         }
         self.vcode.insts.push(insn);
         self.vcode.srclocs.push(self.cur_srcloc);
+        if is_safepoint {
+            self.stackmap_info
+                .safepoint_insns
+                .push(InstIx::new((self.vcode.insts.len() - 1) as u32));
+        }
     }
 
     /// Get the current source location.
@@ -198,19 +237,14 @@ impl<I: VCodeInst> VCodeBuilder<I> {
         self.cur_srcloc = srcloc;
     }
 
-    /// Build the final VCode.
-    pub fn build(self) -> VCode<I> {
-        self.vcode
+    /// Build the final VCode, returning the vcode itself as well as auxiliary
+    /// information, such as the stackmap request information.
+    pub fn build(self) -> (VCode<I>, StackmapRequestInfo) {
+        // TODO: come up with an abstraction for "vcode and auxiliary data". The
+        // auxiliary data needs to be separate from the vcode so that it can be
+        // referenced as the vcode is mutated (e.g. by the register allocator).
+        (self.vcode, self.stackmap_info)
     }
-}
-
-fn block_ranges(indices: &[InstIx], len: usize) -> Vec<(usize, usize)> {
-    let v = indices
-        .iter()
-        .map(|iix| iix.get() as usize)
-        .chain(iter::once(len))
-        .collect::<Vec<usize>>();
-    v.windows(2).map(|p| (p[0], p[1])).collect()
 }
 
 fn is_redundant_move<I: VCodeInst>(insn: &I) -> bool {
@@ -221,6 +255,11 @@ fn is_redundant_move<I: VCodeInst>(insn: &I) -> bool {
     }
 }
 
+/// Is this type a reference type?
+fn is_reftype(ty: Type) -> bool {
+    ty == types::R32 || ty == types::R64
+}
+
 impl<I: VCodeInst> VCode<I> {
     /// New empty VCode.
     fn new(abi: Box<dyn ABIBody<I = I>>, block_order: BlockLoweringOrder) -> VCode<I> {
@@ -228,6 +267,7 @@ impl<I: VCodeInst> VCode<I> {
             liveins: abi.liveins(),
             liveouts: abi.liveouts(),
             vreg_types: vec![],
+            have_ref_values: false,
             insts: vec![],
             srclocs: vec![],
             entry: 0,
@@ -236,6 +276,8 @@ impl<I: VCodeInst> VCode<I> {
             block_succs: vec![],
             block_order,
             abi,
+            safepoint_insns: vec![],
+            safepoint_slots: vec![],
         }
     }
 
@@ -247,6 +289,11 @@ impl<I: VCodeInst> VCode<I> {
     /// Get the IR-level type of a VReg.
     pub fn vreg_type(&self, vreg: VirtualReg) -> Type {
         self.vreg_types[vreg.get_index()]
+    }
+
+    /// Are there any reference-typed values at all among the vregs?
+    pub fn have_ref_values(&self) -> bool {
+        self.have_ref_values
     }
 
     /// Get the entry block.
@@ -265,6 +312,11 @@ impl<I: VCodeInst> VCode<I> {
         self.abi.frame_size()
     }
 
+    /// Inbound stack-args size.
+    pub fn stack_args_size(&self) -> u32 {
+        self.abi.stack_args_size()
+    }
+
     /// Get the successors for a block.
     pub fn succs(&self, block: BlockIndex) -> &[BlockIx] {
         let (start, end) = self.block_succ_range[block as usize];
@@ -281,17 +333,21 @@ impl<I: VCodeInst> VCode<I> {
         self.abi
             .set_clobbered(result.clobbered_registers.map(|r| Writable::from_reg(*r)));
 
-        // We want to move instructions over in final block order, using the new
-        // block-start map given by the regalloc.
-        let block_ranges: Vec<(usize, usize)> =
-            block_ranges(result.target_map.elems(), result.insns.len());
         let mut final_insns = vec![];
         let mut final_block_ranges = vec![(0, 0); self.num_blocks()];
         let mut final_srclocs = vec![];
+        let mut final_safepoint_insns = vec![];
+        let mut safept_idx = 0;
 
+        assert!(result.target_map.elems().len() == self.num_blocks());
         for block in 0..self.num_blocks() {
+            let start = result.target_map.elems()[block].get() as usize;
+            let end = if block == self.num_blocks() - 1 {
+                result.insns.len()
+            } else {
+                result.target_map.elems()[block + 1].get() as usize
+            };
             let block = block as BlockIndex;
-            let (start, end) = block_ranges[block as usize];
             let final_start = final_insns.len() as InsnIndex;
 
             if block == self.entry {
@@ -333,6 +389,16 @@ impl<I: VCodeInst> VCode<I> {
                     final_insns.push(insn.clone());
                     final_srclocs.push(srcloc);
                 }
+
+                // Was this instruction a safepoint instruction? Add its final
+                // index to the safepoint insn-index list if so.
+                if safept_idx < result.new_safepoint_insns.len()
+                    && (result.new_safepoint_insns[safept_idx].get() as usize) == i
+                {
+                    let idx = final_insns.len() - 1;
+                    final_safepoint_insns.push(idx as InsnIndex);
+                    safept_idx += 1;
+                }
             }
 
             let final_end = final_insns.len() as InsnIndex;
@@ -344,6 +410,12 @@ impl<I: VCodeInst> VCode<I> {
         self.insts = final_insns;
         self.srclocs = final_srclocs;
         self.block_ranges = final_block_ranges;
+        self.safepoint_insns = final_safepoint_insns;
+
+        // Save safepoint slot-lists. These will be passed to the `EmitState`
+        // for the machine backend during emission so that it can do
+        // target-specific translations of slot numbers to stack offsets.
+        self.safepoint_slots = result.stackmaps;
     }
 
     /// Emit the instructions to a `MachBuffer`, containing fixed-up code and external
@@ -353,11 +425,12 @@ impl<I: VCodeInst> VCode<I> {
         I: MachInstEmit,
     {
         let mut buffer = MachBuffer::new();
-        let mut state = Default::default();
+        let mut state = I::State::new(&*self.abi);
 
         buffer.reserve_labels_for_blocks(self.num_blocks() as BlockIndex); // first N MachLabels are simply block indices.
 
         let flags = self.abi.flags();
+        let mut safepoint_idx = 0;
         let mut cur_srcloc = None;
         for block in 0..self.num_blocks() {
             let block = block as BlockIndex;
@@ -379,6 +452,19 @@ impl<I: VCodeInst> VCode<I> {
                     }
                     buffer.start_srcloc(srcloc);
                     cur_srcloc = Some(srcloc);
+                }
+
+                if safepoint_idx < self.safepoint_insns.len()
+                    && self.safepoint_insns[safepoint_idx] == iix
+                {
+                    if self.safepoint_slots[safepoint_idx].len() > 0 {
+                        let stackmap = self.abi.spillslots_to_stackmap(
+                            &self.safepoint_slots[safepoint_idx][..],
+                            &state,
+                        );
+                        state.pre_safepoint(stackmap);
+                    }
+                    safepoint_idx += 1;
                 }
 
                 self.insts[iix as usize].emit(&mut buffer, flags, &mut state);
@@ -476,13 +562,18 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
         self.abi.get_spillslot_size(regclass, ty)
     }
 
-    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, vreg: VirtualReg) -> I {
-        let ty = self.vreg_type(vreg);
+    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, vreg: Option<VirtualReg>) -> I {
+        let ty = vreg.map(|v| self.vreg_type(v));
         self.abi.gen_spill(to_slot, from_reg, ty)
     }
 
-    fn gen_reload(&self, to_reg: Writable<RealReg>, from_slot: SpillSlot, vreg: VirtualReg) -> I {
-        let ty = self.vreg_type(vreg);
+    fn gen_reload(
+        &self,
+        to_reg: Writable<RealReg>,
+        from_slot: SpillSlot,
+        vreg: Option<VirtualReg>,
+    ) -> I {
+        let ty = vreg.map(|v| self.vreg_type(v));
         self.abi.gen_reload(to_reg, from_slot, ty)
     }
 
@@ -531,7 +622,7 @@ impl<I: VCodeInst> fmt::Debug for VCode<I> {
 }
 
 /// Pretty-printing with `RealRegUniverse` context.
-impl<I: VCodeInst + ShowWithRRU> ShowWithRRU for VCode<I> {
+impl<I: VCodeInst> ShowWithRRU for VCode<I> {
     fn show_rru(&self, mb_rru: Option<&RealRegUniverse>) -> String {
         use std::fmt::Write;
 
@@ -539,6 +630,8 @@ impl<I: VCodeInst + ShowWithRRU> ShowWithRRU for VCode<I> {
         write!(&mut s, "VCode_ShowWithRRU {{{{\n").unwrap();
         write!(&mut s, "  Entry block: {}\n", self.entry).unwrap();
 
+        let mut state = Default::default();
+        let mut safepoint_idx = 0;
         for i in 0..self.num_blocks() {
             let block = i as BlockIndex;
 
@@ -552,11 +645,22 @@ impl<I: VCodeInst + ShowWithRRU> ShowWithRRU for VCode<I> {
             let (start, end) = self.block_ranges[block as usize];
             write!(&mut s, "  (instruction range: {} .. {})\n", start, end).unwrap();
             for inst in start..end {
+                if safepoint_idx < self.safepoint_insns.len()
+                    && self.safepoint_insns[safepoint_idx] == inst
+                {
+                    write!(
+                        &mut s,
+                        "      (safepoint: slots {:?} with EmitState {:?})\n",
+                        self.safepoint_slots[safepoint_idx], state,
+                    )
+                    .unwrap();
+                    safepoint_idx += 1;
+                }
                 write!(
                     &mut s,
                     "  Inst {}:   {}\n",
                     inst,
-                    self.insts[inst as usize].show_rru(mb_rru)
+                    self.insts[inst as usize].pretty_print(mb_rru, &mut state)
                 )
                 .unwrap();
             }

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -132,7 +132,7 @@ pub struct VCodeBuilder<I: VCodeInst> {
 impl<I: VCodeInst> VCodeBuilder<I> {
     /// Create a new VCodeBuilder.
     pub fn new(abi: Box<dyn ABIBody<I = I>>, block_order: BlockLoweringOrder) -> VCodeBuilder<I> {
-        let reftype_class = I::ref_type_rc(abi.flags());
+        let reftype_class = I::ref_type_regclass(abi.flags());
         let vcode = VCode::new(abi, block_order);
         let stackmap_info = StackmapRequestInfo {
             reftype_class,
@@ -257,7 +257,7 @@ fn is_redundant_move<I: VCodeInst>(insn: &I) -> bool {
 
 /// Is this type a reference type?
 fn is_reftype(ty: Type) -> bool {
-    ty == types::R32 || ty == types::R64
+    ty == types::R64 || ty == types::R32
 }
 
 impl<I: VCodeInst> VCode<I> {

--- a/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
@@ -63,3 +63,65 @@ block0:
 ; nextln: mov sp, fp
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
+
+function %f5(r64, r64) -> r64, r64, r64 {
+    fn0 = %f(r64) -> b1
+    ss0 = explicit_slot 8
+
+block0(v0: r64, v1: r64):
+    v2 = call fn0(v0)
+    stack_store.r64 v0, ss0
+    brz v2, block1(v1, v0)
+    jump block2(v0, v1)
+
+block1(v3: r64, v4: r64):
+    jump block3(v3, v4)
+
+block2(v5: r64, v6: r64):
+    jump block3(v5, v6)
+
+block3(v7: r64, v8: r64):
+    v9 = stack_load.r64 ss0
+    return v7, v8, v9
+}
+
+; check: Block 0:
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: sub sp, sp, #32
+; nextln: stp x19, x20, [sp, #-16]!
+; nextln: virtual_sp_offset_adjust 16
+; nextln: mov x19, x0
+; nextln: mov x20, x1
+; nextln: mov x0, x19
+; nextln: ldr x16, 8 ; b 12 ; data
+; nextln: stur x19, [sp, #24]
+; nextln: stur x20, [sp, #32]
+; nextln: (safepoint: slots [S0, S1]
+; nextln: blr x16
+; nextln: ldur x19, [sp, #24]
+; nextln: ldur x20, [sp, #32]
+; nextln: add x1, sp, #16
+; nextln: stur x19, [x1]
+; nextln: and w0, w0, #1
+; nextln: cbz x0, label1 ; b label3
+; check: Block 1:
+; check:  b label2
+; check: Block 2:
+; check: mov x0, x20
+; nextln: b label5
+; check: Block 3:
+; check: b label4
+; check: Block 4:
+; check: mov x0, x19
+; nextln: mov x19, x20
+; nextln: b label5
+; check: Block 5:
+; check: add x1, sp, #16
+; nextln: ldur x1, [x1]
+; nextln: mov x2, x1
+; nextln: mov x1, x19
+; nextln: ldp x19, x20, [sp], #16
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret

--- a/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
@@ -1,0 +1,65 @@
+test compile
+target aarch64
+
+function %f0(r64) -> r64 {
+block0(v0: r64):
+  return v0
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f1(r32) -> r32 {
+block0(v0: r32):
+  return v0
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f2(r64) -> b1 {
+block0(v0: r64):
+  v1 = is_null v0
+  return v1
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: subs xzr, x0, #0
+; nextln: cset x0, eq
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f3(r64) -> b1 {
+block0(v0: r64):
+  v1 = is_invalid v0
+  return v1
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: adds xzr, x0, #1
+; nextln: cset x0, eq
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f4() -> r64 {
+block0:
+  v0 = null.r64
+  return v0
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: movz x0, #0
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret

--- a/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
@@ -12,18 +12,7 @@ block0(v0: r64):
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
 
-function %f1(r32) -> r32 {
-block0(v0: r32):
-  return v0
-}
-
-; check: stp fp, lr, [sp, #-16]!
-; nextln: mov fp, sp
-; nextln: mov sp, fp
-; nextln: ldp fp, lr, [sp], #16
-; nextln: ret
-
-function %f2(r64) -> b1 {
+function %f1(r64) -> b1 {
 block0(v0: r64):
   v1 = is_null v0
   return v1
@@ -37,7 +26,7 @@ block0(v0: r64):
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
 
-function %f3(r64) -> b1 {
+function %f2(r64) -> b1 {
 block0(v0: r64):
   v1 = is_invalid v0
   return v1
@@ -51,7 +40,7 @@ block0(v0: r64):
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
 
-function %f4() -> r64 {
+function %f3() -> r64 {
 block0:
   v0 = null.r64
   return v0
@@ -64,7 +53,7 @@ block0:
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
 
-function %f5(r64, r64) -> r64, r64, r64 {
+function %f4(r64, r64) -> r64, r64, r64 {
     fn0 = %f(r64) -> b1
     ss0 = explicit_slot 8
 

--- a/cranelift/wasm/src/state/module_state.rs
+++ b/cranelift/wasm/src/state/module_state.rs
@@ -30,6 +30,7 @@ fn cranelift_to_wasmparser_type(ty: Type) -> WasmResult<wasmparser::Type> {
         types::I64 => wasmparser::Type::I64,
         types::F32 => wasmparser::Type::F32,
         types::F64 => wasmparser::Type::F64,
+        types::R32 | types::R64 => wasmparser::Type::ExternRef,
         _ => {
             return Err(WasmError::Unsupported(format!(
                 "Cannot convert Cranelift type to Wasm signature: {:?}",


### PR DESCRIPTION
This PR adds support for reference types in the `MachInst` backend framework and on AArch64. It comes in two parts: the initial support for allowing `R32`/`R64` types to flow through the Wasm program and call boundaries, and the implementation of opcodes that support them (`is_null`, etc.); and then stackmap support to allow GCs to occur while Wasm stackframes are active.

This has been tested with SpiderMonkey and is known to work there with GCs occuring during calls from Wasm into JS. We plan to do further testing in regalloc.rs directly (with our checker) too.

This requires a regalloc.rs version bump (with bytecodealliance/regalloc.rs#79 included) and dep version update; the CI build here will be red until that change is made.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
