### PR TITLE
Remove nightly lint workaround

### DIFF
--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -2,8 +2,6 @@
 //! [Wasm C API](https://github.com/WebAssembly/wasm-c-api).
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#![allow(unknown_lints)]
-#![allow(improper_ctypes_definitions)]
 
 // TODO complete the C API
 


### PR DESCRIPTION
The source of these warnings was fixed in rust-lang/rust#74448, yay!
