### PR TITLE
machinst x64: implement calls and int cmp/store/loads;

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -549,9 +549,9 @@ fn define_simd_lane_access(
             r#"
         Vector swizzle.
 
-        Returns a new vector with byte-width lanes selected from the lanes of the first input 
-        vector ``x`` specified in the second input vector ``s``. The indices ``i`` in range 
-        ``[0, 15]`` select the ``i``-th element of ``x``. For indices outside of the range the 
+        Returns a new vector with byte-width lanes selected from the lanes of the first input
+        vector ``x`` specified in the second input vector ``s``. The indices ``i`` in range
+        ``[0, 15]`` select the ``i``-th element of ``x``. For indices outside of the range the
         resulting lane is 0. Note that this operates on byte-width lanes.
         "#,
             &formats.binary,
@@ -1176,7 +1176,7 @@ pub(crate) fn define(
         Inst::new(
             "uload8x8",
             r#"
-        Load an 8x8 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i16x8 
+        Load an 8x8 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i16x8
         vector.
         "#,
             &formats.load,
@@ -1190,7 +1190,7 @@ pub(crate) fn define(
         Inst::new(
             "uload8x8_complex",
             r#"
-        Load an 8x8 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an 
+        Load an 8x8 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an
         i16x8 vector.
         "#,
             &formats.load_complex,
@@ -1204,7 +1204,7 @@ pub(crate) fn define(
         Inst::new(
             "sload8x8",
             r#"
-        Load an 8x8 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i16x8 
+        Load an 8x8 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i16x8
         vector.
         "#,
             &formats.load,
@@ -1218,7 +1218,7 @@ pub(crate) fn define(
         Inst::new(
             "sload8x8_complex",
             r#"
-        Load an 8x8 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an 
+        Load an 8x8 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an
         i16x8 vector.
         "#,
             &formats.load_complex,
@@ -1243,7 +1243,7 @@ pub(crate) fn define(
         Inst::new(
             "uload16x4",
             r#"
-        Load a 16x4 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i32x4 
+        Load a 16x4 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i32x4
         vector.
         "#,
             &formats.load,
@@ -1257,7 +1257,7 @@ pub(crate) fn define(
         Inst::new(
             "uload16x4_complex",
             r#"
-        Load a 16x4 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an 
+        Load a 16x4 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an
         i32x4 vector.
         "#,
             &formats.load_complex,
@@ -1271,7 +1271,7 @@ pub(crate) fn define(
         Inst::new(
             "sload16x4",
             r#"
-        Load a 16x4 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i32x4 
+        Load a 16x4 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i32x4
         vector.
         "#,
             &formats.load,
@@ -1285,7 +1285,7 @@ pub(crate) fn define(
         Inst::new(
             "sload16x4_complex",
             r#"
-        Load a 16x4 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an 
+        Load a 16x4 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an
         i32x4 vector.
         "#,
             &formats.load_complex,
@@ -1310,7 +1310,7 @@ pub(crate) fn define(
         Inst::new(
             "uload32x2",
             r#"
-        Load an 32x2 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i64x2 
+        Load an 32x2 vector (64 bits) from memory at ``p + Offset`` and zero-extend into an i64x2
         vector.
         "#,
             &formats.load,
@@ -1324,7 +1324,7 @@ pub(crate) fn define(
         Inst::new(
             "uload32x2_complex",
             r#"
-        Load a 32x2 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an 
+        Load a 32x2 vector (64 bits) from memory at ``sum(args) + Offset`` and zero-extend into an
         i64x2 vector.
         "#,
             &formats.load_complex,
@@ -1338,7 +1338,7 @@ pub(crate) fn define(
         Inst::new(
             "sload32x2",
             r#"
-        Load a 32x2 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i64x2 
+        Load a 32x2 vector (64 bits) from memory at ``p + Offset`` and sign-extend into an i64x2
         vector.
         "#,
             &formats.load,
@@ -1352,7 +1352,7 @@ pub(crate) fn define(
         Inst::new(
             "sload32x2_complex",
             r#"
-        Load a 32x2 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an 
+        Load a 32x2 vector (64 bits) from memory at ``sum(args) + Offset`` and sign-extend into an
         i64x2 vector.
         "#,
             &formats.load_complex,

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -899,7 +899,7 @@ pub enum Inst {
     },
 
     /// Marker, no-op in generated code: SP "virtual offset" is adjusted. This
-    /// controls MemArg::NominalSPOffset args are lowered.
+    /// controls how MemArg::NominalSPOffset args are lowered.
     VirtualSPOffsetAdj {
         offset: i64,
     },

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -95,82 +95,82 @@ fn test_x64_emit() {
     //
     // Addr_IR, offset zero
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rax), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rax), w_rdi),
         "488B38",
         "movq    0(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rbx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rbx), w_rdi),
         "488B3B",
         "movq    0(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rcx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rcx), w_rdi),
         "488B39",
         "movq    0(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rdx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rdx), w_rdi),
         "488B3A",
         "movq    0(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rbp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rbp), w_rdi),
         "488B7D00",
         "movq    0(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rsp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rsp), w_rdi),
         "488B3C24",
         "movq    0(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rsi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rsi), w_rdi),
         "488B3E",
         "movq    0(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, rdi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, rdi), w_rdi),
         "488B3F",
         "movq    0(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r8), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r8), w_rdi),
         "498B38",
         "movq    0(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r9), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r9), w_rdi),
         "498B39",
         "movq    0(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r10), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r10), w_rdi),
         "498B3A",
         "movq    0(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r11), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r11), w_rdi),
         "498B3B",
         "movq    0(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r12), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r12), w_rdi),
         "498B3C24",
         "movq    0(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r13), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r13), w_rdi),
         "498B7D00",
         "movq    0(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r14), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r14), w_rdi),
         "498B3E",
         "movq    0(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0, r15), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0, r15), w_rdi),
         "498B3F",
         "movq    0(%r15), %rdi",
     ));
@@ -178,82 +178,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset max simm8
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rax), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rax), w_rdi),
         "488B787F",
         "movq    127(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rbx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rbx), w_rdi),
         "488B7B7F",
         "movq    127(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rcx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rcx), w_rdi),
         "488B797F",
         "movq    127(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rdx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rdx), w_rdi),
         "488B7A7F",
         "movq    127(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rbp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rbp), w_rdi),
         "488B7D7F",
         "movq    127(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rsp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rsp), w_rdi),
         "488B7C247F",
         "movq    127(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rsi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rsi), w_rdi),
         "488B7E7F",
         "movq    127(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, rdi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, rdi), w_rdi),
         "488B7F7F",
         "movq    127(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r8), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r8), w_rdi),
         "498B787F",
         "movq    127(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r9), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r9), w_rdi),
         "498B797F",
         "movq    127(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r10), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r10), w_rdi),
         "498B7A7F",
         "movq    127(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r11), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r11), w_rdi),
         "498B7B7F",
         "movq    127(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r12), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r12), w_rdi),
         "498B7C247F",
         "movq    127(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r13), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r13), w_rdi),
         "498B7D7F",
         "movq    127(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r14), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r14), w_rdi),
         "498B7E7F",
         "movq    127(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(127, r15), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(127, r15), w_rdi),
         "498B7F7F",
         "movq    127(%r15), %rdi",
     ));
@@ -261,82 +261,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset min simm8
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rax), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rax), w_rdi),
         "488B7880",
         "movq    -128(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rbx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rbx), w_rdi),
         "488B7B80",
         "movq    -128(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rcx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rcx), w_rdi),
         "488B7980",
         "movq    -128(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rdx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rdx), w_rdi),
         "488B7A80",
         "movq    -128(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rbp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rbp), w_rdi),
         "488B7D80",
         "movq    -128(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rsp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rsp), w_rdi),
         "488B7C2480",
         "movq    -128(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rsi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rsi), w_rdi),
         "488B7E80",
         "movq    -128(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, rdi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rdi), w_rdi),
         "488B7F80",
         "movq    -128(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r8), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r8), w_rdi),
         "498B7880",
         "movq    -128(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r9), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r9), w_rdi),
         "498B7980",
         "movq    -128(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r10), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r10), w_rdi),
         "498B7A80",
         "movq    -128(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r11), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r11), w_rdi),
         "498B7B80",
         "movq    -128(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r12), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r12), w_rdi),
         "498B7C2480",
         "movq    -128(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r13), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r13), w_rdi),
         "498B7D80",
         "movq    -128(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r14), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r14), w_rdi),
         "498B7E80",
         "movq    -128(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-128i32 as u32, r15), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r15), w_rdi),
         "498B7F80",
         "movq    -128(%r15), %rdi",
     ));
@@ -344,82 +344,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset smallest positive simm32
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rax), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rax), w_rdi),
         "488BB880000000",
         "movq    128(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rbx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rbx), w_rdi),
         "488BBB80000000",
         "movq    128(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rcx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rcx), w_rdi),
         "488BB980000000",
         "movq    128(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rdx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rdx), w_rdi),
         "488BBA80000000",
         "movq    128(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rbp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rbp), w_rdi),
         "488BBD80000000",
         "movq    128(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rsp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rsp), w_rdi),
         "488BBC2480000000",
         "movq    128(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rsi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rsi), w_rdi),
         "488BBE80000000",
         "movq    128(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, rdi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, rdi), w_rdi),
         "488BBF80000000",
         "movq    128(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r8), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r8), w_rdi),
         "498BB880000000",
         "movq    128(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r9), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r9), w_rdi),
         "498BB980000000",
         "movq    128(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r10), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r10), w_rdi),
         "498BBA80000000",
         "movq    128(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r11), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r11), w_rdi),
         "498BBB80000000",
         "movq    128(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r12), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r12), w_rdi),
         "498BBC2480000000",
         "movq    128(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r13), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r13), w_rdi),
         "498BBD80000000",
         "movq    128(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r14), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r14), w_rdi),
         "498BBE80000000",
         "movq    128(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(128, r15), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(128, r15), w_rdi),
         "498BBF80000000",
         "movq    128(%r15), %rdi",
     ));
@@ -427,82 +427,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset smallest negative simm32
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rax), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rax), w_rdi),
         "488BB87FFFFFFF",
         "movq    -129(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rbx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rbx), w_rdi),
         "488BBB7FFFFFFF",
         "movq    -129(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rcx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rcx), w_rdi),
         "488BB97FFFFFFF",
         "movq    -129(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rdx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rdx), w_rdi),
         "488BBA7FFFFFFF",
         "movq    -129(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rbp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rbp), w_rdi),
         "488BBD7FFFFFFF",
         "movq    -129(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rsp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rsp), w_rdi),
         "488BBC247FFFFFFF",
         "movq    -129(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rsi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rsi), w_rdi),
         "488BBE7FFFFFFF",
         "movq    -129(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, rdi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rdi), w_rdi),
         "488BBF7FFFFFFF",
         "movq    -129(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r8), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r8), w_rdi),
         "498BB87FFFFFFF",
         "movq    -129(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r9), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r9), w_rdi),
         "498BB97FFFFFFF",
         "movq    -129(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r10), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r10), w_rdi),
         "498BBA7FFFFFFF",
         "movq    -129(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r11), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r11), w_rdi),
         "498BBB7FFFFFFF",
         "movq    -129(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r12), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r12), w_rdi),
         "498BBC247FFFFFFF",
         "movq    -129(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r13), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r13), w_rdi),
         "498BBD7FFFFFFF",
         "movq    -129(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r14), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r14), w_rdi),
         "498BBE7FFFFFFF",
         "movq    -129(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-129i32 as u32, r15), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r15), w_rdi),
         "498BBF7FFFFFFF",
         "movq    -129(%r15), %rdi",
     ));
@@ -510,82 +510,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset large positive simm32
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rax), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rax), w_rdi),
         "488BB877207317",
         "movq    393420919(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rbx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rbx), w_rdi),
         "488BBB77207317",
         "movq    393420919(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rcx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rcx), w_rdi),
         "488BB977207317",
         "movq    393420919(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rdx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rdx), w_rdi),
         "488BBA77207317",
         "movq    393420919(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rbp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rbp), w_rdi),
         "488BBD77207317",
         "movq    393420919(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rsp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rsp), w_rdi),
         "488BBC2477207317",
         "movq    393420919(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rsi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rsi), w_rdi),
         "488BBE77207317",
         "movq    393420919(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, rdi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rdi), w_rdi),
         "488BBF77207317",
         "movq    393420919(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r8), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r8), w_rdi),
         "498BB877207317",
         "movq    393420919(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r9), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r9), w_rdi),
         "498BB977207317",
         "movq    393420919(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r10), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r10), w_rdi),
         "498BBA77207317",
         "movq    393420919(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r11), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r11), w_rdi),
         "498BBB77207317",
         "movq    393420919(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r12), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r12), w_rdi),
         "498BBC2477207317",
         "movq    393420919(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r13), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r13), w_rdi),
         "498BBD77207317",
         "movq    393420919(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r14), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r14), w_rdi),
         "498BBE77207317",
         "movq    393420919(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(0x17732077, r15), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r15), w_rdi),
         "498BBF77207317",
         "movq    393420919(%r15), %rdi",
     ));
@@ -593,82 +593,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset large negative simm32
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rax), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rax), w_rdi),
         "488BB8D9A6BECE",
         "movq    -826366247(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rbx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rbx), w_rdi),
         "488BBBD9A6BECE",
         "movq    -826366247(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rcx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rcx), w_rdi),
         "488BB9D9A6BECE",
         "movq    -826366247(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rdx), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rdx), w_rdi),
         "488BBAD9A6BECE",
         "movq    -826366247(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rbp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rbp), w_rdi),
         "488BBDD9A6BECE",
         "movq    -826366247(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rsp), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rsp), w_rdi),
         "488BBC24D9A6BECE",
         "movq    -826366247(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rsi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rsi), w_rdi),
         "488BBED9A6BECE",
         "movq    -826366247(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, rdi), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rdi), w_rdi),
         "488BBFD9A6BECE",
         "movq    -826366247(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r8), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r8), w_rdi),
         "498BB8D9A6BECE",
         "movq    -826366247(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r9), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r9), w_rdi),
         "498BB9D9A6BECE",
         "movq    -826366247(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r10), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r10), w_rdi),
         "498BBAD9A6BECE",
         "movq    -826366247(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r11), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r11), w_rdi),
         "498BBBD9A6BECE",
         "movq    -826366247(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r12), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r12), w_rdi),
         "498BBC24D9A6BECE",
         "movq    -826366247(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r13), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r13), w_rdi),
         "498BBDD9A6BECE",
         "movq    -826366247(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r14), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r14), w_rdi),
         "498BBED9A6BECE",
         "movq    -826366247(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg(-0x31415927i32 as u32, r15), w_rdi),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r15), w_rdi),
         "498BBFD9A6BECE",
         "movq    -826366247(%r15), %rdi",
     ));
@@ -680,42 +680,42 @@ fn test_x64_emit() {
     //
     // Addr_IRRS, offset max simm8
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, rax, rax, 0), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rax, rax, 0), w_r11),
         "4C8B5C007F",
         "movq    127(%rax,%rax,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, rdi, rax, 1), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rdi, rax, 1), w_r11),
         "4C8B5C477F",
         "movq    127(%rdi,%rax,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, r8, rax, 2), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r8, rax, 2), w_r11),
         "4D8B5C807F",
         "movq    127(%r8,%rax,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, r15, rax, 3), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r15, rax, 3), w_r11),
         "4D8B5CC77F",
         "movq    127(%r15,%rax,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, rax, rdi, 3), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rax, rdi, 3), w_r11),
         "4C8B5CF87F",
         "movq    127(%rax,%rdi,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, rdi, rdi, 2), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rdi, rdi, 2), w_r11),
         "4C8B5CBF7F",
         "movq    127(%rdi,%rdi,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, r8, rdi, 1), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r8, rdi, 1), w_r11),
         "4D8B5C787F",
         "movq    127(%r8,%rdi,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(127, r15, rdi, 0), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r15, rdi, 0), w_r11),
         "4D8B5C3F7F",
         "movq    127(%r15,%rdi,1), %r11",
     ));
@@ -723,42 +723,42 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IRRS, offset min simm8
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, rax, r8, 2), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rax, r8, 2), w_r11),
         "4E8B5C8080",
         "movq    -128(%rax,%r8,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, rdi, r8, 3), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rdi, r8, 3), w_r11),
         "4E8B5CC780",
         "movq    -128(%rdi,%r8,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, r8, r8, 0), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r8, r8, 0), w_r11),
         "4F8B5C0080",
         "movq    -128(%r8,%r8,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, r15, r8, 1), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r15, r8, 1), w_r11),
         "4F8B5C4780",
         "movq    -128(%r15,%r8,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, rax, r15, 1), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rax, r15, 1), w_r11),
         "4E8B5C7880",
         "movq    -128(%rax,%r15,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, rdi, r15, 0), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rdi, r15, 0), w_r11),
         "4E8B5C3F80",
         "movq    -128(%rdi,%r15,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, r8, r15, 3), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r8, r15, 3), w_r11),
         "4F8B5CF880",
         "movq    -128(%r8,%r15,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(-128i32 as u32, r15, r15, 2), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r15, r15, 2), w_r11),
         "4F8B5CBF80",
         "movq    -128(%r15,%r15,4), %r11",
     ));
@@ -766,42 +766,42 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IRRS, offset large positive simm32
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, rax, rax, 0), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rax, rax, 0), w_r11),
         "4C8B9C00BE25664F",
         "movq    1332094398(%rax,%rax,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, rdi, rax, 1), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rdi, rax, 1), w_r11),
         "4C8B9C47BE25664F",
         "movq    1332094398(%rdi,%rax,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, r8, rax, 2), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r8, rax, 2), w_r11),
         "4D8B9C80BE25664F",
         "movq    1332094398(%r8,%rax,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, r15, rax, 3), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r15, rax, 3), w_r11),
         "4D8B9CC7BE25664F",
         "movq    1332094398(%r15,%rax,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, rax, rdi, 3), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rax, rdi, 3), w_r11),
         "4C8B9CF8BE25664F",
         "movq    1332094398(%rax,%rdi,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, rdi, rdi, 2), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rdi, rdi, 2), w_r11),
         "4C8B9CBFBE25664F",
         "movq    1332094398(%rdi,%rdi,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, r8, rdi, 1), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r8, rdi, 1), w_r11),
         "4D8B9C78BE25664F",
         "movq    1332094398(%r8,%rdi,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(0x4f6625be, r15, rdi, 0), w_r11),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r15, rdi, 0), w_r11),
         "4D8B9C3FBE25664F",
         "movq    1332094398(%r15,%rdi,1), %r11",
     ));
@@ -810,7 +810,7 @@ fn test_x64_emit() {
     // Addr_IRRS, offset large negative simm32
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, rax, r8, 2),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rax, r8, 2),
             w_r11,
         ),
         "4E8B9C8070E9B2D9",
@@ -818,7 +818,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, rdi, r8, 3),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rdi, r8, 3),
             w_r11,
         ),
         "4E8B9CC770E9B2D9",
@@ -826,7 +826,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, r8, r8, 0),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r8, r8, 0),
             w_r11,
         ),
         "4F8B9C0070E9B2D9",
@@ -834,7 +834,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, r15, r8, 1),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r15, r8, 1),
             w_r11,
         ),
         "4F8B9C4770E9B2D9",
@@ -842,7 +842,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, rax, r15, 1),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rax, r15, 1),
             w_r11,
         ),
         "4E8B9C7870E9B2D9",
@@ -850,7 +850,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, rdi, r15, 0),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rdi, r15, 0),
             w_r11,
         ),
         "4E8B9C3F70E9B2D9",
@@ -858,7 +858,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, r8, r15, 3),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r8, r15, 3),
             w_r11,
         ),
         "4F8B9CF870E9B2D9",
@@ -866,7 +866,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Addr::imm_reg_reg_shift(-0x264d1690i32 as u32, r15, r15, 2),
+            Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r15, r15, 2),
             w_r11,
         ),
         "4F8B9CBF70E9B2D9",
@@ -900,7 +900,7 @@ fn test_x64_emit() {
         Inst::alu_rmi_r(
             true,
             AluRmiROpcode::Add,
-            RegMemImm::mem(Addr::imm_reg(99, rdi)),
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rdx,
         ),
         "48035763",
@@ -910,7 +910,7 @@ fn test_x64_emit() {
         Inst::alu_rmi_r(
             false,
             AluRmiROpcode::Add,
-            RegMemImm::mem(Addr::imm_reg(99, rdi)),
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_r8,
         ),
         "44034763",
@@ -920,7 +920,7 @@ fn test_x64_emit() {
         Inst::alu_rmi_r(
             false,
             AluRmiROpcode::Add,
-            RegMemImm::mem(Addr::imm_reg(99, rdi)),
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rsi,
         ),
         "037763",
@@ -1047,7 +1047,7 @@ fn test_x64_emit() {
         Inst::alu_rmi_r(
             true,
             AluRmiROpcode::Mul,
-            RegMemImm::mem(Addr::imm_reg(99, rdi)),
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rdx,
         ),
         "480FAF5763",
@@ -1057,7 +1057,7 @@ fn test_x64_emit() {
         Inst::alu_rmi_r(
             false,
             AluRmiROpcode::Mul,
-            RegMemImm::mem(Addr::imm_reg(99, rdi)),
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_r8,
         ),
         "440FAF4763",
@@ -1067,7 +1067,7 @@ fn test_x64_emit() {
         Inst::alu_rmi_r(
             false,
             AluRmiROpcode::Mul,
-            RegMemImm::mem(Addr::imm_reg(99, rdi)),
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rsi,
         ),
         "0FAF7763",
@@ -1242,104 +1242,229 @@ fn test_x64_emit() {
     ));
 
     // ========================================================
-    // MovZX_M_R
+    // MovZX_RM_R
     insns.push((
-        Inst::movzx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(rax), w_rsi),
+        "0FB6F0",
+        "movzbl  %al, %esi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(r15), w_rsi),
+        "410FB6F7",
+        "movzbl  %r15b, %esi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "0FB671F9",
         "movzbl  -7(%rcx), %esi",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movzx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "410FB658F9",
         "movzbl  -7(%r8), %ebx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movzx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "450FB64AF9",
         "movzbl  -7(%r10), %r9d",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movzx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "410FB653F9",
         "movzbl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movzx_rm_r(ExtMode::BQ, RegMem::reg(rax), w_rsi),
+        "480FB6F0",
+        "movzbq  %al, %rsi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(ExtMode::BQ, RegMem::reg(r10), w_rsi),
+        "490FB6F2",
+        "movzbq  %r10b, %rsi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "480FB671F9",
         "movzbq  -7(%rcx), %rsi",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movzx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "490FB658F9",
         "movzbq  -7(%r8), %rbx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movzx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "4D0FB64AF9",
         "movzbq  -7(%r10), %r9",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movzx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "490FB653F9",
         "movzbq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movzx_rm_r(ExtMode::WL, RegMem::reg(rcx), w_rsi),
+        "0FB7F1",
+        "movzwl  %cx, %esi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(ExtMode::WL, RegMem::reg(r10), w_rsi),
+        "410FB7F2",
+        "movzwl  %r10w, %esi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "0FB771F9",
         "movzwl  -7(%rcx), %esi",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movzx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "410FB758F9",
         "movzwl  -7(%r8), %ebx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movzx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "450FB74AF9",
         "movzwl  -7(%r10), %r9d",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movzx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "410FB753F9",
         "movzwl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movzx_rm_r(ExtMode::WQ, RegMem::reg(rcx), w_rsi),
+        "480FB7F1",
+        "movzwq  %cx, %rsi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(ExtMode::WQ, RegMem::reg(r11), w_rsi),
+        "490FB7F3",
+        "movzwq  %r11w, %rsi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "480FB771F9",
         "movzwq  -7(%rcx), %rsi",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movzx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "490FB758F9",
         "movzwq  -7(%r8), %rbx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movzx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "4D0FB74AF9",
         "movzwq  -7(%r10), %r9",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movzx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "490FB753F9",
         "movzwq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movzx_rm_r(ExtMode::LQ, RegMem::reg(rcx), w_rsi),
+        "8BF1",
+        "movl    %ecx, %esi",
+    ));
+    insns.push((
+        Inst::movzx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "8B71F9",
         "movl    -7(%rcx), %esi",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movzx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "418B58F9",
         "movl    -7(%r8), %ebx",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movzx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "458B4AF9",
         "movl    -7(%r10), %r9d",
     ));
     insns.push((
-        Inst::movzx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movzx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "418B53F9",
         "movl    -7(%r11), %edx",
     ));
@@ -1347,145 +1472,293 @@ fn test_x64_emit() {
     // ========================================================
     // Mov64_M_R
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, rax, rbx, 0), w_rcx),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, rbx, 0), w_rcx),
         "488B8C18B3000000",
         "movq    179(%rax,%rbx,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, rax, rbx, 0), w_r8),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, rbx, 0), w_r8),
         "4C8B8418B3000000",
         "movq    179(%rax,%rbx,1), %r8",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, rax, r9, 0), w_rcx),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, r9, 0), w_rcx),
         "4A8B8C08B3000000",
         "movq    179(%rax,%r9,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, rax, r9, 0), w_r8),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, r9, 0), w_r8),
         "4E8B8408B3000000",
         "movq    179(%rax,%r9,1), %r8",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, r10, rbx, 0), w_rcx),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, rbx, 0), w_rcx),
         "498B8C1AB3000000",
         "movq    179(%r10,%rbx,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, r10, rbx, 0), w_r8),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, rbx, 0), w_r8),
         "4D8B841AB3000000",
         "movq    179(%r10,%rbx,1), %r8",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, r10, r9, 0), w_rcx),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, r9, 0), w_rcx),
         "4B8B8C0AB3000000",
         "movq    179(%r10,%r9,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Addr::imm_reg_reg_shift(179, r10, r9, 0), w_r8),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, r9, 0), w_r8),
         "4F8B840AB3000000",
         "movq    179(%r10,%r9,1), %r8",
     ));
 
     // ========================================================
-    // MovSX_M_R
+    // LoadEffectiveAddress
     insns.push((
-        Inst::movsx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::lea(Amode::imm_reg(42, r10), w_r8),
+        "4D8D422A",
+        "lea     42(%r10), %r8",
+    ));
+    insns.push((
+        Inst::lea(Amode::imm_reg(42, r10), w_r15),
+        "4D8D7A2A",
+        "lea     42(%r10), %r15",
+    ));
+    insns.push((
+        Inst::lea(Amode::imm_reg_reg_shift(179, r10, r9, 0), w_r8),
+        "4F8D840AB3000000",
+        "lea     179(%r10,%r9,1), %r8",
+    ));
+
+    // ========================================================
+    // MovSX_RM_R
+    insns.push((
+        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(rcx), w_rsi),
+        "0FBEF1",
+        "movsbl  %cl, %esi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(r14), w_rsi),
+        "410FBEF6",
+        "movsbl  %r14b, %esi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "0FBE71F9",
         "movsbl  -7(%rcx), %esi",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movsx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "410FBE58F9",
         "movsbl  -7(%r8), %ebx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movsx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "450FBE4AF9",
         "movsbl  -7(%r10), %r9d",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::BL, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movsx_rm_r(
+            ExtMode::BL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "410FBE53F9",
         "movsbl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movsx_rm_r(ExtMode::BQ, RegMem::reg(rcx), w_rsi),
+        "480FBEF1",
+        "movsbq  %cl, %rsi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(ExtMode::BQ, RegMem::reg(r15), w_rsi),
+        "490FBEF7",
+        "movsbq  %r15b, %rsi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "480FBE71F9",
         "movsbq  -7(%rcx), %rsi",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movsx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "490FBE58F9",
         "movsbq  -7(%r8), %rbx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movsx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "4D0FBE4AF9",
         "movsbq  -7(%r10), %r9",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::BQ, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movsx_rm_r(
+            ExtMode::BQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "490FBE53F9",
         "movsbq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movsx_rm_r(ExtMode::WL, RegMem::reg(rcx), w_rsi),
+        "0FBFF1",
+        "movswl  %cx, %esi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(ExtMode::WL, RegMem::reg(r14), w_rsi),
+        "410FBFF6",
+        "movswl  %r14w, %esi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "0FBF71F9",
         "movswl  -7(%rcx), %esi",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movsx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "410FBF58F9",
         "movswl  -7(%r8), %ebx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movsx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "450FBF4AF9",
         "movswl  -7(%r10), %r9d",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WL, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movsx_rm_r(
+            ExtMode::WL,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "410FBF53F9",
         "movswl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movsx_rm_r(ExtMode::WQ, RegMem::reg(rcx), w_rsi),
+        "480FBFF1",
+        "movswq  %cx, %rsi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(ExtMode::WQ, RegMem::reg(r13), w_rsi),
+        "490FBFF5",
+        "movswq  %r13w, %rsi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "480FBF71F9",
         "movswq  -7(%rcx), %rsi",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movsx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "490FBF58F9",
         "movswq  -7(%r8), %rbx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movsx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "4D0FBF4AF9",
         "movswq  -7(%r10), %r9",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::WQ, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movsx_rm_r(
+            ExtMode::WQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "490FBF53F9",
         "movswq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, rcx), w_rsi),
+        Inst::movsx_rm_r(ExtMode::LQ, RegMem::reg(rcx), w_rsi),
+        "4863F1",
+        "movslq  %ecx, %rsi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(ExtMode::LQ, RegMem::reg(r15), w_rsi),
+        "4963F7",
+        "movslq  %r15d, %rsi",
+    ));
+    insns.push((
+        Inst::movsx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
+            w_rsi,
+        ),
         "486371F9",
         "movslq  -7(%rcx), %rsi",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, r8), w_rbx),
+        Inst::movsx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
+            w_rbx,
+        ),
         "496358F9",
         "movslq  -7(%r8), %rbx",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, r10), w_r9),
+        Inst::movsx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
+            w_r9,
+        ),
         "4D634AF9",
         "movslq  -7(%r10), %r9",
     ));
     insns.push((
-        Inst::movsx_m_r(ExtMode::LQ, Addr::imm_reg(-7i32 as u32, r11), w_rdx),
+        Inst::movsx_rm_r(
+            ExtMode::LQ,
+            RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
+            w_rdx,
+        ),
         "496353F9",
         "movslq  -7(%r11), %rdx",
     ));
@@ -1493,325 +1766,325 @@ fn test_x64_emit() {
     // ========================================================
     // Mov_R_M.  Byte stores are tricky.  Check everything carefully.
     insns.push((
-        Inst::mov_r_m(8, rax, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(8, rax, Amode::imm_reg(99, rdi)),
         "48894763",
         "movq    %rax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rbx, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(8, rbx, Amode::imm_reg(99, r8)),
         "49895863",
         "movq    %rbx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rcx, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(8, rcx, Amode::imm_reg(99, rsi)),
         "48894E63",
         "movq    %rcx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rdx, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(8, rdx, Amode::imm_reg(99, r9)),
         "49895163",
         "movq    %rdx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rsi, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(8, rsi, Amode::imm_reg(99, rax)),
         "48897063",
         "movq    %rsi, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rdi, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(8, rdi, Amode::imm_reg(99, r15)),
         "49897F63",
         "movq    %rdi, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rsp, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(8, rsp, Amode::imm_reg(99, rcx)),
         "48896163",
         "movq    %rsp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rbp, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(8, rbp, Amode::imm_reg(99, r14)),
         "49896E63",
         "movq    %rbp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r8, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(8, r8, Amode::imm_reg(99, rdi)),
         "4C894763",
         "movq    %r8, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r9, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(8, r9, Amode::imm_reg(99, r8)),
         "4D894863",
         "movq    %r9, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r10, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(8, r10, Amode::imm_reg(99, rsi)),
         "4C895663",
         "movq    %r10, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r11, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(8, r11, Amode::imm_reg(99, r9)),
         "4D895963",
         "movq    %r11, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r12, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(8, r12, Amode::imm_reg(99, rax)),
         "4C896063",
         "movq    %r12, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r13, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(8, r13, Amode::imm_reg(99, r15)),
         "4D896F63",
         "movq    %r13, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r14, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(8, r14, Amode::imm_reg(99, rcx)),
         "4C897163",
         "movq    %r14, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r15, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(8, r15, Amode::imm_reg(99, r14)),
         "4D897E63",
         "movq    %r15, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(4, rax, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(4, rax, Amode::imm_reg(99, rdi)),
         "894763",
         "movl    %eax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rbx, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(4, rbx, Amode::imm_reg(99, r8)),
         "41895863",
         "movl    %ebx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rcx, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(4, rcx, Amode::imm_reg(99, rsi)),
         "894E63",
         "movl    %ecx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rdx, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(4, rdx, Amode::imm_reg(99, r9)),
         "41895163",
         "movl    %edx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rsi, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(4, rsi, Amode::imm_reg(99, rax)),
         "897063",
         "movl    %esi, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rdi, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(4, rdi, Amode::imm_reg(99, r15)),
         "41897F63",
         "movl    %edi, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rsp, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(4, rsp, Amode::imm_reg(99, rcx)),
         "896163",
         "movl    %esp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rbp, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(4, rbp, Amode::imm_reg(99, r14)),
         "41896E63",
         "movl    %ebp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r8, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(4, r8, Amode::imm_reg(99, rdi)),
         "44894763",
         "movl    %r8d, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r9, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(4, r9, Amode::imm_reg(99, r8)),
         "45894863",
         "movl    %r9d, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r10, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(4, r10, Amode::imm_reg(99, rsi)),
         "44895663",
         "movl    %r10d, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r11, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(4, r11, Amode::imm_reg(99, r9)),
         "45895963",
         "movl    %r11d, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r12, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(4, r12, Amode::imm_reg(99, rax)),
         "44896063",
         "movl    %r12d, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r13, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(4, r13, Amode::imm_reg(99, r15)),
         "45896F63",
         "movl    %r13d, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r14, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(4, r14, Amode::imm_reg(99, rcx)),
         "44897163",
         "movl    %r14d, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r15, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(4, r15, Amode::imm_reg(99, r14)),
         "45897E63",
         "movl    %r15d, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(2, rax, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(2, rax, Amode::imm_reg(99, rdi)),
         "66894763",
         "movw    %ax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rbx, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(2, rbx, Amode::imm_reg(99, r8)),
         "6641895863",
         "movw    %bx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rcx, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(2, rcx, Amode::imm_reg(99, rsi)),
         "66894E63",
         "movw    %cx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rdx, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(2, rdx, Amode::imm_reg(99, r9)),
         "6641895163",
         "movw    %dx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rsi, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(2, rsi, Amode::imm_reg(99, rax)),
         "66897063",
         "movw    %si, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rdi, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(2, rdi, Amode::imm_reg(99, r15)),
         "6641897F63",
         "movw    %di, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rsp, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(2, rsp, Amode::imm_reg(99, rcx)),
         "66896163",
         "movw    %sp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rbp, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(2, rbp, Amode::imm_reg(99, r14)),
         "6641896E63",
         "movw    %bp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r8, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(2, r8, Amode::imm_reg(99, rdi)),
         "6644894763",
         "movw    %r8w, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r9, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(2, r9, Amode::imm_reg(99, r8)),
         "6645894863",
         "movw    %r9w, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r10, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(2, r10, Amode::imm_reg(99, rsi)),
         "6644895663",
         "movw    %r10w, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r11, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(2, r11, Amode::imm_reg(99, r9)),
         "6645895963",
         "movw    %r11w, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r12, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(2, r12, Amode::imm_reg(99, rax)),
         "6644896063",
         "movw    %r12w, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r13, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(2, r13, Amode::imm_reg(99, r15)),
         "6645896F63",
         "movw    %r13w, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r14, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(2, r14, Amode::imm_reg(99, rcx)),
         "6644897163",
         "movw    %r14w, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r15, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(2, r15, Amode::imm_reg(99, r14)),
         "6645897E63",
         "movw    %r15w, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(1, rax, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(1, rax, Amode::imm_reg(99, rdi)),
         "884763",
         "movb    %al, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rbx, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(1, rbx, Amode::imm_reg(99, r8)),
         "41885863",
         "movb    %bl, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rcx, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(1, rcx, Amode::imm_reg(99, rsi)),
         "884E63",
         "movb    %cl, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rdx, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(1, rdx, Amode::imm_reg(99, r9)),
         "41885163",
         "movb    %dl, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rsi, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(1, rsi, Amode::imm_reg(99, rax)),
         "40887063",
         "movb    %sil, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rdi, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(1, rdi, Amode::imm_reg(99, r15)),
         "41887F63",
         "movb    %dil, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rsp, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(1, rsp, Amode::imm_reg(99, rcx)),
         "40886163",
         "movb    %spl, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rbp, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(1, rbp, Amode::imm_reg(99, r14)),
         "41886E63",
         "movb    %bpl, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r8, Addr::imm_reg(99, rdi)),
+        Inst::mov_r_m(1, r8, Amode::imm_reg(99, rdi)),
         "44884763",
         "movb    %r8b, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r9, Addr::imm_reg(99, r8)),
+        Inst::mov_r_m(1, r9, Amode::imm_reg(99, r8)),
         "45884863",
         "movb    %r9b, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r10, Addr::imm_reg(99, rsi)),
+        Inst::mov_r_m(1, r10, Amode::imm_reg(99, rsi)),
         "44885663",
         "movb    %r10b, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r11, Addr::imm_reg(99, r9)),
+        Inst::mov_r_m(1, r11, Amode::imm_reg(99, r9)),
         "45885963",
         "movb    %r11b, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r12, Addr::imm_reg(99, rax)),
+        Inst::mov_r_m(1, r12, Amode::imm_reg(99, rax)),
         "44886063",
         "movb    %r12b, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r13, Addr::imm_reg(99, r15)),
+        Inst::mov_r_m(1, r13, Amode::imm_reg(99, r15)),
         "45886F63",
         "movb    %r13b, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r14, Addr::imm_reg(99, rcx)),
+        Inst::mov_r_m(1, r14, Amode::imm_reg(99, rcx)),
         "44887163",
         "movb    %r14b, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r15, Addr::imm_reg(99, r14)),
+        Inst::mov_r_m(1, r15, Amode::imm_reg(99, r14)),
         "45887E63",
         "movb    %r15b, 99(%r14)",
     ));
@@ -1942,17 +2215,17 @@ fn test_x64_emit() {
         "cmpq    %rcx, %rsi",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::mem(Addr::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(8, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
         "483B5763",
         "cmpq    99(%rdi), %rdx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::mem(Addr::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(8, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
         "4C3B4763",
         "cmpq    99(%rdi), %r8",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::mem(Addr::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(8, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
         "483B7763",
         "cmpq    99(%rdi), %rsi",
     ));
@@ -1988,17 +2261,17 @@ fn test_x64_emit() {
         "cmpl    %ecx, %esi",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::mem(Addr::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(4, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
         "3B5763",
         "cmpl    99(%rdi), %edx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::mem(Addr::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(4, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
         "443B4763",
         "cmpl    99(%rdi), %r8d",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::mem(Addr::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(4, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
         "3B7763",
         "cmpl    99(%rdi), %esi",
     ));
@@ -2034,17 +2307,17 @@ fn test_x64_emit() {
         "cmpw    %cx, %si",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::mem(Addr::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(2, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
         "663B5763",
         "cmpw    99(%rdi), %dx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::mem(Addr::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(2, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
         "66443B4763",
         "cmpw    99(%rdi), %r8w",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::mem(Addr::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(2, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
         "663B7763",
         "cmpw    99(%rdi), %si",
     ));
@@ -2080,17 +2353,17 @@ fn test_x64_emit() {
         "cmpb    %cl, %sil",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::mem(Addr::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(1, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
         "3A5763",
         "cmpb    99(%rdi), %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::mem(Addr::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(1, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
         "443A4763",
         "cmpb    99(%rdi), %r8b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::mem(Addr::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(1, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
         "403A7763",
         "cmpb    99(%rdi), %sil",
     ));
@@ -2202,16 +2475,23 @@ fn test_x64_emit() {
     ));
 
     // ========================================================
+    // SetCC
+    insns.push((Inst::setcc(CC::O, w_rsi), "400F90C6", "seto    %sil"));
+    insns.push((Inst::setcc(CC::NLE, w_rsi), "400F9FC6", "setnle  %sil"));
+    insns.push((Inst::setcc(CC::Z, w_r14), "410F94C6", "setz    %r14b"));
+    insns.push((Inst::setcc(CC::LE, w_r14), "410F9EC6", "setle   %r14b"));
+
+    // ========================================================
     // Push64
     insns.push((Inst::push64(RegMemImm::reg(rdi)), "57", "pushq   %rdi"));
     insns.push((Inst::push64(RegMemImm::reg(r8)), "4150", "pushq   %r8"));
     insns.push((
-        Inst::push64(RegMemImm::mem(Addr::imm_reg_reg_shift(321, rsi, rcx, 3))),
+        Inst::push64(RegMemImm::mem(Amode::imm_reg_reg_shift(321, rsi, rcx, 3))),
         "FFB4CE41010000",
         "pushq   321(%rsi,%rcx,8)",
     ));
     insns.push((
-        Inst::push64(RegMemImm::mem(Addr::imm_reg_reg_shift(321, r9, rbx, 2))),
+        Inst::push64(RegMemImm::mem(Amode::imm_reg_reg_shift(321, r9, rbx, 2))),
         "41FFB49941010000",
         "pushq   321(%r9,%rbx,4)",
     ));
@@ -2251,27 +2531,43 @@ fn test_x64_emit() {
     insns.push((Inst::pop64(w_r15), "415F", "popq    %r15"));
 
     // ========================================================
-    // CallKnown skipped for now
+    // CallKnown
+    insns.push((
+        Inst::call_known(
+            ExternalName::User {
+                namespace: 0,
+                index: 0,
+            },
+            Vec::new(),
+            Vec::new(),
+            SourceLoc::default(),
+            Opcode::Call,
+        ),
+        "E800000000",
+        "call    User { namespace: 0, index: 0 }",
+    ));
 
     // ========================================================
     // CallUnknown
+    fn call_unknown(rm: RegMem) -> Inst {
+        Inst::call_unknown(
+            rm,
+            Vec::new(),
+            Vec::new(),
+            SourceLoc::default(),
+            Opcode::CallIndirect,
+        )
+    }
+
+    insns.push((call_unknown(RegMem::reg(rbp)), "FFD5", "call    *%rbp"));
+    insns.push((call_unknown(RegMem::reg(r11)), "41FFD3", "call    *%r11"));
     insns.push((
-        Inst::call_unknown(RegMem::reg(rbp)),
-        "FFD5",
-        "call    *%rbp",
-    ));
-    insns.push((
-        Inst::call_unknown(RegMem::reg(r11)),
-        "41FFD3",
-        "call    *%r11",
-    ));
-    insns.push((
-        Inst::call_unknown(RegMem::mem(Addr::imm_reg_reg_shift(321, rsi, rcx, 3))),
+        call_unknown(RegMem::mem(Amode::imm_reg_reg_shift(321, rsi, rcx, 3))),
         "FF94CE41010000",
         "call    *321(%rsi,%rcx,8)",
     ));
     insns.push((
-        Inst::call_unknown(RegMem::mem(Addr::imm_reg_reg_shift(321, r10, rdx, 2))),
+        call_unknown(RegMem::mem(Amode::imm_reg_reg_shift(321, r10, rdx, 2))),
         "41FF949241010000",
         "call    *321(%r10,%rdx,4)",
     ));
@@ -2301,12 +2597,12 @@ fn test_x64_emit() {
         "jmp     *%r11",
     ));
     insns.push((
-        Inst::jmp_unknown(RegMem::mem(Addr::imm_reg_reg_shift(321, rsi, rcx, 3))),
+        Inst::jmp_unknown(RegMem::mem(Amode::imm_reg_reg_shift(321, rsi, rcx, 3))),
         "FFA4CE41010000",
         "jmp     *321(%rsi,%rcx,8)",
     ));
     insns.push((
-        Inst::jmp_unknown(RegMem::mem(Addr::imm_reg_reg_shift(321, r10, rdx, 2))),
+        Inst::jmp_unknown(RegMem::mem(Amode::imm_reg_reg_shift(321, r10, rdx, 2))),
         "41FFA49241010000",
         "jmp     *321(%r10,%rdx,4)",
     ));
@@ -2337,7 +2633,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::xmm_rm_r(
             SseOpcode::Addss,
-            RegMem::mem(Addr::imm_reg_reg_shift(123, r10, rdx, 2)),
+            RegMem::mem(Amode::imm_reg_reg_shift(123, r10, rdx, 2)),
             w_xmm0,
         ),
         "F3410F5844927B",
@@ -2346,7 +2642,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::xmm_rm_r(
             SseOpcode::Subss,
-            RegMem::mem(Addr::imm_reg_reg_shift(321, r10, rax, 3)),
+            RegMem::mem(Amode::imm_reg_reg_shift(321, r10, rax, 3)),
             w_xmm10,
         ),
         "F3450F5C94C241010000",
@@ -2409,6 +2705,14 @@ fn test_x64_emit() {
     ));
 
     // ========================================================
+    // Misc instructions.
+
+    insns.push((Inst::Hlt, "CC", "hlt"));
+
+    let trap_info = (SourceLoc::default(), TrapCode::UnreachableCodeReached);
+    insns.push((Inst::Ud2 { trap_info }, "0F0B", "ud2 unreachable"));
+
+    // ========================================================
     // Actually run the tests!
     let flags = settings::Flags::new(settings::builder());
     let rru = regs::create_reg_universe_systemv(&flags);
@@ -2422,6 +2726,6 @@ fn test_x64_emit() {
         let buffer = buffer.finish();
         buffer.emit(&mut sink);
         let actual_encoding = &sink.stringify();
-        assert_eq!(expected_encoding, actual_encoding);
+        assert_eq!(expected_encoding, actual_encoding, "{}", expected_printing);
     }
 }

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -1,20 +1,22 @@
 //! Lowering rules for X64.
 
-#![allow(dead_code)]
 #![allow(non_snake_case)]
 
 use log::trace;
 use regalloc::{Reg, RegClass, Writable};
+use smallvec::SmallVec;
+use std::convert::TryFrom;
 
 use crate::ir::types;
 use crate::ir::types::*;
 use crate::ir::Inst as IRInst;
-use crate::ir::{condcodes::IntCC, InstructionData, Opcode, Type};
+use crate::ir::{condcodes::IntCC, InstructionData, Opcode, TrapCode, Type};
 
 use crate::machinst::lower::*;
 use crate::machinst::*;
 use crate::result::CodegenResult;
 
+use crate::isa::x64::abi::*;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::x64::X64Backend;
@@ -28,6 +30,20 @@ type Ctx<'a> = &'a mut dyn LowerCtx<I = Inst>;
 fn is_int_ty(ty: Type) -> bool {
     match ty {
         types::I8 | types::I16 | types::I32 | types::I64 => true,
+        _ => false,
+    }
+}
+
+fn is_bool_ty(ty: Type) -> bool {
+    match ty {
+        types::B1 | types::B8 | types::B16 | types::B32 | types::B64 => true,
+        _ => false,
+    }
+}
+
+fn is_float_ty(ty: Type) -> bool {
+    match ty {
+        types::F32 | types::F64 => true,
         _ => false,
     }
 }
@@ -48,29 +64,17 @@ fn flt_ty_is_64(ty: Type) -> bool {
     }
 }
 
-fn int_ty_to_sizeB(ty: Type) -> u8 {
-    match ty {
-        types::I8 => 1,
-        types::I16 => 2,
-        types::I32 => 4,
-        types::I64 => 8,
-        _ => panic!("ity_to_sizeB"),
-    }
+fn iri_to_u64_imm(ctx: Ctx, inst: IRInst) -> Option<u64> {
+    ctx.get_constant(inst)
 }
 
-fn iri_to_u64_immediate<'a>(ctx: Ctx<'a>, iri: IRInst) -> Option<u64> {
-    let inst_data = ctx.data(iri);
-    if inst_data.opcode() == Opcode::Null {
-        Some(0)
-    } else {
-        match inst_data {
-            &InstructionData::UnaryImm { opcode: _, imm } => {
-                // Only has Into for i64; we use u64 elsewhere, so we cast.
-                let imm: i64 = imm.into();
-                Some(imm as u64)
-            }
-            _ => None,
-        }
+fn inst_trapcode(data: &InstructionData) -> Option<TrapCode> {
+    match data {
+        &InstructionData::Trap { code, .. }
+        | &InstructionData::CondTrap { code, .. }
+        | &InstructionData::IntCondTrap { code, .. }
+        | &InstructionData::FloatCondTrap { code, .. } => Some(code),
+        _ => None,
     }
 }
 
@@ -87,36 +91,88 @@ fn inst_condcode(data: &InstructionData) -> IntCC {
     }
 }
 
-fn input_to_reg<'a>(ctx: Ctx<'a>, iri: IRInst, input: usize) -> Reg {
-    let inputs = ctx.get_input(iri, input);
+fn ldst_offset(data: &InstructionData) -> Option<i32> {
+    match data {
+        &InstructionData::Load { offset, .. }
+        | &InstructionData::StackLoad { offset, .. }
+        | &InstructionData::LoadComplex { offset, .. }
+        | &InstructionData::Store { offset, .. }
+        | &InstructionData::StackStore { offset, .. }
+        | &InstructionData::StoreComplex { offset, .. } => Some(offset.into()),
+        _ => None,
+    }
+}
+
+/// Identifier for a particular input of an instruction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InsnInput {
+    insn: IRInst,
+    input: usize,
+}
+
+/// Identifier for a particular output of an instruction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InsnOutput {
+    insn: IRInst,
+    output: usize,
+}
+
+fn input_to_reg<'a>(ctx: Ctx<'a>, spec: InsnInput) -> Reg {
+    let inputs = ctx.get_input(spec.insn, spec.input);
     ctx.use_input_reg(inputs);
     inputs.reg
 }
 
-fn output_to_reg<'a>(ctx: Ctx<'a>, iri: IRInst, output: usize) -> Writable<Reg> {
-    ctx.get_output(iri, output)
+/// Try to use an immediate for constant inputs, and a register otherwise.
+/// TODO: handle memory as well!
+fn input_to_reg_mem_imm(ctx: Ctx, spec: InsnInput) -> RegMemImm {
+    let imm = ctx.get_input(spec.insn, spec.input).constant.and_then(|x| {
+        let as_u32 = x as u32;
+        let extended = as_u32 as u64;
+        // If the truncation and sign-extension don't change the value, use it.
+        if extended == x {
+            Some(as_u32)
+        } else {
+            None
+        }
+    });
+    match imm {
+        Some(x) => RegMemImm::imm(x),
+        None => RegMemImm::reg(input_to_reg(ctx, spec)),
+    }
+}
+
+fn output_to_reg<'a>(ctx: Ctx<'a>, spec: InsnOutput) -> Writable<Reg> {
+    ctx.get_output(spec.insn, spec.output)
 }
 
 //=============================================================================
 // Top-level instruction lowering entry point, for one instruction.
 
 /// Actually codegen an instruction's results into registers.
-fn lower_insn_to_regs<'a>(ctx: Ctx<'a>, inst: IRInst) {
-    let op = ctx.data(inst).opcode();
-    let ty = if ctx.num_outputs(inst) == 1 {
-        Some(ctx.output_ty(inst, 0))
+fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) -> CodegenResult<()> {
+    let op = ctx.data(insn).opcode();
+
+    let inputs: SmallVec<[InsnInput; 4]> = (0..ctx.num_inputs(insn))
+        .map(|i| InsnInput { insn, input: i })
+        .collect();
+    let outputs: SmallVec<[InsnOutput; 2]> = (0..ctx.num_outputs(insn))
+        .map(|i| InsnOutput { insn, output: i })
+        .collect();
+
+    let ty = if outputs.len() > 0 {
+        Some(ctx.output_ty(insn, 0))
     } else {
         None
     };
 
-    // This is all outstandingly feeble.  TODO: much better!
     match op {
         Opcode::Iconst => {
-            if let Some(w64) = iri_to_u64_immediate(ctx, inst) {
+            if let Some(w64) = iri_to_u64_imm(ctx, insn) {
                 // Get exactly the bit pattern in 'w64' into the dest.  No
                 // monkeying with sign extension etc.
                 let dst_is_64 = w64 > 0xFFFF_FFFF;
-                let dst = output_to_reg(ctx, inst, 0);
+                let dst = output_to_reg(ctx, outputs[0]);
                 ctx.emit(Inst::imm_r(dst_is_64, w64, dst));
             } else {
                 unimplemented!();
@@ -124,28 +180,32 @@ fn lower_insn_to_regs<'a>(ctx: Ctx<'a>, inst: IRInst) {
         }
 
         Opcode::Iadd | Opcode::Isub => {
-            let dst = output_to_reg(ctx, inst, 0);
-            let lhs = input_to_reg(ctx, inst, 0);
-            let rhs = input_to_reg(ctx, inst, 1);
+            let lhs = input_to_reg(ctx, inputs[0]);
+            let rhs = input_to_reg_mem_imm(ctx, inputs[1]);
+            let dst = output_to_reg(ctx, outputs[0]);
+
+            // TODO For add, try to commute the operands if one is an immediate.
+
             let is_64 = int_ty_is_64(ty.unwrap());
             let alu_op = if op == Opcode::Iadd {
                 AluRmiROpcode::Add
             } else {
                 AluRmiROpcode::Sub
             };
+
             ctx.emit(Inst::mov_r_r(true, lhs, dst));
-            ctx.emit(Inst::alu_rmi_r(is_64, alu_op, RegMemImm::reg(rhs), dst));
+            ctx.emit(Inst::alu_rmi_r(is_64, alu_op, rhs, dst));
         }
 
         Opcode::Ishl | Opcode::Ushr | Opcode::Sshr => {
             // TODO: implement imm shift value into insn
-            let dst_ty = ctx.output_ty(inst, 0);
-            assert_eq!(ctx.input_ty(inst, 0), dst_ty);
+            let dst_ty = ctx.output_ty(insn, 0);
+            assert_eq!(ctx.input_ty(insn, 0), dst_ty);
             assert!(dst_ty == types::I32 || dst_ty == types::I64);
 
-            let lhs = input_to_reg(ctx, inst, 0);
-            let rhs = input_to_reg(ctx, inst, 1);
-            let dst = output_to_reg(ctx, inst, 0);
+            let lhs = input_to_reg(ctx, inputs[0]);
+            let rhs = input_to_reg(ctx, inputs[1]);
+            let dst = output_to_reg(ctx, outputs[0]);
 
             let shift_kind = match op {
                 Opcode::Ishl => ShiftKind::Left,
@@ -161,30 +221,68 @@ fn lower_insn_to_regs<'a>(ctx: Ctx<'a>, inst: IRInst) {
             ctx.emit(Inst::shift_r(is_64, shift_kind, None /*%cl*/, dst));
         }
 
-        Opcode::Uextend | Opcode::Sextend => {
-            // TODO: this is all extremely lame, all because Mov{ZX,SX}_M_R
-            // don't accept a register source operand.  They should be changed
-            // so as to have _RM_R form.
-            // TODO2: if the source operand is a load, incorporate that.
-            let zero_extend = op == Opcode::Uextend;
-            let src_ty = ctx.input_ty(inst, 0);
-            let dst_ty = ctx.output_ty(inst, 0);
-            let src = input_to_reg(ctx, inst, 0);
-            let dst = output_to_reg(ctx, inst, 0);
+        Opcode::Uextend
+        | Opcode::Sextend
+        | Opcode::Bint
+        | Opcode::Breduce
+        | Opcode::Bextend
+        | Opcode::Ireduce => {
+            let src_ty = ctx.input_ty(insn, 0);
+            let dst_ty = ctx.output_ty(insn, 0);
 
-            ctx.emit(Inst::mov_r_r(true, src, dst));
-            match (src_ty, dst_ty, zero_extend) {
-                (types::I8, types::I64, false) => {
-                    ctx.emit(Inst::shift_r(true, ShiftKind::Left, Some(56), dst));
-                    ctx.emit(Inst::shift_r(true, ShiftKind::RightS, Some(56), dst));
-                }
-                _ => unimplemented!(),
+            // TODO: if the source operand is a load, incorporate that.
+            let src = input_to_reg(ctx, inputs[0]);
+            let dst = output_to_reg(ctx, outputs[0]);
+
+            let ext_mode = match (src_ty.bits(), dst_ty.bits()) {
+                (1, 32) | (8, 32) => ExtMode::BL,
+                (1, 64) | (8, 64) => ExtMode::BQ,
+                (16, 32) => ExtMode::WL,
+                (16, 64) => ExtMode::WQ,
+                (32, 64) => ExtMode::LQ,
+                _ => unreachable!(
+                    "unexpected extension kind from {:?} to {:?}",
+                    src_ty, dst_ty
+                ),
+            };
+
+            if op == Opcode::Sextend {
+                ctx.emit(Inst::movsx_rm_r(ext_mode, RegMem::reg(src), dst));
+            } else {
+                // All of these other opcodes are simply a move from a zero-extended source.  Here
+                // is why this works, in each case:
+                //
+                // - Bint: Bool-to-int. We always represent a bool as a 0 or 1, so we
+                //   merely need to zero-extend here.
+                //
+                // - Breduce, Bextend: changing width of a boolean. We represent a
+                //   bool as a 0 or 1, so again, this is a zero-extend / no-op.
+                //
+                // - Ireduce: changing width of an integer. Smaller ints are stored
+                //   with undefined high-order bits, so we can simply do a copy.
+                ctx.emit(Inst::movzx_rm_r(ext_mode, RegMem::reg(src), dst));
             }
         }
 
+        Opcode::Icmp => {
+            let condcode = inst_condcode(ctx.data(insn));
+            let cc = CC::from_intcc(condcode);
+            let ty = ctx.input_ty(insn, 0);
+
+            // TODO Try to commute the operands (and invert the condition) if one is an immediate.
+            let lhs = input_to_reg(ctx, inputs[0]);
+            let rhs = input_to_reg_mem_imm(ctx, inputs[1]);
+            let dst = output_to_reg(ctx, outputs[0]);
+
+            // Cranelift's icmp semantics want to compare lhs - rhs, while Intel gives
+            // us dst - src at the machine instruction level, so invert operands.
+            ctx.emit(Inst::cmp_rmi_r(ty.bytes() as u8, rhs, lhs));
+            ctx.emit(Inst::setcc(cc, dst));
+        }
+
         Opcode::FallthroughReturn | Opcode::Return => {
-            for i in 0..ctx.num_inputs(inst) {
-                let src_reg = input_to_reg(ctx, inst, i);
+            for i in 0..ctx.num_inputs(insn) {
+                let src_reg = input_to_reg(ctx, inputs[i]);
                 let retval_reg = ctx.retval(i);
                 if src_reg.get_class() == RegClass::I64 {
                     ctx.emit(Inst::mov_r_r(true, src_reg, retval_reg));
@@ -199,10 +297,58 @@ fn lower_insn_to_regs<'a>(ctx: Ctx<'a>, inst: IRInst) {
             // N.B.: the Ret itself is generated by the ABI.
         }
 
+        Opcode::Call | Opcode::CallIndirect => {
+            let loc = ctx.srcloc(insn);
+            let (mut abi, inputs) = match op {
+                Opcode::Call => {
+                    let (extname, dist) = ctx.call_target(insn).unwrap();
+                    let sig = ctx.call_sig(insn).unwrap();
+                    assert!(inputs.len() == sig.params.len());
+                    assert!(outputs.len() == sig.returns.len());
+                    (
+                        X64ABICall::from_func(sig, &extname, dist, loc)?,
+                        &inputs[..],
+                    )
+                }
+
+                Opcode::CallIndirect => {
+                    let ptr = input_to_reg(ctx, inputs[0]);
+                    let sig = ctx.call_sig(insn).unwrap();
+                    assert!(inputs.len() - 1 == sig.params.len());
+                    assert!(outputs.len() == sig.returns.len());
+                    (X64ABICall::from_ptr(sig, ptr, loc, op)?, &inputs[1..])
+                }
+
+                _ => unreachable!(),
+            };
+
+            abi.emit_stack_pre_adjust(ctx);
+            assert!(inputs.len() == abi.num_args());
+            for (i, input) in inputs.iter().enumerate() {
+                let arg_reg = input_to_reg(ctx, *input);
+                abi.emit_copy_reg_to_arg(ctx, i, arg_reg);
+            }
+            abi.emit_call(ctx);
+            for (i, output) in outputs.iter().enumerate() {
+                let retval_reg = output_to_reg(ctx, *output);
+                abi.emit_copy_retval_to_reg(ctx, i, retval_reg);
+            }
+            abi.emit_stack_post_adjust(ctx);
+        }
+
+        Opcode::Debugtrap => {
+            ctx.emit(Inst::Hlt);
+        }
+
+        Opcode::Trap => {
+            let trap_info = (ctx.srcloc(insn), inst_trapcode(ctx.data(insn)).unwrap());
+            ctx.emit(Inst::Ud2 { trap_info })
+        }
+
         Opcode::Fadd | Opcode::Fsub | Opcode::Fmul | Opcode::Fdiv => {
-            let dst = output_to_reg(ctx, inst, 0);
-            let lhs = input_to_reg(ctx, inst, 0);
-            let rhs = input_to_reg(ctx, inst, 1);
+            let lhs = input_to_reg(ctx, inputs[0]);
+            let rhs = input_to_reg(ctx, inputs[1]);
+            let dst = output_to_reg(ctx, outputs[0]);
             let is_64 = flt_ty_is_64(ty.unwrap());
             if !is_64 {
                 let sse_op = match op {
@@ -219,10 +365,11 @@ fn lower_insn_to_regs<'a>(ctx: Ctx<'a>, inst: IRInst) {
                 unimplemented!("unimplemented lowering for opcode {:?}", op);
             }
         }
+
         Opcode::Fcopysign => {
-            let dst = output_to_reg(ctx, inst, 0);
-            let lhs = input_to_reg(ctx, inst, 0);
-            let rhs = input_to_reg(ctx, inst, 1);
+            let dst = output_to_reg(ctx, outputs[0]);
+            let lhs = input_to_reg(ctx, inputs[0]);
+            let rhs = input_to_reg(ctx, inputs[1]);
             if !flt_ty_is_64(ty.unwrap()) {
                 // movabs   0x8000_0000, tmp_gpr1
                 // movd     tmp_gpr1, tmp_xmm1
@@ -265,6 +412,185 @@ fn lower_insn_to_regs<'a>(ctx: Ctx<'a>, inst: IRInst) {
                 unimplemented!("{:?} for non 32-bit destination is not supported", op);
             }
         }
+
+        Opcode::Load
+        | Opcode::Uload8
+        | Opcode::Sload8
+        | Opcode::Uload16
+        | Opcode::Sload16
+        | Opcode::Uload32
+        | Opcode::Sload32
+        | Opcode::LoadComplex
+        | Opcode::Uload8Complex
+        | Opcode::Sload8Complex
+        | Opcode::Uload16Complex
+        | Opcode::Sload16Complex
+        | Opcode::Uload32Complex
+        | Opcode::Sload32Complex => {
+            let offset = ldst_offset(ctx.data(insn)).unwrap();
+
+            let elem_ty = match op {
+                Opcode::Sload8 | Opcode::Uload8 | Opcode::Sload8Complex | Opcode::Uload8Complex => {
+                    types::I8
+                }
+                Opcode::Sload16
+                | Opcode::Uload16
+                | Opcode::Sload16Complex
+                | Opcode::Uload16Complex => types::I16,
+                Opcode::Sload32
+                | Opcode::Uload32
+                | Opcode::Sload32Complex
+                | Opcode::Uload32Complex => types::I32,
+                Opcode::Load | Opcode::LoadComplex => ctx.output_ty(insn, 0),
+                _ => unimplemented!(),
+            };
+
+            let ext_mode = match elem_ty.bytes() {
+                1 => Some(ExtMode::BQ),
+                2 => Some(ExtMode::WQ),
+                4 => Some(ExtMode::LQ),
+                _ => None,
+            };
+
+            let sign_extend = match op {
+                Opcode::Sload8
+                | Opcode::Sload8Complex
+                | Opcode::Sload16
+                | Opcode::Sload16Complex
+                | Opcode::Sload32
+                | Opcode::Sload32Complex => true,
+                _ => false,
+            };
+
+            let is_float = is_float_ty(elem_ty);
+
+            let addr = match op {
+                Opcode::Load
+                | Opcode::Uload8
+                | Opcode::Sload8
+                | Opcode::Uload16
+                | Opcode::Sload16
+                | Opcode::Uload32
+                | Opcode::Sload32 => {
+                    assert!(inputs.len() == 1, "only one input for load operands");
+                    let base = input_to_reg(ctx, inputs[0]);
+                    Amode::imm_reg(offset as u32, base)
+                }
+
+                Opcode::LoadComplex
+                | Opcode::Uload8Complex
+                | Opcode::Sload8Complex
+                | Opcode::Uload16Complex
+                | Opcode::Sload16Complex
+                | Opcode::Uload32Complex
+                | Opcode::Sload32Complex => {
+                    assert!(
+                        inputs.len() == 2,
+                        "can't handle more than two inputs in complex load"
+                    );
+                    let base = input_to_reg(ctx, inputs[0]);
+                    let index = input_to_reg(ctx, inputs[1]);
+                    let shift = 0;
+                    Amode::imm_reg_reg_shift(offset as u32, base, index, shift)
+                }
+
+                _ => unreachable!(),
+            };
+
+            let dst = output_to_reg(ctx, outputs[0]);
+            match (sign_extend, is_float) {
+                (true, false) => {
+                    // The load is sign-extended only when the output size is lower than 64 bits,
+                    // so ext-mode is defined in this case.
+                    ctx.emit(Inst::movsx_rm_r(ext_mode.unwrap(), RegMem::mem(addr), dst));
+                }
+                (false, false) => {
+                    if elem_ty.bytes() == 8 {
+                        // Use a plain load.
+                        ctx.emit(Inst::mov64_m_r(addr, dst))
+                    } else {
+                        // Use a zero-extended load.
+                        ctx.emit(Inst::movzx_rm_r(ext_mode.unwrap(), RegMem::mem(addr), dst))
+                    }
+                }
+                (_, true) => unimplemented!("FPU loads"),
+            }
+        }
+
+        Opcode::Store
+        | Opcode::Istore8
+        | Opcode::Istore16
+        | Opcode::Istore32
+        | Opcode::StoreComplex
+        | Opcode::Istore8Complex
+        | Opcode::Istore16Complex
+        | Opcode::Istore32Complex => {
+            let offset = ldst_offset(ctx.data(insn)).unwrap();
+
+            let elem_ty = match op {
+                Opcode::Istore8 | Opcode::Istore8Complex => types::I8,
+                Opcode::Istore16 | Opcode::Istore16Complex => types::I16,
+                Opcode::Istore32 | Opcode::Istore32Complex => types::I32,
+                Opcode::Store | Opcode::StoreComplex => ctx.input_ty(insn, 0),
+                _ => unreachable!(),
+            };
+            let is_float = is_float_ty(elem_ty);
+
+            let addr = match op {
+                Opcode::Store | Opcode::Istore8 | Opcode::Istore16 | Opcode::Istore32 => {
+                    assert!(
+                        inputs.len() == 2,
+                        "only one input for store memory operands"
+                    );
+                    let base = input_to_reg(ctx, inputs[1]);
+                    // TODO sign?
+                    Amode::imm_reg(offset as u32, base)
+                }
+
+                Opcode::StoreComplex
+                | Opcode::Istore8Complex
+                | Opcode::Istore16Complex
+                | Opcode::Istore32Complex => {
+                    assert!(
+                        inputs.len() == 3,
+                        "can't handle more than two inputs in complex load"
+                    );
+                    let base = input_to_reg(ctx, inputs[1]);
+                    let index = input_to_reg(ctx, inputs[2]);
+                    let shift = 0;
+                    Amode::imm_reg_reg_shift(offset as u32, base, index, shift)
+                }
+
+                _ => unreachable!(),
+            };
+
+            let src = input_to_reg(ctx, inputs[0]);
+
+            if is_float {
+                unimplemented!("FPU stores");
+            } else {
+                ctx.emit(Inst::mov_r_m(elem_ty.bytes() as u8, src, addr));
+            }
+        }
+
+        Opcode::StackAddr => {
+            let (stack_slot, offset) = match *ctx.data(insn) {
+                InstructionData::StackLoad {
+                    opcode: Opcode::StackAddr,
+                    stack_slot,
+                    offset,
+                } => (stack_slot, offset),
+                _ => unreachable!(),
+            };
+            let dst = output_to_reg(ctx, outputs[0]);
+            let offset: i32 = offset.into();
+            println!("stackslot_addr: {:?} @ off{}", stack_slot, offset);
+            let inst = ctx
+                .abi()
+                .stackslot_addr(stack_slot, u32::try_from(offset).unwrap(), dst);
+            ctx.emit(inst);
+        }
+
         Opcode::IaddImm
         | Opcode::ImulImm
         | Opcode::UdivImm
@@ -296,6 +622,8 @@ fn lower_insn_to_regs<'a>(ctx: Ctx<'a>, inst: IRInst) {
         }
         _ => unimplemented!("unimplemented lowering for opcode {:?}", op),
     }
+
+    Ok(())
 }
 
 //=============================================================================
@@ -305,8 +633,7 @@ impl LowerBackend for X64Backend {
     type MInst = Inst;
 
     fn lower<C: LowerCtx<I = Inst>>(&self, ctx: &mut C, ir_inst: IRInst) -> CodegenResult<()> {
-        lower_insn_to_regs(ctx, ir_inst);
-        Ok(())
+        lower_insn_to_regs(ctx, ir_inst)
     }
 
     fn lower_branch_group<C: LowerCtx<I = Inst>>(
@@ -346,33 +673,52 @@ impl LowerBackend for X64Backend {
             match op0 {
                 Opcode::Brz | Opcode::Brnz => {
                     let src_ty = ctx.input_ty(branches[0], 0);
-                    if is_int_ty(src_ty) {
-                        let src = input_to_reg(ctx, branches[0], 0);
+                    if is_int_ty(src_ty) || is_bool_ty(src_ty) {
+                        let src = input_to_reg(
+                            ctx,
+                            InsnInput {
+                                insn: branches[0],
+                                input: 0,
+                            },
+                        );
                         let cc = match op0 {
                             Opcode::Brz => CC::Z,
                             Opcode::Brnz => CC::NZ,
                             _ => unreachable!(),
                         };
-                        let sizeB = int_ty_to_sizeB(src_ty);
-                        ctx.emit(Inst::cmp_rmi_r(sizeB, RegMemImm::imm(0), src));
-                        ctx.emit(Inst::jmp_cond_symm(cc, taken, not_taken));
+                        let size_bytes = src_ty.bytes() as u8;
+                        ctx.emit(Inst::cmp_rmi_r(size_bytes, RegMemImm::imm(0), src));
+                        ctx.emit(Inst::jmp_cond(cc, taken, not_taken));
                     } else {
-                        unimplemented!("brz/brnz with non-int type");
+                        unimplemented!("brz/brnz with non-int type {:?}", src_ty);
                     }
                 }
 
                 Opcode::BrIcmp => {
                     let src_ty = ctx.input_ty(branches[0], 0);
-                    if is_int_ty(src_ty) {
-                        let lhs = input_to_reg(ctx, branches[0], 0);
-                        let rhs = input_to_reg(ctx, branches[0], 1);
+                    if is_int_ty(src_ty) || is_bool_ty(src_ty) {
+                        let lhs = input_to_reg(
+                            ctx,
+                            InsnInput {
+                                insn: branches[0],
+                                input: 0,
+                            },
+                        );
+                        let rhs = input_to_reg_mem_imm(
+                            ctx,
+                            InsnInput {
+                                insn: branches[0],
+                                input: 1,
+                            },
+                        );
                         let cc = CC::from_intcc(inst_condcode(ctx.data(branches[0])));
-                        let byte_size = int_ty_to_sizeB(src_ty);
-                        // FIXME verify rSR vs rSL ordering
-                        ctx.emit(Inst::cmp_rmi_r(byte_size, RegMemImm::reg(rhs), lhs));
-                        ctx.emit(Inst::jmp_cond_symm(cc, taken, not_taken));
+                        let byte_size = src_ty.bytes() as u8;
+                        // Cranelift's icmp semantics want to compare lhs - rhs, while Intel gives
+                        // us dst - src at the machine instruction level, so invert operands.
+                        ctx.emit(Inst::cmp_rmi_r(byte_size, rhs, lhs));
+                        ctx.emit(Inst::jmp_cond(cc, taken, not_taken));
                     } else {
-                        unimplemented!("bricmp with non-int type");
+                        unimplemented!("bricmp with non-int type {:?}", src_ty);
                     }
                 }
 
@@ -385,14 +731,8 @@ impl LowerBackend for X64Backend {
             // Must be an unconditional branch or trap.
             let op = ctx.data(branches[0]).opcode();
             match op {
-                Opcode::Jump => {
+                Opcode::Jump | Opcode::Fallthrough => {
                     ctx.emit(Inst::jmp_known(BranchTarget::Label(targets[0])));
-                }
-                Opcode::Fallthrough => {
-                    ctx.emit(Inst::jmp_known(BranchTarget::Label(targets[0])));
-                }
-                Opcode::Trap => {
-                    unimplemented!("trap");
                 }
                 _ => panic!("Unknown branch type!"),
             }

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -40,7 +40,7 @@ impl X64Backend {
     fn compile_vcode(&self, func: &Function, flags: Flags) -> CodegenResult<VCode<inst::Inst>> {
         // This performs lowering to VCode, register-allocates the code, computes
         // block layout and finalizes branches. The result is ready for binary emission.
-        let abi = Box::new(abi::X64ABIBody::new(&func, flags));
+        let abi = Box::new(abi::X64ABIBody::new(&func, flags)?);
         compile::compile::<Self>(&func, self, abi)
     }
 }

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1024,7 +1024,7 @@ impl<I: VCodeInst> MachBuffer<I> {
                 let veneer_offset = self.cur_offset();
                 trace!("making a veneer at {}", veneer_offset);
                 let slice = &mut self.data[start..end];
-                // Patch the original label use to refer to teh veneer.
+                // Patch the original label use to refer to the veneer.
                 trace!(
                     "patching original at offset {} to veneer offset {}",
                     offset,

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -106,6 +106,19 @@ fn apply_reloc(
                 .wrapping_add(reloc_addend as u32);
             write_unaligned(reloc_address as *mut u32, reloc_delta_u32);
         },
+        #[cfg(target_pointer_width = "64")]
+        Reloc::X86CallPCRel4 => unsafe {
+            let reloc_address = body.add(r.offset as usize) as usize;
+            let reloc_addend = r.addend as isize;
+            let reloc_delta_u64 = (target_func_address as u64)
+                .wrapping_sub(reloc_address as u64)
+                .wrapping_add(reloc_addend as u64);
+            assert!(
+                reloc_delta_u64 as isize <= i32::max_value() as isize,
+                "relocation too large to fit in i32"
+            );
+            write_unaligned(reloc_address as *mut u32, reloc_delta_u64 as u32);
+        },
         Reloc::X86PCRelRodata4 => {
             // ignore
         }


### PR DESCRIPTION
This makes it possible to run a simple recursive fibonacci function in
wasmtime, with the new x64 backend. Plenty of todos implemented as assertions that may and will trigger on larger programs, plenty of paths are still untested, still a lot of missing opcodes lowering and code gen, plenty of optimizations, etc etc.