### PR TITLE
Do not return a no-op function if default function isn't found

### DIFF
--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -708,12 +708,7 @@ impl Linker {
             bail!("`_start` in '{}' is not a function", module);
         }
 
-        // Otherwise return a no-op function.
-        Ok(Func::new(
-            &self.store,
-            FuncType::new(Vec::new().into_boxed_slice(), Vec::new().into_boxed_slice()),
-            move |_, _, _| Ok(()),
-        ))
+        bail!("Could not find a default export or _start function.");
     }
 }
 


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [X] This has been discussed in issue #..., or if not, please tell us why
  here.
- [X] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [X] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

This PR changes the `linker.get_default()` deafult return value. It removes the return of a no-op function as this is rarely what users of the method would want. I have replaced it with an error that indicates that the module has no default functions to return.

This has been briefly discussed in the zulip bytecode alliance channel.

I do not know how to add test cases to this, it seems that there were no tests around it, but I'm happy to add some if anyone could guide me on where to put them.

I am unsure who the right reviewer for this is.