### PR TITLE
Remove the `local` field of `Module`

### DIFF
--- a/crates/environ/src/cranelift.rs
+++ b/crates/environ/src/cranelift.rs
@@ -302,17 +302,17 @@ impl Compiler for Cranelift {
         input: &FunctionBodyData<'_>,
         isa: &dyn isa::TargetIsa,
     ) -> Result<CompiledFunction, CompileError> {
-        let local = &translation.module.local;
+        let module = &translation.module;
         let tunables = &translation.tunables;
-        let func_index = local.func_index(func_index);
+        let func_index = module.func_index(func_index);
         let mut context = Context::new();
         context.func.name = get_func_name(func_index);
-        context.func.signature = local.native_func_signature(func_index).clone();
+        context.func.signature = module.native_func_signature(func_index).clone();
         if tunables.debug_info {
             context.func.collect_debug_info();
         }
 
-        let mut func_env = FuncEnvironment::new(isa.frontend_config(), local, tunables);
+        let mut func_env = FuncEnvironment::new(isa.frontend_config(), module, tunables);
 
         // We use these as constant offsets below in
         // `stack_limit_from_arguments`, so assert their values here. This

--- a/crates/environ/src/func_environ.rs
+++ b/crates/environ/src/func_environ.rs
@@ -1,6 +1,6 @@
-use crate::module::{MemoryPlan, MemoryStyle, ModuleLocal, TableStyle};
+use crate::module::{MemoryPlan, MemoryStyle, TableStyle};
 use crate::vmoffsets::VMOffsets;
-use crate::{Tunables, INTERRUPTED, WASM_PAGE_SIZE};
+use crate::{Module, Tunables, INTERRUPTED, WASM_PAGE_SIZE};
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::*;
@@ -203,7 +203,7 @@ pub struct FuncEnvironment<'module_environment> {
     target_config: TargetFrontendConfig,
 
     /// The module-level environment which this function-level environment belongs to.
-    module: &'module_environment ModuleLocal,
+    module: &'module_environment Module,
 
     /// The Cranelift global holding the vmctx address.
     vmctx: Option<ir::GlobalValue>,
@@ -220,7 +220,7 @@ pub struct FuncEnvironment<'module_environment> {
 impl<'module_environment> FuncEnvironment<'module_environment> {
     pub fn new(
         target_config: TargetFrontendConfig,
-        module: &'module_environment ModuleLocal,
+        module: &'module_environment Module,
         tunables: &'module_environment Tunables,
     ) -> Self {
         let builtin_function_signatures = BuiltinFunctionSignatures::new(

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -49,7 +49,7 @@ pub use crate::func_environ::BuiltinFunctionIndex;
 #[cfg(feature = "lightbeam")]
 pub use crate::lightbeam::Lightbeam;
 pub use crate::module::{
-    EntityIndex, MemoryPlan, MemoryStyle, Module, ModuleLocal, TableElements, TablePlan, TableStyle,
+    EntityIndex, MemoryPlan, MemoryStyle, Module, TableElements, TablePlan, TableStyle,
 };
 pub use crate::module_environ::*;
 pub use crate::tunables::Tunables;

--- a/crates/environ/src/lightbeam.rs
+++ b/crates/environ/src/lightbeam.rs
@@ -22,11 +22,11 @@ impl Compiler for Lightbeam {
         if translation.tunables.debug_info {
             return Err(CompileError::DebugInfoNotSupported);
         }
-        let func_index = translation.module.local.func_index(i);
+        let func_index = translation.module.func_index(i);
 
         let env = FuncEnvironment::new(
             isa.frontend_config(),
-            &translation.module.local,
+            &translation.module,
             &translation.tunables,
         );
         let mut codegen_session: CodeGenSession<_> = CodeGenSession::new(

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -146,12 +146,6 @@ pub struct Module {
     /// The name of this wasm module, often found in the wasm file.
     pub name: Option<String>,
 
-    /// Local information about a module which is the bare minimum necessary to
-    /// translate a function body. This is derived as `Hash` whereas this module
-    /// isn't, since it contains too much information needed to translate a
-    /// function.
-    pub local: ModuleLocal,
-
     /// All import records, in the order they are declared in the module.
     pub imports: Vec<(String, String, EntityIndex)>,
 
@@ -173,16 +167,7 @@ pub struct Module {
 
     /// WebAssembly table initializers.
     pub func_names: HashMap<FuncIndex, String>,
-}
 
-/// Local information known about a wasm module, the bare minimum necessary to
-/// translate function bodies.
-///
-/// This is stored within a `Module` and it implements `Hash`, unlike `Module`,
-/// and is used as part of the cache key when we load compiled modules from the
-/// global cache.
-#[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct ModuleLocal {
     /// Unprocessed signatures exactly as provided by `declare_signature()`.
     pub signatures: PrimaryMap<SignatureIndex, (WasmFuncType, ir::Signature)>,
 
@@ -224,17 +209,15 @@ impl Module {
             passive_elements: HashMap::new(),
             passive_data: HashMap::new(),
             func_names: HashMap::new(),
-            local: ModuleLocal {
-                num_imported_funcs: 0,
-                num_imported_tables: 0,
-                num_imported_memories: 0,
-                num_imported_globals: 0,
-                signatures: PrimaryMap::new(),
-                functions: PrimaryMap::new(),
-                table_plans: PrimaryMap::new(),
-                memory_plans: PrimaryMap::new(),
-                globals: PrimaryMap::new(),
-            },
+            num_imported_funcs: 0,
+            num_imported_tables: 0,
+            num_imported_memories: 0,
+            num_imported_globals: 0,
+            signatures: PrimaryMap::new(),
+            functions: PrimaryMap::new(),
+            table_plans: PrimaryMap::new(),
+            memory_plans: PrimaryMap::new(),
+            globals: PrimaryMap::new(),
         }
     }
 
@@ -247,9 +230,7 @@ impl Module {
         static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
         NEXT_ID.fetch_add(1, SeqCst)
     }
-}
 
-impl ModuleLocal {
     /// Convert a `DefinedFuncIndex` into a `FuncIndex`.
     pub fn func_index(&self, defined_func: DefinedFuncIndex) -> FuncIndex {
         FuncIndex::new(self.num_imported_funcs + defined_func.index())

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -19,7 +19,7 @@
 //      builtins: VMBuiltinFunctionsArray,
 // }
 
-use crate::module::ModuleLocal;
+use crate::module::Module;
 use crate::BuiltinFunctionIndex;
 use cranelift_codegen::ir;
 use cranelift_wasm::{
@@ -75,7 +75,7 @@ pub struct VMOffsets {
 
 impl VMOffsets {
     /// Return a new `VMOffsets` instance, for a given pointer size.
-    pub fn new(pointer_size: u8, module: &ModuleLocal) -> Self {
+    pub fn new(pointer_size: u8, module: &Module) -> Self {
         Self {
             pointer_size,
             num_signature_ids: cast_to_u32(module.signatures.len()),

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -72,7 +72,7 @@ fn transform_dwarf_data(
     funcs: &CompiledFunctions,
 ) -> Result<Vec<DwarfSection>, SetupError> {
     let target_config = isa.frontend_config();
-    let ofs = VMOffsets::new(target_config.pointer_bytes(), &module.local);
+    let ofs = VMOffsets::new(target_config.pointer_bytes(), &module);
 
     let memory_offset = if ofs.num_imported_memories > 0 {
         ModuleMemoryOffset::Imported(ofs.vmctx_vmmemory_import(MemoryIndex::new(0)))

--- a/crates/jit/src/imports.rs
+++ b/crates/jit/src/imports.rs
@@ -20,10 +20,10 @@ pub fn resolve_imports(
     signatures: &SignatureRegistry,
     resolver: &mut dyn Resolver,
 ) -> Result<Imports, LinkError> {
-    let mut function_imports = PrimaryMap::with_capacity(module.local.num_imported_funcs);
-    let mut table_imports = PrimaryMap::with_capacity(module.local.num_imported_tables);
-    let mut memory_imports = PrimaryMap::with_capacity(module.local.num_imported_memories);
-    let mut global_imports = PrimaryMap::with_capacity(module.local.num_imported_globals);
+    let mut function_imports = PrimaryMap::with_capacity(module.num_imported_funcs);
+    let mut table_imports = PrimaryMap::with_capacity(module.num_imported_tables);
+    let mut memory_imports = PrimaryMap::with_capacity(module.num_imported_memories);
+    let mut global_imports = PrimaryMap::with_capacity(module.num_imported_globals);
 
     for (import_idx, (module_name, field_name, import)) in module.imports.iter().enumerate() {
         let import_idx = import_idx.try_into().unwrap();
@@ -31,7 +31,7 @@ pub fn resolve_imports(
 
         match (import, &export) {
             (EntityIndex::Function(func_index), Some(Export::Function(f))) => {
-                let import_signature = module.local.native_func_signature(*func_index);
+                let import_signature = module.native_func_signature(*func_index);
                 let signature = signatures
                     .lookup_native(unsafe { f.anyfunc.as_ref().type_index })
                     .unwrap();
@@ -63,7 +63,7 @@ pub fn resolve_imports(
             }
 
             (EntityIndex::Table(table_index), Some(Export::Table(t))) => {
-                let import_table = &module.local.table_plans[*table_index];
+                let import_table = &module.table_plans[*table_index];
                 if !is_table_compatible(&t.table, import_table) {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: exported table incompatible with \
@@ -90,7 +90,7 @@ pub fn resolve_imports(
             }
 
             (EntityIndex::Memory(memory_index), Some(Export::Memory(m))) => {
-                let import_memory = &module.local.memory_plans[*memory_index];
+                let import_memory = &module.memory_plans[*memory_index];
                 if !is_memory_compatible(&m.memory, import_memory) {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: exported memory incompatible with \
@@ -131,7 +131,7 @@ pub fn resolve_imports(
             }
 
             (EntityIndex::Global(global_index), Some(Export::Global(g))) => {
-                let imported_global = module.local.globals[*global_index];
+                let imported_global = module.globals[*global_index];
                 if !is_global_compatible(&g.global, &imported_global) {
                     return Err(LinkError(format!(
                         "{}/{}: incompatible import type: exported global incompatible with \

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -256,7 +256,6 @@ impl CompiledModule {
         // Compute indices into the shared signature table.
         let signatures = {
             self.module
-                .local
                 .signatures
                 .values()
                 .map(|(wasm_sig, native)| {
@@ -387,7 +386,7 @@ fn create_dbg_image(
         .values()
         .map(|allocated: &*mut [VMFunctionBody]| (*allocated) as *const u8)
         .collect::<Vec<_>>();
-    create_gdbjit_image(obj, code_range, module.local.num_imported_funcs, &funcs)
+    create_gdbjit_image(obj, code_range, module.num_imported_funcs, &funcs)
         .map_err(SetupError::DebugInfo)
 }
 
@@ -417,7 +416,7 @@ fn build_code_memory(
         let fat_ptr: *mut [VMFunctionBody] = fat_ptr;
         assert_eq!(
             Some(finished_functions.push(fat_ptr)),
-            module.local.defined_func_index(i)
+            module.defined_func_index(i)
         );
     }
 

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -49,7 +49,7 @@ fn apply_reloc(
             match sym.name() {
                 Some(name) => {
                     if let Some(index) = try_parse_func_name(name) {
-                        match module.local.defined_func_index(index) {
+                        match module.defined_func_index(index) {
                             Some(f) => {
                                 let fatptr: *const [VMFunctionBody] = finished_functions[f];
                                 fatptr as *const VMFunctionBody as usize

--- a/crates/jit/src/object.rs
+++ b/crates/jit/src/object.rs
@@ -39,13 +39,13 @@ pub(crate) fn build_object(
     unwind_info.extend(funcs.iter().filter_map(|(index, func)| {
         func.unwind_info
             .as_ref()
-            .map(|info| ObjectUnwindInfo::Func(module.local.func_index(index), info.clone()))
+            .map(|info| ObjectUnwindInfo::Func(module.func_index(index), info.clone()))
     }));
 
-    let mut trampolines = PrimaryMap::with_capacity(module.local.signatures.len());
+    let mut trampolines = PrimaryMap::with_capacity(module.signatures.len());
     let mut cx = FunctionBuilderContext::new();
     // Build trampolines for every signature.
-    for (i, (_, native_sig)) in module.local.signatures.iter() {
+    for (i, (_, native_sig)) in module.signatures.iter() {
         let func = build_trampoline(isa, &mut cx, native_sig, std::mem::size_of::<u128>())?;
         // Preserve trampoline function unwind info.
         if let Some(info) = &func.unwind_info {

--- a/crates/obj/src/context.rs
+++ b/crates/obj/src/context.rs
@@ -18,14 +18,14 @@ pub fn layout_vmcontext(
     module: &Module,
     target_config: &TargetFrontendConfig,
 ) -> (Box<[u8]>, Box<[TableRelocation]>) {
-    let ofs = VMOffsets::new(target_config.pointer_bytes(), &module.local);
+    let ofs = VMOffsets::new(target_config.pointer_bytes(), &module);
     let out_len = ofs.size_of_vmctx() as usize;
     let mut out = vec![0; out_len];
 
     // Assign unique indices to unique signatures.
     let mut signature_registry = HashMap::new();
     let mut signature_registry_len = signature_registry.len();
-    for (index, sig) in module.local.signatures.iter() {
+    for (index, sig) in module.signatures.iter() {
         let offset = ofs.vmctx_vmshared_signature_id(index) as usize;
         let target_index = match signature_registry.entry(sig) {
             Entry::Occupied(o) => *o.get(),
@@ -42,10 +42,10 @@ pub fn layout_vmcontext(
         }
     }
 
-    let num_tables_imports = module.local.num_imported_tables;
-    let mut table_relocs = Vec::with_capacity(module.local.table_plans.len() - num_tables_imports);
-    for (index, table) in module.local.table_plans.iter().skip(num_tables_imports) {
-        let def_index = module.local.defined_table_index(index).unwrap();
+    let num_tables_imports = module.num_imported_tables;
+    let mut table_relocs = Vec::with_capacity(module.table_plans.len() - num_tables_imports);
+    for (index, table) in module.table_plans.iter().skip(num_tables_imports) {
+        let def_index = module.defined_table_index(index).unwrap();
         let offset = ofs.vmctx_vmtable_definition(def_index) as usize;
         let current_elements = table.table.minimum;
         unsafe {
@@ -66,9 +66,9 @@ pub fn layout_vmcontext(
         });
     }
 
-    let num_globals_imports = module.local.num_imported_globals;
-    for (index, global) in module.local.globals.iter().skip(num_globals_imports) {
-        let def_index = module.local.defined_global_index(index).unwrap();
+    let num_globals_imports = module.num_imported_globals;
+    for (index, global) in module.globals.iter().skip(num_globals_imports) {
+        let def_index = module.defined_global_index(index).unwrap();
         let offset = ofs.vmctx_vmglobal_definition(def_index) as usize;
         let to = unsafe { out.as_mut_ptr().add(offset) };
         match global.initializer {

--- a/crates/obj/src/module.rs
+++ b/crates/obj/src/module.rs
@@ -66,7 +66,7 @@ pub fn emit_module(
         declare_data_segment(&mut obj, initializer, i)?;
     }
 
-    for i in 0..module.local.table_plans.len() {
+    for i in 0..module.table_plans.len() {
         declare_table(&mut obj, i)?;
     }
 
@@ -74,7 +74,7 @@ pub fn emit_module(
         emit_data_segment(&mut obj, initializer, i)?;
     }
 
-    for i in 0..module.local.table_plans.len() {
+    for i in 0..module.table_plans.len() {
         emit_table(&mut obj, i)?;
     }
 

--- a/crates/profiling/src/lib.rs
+++ b/crates/profiling/src/lib.rs
@@ -72,7 +72,7 @@ impl ProfilingAgent for NullProfilerAgent {
 
 #[allow(dead_code)]
 fn debug_name(module: &Module, index: DefinedFuncIndex) -> String {
-    let index = module.local.func_index(index);
+    let index = module.func_index(index);
     match module.func_names.get(&index) {
         Some(s) => s.clone(),
         None => format!("wasm::wasm-function[{}]", index.index()),

--- a/crates/runtime/src/debug_builtins.rs
+++ b/crates/runtime/src/debug_builtins.rs
@@ -16,7 +16,7 @@ pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
     );
     let handle = InstanceHandle::from_vmctx(VMCTX_AND_MEMORY.0);
     assert!(
-        VMCTX_AND_MEMORY.1 < handle.module().local.memory_plans.len(),
+        VMCTX_AND_MEMORY.1 < handle.module().memory_plans.len(),
         "memory index for debugger is out of bounds"
     );
     let index = MemoryIndex::new(VMCTX_AND_MEMORY.1);

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -30,7 +30,7 @@ mod test_vmfunction_import {
     #[test]
     fn check_vmfunction_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMFunctionImport>(),
             usize::from(offsets.size_of_vmfunction_import())
@@ -86,7 +86,7 @@ mod test_vmtable_import {
     #[test]
     fn check_vmtable_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMTableImport>(),
             usize::from(offsets.size_of_vmtable_import())
@@ -124,7 +124,7 @@ mod test_vmmemory_import {
     #[test]
     fn check_vmmemory_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMMemoryImport>(),
             usize::from(offsets.size_of_vmmemory_import())
@@ -159,7 +159,7 @@ mod test_vmglobal_import {
     #[test]
     fn check_vmglobal_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMGlobalImport>(),
             usize::from(offsets.size_of_vmglobal_import())
@@ -194,7 +194,7 @@ mod test_vmmemory_definition {
     #[test]
     fn check_vmmemory_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMMemoryDefinition>(),
             usize::from(offsets.size_of_vmmemory_definition())
@@ -238,7 +238,7 @@ mod test_vmtable_definition {
     #[test]
     fn check_vmtable_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMTableDefinition>(),
             usize::from(offsets.size_of_vmtable_definition())
@@ -285,7 +285,7 @@ mod test_vmglobal_definition {
     #[test]
     fn check_vmglobal_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMGlobalDefinition>(),
             usize::from(offsets.size_of_vmglobal_definition())
@@ -295,7 +295,7 @@ mod test_vmglobal_definition {
     #[test]
     fn check_vmglobal_begins_aligned() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(offsets.vmctx_globals_begin() % 16, 0);
     }
 
@@ -471,7 +471,7 @@ mod test_vmshared_signature_index {
     #[test]
     fn check_vmshared_signature_index() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMSharedSignatureIndex>(),
             usize::from(offsets.size_of_vmshared_signature_index())
@@ -525,7 +525,7 @@ mod test_vmcaller_checked_anyfunc {
     #[test]
     fn check_vmcaller_checked_anyfunc_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMCallerCheckedAnyfunc>(),
             usize::from(offsets.size_of_vmcaller_checked_anyfunc())
@@ -629,7 +629,7 @@ mod test_vm_invoke_argument {
     #[test]
     fn check_vmglobal_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMInvokeArgument>(),
             usize::from(offsets.size_of_vmglobal_definition())
@@ -682,7 +682,7 @@ mod test_vminterrupts {
     #[test]
     fn check_vminterrupts_interrupted_offset() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module.local);
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             offset_of!(VMInterrupts, stack_limit),
             usize::from(offsets.vminterrupts_stack_limit())

--- a/crates/wasmtime/src/frame_info.rs
+++ b/crates/wasmtime/src/frame_info.rs
@@ -162,7 +162,7 @@ pub fn register(module: &CompiledModule) -> Option<GlobalFrameInfoRegistration> 
         max = cmp::max(max, end);
         let func = FunctionInfo {
             start,
-            index: module.module().local.func_index(i),
+            index: module.module().func_index(i),
             traps: traps.to_vec(),
             instr_map: address_map.clone(),
         };

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -31,7 +31,6 @@ pub(crate) fn create_handle(
 
     // Compute indices into the shared signature table.
     let signatures = module
-        .local
         .signatures
         .values()
         .map(|(wasm, native)| store.register_signature(wasm.clone(), native.clone()))

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -229,10 +229,9 @@ pub fn create_handle_with_function(
     // First up we manufacture a trampoline which has the ABI specified by `ft`
     // and calls into `stub_fn`...
     let sig_id = module
-        .local
         .signatures
         .push((ft.to_wasm_func_type(), sig.clone()));
-    let func_id = module.local.functions.push(sig_id);
+    let func_id = module.functions.push(sig_id);
     module
         .exports
         .insert("trampoline".to_string(), EntityIndex::Function(func_id));
@@ -289,10 +288,9 @@ pub unsafe fn create_handle_with_raw_function(
     let mut trampolines = HashMap::new();
 
     let sig_id = module
-        .local
         .signatures
         .push((ft.to_wasm_func_type(), sig.clone()));
-    let func_id = module.local.functions.push(sig_id);
+    let func_id = module.functions.push(sig_id);
     module
         .exports
         .insert("trampoline".to_string(), EntityIndex::Function(func_id));

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -37,11 +37,10 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
                 // our global with a `ref.func` to grab that imported function.
                 let shared_sig_index = f.sig_index();
                 let local_sig_index = module
-                    .local
                     .signatures
                     .push(store.lookup_wasm_and_native_signatures(shared_sig_index));
-                let func_index = module.local.functions.push(local_sig_index);
-                module.local.num_imported_funcs = 1;
+                let func_index = module.functions.push(local_sig_index);
+                module.num_imported_funcs = 1;
                 module
                     .imports
                     .push(("".into(), "".into(), EntityIndex::Function(func_index)));
@@ -59,7 +58,7 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
         },
     };
 
-    let global_id = module.local.globals.push(global);
+    let global_id = module.globals.push(global);
     module
         .exports
         .insert("global".to_string(), EntityIndex::Global(global_id));

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -24,7 +24,7 @@ pub fn create_handle_with_memory(
 
     let memory_plan =
         wasmtime_environ::MemoryPlan::for_memory(memory, &store.engine().config().tunables);
-    let memory_id = module.local.memory_plans.push(memory_plan);
+    let memory_id = module.memory_plans.push(memory_plan);
     module
         .exports
         .insert("memory".to_string(), EntityIndex::Memory(memory_id));

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -22,7 +22,7 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Stor
     let tunable = Default::default();
 
     let table_plan = wasmtime_environ::TablePlan::for_table(table, &tunable);
-    let table_id = module.local.table_plans.push(table_plan);
+    let table_id = module.table_plans.push(table_plan);
     module
         .exports
         .insert("table".to_string(), EntityIndex::Table(table_id));

--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -432,18 +432,16 @@ impl<'module> EntityType<'module> {
     ) -> EntityType<'module> {
         match entity_index {
             EntityIndex::Function(func_index) => {
-                let sig = module.local.wasm_func_type(*func_index);
+                let sig = module.wasm_func_type(*func_index);
                 EntityType::Function(&sig)
             }
             EntityIndex::Table(table_index) => {
-                EntityType::Table(&module.local.table_plans[*table_index].table)
+                EntityType::Table(&module.table_plans[*table_index].table)
             }
             EntityIndex::Memory(memory_index) => {
-                EntityType::Memory(&module.local.memory_plans[*memory_index].memory)
+                EntityType::Memory(&module.memory_plans[*memory_index].memory)
             }
-            EntityIndex::Global(global_index) => {
-                EntityType::Global(&module.local.globals[*global_index])
-            }
+            EntityIndex::Global(global_index) => EntityType::Global(&module.globals[*global_index]),
         }
     }
 


### PR DESCRIPTION
This was added long ago at this point to assist with caching, but
caching has moved to a different level such that this wonky second level
of a `Module` isn't necessary. This commit removes the `ModuleLocal`
type to simplify accessors and generally make it easier to work with.
