### PR TITLE
Updated region versions

### DIFF
--- a/cranelift/simplejit/Cargo.toml
+++ b/cranelift/simplejit/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 cranelift-module = { path = "../module", version = "0.65.0" }
 cranelift-native = { path = "../native", version = "0.65.0" }
 cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false, features = ["std"] }
-region = "2.1.0"
+region = "2.2.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
 target-lexicon = "0.10"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -17,7 +17,7 @@ wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
 wasmparser = "0.58.0"
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0.19"
-region = "2.1.0"
+region = "2.2.0"
 libc = "0.2"
 cfg-if = "0.1.9"
 backtrace = "0.3.42"


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Using region version 2.1.0 or 2.1.2 fails with the following errors:
```
   Compiling cranelift-simplejit v0.65.0
error[E0599]: no associated item named `READ_WRITE` found for struct `region::protect::Protection` in the current scope
   --> /home/gis/.cargo/registry/src/github.com-1ecc6299db9ec823/cranelift-simplejit-0.65.0/src/memory.rs:114:73
    |
114 |                 region::protect(self.ptr, self.len, region::Protection::READ_WRITE)
    |                                                                         ^^^^^^^^^^ associated item not found in `region::protect::Protection`

error[E0599]: no associated item named `READ_EXECUTE` found for struct `region::protect::Protection` in the current scope
   --> /home/gis/.cargo/registry/src/github.com-1ecc6299db9ec823/cranelift-simplejit-0.65.0/src/memory.rs:194:71
    |
194 |                         region::protect(ptr, len, region::Protection::READ_EXECUTE)
    |                                                                       ^^^^^^^^^^^^ associated item not found in `region::protect::Protection`

error[E0599]: no associated item named `READ` found for struct `region::protect::Protection` in the current scope
   --> /home/gis/.cargo/registry/src/github.com-1ecc6299db9ec823/cranelift-simplejit-0.65.0/src/memory.rs:223:71
    |
223 |                         region::protect(ptr, len, region::Protection::READ)
    |                                                                       ^^^^ associated item not found in `region::protect::Protection`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0599`.
error: Could not compile `cranelift-simplejit`.

To learn more, run the command again with --verbose.
```

This was dicussed with @bjorn3 on [Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/206238-general/topic/Cranelift-simplejit.20build.20issue).