### PR TITLE
Add __dso_handle to exception list of deprecated export symbols

### DIFF
--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -445,6 +445,11 @@ impl Linker {
                 // which use --export-dynamic, which unfortunately doesn't work the way
                 // we want it to.
                 warn!("command module exporting '__heap_base' is deprecated");
+            } else if export.name() == "__dso_handle" && export.ty().global().is_some() {
+                // Allow an exported "__dso_handle" memory for compatibility with toolchains
+                // which use --export-dynamic, which unfortunately doesn't work the way
+                // we want it to.
+                warn!("command module exporting '__dso_handle' is deprecated")
             } else if export.name() == "__rtti_base" && export.ty().global().is_some() {
                 // Allow an exported "__rtti_base" memory for compatibility with
                 // AssemblyScript.


### PR DESCRIPTION
When compiling C to WASM with clang-8, __dso_handle is a global
that maybe exported but that currently is not whitelisted along
with __heap_base and _data_end to be handled as allowable depricated
exports. This PR adds the case for __dso_handle.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
