### PR TITLE
test_debug_parse_expressions: improve expression! macro

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -697,6 +697,34 @@ mod tests {
                 need_deref: true
             }
         );
+
+        let e = expression!(
+            DW_OP_WASM_location,
+            0x0,
+            1,
+            DW_OP_plus_uconst,
+            5,
+            DW_OP_deref,
+            DW_OP_stack_value
+        );
+        let ce = compile_expression(&e, DWARF_ENCODING, None)
+            .expect("non-error")
+            .expect("expression");
+        assert_eq!(
+            ce,
+            CompiledExpression {
+                parts: vec![
+                    CompiledExpressionPart::Local {
+                        label: val1,
+                        trailing: false
+                    },
+                    CompiledExpressionPart::Code(vec![35, 5]),
+                    CompiledExpressionPart::Deref,
+                    CompiledExpressionPart::Code(vec![6, 159])
+                ],
+                need_deref: false
+            }
+        );
     }
 
     fn create_mock_address_transform() -> AddressTransform {

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -600,13 +600,19 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
 mod tests {
     use super::compile_expression;
     use super::{AddressTransform, FunctionFrameInfo, ValueLabel, ValueLabelsRanges};
-    use gimli::{self, Encoding, EndianSlice, Expression, RunTimeEndian};
+    use gimli::{self, constants, Encoding, EndianSlice, Expression, RunTimeEndian};
     use wasmtime_environ::CompiledFunction;
 
+    macro_rules! dw_op {
+        (DW_OP_WASM_location) => { 0xed };
+        ($i:literal) => { $i };
+        ($d:ident) => { constants::$d.0 as u8 }
+    }
+
     macro_rules! expression {
-        ($($i:literal),*) => {
+        ($($t:tt),*) => {
             Expression(EndianSlice::new(
-                &[$($i),*],
+                &[$(dw_op!($t)),*],
                 RunTimeEndian::Little,
             ))
         }

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -604,9 +604,15 @@ mod tests {
     use wasmtime_environ::CompiledFunction;
 
     macro_rules! dw_op {
-        (DW_OP_WASM_location) => { 0xed };
-        ($i:literal) => { $i };
-        ($d:ident) => { constants::$d.0 as u8 }
+        (DW_OP_WASM_location) => {
+            0xed
+        };
+        ($i:literal) => {
+            $i
+        };
+        ($d:ident) => {
+            constants::$d.0 as u8
+        };
     }
 
     macro_rules! expression {
@@ -646,7 +652,14 @@ mod tests {
             }
         );
 
-        let e = expression!(DW_OP_WASM_location, 0x0, 1, DW_OP_plus_uconst, 0x10, DW_OP_stack_value);
+        let e = expression!(
+            DW_OP_WASM_location,
+            0x0,
+            1,
+            DW_OP_plus_uconst,
+            0x10,
+            DW_OP_stack_value
+        );
         let ce = compile_expression(&e, DWARF_ENCODING, None)
             .expect("non-error")
             .expect("expression");

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -631,8 +631,7 @@ mod tests {
 
         let (val1, val3, val20) = (ValueLabel::new(1), ValueLabel::new(3), ValueLabel::new(20));
 
-        // DW_OP_WASM_location 0x0 +20, DW_OP_stack_value
-        let e = expression!(0xed, 0x00, 0x14, 0x9f);
+        let e = expression!(DW_OP_WASM_location, 0x0, 20, DW_OP_stack_value);
         let ce = compile_expression(&e, DWARF_ENCODING, None)
             .expect("non-error")
             .expect("expression");
@@ -647,8 +646,7 @@ mod tests {
             }
         );
 
-        //  DW_OP_WASM_location 0x0 +1, DW_OP_plus_uconst 0x10, DW_OP_stack_value
-        let e = expression!(0xed, 0x00, 0x01, 0x23, 0x10, 0x9f);
+        let e = expression!(DW_OP_WASM_location, 0x0, 1, DW_OP_plus_uconst, 0x10, DW_OP_stack_value);
         let ce = compile_expression(&e, DWARF_ENCODING, None)
             .expect("non-error")
             .expect("expression");
@@ -666,8 +664,7 @@ mod tests {
             }
         );
 
-        // Frame base: DW_OP_WASM_location 0x0 +3, DW_OP_stack_value
-        let e = expression!(0xed, 0x00, 0x03, 0x9f);
+        let e = expression!(DW_OP_WASM_location, 0x0, 3, DW_OP_stack_value);
         let fe = compile_expression(&e, DWARF_ENCODING, None).expect("non-error");
         // DW_OP_fpreg 0x12
         let e = expression!(0x91, 0x12);

--- a/crates/debug/src/transform/utils.rs
+++ b/crates/debug/src/transform/utils.rs
@@ -10,7 +10,7 @@ use wasmtime_environ::{CompiledFunctions, ModuleMemoryOffset};
 /// WasmtimeVMContext.
 ///
 /// For unwrapping Wasm pointer, the WasmtimeVMContext has the `set()` method
-/// that allows to contol current Wasm memory to inspect.
+/// that allows to control current Wasm memory to inspect.
 /// Notice that "set_vmctx_memory" is an external/builtin subprogram that
 /// is not part of Wasm code.
 pub(crate) fn add_internal_types(


### PR DESCRIPTION
Provide automatic translation to opcodes from `DW_OP_*` identifiers. They are looked up from `gimli`.
Since `DW_OP_WASM_location` is not contained in `gimli` yet, we take care of manually translating it.

Since the `let e =` definitions now contain the same information as the separate comments previously, we can zap the comments now.

The macros could be improved to handle multi-argument opcodes.