### PR TITLE
machinst: make it possible to test the new x64 backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,10 @@ lightbeam = [
 jitdump = ["wasmtime/jitdump"]
 vtune = ["wasmtime/vtune"]
 
+# Try the experimental, work-in-progress new x86_64 backend. This is not stable
+# as of June 2020.
+experimental_x64 = ["wasmtime-jit/experimental_x64"]
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -150,6 +150,7 @@ pub enum LookupError {
 
 /// Builder for a `TargetIsa`.
 /// Modify the ISA-specific settings before creating the `TargetIsa` trait object with `finish`.
+#[derive(Clone)]
 pub struct Builder {
     triple: Triple,
     setup: settings::Builder,

--- a/crates/environ/src/data_structures.rs
+++ b/crates/environ/src/data_structures.rs
@@ -10,11 +10,13 @@ pub mod ir {
 }
 
 pub mod settings {
-    pub use cranelift_codegen::settings::{builder, Builder, Configurable, Flags};
+    pub use cranelift_codegen::settings::{builder, Builder, Configurable, Flags, SetError};
 }
 
 pub mod isa {
-    pub use cranelift_codegen::isa::{unwind, CallConv, RegUnit, TargetFrontendConfig, TargetIsa};
+    pub use cranelift_codegen::isa::{
+        unwind, Builder, CallConv, RegUnit, TargetFrontendConfig, TargetIsa,
+    };
 }
 
 pub mod entity {

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -39,5 +39,9 @@ lightbeam = ["wasmtime-environ/lightbeam"]
 jitdump = ["wasmtime-profiling/jitdump"]
 vtune = ["wasmtime-profiling/vtune"]
 
+# Try the experimental, work-in-progress new x86_64 backend. This is not stable
+# as of June 2020.
+experimental_x64 = ["cranelift-codegen/x64"]
+
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
- First commit adds capabilities in wasmtime to allow trying the new x64 backing (see commit message for a complete command line example of how to do it). @fitzgen can you have a look, please?
- Second commit makes it possible to run x64 tests in the `test run` mode. It uncovered one issue I'm not quite sure how to handle, but that's preexisting and it's not been a problem so far. @abrown, can you have a look, please?

This should make it much easier to hack on and try the new work-in-progress x64 backend. Eventually we can delete the Cargo feature for wasmtime once the transition to the new backend is over.