### PR TITLE
virtfs file: update cursor position on fd_read

### DIFF
--- a/crates/wasi-common/src/virtfs.rs
+++ b/crates/wasi-common/src/virtfs.rs
@@ -78,7 +78,8 @@ impl FileContents for VecFileContents {
     fn preadv(&self, iovs: &mut [io::IoSliceMut], offset: types::Filesize) -> Result<usize> {
         let mut read_total = 0usize;
         for iov in iovs.iter_mut() {
-            let read = self.pread(iov, offset)?;
+            let skip: u64 = read_total.try_into().map_err(|_| Errno::Inval)?;
+            let read = self.pread(iov, offset + skip)?;
             read_total = read_total.checked_add(read).expect("FileContents::preadv must not be called when reads could total to more bytes than the return value can hold");
         }
         Ok(read_total)
@@ -87,7 +88,8 @@ impl FileContents for VecFileContents {
     fn pwritev(&mut self, iovs: &[io::IoSlice], offset: types::Filesize) -> Result<usize> {
         let mut write_total = 0usize;
         for iov in iovs.iter() {
-            let written = self.pwrite(iov, offset)?;
+            let skip: u64 = write_total.try_into().map_err(|_| Errno::Inval)?;
+            let written = self.pwrite(iov, offset + skip)?;
             write_total = write_total.checked_add(written).expect("FileContents::pwritev must not be called when writes could total to more bytes than the return value can hold");
         }
         Ok(write_total)


### PR DESCRIPTION
If a handle is backed by `InMemoryFile`, `fd_read` (turned into `Handle::read_vectored`) doesn't update the cursor position properly and thus prevents the caller from detecting EOF.

This also fixes a similar issue in `fd_pread`, which doesn't advance the read offset when reading data into multiple iovecs.