### PR TITLE
CI: use `cargo fuzz` 0.8.X

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,10 +124,10 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: nightly-2020-06-03
-    - run: cargo install cargo-fuzz --vers "^0.7"
+    - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
-    - run: cargo fuzz build --features binaryen
+    - run: cargo fuzz build --dev --features binaryen
 
   rebuild_peephole_optimizers:
     name: Rebuild Peephole Optimizers


### PR DESCRIPTION
It has switched to release+debug assertion builds by default, so pass `--dev` to
avoid compiling with optimizations.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
