### PR TITLE
Refactor Cache logic to include debug information

### DIFF
--- a/crates/environ/src/cache.rs
+++ b/crates/environ/src/cache.rs
@@ -14,6 +14,7 @@ mod worker;
 pub use config::{create_new_config, CacheConfig};
 use worker::Worker;
 
+/// Module level cache entry.
 pub struct ModuleCacheEntry<'config>(Option<ModuleCacheEntryInner<'config>>);
 
 struct ModuleCacheEntryInner<'config> {
@@ -24,6 +25,7 @@ struct ModuleCacheEntryInner<'config> {
 struct Sha256Hasher(Sha256);
 
 impl<'config> ModuleCacheEntry<'config> {
+    /// Create the cache entry.
     pub fn new<'data>(compiler_name: &str, cache_config: &'config CacheConfig) -> Self {
         if cache_config.enabled() {
             Self(Some(ModuleCacheEntryInner::new(
@@ -40,6 +42,7 @@ impl<'config> ModuleCacheEntry<'config> {
         Self(Some(inner))
     }
 
+    /// Gets cached data if state matches, otherwise calls the `compute`.
     pub fn get_data<T, U, E>(&self, state: T, compute: fn(T) -> Result<U, E>) -> Result<U, E>
     where
         T: Hash,

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -2,7 +2,6 @@
 //! module.
 
 use crate::address_map::{ModuleAddressMap, ValueLabelsRanges};
-use crate::CacheConfig;
 use crate::ModuleTranslation;
 use cranelift_codegen::{binemit, ir, isa, isa::unwind::UnwindInfo};
 use cranelift_entity::PrimaryMap;
@@ -201,6 +200,5 @@ pub trait Compiler {
     fn compile_module(
         translation: &ModuleTranslation,
         isa: &dyn isa::TargetIsa,
-        cache_config: &CacheConfig,
     ) -> Result<CompileResult, CompileError>;
 }

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -102,7 +102,6 @@ use cranelift_wasm::{DefinedFuncIndex, FuncIndex, FuncTranslator, ModuleTranslat
 #[cfg(feature = "parallel-compilation")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::convert::TryFrom;
-use std::hash::{Hash, Hasher};
 
 /// Implementation of a relocation sink that just saves all the information for later
 pub struct RelocSink {
@@ -290,41 +289,44 @@ impl Compiler for Cranelift {
         translation: &ModuleTranslation,
         isa: &dyn isa::TargetIsa,
     ) -> Result<CompileResult, CompileError> {
-        compile(CompileEnv {
-            local: &translation.module.local,
-            module_translation: HashedModuleTranslationState(
-                translation.module_translation.as_ref().unwrap(),
-            ),
-            function_body_inputs: &translation.function_body_inputs,
-            isa: Isa(isa),
-            tunables: &translation.tunables,
-        })
+        compile(
+            isa,
+            &translation.module.local,
+            translation.module_translation.as_ref().unwrap(),
+            &translation.function_body_inputs,
+            &translation.tunables,
+        )
     }
 }
 
-fn compile(env: CompileEnv<'_>) -> Result<CompileResult, CompileError> {
-    let Isa(isa) = env.isa;
-    let mut functions = PrimaryMap::with_capacity(env.function_body_inputs.len());
-    let mut relocations = PrimaryMap::with_capacity(env.function_body_inputs.len());
-    let mut address_transforms = PrimaryMap::with_capacity(env.function_body_inputs.len());
-    let mut value_ranges = PrimaryMap::with_capacity(env.function_body_inputs.len());
-    let mut stack_slots = PrimaryMap::with_capacity(env.function_body_inputs.len());
-    let mut traps = PrimaryMap::with_capacity(env.function_body_inputs.len());
-    let mut stack_maps = PrimaryMap::with_capacity(env.function_body_inputs.len());
+fn compile(
+    isa: &dyn isa::TargetIsa,
+    local: &ModuleLocal,
+    module_translation: &ModuleTranslationState,
+    function_body_inputs: &PrimaryMap<DefinedFuncIndex, FunctionBodyData<'_>>,
+    tunables: &Tunables,
+) -> Result<CompileResult, CompileError> {
+    let mut functions = PrimaryMap::with_capacity(function_body_inputs.len());
+    let mut relocations = PrimaryMap::with_capacity(function_body_inputs.len());
+    let mut address_transforms = PrimaryMap::with_capacity(function_body_inputs.len());
+    let mut value_ranges = PrimaryMap::with_capacity(function_body_inputs.len());
+    let mut stack_slots = PrimaryMap::with_capacity(function_body_inputs.len());
+    let mut traps = PrimaryMap::with_capacity(function_body_inputs.len());
+    let mut stack_maps = PrimaryMap::with_capacity(function_body_inputs.len());
 
     type FunctionBodyInput<'a> = (DefinedFuncIndex, &'a FunctionBodyData<'a>);
 
     let compile_function = |func_translator: &mut FuncTranslator,
                             (i, input): &FunctionBodyInput| {
-        let func_index = env.local.func_index(*i);
+        let func_index = local.func_index(*i);
         let mut context = Context::new();
         context.func.name = get_func_name(func_index);
-        context.func.signature = env.local.native_func_signature(func_index).clone();
-        if env.tunables.debug_info {
+        context.func.signature = local.native_func_signature(func_index).clone();
+        if tunables.debug_info {
             context.func.collect_debug_info();
         }
 
-        let mut func_env = FuncEnvironment::new(isa.frontend_config(), env.local, env.tunables);
+        let mut func_env = FuncEnvironment::new(isa.frontend_config(), local, tunables);
 
         // We use these as constant offsets below in
         // `stack_limit_from_arguments`, so assert their values here. This
@@ -360,7 +362,7 @@ fn compile(env: CompileEnv<'_>) -> Result<CompileResult, CompileError> {
         });
         context.func.stack_limit = Some(stack_limit);
         func_translator.translate(
-            env.module_translation.0,
+            module_translation,
             input.data,
             input.module_offset,
             &mut context.func,
@@ -389,7 +391,7 @@ fn compile(env: CompileEnv<'_>) -> Result<CompileResult, CompileError> {
 
         let address_transform = get_function_address_map(&context, input, code_buf.len(), isa);
 
-        let ranges = if env.tunables.debug_info {
+        let ranges = if tunables.debug_info {
             let ranges = context.build_value_labels_ranges(isa).map_err(|error| {
                 CompileError::Codegen(pretty_error(&context.func, Some(isa), error))
             })?;
@@ -411,7 +413,7 @@ fn compile(env: CompileEnv<'_>) -> Result<CompileResult, CompileError> {
         ))
     };
 
-    let inputs: Vec<FunctionBodyInput> = env.function_body_inputs.into_iter().collect();
+    let inputs: Vec<FunctionBodyInput> = function_body_inputs.into_iter().collect();
 
     let results: Result<Vec<_>, CompileError> = {
         cfg_if::cfg_if! {
@@ -467,50 +469,4 @@ fn compile(env: CompileEnv<'_>) -> Result<CompileResult, CompileError> {
         traps,
         stack_maps,
     ))
-}
-
-#[derive(Hash)]
-struct CompileEnv<'a> {
-    local: &'a ModuleLocal,
-    module_translation: HashedModuleTranslationState<'a>,
-    function_body_inputs: &'a PrimaryMap<DefinedFuncIndex, FunctionBodyData<'a>>,
-    isa: Isa<'a, 'a>,
-    tunables: &'a Tunables,
-}
-
-/// This is a wrapper struct to hash the specific bits of `TargetIsa` that
-/// affect the output we care about. The trait itself can't implement `Hash`
-/// (it's not object safe) so we have to implement our own hashing.
-struct Isa<'a, 'b>(&'a (dyn isa::TargetIsa + 'b));
-
-impl Hash for Isa<'_, '_> {
-    fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.0.triple().hash(hasher);
-        self.0.frontend_config().hash(hasher);
-
-        // TODO: if this `to_string()` is too expensive then we should upstream
-        // a native hashing ability of flags into cranelift itself, but
-        // compilation and/or cache loading is relatively expensive so seems
-        // unlikely.
-        self.0.flags().to_string().hash(hasher);
-
-        // TODO: ... and should we hash anything else? There's a lot of stuff in
-        // `TargetIsa`, like registers/encodings/etc. Should we be hashing that
-        // too? It seems like wasmtime doesn't configure it too too much, but
-        // this may become an issue at some point.
-    }
-}
-
-/// A wrapper struct around cranelift's `ModuleTranslationState` to implement
-/// `Hash` since it's not `Hash` upstream yet.
-///
-/// TODO: we should upstream a `Hash` implementation, it would be very small! At
-/// this moment though based on the definition it should be fine to not hash it
-/// since we'll re-hash the signatures later.
-struct HashedModuleTranslationState<'a>(&'a ModuleTranslationState);
-
-impl Hash for HashedModuleTranslationState<'_> {
-    fn hash<H: Hasher>(&self, _hasher: &mut H) {
-        // nothing to hash right now
-    }
 }

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -86,7 +86,6 @@
 // assume no valid stack pointer will ever be `usize::max_value() - 32k`.
 
 use crate::address_map::{FunctionAddressMap, InstructionAddressMap};
-use crate::cache::ModuleCacheEntry;
 use crate::compilation::{
     Compilation, CompileError, CompiledFunction, Relocation, RelocationTarget, StackMapInformation,
     TrapInformation,
@@ -290,23 +289,17 @@ impl Compiler for Cranelift {
     fn compile_module(
         translation: &ModuleTranslation,
         isa: &dyn isa::TargetIsa,
-        cache_config: &CacheConfig,
+        _cache_config: &CacheConfig,
     ) -> Result<CompileResult, CompileError> {
-        let cache_entry = ModuleCacheEntry::new("cranelift", cache_config);
-
-        let result = cache_entry.get_data(
-            CompileEnv {
-                local: &translation.module.local,
-                module_translation: HashedModuleTranslationState(
-                    translation.module_translation.as_ref().unwrap(),
-                ),
-                function_body_inputs: &translation.function_body_inputs,
-                isa: Isa(isa),
-                tunables: &translation.tunables,
-            },
-            compile,
-        )?;
-        Ok(result)
+        compile(CompileEnv {
+            local: &translation.module.local,
+            module_translation: HashedModuleTranslationState(
+                translation.module_translation.as_ref().unwrap(),
+            ),
+            function_body_inputs: &translation.function_body_inputs,
+            isa: Isa(isa),
+            tunables: &translation.tunables,
+        })
     }
 }
 

--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -92,7 +92,7 @@ use crate::compilation::{
 };
 use crate::compilation::{CompileResult, Compiler};
 use crate::func_environ::{get_func_name, FuncEnvironment};
-use crate::{CacheConfig, FunctionBodyData, ModuleLocal, ModuleTranslation, Tunables};
+use crate::{FunctionBodyData, ModuleLocal, ModuleTranslation, Tunables};
 use cranelift_codegen::ir::{self, ExternalName};
 use cranelift_codegen::machinst::buffer::MachSrcLoc;
 use cranelift_codegen::print_errors::pretty_error;
@@ -289,7 +289,6 @@ impl Compiler for Cranelift {
     fn compile_module(
         translation: &ModuleTranslation,
         isa: &dyn isa::TargetIsa,
-        _cache_config: &CacheConfig,
     ) -> Result<CompileResult, CompileError> {
         compile(CompileEnv {
             local: &translation.module.local,

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -44,7 +44,7 @@ pub use crate::address_map::{
     ModuleVmctxInfo, ValueLabelsRanges,
 };
 pub use crate::cache::create_new_config as cache_create_new_config;
-pub use crate::cache::CacheConfig;
+pub use crate::cache::{CacheConfig, ModuleCacheEntry};
 pub use crate::compilation::{
     Compilation, CompileError, CompiledFunction, Compiler, Relocation, RelocationTarget,
     Relocations, StackMapInformation, StackMaps, TrapInformation, Traps,

--- a/crates/environ/src/lightbeam.rs
+++ b/crates/environ/src/lightbeam.rs
@@ -20,7 +20,6 @@ impl Compiler for Lightbeam {
     fn compile_module(
         translation: &ModuleTranslation,
         isa: &dyn isa::TargetIsa,
-        _cache_config: &CacheConfig,
     ) -> Result<CompileResult, CompileError> {
         if translation.tunables.debug_info {
             return Err(CompileError::DebugInfoNotSupported);

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -187,17 +187,23 @@ impl Compiler {
 
 impl Hash for Compiler {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
+        let Compiler {
+            strategy,
+            isa,
+            tunables,
+        } = self;
+
         // Hash compiler's flags: compilation strategy, isa, frontend config,
         // misc tunables.
-        self.strategy().hash(hasher);
-        self.isa().triple().hash(hasher);
+        strategy.hash(hasher);
+        isa.triple().hash(hasher);
         // TODO: if this `to_string()` is too expensive then we should upstream
         // a native hashing ability of flags into cranelift itself, but
         // compilation and/or cache loading is relatively expensive so seems
         // unlikely.
-        self.isa().flags().to_string().hash(hasher);
-        self.frontend_config().hash(hasher);
-        self.tunables().hash(hasher);
+        isa.flags().to_string().hash(hasher);
+        isa.frontend_config().hash(hasher);
+        tunables.hash(hasher);
 
         // TODO: ... and should we hash anything else? There's a lot of stuff in
         // `TargetIsa`, like registers/encodings/etc. Should we be hashing that

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -14,7 +14,7 @@ use wasmtime_environ::{
 };
 
 /// Select which kind of compilation to use.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash)]
 pub enum CompilationStrategy {
     /// Let Wasmtime pick the strategy.
     Auto,
@@ -124,6 +124,16 @@ impl Compiler {
     /// Return the tunables in use by this engine.
     pub fn tunables(&self) -> &Tunables {
         &self.tunables
+    }
+
+    /// Return the compilation strategy.
+    pub fn strategy(&self) -> CompilationStrategy {
+        self.strategy
+    }
+
+    /// Return the cache config.
+    pub fn cache_config(&self) -> &CacheConfig {
+        &self.cache_config
     }
 
     /// Compile the given function bodies.

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -20,7 +20,7 @@ use wasmtime_debug::{create_gdbjit_image, read_debuginfo};
 use wasmtime_environ::entity::{BoxedSlice, PrimaryMap};
 use wasmtime_environ::isa::TargetIsa;
 use wasmtime_environ::wasm::{DefinedFuncIndex, SignatureIndex};
-use wasmtime_environ::ModuleCacheEntry;
+use wasmtime_environ::{CacheConfig, ModuleCacheEntry};
 use wasmtime_environ::{
     CompileError, DataInitializer, DataInitializerLocation, Module, ModuleAddressMap,
     ModuleEnvironment, ModuleTranslation, StackMaps, Traps,
@@ -95,8 +95,12 @@ impl<'a> Hash for HashedCompilationArtifactsEnv<'a> {
 
 impl CompilationArtifacts {
     /// Builds compilation artifacts.
-    pub fn build(compiler: &Compiler, data: &[u8]) -> Result<Self, SetupError> {
-        let cache_entry = ModuleCacheEntry::new("wasmtime", compiler.cache_config());
+    pub fn build(
+        compiler: &Compiler,
+        data: &[u8],
+        cache_config: &CacheConfig,
+    ) -> Result<Self, SetupError> {
+        let cache_entry = ModuleCacheEntry::new("wasmtime", cache_config);
         let result = cache_entry.get_data(
             HashedCompilationArtifactsEnv(compiler, data),
             build_artifacts,
@@ -192,8 +196,9 @@ impl CompiledModule {
         compiler: &Compiler,
         data: &'data [u8],
         profiler: &dyn ProfilingAgent,
+        cache_config: &CacheConfig,
     ) -> Result<Self, SetupError> {
-        let artifacts = CompilationArtifacts::build(compiler, data)?;
+        let artifacts = CompilationArtifacts::build(compiler, data, cache_config)?;
         Self::from_artifacts(artifacts, compiler.isa(), profiler)
     }
 

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -4,6 +4,7 @@ use crate::types::{EntityType, ExportType, ExternType, ImportType};
 use anyhow::{bail, Context, Result};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use wasmtime_environ::ModuleCacheEntry;
 use wasmtime_jit::{CompilationArtifacts, CompiledModule};
 
 /// A compiled WebAssembly module, ready to be instantiated.
@@ -300,11 +301,16 @@ impl Module {
     }
 
     unsafe fn compile(engine: &Engine, binary: &[u8]) -> Result<Self> {
-        let compiled = CompiledModule::new(
-            engine.compiler(),
-            binary,
+        let cache_entry = ModuleCacheEntry::new("wasmtime", engine.cache_config());
+        let artifacts = cache_entry
+            .get_data((engine.compiler(), binary), |(compiler, binary)| {
+                CompilationArtifacts::build(compiler, binary)
+            })?;
+
+        let compiled = CompiledModule::from_artifacts(
+            artifacts,
+            engine.compiler().isa(),
             &*engine.config().profiler,
-            engine.cache_config(),
         )?;
 
         Ok(Module {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -300,7 +300,12 @@ impl Module {
     }
 
     unsafe fn compile(engine: &Engine, binary: &[u8]) -> Result<Self> {
-        let compiled = CompiledModule::new(engine.compiler(), binary, &*engine.config().profiler)?;
+        let compiled = CompiledModule::new(
+            engine.compiler(),
+            binary,
+            &*engine.config().profiler,
+            engine.cache_config(),
+        )?;
 
         Ok(Module {
             engine: engine.clone(),

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -628,12 +628,7 @@ impl Config {
 
     fn build_compiler(&self) -> Compiler {
         let isa = self.target_isa();
-        Compiler::new(
-            isa,
-            self.strategy,
-            self.cache_config.clone(),
-            self.tunables.clone(),
-        )
+        Compiler::new(isa, self.strategy, self.tunables.clone())
     }
 
     /// Hashes/fingerprints compiler setting to ensure that compatible
@@ -796,6 +791,10 @@ impl Engine {
 
     pub(crate) fn compiler(&self) -> &Compiler {
         &self.inner.compiler
+    }
+
+    pub(crate) fn cache_config(&self) -> &CacheConfig {
+        &self.config().cache_config
     }
 
     /// Returns whether the engine `a` and `b` refer to the same configuration.

--- a/src/commands/wasm2obj.rs
+++ b/src/commands/wasm2obj.rs
@@ -11,7 +11,6 @@ use std::{
 };
 use structopt::{clap::AppSettings, StructOpt};
 use target_lexicon::Triple;
-use wasmtime_environ::CacheConfig;
 
 /// The after help text for the `wasm2obj` command.
 pub const WASM2OBJ_AFTER_HELP: &str = "The translation is dependent on the environment chosen.\n\
@@ -60,11 +59,6 @@ impl WasmToObjCommand {
             pretty_env_logger::init();
         }
 
-        let cache_config = if self.common.disable_cache {
-            CacheConfig::new_cache_disabled()
-        } else {
-            CacheConfig::from_file(self.common.config.as_deref())?
-        };
         let strategy = pick_compilation_strategy(self.common.cranelift, self.common.lightbeam)?;
 
         let data = wat::parse_file(&self.module).context("failed to parse module")?;
@@ -76,7 +70,6 @@ impl WasmToObjCommand {
             self.common.enable_simd,
             self.common.opt_level(),
             self.common.debug_info,
-            &cache_config,
         )?;
 
         let mut file =

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -21,7 +21,7 @@ pub fn compile_to_obj(
     enable_simd: bool,
     opt_level: wasmtime::OptLevel,
     debug_info: bool,
-    cache_config: &CacheConfig,
+    _cache_config: &CacheConfig,
 ) -> Result<Object> {
     let isa_builder = match target {
         Some(target) => native::lookup(target.clone())?,
@@ -72,11 +72,9 @@ pub fn compile_to_obj(
         _traps,
         _stack_maps,
     ) = match strategy {
-        Strategy::Auto | Strategy::Cranelift => {
-            Cranelift::compile_module(&translation, &*isa, cache_config)
-        }
+        Strategy::Auto | Strategy::Cranelift => Cranelift::compile_module(&translation, &*isa),
         #[cfg(feature = "lightbeam")]
-        Strategy::Lightbeam => Lightbeam::compile_module(&translation, &*isa, cache_config),
+        Strategy::Lightbeam => Lightbeam::compile_module(&translation, &*isa),
         #[cfg(not(feature = "lightbeam"))]
         Strategy::Lightbeam => bail!("lightbeam support not enabled"),
         other => bail!("unsupported compilation strategy {:?}", other),

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -7,8 +7,8 @@ use wasmtime_debug::{emit_dwarf, read_debuginfo};
 use wasmtime_environ::Lightbeam;
 use wasmtime_environ::{
     entity::EntityRef, settings, settings::Configurable, wasm::DefinedMemoryIndex,
-    wasm::MemoryIndex, CacheConfig, Compiler, Cranelift, ModuleEnvironment, ModuleMemoryOffset,
-    ModuleVmctxInfo, Tunables, VMOffsets,
+    wasm::MemoryIndex, Compiler, Cranelift, ModuleEnvironment, ModuleMemoryOffset, ModuleVmctxInfo,
+    Tunables, VMOffsets,
 };
 use wasmtime_jit::native;
 use wasmtime_obj::{emit_module, ObjectBuilderTarget};
@@ -21,7 +21,6 @@ pub fn compile_to_obj(
     enable_simd: bool,
     opt_level: wasmtime::OptLevel,
     debug_info: bool,
-    _cache_config: &CacheConfig,
 ) -> Result<Object> {
     let isa_builder = match target {
         Some(target) => native::lookup(target.clone())?,

--- a/tests/all/debug/obj.rs
+++ b/tests/all/debug/obj.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use target_lexicon::Triple;
 use wasmtime::Strategy;
 use wasmtime_cli::compile_to_obj;
-use wasmtime_environ::CacheConfig;
 
 pub fn compile_cranelift(
     wasm: &[u8],
@@ -19,7 +18,6 @@ pub fn compile_cranelift(
         false,
         wasmtime::OptLevel::None,
         true,
-        &CacheConfig::new_cache_disabled(),
     )?;
 
     let mut file = File::create(output).context("failed to create object file")?;


### PR DESCRIPTION
Currently, it is a responsibility of the compiler to do caching. Moving this logic to the `CompiledModule` level. This allows early access to *all* compilation artifacts without analyzing the wasm file (only bytes hash).