### PR TITLE
DW_TAG_enumerator is owned by parent tag

### DIFF
--- a/crates/debug/src/gc.rs
+++ b/crates/debug/src/gc.rs
@@ -101,6 +101,7 @@ fn has_die_back_edge<R: Reader<Offset = usize>>(die: &read::DebuggingInformation
         | constants::DW_TAG_try_block
         | constants::DW_TAG_catch_block
         | constants::DW_TAG_template_type_parameter
+        | constants::DW_TAG_enumerator
         | constants::DW_TAG_member
         | constants::DW_TAG_formal_parameter => true,
         _ => false,


### PR DESCRIPTION
so mark it as such for GC to not accidentally lose it.

Fixes #2105.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
