### PR TITLE
AArch64: make use of reg-reg-extend amode.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -133,6 +133,9 @@ pub enum MemArg {
     /// first.
     RegScaledExtended(Reg, Reg, Type, ExtendOp),
 
+    /// Register plus register offset, with index sign- or zero-extended first.
+    RegExtended(Reg, Reg, ExtendOp),
+
     /// Unscaled signed 9-bit immediate offset from reg.
     Unscaled(Reg, SImm9),
 
@@ -410,6 +413,19 @@ impl ShowWithRRU for MemArg {
                     show_ireg_sized(r2, mb_rru, size),
                     op,
                     shift
+                )
+            }
+            &MemArg::RegExtended(r1, r2, op) => {
+                let size = match op {
+                    ExtendOp::SXTW | ExtendOp::UXTW => InstSize::Size32,
+                    _ => InstSize::Size64,
+                };
+                let op = op.show_rru(mb_rru);
+                format!(
+                    "[{}, {}, {}]",
+                    r1.show_rru(mb_rru),
+                    show_ireg_sized(r2, mb_rru, size),
+                    op,
                 )
             }
             &MemArg::Label(ref label) => label.show_rru(mb_rru),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -707,6 +707,16 @@ impl MachInstEmit for Inst {
                             op, r1, r2, /* scaled = */ true, extendop, rd,
                         ));
                     }
+                    &MemArg::RegExtended(r1, r2, extendop) => {
+                        sink.put4(enc_ldst_reg(
+                            op,
+                            r1,
+                            r2,
+                            /* scaled = */ false,
+                            Some(extendop),
+                            rd,
+                        ));
+                    }
                     &MemArg::Label(ref label) => {
                         let offset = match label {
                             // cast i32 to u32 (two's-complement)
@@ -831,6 +841,16 @@ impl MachInstEmit for Inst {
                         };
                         sink.put4(enc_ldst_reg(
                             op, r1, r2, /* scaled = */ true, extendop, rd,
+                        ));
+                    }
+                    &MemArg::RegExtended(r1, r2, extendop) => {
+                        sink.put4(enc_ldst_reg(
+                            op,
+                            r1,
+                            r2,
+                            /* scaled = */ false,
+                            Some(extendop),
+                            rd,
                         ));
                     }
                     &MemArg::Label(..) => {

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1284,6 +1284,15 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
+            mem: MemArg::RegExtended(xreg(2), xreg(3), ExtendOp::SXTW),
+            srcloc: None,
+        },
+        "41C863F8",
+        "ldr x1, [x2, w3, SXTW]",
+    ));
+    insns.push((
+        Inst::ULoad64 {
+            rd: writable_xreg(1),
             mem: MemArg::Label(MemLabel::PCRel(64)),
             srcloc: None,
         },
@@ -1473,6 +1482,15 @@ fn test_aarch64_binemit() {
         },
         "415823F8",
         "str x1, [x2, w3, UXTW #3]",
+    ));
+    insns.push((
+        Inst::Store64 {
+            rd: xreg(1),
+            mem: MemArg::RegExtended(xreg(2), xreg(3), ExtendOp::UXTW),
+            srcloc: None,
+        },
+        "414823F8",
+        "str x1, [x2, w3, UXTW]",
     ));
     insns.push((
         Inst::Store64 {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1049,7 +1049,8 @@ fn memarg_regs(memarg: &MemArg, collector: &mut RegUsageCollector) {
         }
         &MemArg::RegReg(r1, r2, ..)
         | &MemArg::RegScaled(r1, r2, ..)
-        | &MemArg::RegScaledExtended(r1, r2, ..) => {
+        | &MemArg::RegScaledExtended(r1, r2, ..)
+        | &MemArg::RegExtended(r1, r2, ..) => {
             collector.add_use(r1);
             collector.add_use(r2);
         }
@@ -1384,15 +1385,10 @@ fn aarch64_map_regs<RUM: RegUsageMapper>(inst: &mut Inst, mapper: &RUM) {
         match mem {
             &mut MemArg::Unscaled(ref mut reg, ..) => map_use(m, reg),
             &mut MemArg::UnsignedOffset(ref mut reg, ..) => map_use(m, reg),
-            &mut MemArg::RegReg(ref mut r1, ref mut r2) => {
-                map_use(m, r1);
-                map_use(m, r2);
-            }
-            &mut MemArg::RegScaled(ref mut r1, ref mut r2, ..) => {
-                map_use(m, r1);
-                map_use(m, r2);
-            }
-            &mut MemArg::RegScaledExtended(ref mut r1, ref mut r2, ..) => {
+            &mut MemArg::RegReg(ref mut r1, ref mut r2)
+            | &mut MemArg::RegScaled(ref mut r1, ref mut r2, ..)
+            | &mut MemArg::RegScaledExtended(ref mut r1, ref mut r2, ..)
+            | &mut MemArg::RegExtended(ref mut r1, ref mut r2, ..) => {
                 map_use(m, r1);
                 map_use(m, r2);
             }

--- a/cranelift/filetests/filetests/vcode/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/amodes.clif
@@ -1,0 +1,58 @@
+test compile
+target aarch64
+
+function %f0(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+  v2 = uextend.i64 v1
+  v3 = load_complex.i32 v0+v2
+  return v3
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: ldr w0, [x0, w1, UXTW]
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f1(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+  v2 = uextend.i64 v1
+  v3 = load_complex.i32 v2+v0
+  return v3
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: ldr w0, [x0, w1, UXTW]
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f1(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+  v2 = sextend.i64 v1
+  v3 = load_complex.i32 v0+v2
+  return v3
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: ldr w0, [x0, w1, SXTW]
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %f1(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+  v2 = sextend.i64 v1
+  v3 = load_complex.i32 v2+v0
+  return v3
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: ldr w0, [x0, w1, SXTW]
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret


### PR DESCRIPTION
When a load/store instruction needs an address of the form `v0 +
uextend(v1)` or `v0 + sextend(v1)` (or the commuted forms thereof), we
currently generate a separate zero/sign-extend operation and then use a
plain `[rA, rB]` addressing mode. This patch extends `lower_address()`
to look at both addends of an address if it has two addends and a zero
offset, recognize extension operations, and incorporate them directly
into a `[rA, rB, UXTW]` or `[rA, rB, SXTW]` form. This should improve
our performence on WebAssembly workloads, at least, because we often see
a 64-bit linear memory base indexed by a 32-bit (Wasm) pointer value.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
