### PR TITLE
CI: Rearrange CI jobs from longest-running to shortest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,64 +22,6 @@ jobs:
     - run: rustup component add rustfmt
     - run: cargo fmt --all -- --check
 
-  # Build `mdBook` documentation for `wasmtime`, and upload it as a temporary
-  # build artifact
-  doc_book:
-    name: Doc - build the book
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - run: |
-        set -e
-        curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
-        echo ::add-path::`pwd`
-    - run: (cd docs && mdbook build)
-    - run: cargo build -p wasmtime
-    - run: (cd docs && mdbook test -L ../target/debug/deps)
-    - uses: actions/upload-artifact@v1
-      with:
-        name: doc-book
-        path: docs/book
-
-  # Build rustdoc API documentation for `wasmtime*` crates. Note that we don't
-  # want to document all our transitive dependencies, hence `--no-deps`. This is
-  # a temporary build artifact we upload to consume later.
-  doc_api:
-    name: Doc - build the API documentation
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dintra-doc-link-resolution-failure
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-      with:
-        toolchain: nightly-2020-06-03
-    - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
-    - run: cargo doc --package cranelift-codegen-meta --document-private-items
-    - uses: actions/upload-artifact@v1
-      with:
-        name: doc-api
-        path: target/doc
-
-  doc_capi:
-    name: Doc - build the C API documentation
-    runs-on: ubuntu-latest
-    container: ubuntu:20.04
-    steps:
-    - run: apt-get update && apt-get install -y doxygen git
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - run: cd crates/c-api && doxygen doxygen.conf
-    - uses: actions/upload-artifact@v1
-      with:
-        name: doc-c-api
-        path: crates/c-api/html
-
   # Quick checks of various feature combinations and whether things
   # compile. The goal here isn't to run tests, mostly just serve as a
   # double-check that Rust code compiles and is likely to work everywhere else.
@@ -129,49 +71,6 @@ jobs:
     - run: rustup install 1.41.0
     - run: cargo +1.41.0 check -p cranelift-codegen
     - run: cargo +1.41.0 check -p cranelift-wasm
-
-
-  fuzz_targets:
-    name: Fuzz Targets
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-      with:
-        toolchain: nightly-2020-06-03
-    - run: cargo install cargo-fuzz --vers "^0.8"
-    - run: cargo fetch
-      working-directory: ./fuzz
-    - run: cargo fuzz build --dev --features binaryen
-
-  rebuild_peephole_optimizers:
-    name: Rebuild Peephole Optimizers
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Test `peepmatic`
-      run: |
-        cargo test \
-          --package peepmatic \
-          --package peepmatic-automata \
-          --package peepmatic-fuzzing \
-          --package peepmatic-macro \
-          --package peepmatic-runtime \
-          --package peepmatic-test
-    - name: Rebuild Cranelift's peepmatic-based peephole optimizers
-      run: |
-        cd cranelift/
-        cargo build --features 'enable-peepmatic cranelift-codegen/rebuild-peephole-optimizers'
-    - name: Check that peephole optimizers are up to date
-      run: git diff --exit-code
-    - name: Test `cranelift-codegen` with `peepmatic` enabled
-      run: |
-        cd cranelift/
-        cargo test --features 'enable-peepmatic'
 
   # Perform all tests (debug mode) for `wasmtime`. This runs stable/beta/nightly
   # channels of Rust as well as macOS/Linux/Windows.
@@ -264,19 +163,6 @@ jobs:
       continue-on-error: true
       env:
         RUST_BACKTRACE: 1
-
-  # Verify that cranelift's code generation is deterministic
-  meta_determinist_check:
-    name: Meta deterministic check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Install Rust
-      run: rustup update stable && rustup default stable
-    - run: cd cranelift/codegen && cargo build --features all-arch
-    - run: ci/ensure_deterministic_build.sh
 
   # Perform release builds of `wasmtime` and `libwasmtime.so`. Builds on
   # Windows/Mac/Linux, and artifacts are uploaded after the build is finished.
@@ -427,6 +313,134 @@ jobs:
         name: bins-${{ matrix.build }}
         path: dist
 
+  rebuild_peephole_optimizers:
+    name: Rebuild Peephole Optimizers
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Test `peepmatic`
+      run: |
+        cargo test \
+          --package peepmatic \
+          --package peepmatic-automata \
+          --package peepmatic-fuzzing \
+          --package peepmatic-macro \
+          --package peepmatic-runtime \
+          --package peepmatic-test
+    - name: Rebuild Cranelift's peepmatic-based peephole optimizers
+      run: |
+        cd cranelift/
+        cargo build --features 'enable-peepmatic cranelift-codegen/rebuild-peephole-optimizers'
+    - name: Check that peephole optimizers are up to date
+      run: git diff --exit-code
+    - name: Test `cranelift-codegen` with `peepmatic` enabled
+      run: |
+        cd cranelift/
+        cargo test --features 'enable-peepmatic'
+
+  fuzz_targets:
+    name: Fuzz Targets
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly-2020-06-03
+    - run: cargo install cargo-fuzz --vers "^0.8"
+    - run: cargo fetch
+      working-directory: ./fuzz
+    - run: cargo fuzz build --dev --features binaryen
+
+  # Build `mdBook` documentation for `wasmtime`, and upload it as a temporary
+  # build artifact
+  doc_book:
+    name: Doc - build the book
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - run: |
+        set -e
+        curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
+        echo ::add-path::`pwd`
+    - run: (cd docs && mdbook build)
+    - run: cargo build -p wasmtime
+    - run: (cd docs && mdbook test -L ../target/debug/deps)
+    - uses: actions/upload-artifact@v1
+      with:
+        name: doc-book
+        path: docs/book
+
+  # Build rustdoc API documentation for `wasmtime*` crates. Note that we don't
+  # want to document all our transitive dependencies, hence `--no-deps`. This is
+  # a temporary build artifact we upload to consume later.
+  doc_api:
+    name: Doc - build the API documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dintra-doc-link-resolution-failure
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly-2020-06-03
+    - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
+    - run: cargo doc --package cranelift-codegen-meta --document-private-items
+    - uses: actions/upload-artifact@v1
+      with:
+        name: doc-api
+        path: target/doc
+
+  doc_capi:
+    name: Doc - build the C API documentation
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    steps:
+    - run: apt-get update && apt-get install -y doxygen git
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - run: cd crates/c-api && doxygen doxygen.conf
+    - uses: actions/upload-artifact@v1
+      with:
+        name: doc-c-api
+        path: crates/c-api/html
+
+  # Verify that cranelift's code generation is deterministic
+  meta_determinist_check:
+    name: Meta deterministic check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - run: cd cranelift/codegen && cargo build --features all-arch
+    - run: ci/ensure_deterministic_build.sh
+
+  cargo-audit:
+    env:
+      CARGO_AUDIT_VERSION: 0.11.2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      with:
+        path: ${{ runner.tool_cache }}/cargo-audit
+        key: cargo-audit-bin-${{ env.CARGO_AUDIT_VERSION }}
+    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-audit/bin"
+    - run: |
+        cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
+        cargo audit
+
   # Consumes all published artifacts from all the previous build steps, creates
   # a bunch of tarballs for all of them, and then publishes the tarballs
   # themselves as an artifact (for inspection) and then optionally creates
@@ -541,18 +555,3 @@ jobs:
         files: "dist/*"
         name: ${{ steps.tagname.outputs.val }}
         token: ${{ secrets.GITHUB_TOKEN }}
-
-  cargo-audit:
-    env:
-      CARGO_AUDIT_VERSION: 0.11.2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: ${{ runner.tool_cache }}/cargo-audit
-        key: cargo-audit-bin-${{ env.CARGO_AUDIT_VERSION }}
-    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-audit/bin"
-    - run: |
-        cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
-        cargo audit


### PR DESCRIPTION
Because CI jobs are spawned in order, this should better take advantage of job
parallelism, so we don't wait on a single long-running job at the end of CI.

The exception is a couple of the quick checks that we want to get out of
the way immediately. These are things where the turn around time is really fast
and we want to be notified of them ASAP so we can fix them and re-push. Right
now these are the rustfmt style checking and the "checks" build.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
