### PR TITLE
Fix `u8::MAX` -> `std::u8::MAX`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,7 @@ jobs:
     - run: rustup install 1.41.0
     - run: cargo +1.41.0 check -p cranelift-codegen
     - run: cargo +1.41.0 check -p cranelift-wasm
+    - run: cargo +1.41.0 check -p cranelift-tools
 
 
   fuzz_targets:

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -322,7 +322,7 @@ fn put_input_in_rs<C: LowerCtx<I = Inst>>(
             // Can we get the shift amount as an immediate?
             if let Some(shiftimm) = input_to_shiftimm(ctx, shift_amt) {
                 let shiftee_bits = ty_bits(ctx.input_ty(insn, 0));
-                if shiftee_bits <= u8::MAX as usize {
+                if shiftee_bits <= std::u8::MAX as usize {
                     let shiftimm = shiftimm.mask(shiftee_bits as u8);
                     let reg = put_input_in_reg(ctx, shiftee, narrow_mode);
                     return ResultRS::RegShift(reg, ShiftOpAndAmt::new(ShiftOp::LSL, shiftimm));


### PR DESCRIPTION
As per Carlo Kok on Zulip #cranelift, this breaks builds with stable
Rust pre-1.43, as `core::u8::MAX` was only stabilized then. We'd like to
support older versions if we can easily do so.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
