### PR TITLE
Correct example module doc comment typo

### DIFF
--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -1,4 +1,4 @@
-//! This is an example of working with mulit-value modules and dealing with
+//! This is an example of working with multi-value modules and dealing with
 //! multi-value functions.
 //!
 //! Note that the `Func::wrap*` interfaces cannot be used to return multiple


### PR DESCRIPTION
This small PR corrects a typo in `examples/multi.rs`:  "mulit" to "multi".

Not entirely sure that it also requires an issue to be opened.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
