### PR TITLE
Integrate wasi-nn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,5 @@
 	url = https://github.com/WebAssembly/wasm-c-api
 [submodule "WASI"]
 	path = crates/wasi-common/WASI
-	url = https://github.com/WebAssembly/WASI
+	url = https://github.com/WebAssembly/wasi-nn
+	branch = integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,18 +2658,18 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "11.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4d67ba9266f4fcaf2e8a1afadc5e2a959e51aecc07b1ecbdf85a6ddaf08bde"
+checksum = "a10df5277f68adee65bba117b40235f07a4cb3d59e5ec9aa86dbee180fb1bc04"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wast"
-version = "15.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10df5277f68adee65bba117b40235f07a4cb3d59e5ec9aa86dbee180fb1bc04"
+checksum = "5fb95ce157a8c779ec301ef3e4c0a7caeb6f9f902f813f1f5f7e464367048924"
 dependencies = [
  "leb128",
 ]
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "diff",
@@ -2799,7 +2799,7 @@ dependencies = [
  "pretty_env_logger",
  "structopt",
  "thiserror",
- "wast 11.0.0",
+ "wast 20.0.0",
 ]
 
 [[package]]

--- a/crates/wasi-common/src/snapshots/mod.rs
+++ b/crates/wasi-common/src/snapshots/mod.rs
@@ -1,1 +1,2 @@
+pub mod wasi_ephemeral_nn;
 pub mod wasi_snapshot_preview1;

--- a/crates/wasi-common/src/snapshots/wasi_ephemeral_nn.rs
+++ b/crates/wasi-common/src/snapshots/wasi_ephemeral_nn.rs
@@ -1,0 +1,40 @@
+use crate::wasi::wasi_ephemeral_nn::WasiEphemeralNn; // see crates/wasi/src/lib.rs
+use crate::wasi::{types, Result};
+use crate::WasiCtx;
+
+impl<'a> WasiEphemeralNn for WasiCtx {
+    fn load<'b>(
+        &self,
+        graph_buf: &wiggle::GuestPtr<'b, u8>,
+        graph_buf_len: types::Size,
+        encoding: types::GraphEncoding,
+        target: types::ExecutionTarget,
+    ) -> Result<types::Graph> {
+        unimplemented!()
+    }
+
+    fn init_execution_context(&self, graph: types::Graph) -> Result<types::GraphExecutionContext> {
+        unimplemented!()
+    }
+
+    fn set_input<'b>(
+        &self,
+        context: types::GraphExecutionContext,
+        index: u32,
+        tensor: &types::Tensor<'b>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn get_output<'b>(
+        &self,
+        context: types::GraphExecutionContext,
+        index: u32,
+    ) -> Result<types::Tensor<'b>> {
+        unimplemented!()
+    }
+
+    fn compute(&self, context: types::GraphExecutionContext) -> Result<()> {
+        unimplemented!()
+    }
+}

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -4,7 +4,7 @@
 use crate::WasiCtx;
 
 wiggle::from_witx!({
-    witx: ["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
+    witx: ["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx", "WASI/phases/ephemeral/witx/wasi_ephemeral_nn.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -10,7 +10,7 @@ wasmtime_wiggle::wasmtime_integration!({
     // The wiggle code to integrate with lives here:
     target: wasi_common::wasi,
     // This must be the same witx document as used above:
-    witx: ["phases/snapshot/witx/wasi_snapshot_preview1.witx"],
+    witx: ["phases/snapshot/witx/wasi_snapshot_preview1.witx", "phases/ephemeral/witx/wasi_ephemeral_nn.witx"],
     // This must be the same ctx type as used for the target:
     ctx: WasiCtx,
     // This macro will emit a struct to represent the instance,
@@ -30,6 +30,11 @@ resolution.",
             proc_exit => wasi_proc_exit
           }
         },
+        wasi_ephemeral_nn => {
+          name: WasiNN,
+          docs: "TODO",
+          function_override: {}
+        }
     },
     // Error to return when caller module is missing memory export:
     missing_memory: { wasi_common::wasi::Errno::Inval },

--- a/crates/wiggle/generate/src/types/struct.rs
+++ b/crates/wiggle/generate/src/types/struct.rs
@@ -33,7 +33,7 @@ pub(super) fn define_struct(
                     let pointee_type = names.type_ref(&pointee, quote!('a));
                     quote!(#rt::GuestPtr<'a, #pointee_type>)
                 }
-                _ => unimplemented!("other anonymous struct members"),
+                _ => unimplemented!("other anonymous struct members: {:?}", m.tref),
             },
         };
         quote!(pub #name: #type_)
@@ -63,7 +63,7 @@ pub(super) fn define_struct(
                         let #name = <#rt::GuestPtr::<#pointee_type> as #rt::GuestType>::read(&#location)?;
                     }
                 }
-                _ => unimplemented!("other anonymous struct members"),
+                _ => unimplemented!("other anonymous struct members: {:?}", ty),
             },
         }
     });

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -11,7 +11,7 @@ use syn::parse_macro_input;
 ///   CamelCase.
 ///
 /// * For each `module` defined in the witx document, a Rust module is defined
-///   containing definitions for that module. Module names are teanslated to the
+///   containing definitions for that module. Module names are translated to the
 ///   Rust-idiomatic snake\_case.
 ///
 ///     * For each `@interface func` defined in a witx module, an abi-level

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -14,7 +14,7 @@ wiggle::from_witx!({
 // The only test in this file is to verify that the witx document provided by the
 // proc macro in the `metadata` module is equal to the document on the disk.
 #[test]
-fn document_equivelant() {
+fn document_equivalent() {
     let macro_doc = metadata::document();
     let disk_doc = witx::load(&["tests/wasi.witx"]).expect("load wasi.witx from disk");
 


### PR DESCRIPTION
This has the very beginnings of wasi-nn support integrated into Wasmtime. I marked this as a draft because I need help working through some of the generation issues:
 - on @pchickey's suggestion, I am trying to only bring in the `wasi_ephemeral_nn.witx` with no external dependencies
 - after pulling in the repository containing `wasi_ephemeral_nn.witx` in 97d03e1 (this is likely not the right way to do things--just a temporary hack), I attempt to use the `wasmtime_wiggle::wasmtime_integration!` and `wiggle::from_witx!` in c18d421 to create the necessary structures
 - I get errors but it is unclear to me what is causing them:

```
wasmtime/crates/wasi-common$ cargo build
   Compiling wasi-common v0.19.1 (wasmtime/crates/wasi-common)
error[E0106]: missing lifetime specifier
 --> crates/wasi-common/src/wasi.rs:6:1
  |
6 | / wiggle::from_witx!({
7 | |     witx: ["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx", "WASI/phases/ephemeral/witx/wasi_ephemeral_nn.witx"],
8 | |     ctx: WasiCtx,
9 | | });
  | |___^
  |
  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider using the named lifetime
  |
6 | wiggle::from_witx!({
7 |     witx: ["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx", "WASI/phases/ephemeral/witx/wasi_ephemeral_nn.witx"],
8 |     ctx: WasiCtx,
9 | });<'a>
  |

error[E0392]: parameter `'a` is never used
 --> crates/wasi-common/src/wasi.rs:6:1
  |
6 | / wiggle::from_witx!({
7 | |     witx: ["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx", "WASI/phases/ephemeral/witx/wasi_ephemeral_nn.witx"],
8 | |     ctx: WasiCtx,
9 | | });
  | |___^ unused parameter
  |
  = help: consider removing `'a`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0106, E0392.
For more information about an error, try `rustc --explain E0106`.
error: could not compile `wasi-common`.

To learn more, run the command again with --verbose.
```

I can attach the macro-expanded `wasi.rs` output if that would help but I'm not too sure where to start here.