### PR TITLE
Remove unused dependencies in Cranelift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,6 @@ dependencies = [
  "log",
  "memmap",
  "num_cpus",
- "region",
  "target-lexicon",
  "thiserror",
 ]
@@ -467,9 +466,7 @@ dependencies = [
  "cranelift-reader",
  "hashbrown 0.7.2",
  "log",
- "pretty_env_logger",
  "thiserror",
- "walkdir",
 ]
 
 [[package]]
@@ -579,7 +576,6 @@ dependencies = [
  "indicatif",
  "log",
  "pretty_env_logger",
- "serde",
  "target-lexicon",
  "term",
  "thiserror",

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -33,7 +33,6 @@ cranelift = { path = "umbrella", version = "0.65.0" }
 filecheck = "0.5.0"
 clap = "2.32.0"
 log = "0.4.8"
-serde = "1.0.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
 wat = { version = "1.0.18", optional = true }

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -23,7 +23,6 @@ gimli = { version = "0.21.0", default-features = false, features = ["read"] }
 log = "0.4.6"
 memmap = "0.7.0"
 num_cpus = "1.8.0"
-region = "2.1.2"
 target-lexicon = "0.10"
 thiserror = "1.0.15"
 

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -17,8 +17,6 @@ cranelift-reader = { path = "../reader", version = "0.65.0" }
 hashbrown = { version = "0.7.1", optional = true }
 log = { version = "0.4.8", default-features = false }
 thiserror = "1.0.15"
-walkdir = "2.3.1"
-pretty_env_logger = "0.4.0"
 
 [dev-dependencies]
 cranelift-frontend = { path = "../frontend", version = "0.65.0" }


### PR DESCRIPTION
Discovered `cargo-udeps` via [this blog post](https://endler.dev/2020/rust-compile-times/) (which also mentions cg_clif!), and tried it on Cranelift, which revealed a few unused dependencies. No compile-time wins, though, since these dependencies are used elsewhere...