### PR TITLE
Fix execution of spectest fuzzer

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -406,7 +406,10 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
 pub fn spectest(config: crate::generators::Config, test: crate::generators::SpecTest) {
     crate::init_fuzzing();
     log::debug!("running {:?} with {:?}", test.file, config);
-    let store = Store::new(&Engine::new(&config.to_wasmtime()));
+    let mut config = config.to_wasmtime();
+    config.wasm_reference_types(false);
+    config.wasm_bulk_memory(false);
+    let store = Store::new(&Engine::new(&config));
     let mut wast_context = WastContext::new(store);
     wast_context.register_spectest().unwrap();
     wast_context


### PR DESCRIPTION
We've enabled bulk memory and reference types by default now which means
that wasmtime in its default settings no longer passes the spec test
suite (due to changes in error messages in initialization), so when
we're running the spec test fuzzer be sure to disable reference types
and bulk memory since that's required to pass.

