### PR TITLE
C API: expose wasmtime_linker_get_one_by_name()

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -129,6 +129,13 @@ WASM_API_EXTERN own wasmtime_error_t* wasmtime_linker_get_default(
     own wasm_func_t **func
 );
 
+WASM_API_EXTERN own wasmtime_error_t* wasmtime_linker_get_one_by_name(
+    const wasmtime_linker_t *linker,
+    const wasm_name_t *module,
+    const wasm_name_t *name,
+    own wasm_extern_t **item
+);
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 // wasmtime_caller_t extension, binding the `Caller` type in the Rust API

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -273,7 +273,7 @@ pub extern "C" fn wasm_func_as_extern(f: &mut wasm_func_t) -> &mut wasm_extern_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasmtime_caller_export_get(
+pub extern "C" fn wasmtime_caller_export_get(
     caller: &wasmtime_caller_t,
     name: &wasm_name_t,
 ) -> Option<Box<wasm_extern_t>> {

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -107,11 +107,11 @@ pub extern "C" fn wasmtime_linker_module(
 
 #[no_mangle]
 pub extern "C" fn wasmtime_linker_get_default(
-    linker: &mut wasmtime_linker_t,
+    linker: &wasmtime_linker_t,
     name: &wasm_name_t,
     func: &mut *mut wasm_func_t,
 ) -> Option<Box<wasmtime_error_t>> {
-    let linker = &mut linker.linker;
+    let linker = &linker.linker;
     let name = match str::from_utf8(name.as_slice()) {
         Ok(s) => s,
         Err(_) => return bad_utf8(),
@@ -123,12 +123,12 @@ pub extern "C" fn wasmtime_linker_get_default(
 
 #[no_mangle]
 pub extern "C" fn wasmtime_linker_get_one_by_name(
-    linker: &mut wasmtime_linker_t,
+    linker: &wasmtime_linker_t,
     module: &wasm_name_t,
     name: &wasm_name_t,
     item_ptr: &mut *mut wasm_extern_t,
 ) -> Option<Box<wasmtime_error_t>> {
-    let linker = &mut linker.linker;
+    let linker = &linker.linker;
     let module = match str::from_utf8(module.as_slice()) {
         Ok(s) => s,
         Err(_) => return bad_utf8(),

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -81,7 +81,7 @@ pub extern "C" fn wasmtime_linker_define_instance(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasmtime_linker_instantiate(
+pub extern "C" fn wasmtime_linker_instantiate(
     linker: &wasmtime_linker_t,
     module: &wasm_module_t,
     instance_ptr: &mut *mut wasm_instance_t,
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn wasmtime_linker_instantiate(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasmtime_linker_module(
+pub extern "C" fn wasmtime_linker_module(
     linker: &mut wasmtime_linker_t,
     name: &wasm_name_t,
     module: &wasm_module_t,
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn wasmtime_linker_module(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasmtime_linker_get_default(
+pub extern "C" fn wasmtime_linker_get_default(
     linker: &mut wasmtime_linker_t,
     name: &wasm_name_t,
     func: &mut *mut wasm_func_t,


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

I'd like to use the new Linker to manage my modules from C, is this a supported use-case for the Linker?