### PR TITLE
Make spectest fuzzing more deterministic

### DIFF
--- a/crates/fuzzing/build.rs
+++ b/crates/fuzzing/build.rs
@@ -13,9 +13,12 @@ fn main() {
         .unwrap()
         .join("../../tests/spec_testsuite");
     let mut code = format!("static FILES: &[(&str, &str)] = &[\n");
-    for entry in dir.read_dir().unwrap() {
-        let entry = entry.unwrap();
-        let path = entry.path().display().to_string();
+    let entries = dir
+        .read_dir()
+        .unwrap()
+        .map(|p| p.unwrap().path().display().to_string())
+        .collect::<Vec<_>>();
+    for path in entries {
         if !path.ends_with(".wast") {
             continue;
         }


### PR DESCRIPTION
Currently spectest fuzzing indexes into a compile-time-created array of
strings which is the list of input files, but the order of this array is
dependent on the filesystem that we're reading from. This means that
inputs from oss-fuzz may not be easily reproducible locally because
files could be read in different orders, so indexes could be distinct.

This commit instead reads the directory paths, then sorts them, then
includes them for testing. That way fuzz inputs at a specific commit
should be consistent.
