### PR TITLE
Allow setting other Cranelift flags when running in Wasmtime

### DIFF
--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -355,6 +355,24 @@ impl Config {
         self
     }
 
+    /// Allows settings another Cranelift flag defined by a flag name and value. This allows
+    /// fine-tuning of Cranelift settings.
+    ///
+    /// Since Cranelift flags may be unstable, this method should not be considered to be stable
+    /// either; other `Config` functions should be preferred for stability.
+    ///
+    /// Note that this is marked as unsafe, because setting the wrong flag might break invariants,
+    /// resulting in execution hazards.
+    ///
+    /// # Errors
+    ///
+    /// This method can fail if the flag's name does not exist, or the value is not appropriate for
+    /// the flag type.
+    pub unsafe fn cranelift_other_flag(&mut self, name: &str, value: &str) -> Result<&mut Self> {
+        self.flags.set(name, value)?;
+        Ok(self)
+    }
+
     /// Loads cache configuration specified at `path`.
     ///
     /// This method will read the file specified by `path` on the filesystem and


### PR DESCRIPTION
This would be handy to try different Cranelift settings while running on real hardware. My immediate use case is trying a different regalloc on aarch64, but I made something generic that would allow to use other cranelift flags in wasmtime too.