### PR TITLE
Fixes needed for 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "log",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle-macro"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 documentation = "https://docs.rs/wasmtime-wasi"

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -10,7 +10,7 @@ wasmtime_wiggle::wasmtime_integration!({
     // The wiggle code to integrate with lives here:
     target: wasi_common::wasi,
     // This must be the same witx document as used above:
-    witx: ["../wasi-common/WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
+    witx: ["phases/snapshot/witx/wasi_snapshot_preview1.witx"],
     // This must be the same ctx type as used for the target:
     ctx: WasiCtx,
     // This macro will emit a struct to represent the instance,

--- a/crates/wiggle/wasmtime/macro/Cargo.toml
+++ b/crates/wiggle/wasmtime/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wiggle-macro"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -48,9 +48,9 @@ use config::{MissingMemoryConf, ModuleConf, TargetConf};
 #[proc_macro]
 pub fn wasmtime_integration(args: TokenStream) -> TokenStream {
     let mut config = parse_macro_input!(args as config::Config);
-    config.witx.make_paths_relative_to(
-        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR env var"),
-    );
+    config
+        .witx
+        .make_paths_relative_to(std::env::var("WASI_ROOT").expect("WASI_ROOT env var"));
     let doc = config.load_document();
     let names = Names::new(&config.ctx.name, quote!(wasmtime_wiggle));
 

--- a/scripts/publish-wasmtime.sh
+++ b/scripts/publish-wasmtime.sh
@@ -23,6 +23,8 @@ for cargo_toml in \
     crates/wasi-common/wig/Cargo.toml \
     crates/wiggle/generate/Cargo.toml \
     crates/wiggle/macro/Cargo.toml \
+    crates/wiggle/wasmtime/macro/Cargo.toml \
+    crates/wiggle/wasmtime/Cargo.toml \
     crates/wiggle/Cargo.toml \
     crates/wasi-common/Cargo.toml \
     crates/lightbeam/Cargo.toml \


### PR DESCRIPTION
These are some fixes for building wasmtime from crates.io and publishing it.