### PR TITLE
Update error message for bad table init

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1300,7 +1300,7 @@ fn initialize_tables(instance: &Instance) -> Result<(), InstantiationError> {
             .map_or(true, |end| end > table.size() as usize)
         {
             return Err(InstantiationError::Trap(Trap::wasm(
-                ir::TrapCode::HeapOutOfBounds,
+                ir::TrapCode::TableOutOfBounds,
             )));
         }
 


### PR DESCRIPTION
Although the string description for `TableOutOfBounds` isn't quite
matching what this error case is, it's a bit more descriptive than
`HeapOutOfBounds` anyway.
