### PR TITLE
Use smallvec for avoid allocations in the trampoline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,6 +2329,7 @@ dependencies = [
  "log",
  "region",
  "rustc-demangle",
+ "smallvec",
  "target-lexicon",
  "tempfile",
  "wasmparser 0.58.0",

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -25,6 +25,7 @@ rustc-demangle = "0.1.16"
 lazy_static = "1.4"
 log = "0.4.8"
 wat = { version = "1.0.18", optional = true }
+smallvec = "1.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"


### PR DESCRIPTION
We, in paritytech, had to momentarily fork wasmtime due to lack of support of sharing `Module`s between threads. Now, with the recent changes landed it is possible for us to return to the upstream!

One of the changes we had in our fork is similar to the presented here. Namely, we noticed a performance increase for our workloads if we avoid allocations for a common case if the number of arguments doesn't exceed some threshold. 

In our fork it wasn't using `smallvec`, but I don't think it's worth the hassle avoiding it since `smallvec` is already used by cranelift. 