### PR TITLE
Remove spam from "do_remove_constant_phis"

### DIFF
--- a/cranelift/codegen/src/remove_constant_phis.rs
+++ b/cranelift/codegen/src/remove_constant_phis.rs
@@ -1,7 +1,5 @@
 //! A Constant-Phi-Node removal pass.
 
-use log::info;
-
 use crate::dominator_tree::DominatorTree;
 use crate::entity::EntityList;
 use crate::fx::FxHashMap;
@@ -384,7 +382,7 @@ pub fn do_remove_constant_phis(func: &mut Function, domtree: &mut DominatorTree)
         }
     }
 
-    info!(
+    log::debug!(
         "do_remove_constant_phis: done, {} iters.   {} formals, of which {} const.",
         iter_no,
         state.absvals.len(),


### PR DESCRIPTION
Otherwise compilation prints a lot of this (with logger that prints `info!` by default):

```
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
2020-07-17 14:05:37 do_remove_constant_phis: done, 1 iters.   0 formals, of which 0 const.
```