### PR TITLE
machinst x64: refactor imports to use rustfmt convention

### DIFF
--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -1,20 +1,17 @@
 //! Implementation of the standard x64 ABI.
 
-use log::trace;
-use regalloc::{RealReg, Reg, RegClass, Set, SpillSlot, Writable};
-
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use std::mem;
-
 use crate::binemit::Stackmap;
 use crate::ir::{self, types, types::*, ArgumentExtension, StackSlot, Type};
 use crate::isa::{x64::inst::*, CallConv};
 use crate::machinst::*;
 use crate::settings;
 use crate::{CodegenError, CodegenResult};
-
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use args::*;
+use log::trace;
+use regalloc::{RealReg, Reg, RegClass, Set, SpillSlot, Writable};
+use std::mem;
 
 /// This is the limit for the size of argument and return-value areas on the
 /// stack. We place a reasonable limit here to avoid integer overflow issues

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1,18 +1,13 @@
 //! Instruction operand sub-components (aka "parts"): definitions and printing.
 
-use std::fmt;
-use std::string::{String, ToString};
-
-use regalloc::{RealRegUniverse, Reg, RegClass, RegUsageCollector, RegUsageMapper};
-
+use super::regs::{self, show_ireg_sized};
+use super::EmitState;
 use crate::ir::condcodes::{FloatCC, IntCC};
 use crate::machinst::*;
-
-use super::{
-    regs::{self, show_ireg_sized},
-    EmitState,
-};
 use core::fmt::Debug;
+use regalloc::{RealRegUniverse, Reg, RegClass, RegUsageCollector, RegUsageMapper};
+use std::fmt;
+use std::string::{String, ToString};
 
 /// A possible addressing mode (amode) that can be used in instructions.
 /// These denote a 64-bit value only.

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -9,10 +9,9 @@
 //! (cd cranelift/codegen && \
 //! RUST_BACKTRACE=1 cargo test isa::x64::inst::test_x64_insn_encoding_and_printing -- --nocapture)
 
-use alloc::vec::Vec;
-
 use super::*;
 use crate::isa::test_utils;
+use alloc::vec::Vec;
 
 #[test]
 fn test_x64_emit() {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -4,21 +4,20 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use std::fmt;
-use std::string::{String, ToString};
-
-use regalloc::RegUsageCollector;
-use regalloc::{RealRegUniverse, Reg, RegClass, RegUsageMapper, SpillSlot, VirtualReg, Writable};
-use smallvec::SmallVec;
-
 use crate::binemit::{CodeOffset, Stackmap};
 use crate::ir::types::*;
 use crate::ir::{ExternalName, Opcode, SourceLoc, TrapCode, Type};
 use crate::machinst::*;
-use crate::settings::Flags;
-use crate::{settings, CodegenError, CodegenResult};
+use crate::{settings, settings::Flags, CodegenError, CodegenResult};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use regalloc::{
+    RealRegUniverse, Reg, RegClass, RegUsageCollector, RegUsageMapper, SpillSlot, VirtualReg,
+    Writable,
+};
+use smallvec::SmallVec;
+use std::fmt;
+use std::string::{String, ToString};
 
 pub mod args;
 mod emit;

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -10,13 +10,10 @@
 //! Also, they will have to be ABI dependent.  Need to find a way to avoid constructing a universe
 //! for each function we compile.
 
+use crate::{machinst::pretty_print::ShowWithRRU, settings};
 use alloc::vec::Vec;
-use std::string::String;
-
 use regalloc::{RealReg, RealRegUniverse, Reg, RegClass, RegClassInfo, NUM_REG_CLASSES};
-
-use crate::machinst::pretty_print::ShowWithRRU;
-use crate::settings;
+use std::string::String;
 
 // Hardware encodings for a few registers.
 

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2,31 +2,26 @@
 
 #![allow(non_snake_case)]
 
-use log::trace;
-use regalloc::{Reg, RegClass, Writable};
-use smallvec::SmallVec;
-
-use crate::ir::types;
 use crate::ir::types::*;
-use crate::ir::Inst as IRInst;
 use crate::ir::{
-    condcodes::FloatCC, condcodes::IntCC, AbiParam, ArgumentPurpose, ExternalName, InstructionData,
-    LibCall, Opcode, Signature, TrapCode, Type,
+    condcodes::FloatCC, condcodes::IntCC, types, AbiParam, ArgumentPurpose, ExternalName,
+    Inst as IRInst, InstructionData, LibCall, Opcode, Signature, TrapCode, Type,
 };
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use cranelift_codegen_shared::condcodes::CondCode;
-use std::convert::TryFrom;
-
-use crate::machinst::lower::*;
-use crate::machinst::*;
-use crate::result::CodegenResult;
-use crate::settings::Flags;
-
 use crate::isa::x64::abi::*;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::{x64::X64Backend, CallConv};
+use crate::machinst::lower::*;
+use crate::machinst::*;
+use crate::result::CodegenResult;
+use crate::settings::Flags;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use cranelift_codegen_shared::condcodes::CondCode;
+use log::trace;
+use regalloc::{Reg, RegClass, Writable};
+use smallvec::SmallVec;
+use std::convert::TryFrom;
 use target_lexicon::Triple;
 
 /// Context passed to all lowering functions.

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -1,21 +1,17 @@
 //! X86_64-bit Instruction Set Architecture.
 
-use alloc::boxed::Box;
-
-use regalloc::RealRegUniverse;
-use target_lexicon::Triple;
-
-use crate::ir::condcodes::IntCC;
-use crate::ir::Function;
+use super::TargetIsa;
+use crate::ir::{condcodes::IntCC, Function};
+use crate::isa::x64::{inst::regs::create_reg_universe_systemv, settings as x64_settings};
 use crate::isa::Builder as IsaBuilder;
-use crate::machinst::pretty_print::ShowWithRRU;
-use crate::machinst::{compile, MachBackend, MachCompileResult, TargetIsaAdapter, VCode};
+use crate::machinst::{
+    compile, pretty_print::ShowWithRRU, MachBackend, MachCompileResult, TargetIsaAdapter, VCode,
+};
 use crate::result::CodegenResult;
 use crate::settings::{self as shared_settings, Flags};
-
-use crate::isa::x64::{inst::regs::create_reg_universe_systemv, settings as x64_settings};
-
-use super::TargetIsa;
+use alloc::boxed::Box;
+use regalloc::RealRegUniverse;
+use target_lexicon::Triple;
 
 mod abi;
 mod inst;


### PR DESCRIPTION
This change is a pure refactoring--no change to functionality. It removes newlines between the `use ...` statements in the x64 backend so that rustfmt can format them according to its convention. I noticed some files had followed a manual convention but subsequent additions did not seem to fit; this change fixes that and lightly coalesces some of the occurrences of `use a::b; use a::c;` into `use::{b, c}`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
