### PR TITLE
wasmtime: Support reference types in the Rust API

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -494,6 +494,16 @@ impl Instance {
         }
     }
 
+    pub(crate) fn defined_table_fill(
+        &self,
+        table_index: DefinedTableIndex,
+        dst: u32,
+        val: TableElement,
+        len: u32,
+    ) -> Result<(), Trap> {
+        self.tables.get(table_index).unwrap().fill(dst, val, len)
+    }
+
     // Get table element by index.
     fn table_get(&self, table_index: DefinedTableIndex, index: u32) -> Option<TableElement> {
         self.tables
@@ -1113,6 +1123,21 @@ impl InstanceHandle {
         val: TableElement,
     ) -> Result<(), ()> {
         self.instance().table_set(table_index, index, val)
+    }
+
+    /// Fill a region of the table.
+    ///
+    /// Returns an error if the region is out of bounds or val is not of the
+    /// correct type.
+    pub fn defined_table_fill(
+        &self,
+        table_index: DefinedTableIndex,
+        dst: u32,
+        val: TableElement,
+        len: u32,
+    ) -> Result<(), Trap> {
+        self.instance()
+            .defined_table_fill(table_index, dst, val, len)
     }
 
     /// Get a table defined locally within this module.

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -15,6 +15,7 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Stor
         maximum: table.limits().max(),
         ty: match table.element() {
             ValType::FuncRef => wasm::TableElementType::Func,
+            ValType::ExternRef => wasm::TableElementType::Val(wasmtime_runtime::ref_type()),
             _ => bail!("cannot support {:?} as a table element", table.element()),
         },
     };

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -174,6 +174,18 @@ impl Val {
         self.externref().expect("expected externref")
     }
 
+    pub(crate) fn into_table_element(self) -> Result<runtime::TableElement> {
+        match self {
+            Val::FuncRef(Some(f)) => Ok(runtime::TableElement::FuncRef(
+                f.caller_checked_anyfunc().as_ptr(),
+            )),
+            Val::FuncRef(None) => Ok(runtime::TableElement::FuncRef(ptr::null_mut())),
+            Val::ExternRef(Some(x)) => Ok(runtime::TableElement::ExternRef(Some(x.inner))),
+            Val::ExternRef(None) => Ok(runtime::TableElement::ExternRef(None)),
+            _ => bail!("value does not match table element type"),
+        }
+    }
+
     pub(crate) fn comes_from_same_store(&self, store: &Store) -> bool {
         match self {
             Val::FuncRef(Some(f)) => Store::same(store, f.store()),


### PR DESCRIPTION
This is a mix of exposing new things (e.g. a `Table::fill` method) and extending
existing support to `externref`s (e.g. `Table::new`).

Part of #929

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
