### PR TITLE
fuzzing: Enforce a maximum input length for `peepmatic_compile` target

### DIFF
--- a/cranelift/peepmatic/crates/fuzzing/src/compile.rs
+++ b/cranelift/peepmatic/crates/fuzzing/src/compile.rs
@@ -4,9 +4,16 @@ use peepmatic_runtime::PeepholeOptimizations;
 use std::path::Path;
 use std::str;
 
+// To avoid timeouts, don't deal with inputs larger than this.
+const MAX_LEN: usize = 2048;
+
 /// Attempt to interpret the given bytes as UTF-8 and then compile them as if
 /// they were source text of our DSL.
 pub fn compile(data: &[u8]) {
+    if data.len() > MAX_LEN {
+        return;
+    }
+
     let source = match str::from_utf8(data) {
         Err(_) => return,
         Ok(s) => s,


### PR DESCRIPTION
This avoids timeouts from large inputs, like
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23906

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
