### PR TITLE
ci: pin Rust nightly to 2020-07-12 to prevent breakage in wasm C api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2020-07-12
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
Alternative to #2031, if it still fails.