### PR TITLE
cranelift-wasm: expose cranelift-frontend's FunctionBuilder in the public API

### DIFF
--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -70,6 +70,7 @@ pub use crate::translation_utils::{
     DefinedTableIndex, ElemIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Memory, MemoryIndex,
     SignatureIndex, Table, TableElementType, TableIndex,
 };
+pub use cranelift_frontend::FunctionBuilder;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Not doing so makes it that users of `cranelift-wasm` also need to import `cranelift-frontend`. This makes the API of `cranelift-wasm` incomplete, and it introduces a risk of desynchronizing the versions of frontend used by wasm and used by the user of wasm.