### PR TITLE
Update to regalloc.rs 0.0.28.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.27"
+version = "0.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ba8aaf5fe7cf307c6dbdaeed85478961d29e25e3bee5169e11b92fa9f027a8"
+checksum = "3598bed0895fe0f72a9e0b00ef9e3a3c8af978a8401b2f2046dec5927de6364a"
 dependencies = [
  "log",
  "rustc-hash",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.2.0" }
-regalloc = { version = "0.0.27" }
+regalloc = { version = "0.0.28" }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/reftypes.clif
@@ -84,12 +84,13 @@ block3(v7: r64, v8: r64):
 ; nextln: mov x20, x1
 ; nextln: mov x0, x19
 ; nextln: ldr x16, 8 ; b 12 ; data
-; nextln: stur x19, [sp, #24]
-; nextln: stur x20, [sp, #32]
-; nextln: (safepoint: slots [S0, S1]
+; nextln: stur x0, [sp, #24]
+; nextln: stur x19, [sp, #32]
+; nextln: stur x20, [sp, #40]
+; nextln: (safepoint: slots [S0, S1, S2]
 ; nextln: blr x16
-; nextln: ldur x19, [sp, #24]
-; nextln: ldur x20, [sp, #32]
+; nextln: ldur x19, [sp, #32]
+; nextln: ldur x20, [sp, #40]
 ; nextln: add x1, sp, #16
 ; nextln: stur x19, [x1]
 ; nextln: and w0, w0, #1


### PR DESCRIPTION
This version of regalloc.rs includes several bugfixes for
reference-types support used by the new backend framework and the
aarch64 backend (bytecodealliance/regalloc.rs#85 and
bytecodealliance/regalloc.rs#86).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
