### PR TITLE
Add timing for several new-backend stages.

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -143,6 +143,7 @@
 use crate::binemit::{Addend, CodeOffset, CodeSink, Reloc, Stackmap};
 use crate::ir::{ExternalName, Opcode, SourceLoc, TrapCode};
 use crate::machinst::{BlockIndex, MachInstLabelUse, VCodeInst};
+use crate::timing;
 
 use log::trace;
 use smallvec::SmallVec;
@@ -1074,6 +1075,8 @@ impl<I: VCodeInst> MachBuffer<I> {
 
     /// Finish any deferred emissions and/or fixups.
     pub fn finish(mut self) -> MachBufferFinalized {
+        let _tt = timing::vcode_emit_finish();
+
         // Ensure that all labels are defined. This is a full (release-mode)
         // assert because we must avoid looping indefinitely below; an
         // unresolved label will prevent the fixup_records vec from emptying.

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -23,7 +23,10 @@ where
     // Build the lowering context.
     let lower = Lower::new(f, abi, block_order)?;
     // Lower the IR.
-    let (mut vcode, stackmap_request_info) = lower.lower(b)?;
+    let (mut vcode, stackmap_request_info) = {
+        let _tt = timing::vcode_lower();
+        lower.lower(b)?
+    };
 
     debug!(
         "vcode from lowering: \n{}",
@@ -92,7 +95,10 @@ where
 
     // Reorder vcode into final order and copy out final instruction sequence
     // all at once. This also inserts prologues/epilogues.
-    vcode.replace_insns_from_regalloc(result);
+    {
+        let _tt = timing::vcode_post_ra();
+        vcode.replace_insns_from_regalloc(result);
+    }
 
     debug!(
         "vcode after regalloc: final version:\n{}",

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -20,6 +20,7 @@
 use crate::ir::{self, types, SourceLoc};
 use crate::machinst::*;
 use crate::settings;
+use crate::timing;
 
 use regalloc::Function as RegallocFunction;
 use regalloc::Set as RegallocSet;
@@ -424,6 +425,7 @@ impl<I: VCodeInst> VCode<I> {
     where
         I: MachInstEmit,
     {
+        let _tt = timing::vcode_emit();
         let mut buffer = MachBuffer::new();
         let mut state = I::State::new(&*self.abi);
 

--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -64,6 +64,11 @@ define_passes! {
     unreachable_code: "Remove unreachable blocks",
     remove_constant_phis: "Remove constant phi-nodes",
 
+    vcode_lower: "VCode lowering",
+    vcode_post_ra: "VCode post-register allocation finalization",
+    vcode_emit: "VCode emission",
+    vcode_emit_finish: "VCode emission finalization",
+
     regalloc: "Register allocation",
     ra_liveness: "RA liveness analysis",
     ra_cssa: "RA coalescing CSSA",


### PR DESCRIPTION
This PR adds a bit more granularity to the output of e.g. `clif-util
compile -T`, indicating how much time is spent in VCode lowering and
various other new-backend-specific tasks.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
