### PR TITLE
Upgrade wasmparser to 0.58.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.57.0",
+ "wasmparser 0.58.0",
  "wat",
 ]
 
@@ -1123,7 +1123,7 @@ dependencies = [
  "staticvec",
  "thiserror",
  "typemap",
- "wasmparser 0.57.0",
+ "wasmparser 0.58.0",
  "wat",
 ]
 
@@ -2299,9 +2299,9 @@ checksum = "af931e2e1960c53f4a28b063fec4cacd036f35acbec8ff3a4739125b17382a87"
 
 [[package]]
 name = "wasmparser"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
+checksum = "721a8d79483738d7aef6397edcf8f04cd862640b1ad5973adf5bb50fc10e86db"
 
 [[package]]
 name = "wasmprinter"
@@ -2327,7 +2327,7 @@ dependencies = [
  "rustc-demangle",
  "target-lexicon",
  "tempfile",
- "wasmparser 0.57.0",
+ "wasmparser 0.58.0",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-profiling",
@@ -2400,7 +2400,7 @@ dependencies = [
  "object 0.19.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.57.0",
+ "wasmparser 0.58.0",
  "wasmtime-environ",
 ]
 
@@ -2431,7 +2431,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "wasmparser 0.57.0",
+ "wasmparser 0.58.0",
  "winapi",
  "zstd",
 ]
@@ -2460,7 +2460,7 @@ dependencies = [
  "env_logger",
  "log",
  "rayon",
- "wasmparser 0.57.0",
+ "wasmparser 0.58.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -2484,7 +2484,7 @@ dependencies = [
  "region",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.57.0",
+ "wasmparser 0.58.0",
  "wasmtime-debug",
  "wasmtime-environ",
  "wasmtime-profiling",

--- a/build.rs
+++ b/build.rs
@@ -205,11 +205,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", "simd_i16x8_arith2") => return true,
             ("simd", "simd_i8x16_arith2") => return true,
 
-            // waiting for the upstream spec to get updated with new binary
-            // encodings of operations and for that to propagate to the
-            // testsuite repo.
-            ("simd", "simd_const") => return true,
-
             ("reference_types", "table_copy_on_imported_tables")
             | ("reference_types", "externref_id_function")
             | ("reference_types", "table_size")

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.57.0", default-features = false }
+wasmparser = { version = "0.58.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.65.0" }
 cranelift-frontend = { path = "../frontend", version = "0.65.0", default-features = false }

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1575,7 +1575,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I32x4WidenLowI16x8S { .. }
         | Operator::I32x4WidenHighI16x8S { .. }
         | Operator::I32x4WidenLowI16x8U { .. }
-        | Operator::I32x4WidenHighI16x8U { .. } => {
+        | Operator::I32x4WidenHighI16x8U { .. }
+        | Operator::I8x16Bitmask
+        | Operator::I16x8Bitmask
+        | Operator::I32x4Bitmask => {
             return Err(wasm_unsupported!("proposed SIMD operator {:?}", op));
         }
 
@@ -2007,7 +2010,8 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I8x16MinU
         | Operator::I8x16MaxS
         | Operator::I8x16MaxU
-        | Operator::I8x16RoundingAverageU => I8X16,
+        | Operator::I8x16RoundingAverageU
+        | Operator::I8x16Bitmask => I8X16,
 
         Operator::I16x8Splat
         | Operator::V16x8LoadSplat { .. }
@@ -2041,7 +2045,8 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I16x8MaxS
         | Operator::I16x8MaxU
         | Operator::I16x8RoundingAverageU
-        | Operator::I16x8Mul => I16X8,
+        | Operator::I16x8Mul
+        | Operator::I16x8Bitmask => I16X8,
 
         Operator::I32x4Splat
         | Operator::V32x4LoadSplat { .. }
@@ -2071,7 +2076,8 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I32x4MaxS
         | Operator::I32x4MaxU
         | Operator::F32x4ConvertI32x4S
-        | Operator::F32x4ConvertI32x4U => I32X4,
+        | Operator::F32x4ConvertI32x4U
+        | Operator::I32x4Bitmask => I32X4,
 
         Operator::I64x2Splat
         | Operator::V64x2LoadSplat { .. }

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -71,6 +71,11 @@ pub fn translate_module<'data>(
                 environ.reserve_passive_data(count)?;
             }
 
+            SectionContent::Module(_)
+            | SectionContent::ModuleCode(_)
+            | SectionContent::Instance(_)
+            | SectionContent::Alias(_) => unimplemented!("module linking not implemented yet"),
+
             SectionContent::Custom {
                 name,
                 binary,

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.21.0"
-wasmparser = "0.57.0"
+wasmparser = "0.58.0"
 object = { version = "0.19", default-features = false, features = ["write"] }
 wasmtime-environ = { path = "../environ", version = "0.18.0" }
 target-lexicon = { version = "0.10.0", default-features = false }

--- a/crates/debug/src/read_debuginfo.rs
+++ b/crates/debug/src/read_debuginfo.rs
@@ -6,7 +6,7 @@ use gimli::{
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
-use wasmparser::{self, ModuleReader, SectionCode};
+use wasmparser::{self, ModuleReader, SectionCode, TypeDef};
 
 trait Reader: gimli::Reader<Offset = usize, Endian = LittleEndian> {}
 
@@ -186,7 +186,13 @@ pub fn read_debuginfo(data: &[u8]) -> Result<DebugInfoData> {
                 signatures_params = section
                     .get_type_section_reader()?
                     .into_iter()
-                    .map(|ft| Ok(ft?.params))
+                    .map(|ft| {
+                        if let Ok(TypeDef::Func(ft)) = ft {
+                            Ok(ft.params)
+                        } else {
+                            unimplemented!("module linking not implemented yet")
+                        }
+                    })
                     .collect::<Result<Vec<_>>>()?;
             }
             SectionCode::Import => {

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.65.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.65.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.65.0", features = ["enable-serde"] }
-wasmparser = "0.57.0"
+wasmparser = "0.58.0"
 lightbeam = { path = "../lightbeam", optional = true, version = "0.18.0" }
 indexmap = "1.0.2"
 rayon = "1.2.1"

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,7 +13,7 @@ binaryen = { version = "0.10.0", optional = true }
 env_logger = "0.7.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.57.0"
+wasmparser = "0.58.0"
 wasmprinter = "0.2.5"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.10.0", default-features = false }
-wasmparser = "0.57.0"
+wasmparser = "0.58.0"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "0.1.9"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "1.0.0"
 staticvec = "0.10"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.57.0"
+wasmparser = "0.58.0"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/src/translate_sections.rs
+++ b/crates/lightbeam/src/translate_sections.rs
@@ -5,14 +5,18 @@ use cranelift_codegen::{binemit, ir};
 use wasmparser::{
     CodeSectionReader, DataSectionReader, ElementSectionReader, ExportSectionReader, FuncType,
     FunctionSectionReader, GlobalSectionReader, ImportSectionReader, MemorySectionReader,
-    MemoryType, TableSectionReader, TableType, TypeSectionReader,
+    MemoryType, TableSectionReader, TableType, TypeDef, TypeSectionReader,
 };
 
 /// Parses the Type section of the wasm module.
 pub fn type_(types_reader: TypeSectionReader) -> Result<Vec<FuncType>, Error> {
     types_reader
         .into_iter()
-        .map(|r| r.map_err(Into::into))
+        .map(|r| match r {
+            Ok(TypeDef::Func(ft)) => Ok(ft),
+            Ok(_) => unimplemented!("module linking is not implemented yet"),
+            Err(e) => Err(e.into()),
+        })
         .collect()
 }
 

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -14,7 +14,7 @@ wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
 wasmtime-environ = { path = "../environ", version = "0.18.0" }
 wasmtime-jit = { path = "../jit", version = "0.18.0" }
 wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
-wasmparser = "0.57.0"
+wasmparser = "0.58.0"
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0.19"
 region = "2.1.0"

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -89,6 +89,7 @@ impl Config {
                     enable_simd: false,
                     enable_multi_value: true,
                     enable_tail_call: false,
+                    enable_module_linking: false,
                 },
             },
             flags,


### PR DESCRIPTION
In order to get access to the newest SIMD instructions, I upgraded wasmparser to 0.58.0. 

There are API changes in wasmparser that need to be resolved before we can merge this. I marked these with `unimplemented!() // TODO` in various places so that at least we could get this to compile. @yurydelendik, @alexcrichton (I think some of this has to do with module linking and I have seen you discuss that before): could you take a look through these and give me your thoughts on how to implement (or temporarily avoid implementing) these `unimplemented!` sections?