### PR TITLE
Remove 'set frame pointer' unwind code from Windows x64 unwind. 

### DIFF
--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -1,4 +1,4 @@
-//! System V ABI unwind information.
+//! Windows x64 ABI unwind information.
 
 use alloc::vec::Vec;
 use byteorder::{ByteOrder, LittleEndian};

--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -80,13 +80,13 @@ impl UnwindCode {
                 stack_offset,
             } => {
                 writer.write_u8(*offset);
-                let stack_offset = stack_offset / 16;
-                if stack_offset <= core::u16::MAX as u32 {
+                let scaled_stack_offset = stack_offset / 16;
+                if scaled_stack_offset <= core::u16::MAX as u32 {
                     writer.write_u8((*reg << 4) | (UnwindOperation::SaveXmm128 as u8));
-                    writer.write_u16::<LittleEndian>(stack_offset as u16);
+                    writer.write_u16::<LittleEndian>(scaled_stack_offset as u16);
                 } else {
                     writer.write_u8((*reg << 4) | (UnwindOperation::SaveXmm128Far as u8));
-                    writer.write_u16::<LittleEndian>(stack_offset as u16);
+                    writer.write_u16::<LittleEndian>(*stack_offset as u16);
                     writer.write_u16::<LittleEndian>((stack_offset >> 16) as u16);
                 }
             }

--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -57,10 +57,6 @@ pub(crate) enum UnwindCode {
         offset: u8,
         size: u32,
     },
-    SetFramePointer {
-        offset: u8,
-        sp_offset: u8,
-    },
 }
 
 impl UnwindCode {
@@ -69,7 +65,6 @@ impl UnwindCode {
             PushNonvolatileRegister = 0,
             LargeStackAlloc = 1,
             SmallStackAlloc = 2,
-            SetFramePointer = 3,
             SaveXmm128 = 8,
             SaveXmm128Far = 9,
         }
@@ -112,10 +107,6 @@ impl UnwindCode {
                     writer.write_u8((1 << 4) | (UnwindOperation::LargeStackAlloc as u8));
                     writer.write_u32::<LittleEndian>(*size);
                 }
-            }
-            Self::SetFramePointer { offset, sp_offset } => {
-                writer.write_u8(*offset);
-                writer.write_u8((*sp_offset << 4) | (UnwindOperation::SetFramePointer as u8));
             }
         };
     }

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -1071,8 +1071,7 @@ pub fn create_unwind_info(
                 .map(|u| UnwindInfo::SystemV(u))
         }
         CallConv::WindowsFastcall => {
-            super::unwind::winx64::create_unwind_info(func, isa, Some(RU::rbp.into()))?
-                .map(|u| UnwindInfo::WindowsX64(u))
+            super::unwind::winx64::create_unwind_info(func, isa)?.map(|u| UnwindInfo::WindowsX64(u))
         }
         _ => None,
     })

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -11,17 +11,13 @@ block0:
 ; sameln:                version: 1
 ; nextln:                  flags: 0
 ; nextln:          prologue size: 4
-; nextln:         frame register: 5
+; nextln:         frame register: 0
 ; nextln:  frame register offset: 0
-; nextln:           unwind codes: 2
+; nextln:           unwind codes: 1
 ; nextln:  
 ; nextln:                 offset: 1
 ; nextln:                     op: PushNonvolatileRegister
 ; nextln:                   info: 5
-; nextln:  
-; nextln:                 offset: 4
-; nextln:                     op: SetFramePointer
-; nextln:                   info: 0
 
 ; check the unwind information with a non-leaf function with no args
 function %no_args() windows_fastcall {
@@ -33,17 +29,13 @@ block0:
 ; sameln:                version: 1
 ; nextln:                  flags: 0
 ; nextln:          prologue size: 8
-; nextln:         frame register: 5
+; nextln:         frame register: 0
 ; nextln:  frame register offset: 0
-; nextln:           unwind codes: 3
+; nextln:           unwind codes: 2
 ; nextln:  
 ; nextln:                 offset: 1
 ; nextln:                     op: PushNonvolatileRegister
 ; nextln:                   info: 5
-; nextln:  
-; nextln:                 offset: 4
-; nextln:                     op: SetFramePointer
-; nextln:                   info: 0
 ; nextln:  
 ; nextln:                 offset: 8
 ; nextln:                     op: SmallStackAlloc
@@ -58,18 +50,14 @@ block0:
 ; sameln:               version: 1
 ; nextln:                 flags: 0
 ; nextln:         prologue size: 17
-; nextln:        frame register: 5
+; nextln:        frame register: 0
 ; nextln: frame register offset: 0
-; nextln:          unwind codes: 3
+; nextln:          unwind codes: 2
 ; nextln: 
 ; nextln:                offset: 1
 ; nextln:                    op: PushNonvolatileRegister
 ; nextln:                  info: 5
-; nextln: 
-; nextln:                offset: 4
-; nextln:                    op: SetFramePointer
-; nextln:                  info: 0
-; nextln: 
+; nextln:  
 ; nextln:                offset: 17
 ; nextln:                    op: LargeStackAlloc
 ; nextln:                  info: 0
@@ -84,17 +72,13 @@ block0:
 ; sameln:                version: 1
 ; nextln:                  flags: 0
 ; nextln:          prologue size: 17
-; nextln:         frame register: 5
+; nextln:         frame register: 0
 ; nextln:  frame register offset: 0
-; nextln:           unwind codes: 3
+; nextln:           unwind codes: 2
 ; nextln:  
 ; nextln:                 offset: 1
 ; nextln:                     op: PushNonvolatileRegister
 ; nextln:                   info: 5
-; nextln:  
-; nextln:                 offset: 4
-; nextln:                     op: SetFramePointer
-; nextln:                   info: 0
 ; nextln:  
 ; nextln:                 offset: 17
 ; nextln:                     op: LargeStackAlloc
@@ -136,17 +120,13 @@ block0(v0: i64, v1: i64):
 ; sameln:                version: 1
 ; nextln:                  flags: 0 
 ; nextln:          prologue size: 22
-; nextln:         frame register: 5
-; nextln:  frame register offset: 2
-; nextln:           unwind codes: 5
+; nextln:         frame register: 0
+; nextln:  frame register offset: 0
+; nextln:           unwind codes: 4
 ; nextln:  
 ; nextln:                 offset: 1
 ; nextln:                     op: PushNonvolatileRegister
 ; nextln:                   info: 5
-; nextln:  
-; nextln:                 offset: 4
-; nextln:                     op: SetFramePointer
-; nextln:                   info: 0
 ; nextln:  
 ; nextln:                 offset: 6
 ; nextln:                     op: PushNonvolatileRegister
@@ -160,7 +140,7 @@ block0(v0: i64, v1: i64):
 ; nextln:                 offset: 22
 ; nextln:                     op: SaveXmm128
 ; nextln:                   info: 15
-; nextln:                  value: 0 (u16)
+; nextln:                  value: 10 (u16)
 
 ; check a function that has CSRs
 function %lots_of_registers(i64, i64) windows_fastcall {
@@ -214,17 +194,13 @@ block0(v0: i64, v1: i64):
 ; sameln:                version: 1
 ; nextln:                  flags: 0
 ; nextln:          prologue size: 35
-; nextln:         frame register: 5
-; nextln:  frame register offset: 7
-; nextln:           unwind codes: 13
+; nextln:         frame register: 0
+; nextln:  frame register offset: 0
+; nextln:           unwind codes: 12
 ; nextln:  
 ; nextln:                 offset: 1
 ; nextln:                     op: PushNonvolatileRegister
 ; nextln:                   info: 5
-; nextln:  
-; nextln:                 offset: 4
-; nextln:                     op: SetFramePointer
-; nextln:                   info: 0
 ; nextln:  
 ; nextln:                 offset: 5
 ; nextln:                     op: PushNonvolatileRegister
@@ -261,14 +237,14 @@ block0(v0: i64, v1: i64):
 ; nextln:                 offset: 24
 ; nextln:                     op: SaveXmm128
 ; nextln:                   info: 6
-; nextln:                  value: 2 (u16)
+; nextln:                  value: 3 (u16)
 ; nextln:  
 ; nextln:                 offset: 29
 ; nextln:                     op: SaveXmm128
 ; nextln:                   info: 7
-; nextln:                  value: 1 (u16)
+; nextln:                  value: 2 (u16)
 ; nextln:  
 ; nextln:                 offset: 35
 ; nextln:                     op: SaveXmm128
 ; nextln:                   info: 8
-; nextln:                  value: 0 (u16)
+; nextln:                  value: 1 (u16)

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -350,3 +350,14 @@ fn greeter_preload_callable_command() -> Result<()> {
     assert_eq!(stdout, "Hello _start\nHello callable greet\nHello done\n");
     Ok(())
 }
+
+// Ensure successful WASI exit call with FPR saving frames on stack for Windows x64
+// See https://github.com/bytecodealliance/wasmtime/issues/1967
+#[test]
+fn exit_with_saved_fprs() -> Result<()> {
+    let wasm = build_wasm("tests/wasm/exit_with_saved_fprs.wat")?;
+    let output = run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;
+    assert_eq!(output.status.code().unwrap(), 0);
+    assert!(output.stdout.is_empty());
+    Ok(())
+}

--- a/tests/wasm/exit_with_saved_fprs.wat
+++ b/tests/wasm/exit_with_saved_fprs.wat
@@ -1,0 +1,40 @@
+;;; This is a test case for https://github.com/bytecodealliance/wasmtime/issues/1967 
+(module
+    (type (func (param i32)))
+    
+    (import "wasi_snapshot_preview1" "proc_exit" (func (type 0)))
+    
+    (func $exit (param i32)
+        local.get 0
+        call 0
+        unreachable
+    )
+    
+    (func $do_something (param f64 f64 f64 f64 f64 f64 f64 f64)
+        i32.const 0
+        call $exit
+        unreachable
+    )
+    
+    (func $has_saved_fprs (export "_start")
+        (local f64 f64 f64 f64 f64 f64 f64 f64)
+        (local.set 0 (f64.const 1))
+        (local.set 1 (f64.const 2))
+        (local.set 2 (f64.const 3))
+        (local.set 3 (f64.const 4))
+        (local.set 4 (f64.const 5))
+        (local.set 5 (f64.const 6))
+        (local.set 6 (f64.const 7))
+        (local.set 7 (f64.const 8))
+        local.get 0
+        local.get 1
+        local.get 2
+        local.get 3
+        local.get 4
+        local.get 5
+        local.get 6
+        local.get 7
+        call $do_something
+        unreachable
+    )
+)


### PR DESCRIPTION
This PR removes the "set frame pointer" unwind code and frame
pointer information from Windows x64 unwind information.

In Windows x64 unwind information, a "frame pointer" is actually the
*base address* of the static part of the local frame and would be at some
negative offset to RSP upon establishing the frame pointer.

Currently Cranelift uses a "traditional" notion of a frame pointer, one
that is the highest address in the local frame (i.e. pointing at the
previous frame pointer on the stack).

Windows x64 unwind doesn't describe such frame pointers and only needs
one described if the frame contains a dynamic stack allocation.

Fixes #1967.