### PR TITLE
Caller get_export() implemented for Extern::Func.

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1482,17 +1482,19 @@ impl Caller<'_> {
                     // custom host data. This function should only be invoke-able while
                     // the `Store` is active, so this upgrade should always succeed.
                     debug_assert!(self.store.upgrade().is_some());
-                    let handle = Store::from_inner(self.store.upgrade()?).existing_instance_handle(instance);
+                    let handle =
+                        Store::from_inner(self.store.upgrade()?).existing_instance_handle(instance);
                     let mem = Memory::from_wasmtime_memory(m, handle);
-                    return Some(Extern::Memory(mem));
-                },
+                    Some(Extern::Memory(mem))
+                }
                 Some(Export::Function(f)) => {
                     debug_assert!(self.store.upgrade().is_some());
-                    let handle = Store::from_inner(self.store.upgrade()?).existing_instance_handle(instance);
+                    let handle =
+                        Store::from_inner(self.store.upgrade()?).existing_instance_handle(instance);
                     let func = Func::from_wasmtime_function(f, handle);
-                    return Some(Extern::Func(func));
-                },
-                _ => return None,
+                    Some(Extern::Func(func))
+                }
+                _ => None,
             }
         }
     }

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -409,7 +409,7 @@ fn caller_memory() -> anyhow::Result<()> {
 
     let f = Func::wrap(&store, |c: Caller<'_>| {
         assert!(c.get_export("m").is_some());
-        assert!(c.get_export("f").is_none());
+        assert!(c.get_export("f").is_some());
         assert!(c.get_export("g").is_none());
         assert!(c.get_export("t").is_none());
     });


### PR DESCRIPTION
To my knowledge, this has not been discussed in an issue. However, comments in the overwritten code make clear that the get_export() function is only currently implemented for Extern::Memory, with potential future support for Extern::Func - which is the update of this PR. This update simply enables user to lookup and return Extern::Func types from Caller structure.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
