### PR TITLE
Fix signature of wasmtime_module_new

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -740,7 +740,7 @@ WASM_API_EXTERN own wasmtime_error_t *wasmtime_instance_new(
  * returned error and module are owned by the caller.
  */
 WASM_API_EXTERN own wasmtime_error_t *wasmtime_module_new(
-    wasm_store_t *store,
+    wasm_engine_t *engine,
     const wasm_byte_vec_t *binary,
     own wasm_module_t **ret
 );

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -66,7 +66,7 @@ int main() {
   // Now that we've got our binary webassembly we can compile our module.
   printf("Compiling module...\n");
   wasm_module_t *module = NULL;
-  error = wasmtime_module_new(store, &wasm, &module);
+  error = wasmtime_module_new(engine, &wasm, &module);
   wasm_byte_vec_delete(&wasm);
   if (error != NULL)
     exit_with_error("failed to compile module", error, NULL);

--- a/examples/fib-debug/main.c
+++ b/examples/fib-debug/main.c
@@ -43,7 +43,7 @@ int main(int argc, const char* argv[]) {
   // Compile.
   printf("Compiling module...\n");
   wasm_module_t *module = NULL;
-  wasmtime_error_t* error = wasmtime_module_new(store, &binary, &module);
+  wasmtime_error_t* error = wasmtime_module_new(engine, &binary, &module);
   if (!module)
     exit_with_error("failed to compile module", error, NULL);
   wasm_byte_vec_delete(&binary);

--- a/examples/gcd.c
+++ b/examples/gcd.c
@@ -59,7 +59,7 @@ int main() {
 
   // Compile and instantiate our module
   wasm_module_t *module = NULL;
-  error = wasmtime_module_new(store, &wasm, &module);
+  error = wasmtime_module_new(engine, &wasm, &module);
   if (module == NULL)
     exit_with_error("failed to compile module", error, NULL);
   wasm_byte_vec_delete(&wasm);

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -67,7 +67,7 @@ int main() {
   // Now that we've got our binary webassembly we can compile our module.
   printf("Compiling module...\n");
   wasm_module_t *module = NULL;
-  error = wasmtime_module_new(store, &wasm, &module);
+  error = wasmtime_module_new(engine, &wasm, &module);
   wasm_byte_vec_delete(&wasm);
   if (error != NULL)
     exit_with_error("failed to compile module", error, NULL);

--- a/examples/hello.cc
+++ b/examples/hello.cc
@@ -67,7 +67,7 @@ int main() {
   // Now that we've got our binary webassembly we can compile our module.
   printf("Compiling module...\n");
   wasm_module_t *module = NULL;
-  error = wasmtime_module_new(store, &wasm, &module);
+  error = wasmtime_module_new(engine, &wasm, &module);
   wasm_byte_vec_delete(&wasm);
   if (error != NULL)
     exit_with_error("failed to compile module", error, NULL);

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -89,7 +89,7 @@ int main() {
   wasm_module_t *module = NULL;
   wasm_trap_t *trap = NULL;
   wasm_instance_t *instance = NULL;
-  error = wasmtime_module_new(store, &wasm, &module);
+  error = wasmtime_module_new(engine, &wasm, &module);
   wasm_byte_vec_delete(&wasm);
   if (error != NULL)
     exit_with_error("failed to compile module", error, NULL);

--- a/examples/linking.c
+++ b/examples/linking.c
@@ -45,10 +45,10 @@ int main() {
   wasmtime_error_t *error;
   wasm_module_t *linking1_module = NULL;
   wasm_module_t *linking2_module = NULL;
-  error = wasmtime_module_new(store, &linking1_wasm, &linking1_module);
+  error = wasmtime_module_new(engine, &linking1_wasm, &linking1_module);
   if (error != NULL)
     exit_with_error("failed to compile linking1", error, NULL);
-  error = wasmtime_module_new(store, &linking2_wasm, &linking2_module);
+  error = wasmtime_module_new(engine, &linking2_wasm, &linking2_module);
   if (error != NULL)
     exit_with_error("failed to compile linking2", error, NULL);
   wasm_byte_vec_delete(&linking1_wasm);

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -158,7 +158,7 @@ int main(int argc, const char* argv[]) {
   // Compile.
   printf("Compiling module...\n");
   wasm_module_t* module = NULL;
-  error = wasmtime_module_new(store, &binary, &module);
+  error = wasmtime_module_new(engine, &binary, &module);
   if (error)
     exit_with_error("failed to compile module", error, NULL);
   wasm_byte_vec_delete(&binary);

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -91,7 +91,7 @@ int main(int argc, const char* argv[]) {
   // Compile.
   printf("Compiling module...\n");
   wasm_module_t* module = NULL;
-  error = wasmtime_module_new(store, &binary, &module);
+  error = wasmtime_module_new(engine, &binary, &module);
   if (error)
     exit_with_error("failed to compile module", error, NULL);
 

--- a/examples/wasi/main.c
+++ b/examples/wasi/main.c
@@ -54,7 +54,7 @@ int main() {
 
   // Compile our modules
   wasm_module_t *module = NULL;
-  wasmtime_error_t *error = wasmtime_module_new(store, &wasm, &module);
+  wasmtime_error_t *error = wasmtime_module_new(engine, &wasm, &module);
   if (!module)
     exit_with_error("failed to compile module", error, NULL);
   wasm_byte_vec_delete(&wasm);


### PR DESCRIPTION
Fix signature of wasmtime_module_new to use engine instead of store.

Closes #2025 