### PR TITLE
Don't GC DW_TAG_variant(_part), they are referenced by their respective parents

### DIFF
--- a/crates/debug/src/gc.rs
+++ b/crates/debug/src/gc.rs
@@ -103,6 +103,8 @@ fn has_die_back_edge<R: Reader<Offset = usize>>(die: &read::DebuggingInformation
         | constants::DW_TAG_template_type_parameter
         | constants::DW_TAG_enumerator
         | constants::DW_TAG_member
+        | constants::DW_TAG_variant_part
+        | constants::DW_TAG_variant
         | constants::DW_TAG_formal_parameter => true,
         _ => false,
     }


### PR DESCRIPTION
This goes analogously to #2107.

- `DW_TAG_variant` is referenced by parent `DW_TAG_variant_part`
- `DW_TAG_variant_part` is referenced by parent `DW_TAG_structure_type`

Here is a random example from the debug build directory (of `wasmtime` itself):

``` rust
0x00000635:       DW_TAG_structure_type
                    DW_AT_name ("Option<usize>")
                    DW_AT_byte_size    (0x10)
                    DW_AT_alignment    (8)

0x0000063c:         DW_TAG_variant_part
                      DW_AT_discr      (0x00000641)

0x00000641:           DW_TAG_member
                        DW_AT_type     (0x000006c7 "u64")
                        DW_AT_alignment        (8)
                        DW_AT_data_member_location     (DW_OP_plus_uconst 0x0)
                        DW_AT_artificial       (0x01)

0x0000064b:           DW_TAG_variant
                        DW_AT_discr_value      (0x00)

0x0000064d:             DW_TAG_member
                          DW_AT_name   ("None")
                          DW_AT_type   (0x0000066c "None")
                          DW_AT_alignment      (8)
                          DW_AT_data_member_location   (DW_OP_plus_uconst 0x0)

0x0000065a:             NULL

0x0000065b:           DW_TAG_variant
                        DW_AT_discr_value      (0x01)

0x0000065d:             DW_TAG_member
                          DW_AT_name   ("Some")
                          DW_AT_type   (0x0000067d "Some")
                          DW_AT_alignment      (8)
                          DW_AT_data_member_location   (DW_OP_plus_uconst 0x0)

0x0000066a:             NULL

0x0000066b:           NULL
```
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
