### PR TITLE
Fix leaking funcrefs in the C API

### DIFF
--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -25,7 +25,7 @@ pub union wasm_val_union {
 impl Drop for wasm_val_t {
     fn drop(&mut self) {
         match into_valtype(self.kind) {
-            ValType::ExternRef => unsafe {
+            ValType::FuncRef | ValType::ExternRef => unsafe {
                 if !self.of.ref_.is_null() {
                     drop(Box::from_raw(self.of.ref_));
                 }


### PR DESCRIPTION
This commit adds a case to the destructor of `wasm_val_t` to be sure to
deallocate the `Box<wasm_ref_t>`.

