### PR TITLE
Aarch64: mask shift-amounts incorporated into reg-reg-shift ALU insts.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -52,6 +52,11 @@ impl ShiftOpShiftImm {
     pub fn value(self) -> u8 {
         self.0
     }
+
+    /// Mask down to a given number of bits.
+    pub fn mask(self, bits: u8) -> ShiftOpShiftImm {
+        ShiftOpShiftImm(self.0 & (bits - 1))
+    }
 }
 
 /// A shift operator with an amount, guaranteed to be within range.

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -321,8 +321,12 @@ fn put_input_in_rs<C: LowerCtx<I = Inst>>(
 
             // Can we get the shift amount as an immediate?
             if let Some(shiftimm) = input_to_shiftimm(ctx, shift_amt) {
-                let reg = put_input_in_reg(ctx, shiftee, narrow_mode);
-                return ResultRS::RegShift(reg, ShiftOpAndAmt::new(ShiftOp::LSL, shiftimm));
+                let shiftee_bits = ty_bits(ctx.input_ty(insn, 0));
+                if shiftee_bits <= u8::MAX as usize {
+                    let shiftimm = shiftimm.mask(shiftee_bits as u8);
+                    let reg = put_input_in_reg(ctx, shiftee, narrow_mode);
+                    return ResultRS::RegShift(reg, ShiftOpAndAmt::new(ShiftOp::LSL, shiftimm));
+                }
             }
         }
     }

--- a/cranelift/filetests/filetests/vcode/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/arithmetic.clif
@@ -365,3 +365,18 @@ block0(v0: i64, v1: i64):
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
+
+function %f25(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+  v2 = iconst.i32 53
+  v3 = ishl.i32 v0, v2
+  v4 = isub.i32 v1, v3
+  return v4
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  sub w0, w1, w0, LSL 21
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret


### PR DESCRIPTION
We had previously fixed a bug in which constant shift amounts should be
masked to modulo the number of bits in the operand; however, we
did not fix the analogous case for shifts incorporated into the second
register argument of ALU instructions that support integrated shifts.
This failure to mask resulted in illegal instructions being generated,
e.g. in https://bugzilla.mozilla.org/show_bug.cgi?id=1653502. This PR
fixes the issue by masking the amount, as the shift semantics require.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
