### PR TITLE
machinst x64: add testing to the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,6 +269,45 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+  # Perform all tests (debug mode) for `wasmtime` with the experimental x64
+  # backend. This runs on the nightly channel of Rust (because of issues with
+  # unifying Cargo features on stable) on Ubuntu.
+  test_x64:
+    name: Test x64 new backend
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly-2020-07-27
+    - uses: ./.github/actions/define-llvm-env
+
+    # Install wasm32 targets in order to build various tests throughout the
+    # repo
+    - run: rustup target add wasm32-wasi
+    - run: rustup target add wasm32-unknown-unknown
+
+    # Build and test all features except for lightbeam
+    - run: |
+        cargo \
+            -Zfeatures=all -Zpackage-features \
+            test \
+            --features test-programs/test_programs \
+            --features experimental_x64 \
+            --all \
+            --exclude lightbeam \
+            --exclude peepmatic \
+            --exclude peepmatic-automata \
+            --exclude peepmatic-fuzzing \
+            --exclude peepmatic-macro \
+            --exclude peepmatic-runtime \
+            --exclude peepmatic-test
+      env:
+        RUST_BACKTRACE: 1
+
+
   # Verify that cranelift's code generation is deterministic
   meta_determinist_check:
     name: Meta deterministic check

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -347,7 +347,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
     };
 
     match op {
-        Opcode::Iconst | Opcode::Null => {
+        Opcode::Iconst | Opcode::Bconst | Opcode::Null => {
             if let Some(w64) = iri_to_u64_imm(ctx, insn) {
                 let dst_is_64 = w64 > 0x7fffffff;
                 let dst = output_to_reg(ctx, outputs[0]);

--- a/cranelift/codegen/src/isa/x86/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x86/unwind/systemv.rs
@@ -397,6 +397,7 @@ mod tests {
     use target_lexicon::triple;
 
     #[test]
+    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_simple_func() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -439,6 +440,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_multi_return_func() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")

--- a/cranelift/codegen/src/isa/x86/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/x86/unwind/winx64.rs
@@ -158,6 +158,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_small_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -215,6 +216,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_medium_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -276,6 +278,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_large_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")

--- a/cranelift/tests/filetests.rs
+++ b/cranelift/tests/filetests.rs
@@ -1,4 +1,5 @@
 #[test]
+#[cfg_attr(feature = "experimental_x64", should_panic)] // TODO #2079
 fn filetests() {
     // Run all the filetests in the following directories.
     cranelift_filetests::run(false, false, &["filetests".into(), "docs".into()])

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -14,6 +14,12 @@ include = ["src/**/*", "LICENSE"]
 proc-macro = true
 test = false
 
+# This has been added to make testing of the experimental_x64 feature possible,
+# working around a Cargo nightly bug: once
+# https://github.com/rust-lang/cargo/issues/8563 has been fixed, we should be
+# able to revert it.
+doctest = false
+
 [dependencies]
 wiggle-generate = { path = "../generate", version = "0.19.0" }
 witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.5" }

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -373,6 +373,7 @@ fn gc_during_gc_when_passing_refs_into_wasm() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "experimental_x64", ignore)] // TODO #2079 investigate.
 fn gc_during_gc_from_many_table_gets() -> anyhow::Result<()> {
     let (store, module) = ref_types_module(
         r#"

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -99,6 +99,7 @@ fn loop_interrupt_from_afar() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "experimental_x64", ignore)] // TODO #2079 interrupts in wasmtime
 fn function_interrupt_from_afar() -> anyhow::Result<()> {
     // Create an instance which calls an imported function on each iteration of
     // the loop so we can count the number of loop iterations we've executed so

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;
 
 #[test]
+#[cfg_attr(feature = "experimental_x64", ignore)] // TODO #2079 require probe stacks
 fn host_always_has_some_stack() -> anyhow::Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
     // assume hosts always have at least 512k of stack

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -32,6 +32,7 @@ fn test_trap_return() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn test_trap_trace() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -74,6 +75,7 @@ fn test_trap_trace() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn test_trap_trace_cb() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -110,6 +112,7 @@ fn test_trap_trace_cb() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn test_trap_stack_overflow() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -142,6 +145,7 @@ fn test_trap_stack_overflow() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn trap_display_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -174,6 +178,7 @@ wasm backtrace:
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn trap_display_multi_module() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -219,6 +224,7 @@ wasm backtrace:
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn trap_start_function_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -246,6 +252,7 @@ fn trap_start_function_import() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn rust_panic_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -291,6 +298,7 @@ fn rust_panic_import() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn rust_panic_start_function() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -325,6 +333,7 @@ fn rust_panic_start_function() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn mismatched_arguments() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -357,6 +366,7 @@ fn mismatched_arguments() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn call_signature_mismatch() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -388,6 +398,7 @@ fn call_signature_mismatch() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1642)
+#[cfg_attr(feature = "experimental_x64", ignore)] // FIXME(#2078)
 fn start_trap_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"


### PR DESCRIPTION
This adds testing for x64; i don't know yet if i got the github CI incantation correctly or not. I've also deferred to later the decisions of what to do with filetests, since it'd be better to have some tests running in CI already (all the non-simd spec tests are passing here too).

Big thanks to @alexcrichton for helping me with Cargo and testing on Zulip!