### PR TITLE
WASI: make O_CREAT|O_TRUNC actually truncate files on Windows

### DIFF
--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -218,6 +218,8 @@ mod wasi_tests {
                         // TODO: virtfs does not support rename yet.
                         "path_rename_trailing_slashes_virtualfs" |
                         "path_rename_virtualfs" => true,
+                        // TODO: virtfs does not support truncation yet.
+                        "file_truncation_virtualfs" => true,
                         _ => false,
                     }
                 } else {
@@ -250,6 +252,8 @@ mod wasi_tests {
                         // TODO: virtfs does not support rename yet.
                         "path_rename_trailing_slashes_virtualfs" |
                         "path_rename_virtualfs" => true,
+                        // TODO: virtfs does not support truncation yet.
+                        "file_truncation_virtualfs" => true,
                         _ => false,
                     }
                 } else {

--- a/crates/test-programs/wasi-tests/src/bin/file_truncation.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_truncation.rs
@@ -1,0 +1,83 @@
+use std::{env, process};
+use wasi_tests::open_scratch_directory;
+
+unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
+    const FILENAME: &str = "test.txt";
+
+    // Open a file for writing
+    let file_fd = wasi::path_open(
+        dir_fd,
+        0,
+        FILENAME,
+        wasi::OFLAGS_CREAT,
+        wasi::RIGHTS_FD_WRITE,
+        0,
+        0,
+    )
+    .expect("creating a file for writing");
+
+    // Write to the file
+    let content = b"this content will be truncated!";
+    let nwritten = wasi::fd_write(
+        file_fd,
+        &[wasi::Ciovec {
+            buf: content.as_ptr() as *const _,
+            buf_len: content.len(),
+        }],
+    )
+    .expect("writing file content");
+    assert_eq!(nwritten, content.len(), "nwritten bytes check");
+
+    wasi::fd_close(file_fd).expect("closing the file");
+
+    // Open the file for truncation
+    let file_fd = wasi::path_open(
+        dir_fd,
+        0,
+        FILENAME,
+        wasi::OFLAGS_CREAT | wasi::OFLAGS_TRUNC,
+        wasi::RIGHTS_FD_WRITE | wasi::RIGHTS_FD_READ,
+        0,
+        0,
+    )
+    .expect("creating a truncated file for reading");
+
+    // Read the file's contents
+    let buffer = &mut [0u8; 100];
+    let nread = wasi::fd_read(
+        file_fd,
+        &[wasi::Iovec {
+            buf: buffer.as_mut_ptr(),
+            buf_len: buffer.len(),
+        }],
+    )
+    .expect("reading file content");
+
+    // The file should be empty due to truncation
+    assert_eq!(nread, 0, "expected an empty file after truncation");
+
+    wasi::fd_close(file_fd).expect("closing the file");
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_file_truncation(dir_fd) }
+}

--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff.rs
@@ -42,9 +42,7 @@ unsafe fn test_timeout() {
         userdata: CLOCK_ID,
         u: wasi::SubscriptionU {
             tag: wasi::EVENTTYPE_CLOCK,
-            u: wasi::SubscriptionUU {
-                clock
-            }
+            u: wasi::SubscriptionUU { clock },
         },
     }];
     let out = poll_oneoff_impl(&r#in, 1);
@@ -80,9 +78,7 @@ unsafe fn test_stdin_read() {
             userdata: CLOCK_ID,
             u: wasi::SubscriptionU {
                 tag: wasi::EVENTTYPE_CLOCK,
-                u: wasi::SubscriptionUU {
-                    clock
-                }
+                u: wasi::SubscriptionUU { clock },
             },
         },
         // Make sure that timeout is returned only once even if there are multiple read events
@@ -91,8 +87,8 @@ unsafe fn test_stdin_read() {
             u: wasi::SubscriptionU {
                 tag: wasi::EVENTTYPE_FD_READ,
                 u: wasi::SubscriptionUU {
-                    fd_read: fd_readwrite
-                }
+                    fd_read: fd_readwrite,
+                },
             },
         },
     ];
@@ -127,7 +123,7 @@ unsafe fn test_stdout_stderr_write() {
             u: wasi::SubscriptionU {
                 tag: wasi::EVENTTYPE_FD_WRITE,
                 u: wasi::SubscriptionUU {
-                    fd_write: stdout_readwrite
+                    fd_write: stdout_readwrite,
                 },
             },
         },
@@ -136,8 +132,8 @@ unsafe fn test_stdout_stderr_write() {
             u: wasi::SubscriptionU {
                 tag: wasi::EVENTTYPE_FD_WRITE,
                 u: wasi::SubscriptionUU {
-                    fd_write: stderr_readwrite
-                }
+                    fd_write: stderr_readwrite,
+                },
             },
         },
     ];
@@ -182,8 +178,8 @@ unsafe fn test_fd_readwrite(fd: wasi::Fd, error_code: wasi::Errno) {
             u: wasi::SubscriptionU {
                 tag: wasi::EVENTTYPE_FD_READ,
                 u: wasi::SubscriptionUU {
-                    fd_read: fd_readwrite
-                }
+                    fd_read: fd_readwrite,
+                },
             },
         },
         wasi::Subscription {
@@ -191,8 +187,8 @@ unsafe fn test_fd_readwrite(fd: wasi::Fd, error_code: wasi::Errno) {
             u: wasi::SubscriptionU {
                 tag: wasi::EVENTTYPE_FD_WRITE,
                 u: wasi::SubscriptionUU {
-                    fd_write: fd_readwrite
-                }
+                    fd_write: fd_readwrite,
+                },
             },
         },
     ];

--- a/crates/wasi-common/src/sys/windows/path.rs
+++ b/crates/wasi-common/src/sys/windows/path.rs
@@ -224,7 +224,7 @@ pub(crate) fn open(
     let mut opts = OpenOptions::new();
     match oflags.into() {
         CreationDisposition::CREATE_ALWAYS => {
-            opts.create(true).write(true);
+            opts.create(true).truncate(true).write(true);
         }
         CreationDisposition::CREATE_NEW => {
             opts.create_new(true).write(true);


### PR DESCRIPTION
Fixes #2009.