### PR TITLE
Wasmtime 0.19.0 and Cranelift 0.66.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,18 +2,18 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli",
+ "gimli 0.22.0",
 ]
 
 [[package]]
-name = "adler32"
-version = "1.1.0"
+name = "adler"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "ahash"
@@ -32,9 +32,9 @@ checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -56,9 +56,9 @@ checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "arbitrary"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5eb01a9ab8a3369f2f7632b9461c34f5920bd454774bab5b9fc6744f21d6143"
+checksum = "7cb544f1057eaaff4b34f8c4dcf56fc3cd04debd291998405d135017a7c3c0f4"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -100,15 +100,15 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.20.0",
  "rustc-demangle",
 ]
 
@@ -120,9 +120,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "binaryen"
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 dependencies = [
  "jobserver",
 ]
@@ -261,9 +261,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -366,14 +366,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -381,7 +381,7 @@ dependencies = [
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli",
+ "gimli 0.21.0",
  "hashbrown 0.7.2",
  "log",
  "peepmatic",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -403,18 +403,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.65.0"
+version = "0.66.0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-faerie"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-filetests"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "byteorder",
  "cranelift-codegen",
@@ -437,7 +437,7 @@ dependencies = [
  "cranelift-reader",
  "file-per-thread-logger",
  "filecheck",
- "gimli",
+ "gimli 0.21.0",
  "log",
  "memmap",
  "num_cpus",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.7.2",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -492,18 +492,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
- "object",
+ "object 0.20.0",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-preopt"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "smallvec",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-simplejit"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift",
  "cranelift-codegen",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-tools"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "capstone",
  "cfg-if",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee758ebd1c79a9c6fb95f242dcc30bdbf555c28369ae908d21fdaf81537496"
+checksum = "02b43185d3e7ce7dcd44a23ca761ec026359753ebf480283a571e6463853d2ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.7"
+version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
+checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -938,6 +938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -1054,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "ittapi-rs"
@@ -1090,9 +1096,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1106,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "lightbeam"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -1179,20 +1185,20 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg 1.0.0",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
 dependencies = [
- "adler32",
+ "adler",
 ]
 
 [[package]]
@@ -1238,6 +1244,12 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+
+[[package]]
+name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
@@ -1280,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "peepmatic"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "peepmatic-automata",
@@ -1373,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -1386,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
+checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1663,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
@@ -1741,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "run-examples"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1850,18 +1862,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1870,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1911,15 +1923,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staticvec"
@@ -1944,9 +1956,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
+checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1955,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
+checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1968,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2029,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
+checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
 dependencies = [
  "libc",
  "winapi",
@@ -2048,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2073,18 +2085,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2121,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
 dependencies = [
  "cfg-if",
  "log",
@@ -2133,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2144,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
 dependencies = [
  "lazy_static",
 ]
@@ -2174,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d53c40489aa69c9aed21ff483f26886ca8403df33bdc2d2f87c60c1617826d2"
+checksum = "c72c8cf3ec4ed69fef614d011a5ae4274537a8a8c59133558029bd731eb71659"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2221,15 +2233,15 @@ checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "unsafe-any"
@@ -2280,7 +2292,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2322,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2347,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2361,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2369,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2379,7 +2391,7 @@ dependencies = [
  "libc",
  "log",
  "more-asserts",
- "object",
+ "object 0.20.0",
  "pretty_env_logger",
  "rayon",
  "structopt",
@@ -2401,12 +2413,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
- "gimli",
+ "gimli 0.21.0",
  "more-asserts",
- "object",
+ "object 0.20.0",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.59.0",
@@ -2415,10 +2427,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
- "base64 0.12.1",
+ "base64 0.12.3",
  "bincode",
  "cfg-if",
  "cranelift-codegen",
@@ -2463,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fuzzing"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2480,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2489,10 +2501,10 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.21.0",
  "log",
  "more-asserts",
- "object",
+ "object 0.20.0",
  "region",
  "target-lexicon",
  "thiserror",
@@ -2507,11 +2519,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object",
+ "object 0.20.0",
  "target-lexicon",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -2519,15 +2531,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "cfg-if",
- "gimli",
+ "gimli 0.21.0",
  "ittapi-rs",
  "lazy_static",
  "libc",
- "object",
+ "object 0.19.0",
  "scroll",
  "serde",
  "target-lexicon",
@@ -2537,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -2556,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -2566,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust-macro"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2575,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "log",
@@ -2589,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -2598,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "wasmtime",
  "wasmtime-wiggle-macro",
@@ -2608,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle-macro"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2655,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2665,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proptest",
  "thiserror",
@@ -2677,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "heck",
@@ -2689,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "quote",
  "syn",
@@ -2700,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-test"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "env_logger",
  "proptest",
@@ -2712,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -2743,7 +2755,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bitflags",
  "cvt",
@@ -2765,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "yanix"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Command-line interface for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -22,14 +22,14 @@ doc = false
 
 [dependencies]
 # Enable all supported architectures by default.
-wasmtime = { path = "crates/wasmtime", version = "0.18.0", default-features = false }
-wasmtime-debug = { path = "crates/debug", version = "0.18.0" }
-wasmtime-environ = { path = "crates/environ", version = "0.18.0" }
-wasmtime-jit = { path = "crates/jit", version = "0.18.0" }
-wasmtime-obj = { path = "crates/obj", version = "0.18.0" }
-wasmtime-wast = { path = "crates/wast", version = "0.18.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "0.18.0" }
-wasi-common = { path = "crates/wasi-common", version = "0.18.0" }
+wasmtime = { path = "crates/wasmtime", version = "0.19.0", default-features = false }
+wasmtime-debug = { path = "crates/debug", version = "0.19.0" }
+wasmtime-environ = { path = "crates/environ", version = "0.19.0" }
+wasmtime-jit = { path = "crates/jit", version = "0.19.0" }
+wasmtime-obj = { path = "crates/obj", version = "0.19.0" }
+wasmtime-wast = { path = "crates/wast", version = "0.19.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "0.19.0" }
+wasi-common = { path = "crates/wasi-common", version = "0.19.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
 object = { version = "0.20", default-features = false, features = ["write"] }
 anyhow = "1.0.19"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,13 +4,78 @@
 
 ## 0.19.0
 
-Unreleased.
+Released 2020-07-14.
 
 ### Added
 
+* The [WebAssembly reference-types proposal][reftypes] is now supported in
+  Wasmtime and the C API.
+  [#1832](https://github.com/bytecodealliance/wasmtime/pull/1832),
+  [#1882](https://github.com/bytecodealliance/wasmtime/pull/1882),
+  [#1894](https://github.com/bytecodealliance/wasmtime/pull/1894),
+  [#1901](https://github.com/bytecodealliance/wasmtime/pull/1901),
+  [#1923](https://github.com/bytecodealliance/wasmtime/pull/1923),
+  [#1969](https://github.com/bytecodealliance/wasmtime/pull/1969),
+  [#1973](https://github.com/bytecodealliance/wasmtime/pull/1973),
+  [#1982](https://github.com/bytecodealliance/wasmtime/pull/1982),
+  [#1984](https://github.com/bytecodealliance/wasmtime/pull/1984),
+  [#1991](https://github.com/bytecodealliance/wasmtime/pull/1991),
+  [#1996](https://github.com/bytecodealliance/wasmtime/pull/1996)
+
+* The [WebAssembly simd proposal's][simd] spec tests now pass in Wasmtime.
+  [#1765](https://github.com/bytecodealliance/wasmtime/pull/1765),
+  [#1876](https://github.com/bytecodealliance/wasmtime/pull/1876),
+  [#1941](https://github.com/bytecodealliance/wasmtime/pull/1941),
+  [#1957](https://github.com/bytecodealliance/wasmtime/pull/1957),
+  [#1990](https://github.com/bytecodealliance/wasmtime/pull/1990),
+  [#1994](https://github.com/bytecodealliance/wasmtime/pull/1994)
+
+* Wasmtime can now be compiled without the usage of threads for parallel
+  compilation, although this is still enabled by default.
+  [#1903](https://github.com/bytecodealliance/wasmtime/pull/1903)
+
+* The C API is [now
+  documented](https://bytecodealliance.github.io/wasmtime/c-api/).
+  [#1928](https://github.com/bytecodealliance/wasmtime/pull/1928),
+  [#1959](https://github.com/bytecodealliance/wasmtime/pull/1959),
+  [#1968](https://github.com/bytecodealliance/wasmtime/pull/1968)
+
+* A `wasmtime_linker_get_one_by_name` function was added to the C API.
+  [#1897](https://github.com/bytecodealliance/wasmtime/pull/1897)
+
+* A `wasmtime_trap_exit_status` function was added to the C API.
+  [#1912](https://github.com/bytecodealliance/wasmtime/pull/1912)
+
+* Compilation for the `aarch64-linux-android` target should now work, although
+  keep in mind this platform is not fully tested still.
+  [#2002](https://github.com/bytecodealliance/wasmtime/pull/2002)
+
+[reftypes]: https://github.com/WebAssembly/reference-types
+
+### Fixed
+
+* Runtime warnings when using Wasmtime on musl have been fixed.
+  [#1914](https://github.com/bytecodealliance/wasmtime/pull/1914)
+
+* A bug affecting Windows unwind information with functions that have spilled
+  floating point registers has been fixed.
+  [#1983](https://github.com/bytecodealliance/wasmtime/pull/1983)
+
 ### Changed
 
+* Wasmtime's default branch and development now happens on the `main` branch
+  instead of `master`.
+  [#1924](https://github.com/bytecodealliance/wasmtime/pull/1924)
+
 ### Removed
+
+* The "host info" support in the C API has been removed since it was never fully
+  or correctly implemented.
+  [#1922](https://github.com/bytecodealliance/wasmtime/pull/1922)
+
+* Support for the `*_same` functions in the C API has been removed in the same
+  vein as the host info APIs.
+  [#1926](https://github.com/bytecodealliance/wasmtime/pull/1926)
 
 --------------------------------------------------------------------------------
 

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-tools"
 authors = ["The Cranelift Project Developers"]
-version = "0.65.0"
+version = "0.66.0"
 description = "Binaries for testing the Cranelift libraries"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/docs/index.md"
@@ -15,21 +15,21 @@ path = "src/clif-util.rs"
 
 [dependencies]
 cfg-if = "0.1"
-cranelift-codegen = { path = "codegen", version = "0.65.0" }
-cranelift-entity = { path = "entity", version = "0.65.0" }
-cranelift-interpreter = { path = "interpreter", version = "0.65.0" }
-cranelift-reader = { path = "reader", version = "0.65.0" }
-cranelift-frontend = { path = "frontend", version = "0.65.0" }
-cranelift-serde = { path = "serde", version = "0.65.0", optional = true }
-cranelift-wasm = { path = "wasm", version = "0.65.0", optional = true }
-cranelift-native = { path = "native", version = "0.65.0" }
-cranelift-filetests = { path = "filetests", version = "0.65.0" }
-cranelift-module = { path = "module", version = "0.65.0" }
-cranelift-faerie = { path = "faerie", version = "0.65.0" }
-cranelift-object = { path = "object", version = "0.65.0" }
-cranelift-simplejit = { path = "simplejit", version = "0.65.0" }
-cranelift-preopt = { path = "preopt", version = "0.65.0" }
-cranelift = { path = "umbrella", version = "0.65.0" }
+cranelift-codegen = { path = "codegen", version = "0.66.0" }
+cranelift-entity = { path = "entity", version = "0.66.0" }
+cranelift-interpreter = { path = "interpreter", version = "0.66.0" }
+cranelift-reader = { path = "reader", version = "0.66.0" }
+cranelift-frontend = { path = "frontend", version = "0.66.0" }
+cranelift-serde = { path = "serde", version = "0.66.0", optional = true }
+cranelift-wasm = { path = "wasm", version = "0.66.0", optional = true }
+cranelift-native = { path = "native", version = "0.66.0" }
+cranelift-filetests = { path = "filetests", version = "0.66.0" }
+cranelift-module = { path = "module", version = "0.66.0" }
+cranelift-faerie = { path = "faerie", version = "0.66.0" }
+cranelift-object = { path = "object", version = "0.66.0" }
+cranelift-simplejit = { path = "simplejit", version = "0.66.0" }
+cranelift-preopt = { path = "preopt", version = "0.66.0" }
+cranelift = { path = "umbrella", version = "0.66.0" }
 filecheck = "0.5.0"
 clap = "2.32.0"
 log = "0.4.8"

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.65.0"
+version = "0.66.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"
@@ -12,7 +12,7 @@ keywords = ["btree", "forest", "set", "map"]
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../entity", version = "0.65.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.66.0", default-features = false }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.65.0"
+version = "0.66.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -13,9 +13,9 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen-shared = { path = "./shared", version = "0.65.0" }
-cranelift-entity = { path = "../entity", version = "0.65.0" }
-cranelift-bforest = { path = "../bforest", version = "0.65.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.66.0" }
+cranelift-entity = { path = "../entity", version = "0.66.0" }
+cranelift-bforest = { path = "../bforest", version = "0.66.0" }
 hashbrown = { version = "0.7", optional = true }
 target-lexicon = "0.10"
 log = { version = "0.4.6", default-features = false }
@@ -33,8 +33,8 @@ regalloc = { version = "0.0.27" }
 # accomodated in `tests`.
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.65.0" }
-peepmatic = { path = "../peepmatic", optional = true, version = "0.65.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.66.0" }
+peepmatic = { path = "../peepmatic", optional = true, version = "0.66.0" }
 
 [features]
 default = ["std", "unwind"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.65.0"
+version = "0.66.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -12,8 +12,8 @@ edition = "2018"
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.65.0" }
-cranelift-entity = { path = "../../entity", version = "0.65.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.66.0" }
+cranelift-entity = { path = "../../entity", version = "0.66.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.65.0"
+version = "0.66.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.65.0"
+version = "0.66.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/faerie/Cargo.toml
+++ b/cranelift/faerie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-faerie"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with Faerie"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -10,8 +10,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../module", version = "0.65.0" }
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false, features = ["std"] }
+cranelift-module = { path = "../module", version = "0.66.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["std"] }
 faerie = "0.15.0"
 goblin = "0.1.0"
 anyhow = "1.0"

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-filetests"
 authors = ["The Cranelift Project Developers"]
-version = "0.65.0"
+version = "0.66.0"
 description = "Test driver and implementations of the filetest commands"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-filetests"
@@ -10,12 +10,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0", features = ["testing_hooks"] }
-cranelift-frontend = { path = "../frontend", version = "0.65.0" }
-cranelift-interpreter = { path = "../interpreter", version = "0.65.0" }
-cranelift-native = { path = "../native", version = "0.65.0" }
-cranelift-reader = { path = "../reader", version = "0.65.0" }
-cranelift-preopt = { path = "../preopt", version = "0.65.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", features = ["testing_hooks"] }
+cranelift-frontend = { path = "../frontend", version = "0.66.0" }
+cranelift-interpreter = { path = "../interpreter", version = "0.66.0" }
+cranelift-native = { path = "../native", version = "0.66.0" }
+cranelift-reader = { path = "../reader", version = "0.66.0" }
+cranelift-preopt = { path = "../preopt", version = "0.66.0" }
 byteorder = { version = "1.3.2", default-features = false }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.65.0"
+version = "0.66.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
 target-lexicon = "0.10"
 log = { version = "0.4.6", default-features = false }
 hashbrown = { version = "0.7", optional = true }

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -11,15 +11,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.65.0" }
-cranelift-reader = { path = "../reader", version = "0.65.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.66.0" }
+cranelift-reader = { path = "../reader", version = "0.66.0" }
 hashbrown = { version = "0.7.1", optional = true }
 log = { version = "0.4.8", default-features = false }
 thiserror = "1.0.15"
 
 [dev-dependencies]
-cranelift-frontend = { path = "../frontend", version = "0.65.0" }
+cranelift-frontend = { path = "../frontend", version = "0.66.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.65.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.66.0" }
 hashbrown = { version = "0.6", optional = true }
 log = { version = "0.4.6", default-features = false }
 thiserror = "1.0.4"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
 target-lexicon = "0.10"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -10,8 +10,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../module", version = "0.65.0" }
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false, features = ["std"] }
+cranelift-module = { path = "../module", version = "0.66.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["std"] }
 object = { version = "0.20", default-features = false, features = ["write"] }
 target-lexicon = "0.10"
 anyhow = "1.0"

--- a/cranelift/peepmatic/Cargo.toml
+++ b/cranelift/peepmatic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peepmatic"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/preopt/Cargo.toml
+++ b/cranelift/preopt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-preopt"
-version = "0.65.0"
+version = "0.66.0"
 description = "Support for optimizations in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-preopt"
@@ -12,8 +12,8 @@ keywords = ["optimize", "compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.65.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.66.0" }
 # This is commented out because it doesn't build on Rust 1.25.0, which
 # cranelift currently supports.
 # rustc_apfloat = { version = "0.1.2", default-features = false }

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.65.0"
+version = "0.66.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0" }
 smallvec = "1.0.0"
 target-lexicon = "0.10"
 thiserror = "1.0.15"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -18,8 +18,8 @@ clap = "2.32.0"
 serde = "1.0.8"
 serde_derive = "1.0.75"
 serde_json = "1.0.26"
-cranelift-codegen = { path = "../codegen", version = "0.65.0" }
-cranelift-reader = { path = "../reader", version = "0.65.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0" }
+cranelift-reader = { path = "../reader", version = "0.66.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/simplejit/Cargo.toml
+++ b/cranelift/simplejit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-simplejit"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "A simple JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -10,9 +10,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../module", version = "0.65.0" }
-cranelift-native = { path = "../native", version = "0.65.0" }
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false, features = ["std"] }
+cranelift-module = { path = "../module", version = "0.66.0" }
+cranelift-native = { path = "../native", version = "0.66.0" }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["std"] }
 region = "2.2.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
@@ -27,9 +27,9 @@ selinux-fix = ['memmap']
 default = []
 
 [dev-dependencies]
-cranelift = { path = "../umbrella", version = "0.65.0" }
-cranelift-frontend = { path = "../frontend", version = "0.65.0" }
-cranelift-entity = { path = "../entity", version = "0.65.0" }
+cranelift = { path = "../umbrella", version = "0.66.0" }
+cranelift-frontend = { path = "../frontend", version = "0.66.0" }
+cranelift-entity = { path = "../entity", version = "0.66.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.65.0"
+version = "0.66.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"
@@ -12,8 +12,8 @@ keywords = ["compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
-cranelift-frontend = { path = "../frontend", version = "0.65.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
+cranelift-frontend = { path = "../frontend", version = "0.66.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.65.0"
+version = "0.66.0"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"
@@ -13,9 +13,9 @@ edition = "2018"
 
 [dependencies]
 wasmparser = { version = "0.59.0", default-features = false }
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.65.0" }
-cranelift-frontend = { path = "../frontend", version = "0.65.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.66.0" }
+cranelift-frontend = { path = "../frontend", version = "0.66.0", default-features = false }
 hashbrown = { version = "0.7", optional = true }
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
@@ -25,7 +25,7 @@ thiserror = "1.0.4"
 wat = "1.0.18"
 target-lexicon = "0.10"
 # Enable the riscv feature for cranelift-codegen, as some tests require it
-cranelift-codegen = { path = "../codegen", version = "0.65.0", default-features = false, features = ["riscv"] }
+cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["riscv"] }
 
 [features]
 default = ["std"]

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-c-api"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "C API to expose the Wasmtime runtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/c-api/macros/Cargo.toml
+++ b/crates/c-api/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-c-api-macros"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 publish = false

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-debug"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Debug utils for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,7 +15,7 @@ edition = "2018"
 gimli = "0.21.0"
 wasmparser = "0.59.0"
 object = { version = "0.20", default-features = false, features = ["read", "write"] }
-wasmtime-environ = { path = "../environ", version = "0.18.0" }
+wasmtime-environ = { path = "../environ", version = "0.19.0" }
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0"
 thiserror = "1.0.4"

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-environ"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Standalone environment support for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,12 +13,12 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.65.0", features = ["enable-serde"] }
-cranelift-entity = { path = "../../cranelift/entity", version = "0.65.0", features = ["enable-serde"] }
-cranelift-frontend = { path = "../../cranelift/frontend", version = "0.65.0" }
-cranelift-wasm = { path = "../../cranelift/wasm", version = "0.65.0", features = ["enable-serde"] }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.66.0", features = ["enable-serde"] }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.66.0", features = ["enable-serde"] }
+cranelift-frontend = { path = "../../cranelift/frontend", version = "0.66.0" }
+cranelift-wasm = { path = "../../cranelift/wasm", version = "0.66.0", features = ["enable-serde"] }
 wasmparser = "0.59.0"
-lightbeam = { path = "../lightbeam", optional = true, version = "0.18.0" }
+lightbeam = { path = "../lightbeam", optional = true, version = "0.19.0" }
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 rayon = { version = "1.2.1", optional = true }
 thiserror = "1.0.4"

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -4,7 +4,7 @@ description = "Fuzzing infrastructure for Wasmtime"
 edition = "2018"
 name = "wasmtime-fuzzing"
 publish = false
-version = "0.18.0"
+version = "0.19.0"
 
 [dependencies]
 anyhow = "1.0.22"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT-style execution for WebAsssembly code in Cranelift"
 documentation = "https://docs.rs/wasmtime-jit"
@@ -12,16 +12,16 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.65.0", features = ["enable-serde"] }
-cranelift-entity = { path = "../../cranelift/entity", version = "0.65.0", features = ["enable-serde"] }
-cranelift-wasm = { path = "../../cranelift/wasm", version = "0.65.0", features = ["enable-serde"] }
-cranelift-native = { path = "../../cranelift/native", version = "0.65.0" }
-cranelift-frontend = { path = "../../cranelift/frontend", version = "0.65.0" }
-wasmtime-environ = { path = "../environ", version = "0.18.0" }
-wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
-wasmtime-debug = { path = "../debug", version = "0.18.0" }
-wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
-wasmtime-obj = { path = "../obj", version = "0.18.0" }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.66.0", features = ["enable-serde"] }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.66.0", features = ["enable-serde"] }
+cranelift-wasm = { path = "../../cranelift/wasm", version = "0.66.0", features = ["enable-serde"] }
+cranelift-native = { path = "../../cranelift/native", version = "0.66.0" }
+cranelift-frontend = { path = "../../cranelift/frontend", version = "0.66.0" }
+wasmtime-environ = { path = "../environ", version = "0.19.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.19.0" }
+wasmtime-debug = { path = "../debug", version = "0.19.0" }
+wasmtime-profiling = { path = "../profiling", version = "0.19.0" }
+wasmtime-obj = { path = "../obj", version = "0.19.0" }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.10.0", default-features = false }

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightbeam"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Lightbeam Project Developers"]
 description = "An optimising one-pass streaming compiler for WebAssembly"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 capstone = "0.6.0"
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.65.0" }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.66.0" }
 derive_more = "0.99"
 dynasm = "0.5.2"
 dynasmrt = "0.5.2"

--- a/crates/misc/run-examples/Cargo.toml
+++ b/crates/misc/run-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run-examples"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 publish = false

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Rust extension for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,9 +15,9 @@ test = false
 doctest = false
 
 [dependencies]
-wasmtime-rust-macro = { path = "./macro", version = "0.18.0" }
-wasmtime-wasi = { path = "../../wasi", version = "0.18.0" }
-wasmtime = { path = "../../wasmtime", version = "0.18.0" }
+wasmtime-rust-macro = { path = "./macro", version = "0.19.0" }
+wasmtime-wasi = { path = "../../wasi", version = "0.19.0" }
+wasmtime = { path = "../../wasmtime", version = "0.19.0" }
 anyhow = "1.0.19"
 
 [badges]

--- a/crates/misc/rust/macro/Cargo.toml
+++ b/crates/misc/rust/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust-macro"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Macro support crate for wasmtime-rust"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-obj"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Native object file output for WebAsssembly code in Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,11 +12,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmtime-environ = { path = "../environ", version = "0.18.0" }
+wasmtime-environ = { path = "../environ", version = "0.19.0" }
 object = { version = "0.20", default-features = false, features = ["write"] }
 more-asserts = "0.2.1"
 target-lexicon = { version = "0.10.0", default-features = false }
-wasmtime-debug = { path = "../debug", version = "0.18.0" }
+wasmtime-debug = { path = "../debug", version = "0.19.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-profiling"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -19,12 +19,12 @@ libc = { version = "0.2.60", default-features = false }
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
 serde = { version = "1.0.99", features = ["derive"] }
 target-lexicon = "0.10.0"
-wasmtime-environ = { path = "../environ", version = "0.18.0" }
-wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
+wasmtime-environ = { path = "../environ", version = "0.19.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.19.0" }
 ittapi-rs = { version = "0.1.5", optional = true }
 
 [dependencies.object]
-version = "0.20.0"
+version = "0.19.0"
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'std']

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-runtime"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 documentation = "https://docs.rs/wasmtime-runtime"
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-environ = { path = "../environ", version = "0.18.0" }
+wasmtime-environ = { path = "../environ", version = "0.19.0" }
 region = "2.1.0"
 libc = { version = "0.2.70", default-features = false }
 log = "0.4.8"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-programs"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 readme = "README.md"
 edition = "2018"
@@ -10,9 +10,9 @@ publish = false
 cfg-if = "0.1.9"
 
 [dev-dependencies]
-wasi-common = { path = "../wasi-common", version = "0.18.0" }
-wasmtime-wasi = { path = "../wasi", version = "0.18.0" }
-wasmtime = { path = "../wasmtime", version = "0.18.0" }
+wasi-common = { path = "../wasi-common", version = "0.19.0" }
+wasmtime-wasi = { path = "../wasi", version = "0.19.0" }
+wasmtime = { path = "../wasmtime", version = "0.19.0" }
 target-lexicon = "0.10.0"
 pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"

--- a/crates/test-programs/wasi-tests/Cargo.lock
+++ b/crates/test-programs/wasi-tests/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -17,14 +17,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasi-tests"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.10.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+"checksum libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)" = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 "checksum more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 "checksum wasi 0.10.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-tests"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 readme = "README.md"
 edition = "2018"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,9 +12,9 @@ edition = "2018"
 include = ["src/**/*", "LICENSE", "WASI/phases", "build.rs"]
 
 # This doesn't actually link to a native library, but it allows us to set env
-# vars like `DEP_WASI_COMMON_18_*` for crates that have build scripts and depend
+# vars like `DEP_WASI_COMMON_19_*` for crates that have build scripts and depend
 # on this crate, allowing other crates to use the same witx files.
-links = "wasi-common-18"
+links = "wasi-common-19"
 
 [dependencies]
 anyhow = "1.0"
@@ -25,14 +25,14 @@ cfg-if = "0.1.9"
 log = "0.4"
 filetime = "0.2.7"
 lazy_static = "1.4.0"
-wig = { path = "wig", version = "0.18.0" }
-wiggle = { path = "../wiggle", default-features = false, version = "0.18.0" }
+wig = { path = "wig", version = "0.19.0" }
+wiggle = { path = "../wiggle", default-features = false, version = "0.19.0" }
 
 [target.'cfg(unix)'.dependencies]
-yanix = { path = "yanix", version = "0.18.0" }
+yanix = { path = "yanix", version = "0.19.0" }
 
 [target.'cfg(windows)'.dependencies]
-winx = { path = "winx", version = "0.18.0" }
+winx = { path = "winx", version = "0.19.0" }
 winapi = "0.3"
 cpu-time = "1.0"
 

--- a/crates/wasi-common/wig/Cargo.toml
+++ b/crates/wasi-common/wig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wig"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Dan Gohman <sunfish@mozilla.com>"]
 description = "WebAssembly Interface Generator"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/winx/Cargo.toml
+++ b/crates/wasi-common/winx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winx"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Jakub Konka <kubkon@jakubkonka.com>"]
 description = "Windows API helper library"
 documentation = "https://docs.rs/winx"

--- a/crates/wasi-common/yanix/Cargo.toml
+++ b/crates/wasi-common/yanix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yanix"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Yet Another Nix crate: a Unix API helper library"
 documentation = "https://docs.rs/yanix"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 documentation = "https://docs.rs/wasmtime-wasi"
@@ -14,12 +14,12 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 log = { version = "0.4.8", default-features = false }
-wasi-common = { path = "../wasi-common", version = "0.18.0" }
-wasmtime = { path = "../wasmtime", version = "0.18.0", default-features = false }
-wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
-wig = { path = "../wasi-common/wig", version = "0.18.0" }
-wiggle = { path = "../wiggle", version = "0.18.0" }
-wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.18.0" }
+wasi-common = { path = "../wasi-common", version = "0.19.0" }
+wasmtime = { path = "../wasmtime", version = "0.19.0", default-features = false }
+wasmtime-runtime = { path = "../runtime", version = "0.19.0" }
+wig = { path = "../wasi-common/wig", version = "0.19.0" }
+wiggle = { path = "../wiggle", version = "0.19.0" }
+wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.19.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wasi/build.rs
+++ b/crates/wasi/build.rs
@@ -1,4 +1,4 @@
 fn main() {
-    let wasi_root = std::env::var("DEP_WASI_COMMON_18_WASI").unwrap();
+    let wasi_root = std::env::var("DEP_WASI_COMMON_19_WASI").unwrap();
     println!("cargo:rustc-env=WASI_ROOT={}", wasi_root);
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "High-level API to expose the Wasmtime runtime"
 documentation = "https://docs.rs/wasmtime"
@@ -10,10 +10,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-runtime = { path = "../runtime", version = "0.18.0" }
-wasmtime-environ = { path = "../environ", version = "0.18.0" }
-wasmtime-jit = { path = "../jit", version = "0.18.0" }
-wasmtime-profiling = { path = "../profiling", version = "0.18.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.19.0" }
+wasmtime-environ = { path = "../environ", version = "0.19.0" }
+wasmtime-jit = { path = "../jit", version = "0.19.0" }
+wasmtime-profiling = { path = "../profiling", version = "0.19.0" }
 wasmparser = "0.59.0"
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0.19"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wast"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Wasmtime Project Developers"]
 description = "wast testing support for wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.19"
-wasmtime = { path = "../wasmtime", version = "0.18.0", default-features = false }
+wasmtime = { path = "../wasmtime", version = "0.19.0", default-features = false }
 wast = "21.0.0"
 
 [badges]

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,7 +13,7 @@ include = ["src/**/*", "LICENSE"]
 [dependencies]
 thiserror = "1"
 witx = { path = "../wasi-common/WASI/tools/witx", version = "0.8.5", optional = true }
-wiggle-macro = { path = "macro", version = "0.18.0" }
+wiggle-macro = { path = "macro", version = "0.19.0" }
 tracing = "0.1.15"
 
 [badges]

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-generate"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2018"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-macro"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-wiggle-generate = { path = "../generate", version = "0.18.0" }
+wiggle-generate = { path = "../generate", version = "0.19.0" }
 witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.5" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-test"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2018"

--- a/crates/wiggle/wasmtime/Cargo.toml
+++ b/crates/wiggle/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wiggle"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,10 +11,10 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 include = ["src/**/*", "LICENSE"]
 
 [dependencies]
-wasmtime = { path = "../../wasmtime", version = "0.18.0", default-features = false }
-wasmtime-wiggle-macro = { path = "./macro", version = "0.18.0" }
+wasmtime = { path = "../../wasmtime", version = "0.19.0", default-features = false }
+wasmtime-wiggle-macro = { path = "./macro", version = "0.19.0" }
 witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.5", optional = true }
-wiggle = { path = "..", version = "0.18.0" }
+wiggle = { path = "..", version = "0.19.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wiggle/wasmtime/macro/Cargo.toml
+++ b/crates/wiggle/wasmtime/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wiggle-macro"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -16,7 +16,7 @@ test = false
 
 [dependencies]
 witx = { path = "../../../wasi-common/WASI/tools/witx", version = "0.8.5" }
-wiggle-generate = { path = "../../generate", version = "0.18.0" }
+wiggle-generate = { path = "../../generate", version = "0.19.0" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"

--- a/scripts/bump-cranelift-version.sh
+++ b/scripts/bump-cranelift-version.sh
@@ -9,7 +9,7 @@ topdir=$(dirname "$0")/..
 cd "$topdir"
 
 # All the cranelift-* crates have the same version number
-version="0.65.0"
+version="0.66.0"
 
 # Update all of the Cargo.toml files.
 echo "Updating crate versions to $version"

--- a/scripts/bump-wasmtime-version.sh
+++ b/scripts/bump-wasmtime-version.sh
@@ -9,7 +9,7 @@ topdir=$(dirname "$0")/..
 cd "$topdir"
 
 # All the wasmtime-* crates have the same version number
-short_version="18"
+short_version="19"
 version="0.$short_version.0"
 
 # Update the version numbers of the crates to $version. Skip crates with


### PR DESCRIPTION
This commit updates Wasmtime's version to 0.19.0, Cranelift's version to
0.66.0, and updates the release notes as well.
