### PR TITLE
Enable the wast::Cranelift::spec::simd::simd_load_splat test for AArch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -181,10 +181,11 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         },
         "Cranelift" => match (testsuite, testname) {
             ("simd", "simd_i8x16_cmp") => return false,
-            ("simd", "simd_load_extend") => return false,
-            ("simd", "simd_store") => return false,
             ("simd", "simd_i16x8_cmp") => return false,
             ("simd", "simd_i32x4_cmp") => return false,
+            ("simd", "simd_load_extend") => return false,
+            ("simd", "simd_load_splat") => return false,
+            ("simd", "simd_store") => return false,
             // Most simd tests are known to fail on aarch64 for now, it's going
             // to be a big chunk of work to implement them all there!
             ("simd", _) if target.contains("aarch64") => return true,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -1175,6 +1175,34 @@ impl MachInstEmit for Inst {
                         | machreg_to_gpr(rd.to_reg()),
                 );
             }
+            &Inst::VecDup { rd, rn, ty } => {
+                let imm5 = match ty {
+                    I8 => 0b00001,
+                    I16 => 0b00010,
+                    I32 => 0b00100,
+                    I64 => 0b01000,
+                    _ => unimplemented!(),
+                };
+                sink.put4(
+                    0b010_01110000_00000_000011_00000_00000
+                        | (imm5 << 16)
+                        | (machreg_to_gpr(rn) << 5)
+                        | machreg_to_vec(rd.to_reg()),
+                );
+            }
+            &Inst::VecDupFromFpu { rd, rn, ty } => {
+                let imm5 = match ty {
+                    F32 => 0b00100,
+                    F64 => 0b01000,
+                    _ => unimplemented!(),
+                };
+                sink.put4(
+                    0b010_01110000_00000_000001_00000_00000
+                        | (imm5 << 16)
+                        | (machreg_to_vec(rn) << 5)
+                        | machreg_to_vec(rd.to_reg()),
+                );
+            }
             &Inst::VecExtend { t, rd, rn } => {
                 let (u, immh) = match t {
                     VecExtendOp::Sxtl8 => (0b0, 0b001),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1859,6 +1859,60 @@ fn test_aarch64_binemit() {
         "cset x5, hi",
     ));
     insns.push((
+        Inst::VecDup {
+            rd: writable_vreg(25),
+            rn: xreg(7),
+            ty: I8,
+        },
+        "F90C014E",
+        "dup v25.16b, w7",
+    ));
+    insns.push((
+        Inst::VecDup {
+            rd: writable_vreg(2),
+            rn: xreg(23),
+            ty: I16,
+        },
+        "E20E024E",
+        "dup v2.8h, w23",
+    ));
+    insns.push((
+        Inst::VecDup {
+            rd: writable_vreg(0),
+            rn: xreg(28),
+            ty: I32,
+        },
+        "800F044E",
+        "dup v0.4s, w28",
+    ));
+    insns.push((
+        Inst::VecDup {
+            rd: writable_vreg(31),
+            rn: xreg(5),
+            ty: I64,
+        },
+        "BF0C084E",
+        "dup v31.2d, x5",
+    ));
+    insns.push((
+        Inst::VecDupFromFpu {
+            rd: writable_vreg(14),
+            rn: vreg(19),
+            ty: F32,
+        },
+        "6E06044E",
+        "dup v14.4s, v19.s[0]",
+    ));
+    insns.push((
+        Inst::VecDupFromFpu {
+            rd: writable_vreg(18),
+            rn: vreg(10),
+            ty: F64,
+        },
+        "5205084E",
+        "dup v18.2d, v10.d[0]",
+    ));
+    insns.push((
         Inst::VecExtend {
             t: VecExtendOp::Sxtl8,
             rd: writable_vreg(4),

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -319,13 +319,15 @@ pub fn show_vreg_vector(reg: Reg, mb_rru: Option<&RealRegUniverse>, ty: Type) ->
     let mut s = reg.show_rru(mb_rru);
 
     match ty {
-        I8X16 => s.push_str(".16b"),
-        I16X8 => s.push_str(".8h"),
-        I32X4 => s.push_str(".4s"),
         F32X2 => s.push_str(".2s"),
+        F32X4 => s.push_str(".4s"),
+        F64X2 => s.push_str(".2d"),
         I8X8 => s.push_str(".8b"),
+        I8X16 => s.push_str(".16b"),
         I16X4 => s.push_str(".4h"),
+        I16X8 => s.push_str(".8h"),
         I32X2 => s.push_str(".2s"),
+        I32X4 => s.push_str(".4s"),
         I64X2 => s.push_str(".2d"),
         _ => unimplemented!(),
     }

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1483,13 +1483,24 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         }
 
+        Opcode::Splat => {
+            let rn = input_to_reg(ctx, inputs[0], NarrowValueMode::None);
+            let rd = output_to_reg(ctx, outputs[0]);
+            let ty = ctx.input_ty(insn, 0);
+            let inst = if ty_is_int(ty) {
+                Inst::VecDup { rd, rn, ty }
+            } else {
+                Inst::VecDupFromFpu { rd, rn, ty }
+            };
+            ctx.emit(inst);
+        }
+
         Opcode::Shuffle
         | Opcode::Vsplit
         | Opcode::Vconcat
         | Opcode::Vselect
         | Opcode::VanyTrue
         | Opcode::VallTrue
-        | Opcode::Splat
         | Opcode::Insertlane
         | Opcode::ScalarToVector
         | Opcode::Swizzle


### PR DESCRIPTION
One problem with this implementation is that a SIMD load and splat operation is represented as two IR instructions - `load` and `splat`. As a result, two A64 instructions are generated - a scalar load, followed by `DUP`, while the operation can be expressed with just `LD1R`. Is there a relatively easy way to fix this?