### PR TITLE
Remove uses of `matches!()` macro, incompatible with Firefox build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,12 @@ jobs:
     - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
     - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
 
+    # Check that codegen and wasm crates typecheck on 1.41.0; this is required
+    # for Firefox.
+    - run: rustup install 1.41.0
+    - run: cargo +1.41.0 check -p cranelift-codegen
+    - run: cargo +1.41.0 check -p cranelift-wasm
+
 
   fuzz_targets:
     name: Fuzz Targets

--- a/cranelift/codegen/src/abi.rs
+++ b/cranelift/codegen/src/abi.rs
@@ -80,7 +80,10 @@ impl ValueConversion {
 
     /// Is this a conversion to pointer?
     pub fn is_pointer(self) -> bool {
-        matches!(self, Self::Pointer(_))
+        match self {
+            Self::Pointer(_) => true,
+            _ => false,
+        }
     }
 }
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -311,7 +311,7 @@ impl InstructionData {
                 arg: _,
                 imm,
             } => {
-                if matches!(opcode, Opcode::SdivImm | Opcode::SremImm) {
+                if *opcode == Opcode::SdivImm || *opcode == Opcode::SremImm {
                     imm.sign_extend_from_width(bit_width);
                 }
             }


### PR DESCRIPTION
When we vendor Cranelift into Firefox, we need to be able to build with
the Firefox CI setup (unless we carry patches on top of upstream).
Unfortunately, the Firefox CI currently appears to build with a slightly
older version of Rust: I can't work out which version exactly, but one
without stable support for `matches!()`.

A recent attempt to version-bump Cranelift failed with build errors at
the two locations in this patch:

https://treeherder.mozilla.org/logviewer.html#/jobs?job_id=305994046&repo=autoland&lineNumber=24829

I also see a bunch of uses of `matches!()` in Peepmatic, but those
crates are not built by Firefox, so we can leave them be for now, I
think.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
