### PR TITLE
Bind `Trap::i32_exit_status` in C API

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -169,6 +169,15 @@ WASM_API_EXTERN void wasmtime_interrupt_handle_interrupt(wasmtime_interrupt_hand
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+// Extensions to `wasm_trap_t`
+
+// Returns `true` if the trap is a WASI "exit" trap and has a return status. If
+// `true` is returned then the exit status is returned through the `status`
+// pointer. If `false` is returned then this is not a wasi exit trap.
+WASM_API_EXTERN bool wasmtime_trap_exit_status(const wasm_trap_t*, int *status);
+
+///////////////////////////////////////////////////////////////////////////////
+//
 // Extensions to `wasm_frame_t`
 
 WASM_API_EXTERN const wasm_name_t *wasmtime_frame_func_name(const wasm_frame_t*);

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -92,6 +92,18 @@ pub extern "C" fn wasm_trap_trace(raw: &wasm_trap_t, out: &mut wasm_frame_vec_t)
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_trap_exit_status(raw: &wasm_trap_t, status: &mut i32) -> bool {
+    let trap = raw.trap.borrow();
+    match trap.i32_exit_status() {
+        Some(i) => {
+            *status = i;
+            true
+        }
+        None => false,
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn wasm_frame_func_index(frame: &wasm_frame_t) -> u32 {
     frame.trap.borrow().trace()[frame.idx].func_index()
 }


### PR DESCRIPTION
This allows embedders to take a different action when a WASI program
exits depending on whether it exited with an exit status or exited with
a trap.

cc bytecodealliance/wasmtime-py#30
