### PR TITLE
wasi-common: don't rely on platform dependent "NUL" device

### DIFF
--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -2,7 +2,7 @@ use crate::entry::{Entry, EntryHandle};
 use crate::fdpool::FdPool;
 use crate::handle::Handle;
 use crate::sys::osdir::OsDir;
-use crate::sys::osother::{OsOther, OsOtherExt};
+use crate::sys::stdio::NullDevice;
 use crate::sys::stdio::{Stderr, StderrExt, Stdin, StdinExt, Stdout, StdoutExt};
 use crate::virtfs::{VirtualDir, VirtualDirEntry};
 use crate::wasi::types;
@@ -136,9 +136,9 @@ pub struct WasiCtxBuilder {
 impl WasiCtxBuilder {
     /// Builder for a new `WasiCtx`.
     pub fn new() -> Self {
-        let stdin = Some(PendingEntry::Thunk(OsOther::from_null));
-        let stdout = Some(PendingEntry::Thunk(OsOther::from_null));
-        let stderr = Some(PendingEntry::Thunk(OsOther::from_null));
+        let stdin = Some(PendingEntry::Handle(Box::new(NullDevice::new())));
+        let stdout = Some(PendingEntry::Handle(Box::new(NullDevice::new())));
+        let stderr = Some(PendingEntry::Handle(Box::new(NullDevice::new())));
 
         Self {
             stdin,

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -39,6 +39,6 @@ pub use ctx::{WasiCtx, WasiCtxBuilder, WasiCtxBuilderError};
 pub use handle::{Handle, HandleRights};
 pub use sys::osdir::OsDir;
 pub use sys::osfile::OsFile;
-pub use sys::osother::{OsOther, OsOtherExt};
+pub use sys::osother::OsOther;
 pub use sys::preopen_dir;
 pub use virtfs::{FileContents, VirtualDirEntry};

--- a/crates/wasi-common/src/sys/osother.rs
+++ b/crates/wasi-common/src/sys/osother.rs
@@ -10,13 +10,6 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::ops::Deref;
 
-/// Extra methods for `OsOther` that are only available when configured for
-/// some operating systems.
-pub trait OsOtherExt {
-    /// Create `OsOther` as `dyn Handle` from null device.
-    fn from_null() -> io::Result<Box<dyn Handle>>;
-}
-
 /// `OsOther` is something of a catch-all for everything not covered with the specific handle
 /// types (`OsFile`, `OsDir`, `Stdio`). It currently encapsulates handles such as OS pipes,
 /// sockets, streams, etc. As such, when redirecting stdio within `WasiCtxBuilder`, the redirected

--- a/crates/wasi-common/src/sys/unix/osother.rs
+++ b/crates/wasi-common/src/sys/unix/osother.rs
@@ -1,10 +1,9 @@
 use super::oshandle::RawOsHandle;
 use super::{get_file_type, get_rights};
-use crate::handle::Handle;
-use crate::sys::osother::{OsOther, OsOtherExt};
+use crate::sys::osother::OsOther;
 use crate::wasi::types;
 use std::convert::TryFrom;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io;
 use std::os::unix::prelude::{FromRawFd, IntoRawFd};
 
@@ -19,16 +18,5 @@ impl TryFrom<File> for OsOther {
         let rights = get_rights(&file, &file_type)?;
         let handle = unsafe { RawOsHandle::from_raw_fd(file.into_raw_fd()) };
         Ok(Self::new(file_type, rights, handle))
-    }
-}
-
-impl OsOtherExt for OsOther {
-    fn from_null() -> io::Result<Box<dyn Handle>> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open("/dev/null")?;
-        let file = Self::try_from(file)?;
-        Ok(Box::new(file))
     }
 }

--- a/crates/wasi-common/src/sys/windows/osother.rs
+++ b/crates/wasi-common/src/sys/windows/osother.rs
@@ -1,10 +1,9 @@
 use super::oshandle::RawOsHandle;
 use super::{get_file_type, get_rights};
-use crate::handle::Handle;
-use crate::sys::osother::{OsOther, OsOtherExt};
+use crate::sys::osother::OsOther;
 use crate::wasi::types;
 use std::convert::TryFrom;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io;
 use std::os::windows::prelude::{FromRawHandle, IntoRawHandle};
 
@@ -19,13 +18,5 @@ impl TryFrom<File> for OsOther {
         let rights = get_rights(&file_type)?;
         let handle = unsafe { RawOsHandle::from_raw_handle(file.into_raw_handle()) };
         Ok(Self::new(file_type, rights, handle))
-    }
-}
-
-impl OsOtherExt for OsOther {
-    fn from_null() -> io::Result<Box<dyn Handle>> {
-        let file = OpenOptions::new().read(true).write(true).open("NUL")?;
-        let file = Self::try_from(file)?;
-        Ok(Box::new(file))
     }
 }


### PR DESCRIPTION
If stdio is not inherited nor associated with a file, `WasiCtxBuilder` tries to open "/dev/null" ("NUL" on Windows) and attach stdio to it. While most platforms today support those device files, it would be
good to avoid unnecessary access to the host device if possible.  This patch instead uses a virtual Handle that emulates the "NUL" device.

This is particularly needed when using wasmtime in a restricted environment, such as inside TEE (see https://github.com/enarx/enarx/issues/559 for the context).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
