### PR TITLE
wasmtime: Implement `table.get` and `table.set`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "bincode",
  "cranelift-codegen",
  "cranelift-entity",
+ "cranelift-frontend",
  "cranelift-wasm",
  "directories",
  "errno",

--- a/build.rs
+++ b/build.rs
@@ -205,18 +205,20 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", "simd_i16x8_arith2") => return true,
             ("simd", "simd_i8x16_arith2") => return true,
 
-            ("reference_types", "table_copy_on_imported_tables")
-            | ("reference_types", "externref_id_function")
-            | ("reference_types", "table_size")
-            | ("reference_types", "simple_ref_is_null")
-            | ("reference_types", "table_grow_with_funcref") => {
-                // TODO(#1886): Ignore if this isn't x64, because Cranelift only
-                // supports reference types on x64.
-                return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
+            // Still working on implementing these. See #929.
+            ("reference_types", "global")
+            | ("reference_types", "linking")
+            | ("reference_types", "ref_func")
+            | ("reference_types", "ref_null")
+            | ("reference_types", "table_fill") => {
+                return true;
             }
 
-            // Still working on implementing these. See #929.
-            ("reference_types", _) => return true,
+            // TODO(#1886): Ignore reference types tests if this isn't x64,
+            // because Cranelift only supports reference types on x64.
+            ("reference_types", _) => {
+                return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
+            }
 
             _ => {}
         },

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -211,7 +211,7 @@ fn define_control_flow(
     let iAddr = &TypeVar::new(
         "iAddr",
         "An integer address type",
-        TypeSetBuilder::new().ints(32..64).build(),
+        TypeSetBuilder::new().ints(32..64).refs(32..64).build(),
     );
 
     {
@@ -744,7 +744,7 @@ pub(crate) fn define(
     let iAddr = &TypeVar::new(
         "iAddr",
         "An integer address type",
-        TypeSetBuilder::new().ints(32..64).build(),
+        TypeSetBuilder::new().ints(32..64).refs(32..64).build(),
     );
 
     let Ref = &TypeVar::new(

--- a/cranelift/codegen/src/binemit/relaxation.rs
+++ b/cranelift/codegen/src/binemit/relaxation.rs
@@ -302,7 +302,11 @@ fn fallthroughs(func: &mut Function) {
                 Opcode::Fallthrough => {
                     // Somebody used a fall-through instruction before the branch relaxation pass.
                     // Make sure it is correct, i.e. the destination is the layout successor.
-                    debug_assert_eq!(destination, succ, "Illegal fall-through in {}", block)
+                    debug_assert_eq!(
+                        destination, succ,
+                        "Illegal fallthrough from {} to {}, but {}'s successor is {}",
+                        block, destination, block, succ
+                    )
                 }
                 Opcode::Jump => {
                     // If this is a jump to the successor block, change it to a fall-through.

--- a/cranelift/codegen/src/ir/valueloc.rs
+++ b/cranelift/codegen/src/ir/valueloc.rs
@@ -41,7 +41,7 @@ impl ValueLoc {
     pub fn unwrap_reg(self) -> RegUnit {
         match self {
             Self::Reg(ru) => ru,
-            _ => panic!("Expected register: {:?}", self),
+            _ => panic!("unwrap_reg expected register, found {:?}", self),
         }
     }
 
@@ -49,7 +49,7 @@ impl ValueLoc {
     pub fn unwrap_stack(self) -> StackSlot {
         match self {
             Self::Stack(ss) => ss,
-            _ => panic!("Expected stack slot: {:?}", self),
+            _ => panic!("unwrap_stack expected stack slot, found {:?}", self),
         }
     }
 

--- a/cranelift/codegen/src/postopt.rs
+++ b/cranelift/codegen/src/postopt.rs
@@ -386,7 +386,11 @@ fn optimize_complex_addresses(pos: &mut EncCursor, inst: Inst, isa: &dyn TargetI
     }
 
     let ok = pos.func.update_encoding(inst, isa).is_ok();
-    debug_assert!(ok);
+    debug_assert!(
+        ok,
+        "failed to update encoding for `{}`",
+        pos.func.dfg.display_inst(inst, isa)
+    );
 }
 
 //----------------------------------------------------------------------

--- a/cranelift/codegen/src/redundant_reload_remover.rs
+++ b/cranelift/codegen/src/redundant_reload_remover.rs
@@ -635,7 +635,11 @@ impl RedundantReloadRemover {
                 // Load is completely redundant.  Convert it to a no-op.
                 dfg.replace(inst).fill_nop(arg);
                 let ok = func.update_encoding(inst, isa).is_ok();
-                debug_assert!(ok, "fill_nop encoding missing for this type");
+                debug_assert!(
+                    ok,
+                    "fill_nop encoding missing for this type: `{}`",
+                    func.dfg.display_inst(inst, isa)
+                );
             }
             Transform::ChangeToCopyToSSA(ty, reg) => {
                 // We already have the relevant value in some other register.  Convert the

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -228,6 +228,11 @@ impl<'a> FunctionBuilder<'a> {
         block
     }
 
+    /// Insert `block` in the layout *after* the existing block `after`.
+    pub fn insert_block_after(&mut self, block: Block, after: Block) {
+        self.func.layout.insert_block_after(block, after);
+    }
+
     /// After the call to this function, new instructions will be inserted into the designated
     /// block, in the order they are declared. You must declare the types of the Block arguments
     /// you will use here.

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -206,6 +206,11 @@ impl<'a> FunctionBuilder<'a> {
         }
     }
 
+    /// Get the block that this builder is currently at.
+    pub fn current_block(&self) -> Option<Block> {
+        self.position.expand()
+    }
+
     /// Set the source location that should be assigned to all new instructions.
     pub fn set_srcloc(&mut self, srcloc: ir::SourceLoc) {
         self.srcloc = srcloc;

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1186,19 +1186,14 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let table_index = TableIndex::from_u32(*index);
             let table = state.get_or_create_table(builder.func, *index, environ)?;
             let index = state.pop1();
-            state.push1(environ.translate_table_get(
-                builder.cursor(),
-                table_index,
-                table,
-                index,
-            )?);
+            state.push1(environ.translate_table_get(builder, table_index, table, index)?);
         }
         Operator::TableSet { table: index } => {
             let table_index = TableIndex::from_u32(*index);
             let table = state.get_or_create_table(builder.func, *index, environ)?;
             let value = state.pop1();
             let index = state.pop1();
-            environ.translate_table_set(builder.cursor(), table_index, table, value, index)?;
+            environ.translate_table_set(builder, table_index, table, value, index)?;
         }
         Operator::TableCopy {
             dst_table: dst_table_index,

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -22,6 +22,7 @@ use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_codegen::isa::TargetFrontendConfig;
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
+use cranelift_frontend::FunctionBuilder;
 use std::boxed::Box;
 use std::string::String;
 use std::vec::Vec;
@@ -452,17 +453,17 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 
     fn translate_table_get(
         &mut self,
-        mut pos: FuncCursor,
+        builder: &mut FunctionBuilder,
         _table_index: TableIndex,
         _table: ir::Table,
         _index: ir::Value,
     ) -> WasmResult<ir::Value> {
-        Ok(pos.ins().null(self.reference_type()))
+        Ok(builder.ins().null(self.reference_type()))
     }
 
     fn translate_table_set(
         &mut self,
-        _pos: FuncCursor,
+        _builder: &mut FunctionBuilder,
         _table_index: TableIndex,
         _table: ir::Table,
         _value: ir::Value,

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -368,7 +368,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// Translate a `table.get` WebAssembly instruction.
     fn translate_table_get(
         &mut self,
-        pos: FuncCursor,
+        builder: &mut FunctionBuilder,
         table_index: TableIndex,
         table: ir::Table,
         index: ir::Value,
@@ -377,7 +377,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// Translate a `table.set` WebAssembly instruction.
     fn translate_table_set(
         &mut self,
-        pos: FuncCursor,
+        builder: &mut FunctionBuilder,
         table_index: TableIndex,
         table: ir::Table,
         value: ir::Value,

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -349,7 +349,9 @@ pub fn parse_element_section<'data>(
                 let index = ElemIndex::from_u32(index as u32);
                 environ.declare_passive_element(index, segments)?;
             }
-            ElementKind::Declared => return Err(wasm_unsupported!("element kind declared")),
+            ElementKind::Declared => {
+                // Nothing to do here.
+            }
         }
     }
     Ok(())

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.65.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.65.0", features = ["enable-serde"] }
+cranelift-frontend = { path = "../../cranelift/frontend", version = "0.65.0" }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.65.0", features = ["enable-serde"] }
 wasmparser = "0.58.0"
 lightbeam = { path = "../lightbeam", optional = true, version = "0.18.0" }

--- a/crates/environ/src/func_environ.rs
+++ b/crates/environ/src/func_environ.rs
@@ -735,22 +735,10 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 let gc_block = builder.create_block();
                 let no_gc_block = builder.create_block();
                 let current_block = builder.current_block().unwrap();
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(non_null_elem_block, current_block);
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(no_gc_block, non_null_elem_block);
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(gc_block, no_gc_block);
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(continue_block, gc_block);
+                builder.insert_block_after(non_null_elem_block, current_block);
+                builder.insert_block_after(no_gc_block, non_null_elem_block);
+                builder.insert_block_after(gc_block, no_gc_block);
+                builder.insert_block_after(continue_block, gc_block);
 
                 // Load the table element.
                 let elem_addr = builder.ins().table_addr(pointer_type, table, index, 0);
@@ -893,30 +881,15 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
                 let current_block = builder.current_block().unwrap();
                 let inc_ref_count_block = builder.create_block();
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(inc_ref_count_block, current_block);
+                builder.insert_block_after(inc_ref_count_block, current_block);
                 let check_current_elem_block = builder.create_block();
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(check_current_elem_block, inc_ref_count_block);
+                builder.insert_block_after(check_current_elem_block, inc_ref_count_block);
                 let dec_ref_count_block = builder.create_block();
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(dec_ref_count_block, check_current_elem_block);
+                builder.insert_block_after(dec_ref_count_block, check_current_elem_block);
                 let drop_block = builder.create_block();
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(drop_block, dec_ref_count_block);
+                builder.insert_block_after(drop_block, dec_ref_count_block);
                 let continue_block = builder.create_block();
-                builder
-                    .func
-                    .layout
-                    .insert_block_after(continue_block, drop_block);
+                builder.insert_block_after(continue_block, drop_block);
 
                 // Calculate the table address of the current element and do
                 // bounds checks. This is the first thing we do, because we

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -11,6 +11,8 @@
 #[cfg(feature = "binaryen")]
 pub mod api;
 
+pub mod table_ops;
+
 use arbitrary::{Arbitrary, Unstructured};
 
 /// A Wasm test case generator that is powered by Binaryen's `wasm-opt -ttf`.

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -1,0 +1,148 @@
+//! Generating series of `table.get` and `table.set` operations.
+
+use arbitrary::Arbitrary;
+use std::fmt::Write;
+use std::ops::Range;
+
+/// A description of a Wasm module that makes a series of `externref` table
+/// operations.
+#[derive(Arbitrary, Debug)]
+pub struct TableOps {
+    num_params: u8,
+    table_size: u32,
+    ops: Vec<TableOp>,
+}
+
+const NUM_PARAMS_RANGE: Range<u8> = 1..10;
+const TABLE_SIZE_RANGE: Range<u32> = 1..100;
+const MAX_OPS: usize = 1000;
+
+impl TableOps {
+    /// Get the number of parameters this module's "run" function takes.
+    pub fn num_params(&self) -> u8 {
+        let num_params = std::cmp::max(self.num_params, NUM_PARAMS_RANGE.start);
+        let num_params = std::cmp::min(num_params, NUM_PARAMS_RANGE.end);
+        num_params
+    }
+
+    /// Get the size of the table that this module uses.
+    pub fn table_size(&self) -> u32 {
+        let table_size = std::cmp::max(self.table_size, TABLE_SIZE_RANGE.start);
+        let table_size = std::cmp::min(table_size, TABLE_SIZE_RANGE.end);
+        table_size
+    }
+
+    /// Convert this into a WAT string.
+    ///
+    /// The module requires a single import: `(import "" "gc" (func))`. This
+    /// should be a function to trigger GC.
+    ///
+    /// The single export of the module is a function "run" that takes
+    /// `self.num_params()` parameters of type `externref`.
+    ///
+    /// The "run" function is guaranteed to terminate (no loops or recursive
+    /// calls), but is not guaranteed to avoid traps (might access out-of-bounds
+    /// of the table).
+    pub fn to_wat_string(&self) -> String {
+        let mut wat = "(module\n".to_string();
+
+        // Import the GC function.
+        wat.push_str("  (import \"\" \"gc\" (func))\n");
+
+        // Define our table.
+        wat.push_str("  (table $table ");
+        write!(&mut wat, "{}", self.table_size()).unwrap();
+        wat.push_str(" externref)\n");
+
+        // Define the "run" function export.
+        wat.push_str(r#"  (func (export "run") (param"#);
+        for _ in 0..self.num_params() {
+            wat.push_str(" externref");
+        }
+        wat.push_str(")\n");
+        for op in self.ops.iter().take(MAX_OPS) {
+            wat.push_str("    ");
+            op.to_wat_string(&mut wat);
+            wat.push('\n');
+        }
+        wat.push_str("  )\n");
+
+        wat.push_str(")\n");
+        wat
+    }
+}
+
+#[derive(Arbitrary, Debug)]
+pub(crate) enum TableOp {
+    // `(call 0)`
+    Gc,
+    // `(drop (table.get x))`
+    Get(u32),
+    // `(table.set x (local.get y))`
+    SetFromParam(u32, u8),
+    // `(table.set x (table.get y))`
+    SetFromGet(u32, u32),
+}
+
+impl TableOp {
+    fn to_wat_string(&self, wat: &mut String) {
+        match self {
+            Self::Gc => {
+                wat.push_str("(call 0)");
+            }
+            Self::Get(x) => {
+                wat.push_str("(drop (table.get $table (i32.const ");
+                write!(wat, "{}", x).unwrap();
+                wat.push_str(")))");
+            }
+            Self::SetFromParam(x, y) => {
+                wat.push_str("(table.set $table (i32.const ");
+                write!(wat, "{}", x).unwrap();
+                wat.push_str(") (local.get ");
+                write!(wat, "{}", y).unwrap();
+                wat.push_str("))");
+            }
+            Self::SetFromGet(x, y) => {
+                wat.push_str("(table.set $table (i32.const ");
+                write!(wat, "{}", x).unwrap();
+                wat.push_str(") (table.get $table (i32.const ");
+                write!(wat, "{}", y).unwrap();
+                wat.push_str(")))");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wat_string() {
+        let ops = TableOps {
+            num_params: 2,
+            table_size: 10,
+            ops: vec![
+                TableOp::Gc,
+                TableOp::Get(0),
+                TableOp::SetFromParam(1, 2),
+                TableOp::SetFromGet(3, 4),
+            ],
+        };
+
+        let expected = r#"
+(module
+  (import "" "gc" (func))
+  (table $table 10 externref)
+  (func (export "run") (param externref externref)
+    (call 0)
+    (drop (table.get $table (i32.const 0)))
+    (table.set $table (i32.const 1) (local.get 2))
+    (table.set $table (i32.const 3) (table.get $table (i32.const 4)))
+  )
+)
+"#;
+        let actual = ops.to_wat_string();
+        assert_eq!(actual.trim(), expected.trim());
+    }
+}

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -168,7 +168,7 @@ use wasmtime_environ::{ir::Stackmap, StackMapInformation};
 pub struct VMExternRef(NonNull<VMExternData>);
 
 #[repr(C)]
-struct VMExternData {
+pub(crate) struct VMExternData {
     // Implicit, dynamically-sized member that always preceded an
     // `VMExternData`.
     //
@@ -237,7 +237,7 @@ impl VMExternData {
     }
 
     /// Drop the inner value and then free this `VMExternData` heap allocation.
-    unsafe fn drop_and_dealloc(mut data: NonNull<VMExternData>) {
+    pub(crate) unsafe fn drop_and_dealloc(mut data: NonNull<VMExternData>) {
         // Note: we introduce a block scope so that we drop the live
         // reference to the data before we free the heap allocation it
         // resides within after this block.
@@ -614,17 +614,39 @@ impl VMExternRefActivationsTable {
         }
     }
 
-    fn insert_precise_stack_root(&self, root: NonNull<VMExternData>) {
-        let mut precise_stack_roots = self.precise_stack_roots.borrow_mut();
+    fn insert_precise_stack_root(
+        precise_stack_roots: &mut HashSet<VMExternRefWithTraits>,
+        root: NonNull<VMExternData>,
+    ) {
         let root = unsafe { VMExternRef::clone_from_raw(root.as_ptr() as *mut _) };
         precise_stack_roots.insert(VMExternRefWithTraits(root));
     }
 
     /// Sweep the bump allocation table after we've discovered our precise stack
     /// roots.
-    fn sweep(&self) {
+    fn sweep(&self, precise_stack_roots: &mut HashSet<VMExternRefWithTraits>) {
+        // Swap out the over-approximated set so we can distinguish between the
+        // over-approximation before we started sweeping, and any new elements
+        // we might insert into the table because of re-entering Wasm via an
+        // `externref`'s destructor. The new elements must be kept alive for
+        // memory safety, but we keep this set around because we likely want to
+        // reuse its allocation/capacity for the new `precise_stack_roots` in
+        // the next GC cycle.
+        let mut old_over_approximated = mem::replace(
+            &mut *self.over_approximated_stack_roots.borrow_mut(),
+            Default::default(),
+        );
+
         // Sweep our bump chunk.
+        //
+        // Just in case an `externref` destructor calls back into Wasm, passing
+        // more `externref`s into that Wasm, which requires the `externref`s to
+        // be inserted into this `VMExternRefActivationsTable`, make sure `next
+        // == end` so that they go into the over-approximation hash set.
         let num_filled = self.num_filled_in_bump_chunk();
+        unsafe {
+            *self.next.get() = self.end;
+        }
         for slot in self.chunk.iter().take(num_filled) {
             unsafe {
                 *slot.get() = None;
@@ -637,22 +659,35 @@ impl VMExternRefActivationsTable {
             "after sweeping the bump chunk, all slots should be `None`"
         );
 
-        // Reset our `next` bump allocation finger.
+        // Reset our `next` finger to the start of the bump allocation chunk.
         unsafe {
             let next = self.chunk.as_ptr() as *mut TableElem;
             debug_assert!(!next.is_null());
             *self.next.get() = NonNull::new_unchecked(next);
         }
 
-        // The current `precise_roots` becomes our new over-appoximated set for
-        // the next GC cycle.
-        let mut precise_roots = self.precise_stack_roots.borrow_mut();
+        // The current `precise_stack_roots` becomes our new over-appoximated
+        // set for the next GC cycle.
         let mut over_approximated = self.over_approximated_stack_roots.borrow_mut();
-        mem::swap(&mut *precise_roots, &mut *over_approximated);
+        mem::swap(&mut *precise_stack_roots, &mut *over_approximated);
 
-        // And finally, the new `precise_roots` should be cleared and remain
-        // empty until the next GC cycle.
-        precise_roots.clear();
+        // And finally, the new `precise_stack_roots` should be cleared and
+        // remain empty until the next GC cycle.
+        //
+        // However, if an `externref` destructor called re-entered Wasm with
+        // more `externref`s, then the temp over-approximated set we were using
+        // during sweeping (now `precise_stack_roots`) is not empty, and we need
+        // to keep its references alive in our new over-approximated set.
+        over_approximated.extend(precise_stack_roots.drain());
+
+        // If we didn't re-enter Wasm during destructors (likely),
+        // `precise_stack_roots` has zero capacity, and the old
+        // over-approximated has a bunch of capacity. Reuse whichever set has
+        // most capacity.
+        if old_over_approximated.capacity() > precise_stack_roots.capacity() {
+            old_over_approximated.clear();
+            *precise_stack_roots = old_over_approximated;
+        }
     }
 
     /// Set the stack canary around a call into Wasm.
@@ -944,6 +979,20 @@ pub unsafe fn gc(
     stack_maps_registry: &StackMapRegistry,
     externref_activations_table: &VMExternRefActivationsTable,
 ) {
+    // We borrow the precise stack roots `RefCell` for the whole duration of
+    // GC. Whether it is dynamically borrowed serves as a flag for detecting
+    // re-entrancy into GC. Re-entrancy can occur if we do a GC, drop an
+    // `externref`, and that `externref`'s destructor then triggers another
+    // GC. Whenever we detect re-entrancy, we return and give the first,
+    // outermost GC call priority.
+    let mut precise_stack_roots = match externref_activations_table
+        .precise_stack_roots
+        .try_borrow_mut()
+    {
+        Err(_) => return,
+        Ok(roots) => roots,
+    };
+
     log::debug!("start GC");
 
     debug_assert!({
@@ -952,7 +1001,6 @@ pub unsafe fn gc(
         // into the activations table's bump-allocated space at the
         // end. Therefore, it should always be empty upon entering this
         // function.
-        let precise_stack_roots = externref_activations_table.precise_stack_roots.borrow();
         precise_stack_roots.is_empty()
     });
 
@@ -971,7 +1019,7 @@ pub unsafe fn gc(
                     true
                 });
             }
-            externref_activations_table.sweep();
+            externref_activations_table.sweep(&mut precise_stack_roots);
             log::debug!("end GC");
             return;
         }
@@ -1029,7 +1077,10 @@ pub unsafe fn gc(
                          have an entry in the VMExternRefActivationsTable"
                     );
                     if let Some(r) = NonNull::new(r) {
-                        externref_activations_table.insert_precise_stack_root(r);
+                        VMExternRefActivationsTable::insert_precise_stack_root(
+                            &mut precise_stack_roots,
+                            r,
+                        );
                     }
                 }
             }
@@ -1056,11 +1107,10 @@ pub unsafe fn gc(
     // would free those missing roots while they are still in use, leading to
     // use-after-free.
     if found_canary {
-        externref_activations_table.sweep();
+        externref_activations_table.sweep(&mut precise_stack_roots);
     } else {
         log::warn!("did not find stack canary; skipping GC sweep");
-        let mut roots = externref_activations_table.precise_stack_roots.borrow_mut();
-        roots.clear();
+        precise_stack_roots.clear();
     }
 
     log::debug!("end GC");

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -901,18 +901,14 @@ impl StackMapRegistry {
             // Exact hit.
             Ok(i) => i,
 
-            Err(n) => {
-                // `Err(0)` means that the associated stack map would have been
-                // the first element in the array if this pc had an associated
-                // stack map, but this pc does not have an associated stack
-                // map. That doesn't make sense since every call and trap inside
-                // Wasm is a GC safepoint and should have a stack map, and the
-                // only way to have Wasm frames under this native frame is if we
-                // are at a call or a trap.
-                debug_assert!(n != 0);
+            // `Err(0)` means that the associated stack map would have been the
+            // first element in the array if this pc had an associated stack
+            // map, but this pc does not have an associated stack map. This can
+            // only happen inside a Wasm frame if there are no live refs at this
+            // pc.
+            Err(0) => return None,
 
-                n - 1
-            }
+            Err(n) => n - 1,
         };
 
         let stack_map = stack_maps.pc_to_stack_map[index].1.clone();

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -555,6 +555,10 @@ impl VMBuiltinFunctionsArray {
             wasmtime_imported_memory_fill as usize;
         ptrs[BuiltinFunctionIndex::memory_init().index() as usize] = wasmtime_memory_init as usize;
         ptrs[BuiltinFunctionIndex::data_drop().index() as usize] = wasmtime_data_drop as usize;
+        ptrs[BuiltinFunctionIndex::drop_externref().index() as usize] =
+            wasmtime_drop_externref as usize;
+        ptrs[BuiltinFunctionIndex::activations_table_insert_with_gc().index() as usize] =
+            wasmtime_activations_table_insert_with_gc as usize;
 
         if cfg!(debug_assertions) {
             for i in 0..ptrs.len() {

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -52,8 +52,8 @@ fn instantiate(
             config.memory_creator.as_ref().map(|a| a as _),
             store.interrupts().clone(),
             host,
-            &**store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
-            &**store.stack_map_registry() as *const StackMapRegistry as *mut _,
+            store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
+            store.stack_map_registry() as *const StackMapRegistry as *mut _,
         )?;
 
         // After we've created the `InstanceHandle` we still need to run

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -813,8 +813,8 @@ pub(crate) struct StoreInner {
     instances: RefCell<Vec<InstanceHandle>>,
     signal_handler: RefCell<Option<Box<SignalHandler<'static>>>>,
     jit_code_ranges: RefCell<Vec<(usize, usize)>>,
-    externref_activations_table: Rc<VMExternRefActivationsTable>,
-    stack_map_registry: Rc<StackMapRegistry>,
+    externref_activations_table: VMExternRefActivationsTable,
+    stack_map_registry: StackMapRegistry,
 }
 
 struct HostInfoKey(VMExternRef);
@@ -854,8 +854,8 @@ impl Store {
                 instances: RefCell::new(Vec::new()),
                 signal_handler: RefCell::new(None),
                 jit_code_ranges: RefCell::new(Vec::new()),
-                externref_activations_table: Rc::new(VMExternRefActivationsTable::new()),
-                stack_map_registry: Rc::new(StackMapRegistry::default()),
+                externref_activations_table: VMExternRefActivationsTable::new(),
+                stack_map_registry: StackMapRegistry::default(),
             }),
         }
     }
@@ -1091,11 +1091,11 @@ impl Store {
         }
     }
 
-    pub(crate) fn externref_activations_table(&self) -> &Rc<VMExternRefActivationsTable> {
+    pub(crate) fn externref_activations_table(&self) -> &VMExternRefActivationsTable {
         &self.inner.externref_activations_table
     }
 
-    pub(crate) fn stack_map_registry(&self) -> &Rc<StackMapRegistry> {
+    pub(crate) fn stack_map_registry(&self) -> &StackMapRegistry {
         &self.inner.stack_map_registry
     }
 
@@ -1106,8 +1106,8 @@ impl Store {
         // used with this store in `self.inner.stack_map_registry`.
         unsafe {
             wasmtime_runtime::gc(
-                &*self.inner.stack_map_registry,
-                &*self.inner.externref_activations_table,
+                &self.inner.stack_map_registry,
+                &self.inner.externref_activations_table,
             );
         }
     }

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -47,8 +47,8 @@ pub(crate) fn create_handle(
             signatures.into_boxed_slice(),
             state,
             store.interrupts().clone(),
-            &**store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
-            &**store.stack_map_registry() as *const StackMapRegistry as *mut _,
+            store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
+            store.stack_map_registry() as *const StackMapRegistry as *mut _,
         )?;
         Ok(store.add_instance(handle))
     }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -58,6 +58,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "table_ops"
+path = "fuzz_targets/table_ops.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "peepmatic_simple_automata"
 path = "fuzz_targets/peepmatic_simple_automata.rs"
 test = false

--- a/fuzz/fuzz_targets/table_ops.rs
+++ b/fuzz/fuzz_targets/table_ops.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use wasmtime_fuzzing::generators::{table_ops::TableOps, Config};
+
+fuzz_target!(|pair: (Config, TableOps)| {
+    let (config, ops) = pair;
+    wasmtime_fuzzing::oracles::table_ops(config, ops);
+});

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -3,6 +3,26 @@ use std::cell::Cell;
 use std::rc::Rc;
 use wasmtime::*;
 
+struct SetFlagOnDrop(Rc<Cell<bool>>);
+
+impl Drop for SetFlagOnDrop {
+    fn drop(&mut self) {
+        self.0.set(true);
+    }
+}
+
+struct GcOnDrop {
+    store: Store,
+    gc_count: Rc<Cell<usize>>,
+}
+
+impl Drop for GcOnDrop {
+    fn drop(&mut self) {
+        self.store.gc();
+        self.gc_count.set(self.gc_count.get() + 1);
+    }
+}
+
 #[test]
 fn smoke_test_gc() -> anyhow::Result<()> {
     let (store, module) = ref_types_module(
@@ -57,15 +77,7 @@ fn smoke_test_gc() -> anyhow::Result<()> {
     drop(r);
     assert!(inner_dropped.get());
 
-    return Ok(());
-
-    struct SetFlagOnDrop(Rc<Cell<bool>>);
-
-    impl Drop for SetFlagOnDrop {
-        fn drop(&mut self) {
-            self.0.set(true);
-        }
-    }
+    Ok(())
 }
 
 #[test]
@@ -207,6 +219,304 @@ fn many_live_refs() -> anyhow::Result<()> {
         fn drop(&mut self) {
             let live = self.live_refs.get();
             self.live_refs.set(live - 1);
+        }
+    }
+}
+
+#[test]
+fn drop_externref_via_table_set() -> anyhow::Result<()> {
+    let (store, module) = ref_types_module(
+        r#"
+            (module
+                (table $t 1 externref)
+
+                (func (export "table-set") (param externref)
+                  (table.set $t (i32.const 0) (local.get 0))
+                )
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&store, &module, &[])?;
+    let table_set = instance.get_func("table-set").unwrap();
+
+    let foo_is_dropped = Rc::new(Cell::new(false));
+    let bar_is_dropped = Rc::new(Cell::new(false));
+
+    let foo = ExternRef::new(SetFlagOnDrop(foo_is_dropped.clone()));
+    let bar = ExternRef::new(SetFlagOnDrop(bar_is_dropped.clone()));
+
+    {
+        let args = vec![Val::ExternRef(Some(foo))];
+        table_set.call(&args)?;
+    }
+    store.gc();
+    assert!(!foo_is_dropped.get());
+    assert!(!bar_is_dropped.get());
+
+    {
+        let args = vec![Val::ExternRef(Some(bar))];
+        table_set.call(&args)?;
+    }
+    store.gc();
+    assert!(foo_is_dropped.get());
+    assert!(!bar_is_dropped.get());
+
+    table_set.call(&[Val::ExternRef(None)])?;
+    assert!(foo_is_dropped.get());
+    assert!(bar_is_dropped.get());
+
+    Ok(())
+}
+
+#[test]
+fn gc_in_externref_dtor() -> anyhow::Result<()> {
+    let (store, module) = ref_types_module(
+        r#"
+            (module
+                (table $t 1 externref)
+
+                (func (export "table-set") (param externref)
+                  (table.set $t (i32.const 0) (local.get 0))
+                )
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&store, &module, &[])?;
+    let table_set = instance.get_func("table-set").unwrap();
+
+    let gc_count = Rc::new(Cell::new(0));
+
+    // Put a `GcOnDrop` into the table.
+    {
+        let args = vec![Val::ExternRef(Some(ExternRef::new(GcOnDrop {
+            store: store.clone(),
+            gc_count: gc_count.clone(),
+        })))];
+        table_set.call(&args)?;
+    }
+
+    // Remove the `GcOnDrop` from the `VMExternRefActivationsTable`.
+    store.gc();
+
+    // Overwrite the `GcOnDrop` table element, causing it to be dropped, and
+    // triggering a GC.
+    table_set.call(&[Val::ExternRef(None)])?;
+    assert_eq!(gc_count.get(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn touch_own_table_element_in_externref_dtor() -> anyhow::Result<()> {
+    let (store, module) = ref_types_module(
+        r#"
+            (module
+                (table $t (export "table") 1 externref)
+
+                (func (export "table-set") (param externref)
+                  (table.set $t (i32.const 0) (local.get 0))
+                )
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&store, &module, &[])?;
+    let table = instance.get_table("table").unwrap();
+    let table_set = instance.get_func("table-set").unwrap();
+
+    let touched = Rc::new(Cell::new(false));
+
+    {
+        let args = vec![Val::ExternRef(Some(ExternRef::new(TouchTableOnDrop {
+            table,
+            touched: touched.clone(),
+        })))];
+        table_set.call(&args)?;
+    }
+
+    // Remove the `TouchTableOnDrop` from the `VMExternRefActivationsTable`.
+    store.gc();
+
+    table_set.call(&[Val::ExternRef(Some(ExternRef::new("hello".to_string())))])?;
+    assert!(touched.get());
+
+    return Ok(());
+
+    struct TouchTableOnDrop {
+        table: Table,
+        touched: Rc<Cell<bool>>,
+    }
+
+    impl Drop for TouchTableOnDrop {
+        fn drop(&mut self) {
+            // From the `Drop` implementation, we see the new table element, not
+            // `self`.
+            let elem = self.table.get(0).unwrap().unwrap_externref().unwrap();
+            assert!(elem.data().is::<String>());
+            assert_eq!(elem.data().downcast_ref::<String>().unwrap(), "hello");
+            self.touched.set(true);
+        }
+    }
+}
+
+#[test]
+fn gc_during_gc_when_passing_refs_into_wasm() -> anyhow::Result<()> {
+    let (store, module) = ref_types_module(
+        r#"
+            (module
+                (table $t 1 externref)
+                (func (export "f") (param externref)
+                  (table.set $t (i32.const 0) (local.get 0))
+                )
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&store, &module, &[])?;
+    let f = instance.get_func("f").unwrap();
+
+    let gc_count = Rc::new(Cell::new(0));
+
+    for _ in 0..1024 {
+        let args = vec![Val::ExternRef(Some(ExternRef::new(GcOnDrop {
+            store: store.clone(),
+            gc_count: gc_count.clone(),
+        })))];
+        f.call(&args)?;
+    }
+
+    f.call(&[Val::ExternRef(None)])?;
+    store.gc();
+    assert_eq!(gc_count.get(), 1024);
+
+    Ok(())
+}
+
+#[test]
+fn gc_during_gc_from_many_table_gets() -> anyhow::Result<()> {
+    let (store, module) = ref_types_module(
+        r#"
+            (module
+                (import "" "" (func $observe_ref (param externref)))
+                (table $t 1 externref)
+                (func (export "init") (param externref)
+                    (table.set $t (i32.const 0) (local.get 0))
+                )
+                (func (export "run") (param i32)
+                    (loop $continue
+                        (if (i32.eqz (local.get 0)) (return))
+                        (call $observe_ref (table.get $t (i32.const 0)))
+                        (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+                        (br $continue)
+                    )
+                )
+            )
+        "#,
+    )?;
+
+    let observe_ref = Func::new(
+        &store,
+        FuncType::new(
+            vec![ValType::ExternRef].into_boxed_slice(),
+            vec![].into_boxed_slice(),
+        ),
+        |_caller, _params, _results| Ok(()),
+    );
+
+    let instance = Instance::new(&store, &module, &[observe_ref.into()])?;
+    let init = instance.get_func("init").unwrap();
+    let run = instance.get_func("run").unwrap();
+
+    let gc_count = Rc::new(Cell::new(0));
+
+    // Initialize the table element with a `GcOnDrop`. This also puts it in the
+    // `VMExternRefActivationsTable`.
+    {
+        let args = vec![Val::ExternRef(Some(ExternRef::new(GcOnDrop {
+            store: store.clone(),
+            gc_count: gc_count.clone(),
+        })))];
+        init.call(&args)?;
+    }
+
+    // Overwrite the `GcOnDrop` with another reference. The `GcOnDrop` is still
+    // in the `VMExternRefActivationsTable`.
+    {
+        let args = vec![Val::ExternRef(Some(ExternRef::new(String::from("hello"))))];
+        init.call(&args)?;
+    }
+
+    // Now call `run`, which does a bunch of `table.get`s, filling up the
+    // `VMExternRefActivationsTable`'s bump region, and eventually triggering a
+    // GC that will deallocate our `GcOnDrop` which will also trigger a nested
+    // GC.
+    run.call(&[Val::I32(1024)])?;
+
+    // We should have done our nested GC.
+    assert_eq!(gc_count.get(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn pass_externref_into_wasm_during_destructor_in_gc() -> anyhow::Result<()> {
+    let (store, module) = ref_types_module(
+        r#"
+            (module
+                (table $t 1 externref)
+
+                (func (export "f") (param externref)
+                  nop
+                )
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&store, &module, &[])?;
+    let f = instance.get_func("f").unwrap();
+    let r = ExternRef::new("hello");
+    let did_call = Rc::new(Cell::new(false));
+
+    // Put a `CallOnDrop` into the `VMExternRefActivationsTable`.
+    {
+        let args = vec![Val::ExternRef(Some(ExternRef::new(CallOnDrop(
+            f.clone(),
+            r.clone(),
+            did_call.clone(),
+        ))))];
+        f.call(&args)?;
+    }
+
+    // One ref count for `r`, one for the `CallOnDrop`.
+    assert_eq!(r.strong_count(), 2);
+
+    // Do a GC, which will see that the only reference holding the `CallOnDrop`
+    // is the `VMExternRefActivationsTable`, and will drop it. Dropping it will
+    // cause it to call into `f` again.
+    store.gc();
+    assert!(did_call.get());
+
+    // The `CallOnDrop` is no longer holding onto `r`, but the
+    // `VMExternRefActivationsTable` is.
+    assert_eq!(r.strong_count(), 2);
+
+    // GC again to empty the `VMExternRefActivationsTable`. Now `r` is the only
+    // thing holding its `externref` alive.
+    store.gc();
+    assert_eq!(r.strong_count(), 1);
+
+    return Ok(());
+
+    struct CallOnDrop(Func, ExternRef, Rc<Cell<bool>>);
+
+    impl Drop for CallOnDrop {
+        fn drop(&mut self) {
+            self.0
+                .call(&[Val::ExternRef(Some(self.1.clone()))])
+                .unwrap();
+            self.2.set(true);
         }
     }
 }

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -47,12 +47,9 @@ fn smoke_test_gc() -> anyhow::Result<()> {
         "#,
     )?;
 
-    let do_gc = Func::wrap(&store, {
-        let store = store.clone();
-        move || {
-            // Do a GC with `externref`s on the stack in Wasm frames.
-            store.gc();
-        }
+    let do_gc = Func::wrap(&store, |caller: Caller| {
+        // Do a GC with `externref`s on the stack in Wasm frames.
+        caller.store().gc();
     });
     let instance = Instance::new(&store, &module, &[do_gc.into()])?;
     let func = instance.get_func("func").unwrap();

--- a/tests/misc_testsuite/reference-types/many_table_gets_lead_to_gc.wast
+++ b/tests/misc_testsuite/reference-types/many_table_gets_lead_to_gc.wast
@@ -1,0 +1,35 @@
+(module
+  (table $t 1 externref)
+
+  (func (export "init") (param externref)
+    (table.set $t (i32.const 0) (local.get 0))
+  )
+
+  (func (export "get-many-externrefs") (param $i i32)
+    (loop $continue
+      ;; Exit when our loop counter `$i` reaches zero.
+      (if (i32.eqz (local.get $i))
+        (return)
+      )
+
+      ;; Get an `externref` out of the table. This could cause the
+      ;; `VMExternRefActivationsTable`'s bump region to reach full capacity,
+      ;; which triggers a GC.
+      ;;
+      ;; Set the table element back into the table, just so that the element is
+      ;; still considered live at the time of the `table.get`, it ends up in the
+      ;; stack map, and we poke more of our GC bits.
+      (table.set $t (i32.const 0) (table.get $t (i32.const 0)))
+
+      ;; Decrement our loop counter `$i`.
+      (local.set $i (i32.sub (local.get $i) (i32.const 1)))
+
+      ;; Continue to the next loop iteration.
+      (br $continue)
+    )
+    unreachable
+  )
+)
+
+(invoke "init" (ref.extern 1))
+(invoke "get-many-externrefs" (i32.const 8192))


### PR DESCRIPTION
These instructions have fast, inline JIT paths for the common cases, and only
call out to host VM functions for the slow paths. This required some changes to
`cranelift-wasm`'s `FuncEnvironment`: instead of taking a `FuncCursor` to insert
an instruction sequence within the current basic block,
`FuncEnvironment::translate_table_{get,set}` now take a `&mut FunctionBuilder`
so that they can create whole new basic blocks. This is necessary for
implementing GC read/write barriers that involve branching (e.g. checking for
null, or whether a store buffer is at capacity).

Furthermore, it required that the `load`, `load_complex`, and `store`
instructions handle loading and storing through an `r{32,64}` rather than just
`i{32,64}` addresses. This involved making `r{32,64}` types acceptable
instantiations of the `iAddr` type variable, plus a few new instruction
encodings.

Part of #929

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
