### PR TITLE
wiggle: GuestPtr<[u8]> => GuestPtr<str> conversions 

### DIFF
--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -499,6 +499,12 @@ impl<'a> GuestPtr<'a, str> {
         GuestPtr::new(self.mem, self.pointer)
     }
 
+    /// Returns a raw pointer for the underlying slice of bytes that this
+    /// pointer points to.
+    pub fn as_byte_ptr(&self) -> GuestPtr<'a, [u8]> {
+        GuestPtr::new(self.mem, self.pointer)
+    }
+
     /// Attempts to create a [`GuestStr<'_>`] from this pointer, performing
     /// bounds checks and utf-8 checks. The resulting `GuestStr` can be used
     /// as a `&str` or `&mut str` via the `Deref` and `DerefMut` traits. The

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -536,7 +536,7 @@ impl<'a> GuestPtr<'a, str> {
 impl<'a> GuestPtr<'a, [u8]> {
     /// Returns a raw pointer to the string represented by a `[u8]` without
     /// validating whether each u8 is a utf-8 codepoint.
-    pub fn as_str_ptr(&self) -> GuestPtr<str> {
+    pub fn as_str_ptr(&self) -> GuestPtr<'a, str> {
         GuestPtr::new(self.mem, self.pointer)
     }
 }

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -540,7 +540,7 @@ impl<'a> GuestPtr<'a, str> {
 }
 
 impl<'a> GuestPtr<'a, [u8]> {
-    /// Returns a raw pointer to the string represented by a `[u8]` without
+    /// Returns a pointer to the string represented by a `[u8]` without
     /// validating whether each u8 is a utf-8 codepoint.
     pub fn as_str_ptr(&self) -> GuestPtr<'a, str> {
         GuestPtr::new(self.mem, self.pointer)

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -499,7 +499,7 @@ impl<'a> GuestPtr<'a, str> {
         GuestPtr::new(self.mem, self.pointer)
     }
 
-    /// Returns a raw pointer for the underlying slice of bytes that this
+    /// Returns a pointer for the underlying slice of bytes that this
     /// pointer points to.
     pub fn as_byte_ptr(&self) -> GuestPtr<'a, [u8]> {
         GuestPtr::new(self.mem, self.pointer)

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -533,6 +533,14 @@ impl<'a> GuestPtr<'a, str> {
     }
 }
 
+impl<'a> GuestPtr<'a, [u8]> {
+    /// Returns a raw pointer to the string represented by a `[u8]` without
+    /// validating whether each u8 is a utf-8 codepoint.
+    pub fn as_str_ptr(&self) -> GuestPtr<str> {
+        GuestPtr::new(self.mem, self.pointer)
+    }
+}
+
 impl<T: ?Sized + Pointee> Clone for GuestPtr<'_, T> {
     fn clone(&self) -> Self {
         *self

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -259,7 +259,7 @@ impl<'a, T: ?Sized + Pointee> GuestPtr<'a, T> {
     /// Creates a new `GuestPtr` from the given `mem` and `pointer` values.
     ///
     /// Note that for sized types like `u32`, `GuestPtr<T>`, etc, the `pointer`
-    /// vlue is a `u32` offset into guest memory. For slices and strings,
+    /// value is a `u32` offset into guest memory. For slices and strings,
     /// `pointer` is a `(u32, u32)` offset/length pair.
     pub fn new(mem: &'a (dyn GuestMemory + 'a), pointer: T::Pointer) -> GuestPtr<'a, T> {
         GuestPtr {
@@ -488,7 +488,7 @@ impl<'a> GuestPtr<'a, str> {
         self.pointer.0
     }
 
-    /// Returns the length, in bytes, of th estring.
+    /// Returns the length, in bytes, of the string.
     pub fn len(&self) -> u32 {
         self.pointer.1
     }


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

As requested in #1888, adds a method to convert a `GuestPtr<[u8]>`  to  a `GuestPtr<str>` without first validating that the `[u8]` consists of utf-8 codepoints. The conversion in the other direction already exists as `as_bytes`.

Although unrelated to this PR, while I was in there I found a couple of small typos in the docs so I fixed them.

Resolves #1888.