### PR TITLE
deps: Bump `z3` to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "z3"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded00cd90f8e3a7ea3155bddd72573f2b099ea201877542d924e47b58dd04e72"
+checksum = "f0354c65dfe00e08c4ab30581732906874f97156f424bfb390cf0cca2cb6ac29"
 dependencies = [
  "lazy_static",
  "log",
@@ -2781,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "z3-sys"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4002d8a1facb54d02dbfb86151281e5450618ab330936bc2f3acaab31eae11ae"
+checksum = "e1863cafae8eb86dd7d69c9218421b288594e8836346e93d4f36ade427195a21"
 dependencies = [
  "cmake",
 ]

--- a/cranelift/peepmatic/Cargo.toml
+++ b/cranelift/peepmatic/Cargo.toml
@@ -14,4 +14,4 @@ peepmatic-automata = { version = "0.2.0", path = "crates/automata", features = [
 peepmatic-macro = { version = "0.2.0", path = "crates/macro" }
 peepmatic-runtime = { version = "0.2.0", path = "crates/runtime", features = ["construct"] }
 wast = "15.0.0"
-z3 = { version = "0.5.1", features = ["static-link-z3"] }
+z3 = { version = "0.6.0", features = ["static-link-z3"] }

--- a/cranelift/peepmatic/src/verify.rs
+++ b/cranelift/peepmatic/src/verify.rs
@@ -255,7 +255,7 @@ impl<'a> TypingContext<'a> {
         let is_void = self.is_void(&root_ty);
         let is_cpu_flags = self.is_cpu_flags(&root_ty);
         self.constraints.push((
-            is_int.or(&[&is_bool, &is_void, &is_cpu_flags]),
+            z3::ast::Bool::or(&self.z3, &[&is_int, &is_bool, &is_void, &is_cpu_flags]),
             span,
             Some(
                 "the root of an optimization must be an integer, a boolean, void, or CPU flags"
@@ -719,7 +719,7 @@ impl<'a> TypingContextTrait<'a> for TypingContext<'a> {
             .as_bool()
             .unwrap();
         self.constraints.push((
-            is_int.or(&[&is_bool]),
+            z3::ast::Bool::or(&self.z3, &[&is_int, &is_bool]),
             span,
             Some("type error: must be either an int or a bool type".into()),
         ));


### PR DESCRIPTION
Z3 is used by `peepmatic`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
