### PR TITLE
Rename `OFlag`/`AtFlag` to `OFlags`/`AtFlags`.

### DIFF
--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/host_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/host_impl.rs
@@ -1,7 +1,7 @@
 use crate::old::snapshot_0::wasi::{self, WasiResult};
 use std::convert::TryFrom;
 
-pub(crate) const O_RSYNC: yanix::file::OFlag = yanix::file::OFlag::SYNC;
+pub(crate) const O_RSYNC: yanix::file::OFlags = yanix::file::OFlags::SYNC;
 
 pub(crate) fn stdev_from_nix(dev: libc::dev_t) -> WasiResult<wasi::__wasi_device_t> {
     wasi::__wasi_device_t::try_from(dev).map_err(Into::into)

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/bsd/hostcalls_impl.rs
@@ -3,12 +3,12 @@ use crate::old::snapshot_0::wasi::{WasiError, WasiResult};
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn path_unlink_file(resolved: PathGet) -> WasiResult<()> {
-    use yanix::file::{unlinkat, AtFlag};
+    use yanix::file::{unlinkat, AtFlags};
     match unsafe {
         unlinkat(
             resolved.dirfd().as_raw_fd(),
             resolved.path(),
-            AtFlag::empty(),
+            AtFlags::empty(),
         )
     } {
         Err(err) => {
@@ -27,7 +27,7 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> WasiResult<()> {
                     fstatat(
                         resolved.dirfd().as_raw_fd(),
                         resolved.path(),
-                        AtFlag::SYMLINK_NOFOLLOW,
+                        AtFlags::SYMLINK_NOFOLLOW,
                     )
                 } {
                     Ok(stat) => {
@@ -48,7 +48,7 @@ pub(crate) fn path_unlink_file(resolved: PathGet) -> WasiResult<()> {
 }
 
 pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> WasiResult<()> {
-    use yanix::file::{fstatat, symlinkat, AtFlag};
+    use yanix::file::{fstatat, symlinkat, AtFlags};
 
     log::debug!("path_symlink old_path = {:?}", old_path);
     log::debug!("path_symlink resolved = {:?}", resolved);
@@ -66,7 +66,7 @@ pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> WasiResult<()> 
                     fstatat(
                         resolved.dirfd().as_raw_fd(),
                         new_path,
-                        AtFlag::SYMLINK_NOFOLLOW,
+                        AtFlags::SYMLINK_NOFOLLOW,
                     )
                 } {
                     Ok(_) => return Err(WasiError::EEXIST),
@@ -82,7 +82,7 @@ pub(crate) fn path_symlink(old_path: &str, resolved: PathGet) -> WasiResult<()> 
 }
 
 pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> WasiResult<()> {
-    use yanix::file::{fstatat, renameat, AtFlag};
+    use yanix::file::{fstatat, renameat, AtFlags};
     match unsafe {
         renameat(
             resolved_old.dirfd().as_raw_fd(),
@@ -107,7 +107,7 @@ pub(crate) fn path_rename(resolved_old: PathGet, resolved_new: PathGet) -> WasiR
                     fstatat(
                         resolved_old.dirfd().as_raw_fd(),
                         resolved_old.path(),
-                        AtFlag::SYMLINK_NOFOLLOW,
+                        AtFlags::SYMLINK_NOFOLLOW,
                     )
                 } {
                     Ok(_) => {

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/emscripten/host_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/emscripten/host_impl.rs
@@ -1,6 +1,6 @@
 use crate::old::snapshot_0::wasi::{self, WasiResult};
 
-pub(crate) const O_RSYNC: yanix::file::OFlag = yanix::file::OFlag::RSYNC;
+pub(crate) const O_RSYNC: yanix::file::OFlags = yanix::file::OFlags::RSYNC;
 
 pub(crate) fn stdev_from_nix(dev: libc::dev_t) -> WasiResult<wasi::__wasi_device_t> {
     Ok(wasi::__wasi_device_t::from(dev))

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/entry_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/entry_impl.rs
@@ -36,12 +36,12 @@ pub(crate) unsafe fn determine_type_and_access_rights<Fd: AsRawFd>(
 )> {
     let (file_type, mut rights_base, rights_inheriting) = determine_type_rights(fd)?;
 
-    use yanix::{fcntl, file::OFlag};
+    use yanix::{fcntl, file::OFlags};
     let flags = fcntl::get_status_flags(fd.as_raw_fd())?;
-    let accmode = flags & OFlag::ACCMODE;
-    if accmode == OFlag::RDONLY {
+    let accmode = flags & OFlags::ACCMODE;
+    if accmode == OFlags::RDONLY {
         rights_base &= !wasi::__WASI_RIGHTS_FD_WRITE;
-    } else if accmode == OFlag::WRONLY {
+    } else if accmode == OFlags::WRONLY {
         rights_base &= !wasi::__WASI_RIGHTS_FD_READ;
     }
 

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/host_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/host_impl.rs
@@ -8,7 +8,7 @@ use crate::old::snapshot_0::{helpers, sys::unix::sys_impl};
 use std::ffi::OsStr;
 use std::io;
 use std::os::unix::prelude::OsStrExt;
-use yanix::file::OFlag;
+use yanix::file::OFlags;
 
 pub(crate) use sys_impl::host_impl::*;
 
@@ -104,59 +104,59 @@ impl From<io::Error> for WasiError {
     }
 }
 
-pub(crate) fn nix_from_fdflags(fdflags: wasi::__wasi_fdflags_t) -> OFlag {
-    let mut nix_flags = OFlag::empty();
+pub(crate) fn nix_from_fdflags(fdflags: wasi::__wasi_fdflags_t) -> OFlags {
+    let mut nix_flags = OFlags::empty();
     if fdflags & wasi::__WASI_FDFLAGS_APPEND != 0 {
-        nix_flags.insert(OFlag::APPEND);
+        nix_flags.insert(OFlags::APPEND);
     }
     if fdflags & wasi::__WASI_FDFLAGS_DSYNC != 0 {
-        nix_flags.insert(OFlag::DSYNC);
+        nix_flags.insert(OFlags::DSYNC);
     }
     if fdflags & wasi::__WASI_FDFLAGS_NONBLOCK != 0 {
-        nix_flags.insert(OFlag::NONBLOCK);
+        nix_flags.insert(OFlags::NONBLOCK);
     }
     if fdflags & wasi::__WASI_FDFLAGS_RSYNC != 0 {
         nix_flags.insert(O_RSYNC);
     }
     if fdflags & wasi::__WASI_FDFLAGS_SYNC != 0 {
-        nix_flags.insert(OFlag::SYNC);
+        nix_flags.insert(OFlags::SYNC);
     }
     nix_flags
 }
 
-pub(crate) fn fdflags_from_nix(oflags: OFlag) -> wasi::__wasi_fdflags_t {
+pub(crate) fn fdflags_from_nix(oflags: OFlags) -> wasi::__wasi_fdflags_t {
     let mut fdflags = 0;
-    if oflags.contains(OFlag::APPEND) {
+    if oflags.contains(OFlags::APPEND) {
         fdflags |= wasi::__WASI_FDFLAGS_APPEND;
     }
-    if oflags.contains(OFlag::DSYNC) {
+    if oflags.contains(OFlags::DSYNC) {
         fdflags |= wasi::__WASI_FDFLAGS_DSYNC;
     }
-    if oflags.contains(OFlag::NONBLOCK) {
+    if oflags.contains(OFlags::NONBLOCK) {
         fdflags |= wasi::__WASI_FDFLAGS_NONBLOCK;
     }
     if oflags.contains(O_RSYNC) {
         fdflags |= wasi::__WASI_FDFLAGS_RSYNC;
     }
-    if oflags.contains(OFlag::SYNC) {
+    if oflags.contains(OFlags::SYNC) {
         fdflags |= wasi::__WASI_FDFLAGS_SYNC;
     }
     fdflags
 }
 
-pub(crate) fn nix_from_oflags(oflags: wasi::__wasi_oflags_t) -> OFlag {
-    let mut nix_flags = OFlag::empty();
+pub(crate) fn nix_from_oflags(oflags: wasi::__wasi_oflags_t) -> OFlags {
+    let mut nix_flags = OFlags::empty();
     if oflags & wasi::__WASI_OFLAGS_CREAT != 0 {
-        nix_flags.insert(OFlag::CREAT);
+        nix_flags.insert(OFlags::CREAT);
     }
     if oflags & wasi::__WASI_OFLAGS_DIRECTORY != 0 {
-        nix_flags.insert(OFlag::DIRECTORY);
+        nix_flags.insert(OFlags::DIRECTORY);
     }
     if oflags & wasi::__WASI_OFLAGS_EXCL != 0 {
-        nix_flags.insert(OFlag::EXCL);
+        nix_flags.insert(OFlags::EXCL);
     }
     if oflags & wasi::__WASI_OFLAGS_TRUNC != 0 {
-        nix_flags.insert(OFlag::TRUNC);
+        nix_flags.insert(OFlags::TRUNC);
     }
     nix_flags
 }

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -3,7 +3,7 @@
 use crate::old::snapshot_0::sys::host_impl;
 use crate::old::snapshot_0::wasi::{self, WasiResult};
 use std::fs::File;
-use yanix::file::OFlag;
+use yanix::file::OFlags;
 
 pub(crate) fn path_open_rights(
     rights_base: wasi::__wasi_rights_t,
@@ -17,19 +17,19 @@ pub(crate) fn path_open_rights(
 
     // convert open flags
     let oflags = host_impl::nix_from_oflags(oflags);
-    if oflags.contains(OFlag::CREAT) {
+    if oflags.contains(OFlags::CREAT) {
         needed_base |= wasi::__WASI_RIGHTS_PATH_CREATE_FILE;
     }
-    if oflags.contains(OFlag::TRUNC) {
+    if oflags.contains(OFlags::TRUNC) {
         needed_base |= wasi::__WASI_RIGHTS_PATH_FILESTAT_SET_SIZE;
     }
 
     // convert file descriptor flags
     let fdflags = host_impl::nix_from_fdflags(fs_flags);
-    if fdflags.contains(OFlag::DSYNC) {
+    if fdflags.contains(OFlags::DSYNC) {
         needed_inheriting |= wasi::__WASI_RIGHTS_FD_DATASYNC;
     }
-    if fdflags.intersects(host_impl::O_RSYNC | OFlag::SYNC) {
+    if fdflags.intersects(host_impl::O_RSYNC | OFlags::SYNC) {
         needed_inheriting |= wasi::__WASI_RIGHTS_FD_SYNC;
     }
 
@@ -46,7 +46,7 @@ pub(crate) fn openat(dirfd: &File, path: &str) -> WasiResult<File> {
         openat(
             dirfd.as_raw_fd(),
             path,
-            OFlag::RDONLY | OFlag::DIRECTORY | OFlag::NOFOLLOW,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW,
             Mode::empty(),
         )
     }

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/host_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/host_impl.rs
@@ -1,7 +1,7 @@
 use crate::old::snapshot_0::wasi::{self, WasiResult};
 use std::convert::TryInto;
 
-pub(crate) const O_RSYNC: yanix::file::OFlag = yanix::file::OFlag::RSYNC;
+pub(crate) const O_RSYNC: yanix::file::OFlags = yanix::file::OFlags::RSYNC;
 
 pub(crate) fn stdev_from_nix(dev: libc::dev_t) -> WasiResult<wasi::__wasi_device_t> {
     Ok(wasi::__wasi_device_t::from(dev))

--- a/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/hostcalls_impl.rs
+++ b/crates/wasi-common/src/old/snapshot_0/sys/unix/linux/hostcalls_impl.rs
@@ -3,12 +3,12 @@ use crate::old::snapshot_0::wasi::WasiResult;
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn path_unlink_file(resolved: PathGet) -> WasiResult<()> {
-    use yanix::file::{unlinkat, AtFlag};
+    use yanix::file::{unlinkat, AtFlags};
     unsafe {
         unlinkat(
             resolved.dirfd().as_raw_fd(),
             resolved.path(),
-            AtFlag::empty(),
+            AtFlags::empty(),
         )
     }
     .map_err(Into::into)

--- a/crates/wasi-common/src/sys/unix/bsd/mod.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod osdir;
 pub(crate) mod path;
 
-pub(crate) const O_RSYNC: yanix::file::OFlag = yanix::file::OFlag::SYNC;
+pub(crate) const O_RSYNC: yanix::file::OFlags = yanix::file::OFlags::SYNC;

--- a/crates/wasi-common/src/sys/unix/emscripten/mod.rs
+++ b/crates/wasi-common/src/sys/unix/emscripten/mod.rs
@@ -3,4 +3,4 @@ pub(crate) mod osdir;
 #[path = "../linux/path.rs"]
 pub(crate) mod path;
 
-pub(crate) const O_RSYNC: yanix::file::OFlag = yanix::file::OFlag::RSYNC;
+pub(crate) const O_RSYNC: yanix::file::OFlags = yanix::file::OFlags::RSYNC;

--- a/crates/wasi-common/src/sys/unix/linux/mod.rs
+++ b/crates/wasi-common/src/sys/unix/linux/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod osdir;
 pub(crate) mod path;
 
-pub(crate) const O_RSYNC: yanix::file::OFlag = yanix::file::OFlag::RSYNC;
+pub(crate) const O_RSYNC: yanix::file::OFlags = yanix::file::OFlags::RSYNC;

--- a/crates/wasi-common/src/sys/unix/linux/path.rs
+++ b/crates/wasi-common/src/sys/unix/linux/path.rs
@@ -3,8 +3,8 @@ use crate::wasi::Result;
 use std::os::unix::prelude::AsRawFd;
 
 pub(crate) fn unlink_file(dirfd: &OsDir, path: &str) -> Result<()> {
-    use yanix::file::{unlinkat, AtFlag};
-    unsafe { unlinkat(dirfd.as_raw_fd(), path, AtFlag::empty())? };
+    use yanix::file::{unlinkat, AtFlags};
+    unsafe { unlinkat(dirfd.as_raw_fd(), path, AtFlags::empty())? };
     Ok(())
 }
 

--- a/crates/wasi-common/src/sys/unix/osdir.rs
+++ b/crates/wasi-common/src/sys/unix/osdir.rs
@@ -23,16 +23,16 @@ impl TryFrom<File> for OsDir {
 }
 
 fn get_rights(file: &File) -> io::Result<HandleRights> {
-    use yanix::{fcntl, file::OFlag};
+    use yanix::{fcntl, file::OFlags};
     let mut rights = HandleRights::new(
         types::Rights::directory_base(),
         types::Rights::directory_inheriting(),
     );
     let flags = unsafe { fcntl::get_status_flags(file.as_raw_fd())? };
-    let accmode = flags & OFlag::ACCMODE;
-    if accmode == OFlag::RDONLY {
+    let accmode = flags & OFlags::ACCMODE;
+    if accmode == OFlags::RDONLY {
         rights.base &= !types::Rights::FD_WRITE;
-    } else if accmode == OFlag::WRONLY {
+    } else if accmode == OFlags::WRONLY {
         rights.base &= !types::Rights::FD_READ;
     }
     Ok(rights)

--- a/crates/wasi-common/src/sys/unix/osfile.rs
+++ b/crates/wasi-common/src/sys/unix/osfile.rs
@@ -22,16 +22,16 @@ impl TryFrom<File> for OsFile {
 }
 
 fn get_rights(file: &File) -> io::Result<HandleRights> {
-    use yanix::{fcntl, file::OFlag};
+    use yanix::{fcntl, file::OFlags};
     let mut rights = HandleRights::new(
         types::Rights::regular_file_base(),
         types::Rights::regular_file_inheriting(),
     );
     let flags = unsafe { fcntl::get_status_flags(file.as_raw_fd())? };
-    let accmode = flags & OFlag::ACCMODE;
-    if accmode == OFlag::RDONLY {
+    let accmode = flags & OFlags::ACCMODE;
+    if accmode == OFlags::RDONLY {
         rights.base &= !types::Rights::FD_WRITE;
-    } else if accmode == OFlag::WRONLY {
+    } else if accmode == OFlags::WRONLY {
         rights.base &= !types::Rights::FD_READ;
     }
     Ok(rights)

--- a/crates/wasi-common/yanix/src/fcntl.rs
+++ b/crates/wasi-common/yanix/src/fcntl.rs
@@ -1,5 +1,5 @@
 use crate::{
-    file::{FdFlag, OFlag},
+    file::{FdFlags, OFlags},
     from_result, from_success_code,
 };
 use std::io::Result;
@@ -17,18 +17,18 @@ pub unsafe fn dup_fd(fd: RawFd, close_on_exec: bool) -> Result<RawFd> {
     })
 }
 
-pub unsafe fn get_fd_flags(fd: RawFd) -> Result<FdFlag> {
-    from_result(libc::fcntl(fd, libc::F_GETFD)).map(FdFlag::from_bits_truncate)
+pub unsafe fn get_fd_flags(fd: RawFd) -> Result<FdFlags> {
+    from_result(libc::fcntl(fd, libc::F_GETFD)).map(FdFlags::from_bits_truncate)
 }
 
-pub unsafe fn set_fd_flags(fd: RawFd, flags: FdFlag) -> Result<()> {
+pub unsafe fn set_fd_flags(fd: RawFd, flags: FdFlags) -> Result<()> {
     from_success_code(libc::fcntl(fd, libc::F_SETFD, flags.bits()))
 }
 
-pub unsafe fn get_status_flags(fd: RawFd) -> Result<OFlag> {
-    from_result(libc::fcntl(fd, libc::F_GETFL)).map(OFlag::from_bits_truncate)
+pub unsafe fn get_status_flags(fd: RawFd) -> Result<OFlags> {
+    from_result(libc::fcntl(fd, libc::F_GETFL)).map(OFlags::from_bits_truncate)
 }
 
-pub unsafe fn set_status_flags(fd: RawFd, flags: OFlag) -> Result<()> {
+pub unsafe fn set_status_flags(fd: RawFd, flags: OFlags) -> Result<()> {
     from_success_code(libc::fcntl(fd, libc::F_SETFL, flags.bits()))
 }

--- a/crates/wasi-common/yanix/src/file.rs
+++ b/crates/wasi-common/yanix/src/file.rs
@@ -11,13 +11,13 @@ use std::{
 pub use crate::sys::file::*;
 
 bitflags! {
-    pub struct FdFlag: libc::c_int {
+    pub struct FdFlags: libc::c_int {
         const CLOEXEC = libc::FD_CLOEXEC;
     }
 }
 
 bitflags! {
-    pub struct AtFlag: libc::c_int {
+    pub struct AtFlags: libc::c_int {
         const REMOVEDIR = libc::AT_REMOVEDIR;
         const SYMLINK_FOLLOW = libc::AT_SYMLINK_FOLLOW;
         const SYMLINK_NOFOLLOW = libc::AT_SYMLINK_NOFOLLOW;
@@ -45,7 +45,7 @@ bitflags! {
 }
 
 bitflags! {
-    pub struct OFlag: libc::c_int {
+    pub struct OFlags: libc::c_int {
         const ACCMODE = libc::O_ACCMODE;
         const APPEND = libc::O_APPEND;
         const CREAT = libc::O_CREAT;
@@ -134,7 +134,7 @@ impl FileType {
 pub unsafe fn openat<P: AsRef<OsStr>>(
     dirfd: RawFd,
     path: P,
-    oflag: OFlag,
+    oflag: OFlags,
     mode: Mode,
 ) -> Result<RawFd> {
     let path = CString::new(path.as_ref().as_bytes())?;
@@ -173,7 +173,7 @@ pub unsafe fn linkat<P: AsRef<OsStr>>(
     old_path: P,
     new_dirfd: RawFd,
     new_path: P,
-    flags: AtFlag,
+    flags: AtFlags,
 ) -> Result<()> {
     let old_path = CString::new(old_path.as_ref().as_bytes())?;
     let new_path = CString::new(new_path.as_ref().as_bytes())?;
@@ -186,7 +186,7 @@ pub unsafe fn linkat<P: AsRef<OsStr>>(
     ))
 }
 
-pub unsafe fn unlinkat<P: AsRef<OsStr>>(dirfd: RawFd, path: P, flags: AtFlag) -> Result<()> {
+pub unsafe fn unlinkat<P: AsRef<OsStr>>(dirfd: RawFd, path: P, flags: AtFlags) -> Result<()> {
     let path = CString::new(path.as_ref().as_bytes())?;
     from_success_code(libc::unlinkat(dirfd, path.as_ptr(), flags.bits()))
 }
@@ -217,7 +217,7 @@ pub unsafe fn symlinkat<P: AsRef<OsStr>>(old_path: P, new_dirfd: RawFd, new_path
     ))
 }
 
-pub unsafe fn fstatat<P: AsRef<OsStr>>(dirfd: RawFd, path: P, flags: AtFlag) -> Result<libc::stat> {
+pub unsafe fn fstatat<P: AsRef<OsStr>>(dirfd: RawFd, path: P, flags: AtFlags) -> Result<libc::stat> {
     use std::mem::MaybeUninit;
     let path = CString::new(path.as_ref().as_bytes())?;
     let mut filestat = MaybeUninit::<libc::stat>::uninit();

--- a/crates/wasi-common/yanix/src/file.rs
+++ b/crates/wasi-common/yanix/src/file.rs
@@ -217,7 +217,11 @@ pub unsafe fn symlinkat<P: AsRef<OsStr>>(old_path: P, new_dirfd: RawFd, new_path
     ))
 }
 
-pub unsafe fn fstatat<P: AsRef<OsStr>>(dirfd: RawFd, path: P, flags: AtFlags) -> Result<libc::stat> {
+pub unsafe fn fstatat<P: AsRef<OsStr>>(
+    dirfd: RawFd,
+    path: P,
+    flags: AtFlags,
+) -> Result<libc::stat> {
     use std::mem::MaybeUninit;
     let path = CString::new(path.as_ref().as_bytes())?;
     let mut filestat = MaybeUninit::<libc::stat>::uninit();


### PR DESCRIPTION
This makes them consistent with `PollFlags` and common usage of
bitflags types in Rust code in general.

POSIX does tend to use names like `oflag` and `flag`, so this is in mild
disagreement with POSIX style, however I find this particular aspects of
POSIX confusing because these values hold multiple flags.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
