### PR TITLE
Spectre mitigation on heap access overflow checks.

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -1355,6 +1355,7 @@ fn define_alu(
     let rotr = shared.by_name("rotr");
     let rotr_imm = shared.by_name("rotr_imm");
     let selectif = shared.by_name("selectif");
+    let selectif_spectre_guard = shared.by_name("selectif_spectre_guard");
     let sshr = shared.by_name("sshr");
     let sshr_imm = shared.by_name("sshr_imm");
     let trueff = shared.by_name("trueff");
@@ -1568,6 +1569,11 @@ fn define_alu(
 
     // Conditional move (a.k.a integer select).
     e.enc_i32_i64(selectif, rec_cmov.opcodes(&CMOV_OVERFLOW));
+    // A Spectre-guard integer select is exactly the same as a selectif, but
+    // is not associated with any other legalization rules and is not
+    // recognized by any optimizations, so it must arrive here unmodified
+    // and in its original place.
+    e.enc_i32_i64(selectif_spectre_guard, rec_cmov.opcodes(&CMOV_OVERFLOW));
 }
 
 #[inline(never)]

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1748,6 +1748,34 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    ig.push(
+        Inst::new(
+            "selectif_spectre_guard",
+            r#"
+            Conditional select intended for Spectre guards.
+
+            This operation is semantically equivalent to a selectif instruction.
+            However, it is guaranteed to not be removed or otherwise altered by any
+            optimization pass, and is guaranteed to result in a conditional-move
+            instruction, not a branch-based lowering.  As such, it is suitable
+            for use when producing Spectre guards. For example, a bounds-check
+            may guard against unsafe speculation past a bounds-check conditional
+            branch by passing the address or index to be accessed through a
+            conditional move, also gated on the same condition. Because no
+            Spectre-vulnerable processors are known to perform speculation on
+            conditional move instructions, this is guaranteed to pick the
+            correct input. If the selected input in case of overflow is a "safe"
+            value, for example a null pointer that causes an exception in the
+            speculative path, this ensures that no Spectre vulnerability will
+            exist.
+            "#,
+            &formats.int_select,
+        )
+        .operands_in(vec![cc, flags, x, y])
+        .operands_out(vec![a])
+        .other_side_effects(true),
+    );
+
     let c = &Operand::new("c", Any).with_doc("Controlling value to test");
     ig.push(
         Inst::new(

--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -264,5 +264,23 @@ pub(crate) fn define() -> SettingGroup {
         true,
     );
 
+    // Spectre options.
+
+    settings.add_bool(
+        "enable_heap_access_spectre_mitigation",
+        r#"
+        Enable Spectre mitigation on heap bounds checks.
+        
+        This is a no-op for any heap that needs no bounds checks; e.g.,
+        if the limit is static and the guard region is large enough that
+        the index cannot reach past it.
+
+        This option is enabled by default because it is highly
+        recommended for secure sandboxing. The embedder should consider
+        the security implications carefully before disabling this option.
+        "#,
+        true,
+    );
+
     settings.build()
 }

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1023,7 +1023,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // Nothing.
         }
 
-        Opcode::Select | Opcode::Selectif => {
+        Opcode::Select | Opcode::Selectif | Opcode::SelectifSpectreGuard => {
             let cond = if op == Opcode::Select {
                 let (cmp_op, narrow_mode) = if ty_bits(ctx.input_ty(insn, 0)) > 32 {
                     (ALUOp::SubS64, NarrowValueMode::ZeroExtend64)

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -399,6 +399,7 @@ emit_all_ones_funcaddrs = false
 enable_probestack = true
 probestack_func_adjusts_sp = false
 enable_jump_tables = true
+enable_heap_access_spectre_mitigation = true
 "#
         );
         assert_eq!(f.opt_level(), super::OptLevel::None);

--- a/cranelift/filetests/filetests/isa/x86/legalize-heaps.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-heaps.clif
@@ -1,4 +1,5 @@
 test legalizer
+set enable_heap_access_spectre_mitigation=false
 target x86_64
 
 ; Test legalization for various forms of heap addresses.

--- a/cranelift/filetests/filetests/isa/x86/legalize-memory.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-memory.clif
@@ -1,5 +1,6 @@
 ; Test the legalization of memory objects.
 test legalizer
+set enable_heap_access_spectre_mitigation=false
 target x86_64
 
 ; regex: V=v\d+

--- a/cranelift/filetests/filetests/vcode/aarch64/heap_addr.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/heap_addr.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_heap_access_spectre_mitigation=true
 target aarch64
 
 function %dynamic_heap_check(i64 vmctx, i32) -> i64 {
@@ -11,20 +12,23 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
-; check:   stp fp, lr, [sp, #-16]!
-; nextln:  mov fp, sp
-; nextln:  ldur w2, [x0]
-; nextln:  add w2, w2, #0
-; nextln:  subs wzr, w1, w2
-; nextln:  b.ls label1 ; b label2
-; nextln:  Block 1:
-; check:   add x0, x0, x1, UXTW
-; nextln:  mov sp, fp
-; nextln:  ldp fp, lr, [sp], #16
-; nextln:  ret
-; nextln:  Block 2:
-; check:  udf
-
+; check: Block 0:
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: ldur w2, [x0]
+; nextln: add w2, w2, #0
+; nextln: subs wzr, w1, w2
+; nextln: b.ls label1 ; b label2
+; check: Block 1:
+; check: add x0, x0, x1, UXTW
+; nextln: subs wzr, w1, w2
+; nextln: movz x1, #0
+; nextln: csel x0, x1, x0, hi
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+; check: Block 2:
+; check: udf
 
 function %static_heap_check(i64 vmctx, i32) -> i64 {
     gv0 = vmctx
@@ -35,15 +39,18 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
-; check:   stp fp, lr, [sp, #-16]!
-; nextln:  mov fp, sp
-; nextln:  subs wzr, w1, #65536
-; nextln:  b.ls label1 ; b label2
-; nextln:  Block 1:
-; check:   add x0, x0, x1, UXTW
-; nextln:  mov sp, fp
-; nextln:  ldp fp, lr, [sp], #16
-; nextln:  ret
-; nextln:  Block 2:
-; check:   udf
-
+; check: Block 0:
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: subs wzr, w1, #65536
+; nextln: b.ls label1 ; b label2
+; check: Block 1:
+; check: add x0, x0, x1, UXTW
+; nextln: subs wzr, w1, #65536
+; nextln: movz x1, #0
+; nextln: csel x0, x1, x0, hi
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+; check: Block 2:
+; check: udf


### PR DESCRIPTION
This PR adds a conditional move following a heap bounds check through which the address to be accessed flows. This conditional move ensures that even if the branch is mispredicted (access is actually out of bounds, but speculation goes down in-bounds path), the acually accessed address is zero (a NULL pointer) rather than the out-of-bounds address.

The technique used is well-known and fairly standard: see, e.g., [SpiderMonkey's heap access bounds check](https://searchfox.org/mozilla-central/source/js/src/jit/arm64/MacroAssembler-arm64-inl.h#1726-1729) (thanks to @bnjbvr for locating this).

The mitigation is controlled by a flag that is off by default, but can be set by the embedding, to avoid unexpected performance impact for existing users.

Note that the mitigation is unneccessary when we use the "huge heap" technique on 64-bit systems, in which we allocate a range of virtual address space such that no 32-bit offset can reach other data. Hence, this only affects small-heap configurations.

The generated code is not great on aarch64 because the overflow flag must be materialized as a boolean in a register, rather than reusing flags (because the dataflow crosses basic blocks); in theory we could do much better with a later lowering, codegenning one comparison and two ops that use its flags.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
