### PR TITLE
Switch CI back to nightly channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-06-03
+        toolchain: nightly
     - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
     - run: cargo doc --package cranelift-codegen-meta --document-private-items
     - uses: actions/upload-artifact@v1
@@ -92,7 +92,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-06-03
+        toolchain: nightly
 
     # Check some feature combinations of the `wasmtime` crate
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --no-default-features
@@ -140,7 +140,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-06-03
+        toolchain: nightly
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
@@ -190,7 +190,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2020-06-03
+            rust: nightly
           - build: macos
             os: macos-latest
             rust: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,9 +1922,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "staticvec"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0968d58741ac061880be1ca69c5ca6f27a1942ed456f08fd987e9c9013cead"
+checksum = "ba02879e2cff631c9dad99168c191fa75201a263e159cc9669d3df58cb242093"
 
 [[package]]
 name = "string-interner"

--- a/cranelift/codegen/src/ir/constant.rs
+++ b/cranelift/codegen/src/ir/constant.rs
@@ -166,7 +166,7 @@ pub type ConstantOffset = u32;
 /// function body); because the function is not yet compiled when constants are inserted,
 /// [`set_offset`](crate::ir::ConstantPool::set_offset) must be called once a constant's offset
 /// from the beginning of the function is known (see
-/// [`relaxation.rs`](crate::binemit::relaxation)).
+/// `relaxation` in `relaxation.rs`).
 #[derive(Clone)]
 pub struct ConstantPoolEntry {
     data: ConstantData,

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -23,7 +23,7 @@
 //! being adjusted to set up a call, we implement a "nominal SP" tracking
 //! feature by which a fixup (distance between actual SP and a "nominal" SP) is
 //! known at each instruction. See the documentation for
-//! [MemArg::NominalSPOffset] for more on this.
+//! `MemArg::NominalSPOffset` for more on this.
 //!
 //! The stack looks like:
 //!

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 ///
 /// Several Cranelift functions need the ability to run Cranelift IR (e.g. `test_run`); this
 /// [SingleFunctionCompiler] provides a way for compiling Cranelift [Function]s to
-/// [CompiledFunction]s and subsequently calling them through the use of a [Trampoline]. As its
+/// `CompiledFunction`s and subsequently calling them through the use of a `Trampoline`. As its
 /// name indicates, this compiler is limited: any functionality that requires knowledge of things
 /// outside the [Function] will likely not work (e.g. global values, calls). For an example of this
 /// "outside-of-function" functionality, see `cranelift_simplejit::backend::SimpleJITBackend`.
@@ -60,10 +60,10 @@ impl SingleFunctionCompiler {
         Self::with_host_isa(flags)
     }
 
-    /// Compile the passed [Function] to a [CompiledFunction]. This function will:
+    /// Compile the passed [Function] to a `CompiledFunction`. This function will:
     ///  - check that the default ISA calling convention is used (to ensure it can be called)
     ///  - compile the [Function]
-    ///  - compile a [Trampoline] for the [Function]'s signature (or used a cached [Trampoline];
+    ///  - compile a `Trampoline` for the [Function]'s signature (or used a cached `Trampoline`;
     ///    this makes it possible to call functions when the signature is not known until runtime.
     pub fn compile(&mut self, function: Function) -> Result<CompiledFunction, CompilationError> {
         let signature = function.signature.clone();

--- a/cranelift/reader/src/run_command.rs
+++ b/cranelift/reader/src/run_command.rs
@@ -14,8 +14,7 @@ use thiserror::Error;
 
 /// A run command appearing in a test file.
 ///
-/// For parsing, see
-/// [Parser::parse_run_command](crate::parser::Parser::parse_run_command).
+/// For parsing, see `Parser::parse_run_command`
 #[derive(PartialEq, Debug)]
 pub enum RunCommand {
     /// Invoke a function and print its result.


### PR DESCRIPTION
I think all upstream issues are now fixed so we should be good to switch
back to nightly from our previously pinned version.
