### PR TITLE
cranelift: add a new resumable_trapnz instruction;

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -340,7 +340,21 @@ fn define_control_flow(
                 r#"
         Trap when non-zero.
 
-        if ``c`` is zero, execution continues at the following instruction.
+        If ``c`` is zero, execution continues at the following instruction.
+        "#,
+                &formats.cond_trap,
+            )
+            .operands_in(vec![c, code])
+            .can_trap(true),
+        );
+
+        ig.push(
+            Inst::new(
+                "resumable_trapnz",
+                r#"
+        A resumable trap to be called when the passed condition is non-zero.
+
+        If ``c`` is zero, execution continues at the following instruction.
         "#,
                 &formats.cond_trap,
             )

--- a/cranelift/codegen/meta/src/shared/legalize.rs
+++ b/cranelift/codegen/meta/src/shared/legalize.rs
@@ -99,6 +99,7 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     let jump = insts.by_name("jump");
     let load = insts.by_name("load");
     let popcnt = insts.by_name("popcnt");
+    let resumable_trapnz = insts.by_name("resumable_trapnz");
     let rotl = insts.by_name("rotl");
     let rotl_imm = insts.by_name("rotl_imm");
     let rotr = insts.by_name("rotr");
@@ -138,6 +139,7 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     // TODO: Add sufficient XForm syntax that we don't need to hand-code these.
     expand.custom_legalize(trapz, "expand_cond_trap");
     expand.custom_legalize(trapnz, "expand_cond_trap");
+    expand.custom_legalize(resumable_trapnz, "expand_cond_trap");
     expand.custom_legalize(br_table, "expand_br_table");
     expand.custom_legalize(select, "expand_select");
     widen.custom_legalize(select, "expand_select"); // small ints

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -59,6 +59,14 @@ impl Opcode {
     pub fn constraints(self) -> OpcodeConstraints {
         OPCODE_CONSTRAINTS[self as usize - 1]
     }
+
+    /// Returns true if the instruction is a resumable trap.
+    pub fn is_resumable_trap(&self) -> bool {
+        match self {
+            Opcode::ResumableTrap | Opcode::ResumableTrapnz => true,
+            _ => false,
+        }
+    }
 }
 
 // This trait really belongs in cranelift-reader where it is used by the `.clif` file parser, but since

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1334,7 +1334,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             ctx.emit(Inst::Brk);
         }
 
-        Opcode::Trap => {
+        Opcode::Trap | Opcode::ResumableTrap => {
             let trap_info = (ctx.srcloc(insn), inst_trapcode(ctx.data(insn)).unwrap());
             ctx.emit(Inst::Udf { trap_info })
         }
@@ -1385,12 +1385,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             panic!("safepoint support not implemented!");
         }
 
-        Opcode::Trapz | Opcode::Trapnz => {
-            panic!("trapz / trapnz should have been removed by legalization!");
-        }
-
-        Opcode::ResumableTrap => {
-            panic!("Resumable traps not supported");
+        Opcode::Trapz | Opcode::Trapnz | Opcode::ResumableTrapnz => {
+            panic!("trapz / trapnz / resumable_trapnz should have been removed by legalization!");
         }
 
         Opcode::FuncAddr => {
@@ -2277,6 +2273,7 @@ pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
                     dest: BranchTarget::Label(targets[0]),
                 });
             }
+
             Opcode::BrTable => {
                 // Expand `br_table index, default, JT` to:
                 //

--- a/cranelift/codegen/src/regalloc/safepoint.rs
+++ b/cranelift/codegen/src/regalloc/safepoint.rs
@@ -1,6 +1,6 @@
 use crate::cursor::{Cursor, FuncCursor};
 use crate::dominator_tree::DominatorTree;
-use crate::ir::{Function, InstBuilder, InstructionData, Opcode, TrapCode};
+use crate::ir::{Function, InstBuilder, Opcode};
 use crate::isa::TargetIsa;
 use crate::regalloc::live_value_tracker::LiveValueTracker;
 use crate::regalloc::liveness::Liveness;
@@ -51,11 +51,7 @@ pub fn emit_stackmaps(
         pos.goto_top(block);
 
         while let Some(inst) = pos.next_inst() {
-            if let InstructionData::Trap {
-                code: TrapCode::Interrupt,
-                ..
-            } = &pos.func.dfg[inst]
-            {
+            if pos.func.dfg[inst].opcode().is_resumable_trap() {
                 insert_and_encode_safepoint(&mut pos, tracker, isa);
             } else if pos.func.dfg[inst].opcode().is_call() {
                 insert_and_encode_safepoint(&mut pos, tracker, isa);


### PR DESCRIPTION
This is useful to have to allow resumable_trap to happen in loop
headers, for instance. This is the correct way to implement interrupt
checks in Spidermonkey, which are effectively resumable traps. Previous
implementation was using traps, which is wrong, since traps semantically
can't be resumed after.