### PR TITLE
wasmtime-wiggle: change stray `log` ecosystem macro to `tracing`

### DIFF
--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -207,7 +207,7 @@ fn generate_func(
                     let mem = match caller.get_export("memory") {
                         Some(wasmtime::Extern::Memory(m)) => m,
                         _ => {
-                            log::warn!("callee does not export a memory as \"memory\"");
+                            wasmtime_wiggle::tracing::warn!("callee does not export a memory as \"memory\"");
                             let e = { #missing_mem_err };
                             #handle_early_error
                         }


### PR DESCRIPTION
Wiggle has bought into the `tracing` ecosystem, which can target either the `log` or `tracing`. One stray `log::warn!` survived the wig -> wasmtime-wiggle transformation in #1910, which means consuming crates need a dep on `log`. This PR resolves that issue by using the wasmtime-wiggle re-export of `tracing`, so no additional deps are required.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
