### PR TITLE
Make wasmtime_environ::Module serializable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg 1.0.0",
+ "serde",
 ]
 
 [[package]]

--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -11,6 +11,8 @@ use crate::machinst::RelocDistance;
 use alloc::vec::Vec;
 use core::fmt;
 use core::str::FromStr;
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
 
 /// Function signature.
 ///
@@ -20,6 +22,7 @@ use core::str::FromStr;
 /// A signature can optionally include ISA-specific ABI information which specifies exactly how
 /// arguments and return values are passed.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Signature {
     /// The arguments passed to the function.
     pub params: Vec<AbiParam>,
@@ -145,6 +148,7 @@ impl fmt::Display for Signature {
 /// This describes the value type being passed to or from a function along with flags that affect
 /// how the argument is passed.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct AbiParam {
     /// Type of the argument value.
     pub value_type: Type,
@@ -255,6 +259,7 @@ impl fmt::Display for AbiParam {
 /// On some architectures, small integer function arguments are extended to the width of a
 /// general-purpose register.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum ArgumentExtension {
     /// No extension, high bits are indeterminate.
     None,
@@ -272,6 +277,7 @@ pub enum ArgumentExtension {
 ///
 /// The argument purpose is used to indicate any special meaning of an argument or return value.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum ArgumentPurpose {
     /// A normal user program value passed to or from a function.
     Normal,

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -8,6 +8,8 @@ use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
 use core::str::FromStr;
 use core::{i32, u32};
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
 
 /// Convert a type into a vector of bytes; all implementors in this file must use little-endian
 /// orderings of bytes to match WebAssembly's little-endianness.
@@ -325,6 +327,7 @@ impl FromStr for Uimm32 {
 ///
 /// This is used as an immediate value in SIMD instructions.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct V128Imm(pub [u8; 16]);
 
 impl V128Imm {

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -3,6 +3,8 @@
 use core::default::Default;
 use core::fmt::{self, Debug, Display, Formatter};
 use cranelift_codegen_shared::constants;
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
 use target_lexicon::{PointerWidth, Triple};
 
 /// The type of an SSA value.
@@ -21,6 +23,7 @@ use target_lexicon::{PointerWidth, Triple};
 /// SIMD vector types have power-of-two lanes, up to 256. Lanes can be any int/float/bool type.
 ///
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Type(u8);
 
 /// Not a valid type. Can't be loaded or stored. Can't be part of a SIMD vector.

--- a/cranelift/codegen/src/ir/valueloc.rs
+++ b/cranelift/codegen/src/ir/valueloc.rs
@@ -98,6 +98,7 @@ impl<'a> fmt::Display for DisplayValueLoc<'a> {
 /// - For register arguments, there is usually no difference, but if we ever add support for a
 ///   register-window ISA like SPARC, register arguments would also need to be translated.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum ArgumentLoc {
     /// This argument has not been assigned to a location yet.
     Unassigned,

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1039,7 +1039,9 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::F32Le | Operator::F64Le => {
             translate_fcmp(FloatCC::LessThanOrEqual, builder, state)
         }
-        Operator::RefNull { ty } => state.push1(environ.translate_ref_null(builder.cursor(), *ty)?),
+        Operator::RefNull { ty } => {
+            state.push1(environ.translate_ref_null(builder.cursor(), (*ty).into())?)
+        }
         Operator::RefIsNull { ty: _ } => {
             let value = state.pop1();
             state.push1(environ.translate_ref_is_null(builder.cursor(), value)?);

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -30,6 +30,7 @@ use crate::translation_utils::{
 };
 use crate::translation_utils::{FuncIndex, GlobalIndex, MemoryIndex, SignatureIndex, TableIndex};
 use crate::wasm_unsupported;
+use core::convert::TryInto;
 use core::{i32, u32};
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::Offset32;
@@ -1040,7 +1041,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             translate_fcmp(FloatCC::LessThanOrEqual, builder, state)
         }
         Operator::RefNull { ty } => {
-            state.push1(environ.translate_ref_null(builder.cursor(), (*ty).into())?)
+            state.push1(environ.translate_ref_null(builder.cursor(), (*ty).try_into()?)?)
         }
         Operator::RefIsNull { ty: _ } => {
             let value = state.pop1();

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -547,7 +547,7 @@ impl TargetEnvironment for DummyEnvironment {
 }
 
 impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
-    fn declare_signature(&mut self, _wasm: &WasmFuncType, sig: ir::Signature) -> WasmResult<()> {
+    fn declare_signature(&mut self, _wasm: WasmFuncType, sig: ir::Signature) -> WasmResult<()> {
         self.info.signatures.push(sig);
         Ok(())
     }

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -17,12 +17,12 @@ use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_codegen::isa::TargetFrontendConfig;
 use cranelift_frontend::FunctionBuilder;
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
 use std::boxed::Box;
 use thiserror::Error;
 use wasmparser::BinaryReaderError;
 use wasmparser::Operator;
-#[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
 
 /// Equivalent of `wasmparser`'s FuncType.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -12,6 +12,7 @@ use crate::translation_utils::{
     Table, TableIndex,
 };
 use core::convert::From;
+use core::convert::TryFrom;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{self, InstBuilder};
@@ -20,40 +21,12 @@ use cranelift_frontend::FunctionBuilder;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use std::boxed::Box;
+use std::string::ToString;
 use thiserror::Error;
 use wasmparser::BinaryReaderError;
 use wasmparser::Operator;
 
-/// Equivalent of `wasmparser`'s FuncType.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct WasmFuncType {
-    /// Function params types.
-    pub params: Box<[WasmType]>,
-    /// Returns params types.
-    pub returns: Box<[WasmType]>,
-}
-
-impl From<wasmparser::FuncType> for WasmFuncType {
-    fn from(ty: wasmparser::FuncType) -> Self {
-        Self {
-            params: ty
-                .params
-                .into_vec()
-                .into_iter()
-                .map(WasmType::from)
-                .collect(),
-            returns: ty
-                .returns
-                .into_vec()
-                .into_iter()
-                .map(WasmType::from)
-                .collect(),
-        }
-    }
-}
-
-/// Equivalent of `wasmparser`'s Type.
+/// WebAssembly value type -- equivalent of `wasmparser`'s Type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum WasmType {
@@ -73,19 +46,53 @@ pub enum WasmType {
     ExternRef,
 }
 
-impl From<wasmparser::Type> for WasmType {
-    fn from(ty: wasmparser::Type) -> Self {
+impl TryFrom<wasmparser::Type> for WasmType {
+    type Error = WasmError;
+    fn try_from(ty: wasmparser::Type) -> Result<Self, Self::Error> {
         use wasmparser::Type::*;
         match ty {
-            I32 => WasmType::I32,
-            I64 => WasmType::I64,
-            F32 => WasmType::F32,
-            F64 => WasmType::F64,
-            V128 => WasmType::V128,
-            FuncRef => WasmType::FuncRef,
-            ExternRef => WasmType::ExternRef,
-            EmptyBlockType | Func => panic!(),
+            I32 => Ok(WasmType::I32),
+            I64 => Ok(WasmType::I64),
+            F32 => Ok(WasmType::F32),
+            F64 => Ok(WasmType::F64),
+            V128 => Ok(WasmType::V128),
+            FuncRef => Ok(WasmType::FuncRef),
+            ExternRef => Ok(WasmType::ExternRef),
+            EmptyBlockType | Func => Err(WasmError::InvalidWebAssembly {
+                message: "unexpected value type".to_string(),
+                offset: 0,
+            }),
         }
+    }
+}
+
+/// WebAssembly function type -- equivalent of `wasmparser`'s FuncType.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct WasmFuncType {
+    /// Function params types.
+    pub params: Box<[WasmType]>,
+    /// Returns params types.
+    pub returns: Box<[WasmType]>,
+}
+
+impl TryFrom<wasmparser::FuncType> for WasmFuncType {
+    type Error = WasmError;
+    fn try_from(ty: wasmparser::FuncType) -> Result<Self, Self::Error> {
+        Ok(Self {
+            params: ty
+                .params
+                .into_vec()
+                .into_iter()
+                .map(WasmType::try_from)
+                .collect::<Result<_, Self::Error>>()?,
+            returns: ty
+                .returns
+                .into_vec()
+                .into_iter()
+                .map(WasmType::try_from)
+                .collect::<Result<_, Self::Error>>()?,
+        })
     }
 }
 

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -196,7 +196,7 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
             let constant_handle = builder.func.dfg.constants.insert([0; 16].to_vec().into());
             builder.ins().vconst(ir::types::I8X16, constant_handle)
         }
-        ExternRef | FuncRef => environ.translate_ref_null(builder.cursor(), wasm_type)?,
+        ExternRef | FuncRef => environ.translate_ref_null(builder.cursor(), wasm_type.into())?,
         ty => return Err(wasm_unsupported!("unsupported local type {:?}", ty)),
     };
 

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -9,6 +9,7 @@ use crate::environ::{FuncEnvironment, ReturnMode, WasmResult};
 use crate::state::{FuncTranslationState, ModuleTranslationState};
 use crate::translation_utils::get_vmctx_value_label;
 use crate::wasm_unsupported;
+use core::convert::TryInto;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, Block, InstBuilder, ValueLabel};
 use cranelift_codegen::timing;
@@ -196,7 +197,9 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
             let constant_handle = builder.func.dfg.constants.insert([0; 16].to_vec().into());
             builder.ins().vconst(ir::types::I8X16, constant_handle)
         }
-        ExternRef | FuncRef => environ.translate_ref_null(builder.cursor(), wasm_type.into())?,
+        ExternRef | FuncRef => {
+            environ.translate_ref_null(builder.cursor(), wasm_type.try_into()?)?
+        }
         ty => return Err(wasm_unsupported!("unsupported local type {:?}", ty)),
     };
 

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -53,7 +53,7 @@ pub fn parse_type_section(
                     .expect("only numeric types are supported in function signatures");
                 AbiParam::new(cret_arg)
             }));
-            environ.declare_signature(&wasm_func_ty, sig)?;
+            environ.declare_signature(wasm_func_ty.clone().into(), sig)?;
             module_translation_state
                 .wasm_types
                 .push((wasm_func_ty.params, wasm_func_ty.returns));
@@ -104,7 +104,7 @@ pub fn parse_import_section<'data>(
             ImportSectionEntryType::Global(ref ty) => {
                 environ.declare_global_import(
                     Global {
-                        wasm_ty: ty.content_type,
+                        wasm_ty: ty.content_type.into(),
                         ty: type_to_type(ty.content_type, environ).unwrap(),
                         mutability: ty.mutable,
                         initializer: GlobalInit::Import,
@@ -116,7 +116,7 @@ pub fn parse_import_section<'data>(
             ImportSectionEntryType::Table(ref tab) => {
                 environ.declare_table_import(
                     Table {
-                        wasm_ty: tab.element_type,
+                        wasm_ty: tab.element_type.into(),
                         ty: match tabletype_to_type(tab.element_type, environ)? {
                             Some(t) => TableElementType::Val(t),
                             None => TableElementType::Func,
@@ -166,7 +166,7 @@ pub fn parse_table_section(
     for entry in tables {
         let table = entry?;
         environ.declare_table(Table {
-            wasm_ty: table.element_type,
+            wasm_ty: table.element_type.into(),
             ty: match tabletype_to_type(table.element_type, environ)? {
                 Some(t) => TableElementType::Val(t),
                 None => TableElementType::Func,
@@ -237,7 +237,7 @@ pub fn parse_global_section(
             }
         };
         let global = Global {
-            wasm_ty: content_type,
+            wasm_ty: content_type.into(),
             ty: type_to_type(content_type, environ).unwrap(),
             mutability: mutable,
             initializer,

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -15,6 +15,7 @@ use crate::translation_utils::{
 };
 use crate::{wasm_unsupported, HashMap};
 use core::convert::TryFrom;
+use core::convert::TryInto;
 use cranelift_codegen::ir::immediates::V128Imm;
 use cranelift_codegen::ir::{self, AbiParam, Signature};
 use cranelift_entity::packed_option::ReservedValue;
@@ -53,7 +54,7 @@ pub fn parse_type_section(
                     .expect("only numeric types are supported in function signatures");
                 AbiParam::new(cret_arg)
             }));
-            environ.declare_signature(wasm_func_ty.clone().into(), sig)?;
+            environ.declare_signature(wasm_func_ty.clone().try_into()?, sig)?;
             module_translation_state
                 .wasm_types
                 .push((wasm_func_ty.params, wasm_func_ty.returns));
@@ -104,7 +105,7 @@ pub fn parse_import_section<'data>(
             ImportSectionEntryType::Global(ref ty) => {
                 environ.declare_global_import(
                     Global {
-                        wasm_ty: ty.content_type.into(),
+                        wasm_ty: ty.content_type.try_into()?,
                         ty: type_to_type(ty.content_type, environ).unwrap(),
                         mutability: ty.mutable,
                         initializer: GlobalInit::Import,
@@ -116,7 +117,7 @@ pub fn parse_import_section<'data>(
             ImportSectionEntryType::Table(ref tab) => {
                 environ.declare_table_import(
                     Table {
-                        wasm_ty: tab.element_type.into(),
+                        wasm_ty: tab.element_type.try_into()?,
                         ty: match tabletype_to_type(tab.element_type, environ)? {
                             Some(t) => TableElementType::Val(t),
                             None => TableElementType::Func,
@@ -166,7 +167,7 @@ pub fn parse_table_section(
     for entry in tables {
         let table = entry?;
         environ.declare_table(Table {
-            wasm_ty: table.element_type.into(),
+            wasm_ty: table.element_type.try_into()?,
             ty: match tabletype_to_type(table.element_type, environ)? {
                 Some(t) => TableElementType::Val(t),
                 None => TableElementType::Func,
@@ -237,7 +238,7 @@ pub fn parse_global_section(
             }
         };
         let global = Global {
-            wasm_ty: content_type.into(),
+            wasm_ty: content_type.try_into()?,
             ty: type_to_type(content_type, environ).unwrap(),
             mutability: mutable,
             initializer,

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -153,7 +153,9 @@ pub fn type_to_type<PE: TargetEnvironment + ?Sized>(
         wasmparser::Type::F32 => Ok(ir::types::F32),
         wasmparser::Type::F64 => Ok(ir::types::F64),
         wasmparser::Type::V128 => Ok(ir::types::I8X16),
-        wasmparser::Type::ExternRef | wasmparser::Type::FuncRef => Ok(environ.reference_type(ty)),
+        wasmparser::Type::ExternRef | wasmparser::Type::FuncRef => {
+            Ok(environ.reference_type(ty.into()))
+        }
         ty => Err(wasm_unsupported!("type_to_type: wasm type {:?}", ty)),
     }
 }
@@ -170,7 +172,7 @@ pub fn tabletype_to_type<PE: TargetEnvironment + ?Sized>(
         wasmparser::Type::F32 => Ok(Some(ir::types::F32)),
         wasmparser::Type::F64 => Ok(Some(ir::types::F64)),
         wasmparser::Type::V128 => Ok(Some(ir::types::I8X16)),
-        wasmparser::Type::ExternRef => Ok(Some(environ.reference_type(ty))),
+        wasmparser::Type::ExternRef => Ok(Some(environ.reference_type(ty.into()))),
         wasmparser::Type::FuncRef => Ok(None),
         ty => Err(wasm_unsupported!(
             "tabletype_to_type: table wasm type {:?}",
@@ -226,7 +228,7 @@ pub fn block_with_params<PE: TargetEnvironment + ?Sized>(
                 builder.append_block_param(block, ir::types::F64);
             }
             wasmparser::Type::ExternRef | wasmparser::Type::FuncRef => {
-                builder.append_block_param(block, environ.reference_type(*ty));
+                builder.append_block_param(block, environ.reference_type((*ty).into()));
             }
             wasmparser::Type::V128 => {
                 builder.append_block_param(block, ir::types::I8X16);

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -39,31 +39,37 @@ entity_impl!(DefinedGlobalIndex);
 
 /// Index type of a table (imported or defined) inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct TableIndex(u32);
 entity_impl!(TableIndex);
 
 /// Index type of a global variable (imported or defined) inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct GlobalIndex(u32);
 entity_impl!(GlobalIndex);
 
 /// Index type of a linear memory (imported or defined) inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct MemoryIndex(u32);
 entity_impl!(MemoryIndex);
 
 /// Index type of a signature (imported or defined) inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct SignatureIndex(u32);
 entity_impl!(SignatureIndex);
 
 /// Index type of a passive data segment inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct DataIndex(u32);
 entity_impl!(DataIndex);
 
 /// Index type of a passive element segment inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct ElemIndex(u32);
 entity_impl!(ElemIndex);
 
@@ -75,6 +81,7 @@ entity_impl!(ElemIndex);
 /// Wasm `i64` and a `funcref` might be represented with a Cranelift `i64` on
 /// 64-bit architectures, and when GC is not required for func refs.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Global {
     /// The Wasm type of the value stored in the global.
     pub wasm_ty: crate::WasmType,
@@ -88,6 +95,7 @@ pub struct Global {
 
 /// Globals are initialized via the `const` operators or by referring to another import.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum GlobalInit {
     /// An `i32.const`.
     I32Const(i32),
@@ -111,6 +119,7 @@ pub enum GlobalInit {
 
 /// WebAssembly table.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Table {
     /// The table elements' Wasm type.
     pub wasm_ty: WasmType,
@@ -124,6 +133,7 @@ pub struct Table {
 
 /// WebAssembly table element. Can be a function or a scalar type.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum TableElementType {
     /// A scalar type.
     Val(ir::Type),
@@ -133,6 +143,7 @@ pub enum TableElementType {
 
 /// WebAssembly linear memory.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Memory {
     /// The minimum number of pages in the memory.
     pub minimum: u32,

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -2,6 +2,7 @@
 use crate::environ::{TargetEnvironment, WasmResult, WasmType};
 use crate::state::ModuleTranslationState;
 use crate::wasm_unsupported;
+use core::convert::TryInto;
 use core::u32;
 use cranelift_codegen::entity::entity_impl;
 use cranelift_codegen::ir;
@@ -165,7 +166,7 @@ pub fn type_to_type<PE: TargetEnvironment + ?Sized>(
         wasmparser::Type::F64 => Ok(ir::types::F64),
         wasmparser::Type::V128 => Ok(ir::types::I8X16),
         wasmparser::Type::ExternRef | wasmparser::Type::FuncRef => {
-            Ok(environ.reference_type(ty.into()))
+            Ok(environ.reference_type(ty.try_into()?))
         }
         ty => Err(wasm_unsupported!("type_to_type: wasm type {:?}", ty)),
     }
@@ -183,7 +184,7 @@ pub fn tabletype_to_type<PE: TargetEnvironment + ?Sized>(
         wasmparser::Type::F32 => Ok(Some(ir::types::F32)),
         wasmparser::Type::F64 => Ok(Some(ir::types::F64)),
         wasmparser::Type::V128 => Ok(Some(ir::types::I8X16)),
-        wasmparser::Type::ExternRef => Ok(Some(environ.reference_type(ty.into()))),
+        wasmparser::Type::ExternRef => Ok(Some(environ.reference_type(ty.try_into()?))),
         wasmparser::Type::FuncRef => Ok(None),
         ty => Err(wasm_unsupported!(
             "tabletype_to_type: table wasm type {:?}",
@@ -239,7 +240,7 @@ pub fn block_with_params<PE: TargetEnvironment + ?Sized>(
                 builder.append_block_param(block, ir::types::F64);
             }
             wasmparser::Type::ExternRef | wasmparser::Type::FuncRef => {
-                builder.append_block_param(block, environ.reference_type((*ty).into()));
+                builder.append_block_param(block, environ.reference_type((*ty).try_into()?));
             }
             wasmparser::Type::V128 => {
                 builder.append_block_param(block, ir::types::I8X16);

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -19,7 +19,7 @@ cranelift-frontend = { path = "../../cranelift/frontend", version = "0.65.0" }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.65.0", features = ["enable-serde"] }
 wasmparser = "0.58.0"
 lightbeam = { path = "../lightbeam", optional = true, version = "0.18.0" }
-indexmap = "1.0.2"
+indexmap = { version = "1.0.2", features = ["serde-1"] }
 rayon = { version = "1.2.1", optional = true }
 thiserror = "1.0.4"
 directories = "2.0.1"

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -110,14 +110,10 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         Ok(())
     }
 
-    fn declare_signature(&mut self, wasm: &WasmFuncType, sig: ir::Signature) -> WasmResult<()> {
+    fn declare_signature(&mut self, wasm: WasmFuncType, sig: ir::Signature) -> WasmResult<()> {
         let sig = translate_signature(sig, self.pointer_type());
         // TODO: Deduplicate signatures.
-        self.result
-            .module
-            .local
-            .signatures
-            .push((wasm.clone(), sig));
+        self.result.module.local.signatures.push((wasm, sig));
         Ok(())
     }
 

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -202,13 +202,11 @@ impl Global {
         // The original export is coming from wasmtime_runtime itself we should
         // support all the types coming out of it, so assert such here.
         GlobalType::from_wasmtime_global(&self.wasmtime_export.global)
-            .expect("core wasm global type should be supported")
     }
 
     /// Returns the value type of this `global`.
     pub fn val_type(&self) -> ValType {
         ValType::from_wasm_type(&self.wasmtime_export.global.wasm_ty)
-            .expect("core wasm type should be supported")
     }
 
     /// Returns the underlying mutability of this `global`.

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -545,7 +545,7 @@ impl Func {
         // This is only called with `Export::Function`, and since it's coming
         // from wasmtime_runtime itself we should support all the types coming
         // out of it, so assert such here.
-        FuncType::from_wasm_func_type(&wft).expect("core wasm signature should be supported")
+        FuncType::from_wasm_func_type(&wft)
     }
 
     /// Returns the number of parameters that this function takes.


### PR DESCRIPTION
As being part of `CompilationArtifacts`, it will be nice to make `Module` and `ModuleLocal` serializable.

Changes:
- Defines WasmTime and WasmFuncType in the Cranelift, instead of re-exporting from wasmparser (also removes un-need cases in wasmtime crate)
- Adds serde attributes to cranelift_wasm types (that need them)
- Adds logic for serializing Module::id and Module::passive_data
