### PR TITLE
machinst x64: enable simd_const.wast spec test

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -181,6 +181,7 @@ fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str
 
     match (testsuite, testname) {
         ("simd", "simd_address") => return false,
+        ("simd", "simd_const") => return false,
         ("simd", "simd_f32x4_arith") => return false,
         ("simd", "simd_f32x4_cmp") => return false,
         ("simd", "simd_f64x2_arith") => return false,

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -380,6 +380,8 @@ pub enum SseOpcode {
     Movaps,
     Movapd,
     Movd,
+    Movdqa,
+    Movdqu,
     Movq,
     Movss,
     Movsd,
@@ -487,6 +489,8 @@ impl SseOpcode {
             | SseOpcode::Movq
             | SseOpcode::Movsd
             | SseOpcode::Movupd
+            | SseOpcode::Movdqa
+            | SseOpcode::Movdqu
             | SseOpcode::Mulpd
             | SseOpcode::Mulsd
             | SseOpcode::Orpd
@@ -571,6 +575,8 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Movaps => "movaps",
             SseOpcode::Movapd => "movapd",
             SseOpcode::Movd => "movd",
+            SseOpcode::Movdqa => "movdqa",
+            SseOpcode::Movdqu => "movdqu",
             SseOpcode::Movq => "movq",
             SseOpcode::Movss => "movss",
             SseOpcode::Movsd => "movsd",

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -634,6 +634,16 @@ impl fmt::Display for SseOpcode {
     }
 }
 
+/// This defines the ways a value can be extended: either signed- or zero-extension, or none for
+/// types that are not extended. Contrast with [ExtMode], which defines the widths from and to which
+/// values can be extended.
+#[derive(Clone, PartialEq)]
+pub enum ExtKind {
+    None,
+    SignExtend,
+    ZeroExtend,
+}
+
 /// These indicate ways of extending (widening) a value, using the Intel
 /// naming: B(yte) = u8, W(ord) = u16, L(ong)word = u32, Q(uad)word = u64
 #[derive(Clone, PartialEq)]

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1596,8 +1596,12 @@ pub(crate) fn emit(
             let rex = RexFlags::clear_w();
 
             let (prefix, opcode) = match op {
+                SseOpcode::Cvtss2sd => (LegacyPrefix::_F3, 0x0F5A),
+                SseOpcode::Cvtsd2ss => (LegacyPrefix::_F2, 0x0F5A),
                 SseOpcode::Movaps => (LegacyPrefix::None, 0x0F28),
                 SseOpcode::Movapd => (LegacyPrefix::_66, 0x0F28),
+                SseOpcode::Movdqa => (LegacyPrefix::_66, 0x0F6F),
+                SseOpcode::Movdqu => (LegacyPrefix::_F3, 0x0F6F),
                 SseOpcode::Movsd => (LegacyPrefix::_F2, 0x0F10),
                 SseOpcode::Movss => (LegacyPrefix::_F3, 0x0F10),
                 SseOpcode::Movups => (LegacyPrefix::None, 0x0F10),
@@ -1606,8 +1610,6 @@ pub(crate) fn emit(
                 SseOpcode::Sqrtpd => (LegacyPrefix::_66, 0x0F51),
                 SseOpcode::Sqrtss => (LegacyPrefix::_F3, 0x0F51),
                 SseOpcode::Sqrtsd => (LegacyPrefix::_F2, 0x0F51),
-                SseOpcode::Cvtss2sd => (LegacyPrefix::_F3, 0x0F5A),
-                SseOpcode::Cvtsd2ss => (LegacyPrefix::_F2, 0x0F5A),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
 
@@ -1839,10 +1841,14 @@ pub(crate) fn emit(
             srcloc,
         } => {
             let (prefix, opcode) = match op {
+                SseOpcode::Movaps => (LegacyPrefix::None, 0x0F29),
+                SseOpcode::Movapd => (LegacyPrefix::_66, 0x0F29),
+                SseOpcode::Movdqa => (LegacyPrefix::_66, 0x0F7F),
+                SseOpcode::Movdqu => (LegacyPrefix::_F3, 0x0F7F),
                 SseOpcode::Movss => (LegacyPrefix::_F3, 0x0F11),
                 SseOpcode::Movsd => (LegacyPrefix::_F2, 0x0F11),
-                SseOpcode::Movaps => (LegacyPrefix::None, 0x0F29),
                 SseOpcode::Movups => (LegacyPrefix::None, 0x0F11),
+                SseOpcode::Movupd => (LegacyPrefix::_66, 0x0F11),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
             let dst = &dst.finalize(state);


### PR DESCRIPTION
This change enables the `simd_const.wast` spec test and adds encodings for integer vectors and new `Inst::[move|load|store]` utility functions.

Before merging:
 - [x] this should be rebased on @jlb6740's integer arithmetic changes since `simd_const.wast` contains a single use each of `i64x2.add` and `i32x4.add`
 - [x] I would like feedback on what others think about the `Inst::[move|load|store]` utility functions: are they the right level of abstraction? Is the de-duplication of code worth the overhead? Should we remove `Inst::xmm_mov` (and/or others)?