### PR TITLE
Enable reftypes tests on aarch64.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -202,12 +202,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             // to be a big chunk of work to implement them all there!
             ("simd", _) if target.contains("aarch64") => return true,
 
-            // TODO(#1886): Ignore reference types tests if this isn't x64,
-            // because Cranelift only supports reference types on x64.
-            ("reference_types", _) => {
-                return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
-            }
-
             _ => {}
         },
         _ => panic!("unrecognized strategy"),

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -121,9 +121,6 @@ fn signatures_match() {
 }
 
 #[test]
-// Note: Cranelift only supports refrerence types (used in the wasm in this
-// test) on x64.
-#[cfg(target_arch = "x86_64")]
 fn import_works() -> Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
 
@@ -444,9 +441,6 @@ fn func_write_nothing() -> anyhow::Result<()> {
 }
 
 #[test]
-// Note: Cranelift only supports refrerence types (used in the wasm in this
-// test) on x64.
-#[cfg(target_arch = "x86_64")]
 fn return_cross_store_value() -> anyhow::Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -479,9 +473,6 @@ fn return_cross_store_value() -> anyhow::Result<()> {
 }
 
 #[test]
-// Note: Cranelift only supports refrerence types (used in the wasm in this
-// test) on x64.
-#[cfg(target_arch = "x86_64")]
 fn pass_cross_store_arg() -> anyhow::Result<()> {
     let mut config = Config::new();
     config.wasm_reference_types(true);

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -3,7 +3,9 @@ mod custom_signal_handler;
 mod debug;
 mod externals;
 mod func;
+mod funcref;
 mod fuzzing;
+mod gc;
 mod globals;
 mod iloop;
 mod import_calling_export;
@@ -19,14 +21,6 @@ mod traps;
 mod use_after_drop;
 mod wast;
 
-// TODO(#1886): Cranelift only supports reference types on x64.
-#[cfg(target_arch = "x86_64")]
-mod funcref;
-#[cfg(target_arch = "x86_64")]
-mod gc;
-
-/// A helper to compile a module in a new store with reference types enabled.
-#[cfg(target_arch = "x86_64")]
 pub(crate) fn ref_types_module(
     source: &str,
 ) -> anyhow::Result<(wasmtime::Store, wasmtime::Module)> {


### PR DESCRIPTION
With #1852, we now have support for reference types in the new backend
framework generally, and on aarch64 in particular. This PR removes the
test-ignore directive for reftypes tests on this platform.

This actually enables reftypes support for all platforms, rather than explicitly
only on x86_64, but going forward all new backends should include reftypes
support (since the new-backend framework does, and it just takes a few
machine-specific opcodes beyond that to do so), so I think it's best just to
set this baseline now.

Fixes #1886 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
