### PR TITLE
Update wasmparser to 0.59.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "wat",
 ]
 
@@ -1124,7 +1124,7 @@ dependencies = [
  "staticvec",
  "thiserror",
  "typemap",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "wat",
 ]
 
@@ -2299,30 +2299,24 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af931e2e1960c53f4a28b063fec4cacd036f35acbec8ff3a4739125b17382a87"
-
-[[package]]
-name = "wasmparser"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmparser"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721a8d79483738d7aef6397edcf8f04cd862640b1ad5973adf5bb50fc10e86db"
+checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93ba310101ec5ee980db66b47b3d276577c8310df1570e19994347137650454"
+checksum = "334551eb8b0b1be16cf366a54ce9b541ac32a96e9b51e67ebbae1696f108f112"
 dependencies = [
  "anyhow",
- "wasmparser 0.55.0",
+ "wasmparser 0.59.0",
 ]
 
 [[package]]
@@ -2340,7 +2334,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-profiling",
@@ -2414,7 +2408,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "wasmtime-environ",
 ]
 
@@ -2447,7 +2441,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "winapi",
  "zstd",
 ]
@@ -2476,7 +2470,7 @@ dependencies = [
  "env_logger",
  "log",
  "rayon",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -2501,7 +2495,7 @@ dependencies = [
  "region",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "wasmtime-debug",
  "wasmtime-environ",
  "wasmtime-obj",
@@ -2598,7 +2592,7 @@ version = "0.18.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 18.0.0",
+ "wast 21.0.0",
 ]
 
 [[package]]
@@ -2642,20 +2636,20 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "18.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b1f23531740a81f9300bd2febd397a95c76bfa4aa4bfaf4ca8b1ee3438f337"
+checksum = "0b1844f66a2bc8526d71690104c0e78a8e59ffa1597b7245769d174ebb91deb5"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4006d418d59293172aebfeeadb7673459dc151874a79135946ea7996b6a98515"
+checksum = "ce85d72b74242c340e9e3492cfb602652d7bb324c3172dd441b5577e39a2e18c"
 dependencies = [
- "wast 18.0.0",
+ "wast 21.0.0",
 ]
 
 [[package]]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.58.0", default-features = false }
+wasmparser = { version = "0.59.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.65.0" }
 cranelift-frontend = { path = "../frontend", version = "0.65.0", default-features = false }

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1043,7 +1043,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::RefNull { ty } => {
             state.push1(environ.translate_ref_null(builder.cursor(), (*ty).try_into()?)?)
         }
-        Operator::RefIsNull { ty: _ } => {
+        Operator::RefIsNull => {
             let value = state.pop1();
             state.push1(environ.translate_ref_is_null(builder.cursor(), value)?);
         }

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -2,13 +2,13 @@
 //! to deal with each part of it.
 use crate::environ::{ModuleEnvironment, WasmResult};
 use crate::sections_translator::{
-    parse_code_section, parse_data_section, parse_element_section, parse_export_section,
-    parse_function_section, parse_global_section, parse_import_section, parse_memory_section,
-    parse_name_section, parse_start_section, parse_table_section, parse_type_section,
+    parse_data_section, parse_element_section, parse_export_section, parse_function_section,
+    parse_global_section, parse_import_section, parse_memory_section, parse_name_section,
+    parse_start_section, parse_table_section, parse_type_section,
 };
 use crate::state::ModuleTranslationState;
 use cranelift_codegen::timing;
-use wasmparser::{CustomSectionContent, ModuleReader, SectionContent};
+use wasmparser::{NameSectionReader, Parser, Payload};
 
 /// Translate a sequence of bytes forming a valid Wasm binary into a list of valid Cranelift IR
 /// [`Function`](cranelift_codegen::ir::Function).
@@ -17,80 +17,85 @@ pub fn translate_module<'data>(
     environ: &mut dyn ModuleEnvironment<'data>,
 ) -> WasmResult<ModuleTranslationState> {
     let _tt = timing::wasm_translate_module();
-    let mut reader = ModuleReader::new(data)?;
     let mut module_translation_state = ModuleTranslationState::new();
 
-    while !reader.eof() {
-        let section = reader.read()?;
-        match section.content()? {
-            SectionContent::Type(types) => {
+    for payload in Parser::new(0).parse_all(data) {
+        match payload? {
+            Payload::Version { .. } | Payload::End => {}
+
+            Payload::TypeSection(types) => {
                 parse_type_section(types, &mut module_translation_state, environ)?;
             }
 
-            SectionContent::Import(imports) => {
+            Payload::ImportSection(imports) => {
                 parse_import_section(imports, environ)?;
             }
 
-            SectionContent::Function(functions) => {
+            Payload::FunctionSection(functions) => {
                 parse_function_section(functions, environ)?;
             }
 
-            SectionContent::Table(tables) => {
+            Payload::TableSection(tables) => {
                 parse_table_section(tables, environ)?;
             }
 
-            SectionContent::Memory(memories) => {
+            Payload::MemorySection(memories) => {
                 parse_memory_section(memories, environ)?;
             }
 
-            SectionContent::Global(globals) => {
+            Payload::GlobalSection(globals) => {
                 parse_global_section(globals, environ)?;
             }
 
-            SectionContent::Export(exports) => {
+            Payload::ExportSection(exports) => {
                 parse_export_section(exports, environ)?;
             }
 
-            SectionContent::Start(start) => {
-                parse_start_section(start, environ)?;
+            Payload::StartSection { func, .. } => {
+                parse_start_section(func, environ)?;
             }
 
-            SectionContent::Element(elements) => {
+            Payload::ElementSection(elements) => {
                 parse_element_section(elements, environ)?;
             }
 
-            SectionContent::Code(code) => {
-                parse_code_section(code, &module_translation_state, environ)?;
+            Payload::CodeSectionStart { .. } => {}
+            Payload::CodeSectionEntry(code) => {
+                let mut code = code.get_binary_reader();
+                let size = code.bytes_remaining();
+                let offset = code.original_position();
+                environ.define_function_body(
+                    &module_translation_state,
+                    code.read_bytes(size)?,
+                    offset,
+                )?;
             }
 
-            SectionContent::Data(data) => {
+            Payload::DataSection(data) => {
                 parse_data_section(data, environ)?;
             }
 
-            SectionContent::DataCount(count) => {
+            Payload::DataCountSection { count, .. } => {
                 environ.reserve_passive_data(count)?;
             }
 
-            SectionContent::Module(_)
-            | SectionContent::ModuleCode(_)
-            | SectionContent::Instance(_)
-            | SectionContent::Alias(_) => unimplemented!("module linking not implemented yet"),
+            Payload::ModuleSection(_)
+            | Payload::InstanceSection(_)
+            | Payload::AliasSection(_)
+            | Payload::ModuleCodeSectionStart { .. }
+            | Payload::ModuleCodeSectionEntry { .. } => {
+                unimplemented!("module linking not implemented yet")
+            }
 
-            SectionContent::Custom {
-                name,
-                binary,
-                content,
-            } => match content {
-                Some(CustomSectionContent::Name(names)) => {
-                    parse_name_section(names, environ)?;
-                }
-                _ => {
-                    let mut reader = binary.clone();
-                    let len = reader.bytes_remaining();
-                    let payload = reader.read_bytes(len)?;
-                    environ.custom_section(name, payload)?;
-                }
-            },
+            Payload::CustomSection {
+                name: "name",
+                data,
+                data_offset,
+            } => parse_name_section(NameSectionReader::new(data, data_offset)?, environ)?,
+
+            Payload::CustomSection { name, data, .. } => environ.custom_section(name, data)?,
+
+            Payload::UnknownSection { .. } => unreachable!(),
         }
     }
 

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -23,11 +23,11 @@ use cranelift_entity::EntityRef;
 use std::boxed::Box;
 use std::vec::Vec;
 use wasmparser::{
-    self, CodeSectionReader, Data, DataKind, DataSectionReader, Element, ElementItem, ElementItems,
-    ElementKind, ElementSectionReader, Export, ExportSectionReader, ExternalKind,
-    FunctionSectionReader, GlobalSectionReader, GlobalType, ImportSectionEntryType,
-    ImportSectionReader, MemorySectionReader, MemoryType, NameSectionReader, Naming, NamingReader,
-    Operator, TableSectionReader, Type, TypeDef, TypeSectionReader,
+    self, Data, DataKind, DataSectionReader, Element, ElementItem, ElementItems, ElementKind,
+    ElementSectionReader, Export, ExportSectionReader, ExternalKind, FunctionSectionReader,
+    GlobalSectionReader, GlobalType, ImportSectionEntryType, ImportSectionReader,
+    MemorySectionReader, MemoryType, NameSectionReader, Naming, NamingReader, Operator,
+    TableSectionReader, Type, TypeDef, TypeSectionReader,
 };
 
 /// Parses the Type section of the wasm module.
@@ -354,21 +354,6 @@ pub fn parse_element_section<'data>(
                 // Nothing to do here.
             }
         }
-    }
-    Ok(())
-}
-
-/// Parses the Code section of the wasm module.
-pub fn parse_code_section<'data>(
-    code: CodeSectionReader<'data>,
-    module_translation_state: &ModuleTranslationState,
-    environ: &mut dyn ModuleEnvironment<'data>,
-) -> WasmResult<()> {
-    for body in code {
-        let mut reader = body?.get_binary_reader();
-        let size = reader.bytes_remaining();
-        let offset = reader.original_position();
-        environ.define_function_body(module_translation_state, reader.read_bytes(size)?, offset)?;
     }
     Ok(())
 }

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.21.0"
-wasmparser = "0.58.0"
+wasmparser = "0.59.0"
 object = { version = "0.20", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.18.0" }
 target-lexicon = { version = "0.10.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -17,7 +17,7 @@ cranelift-codegen = { path = "../../cranelift/codegen", version = "0.65.0", feat
 cranelift-entity = { path = "../../cranelift/entity", version = "0.65.0", features = ["enable-serde"] }
 cranelift-frontend = { path = "../../cranelift/frontend", version = "0.65.0" }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.65.0", features = ["enable-serde"] }
-wasmparser = "0.58.0"
+wasmparser = "0.59.0"
 lightbeam = { path = "../lightbeam", optional = true, version = "0.18.0" }
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 rayon = { version = "1.2.1", optional = true }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,8 +13,8 @@ binaryen = { version = "0.10.0", optional = true }
 env_logger = "0.7.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.58.0"
-wasmprinter = "0.2.5"
+wasmparser = "0.59.0"
+wasmprinter = "0.2.6"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -25,7 +25,7 @@ wasmtime-obj = { path = "../obj", version = "0.18.0" }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.10.0", default-features = false }
-wasmparser = "0.58.0"
+wasmparser = "0.59.0"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "0.1.9"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "1.0.0"
 staticvec = "0.10"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.58.0"
+wasmparser = "0.59.0"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/src/microwasm.rs
+++ b/crates/lightbeam/src/microwasm.rs
@@ -2130,7 +2130,7 @@ where
             WasmOperator::RefNull { ty: _ } => {
                 return Err(Error::Microwasm("RefNull unimplemented".into()))
             }
-            WasmOperator::RefIsNull { ty: _ } => {
+            WasmOperator::RefIsNull => {
                 return Err(Error::Microwasm("RefIsNull unimplemented".into()))
             }
             WasmOperator::I32Eqz => one(Operator::Eqz(Size::_32)),

--- a/crates/lightbeam/src/translate_sections.rs
+++ b/crates/lightbeam/src/translate_sections.rs
@@ -108,6 +108,7 @@ impl binemit::RelocSink for UnimplementedRelocSink {
 }
 
 /// Parses the Code section of the wasm module.
+#[allow(dead_code)]
 pub fn code(
     _code: CodeSectionReader,
     _translation_ctx: &SimpleContext,

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -14,7 +14,7 @@ wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
 wasmtime-environ = { path = "../environ", version = "0.18.0" }
 wasmtime-jit = { path = "../jit", version = "0.18.0" }
 wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
-wasmparser = "0.58.0"
+wasmparser = "0.59.0"
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0.19"
 region = "2.2.0"

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -66,7 +66,7 @@ fn instantiate(
         let instance = store.add_instance(instance);
         instance
             .initialize(
-                config.validating_config.operator_config.enable_bulk_memory,
+                config.wasm_bulk_memory,
                 &compiled_module.data_initializers(),
             )
             .map_err(|e| -> Error {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -1,10 +1,9 @@
 use crate::frame_info::GlobalFrameInfoRegistration;
 use crate::runtime::Engine;
 use crate::types::{EntityType, ExportType, ExternType, ImportType};
-use anyhow::{Error, Result};
+use anyhow::Result;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use wasmparser::validate;
 use wasmtime_jit::CompiledModule;
 
 /// A compiled WebAssembly module, ready to be instantiated.
@@ -296,8 +295,8 @@ impl Module {
     ///
     /// [binary]: https://webassembly.github.io/spec/core/binary/index.html
     pub fn validate(engine: &Engine, binary: &[u8]) -> Result<()> {
-        let config = engine.config().validating_config.clone();
-        validate(binary, Some(config)).map_err(Error::new)
+        engine.config().validator().validate_all(binary)?;
+        Ok(())
     }
 
     unsafe fn compile(engine: &Engine, binary: &[u8]) -> Result<Self> {

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.18.0", default-features = false }
-wast = "18.0.0"
+wast = "21.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -6,7 +6,7 @@ use wasmtime::*;
 use wast::Wat;
 use wast::{
     parser::{self, ParseBuffer},
-    RefType,
+    HeapType,
 };
 
 /// Translate from a `script::Value` to a `RuntimeValue`.
@@ -22,8 +22,8 @@ fn runtime_value(v: &wast::Expression<'_>) -> Result<Val> {
         F32Const(x) => Val::F32(x.bits),
         F64Const(x) => Val::F64(x.bits),
         V128Const(x) => Val::V128(u128::from_le_bytes(x.to_le_bytes())),
-        RefNull(RefType::Extern) => Val::ExternRef(None),
-        RefNull(RefType::Func) => Val::FuncRef(None),
+        RefNull(HeapType::Extern) => Val::ExternRef(None),
+        RefNull(HeapType::Func) => Val::FuncRef(None),
         RefExtern(x) => Val::ExternRef(Some(ExternRef::new(*x))),
         other => bail!("couldn't convert {:?} to a runtime value", other),
     })
@@ -409,7 +409,7 @@ fn val_matches(actual: &Val, expected: &wast::AssertExpression) -> Result<bool> 
         (Val::F32(a), wast::AssertExpression::F32(b)) => f32_matches(*a, b),
         (Val::F64(a), wast::AssertExpression::F64(b)) => f64_matches(*a, b),
         (Val::V128(a), wast::AssertExpression::V128(b)) => v128_matches(*a, b),
-        (Val::ExternRef(x), wast::AssertExpression::RefNull(wast::RefType::Extern)) => x.is_none(),
+        (Val::ExternRef(x), wast::AssertExpression::RefNull(HeapType::Extern)) => x.is_none(),
         (Val::ExternRef(x), wast::AssertExpression::RefExtern(y)) => {
             if let Some(x) = x {
                 let x = x
@@ -421,7 +421,7 @@ fn val_matches(actual: &Val, expected: &wast::AssertExpression) -> Result<bool> 
                 false
             }
         }
-        (Val::FuncRef(x), wast::AssertExpression::RefNull(wast::RefType::Func)) => x.is_none(),
+        (Val::FuncRef(x), wast::AssertExpression::RefNull(HeapType::Func)) => x.is_none(),
         _ => bail!(
             "don't know how to compare {:?} and {:?} yet",
             actual,

--- a/tests/misc_testsuite/reference-types/simple_ref_is_null.wast
+++ b/tests/misc_testsuite/reference-types/simple_ref_is_null.wast
@@ -1,12 +1,12 @@
 (module
   (func (export "func_is_null") (param funcref) (result i32)
-    (ref.is_null func (local.get 0))
+    (ref.is_null (local.get 0))
   )
   (func (export "func_is_null_with_non_null_funcref") (result i32)
     (call 0 (ref.func 0))
   )
   (func (export "extern_is_null") (param externref) (result i32)
-    (ref.is_null extern (local.get 0))
+    (ref.is_null (local.get 0))
   )
 )
 


### PR DESCRIPTION
This commit is intended to update wasmparser to 0.59.0. This primarily
includes bytecodealliance/wasm-tools#40 which is a large update to how
parsing and validation works. The impact on Wasmtime is pretty small at
this time, but over time I'd like to refactor the internals here to lean
more heavily on that upstream wasmparser refactoring.

For now, though, the intention is to get on the train of wasmparser's
latest `main` branch to ensure we get bug fixes and such.

As part of this update a few other crates and such were updated. This is
primarily to handle the new encoding of `ref.is_null` where the type is
not part of the instruction encoding any more.
