### PR TITLE
Disable static memory under QEMU on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -327,6 +327,10 @@ jobs:
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo ::set-env name=CARGO_TARGET_${upcase}_RUNNER::$HOME/qemu/bin/${{ matrix.qemu }}
         echo ::set-env name=CARGO_TARGET_${upcase}_LINKER::${{ matrix.gcc }}
+
+        # See comments in the source for why we enable this during QEMU
+        # emulation.
+        echo ::set-env name=WASMTIME_TEST_NO_HOG_MEMORY::1
       if: matrix.target != '' && matrix.os == 'ubuntu-latest'
 
     # Install wasm32-wasi target in order to build wasi-common's integration

--- a/build.rs
+++ b/build.rs
@@ -181,6 +181,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         },
         "Cranelift" => match (testsuite, testname) {
             ("simd", "simd_address") => return false,
+            ("simd", "simd_align") => return false,
             ("simd", "simd_bitwise") => return false,
             ("simd", "simd_boolean") => return false,
             ("simd", "simd_i8x16_cmp") => return false,

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -25,6 +25,19 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
         .strategy(strategy)?
         .cranelift_debug_verifier(true);
 
+    // By default we'll allocate huge chunks (6gb) of the address space for each
+    // linear memory. This is typically fine but when we emulate tests with QEMU
+    // it turns out that it causes memory usage to balloon massively. Leave a
+    // knob here so on CI we can cut down the memory usage of QEMU and avoid the
+    // OOM killer.
+    //
+    // Locally testing this out this drops QEMU's memory usage running this
+    // tests suite from 10GiB to 600MiB. Prevoiusly we saw that crossing the
+    // 10GiB threshold caused our processes to get OOM killed on CI.
+    if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
+        cfg.static_memory_maximum_size(0);
+    }
+
     let store = Store::new(&Engine::new(&cfg));
     let mut wast_context = WastContext::new(store);
     wast_context.register_spectest()?;

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -32,7 +32,7 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
     // OOM killer.
     //
     // Locally testing this out this drops QEMU's memory usage running this
-    // tests suite from 10GiB to 600MiB. Prevoiusly we saw that crossing the
+    // tests suite from 10GiB to 600MiB. Previously we saw that crossing the
     // 10GiB threshold caused our processes to get OOM killed on CI.
     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         cfg.static_memory_maximum_size(0);


### PR DESCRIPTION


This commit disables the usage of "static" memory on CI and instead
forces all memories to be "dynamic" meaning that they reserve much
smaller chunks of memory. This causes the QEMU process's memory to
drastically drop (10GiB -> 600MiB) and should allow us to keep enabling
tests without hitting the OOM killer on CI.

Closes #1871 (includes that)
Closes #1893

