### PR TITLE
Chore: update various crates' `object` and `wast` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.20.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -497,7 +497,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
- "object 0.19.0",
+ "object",
  "target-lexicon",
 ]
 
@@ -1237,19 +1237,13 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 dependencies = [
  "crc32fast",
  "indexmap",
 ]
-
-[[package]]
-name = "object"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
@@ -2380,7 +2374,7 @@ dependencies = [
  "libc",
  "log",
  "more-asserts",
- "object 0.19.0",
+ "object",
  "pretty_env_logger",
  "rayon",
  "structopt",
@@ -2407,7 +2401,7 @@ dependencies = [
  "anyhow",
  "gimli",
  "more-asserts",
- "object 0.19.0",
+ "object",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.58.0",
@@ -2509,7 +2503,7 @@ version = "0.18.0"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object 0.19.0",
+ "object",
  "wasmtime-environ",
 ]
 
@@ -2523,7 +2517,7 @@ dependencies = [
  "ittapi-rs",
  "lazy_static",
  "libc",
- "object 0.19.0",
+ "object",
  "scroll",
  "serde",
  "target-lexicon",
@@ -2589,7 +2583,7 @@ version = "0.18.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 17.0.0",
+ "wast 18.0.0",
 ]
 
 [[package]]
@@ -2627,15 +2621,6 @@ name = "wast"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a10df5277f68adee65bba117b40235f07a4cb3d59e5ec9aa86dbee180fb1bc04"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0e1c36b928fca33dbaf96235188f5fad22ee87100e26cc606bd0fbabdf1932"
 dependencies = [
  "leb128",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ wasmtime-wast = { path = "crates/wast", version = "0.18.0" }
 wasmtime-wasi = { path = "crates/wasi", version = "0.18.0" }
 wasi-common = { path = "crates/wasi-common", version = "0.18.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
-object = { version = "0.19", default-features = false, features = ["write"] }
+object = { version = "0.20", default-features = false, features = ["write"] }
 anyhow = "1.0.19"
 target-lexicon = { version = "0.10.0", default-features = false }
 pretty_env_logger = "0.4.0"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 cranelift-module = { path = "../module", version = "0.65.0" }
 cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false, features = ["std"] }
-object = { version = "0.19", default-features = false, features = ["write"] }
+object = { version = "0.20", default-features = false, features = ["write"] }
 target-lexicon = "0.10"
 anyhow = "1.0"
 

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 gimli = "0.21.0"
 wasmparser = "0.58.0"
-object = { version = "0.19", default-features = false, features = ["write"] }
+object = { version = "0.20", default-features = false, features = ["write"] }
 wasmtime-environ = { path = "../environ", version = "0.18.0" }
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0"

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 wasmtime-environ = { path = "../environ", version = "0.18.0" }
-object = { version = "0.19", default-features = false, features = ["write"] }
+object = { version = "0.20", default-features = false, features = ["write"] }
 more-asserts = "0.2.1"
 
 [badges]

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
 ittapi-rs = { version = "0.1.5", optional = true }
 
 [dependencies.object]
-version = "0.19.0"
+version = "0.20.0"
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'std']

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.18.0", default-features = false }
-wast = "17.0.0"
+wast = "18.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This somewhat cuts down on duplicate dependencies. `wast` is used in a much older version (`11.0.0`) by `witx`, and can be updated without issues there as well, but this at least gets us from 3 copies to 2.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
  This hasn't been discussed, it's just a bit of maintenance.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
  n/a
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.
