### PR TITLE
wasmtime: add config option for parallel compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "anyhow",
  "base64 0.12.1",
  "bincode",
+ "cfg-if",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ members = [
 ]
 
 [features]
-default = ["jitdump", "wasmtime/wat"]
+default = ["jitdump", "wasmtime/wat", "wasmtime/parallel-compilation"]
 lightbeam = [
     "wasmtime-environ/lightbeam",
     "wasmtime-jit/lightbeam",

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-wasm = { path = "../../cranelift/wasm", version = "0.65.0", features =
 wasmparser = "0.58.0"
 lightbeam = { path = "../lightbeam", optional = true, version = "0.18.0" }
 indexmap = "1.0.2"
-rayon = "1.2.1"
+rayon = { version = "1.2.1", optional = true }
 thiserror = "1.0.4"
 directories = "2.0.1"
 sha2 = "0.8.0"
@@ -32,6 +32,7 @@ zstd = "0.5"
 toml = "0.5.5"
 file-per-thread-logger = "0.1.1"
 more-asserts = "0.2.1"
+cfg-if = "0.1.9"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"
@@ -45,6 +46,9 @@ tempfile = "3"
 pretty_env_logger = "0.4.0"
 filetime = "0.2.7"
 lazy_static = "1.3.0"
+
+[features]
+parallel-compilation = ["rayon"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -38,7 +38,7 @@ wasmtime-wasi = { path = "../wasi" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ['wat', 'jitdump']
+default = ['wat', 'jitdump', 'parallel-compilation']
 
 # Enables experimental support for the lightbeam codegen backend, an alternative
 # to cranelift. Requires Nightly Rust currently, and this is not enabled by
@@ -50,3 +50,6 @@ jitdump = ["wasmtime-jit/jitdump"]
 
 # Enables support for the `VTune` profiler
 vtune = ["wasmtime-jit/vtune"]
+
+# Enables parallel compilation of WebAssembly code
+parallel-compilation = ["wasmtime-environ/parallel-compilation"]

--- a/crates/wiggle/wasmtime/Cargo.toml
+++ b/crates/wiggle/wasmtime/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 include = ["src/**/*", "LICENSE"]
 
 [dependencies]
-wasmtime = { path = "../../wasmtime", version = "0.18.0" }
+wasmtime = { path = "../../wasmtime", version = "0.18.0", default-features = false }
 wasmtime-wiggle-macro = { path = "./macro", version = "0.18.0" }
 witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.5", optional = true }
 wiggle = { path = "..", version = "0.18.0" }


### PR DESCRIPTION
When running in embedded environments, threads creation is sometimes undesirable. This adds a means to disable wasmtime's internal thread creation for parallel compilation and caches, by reusing the cache configuration as the indication (i.e., if cache is disabled, parallel compilation is also disabled).
