### PR TITLE
wasmtime-runtime: Allow tables to internally hold `externref`s

### DIFF
--- a/crates/environ/src/func_environ.rs
+++ b/crates/environ/src/func_environ.rs
@@ -1192,7 +1192,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         _table: ir::Table,
     ) -> WasmResult<ir::Value> {
         Err(WasmError::Unsupported(
-            "bulk memory: `table.size`".to_string(),
+            "reference types: `table.size`".to_string(),
         ))
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -44,7 +44,7 @@ pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
 pub use crate::sig_registry::SignatureRegistry;
-pub use crate::table::Table;
+pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
     catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, SignalHandler, Trap,
 };

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -2,8 +2,10 @@ use crate::trampoline::{
     generate_global_export, generate_memory_export, generate_table_export, StoreInstanceHandle,
 };
 use crate::values::{from_checked_anyfunc, into_checked_anyfunc, Val};
-use crate::{ExternType, GlobalType, MemoryType, Mutability, TableType, ValType};
-use crate::{Func, Store, Trap};
+use crate::{
+    ExternRef, ExternType, Func, GlobalType, MemoryType, Mutability, Store, TableType, Trap,
+    ValType,
+};
 use anyhow::{anyhow, bail, Result};
 use std::slice;
 use wasmtime_environ::wasm;
@@ -299,7 +301,11 @@ fn set_table_item(
     item: wasmtime_runtime::VMCallerCheckedAnyfunc,
 ) -> Result<()> {
     instance
-        .table_set(table_index, item_index, item)
+        .table_set(
+            table_index,
+            item_index,
+            runtime::TableElement::FuncRef(item),
+        )
         .map_err(|()| anyhow!("table element index out of bounds"))
 }
 
@@ -348,7 +354,16 @@ impl Table {
     pub fn get(&self, index: u32) -> Option<Val> {
         let table_index = self.wasmtime_table_index();
         let item = self.instance.table_get(table_index, index)?;
-        Some(from_checked_anyfunc(item, &self.instance.store))
+        match item {
+            runtime::TableElement::FuncRef(f) => {
+                Some(from_checked_anyfunc(f, &self.instance.store))
+            }
+            runtime::TableElement::ExternRef(None) => Some(Val::ExternRef(None)),
+            runtime::TableElement::ExternRef(Some(x)) => Some(Val::ExternRef(Some(ExternRef {
+                inner: x,
+                store: self.instance.store.weak(),
+            }))),
+        }
     }
 
     /// Writes the `val` provided into `index` within this table.


### PR DESCRIPTION
This commit enables `wasmtime_runtime::Table` to internally hold elements of
either `funcref` (all that is currently supported) or `externref` (newly
introduced in this commit).

This commit updates `Table`'s API, but does NOT generally propagate those
changes outwards all the way through the Wasmtime embedding API. It only does
enough to get everything compiling and the current test suite passing. It is
expected that as we implement more of the reference types spec, we will bubble
these changes out and expose them to the embedding API.

cc #929