### PR TITLE
Allow `improper_ctypes_definitions` in C API

### DIFF
--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -2,6 +2,8 @@
 //! [Wasm C API](https://github.com/WebAssembly/wasm-c-api).
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![allow(unknown_lints)]
+#![allow(improper_ctypes_definitions)]
 
 // TODO complete the C API
 


### PR DESCRIPTION
This was enabled in rust-lang/rust#72700 but it looks like it's still
too noisy for it to be useful to us.
