### PR TITLE
Fix a memory leak with command modules

### DIFF
--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -160,6 +160,17 @@ impl Extern {
             Extern::Module(_) => "module",
         }
     }
+
+    pub(crate) fn wasmtime_export(&self) -> wasmtime_runtime::Export {
+        match self {
+            Extern::Func(f) => f.wasmtime_export().clone().into(),
+            Extern::Global(f) => f.wasmtime_export().clone().into(),
+            Extern::Table(f) => f.wasmtime_export().clone().into(),
+            Extern::Memory(f) => f.wasmtime_export().clone().into(),
+            Extern::Instance(f) => wasmtime_runtime::Export::Instance(f.wasmtime_export().clone()),
+            Extern::Module(f) => wasmtime_runtime::Export::Module(Box::new(f.clone())),
+        }
+    }
 }
 
 impl From<Func> for Extern {

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -121,6 +121,10 @@ impl Instance {
         ty
     }
 
+    pub(crate) fn wasmtime_export(&self) -> &RuntimeInstance {
+        &self.items
+    }
+
     /// Returns the associated [`Store`] that this `Instance` is compiled into.
     ///
     /// This is the [`Store`] that generally serves as a sort of global cache


### PR DESCRIPTION
This commit fixes a memory leak that can happen with `Linker::module`
when the provided module is a command. This function creates a closure
but the closure closed over a strong reference to `Store` (and
transitively through any imports provided). Unfortunately a `Store`
keeps everything alive, including `Func`, so this meant that `Store` was
inserted into a cycle which caused the leak.


The cycle here is manually broken by closing over the raw value of each
external value rather than the external value itself (which has a
strong reference to `Store`).
