### PR TITLE
Implement fcvt_to_uint_sat (f32x4 -> i32x4) for x86

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -200,8 +200,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", _) if target.contains("aarch64") => return true,
 
             ("simd", "simd_conversions") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
-            ("simd", "simd_load") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
-            ("simd", "simd_splat") => return true, // FIXME Unsupported feature: proposed SIMD operator I32x4TruncSatF32x4S
 
             // TODO(#1886): Ignore reference types tests if this isn't x64,
             // because Cranelift only supports reference types on x64.

--- a/cranelift/codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift/codegen/meta/src/isa/x86/legalize.rs
@@ -383,6 +383,7 @@ fn define_simd(
     let fcmp = insts.by_name("fcmp");
     let fcvt_from_uint = insts.by_name("fcvt_from_uint");
     let fcvt_to_sint_sat = insts.by_name("fcvt_to_sint_sat");
+    let fcvt_to_uint_sat = insts.by_name("fcvt_to_uint_sat");
     let fmax = insts.by_name("fmax");
     let fmin = insts.by_name("fmin");
     let fneg = insts.by_name("fneg");
@@ -797,4 +798,5 @@ fn define_simd(
 
     narrow_avx.custom_legalize(imul, "convert_i64x2_imul");
     narrow_avx.custom_legalize(fcvt_from_uint, "expand_fcvt_from_uint_vector");
+    narrow_avx.custom_legalize(fcvt_to_uint_sat, "expand_fcvt_to_uint_sat_vector");
 }

--- a/cranelift/codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift/codegen/meta/src/isa/x86/mod.rs
@@ -47,6 +47,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_32.legalize_value_type(ReferenceType(R32), x86_expand);
     x86_32.legalize_type(F32, x86_expand);
     x86_32.legalize_type(F64, x86_expand);
+    x86_32.legalize_value_type(VectorType::new(I32.into(), 4), x86_narrow_avx);
     x86_32.legalize_value_type(VectorType::new(I64.into(), 2), x86_narrow_avx);
     x86_32.legalize_value_type(VectorType::new(F32.into(), 4), x86_narrow_avx);
 
@@ -60,6 +61,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_64.legalize_value_type(ReferenceType(R64), x86_expand);
     x86_64.legalize_type(F32, x86_expand);
     x86_64.legalize_type(F64, x86_expand);
+    x86_64.legalize_value_type(VectorType::new(I32.into(), 4), x86_narrow_avx);
     x86_64.legalize_value_type(VectorType::new(I64.into(), 2), x86_narrow_avx);
     x86_64.legalize_value_type(VectorType::new(F32.into(), 4), x86_narrow_avx);
 

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
@@ -32,3 +32,23 @@ block0(v0:f32x4):
     ; nextln: v1 = bxor v7, v9
     return v1
 }
+
+function %fcvt_to_uint_sat(f32x4) -> i32x4 {
+; check: const0 = 0x00000000000000000000000000000000
+; nextln: const1 = 0x4f0000004f0000004f0000004f000000
+block0(v0:f32x4):
+    v1 = fcvt_to_uint_sat.i32x4 v0
+    ; check: v2 = vconst.f32x4 const0
+    ; nextln: v3 = vconst.f32x4 const1
+    ; nextln: v4 = x86_fmax v0, v2
+    ; nextln: v5 = fsub v4, v3
+    ; nextln: v6 = fcmp le v3, v5
+    ; nextln: v7 = x86_cvtt2si.i32x4 v5
+    ; nextln: v8 = raw_bitcast.i32x4 v6
+    ; nextln: v9 = bxor v7, v8
+    ; nextln: v10 = raw_bitcast.i32x4 v2
+    ; nextln: v11 = x86_pmaxs v9, v10
+    ; nextln: v12 = x86_cvtt2si.i32x4 v4
+    ; nextln: v1 = iadd v12, v11
+    return v1
+}

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
@@ -28,3 +28,12 @@ block0(v0:f32x4):
 }
 ; run: %fcvt_to_sint_sat([0x0.0 -0x1.0 0x1.0 0x1.0p100]) == [0 -1 1 0x7FFFFFFF]
 ; run: %fcvt_to_sint_sat([-0x8.1 0x0.0 0x0.0 -0x1.0p100]) == [-8 0 0 0x80000000]
+
+function %fcvt_to_uint_sat(f32x4) -> i32x4 {
+block0(v0:f32x4):
+    v1 = fcvt_to_uint_sat.i32x4 v0
+    return v1
+}
+; run: %fcvt_to_uint_sat([0x1.0 0x4.2 0x4.6 0x1.0p100]) == [1 4 4 0xFFFFFFFF]
+; run: %fcvt_to_uint_sat([-0x8.1 -0x0.0 0x0.0 -0x1.0p100]) == [0 0 0 0]
+; run: %fcvt_to_uint_sat([0xB2D05E00.0 0.0 0.0 0.0]) == [3000000000 0 0 0]

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1559,6 +1559,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, F32X4, builder);
             state.push1(builder.ins().fcvt_to_sint_sat(I32X4, a))
         }
+        Operator::I32x4TruncSatF32x4U => {
+            let a = pop1_with_bitcast(state, F32X4, builder);
+            state.push1(builder.ins().fcvt_to_uint_sat(I32X4, a))
+        }
         Operator::I8x16NarrowI16x8S => {
             let (a, b) = pop2_with_bitcast(state, I16X8, builder);
             state.push1(builder.ins().snarrow(a, b))
@@ -1575,8 +1579,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = pop2_with_bitcast(state, I32X4, builder);
             state.push1(builder.ins().unarrow(a, b))
         }
-        Operator::I32x4TruncSatF32x4U
-        | Operator::I16x8WidenLowI8x16S { .. }
+        Operator::I16x8WidenLowI8x16S { .. }
         | Operator::I16x8WidenHighI8x16S { .. }
         | Operator::I16x8WidenLowI8x16U { .. }
         | Operator::I16x8WidenHighI8x16U { .. }


### PR DESCRIPTION
This replaces #1822; it consists of the same functionality but removes the AVX512 instruction lowering for the time being. There are two reasons for this:
 - the default MXCSR rounding is round to nearest even, which does not match the semantics required by [`i32x4.trunc_sat_f32x4_u`](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#floating-point-to-integer-with-saturation). We can then use embedded rounding control but lose the ability to specify the vector length, so the instruction would operate on 512-bits which we should discuss (@sunfishcode has reported issues with 512-bit vectors in Spidermonkey)
 - the output of `VCVTPS2UDQ` for negative lanes is `0xFFFFFFFF` (I had thought it would be `0x00000000`); this can be resolved with the following sequence: `v0 = pxor ...; v2 = fcmp gte v1, v0 (gte ensures they are ordered); v3 = vcvtps2udq v1; v4 = band v2, v3`. However, I would like to look at this a little bit more before submitting a separate PR for it (this is the reason for keeping the legalization in `enc_tables.rs` and under `narrow_avx`, BTW).