### PR TITLE
wasmtime: Rip out incomplete/incorrect externref "host info" support

### DIFF
--- a/crates/c-api/macros/src/lib.rs
+++ b/crates/c-api/macros/src/lib.rs
@@ -77,12 +77,13 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[no_mangle]
         pub extern fn #get_host_info(a: &#ty) -> *mut std::os::raw::c_void {
-            crate::r#ref::get_host_info(&a.externref())
+            std::ptr::null_mut()
         }
 
         #[no_mangle]
         pub extern fn #set_host_info(a: &#ty, info: *mut std::os::raw::c_void) {
-            crate::r#ref::set_host_info(&a.externref(), info, None)
+            eprintln!("`{}` is not implemented", stringify!(#set_host_info));
+            std::process::abort();
         }
 
         #[no_mangle]
@@ -91,7 +92,8 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             info: *mut std::os::raw::c_void,
             finalizer: Option<extern "C" fn(*mut std::os::raw::c_void)>,
         ) {
-            crate::r#ref::set_host_info(&a.externref(), info, finalizer)
+            eprintln!("`{}` is not implemented", stringify!(#set_host_info_final));
+            std::process::abort();
         }
 
         #[no_mangle]

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -1,6 +1,6 @@
 use crate::{wasm_name_t, wasm_trap_t};
 use anyhow::{anyhow, Error, Result};
-use wasmtime::{Store, Trap};
+use wasmtime::Trap;
 
 #[repr(C)]
 pub struct wasmtime_error_t {
@@ -10,8 +10,8 @@ pub struct wasmtime_error_t {
 wasmtime_c_api_macros::declare_own!(wasmtime_error_t);
 
 impl wasmtime_error_t {
-    pub(crate) fn to_trap(self, store: &Store) -> Box<wasm_trap_t> {
-        Box::new(wasm_trap_t::new(store, Trap::from(self.error)))
+    pub(crate) fn to_trap(self) -> Box<wasm_trap_t> {
+        Box::new(wasm_trap_t::new(Trap::from(self.error)))
     }
 }
 

--- a/crates/c-api/src/global.rs
+++ b/crates/c-api/src/global.rs
@@ -59,7 +59,7 @@ pub extern "C" fn wasmtime_global_new(
     handle_result(global, |global| {
         *ret = Box::into_raw(Box::new(wasm_global_t {
             ext: wasm_extern_t {
-                which: ExternHost::Global(HostRef::new(&store.store, global)),
+                which: ExternHost::Global(HostRef::new(global)),
             },
         }));
     })

--- a/crates/c-api/src/host_ref.rs
+++ b/crates/c-api/src/host_ref.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::cell::{self, RefCell};
 use std::convert::TryFrom;
 use std::marker::PhantomData;
-use wasmtime::{ExternRef, Store};
+use wasmtime::ExternRef;
 
 /// Represents a piece of data located in the host environment.
 #[derive(Debug)]
@@ -19,9 +19,9 @@ where
     T: 'static + Any,
 {
     /// Creates a new `HostRef<T>` from `T`.
-    pub fn new(store: &Store, item: T) -> HostRef<T> {
+    pub fn new(item: T) -> HostRef<T> {
         HostRef {
-            externref: ExternRef::new(store, RefCell::new(item)),
+            externref: ExternRef::new(RefCell::new(item)),
             _phantom: PhantomData,
         }
     }

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -88,7 +88,7 @@ pub extern "C" fn wasmtime_linker_instantiate(
     trap_ptr: &mut *mut wasm_trap_t,
 ) -> Option<Box<wasmtime_error_t>> {
     let result = linker.linker.instantiate(&module.module.borrow());
-    super::instance::handle_instantiate(linker.linker.store(), result, instance_ptr, trap_ptr)
+    super::instance::handle_instantiate(result, instance_ptr, trap_ptr)
 }
 
 #[no_mangle]
@@ -117,7 +117,7 @@ pub extern "C" fn wasmtime_linker_get_default(
         Err(_) => return bad_utf8(),
     };
     handle_result(linker.get_default(name), |f| {
-        *func = Box::into_raw(Box::new(HostRef::new(linker.store(), f).into()))
+        *func = Box::into_raw(Box::new(HostRef::new(f).into()))
     })
 }
 
@@ -138,12 +138,11 @@ pub extern "C" fn wasmtime_linker_get_one_by_name(
         Err(_) => return bad_utf8(),
     };
     handle_result(linker.get_one_by_name(module, name), |item| {
-        let store = linker.store();
         let which = match item {
-            Extern::Func(f) => ExternHost::Func(HostRef::new(&store, f)),
-            Extern::Global(g) => ExternHost::Global(HostRef::new(&store, g)),
-            Extern::Memory(m) => ExternHost::Memory(HostRef::new(&store, m)),
-            Extern::Table(t) => ExternHost::Table(HostRef::new(&store, t)),
+            Extern::Func(f) => ExternHost::Func(HostRef::new(f)),
+            Extern::Global(g) => ExternHost::Global(HostRef::new(g)),
+            Extern::Memory(m) => ExternHost::Memory(HostRef::new(m)),
+            Extern::Table(t) => ExternHost::Table(HostRef::new(t)),
         };
         *item_ptr = Box::into_raw(Box::new(wasm_extern_t { which }))
     })

--- a/crates/c-api/src/memory.rs
+++ b/crates/c-api/src/memory.rs
@@ -37,7 +37,7 @@ pub extern "C" fn wasm_memory_new(
     store: &wasm_store_t,
     mt: &wasm_memorytype_t,
 ) -> Box<wasm_memory_t> {
-    let memory = HostRef::new(&store.store, Memory::new(&store.store, mt.ty().ty.clone()));
+    let memory = HostRef::new(Memory::new(&store.store, mt.ty().ty.clone()));
     Box::new(wasm_memory_t {
         ext: wasm_extern_t {
             which: ExternHost::Memory(memory),

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -63,7 +63,7 @@ pub extern "C" fn wasmtime_module_new(
             .map(|e| wasm_exporttype_t::new(e.name().to_owned(), e.ty()))
             .collect::<Vec<_>>();
         let module = Box::new(wasm_module_t {
-            module: HostRef::new(store, module),
+            module: HostRef::new(module),
             imports,
             exports,
         });
@@ -130,7 +130,7 @@ pub extern "C" fn wasm_module_obtain(
         .map(|e| wasm_exporttype_t::new(e.name().to_owned(), e.ty()))
         .collect::<Vec<_>>();
     Some(Box::new(wasm_module_t {
-        module: HostRef::new(&store.store, module),
+        module: HostRef::new(module),
         imports,
         exports,
     }))

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -1,4 +1,3 @@
-use crate::HostInfoState;
 use std::os::raw::c_void;
 use wasmtime::ExternRef;
 
@@ -24,47 +23,23 @@ pub extern "C" fn wasm_ref_same(a: &wasm_ref_t, b: &wasm_ref_t) -> bool {
     }
 }
 
-pub(crate) fn get_host_info(r: &ExternRef) -> *mut c_void {
-    let host_info = match r.host_info() {
-        Some(info) => info,
-        None => return std::ptr::null_mut(),
-    };
-    let host_info = host_info.borrow();
-    match host_info.downcast_ref::<HostInfoState>() {
-        Some(state) => state.info,
-        None => std::ptr::null_mut(),
-    }
+#[no_mangle]
+pub extern "C" fn wasm_ref_get_host_info(_ref: &wasm_ref_t) -> *mut c_void {
+    std::ptr::null_mut()
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_ref_get_host_info(a: &wasm_ref_t) -> *mut c_void {
-    a.r.as_ref()
-        .map_or(std::ptr::null_mut(), |r| get_host_info(r))
-}
-
-pub(crate) fn set_host_info(
-    r: &ExternRef,
-    info: *mut c_void,
-    finalizer: Option<extern "C" fn(*mut c_void)>,
-) {
-    let info = if info.is_null() && finalizer.is_none() {
-        None
-    } else {
-        Some(Box::new(crate::HostInfoState { info, finalizer }) as Box<dyn std::any::Any>)
-    };
-    r.set_host_info(info);
-}
-
-#[no_mangle]
-pub extern "C" fn wasm_ref_set_host_info(a: &wasm_ref_t, info: *mut c_void) {
-    a.r.as_ref().map(|r| set_host_info(r, info, None));
+pub extern "C" fn wasm_ref_set_host_info(_ref: &wasm_ref_t, _info: *mut c_void) {
+    eprintln!("`wasm_ref_set_host_info` is not implemented");
+    std::process::abort();
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
-    a: &wasm_ref_t,
-    info: *mut c_void,
-    finalizer: Option<extern "C" fn(*mut c_void)>,
+    _ref: &wasm_ref_t,
+    _info: *mut c_void,
+    _finalizer: Option<extern "C" fn(*mut c_void)>,
 ) {
-    a.r.as_ref().map(|r| set_host_info(r, info, finalizer));
+    eprintln!("`wasm_ref_set_host_info_with_finalizer` is not implemented");
+    std::process::abort();
 }

--- a/crates/c-api/src/table.rs
+++ b/crates/c-api/src/table.rs
@@ -47,7 +47,7 @@ pub extern "C" fn wasm_table_new(
     let table = Table::new(&store.store, tt.ty().ty.clone(), init).ok()?;
     Some(Box::new(wasm_table_t {
         ext: wasm_extern_t {
-            which: ExternHost::Table(HostRef::new(&store.store, table)),
+            which: ExternHost::Table(HostRef::new(table)),
         },
     }))
 }
@@ -68,7 +68,7 @@ pub extern "C" fn wasmtime_funcref_table_new(
         |table| {
             *out = Box::into_raw(Box::new(wasm_table_t {
                 ext: wasm_extern_t {
-                    which: ExternHost::Table(HostRef::new(&store.store, table)),
+                    which: ExternHost::Table(HostRef::new(table)),
                 },
             }));
         },
@@ -100,13 +100,7 @@ pub extern "C" fn wasmtime_funcref_table_get(
             *ptr = match val {
                 // TODO: what do do about creating new `HostRef` handles here?
                 Val::FuncRef(None) => ptr::null_mut(),
-                Val::FuncRef(Some(f)) => {
-                    let store = match t.table().as_ref().store() {
-                        None => return false,
-                        Some(store) => store,
-                    };
-                    Box::into_raw(Box::new(HostRef::new(&store, f).into()))
-                }
+                Val::FuncRef(Some(f)) => Box::into_raw(Box::new(HostRef::new(f).into())),
                 _ => return false,
             };
         }

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -1,7 +1,7 @@
 use crate::host_ref::HostRef;
 use crate::{wasm_frame_vec_t, wasm_instance_t, wasm_name_t, wasm_store_t};
 use once_cell::unsync::OnceCell;
-use wasmtime::{Store, Trap};
+use wasmtime::Trap;
 
 #[repr(C)]
 #[derive(Clone)]
@@ -12,9 +12,9 @@ pub struct wasm_trap_t {
 wasmtime_c_api_macros::declare_ref!(wasm_trap_t);
 
 impl wasm_trap_t {
-    pub(crate) fn new(store: &Store, trap: Trap) -> wasm_trap_t {
+    pub(crate) fn new(trap: Trap) -> wasm_trap_t {
         wasm_trap_t {
-            trap: HostRef::new(store, trap),
+            trap: HostRef::new(trap),
         }
     }
 
@@ -38,7 +38,7 @@ pub type wasm_message_t = wasm_name_t;
 
 #[no_mangle]
 pub extern "C" fn wasm_trap_new(
-    store: &wasm_store_t,
+    _store: &wasm_store_t,
     message: &wasm_message_t,
 ) -> Box<wasm_trap_t> {
     let message = message.as_slice();
@@ -47,7 +47,7 @@ pub extern "C" fn wasm_trap_new(
     }
     let message = String::from_utf8_lossy(&message[..message.len() - 1]);
     Box::new(wasm_trap_t {
-        trap: HostRef::new(&store.store, Trap::new(message)),
+        trap: HostRef::new(Trap::new(message)),
     })
 }
 

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -314,7 +314,7 @@ pub unsafe extern "C" fn wasi_instance_new(
         })),
         Err(e) => {
             *trap = Box::into_raw(Box::new(wasm_trap_t {
-                trap: HostRef::new(store, Trap::new(e)),
+                trap: HostRef::new(Trap::new(e)),
             }));
 
             None
@@ -352,14 +352,13 @@ pub extern "C" fn wasi_instance_bind_import<'a>(
     if &export.ty() != import.ty.func()? {
         return None;
     }
-    let store = export.store();
 
     let entry = instance
         .export_cache
         .entry(name.to_string())
         .or_insert_with(|| {
             Box::new(wasm_extern_t {
-                which: ExternHost::Func(HostRef::new(store, export.clone())),
+                which: ExternHost::Func(HostRef::new(export.clone())),
             })
         });
     Some(entry)

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -355,10 +355,9 @@ impl Table {
                 Some(unsafe { from_checked_anyfunc(f, &self.instance.store) })
             }
             runtime::TableElement::ExternRef(None) => Some(Val::ExternRef(None)),
-            runtime::TableElement::ExternRef(Some(x)) => Some(Val::ExternRef(Some(ExternRef {
-                inner: x,
-                store: self.instance.store.weak(),
-            }))),
+            runtime::TableElement::ExternRef(Some(x)) => {
+                Some(Val::ExternRef(Some(ExternRef { inner: x })))
+            }
         }
     }
 

--- a/crates/wasmtime/src/ref.rs
+++ b/crates/wasmtime/src/ref.rs
@@ -1,34 +1,22 @@
 #![allow(missing_docs)]
 
 use std::any::Any;
-use std::cell::RefCell;
-use std::fmt;
-use std::rc::{Rc, Weak};
 use wasmtime_runtime::VMExternRef;
 
 /// Represents an opaque reference to any data within WebAssembly.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ExternRef {
     pub(crate) inner: VMExternRef,
-    pub(crate) store: Weak<crate::runtime::StoreInner>,
 }
 
 impl ExternRef {
     /// Creates a new instance of `ExternRef` wrapping the given value.
-    pub fn new<T>(store: &crate::Store, value: T) -> ExternRef
+    pub fn new<T>(value: T) -> ExternRef
     where
         T: 'static + Any,
     {
         let inner = VMExternRef::new(value);
-        let store = store.weak();
-        ExternRef { inner, store }
-    }
-
-    /// Get this reference's store.
-    ///
-    /// Returns `None` if this reference outlived its store.
-    pub fn store(&self) -> Option<crate::runtime::Store> {
-        crate::runtime::Store::upgrade(&self.store)
+        ExternRef { inner }
     }
 
     /// Get the underlying data for this `ExternRef`.
@@ -47,40 +35,5 @@ impl ExternRef {
     /// `Eq` implementation.
     pub fn ptr_eq(&self, other: &ExternRef) -> bool {
         VMExternRef::eq(&self.inner, &other.inner)
-    }
-
-    /// Returns the host information for this `externref`, if previously created
-    /// with `set_host_info`.
-    pub fn host_info(&self) -> Option<Rc<RefCell<dyn Any>>> {
-        let store = crate::Store::upgrade(&self.store)?;
-        store.host_info(self)
-    }
-
-    /// Set the host information for this `externref`, returning the old host
-    /// information if it was previously set.
-    pub fn set_host_info<T>(&self, info: T) -> Option<Rc<RefCell<dyn Any>>>
-    where
-        T: 'static + Any,
-    {
-        let store = crate::Store::upgrade(&self.store)?;
-        store.set_host_info(self, Some(Rc::new(RefCell::new(info))))
-    }
-
-    /// Remove the host information for this `externref`, returning the old host
-    /// information if it was previously set.
-    pub fn remove_host_info(&self) -> Option<Rc<RefCell<dyn Any>>> {
-        let store = crate::Store::upgrade(&self.store)?;
-        store.set_host_info(self, None)
-    }
-}
-
-impl fmt::Debug for ExternRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ExternRef { inner, store: _ } = self;
-        let store = self.store();
-        f.debug_struct("ExternRef")
-            .field("inner", &inner)
-            .field("store", &store)
-            .finish()
     }
 }

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -126,7 +126,6 @@ impl Val {
                 } else {
                     Val::ExternRef(Some(ExternRef {
                         inner: VMExternRef::clone_from_raw(raw),
-                        store: store.weak(),
                     }))
                 }
             }
@@ -180,15 +179,15 @@ impl Val {
             Val::FuncRef(Some(f)) => Store::same(store, f.store()),
             Val::FuncRef(None) => true,
 
-            // TODO: need to implement this once we actually finalize what
-            // `externref` will look like and it's actually implemented to pass it
-            // to compiled wasm as well.
-            Val::ExternRef(Some(e)) => e.store.ptr_eq(&store.weak()),
-            Val::ExternRef(None) => true,
-
-            // Integers have no association with any particular store, so
-            // they're always considered as "yes I came from that store",
-            Val::I32(_) | Val::I64(_) | Val::F32(_) | Val::F64(_) | Val::V128(_) => true,
+            // Integers, floats, vectors, and `externref`s have no association
+            // with any particular store, so they're always considered as "yes I
+            // came from that store",
+            Val::I32(_)
+            | Val::I64(_)
+            | Val::F32(_)
+            | Val::F64(_)
+            | Val::V128(_)
+            | Val::ExternRef(_) => true,
         }
     }
 }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -10,7 +10,7 @@ use wast::{
 };
 
 /// Translate from a `script::Value` to a `RuntimeValue`.
-fn runtime_value(store: &Store, v: &wast::Expression<'_>) -> Result<Val> {
+fn runtime_value(v: &wast::Expression<'_>) -> Result<Val> {
     use wast::Instruction::*;
 
     if v.instrs.len() != 1 {
@@ -24,7 +24,7 @@ fn runtime_value(store: &Store, v: &wast::Expression<'_>) -> Result<Val> {
         V128Const(x) => Val::V128(u128::from_le_bytes(x.to_le_bytes())),
         RefNull(RefType::Extern) => Val::ExternRef(None),
         RefNull(RefType::Func) => Val::FuncRef(None),
-        RefExtern(x) => Val::ExternRef(Some(ExternRef::new(store, *x))),
+        RefExtern(x) => Val::ExternRef(Some(ExternRef::new(*x))),
         other => bail!("couldn't convert {:?} to a runtime value", other),
     })
 }
@@ -120,7 +120,7 @@ impl WastContext {
         let values = exec
             .args
             .iter()
-            .map(|v| runtime_value(&self.store, v))
+            .map(|v| runtime_value(v))
             .collect::<Result<Vec<_>>>()?;
         self.invoke(exec.module.map(|i| i.name()), exec.name, &values)
     }

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -38,7 +38,7 @@ fn smoke_test_gc() -> anyhow::Result<()> {
     let func = instance.get_func("func").unwrap();
 
     let inner_dropped = Rc::new(Cell::new(false));
-    let r = ExternRef::new(&store, SetFlagOnDrop(inner_dropped.clone()));
+    let r = ExternRef::new(SetFlagOnDrop(inner_dropped.clone()));
     {
         let args = [Val::I32(5), Val::ExternRef(Some(r.clone()))];
         func.call(&args)?;
@@ -88,7 +88,7 @@ fn wasm_dropping_refs() -> anyhow::Result<()> {
     // NB: 4096 is greater than the initial `VMExternRefActivationsTable`
     // capacity, so this will trigger at least one GC.
     for _ in 0..4096 {
-        let r = ExternRef::new(&store, CountDrops(num_refs_dropped.clone()));
+        let r = ExternRef::new(CountDrops(num_refs_dropped.clone()));
         let args = [Val::ExternRef(Some(r))];
         drop_ref.call(&args)?;
     }
@@ -158,13 +158,10 @@ fn many_live_refs() -> anyhow::Result<()> {
             vec![ValType::ExternRef].into_boxed_slice(),
         ),
         {
-            let store = store.clone();
             let live_refs = live_refs.clone();
             move |_caller, _params, results| {
-                results[0] = Val::ExternRef(Some(ExternRef::new(
-                    &store,
-                    CountLiveRefs::new(live_refs.clone()),
-                )));
+                results[0] =
+                    Val::ExternRef(Some(ExternRef::new(CountLiveRefs::new(live_refs.clone()))));
                 Ok(())
             }
         },


### PR DESCRIPTION
Better to be loud that we don't support attaching arbitrary host info to
`externref`s than to limp along and pretend we do support it. Supporting it
properly won't reuse any of this code anyways.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
