### PR TITLE
Add link to C API docs in the guide

### DIFF
--- a/docs/lang-c.md
+++ b/docs/lang-c.md
@@ -1,3 +1,7 @@
 # C
 
 ... more coming soon
+
+In the meantime, have a look at the [C API docs].
+
+[C API docs]: https://bytecodealliance.github.io/wasmtime/c-api/


### PR DESCRIPTION
While we're working on the C API section in the official guide, I thought it might be useful to at least point the user to the docs.