### PR TITLE
arm64: Implement Vselect opcode

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1152,9 +1152,10 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         }
 
-        Opcode::Bitselect => {
+        Opcode::Bitselect | Opcode::Vselect => {
             let ty = ty.unwrap();
             if ty_bits(ty) < 128 {
+                debug_assert_ne!(Opcode::Vselect, op);
                 let tmp = ctx.alloc_tmp(RegClass::I64, I64);
                 let rd = get_output_reg(ctx, outputs[0]);
                 let rcond = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
@@ -1664,7 +1665,6 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Shuffle
         | Opcode::Vsplit
         | Opcode::Vconcat
-        | Opcode::Vselect
         | Opcode::Insertlane
         | Opcode::ScalarToVector
         | Opcode::Swizzle


### PR DESCRIPTION
This is implemented the same as Bitselect, as the controlling vector
is a boolean vector. A boolean vector in cranelift has elements
that are either 0 or all 1s, so it can be used to select elements
lane wise.