### PR TITLE
Add FD_READ and FD_SEEK to dir handles

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
+++ b/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
@@ -31,9 +31,8 @@ unsafe fn test_directory_seek(dir_fd: wasi::Fd) {
         wasi::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
-    assert_eq!(
-        (fdstat.fs_rights_base & wasi::RIGHTS_FD_SEEK),
-        0,
+    assert!(
+        fdstat.fs_rights_base & wasi::RIGHTS_FD_SEEK != 0,
         "directory has the seek right",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/fd_read_on_dirfd.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_read_on_dirfd.rs
@@ -39,8 +39,16 @@ unsafe fn test_fd_read_on_dirfd(dir_fd: wasi::Fd) {
     wasi::fd_close(fd).expect("closing an fd");
 
     // Now, open as file
-    let fd = wasi::path_open(dir_fd, 0, "subdir", 0, wasi::RIGHTS_FD_READ, 0, 0)
-        .expect("open subdir as file for reading");
+    let fd = wasi::path_open(
+        dir_fd,
+        0,
+        "subdir",
+        0,
+        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_SEEK,
+        0,
+        0,
+    )
+    .expect("open subdir as file for reading");
     // Try reading from it
     let contents = &mut [0u8; 4];
     let iovec = wasi::Iovec {

--- a/crates/test-programs/wasi-tests/src/bin/fd_read_on_dirfd.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_read_on_dirfd.rs
@@ -1,0 +1,88 @@
+use std::{env, process};
+use wasi_tests::open_scratch_directory;
+
+unsafe fn test_fd_read_on_dirfd(dir_fd: wasi::Fd) {
+    // Create a directory.
+    wasi::path_create_directory(dir_fd, "subdir").expect("creating subdirectory");
+
+    // Open it as dir
+    let fd = wasi::path_open(
+        dir_fd,
+        0,
+        "subdir",
+        wasi::OFLAGS_DIRECTORY,
+        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_SEEK,
+        0,
+        0,
+    )
+    .expect("open subdir for reading");
+    // Try reading from it
+    let contents = &mut [0u8; 4];
+    let iovec = wasi::Iovec {
+        buf: contents.as_mut_ptr() as *mut _,
+        buf_len: contents.len(),
+    };
+    assert_eq!(
+        wasi::fd_read(fd, &[iovec])
+            .expect_err("calling fd_read on directory should get ERRNO_ISDIR")
+            .raw_error(),
+        wasi::ERRNO_ISDIR,
+        "errno should be ERRNO_ISDIR"
+    );
+    assert_eq!(
+        wasi::fd_pread(fd, &[iovec], 0)
+            .expect_err("calling fd_pread on directory should get ERRNO_ISDIR")
+            .raw_error(),
+        wasi::ERRNO_ISDIR,
+        "errno should be ERRNO_ISDIR"
+    );
+    wasi::fd_close(fd).expect("closing an fd");
+
+    // Now, open as file
+    let fd = wasi::path_open(dir_fd, 0, "subdir", 0, wasi::RIGHTS_FD_READ, 0, 0)
+        .expect("open subdir as file for reading");
+    // Try reading from it
+    let contents = &mut [0u8; 4];
+    let iovec = wasi::Iovec {
+        buf: contents.as_mut_ptr() as *mut _,
+        buf_len: contents.len(),
+    };
+    assert_eq!(
+        wasi::fd_read(fd, &[iovec])
+            .expect_err("calling fd_read on directory should get ERRNO_ISDIR")
+            .raw_error(),
+        wasi::ERRNO_ISDIR,
+        "errno should be ERRNO_ISDIR"
+    );
+    assert_eq!(
+        wasi::fd_pread(fd, &[iovec], 0)
+            .expect_err("calling fd_pread on directory should get ERRNO_ISDIR")
+            .raw_error(),
+        wasi::ERRNO_ISDIR,
+        "errno should be ERRNO_ISDIR"
+    );
+    wasi::fd_close(fd).expect("closing an fd");
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_fd_read_on_dirfd(dir_fd) }
+}

--- a/crates/wasi-common/src/sys/osdir.rs
+++ b/crates/wasi-common/src/sys/osdir.rs
@@ -39,6 +39,12 @@ impl Handle for OsDir {
         self.rights.set(rights)
     }
     // FdOps
+    fn read_vectored(&self, _iovs: &mut [io::IoSliceMut]) -> Result<usize> {
+        Err(Errno::Isdir)
+    }
+    fn preadv(&self, _buf: &mut [io::IoSliceMut], _offset: u64) -> Result<usize> {
+        Err(Errno::Isdir)
+    }
     fn fdstat_get(&self) -> Result<types::Fdflags> {
         fd::fdstat_get(&*self.as_file()?)
     }

--- a/crates/wasi-common/src/virtfs.rs
+++ b/crates/wasi-common/src/virtfs.rs
@@ -506,6 +506,12 @@ impl Handle for VirtualDir {
         };
         Ok(stat)
     }
+    fn read_vectored(&self, _iovs: &mut [io::IoSliceMut]) -> Result<usize> {
+        Err(Errno::Isdir)
+    }
+    fn preadv(&self, _buf: &mut [io::IoSliceMut], _offset: u64) -> Result<usize> {
+        Err(Errno::Isdir)
+    }
     fn readdir(
         &self,
         cookie: types::Dircookie,

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -143,6 +143,8 @@ impl RightsExt for types::Rights {
             | Self::PATH_LINK_SOURCE
             | Self::PATH_LINK_TARGET
             | Self::PATH_OPEN
+            | Self::FD_READ
+            | Self::FD_SEEK
             | Self::FD_READDIR
             | Self::PATH_READLINK
             | Self::PATH_RENAME_SOURCE


### PR DESCRIPTION
This commit adds `FD_READ` and `FD_SEEK` rights to dir handles. This way
we allow the user to open a directory with those rights (perhaps by mistake)
but we throw `EISDIR` when the user attemps to call `fd_read` or `fd_pread`
on the obtained handle. This matches the expected behaviour one would expect
in POSIX and related.

Closes #1935 