### PR TITLE
Temporarily disable new x64 backend CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,45 +269,6 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-  # Perform all tests (debug mode) for `wasmtime` with the experimental x64
-  # backend. This runs on the nightly channel of Rust (because of issues with
-  # unifying Cargo features on stable) on Ubuntu.
-  test_x64:
-    name: Test x64 new backend
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-      with:
-        toolchain: nightly-2020-07-27
-    - uses: ./.github/actions/define-llvm-env
-
-    # Install wasm32 targets in order to build various tests throughout the
-    # repo
-    - run: rustup target add wasm32-wasi
-    - run: rustup target add wasm32-unknown-unknown
-
-    # Build and test all features except for lightbeam
-    - run: |
-        cargo \
-            -Zfeatures=all -Zpackage-features \
-            test \
-            --features test-programs/test_programs \
-            --features experimental_x64 \
-            --all \
-            --exclude lightbeam \
-            --exclude peepmatic \
-            --exclude peepmatic-automata \
-            --exclude peepmatic-fuzzing \
-            --exclude peepmatic-macro \
-            --exclude peepmatic-runtime \
-            --exclude peepmatic-test
-      env:
-        RUST_BACKTRACE: 1
-
-
   # Verify that cranelift's code generation is deterministic
   meta_determinist_check:
     name: Meta deterministic check


### PR DESCRIPTION
This CI test has been intermittently failing, which is causing issues
with other PRs. We should turn it back off until we can work out why the
intermittent failures are occuring.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
