### PR TITLE
Re-enable the spec::simd::simd_align test for AArch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -181,6 +181,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         },
         "Cranelift" => match (testsuite, testname) {
             ("simd", "simd_address") => return false,
+            ("simd", "simd_align") => return false,
             ("simd", "simd_bitwise") => return false,
             ("simd", "simd_i8x16_cmp") => return false,
             ("simd", "simd_i16x8_cmp") => return false,


### PR DESCRIPTION
This test was previously enabled by PR #1802, which was failing in CI for unclear reasons and was subsequently merged without enabling any tests to unblock further work. However, the same PR enabled another test as well, so now we just isolate `spec::simd::simd_align` in a small change to check if it is problematic or not.