### PR TITLE
wasmtime: Implement `global.{get,set}` for externref globals

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -201,11 +201,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", "simd_splat") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
 
             // Still working on implementing these. See #929.
-            ("reference_types", "global")
-            | ("reference_types", "linking")
-            | ("reference_types", "ref_func")
-            | ("reference_types", "ref_null")
-            | ("reference_types", "table_fill") => {
+            ("reference_types", "table_fill") => {
                 return true;
             }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -67,3 +67,14 @@ pub fn ref_type() -> wasmtime_environ::ir::Type {
         unreachable!()
     }
 }
+
+/// The Cranelift IR type used for pointer types for this target architecture.
+pub fn pointer_type() -> wasmtime_environ::ir::Type {
+    if cfg!(target_pointer_width = "32") {
+        wasmtime_environ::ir::types::I32
+    } else if cfg!(target_pointer_width = "64") {
+        wasmtime_environ::ir::types::I64
+    } else {
+        unreachable!()
+    }
+}

--- a/crates/runtime/src/sig_registry.rs
+++ b/crates/runtime/src/sig_registry.rs
@@ -65,4 +65,18 @@ impl SignatureRegistry {
     pub fn lookup_wasm(&self, idx: VMSharedSignatureIndex) -> Option<WasmFuncType> {
         self.index2wasm.get(&idx).cloned()
     }
+
+    /// Looks up both a shared Wasm function signature and its associated native
+    /// `ir::Signature` within this registry.
+    ///
+    /// Note that for this operation to be semantically correct the `idx` must
+    /// have previously come from a call to `register` of this same object.
+    pub fn lookup_wasm_and_native_signatures(
+        &self,
+        idx: VMSharedSignatureIndex,
+    ) -> Option<(WasmFuncType, ir::Signature)> {
+        let wasm = self.lookup_wasm(idx)?;
+        let native = self.lookup_native(idx)?;
+        Some((wasm, native))
+    }
 }

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -9,7 +9,8 @@ use std::panic::{self, AssertUnwindSafe};
 use std::ptr::{self, NonNull};
 use std::rc::Weak;
 use wasmtime_runtime::{
-    raise_user_trap, Export, InstanceHandle, VMContext, VMFunctionBody, VMTrampoline,
+    raise_user_trap, Export, InstanceHandle, VMContext, VMFunctionBody, VMSharedSignatureIndex,
+    VMTrampoline,
 };
 
 /// A WebAssembly function which can be called.
@@ -486,19 +487,20 @@ impl Func {
         func.into_func(store)
     }
 
+    pub(crate) fn sig_index(&self) -> VMSharedSignatureIndex {
+        unsafe { self.export.anyfunc.as_ref().type_index }
+    }
+
     /// Returns the underlying wasm type that this `Func` has.
     pub fn ty(&self) -> FuncType {
         // Signatures should always be registered in the store's registry of
         // shared signatures, so we should be able to unwrap safely here.
-        let sig = self
-            .instance
-            .store
-            .lookup_signature(unsafe { self.export.anyfunc.as_ref().type_index });
+        let wft = self.instance.store.lookup_signature(self.sig_index());
 
         // This is only called with `Export::Function`, and since it's coming
         // from wasmtime_runtime itself we should support all the types coming
         // out of it, so assert such here.
-        FuncType::from_wasm_func_type(&sig).expect("core wasm signature should be supported")
+        FuncType::from_wasm_func_type(&wft).expect("core wasm signature should be supported")
     }
 
     /// Returns the number of parameters that this function takes.

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -900,6 +900,17 @@ impl Store {
             .expect("failed to lookup signature")
     }
 
+    pub(crate) fn lookup_wasm_and_native_signatures(
+        &self,
+        sig_index: VMSharedSignatureIndex,
+    ) -> (wasm::WasmFuncType, ir::Signature) {
+        self.inner
+            .signatures
+            .borrow()
+            .lookup_wasm_and_native_signatures(sig_index)
+            .expect("failed to lookup signature")
+    }
+
     pub(crate) fn register_signature(
         &self,
         wasm_sig: wasm::WasmFuncType,

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -7,11 +7,11 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 use wasmtime_environ::entity::PrimaryMap;
-use wasmtime_environ::wasm::DefinedFuncIndex;
+use wasmtime_environ::wasm::{DefinedFuncIndex, FuncIndex};
 use wasmtime_environ::Module;
 use wasmtime_runtime::{
     Imports, InstanceHandle, StackMapRegistry, VMExternRefActivationsTable, VMFunctionBody,
-    VMSharedSignatureIndex, VMTrampoline,
+    VMFunctionImport, VMSharedSignatureIndex, VMTrampoline,
 };
 
 pub(crate) fn create_handle(
@@ -20,9 +20,10 @@ pub(crate) fn create_handle(
     finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
     trampolines: HashMap<VMSharedSignatureIndex, VMTrampoline>,
     state: Box<dyn Any>,
+    func_imports: PrimaryMap<FuncIndex, VMFunctionImport>,
 ) -> Result<StoreInstanceHandle> {
     let imports = Imports::new(
-        PrimaryMap::new(),
+        func_imports,
         PrimaryMap::new(),
         PrimaryMap::new(),
         PrimaryMap::new(),

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -35,6 +35,7 @@ pub fn create_handle_with_memory(
         PrimaryMap::new(),
         Default::default(),
         Box::new(()),
+        PrimaryMap::new(),
     )
 }
 

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -32,5 +32,6 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Stor
         PrimaryMap::new(),
         Default::default(),
         Box::new(()),
+        PrimaryMap::new(),
     )
 }

--- a/tests/misc_testsuite/reference-types/mutable_externref_globals.wast
+++ b/tests/misc_testsuite/reference-types/mutable_externref_globals.wast
@@ -1,0 +1,13 @@
+;; This test contains the changes in
+;; https://github.com/WebAssembly/reference-types/pull/104, and can be deleted
+;; once that merges and we update our upstream tests.
+
+(module
+  (global $mr (mut externref) (ref.null extern))
+  (func (export "get-mr") (result externref) (global.get $mr))
+  (func (export "set-mr") (param externref) (global.set $mr (local.get 0)))
+)
+
+(assert_return (invoke "get-mr") (ref.null extern))
+(assert_return (invoke "set-mr" (ref.extern 10)))
+(assert_return (invoke "get-mr") (ref.extern 10))


### PR DESCRIPTION
We use libcalls to implement these -- unlike `table.{get,set}`, for which we
create inline JIT fast paths -- because no known toolchain actually uses
externref globals.

Part of #929

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
