### PR TITLE
machinst x64: refactor to use types::[type] everywhere

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1975,7 +1975,7 @@ pub(crate) fn emit(
 
             // Divide x by two to get it in range for the signed conversion, keep the LSB, and
             // scale it back up on the FP side.
-            let inst = Inst::gen_move(*tmp_gpr1, src.to_reg(), I64);
+            let inst = Inst::gen_move(*tmp_gpr1, src.to_reg(), types::I64);
             inst.emit(sink, flags, state);
 
             // tmp_gpr1 := src >> 1
@@ -1987,7 +1987,7 @@ pub(crate) fn emit(
             );
             inst.emit(sink, flags, state);
 
-            let inst = Inst::gen_move(*tmp_gpr2, src.to_reg(), I64);
+            let inst = Inst::gen_move(*tmp_gpr2, src.to_reg(), types::I64);
             inst.emit(sink, flags, state);
 
             let inst = Inst::alu_rmi_r(


### PR DESCRIPTION
This change is a pure refactoring--no change to functionality. It removes `use crate::ir::types::*` imports and uses instead `types::I32`, e.g., throughout the x64 code. Though it increases code verbosity, this change makes it more clear where the type identifiers come from (they are generated by `cranelif-codegen-meta` so without a prefix it is difficult to find their origin), avoids IDE confusion (e.g. CLion flags the un-prefixed identifiers as errors), and avoids importing unwanted identifiers into the namespace.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
