### PR TITLE
Refactor wasmtime's internal cache slightly

### DIFF
--- a/crates/environ/src/cache/tests.rs
+++ b/crates/environ/src/cache/tests.rs
@@ -1,6 +1,5 @@
 use super::config::tests::test_prolog;
 use super::*;
-use cranelift_entity::PrimaryMap;
 use std::fs;
 
 // Since cache system is a global thing, each test needs to be run in seperate process.
@@ -66,40 +65,28 @@ fn test_write_read_cache() {
     let entry1 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler1, &cache_config));
     let entry2 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler2, &cache_config));
 
-    entry1.get_data(1, |_| new_module_cache_data()).unwrap();
-    entry1.get_data::<_, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
 
-    entry1.get_data(2, |_| new_module_cache_data()).unwrap();
-    entry1.get_data::<_, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(2, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
 
-    entry1.get_data(3, |_| new_module_cache_data()).unwrap();
-    entry1.get_data::<_, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(3, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
 
-    entry1.get_data(4, |_| new_module_cache_data()).unwrap();
-    entry1.get_data::<_, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(3, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(4, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(4, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
 
-    entry2.get_data(1, |_| new_module_cache_data()).unwrap();
-    entry1.get_data::<_, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(3, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32>(4, |_| panic!()).unwrap();
-    entry2.get_data::<_, i32>(1, |_| panic!()).unwrap();
-}
-
-fn new_module_cache_data() -> Result<ModuleCacheDataTupleType, ()> {
-    Ok((
-        Compilation::new(PrimaryMap::new()),
-        PrimaryMap::new(),
-        PrimaryMap::new(),
-        PrimaryMap::new(),
-        PrimaryMap::new(),
-        PrimaryMap::new(),
-        PrimaryMap::new(),
-    ))
+    entry2.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
+    entry2.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
 }

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -1,7 +1,7 @@
 //! A `Compilation` contains the compiled function bodies for a WebAssembly
 //! module.
 
-use crate::cache::ModuleCacheDataTupleType;
+use crate::address_map::{ModuleAddressMap, ValueLabelsRanges};
 use crate::CacheConfig;
 use crate::ModuleTranslation;
 use cranelift_codegen::{binemit, ir, isa, isa::unwind::UnwindInfo};
@@ -184,6 +184,17 @@ pub enum CompileError {
     DebugInfoNotSupported,
 }
 
+/// A type alias for the result of `Compiler::compile_module`
+pub type CompileResult = (
+    Compilation,
+    Relocations,
+    ModuleAddressMap,
+    ValueLabelsRanges,
+    PrimaryMap<DefinedFuncIndex, ir::StackSlots>,
+    Traps,
+    StackMaps,
+);
+
 /// An implementation of a compiler from parsed WebAssembly module to native code.
 pub trait Compiler {
     /// Compile a parsed module with the given `TargetIsa`.
@@ -191,5 +202,5 @@ pub trait Compiler {
         translation: &ModuleTranslation,
         isa: &dyn isa::TargetIsa,
         cache_config: &CacheConfig,
-    ) -> Result<ModuleCacheDataTupleType, CompileError>;
+    ) -> Result<CompileResult, CompileError>;
 }

--- a/crates/environ/src/lightbeam.rs
+++ b/crates/environ/src/lightbeam.rs
@@ -1,7 +1,6 @@
 //! Support for compiling with Lightbeam.
 
-use crate::cache::ModuleCacheDataTupleType;
-use crate::compilation::{Compilation, CompileError};
+use crate::compilation::{Compilation, CompileError, CompileResult, Compiler};
 use crate::func_environ::FuncEnvironment;
 use crate::CacheConfig;
 use crate::ModuleTranslation;
@@ -15,14 +14,14 @@ use lightbeam::{CodeGenSession, NullOffsetSink, Sinks};
 /// A compiler that compiles a WebAssembly module with Lightbeam, directly translating the Wasm file.
 pub struct Lightbeam;
 
-impl crate::compilation::Compiler for Lightbeam {
+impl Compiler for Lightbeam {
     /// Compile the module using Lightbeam, producing a compilation result with
     /// associated relocations.
     fn compile_module(
         translation: &ModuleTranslation,
         isa: &dyn isa::TargetIsa,
         _cache_config: &CacheConfig,
-    ) -> Result<ModuleCacheDataTupleType, CompileError> {
+    ) -> Result<CompileResult, CompileError> {
         if translation.tunables.debug_info {
             return Err(CompileError::DebugInfoNotSupported);
         }


### PR DESCRIPTION
Be more generic over the type being serialized, and remove an
intermediate struct which was only used for serialization but isn't
necessary.
