### PR TITLE
readme: Make "wasmtime-go" use monospace font

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ the implementation:
 * **[C]** - the [`wasm.h`, `wasi.h`, and `wasmtime.h` headers][c-headers]
 * **[Python]** - the [`wasmtime` PyPI package]
 * **[.NET]** - the [`Wasmtime` NuGet package]
-* **[Go]** - the [wasmtime-go repository]
+* **[Go]** - the [`wasmtime-go` repository]
 
 [Rust]: https://bytecodealliance.github.io/wasmtime/lang-rust.html
 [C]: https://bytecodealliance.github.io/wasmtime/examples-c-embed.html
@@ -106,7 +106,7 @@ the implementation:
 [.NET]: https://bytecodealliance.github.io/wasmtime/lang-dotnet.html
 [`Wasmtime` NuGet package]: https://www.nuget.org/packages/Wasmtime
 [Go]: https://bytecodealliance.github.io/wasmtime/lang-go.html
-[wasmtime-go repository]: https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go
+[`wasmtime-go` repository]: https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go
 
 ## Documentation
 


### PR DESCRIPTION
Similar to other package names.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
