### PR TITLE
Remove a runaway explicit drop

### DIFF
--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -223,7 +223,6 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
                 .preadv(&mut buf, offset)?
                 .try_into()?
         };
-        drop(guest_slices);
         Ok(host_nread)
     }
 


### PR DESCRIPTION
Looks like a runaway from the latest `wiggle`-related improvements.