### PR TITLE
Correct version of region dependency

### DIFF
--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -21,7 +21,7 @@ wasmtime-environ = { path = "../environ", version = "0.18.0" }
 wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
 wasmtime-debug = { path = "../debug", version = "0.18.0" }
 wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
-region = "2.0.0"
+region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.10.0", default-features = false }
 wasmparser = "0.57.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 wasmtime-environ = { path = "../environ", version = "0.18.0" }
-region = "2.0.0"
+region = "2.1.0"
 libc = { version = "0.2.70", default-features = false }
 log = "0.4.8"
 memoffset = "0.5.3"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -17,7 +17,7 @@ wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
 wasmparser = "0.57.0"
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0.19"
-region = "2.0.0"
+region = "2.1.0"
 libc = "0.2"
 cfg-if = "0.1.9"
 backtrace = "0.3.42"


### PR DESCRIPTION
In a similar vein of #1827, wasmtime-runtime's build fails with region 2.0.0.

I've also modified the version from the wasmtime and jit crates for consistency.