### PR TITLE
Wasm translation bugfix: properly clean up value stack for else-branch when if-branch ends in unreachable.

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1888,13 +1888,21 @@ fn translate_unreachable_operator<FE: FuncEnvironment + ?Sized>(
                                 let (params, _results) =
                                     blocktype_params_results(module_translation_state, blocktype)?;
                                 let else_block = block_with_params(builder, params, environ)?;
+                                state.stack.truncate(
+                                    state.control_stack.last().unwrap().original_stack_size(),
+                                );
 
                                 // We change the target of the branch instruction.
                                 builder.change_jump_destination(branch_inst, else_block);
                                 builder.seal_block(else_block);
                                 else_block
                             }
-                            ElseData::WithElse { else_block } => else_block,
+                            ElseData::WithElse { else_block } => {
+                                state.stack.truncate(
+                                    state.control_stack.last().unwrap().original_stack_size(),
+                                );
+                                else_block
+                            }
                         };
 
                         builder.switch_to_block(else_block);

--- a/cranelift/wasmtests/if-unreachable-else-params.wat
+++ b/cranelift/wasmtests/if-unreachable-else-params.wat
@@ -1,0 +1,41 @@
+(module
+  (type (;0;) (func (param i32)))
+  (func $main (type 0) (param i32)
+    i32.const 35
+    loop (param i32)  ;; label = @1
+      local.get 0
+      if (param i32)  ;; label = @2
+        i64.load16_s align=1
+        unreachable
+        unreachable
+        unreachable
+        unreachable
+        unreachable
+        local.get 0
+        unreachable
+        unreachable
+        i64.load8_u offset=11789
+        unreachable
+      else
+        i32.popcnt
+        local.set 0
+        return
+        unreachable
+      end
+      unreachable
+      unreachable
+      nop
+      f32.lt
+      i32.store8 offset=82
+      unreachable
+    end
+    unreachable
+    unreachable
+    unreachable
+    unreachable)
+  (table (;0;) 63 255 funcref)
+  (memory (;0;) 13 16)
+  (export "t1" (table 0))
+  (export "m1" (memory 0))
+  (export "main" (func $main))
+  (export "memory" (memory 0)))


### PR DESCRIPTION
The Wasm translation handles unreachable code sections
specially, skipping ops until the end of a block and a control-flow
merger at which code becomes reachable again. Unfortunately, while the
ordinary else-op handler properly sets up the value stack for the
else-branch with the parameters to the if/else, the unreachable-case
else-op handler did not. This resulted in a bad translation and CLIF
type error despite valid Wasm.

Found via fuzzing by :decoder in
https://bugzilla.mozilla.org/show_bug.cgi?id=1657895.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
