### PR TITLE
machinst x64: use a sign-extension when loading jump table offsets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2020-07-27
     - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
     - run: cargo doc --package cranelift-codegen-meta --document-private-items
     - uses: actions/upload-artifact@v1
@@ -92,7 +92,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2020-07-27
 
     # Check some feature combinations of the `wasmtime` crate
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --no-default-features
@@ -141,7 +141,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2020-07-27
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
@@ -192,7 +192,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2020-07-27
           - build: macos
             os: macos-latest
             rust: stable

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -350,6 +350,7 @@ pub enum Inst {
     /// Jump-table sequence, as one compound instruction (see note in lower.rs for rationale).
     /// The generated code sequence is described in the emit's function match arm for this
     /// instruction.
+    /// See comment in lowering about the temporaries signedness.
     JmpTableSeq {
         idx: Reg,
         tmp1: Writable<Reg>,

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -1989,8 +1989,13 @@ impl LowerBackend for X64Backend {
                     // is to introduce a relocation pass for inlined jumptables, which is much
                     // worse.)
 
-                    let tmp1 = ctx.alloc_tmp(RegClass::I64, I32);
-                    let tmp2 = ctx.alloc_tmp(RegClass::I64, I32);
+                    // This temporary is used as a signed integer of 64-bits (to hold addresses).
+                    let tmp1 = ctx.alloc_tmp(RegClass::I64, I64);
+                    // This temporary is used as a signed integer of 32-bits (for the wasm-table
+                    // index) and then 64-bits (address addend). The small lie about the I64 type
+                    // is benign, since the temporary is dead after this instruction (and its
+                    // Cranelift type is thus unused).
+                    let tmp2 = ctx.alloc_tmp(RegClass::I64, I64);
 
                     let targets_for_term: Vec<MachLabel> = targets.to_vec();
                     let default_target = BranchTarget::Label(targets[0]);


### PR DESCRIPTION
The jump table offset that's loaded out of the jump table could be
signed (if it's an offset to before the jump table itself), so we should
use a signed extension there, not an unsigned extension.