### PR TITLE
machinst x64: branch table, spill/reload, cmov, ALU ops

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -1591,6 +1591,10 @@ impl MachInstEmit for Inst {
                 let jt_off = sink.cur_offset();
                 for &target in info.targets.iter() {
                     let word_off = sink.cur_offset();
+                    // off_into_table is an addend here embedded in the label to be later patched
+                    // at the end of codegen. The offset is initially relative to this jump table
+                    // entry; with the extra addend, it'll be relative to the jump table's start,
+                    // after patching.
                     let off_into_table = word_off - jt_off;
                     sink.use_label_at_offset(
                         word_off,

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -875,8 +875,7 @@ pub enum Inst {
         data: u64,
     },
 
-    /// Jump-table sequence, as one compound instruction (see note in lower.rs
-    /// for rationale).
+    /// Jump-table sequence, as one compound instruction (see note in lower_inst.rs for rationale).
     JTSequence {
         info: Box<JTSequenceInfo>,
         ridx: Reg,

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -988,16 +988,7 @@ pub(crate) fn lower_icmp_or_ifcmp_to_flags<C: LowerCtx<I = Inst>>(
         (false, true) => NarrowValueMode::SignExtend64,
         (false, false) => NarrowValueMode::ZeroExtend64,
     };
-    let inputs = [
-        InsnInput {
-            insn: insn,
-            input: 0,
-        },
-        InsnInput {
-            insn: insn,
-            input: 1,
-        },
-    ];
+    let inputs = [InsnInput { insn, input: 0 }, InsnInput { insn, input: 1 }];
     let ty = ctx.input_ty(insn, 0);
     let rn = put_input_in_reg(ctx, inputs[0], narrow_mode);
     let rm = put_input_in_rse_imm12(ctx, inputs[1], narrow_mode);
@@ -1010,16 +1001,7 @@ pub(crate) fn lower_icmp_or_ifcmp_to_flags<C: LowerCtx<I = Inst>>(
 pub(crate) fn lower_fcmp_or_ffcmp_to_flags<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) {
     let ty = ctx.input_ty(insn, 0);
     let bits = ty_bits(ty);
-    let inputs = [
-        InsnInput {
-            insn: insn,
-            input: 0,
-        },
-        InsnInput {
-            insn: insn,
-            input: 1,
-        },
-    ];
+    let inputs = [InsnInput { insn, input: 0 }, InsnInput { insn, input: 1 }];
     let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
     let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
     match bits {

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -2380,7 +2380,7 @@ pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
                     info: Box::new(JTSequenceInfo {
                         targets: jt_targets,
                         default_target,
-                        targets_for_term: targets_for_term,
+                        targets_for_term,
                     }),
                 });
             }

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -532,7 +532,7 @@ pub enum CC {
 
     /// <= unsigned
     BE = 6,
-    /// > unsigend
+    /// > unsigned
     NBE = 7,
 
     /// negative

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -90,7 +90,13 @@ impl ShowWithRRU for Amode {
                 index.show_rru(mb_rru),
                 1 << shift
             ),
-            Amode::RipRelative { ref target } => format!("{}(%rip)", target.show_rru(mb_rru)),
+            Amode::RipRelative { ref target } => format!(
+                "{}(%rip)",
+                match target {
+                    BranchTarget::Label(label) => format!("label{}", label.get()),
+                    BranchTarget::ResolvedOffset(offset) => offset.to_string(),
+                }
+            ),
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1021,6 +1021,18 @@ pub(crate) fn emit(
             sink.put4(nt_disp);
         }
 
+        Inst::OneWayJmpCond { cc, dst } => {
+            let cond_start = sink.cur_offset();
+            let cond_disp_off = cond_start + 2;
+            if let Some(l) = dst.as_label() {
+                sink.use_label_at_offset(cond_disp_off, l, LabelUse::JmpRel32);
+            }
+            let dst_disp = dst.as_offset32_or_zero() as u32;
+            sink.put1(0x0F);
+            sink.put1(0x80 + cc.get_enc());
+            sink.put4(dst_disp);
+        }
+
         Inst::JmpUnknown { target } => {
             match target {
                 RegMem::Reg { reg } => {

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1155,6 +1155,55 @@ fn test_x64_emit() {
     ));
 
     // ========================================================
+    // Div
+    insns.push((
+        Inst::div(
+            4,
+            true, /*signed*/
+            RegMem::reg(regs::rsi()),
+            SourceLoc::default(),
+        ),
+        "F7FE",
+        "idiv    %esi",
+    ));
+    insns.push((
+        Inst::div(
+            8,
+            true, /*signed*/
+            RegMem::reg(regs::r15()),
+            SourceLoc::default(),
+        ),
+        "49F7FF",
+        "idiv    %r15",
+    ));
+    insns.push((
+        Inst::div(
+            4,
+            false, /*signed*/
+            RegMem::reg(regs::r14()),
+            SourceLoc::default(),
+        ),
+        "41F7F6",
+        "div     %r14d",
+    ));
+    insns.push((
+        Inst::div(
+            8,
+            false, /*signed*/
+            RegMem::reg(regs::rdi()),
+            SourceLoc::default(),
+        ),
+        "48F7F7",
+        "div     %rdi",
+    ));
+
+    // ========================================================
+    // cdq family: SignExtendRaxRdx
+    insns.push((Inst::sign_extend_rax_to_rdx(2), "6699", "cwd"));
+    insns.push((Inst::sign_extend_rax_to_rdx(4), "99", "cdq"));
+    insns.push((Inst::sign_extend_rax_to_rdx(8), "4899", "cqo"));
+
+    // ========================================================
     // Imm_R
     //
     insns.push((
@@ -1532,7 +1581,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::lea(Amode::rip_relative(BranchTarget::ResolvedOffset(0)), w_rdi),
         "488D3D00000000",
-        "lea     (offset 0)(%rip), %rdi",
+        "lea     0(%rip), %rdi",
     ));
     insns.push((
         Inst::lea(
@@ -1540,7 +1589,7 @@ fn test_x64_emit() {
             w_r15,
         ),
         "4C8D3D39050000",
-        "lea     (offset 1337)(%rip), %r15",
+        "lea     1337(%rip), %r15",
     ));
 
     // ========================================================

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -2482,6 +2482,44 @@ fn test_x64_emit() {
     insns.push((Inst::setcc(CC::LE, w_r14), "410F9EC6", "setle   %r14b"));
 
     // ========================================================
+    // Cmove
+    insns.push((
+        Inst::cmove(2, CC::O, RegMem::reg(rdi), w_rsi),
+        "660F40F7",
+        "cmovow  %di, %si",
+    ));
+    insns.push((
+        Inst::cmove(
+            2,
+            CC::NO,
+            RegMem::mem(Amode::imm_reg_reg_shift(37, rdi, rsi, 2)),
+            w_r15,
+        ),
+        "66440F417CB725",
+        "cmovnow 37(%rdi,%rsi,4), %r15w",
+    ));
+    insns.push((
+        Inst::cmove(4, CC::LE, RegMem::reg(rdi), w_rsi),
+        "0F4EF7",
+        "cmovlel %edi, %esi",
+    ));
+    insns.push((
+        Inst::cmove(4, CC::NLE, RegMem::mem(Amode::imm_reg(0, r15)), w_rsi),
+        "410F4F37",
+        "cmovnlel 0(%r15), %esi",
+    ));
+    insns.push((
+        Inst::cmove(8, CC::Z, RegMem::reg(rdi), w_r14),
+        "4C0F44F7",
+        "cmovzq  %rdi, %r14",
+    ));
+    insns.push((
+        Inst::cmove(8, CC::NZ, RegMem::mem(Amode::imm_reg(13, rdi)), w_r14),
+        "4C0F45770D",
+        "cmovnzq 13(%rdi), %r14",
+    ));
+
+    // ========================================================
     // Push64
     insns.push((Inst::push64(RegMemImm::reg(rdi)), "57", "pushq   %rdi"));
     insns.push((Inst::push64(RegMemImm::reg(r8)), "4150", "pushq   %r8"));

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1529,6 +1529,19 @@ fn test_x64_emit() {
         "4F8D840AB3000000",
         "lea     179(%r10,%r9,1), %r8",
     ));
+    insns.push((
+        Inst::lea(Amode::rip_relative(BranchTarget::ResolvedOffset(0)), w_rdi),
+        "488D3D00000000",
+        "lea     (offset 0)(%rip), %rdi",
+    ));
+    insns.push((
+        Inst::lea(
+            Amode::rip_relative(BranchTarget::ResolvedOffset(1337)),
+            w_r15,
+        ),
+        "4C8D3D39050000",
+        "lea     (offset 1337)(%rip), %r15",
+    ));
 
     // ========================================================
     // MovSX_RM_R

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -179,7 +179,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) -> Codeg
             }
         }
 
-        Opcode::Iadd | Opcode::Isub => {
+        Opcode::Iadd | Opcode::Isub | Opcode::Imul | Opcode::Band | Opcode::Bor | Opcode::Bxor => {
             let lhs = input_to_reg(ctx, inputs[0]);
             let rhs = input_to_reg_mem_imm(ctx, inputs[1]);
             let dst = output_to_reg(ctx, outputs[0]);
@@ -187,10 +187,14 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) -> Codeg
             // TODO For add, try to commute the operands if one is an immediate.
 
             let is_64 = int_ty_is_64(ty.unwrap());
-            let alu_op = if op == Opcode::Iadd {
-                AluRmiROpcode::Add
-            } else {
-                AluRmiROpcode::Sub
+            let alu_op = match op {
+                Opcode::Iadd => AluRmiROpcode::Add,
+                Opcode::Isub => AluRmiROpcode::Sub,
+                Opcode::Imul => AluRmiROpcode::Mul,
+                Opcode::Band => AluRmiROpcode::And,
+                Opcode::Bor => AluRmiROpcode::Or,
+                Opcode::Bxor => AluRmiROpcode::Xor,
+                _ => unreachable!(),
             };
 
             ctx.emit(Inst::mov_r_r(true, lhs, dst));


### PR DESCRIPTION
This makes it possible to run a basic C hello world with wasmtime. It's a large PR but the commit splitting should make it easier to review. I'll add emit tests for div/idiv before landing, but reviewing shouldn't be blocked on this.