### PR TITLE
Refactor AArch64 ABI support to extract common bits for shared impl with x64.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1,145 +1,28 @@
-//! Implementation of the standard AArch64 ABI.
-//!
-//! We implement the standard AArch64 ABI, as documented by ARM. This ABI
-//! specifies how arguments are passed (in registers or on the stack, as
-//! appropriate), which registers are caller- and callee-saved, and how a
-//! particular part of the stack frame (the FP/LR pair) must be linked through
-//! the active stack frames.
-//!
-//! Note, however, that the exact stack layout is up to us. We settled on the
-//! below design based on several requirements. In particular, we need to be
-//! able to generate instructions (or instruction sequences) to access
-//! arguments, stack slots, and spill slots before we know how many spill slots
-//! or clobber-saves there will be, because of our pass structure. We also
-//! prefer positive offsets to negative offsets because of an asymmetry in
-//! AArch64 addressing modes (positive offsets have a larger possible range
-//! without a long-form sequence to synthesize an arbitrary offset). Finally, it
-//! is not allowed to access memory below the current SP value.
-//!
-//! As a result, we keep the FP/LR pair just below stack args so that we can
-//! access these args at known offsets from FP, and we access on-stack storage
-//! using positive offsets from SP. In order to allow codegen for the latter
-//! before knowing how many clobber-saves we have, and also allow it while SP is
-//! being adjusted to set up a call, we implement a "nominal SP" tracking
-//! feature by which a fixup (distance between actual SP and a "nominal" SP) is
-//! known at each instruction. See the documentation for
-//! `MemArg::NominalSPOffset` for more on this.
-//!
-//! The stack looks like:
-//!
-//! ```plain
-//!   (high address)
-//!
-//!                              +---------------------------+
-//!                              |          ...              |
-//!                              | stack args                |
-//!                              | (accessed via FP)         |
-//!                              +---------------------------+
-//! SP at function entry ----->  | LR (pushed by prologue)   |
-//!                              +---------------------------+
-//! FP after prologue -------->  | FP (pushed by prologue)   |
-//!                              +---------------------------+
-//!                              |          ...              |
-//!                              | spill slots               |
-//!                              | (accessed via nominal-SP) |
-//!                              |          ...              |
-//!                              | stack slots               |
-//!                              | (accessed via nominal-SP) |
-//! nominal SP --------------->  | (alloc'd by prologue)     |
-//!                              +---------------------------+
-//!                              |          ...              |
-//!                              | clobbered callee-saves    |
-//! SP at end of prologue ---->  | (pushed by prologue)      |
-//!                              +---------------------------+
-//!                              |          ...              |
-//!                              | args for call             |
-//! SP before making a call -->  | (pushed at callsite)      |
-//!                              +---------------------------+
-//!
-//!   (low address)
-//! ```
-//!
-//! # Multi-value Returns
-//!
-//! Note that we support multi-value returns by adopting the SpiderMonkey Wasm
-//! ABI internally. Because we do not support linking with externally-compiled
-//! multi-value-returning functions (yet), this choice is arbitrary and we are
-//! free to make it as we please. Wasmtime generates trampolines to enter
-//! toplevel multi-value-returning functions, so this does not concern the
-//! Wasmtime embedding.
-//!
-//! For details of the multi-value return ABI, see:
-//!
-//! https://searchfox.org/mozilla-central/rev/bc3600def806859c31b2c7ac06e3d69271052a89/js/src/wasm/WasmStubs.h#134
-//!
-//! In brief:
-//! - Return values are processed in *reverse* order.
-//! - The first return value in this order (so the last return) goes into the
-//!   ordinary return register, X0.
-//! - Any further returns go in a struct-return area, allocated upwards (in
-//!   address order) during the reverse traversal.
-//! - This struct-return area is provided by the caller, and a pointer to its
-//!   start is passed as an invisible last (extra) argument. Normally the caller
-//!   will allocate this area on the stack. When we generate calls, we place it
-//!   just above the on-stack argument area.
-//! - So, for example, a function returning 4 i64's (v0, v1, v2, v3), with no
-//!   formal arguments, would:
-//!   - Accept a pointer P to the struct return area in x0 on entry.
-//!   - Return v3 in x0.
-//!   - Return v2 in memory at `[P]`.
-//!   - Return v1 in memory at `[P+8]`.
-//!   - Return v0 in memory at `[P+16]`.
+//! Implementation of a standard AArch64 ABI.
 
-use crate::binemit::StackMap;
 use crate::ir;
 use crate::ir::types;
 use crate::ir::types::*;
-use crate::ir::{ArgumentExtension, StackSlot};
+use crate::ir::SourceLoc;
 use crate::isa;
-use crate::isa::aarch64::{inst::EmitState, inst::*, lower::ty_bits};
+use crate::isa::aarch64::{inst::EmitState, inst::*};
 use crate::machinst::*;
 use crate::settings;
 use crate::{CodegenError, CodegenResult};
-
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use regalloc::{RealReg, Reg, RegClass, Set, Writable};
+use smallvec::SmallVec;
+use std::convert::TryFrom;
 
-use regalloc::{RealReg, Reg, RegClass, Set, SpillSlot, Writable};
+// We use a generic implementation that factors out AArch64 and x64 ABI commonalities, because
+// these ABIs are very similar.
 
-use core::mem;
-use log::{debug, trace};
+/// Support for the AArch64 ABI from the callee side (within a function body).
+pub type AArch64ABIBody = ABIBodyImpl<AArch64MachineImpl>;
 
-/// A location for an argument or return value.
-#[derive(Clone, Copy, Debug)]
-enum ABIArg {
-    /// In a real register.
-    Reg(RealReg, ir::Type, ir::ArgumentExtension),
-    /// Arguments only: on stack, at given offset from SP at entry.
-    Stack(i64, ir::Type, ir::ArgumentExtension),
-}
-
-/// AArch64 ABI information shared between body (callee) and caller.
-struct ABISig {
-    /// Argument locations (regs or stack slots). Stack offsets are relative to
-    /// SP on entry to function.
-    args: Vec<ABIArg>,
-    /// Return-value locations. Stack offsets are relative to the return-area
-    /// pointer.
-    rets: Vec<ABIArg>,
-    /// Space on stack used to store arguments.
-    stack_arg_space: i64,
-    /// Space on stack used to store return values.
-    stack_ret_space: i64,
-    /// Index in `args` of the stack-return-value-area argument.
-    stack_ret_arg: Option<usize>,
-    /// Calling convention used.
-    call_conv: isa::CallConv,
-}
-
-/// This is the limit for the size of argument and return-value areas on the
-/// stack. We place a reasonable limit here to avoid integer overflow issues
-/// with 32-bit arithmetic: for now, 128 MB.
-static STACK_ARG_RET_SIZE_LIMIT: u64 = 128 * 1024 * 1024;
+/// Support for the AArch64 ABI from the caller side (at a callsite).
+pub type AArch64ABICall = ABICallImpl<AArch64MachineImpl>;
 
 // Spidermonkey specific ABI convention.
 
@@ -178,6 +61,11 @@ static BALDRDASH_JIT_CALLEE_SAVED_FPU: &[bool] = &[
     /* 24 = */ false, false, false, false, false, false, false, true /* v31 / d31 */
 ];
 
+/// This is the limit for the size of argument and return-value areas on the
+/// stack. We place a reasonable limit here to avoid integer overflow issues
+/// with 32-bit arithmetic: for now, 128 MB.
+static STACK_ARG_RET_SIZE_LIMIT: u64 = 128 * 1024 * 1024;
+
 /// Try to fill a Baldrdash register, returning it if it was found.
 fn try_fill_baldrdash_reg(call_conv: isa::CallConv, param: &ir::AbiParam) -> Option<ABIArg> {
     if call_conv.extends_baldrdash() {
@@ -205,373 +93,148 @@ fn try_fill_baldrdash_reg(call_conv: isa::CallConv, param: &ir::AbiParam) -> Opt
     }
 }
 
-/// Are we computing information about arguments or return values? Much of the
-/// handling is factored out into common routines; this enum allows us to
-/// distinguish which case we're handling.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ArgsOrRets {
-    Args,
-    Rets,
+impl Into<AMode> for StackAMode {
+    fn into(self) -> AMode {
+        match self {
+            StackAMode::FPOffset(off, ty) => AMode::FPOffset(off, ty),
+            StackAMode::NominalSPOffset(off, ty) => AMode::NominalSPOffset(off, ty),
+            StackAMode::SPOffset(off, ty) => AMode::SPOffset(off, ty),
+        }
+    }
 }
 
-/// Process a list of parameters or return values and allocate them to X-regs,
-/// V-regs, and stack slots.
-///
-/// Returns the list of argument locations, the stack-space used (rounded up
-/// to a 16-byte-aligned boundary), and if `add_ret_area_ptr` was passed, the
-/// index of the extra synthetic arg that was added.
-fn compute_arg_locs(
-    call_conv: isa::CallConv,
-    params: &[ir::AbiParam],
-    args_or_rets: ArgsOrRets,
-    add_ret_area_ptr: bool,
-) -> CodegenResult<(Vec<ABIArg>, i64, Option<usize>)> {
-    let is_baldrdash = call_conv.extends_baldrdash();
+/// AArch64-specific ABI behavior. This struct just serves as an implementation
+/// point for the trait; it is never actually instantiated.
+pub struct AArch64MachineImpl;
 
-    // See AArch64 ABI (https://c9x.me/compile/bib/abi-arm64.pdf), sections 5.4.
-    let mut next_xreg = 0;
-    let mut next_vreg = 0;
-    let mut next_stack: u64 = 0;
-    let mut ret = vec![];
+impl ABIMachineImpl for AArch64MachineImpl {
+    type I = Inst;
 
-    let max_reg_vals = match (args_or_rets, is_baldrdash) {
-        (ArgsOrRets::Args, _) => 8,     // x0-x7, v0-v7
-        (ArgsOrRets::Rets, false) => 8, // x0-x7, v0-v7
-        (ArgsOrRets::Rets, true) => 1,  // x0 or v0
-    };
+    fn compute_arg_locs(
+        call_conv: isa::CallConv,
+        params: &[ir::AbiParam],
+        args_or_rets: ArgsOrRets,
+        add_ret_area_ptr: bool,
+    ) -> CodegenResult<(Vec<ABIArg>, i64, Option<usize>)> {
+        let is_baldrdash = call_conv.extends_baldrdash();
 
-    for i in 0..params.len() {
-        // Process returns backward, according to the SpiderMonkey ABI (which we
-        // adopt internally if `is_baldrdash` is set).
-        let param = match (args_or_rets, is_baldrdash) {
-            (ArgsOrRets::Args, _) => &params[i],
-            (ArgsOrRets::Rets, false) => &params[i],
-            (ArgsOrRets::Rets, true) => &params[params.len() - 1 - i],
+        // See AArch64 ABI (https://c9x.me/compile/bib/abi-arm64.pdf), sections 5.4.
+        let mut next_xreg = 0;
+        let mut next_vreg = 0;
+        let mut next_stack: u64 = 0;
+        let mut ret = vec![];
+
+        let max_reg_vals = match (args_or_rets, is_baldrdash) {
+            (ArgsOrRets::Args, _) => 8,     // x0-x7, v0-v7
+            (ArgsOrRets::Rets, false) => 8, // x0-x7, v0-v7
+            (ArgsOrRets::Rets, true) => 1,  // x0 or v0
         };
 
-        // Validate "purpose".
-        match &param.purpose {
-            &ir::ArgumentPurpose::VMContext
-            | &ir::ArgumentPurpose::Normal
-            | &ir::ArgumentPurpose::StackLimit
-            | &ir::ArgumentPurpose::SignatureId => {}
-            _ => panic!(
-                "Unsupported argument purpose {:?} in signature: {:?}",
-                param.purpose, params
-            ),
-        }
-
-        let intreg = in_int_reg(param.value_type);
-        let vecreg = in_vec_reg(param.value_type);
-        debug_assert!(intreg || vecreg);
-        debug_assert!(!(intreg && vecreg));
-
-        let next_reg = if intreg {
-            &mut next_xreg
-        } else {
-            &mut next_vreg
-        };
-
-        if let Some(param) = try_fill_baldrdash_reg(call_conv, param) {
-            assert!(intreg);
-            ret.push(param);
-        } else if *next_reg < max_reg_vals {
-            let reg = if intreg {
-                xreg(*next_reg)
-            } else {
-                vreg(*next_reg)
+        for i in 0..params.len() {
+            // Process returns backward, according to the SpiderMonkey ABI (which we
+            // adopt internally if `is_baldrdash` is set).
+            let param = match (args_or_rets, is_baldrdash) {
+                (ArgsOrRets::Args, _) => &params[i],
+                (ArgsOrRets::Rets, false) => &params[i],
+                (ArgsOrRets::Rets, true) => &params[params.len() - 1 - i],
             };
-            ret.push(ABIArg::Reg(
-                reg.to_real_reg(),
-                param.value_type,
-                param.extension,
-            ));
-            *next_reg += 1;
-        } else {
-            // Compute size. Every arg takes a minimum slot of 8 bytes. (16-byte
-            // stack alignment happens separately after all args.)
-            let size = (ty_bits(param.value_type) / 8) as u64;
-            let size = std::cmp::max(size, 8);
-            // Align.
-            debug_assert!(size.is_power_of_two());
-            next_stack = (next_stack + size - 1) & !(size - 1);
-            ret.push(ABIArg::Stack(
-                next_stack as i64,
-                param.value_type,
-                param.extension,
-            ));
-            next_stack += size;
-        }
-    }
 
-    if args_or_rets == ArgsOrRets::Rets && is_baldrdash {
-        ret.reverse();
-    }
-
-    let extra_arg = if add_ret_area_ptr {
-        debug_assert!(args_or_rets == ArgsOrRets::Args);
-        if next_xreg < max_reg_vals {
-            ret.push(ABIArg::Reg(
-                xreg(next_xreg).to_real_reg(),
-                I64,
-                ir::ArgumentExtension::None,
-            ));
-        } else {
-            ret.push(ABIArg::Stack(
-                next_stack as i64,
-                I64,
-                ir::ArgumentExtension::None,
-            ));
-            next_stack += 8;
-        }
-        Some(ret.len() - 1)
-    } else {
-        None
-    };
-
-    next_stack = (next_stack + 15) & !15;
-
-    // To avoid overflow issues, limit the arg/return size to something
-    // reasonable -- here, 128 MB.
-    if next_stack > STACK_ARG_RET_SIZE_LIMIT {
-        return Err(CodegenError::ImplLimitExceeded);
-    }
-
-    Ok((ret, next_stack as i64, extra_arg))
-}
-
-impl ABISig {
-    fn from_func_sig(sig: &ir::Signature) -> CodegenResult<ABISig> {
-        // Compute args and retvals from signature. Handle retvals first,
-        // because we may need to add a return-area arg to the args.
-        let (rets, stack_ret_space, _) = compute_arg_locs(
-            sig.call_conv,
-            &sig.returns,
-            ArgsOrRets::Rets,
-            /* extra ret-area ptr = */ false,
-        )?;
-        let need_stack_return_area = stack_ret_space > 0;
-        let (args, stack_arg_space, stack_ret_arg) = compute_arg_locs(
-            sig.call_conv,
-            &sig.params,
-            ArgsOrRets::Args,
-            need_stack_return_area,
-        )?;
-
-        trace!(
-            "ABISig: sig {:?} => args = {:?} rets = {:?} arg stack = {} ret stack = {} stack_ret_arg = {:?}",
-            sig,
-            args,
-            rets,
-            stack_arg_space,
-            stack_ret_space,
-            stack_ret_arg
-        );
-
-        Ok(ABISig {
-            args,
-            rets,
-            stack_arg_space,
-            stack_ret_space,
-            stack_ret_arg,
-            call_conv: sig.call_conv,
-        })
-    }
-}
-
-/// AArch64 ABI object for a function body.
-pub struct AArch64ABIBody {
-    /// Signature: arg and retval regs.
-    sig: ABISig,
-    /// Offsets to each stackslot.
-    stackslots: Vec<u32>,
-    /// Total stack size of all stackslots.
-    stackslots_size: u32,
-    /// Clobbered registers, from regalloc.
-    clobbered: Set<Writable<RealReg>>,
-    /// Total number of spillslots, from regalloc.
-    spillslots: Option<usize>,
-    /// "Total frame size", as defined by "distance between FP and nominal-SP".
-    /// Some items are pushed below nominal SP, so the function may actually use
-    /// more stack than this would otherwise imply. It is simply the initial
-    /// frame/allocation size needed for stackslots and spillslots.
-    total_frame_size: Option<u32>,
-    /// The register holding the return-area pointer, if needed.
-    ret_area_ptr: Option<Writable<Reg>>,
-    /// Calling convention this function expects.
-    call_conv: isa::CallConv,
-    /// The settings controlling this function's compilation.
-    flags: settings::Flags,
-    /// Whether or not this function is a "leaf", meaning it calls no other
-    /// functions
-    is_leaf: bool,
-    /// If this function has a stack limit specified, then `Reg` is where the
-    /// stack limit will be located after the instructions specified have been
-    /// executed.
-    ///
-    /// Note that this is intended for insertion into the prologue, if
-    /// present. Also note that because the instructions here execute in the
-    /// prologue this happens after legalization/register allocation/etc so we
-    /// need to be extremely careful with each instruction. The instructions are
-    /// manually register-allocated and carefully only use caller-saved
-    /// registers and keep nothing live after this sequence of instructions.
-    stack_limit: Option<(Reg, Vec<Inst>)>,
-}
-
-fn in_int_reg(ty: ir::Type) -> bool {
-    match ty {
-        types::I8 | types::I16 | types::I32 | types::I64 => true,
-        types::B1 | types::B8 | types::B16 | types::B32 | types::B64 => true,
-        types::R64 => true,
-        types::R32 => panic!("Unexpected 32-bit reference on a 64-bit platform!"),
-        _ => false,
-    }
-}
-
-fn in_vec_reg(ty: ir::Type) -> bool {
-    match ty {
-        types::F32 | types::F64 => true,
-        types::B8X16
-        | types::I8X16
-        | types::B16X8
-        | types::I16X8
-        | types::B32X4
-        | types::I32X4
-        | types::B64X2
-        | types::I64X2 => true,
-        _ => false,
-    }
-}
-
-/// Generates the instructions necessary for the `gv` to be materialized into a
-/// register.
-///
-/// This function will return a register that will contain the result of
-/// evaluating `gv`. It will also return any instructions necessary to calculate
-/// the value of the register.
-///
-/// Note that global values are typically lowered to instructions via the
-/// standard legalization pass. Unfortunately though prologue generation happens
-/// so late in the pipeline that we can't use these legalization passes to
-/// generate the instructions for `gv`. As a result we duplicate some lowering
-/// of `gv` here and support only some global values. This is similar to what
-/// the x86 backend does for now, and hopefully this can be somewhat cleaned up
-/// in the future too!
-///
-/// Also note that this function will make use of `writable_spilltmp_reg()` as a
-/// temporary register to store values in if necessary. Currently after we write
-/// to this register there's guaranteed to be no spilled values between where
-/// it's used, because we're not participating in register allocation anyway!
-fn gen_stack_limit(f: &ir::Function, abi: &ABISig, gv: ir::GlobalValue) -> (Reg, Vec<Inst>) {
-    let mut insts = Vec::new();
-    let reg = generate_gv(f, abi, gv, &mut insts);
-    return (reg, insts);
-
-    fn generate_gv(
-        f: &ir::Function,
-        abi: &ABISig,
-        gv: ir::GlobalValue,
-        insts: &mut Vec<Inst>,
-    ) -> Reg {
-        match f.global_values[gv] {
-            // Return the direct register the vmcontext is in
-            ir::GlobalValueData::VMContext => {
-                get_special_purpose_param_register(f, abi, ir::ArgumentPurpose::VMContext)
-                    .expect("no vmcontext parameter found")
+            // Validate "purpose".
+            match &param.purpose {
+                &ir::ArgumentPurpose::VMContext
+                | &ir::ArgumentPurpose::Normal
+                | &ir::ArgumentPurpose::StackLimit
+                | &ir::ArgumentPurpose::SignatureId => {}
+                _ => panic!(
+                    "Unsupported argument purpose {:?} in signature: {:?}",
+                    param.purpose, params
+                ),
             }
-            // Load our base value into a register, then load from that register
-            // in to a temporary register.
-            ir::GlobalValueData::Load {
-                base,
-                offset,
-                global_type: _,
-                readonly: _,
-            } => {
-                let base = generate_gv(f, abi, base, insts);
-                let into_reg = writable_spilltmp_reg();
-                let mem = MemArg::RegOffset(base, offset.into(), I64);
-                insts.push(Inst::ULoad64 {
-                    rd: into_reg,
-                    mem,
-                    srcloc: None,
-                });
-                return into_reg.to_reg();
+
+            assert!(
+                legal_type_for_machine(param.value_type),
+                "Invalid type for AArch64: {:?}",
+                param.value_type
+            );
+            let rc = Inst::rc_for_type(param.value_type).unwrap();
+
+            let next_reg = match rc {
+                RegClass::I64 => &mut next_xreg,
+                RegClass::V128 => &mut next_vreg,
+                _ => panic!("Invalid register class: {:?}", rc),
+            };
+
+            if let Some(param) = try_fill_baldrdash_reg(call_conv, param) {
+                assert!(rc == RegClass::I64);
+                ret.push(param);
+            } else if *next_reg < max_reg_vals {
+                let reg = match rc {
+                    RegClass::I64 => xreg(*next_reg),
+                    RegClass::V128 => vreg(*next_reg),
+                    _ => unreachable!(),
+                };
+                ret.push(ABIArg::Reg(
+                    reg.to_real_reg(),
+                    param.value_type,
+                    param.extension,
+                ));
+                *next_reg += 1;
+            } else {
+                // Compute size. Every arg takes a minimum slot of 8 bytes. (16-byte
+                // stack alignment happens separately after all args.)
+                let size = (ty_bits(param.value_type) / 8) as u64;
+                let size = std::cmp::max(size, 8);
+                // Align.
+                debug_assert!(size.is_power_of_two());
+                next_stack = (next_stack + size - 1) & !(size - 1);
+                ret.push(ABIArg::Stack(
+                    next_stack as i64,
+                    param.value_type,
+                    param.extension,
+                ));
+                next_stack += size;
             }
-            ref other => panic!("global value for stack limit not supported: {}", other),
-        }
-    }
-}
-
-fn get_special_purpose_param_register(
-    f: &ir::Function,
-    abi: &ABISig,
-    purpose: ir::ArgumentPurpose,
-) -> Option<Reg> {
-    let idx = f.signature.special_param_index(purpose)?;
-    match abi.args[idx] {
-        ABIArg::Reg(reg, ..) => Some(reg.to_reg()),
-        ABIArg::Stack(..) => None,
-    }
-}
-
-impl AArch64ABIBody {
-    /// Create a new body ABI instance.
-    pub fn new(f: &ir::Function, flags: settings::Flags) -> CodegenResult<Self> {
-        debug!("AArch64 ABI: func signature {:?}", f.signature);
-
-        let sig = ABISig::from_func_sig(&f.signature)?;
-
-        let call_conv = f.signature.call_conv;
-        // Only these calling conventions are supported.
-        debug_assert!(
-            call_conv == isa::CallConv::SystemV
-                || call_conv == isa::CallConv::Fast
-                || call_conv == isa::CallConv::Cold
-                || call_conv.extends_baldrdash(),
-            "Unsupported calling convention: {:?}",
-            call_conv
-        );
-
-        // Compute stackslot locations and total stackslot size.
-        let mut stack_offset: u32 = 0;
-        let mut stackslots = vec![];
-        for (stackslot, data) in f.stack_slots.iter() {
-            let off = stack_offset;
-            stack_offset += data.size;
-            stack_offset = (stack_offset + 7) & !7;
-            debug_assert_eq!(stackslot.as_u32() as usize, stackslots.len());
-            stackslots.push(off);
         }
 
-        // Figure out what instructions, if any, will be needed to check the
-        // stack limit. This can either be specified as a special-purpose
-        // argument or as a global value which often calculates the stack limit
-        // from the arguments.
-        let stack_limit =
-            get_special_purpose_param_register(f, &sig, ir::ArgumentPurpose::StackLimit)
-                .map(|reg| (reg, Vec::new()))
-                .or_else(|| f.stack_limit.map(|gv| gen_stack_limit(f, &sig, gv)));
+        if args_or_rets == ArgsOrRets::Rets && is_baldrdash {
+            ret.reverse();
+        }
 
-        Ok(Self {
-            sig,
-            stackslots,
-            stackslots_size: stack_offset,
-            clobbered: Set::empty(),
-            spillslots: None,
-            total_frame_size: None,
-            ret_area_ptr: None,
-            call_conv,
-            flags,
-            is_leaf: f.is_leaf(),
-            stack_limit,
-        })
+        let extra_arg = if add_ret_area_ptr {
+            debug_assert!(args_or_rets == ArgsOrRets::Args);
+            if next_xreg < max_reg_vals {
+                ret.push(ABIArg::Reg(
+                    xreg(next_xreg).to_real_reg(),
+                    I64,
+                    ir::ArgumentExtension::None,
+                ));
+            } else {
+                ret.push(ABIArg::Stack(
+                    next_stack as i64,
+                    I64,
+                    ir::ArgumentExtension::None,
+                ));
+                next_stack += 8;
+            }
+            Some(ret.len() - 1)
+        } else {
+            None
+        };
+
+        next_stack = (next_stack + 15) & !15;
+
+        // To avoid overflow issues, limit the arg/return size to something
+        // reasonable -- here, 128 MB.
+        if next_stack > STACK_ARG_RET_SIZE_LIMIT {
+            return Err(CodegenError::ImplLimitExceeded);
+        }
+
+        Ok((ret, next_stack as i64, extra_arg))
     }
 
-    /// Returns the offset from FP to the argument area, i.e., jumping over the saved FP, return
-    /// address, and maybe other standard elements depending on ABI (e.g. Wasm TLS reg).
-    fn fp_to_arg_offset(&self) -> i64 {
-        if self.call_conv.extends_baldrdash() {
-            let num_words = self.flags.baldrdash_prologue_words() as i64;
+    fn fp_to_arg_offset(call_conv: isa::CallConv, flags: &settings::Flags) -> i64 {
+        if call_conv.extends_baldrdash() {
+            let num_words = flags.baldrdash_prologue_words() as i64;
             debug_assert!(num_words > 0, "baldrdash must set baldrdash_prologue_words");
             debug_assert_eq!(num_words % 2, 0, "stack must be 16-aligned");
             num_words * 8
@@ -580,597 +243,206 @@ impl AArch64ABIBody {
         }
     }
 
-    /// Inserts instructions necessary for checking the stack limit into the
-    /// prologue.
-    ///
-    /// This function will generate instructions necessary for perform a stack
-    /// check at the header of a function. The stack check is intended to trap
-    /// if the stack pointer goes below a particular threshold, preventing stack
-    /// overflow in wasm or other code. The `stack_limit` argument here is the
-    /// register which holds the threshold below which we're supposed to trap.
-    /// This function is known to allocate `stack_size` bytes and we'll push
-    /// instructions onto `insts`.
-    ///
-    /// Note that the instructions generated here are special because this is
-    /// happening so late in the pipeline (e.g. after register allocation). This
-    /// means that we need to do manual register allocation here and also be
-    /// careful to not clobber any callee-saved or argument registers. For now
-    /// this routine makes do with the `spilltmp_reg` as one temporary
-    /// register, and a second register of `tmp2` which is caller-saved. This
-    /// should be fine for us since no spills should happen in this sequence of
-    /// instructions, so our register won't get accidentally clobbered.
-    ///
-    /// No values can be live after the prologue, but in this case that's ok
-    /// because we just need to perform a stack check before progressing with
-    /// the rest of the function.
-    fn insert_stack_check(&self, stack_limit: Reg, stack_size: u32, insts: &mut Vec<Inst>) {
-        // With no explicit stack allocated we can just emit the simple check of
-        // the stack registers against the stack limit register, and trap if
-        // it's out of bounds.
-        if stack_size == 0 {
-            return push_check(stack_limit, insts);
-        }
+    fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Inst {
+        Inst::gen_load(into_reg, mem.into(), ty)
+    }
 
-        // Note that the 32k stack size here is pretty special. See the
-        // documentation in x86/abi.rs for why this is here. The general idea is
-        // that we're protecting against overflow in the addition that happens
-        // below.
-        if stack_size >= 32 * 1024 {
-            push_check(stack_limit, insts);
-        }
+    fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type) -> Inst {
+        Inst::gen_store(mem.into(), from_reg, ty)
+    }
 
-        // Add the `stack_size` to `stack_limit`, placing the result in
-        // `scratch`.
-        //
-        // Note though that `stack_limit`'s register may be the same as
-        // `scratch`. If our stack size doesn't fit into an immediate this
-        // means we need a second scratch register for loading the stack size
-        // into a register.
-        let scratch = writable_spilltmp_reg();
-        let scratch2 = writable_tmp2_reg();
-        let stack_size = u64::from(stack_size);
-        if let Some(imm12) = Imm12::maybe_from_u64(stack_size) {
+    fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Inst {
+        Inst::gen_move(to_reg, from_reg, ty)
+    }
+
+    fn gen_extend(
+        to_reg: Writable<Reg>,
+        from_reg: Reg,
+        signed: bool,
+        from_bits: u8,
+        to_bits: u8,
+    ) -> Inst {
+        assert!(from_bits < to_bits);
+        Inst::Extend {
+            rd: to_reg,
+            rn: from_reg,
+            signed,
+            from_bits,
+            to_bits,
+        }
+    }
+
+    fn gen_ret() -> Inst {
+        Inst::Ret
+    }
+
+    fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u64) -> SmallVec<[Inst; 4]> {
+        let mut insts = SmallVec::new();
+        if let Some(imm12) = Imm12::maybe_from_u64(imm) {
             insts.push(Inst::AluRRImm12 {
                 alu_op: ALUOp::Add64,
-                rd: scratch,
-                rn: stack_limit,
+                rd: into_reg,
+                rn: from_reg,
                 imm12,
             });
         } else {
-            insts.extend(Inst::load_constant(scratch2, stack_size.into()));
+            let scratch2 = writable_tmp2_reg();
+            insts.extend(Inst::load_constant(scratch2, imm.into()));
             insts.push(Inst::AluRRRExtend {
                 alu_op: ALUOp::Add64,
-                rd: scratch,
-                rn: stack_limit,
+                rd: into_reg,
+                rn: from_reg,
                 rm: scratch2.to_reg(),
                 extendop: ExtendOp::UXTX,
             });
         }
-        push_check(scratch.to_reg(), insts);
-
-        fn push_check(stack_limit: Reg, insts: &mut Vec<Inst>) {
-            insts.push(Inst::AluRRR {
-                alu_op: ALUOp::SubS64XR,
-                rd: writable_zero_reg(),
-                rn: stack_reg(),
-                rm: stack_limit,
-            });
-            insts.push(Inst::TrapIf {
-                trap_info: (ir::SourceLoc::default(), ir::TrapCode::StackOverflow),
-                // Here `Lo` == "less than" when interpreting the two
-                // operands as unsigned integers.
-                kind: CondBrKind::Cond(Cond::Lo),
-            });
-        }
-    }
-}
-
-fn load_stack(mem: MemArg, into_reg: Writable<Reg>, ty: Type) -> Inst {
-    match ty {
-        types::B1 | types::B8 | types::I8 => Inst::ULoad8 {
-            rd: into_reg,
-            mem,
-            srcloc: None,
-        },
-        types::B16 | types::I16 => Inst::ULoad16 {
-            rd: into_reg,
-            mem,
-            srcloc: None,
-        },
-        types::B32 | types::I32 | types::R32 => Inst::ULoad32 {
-            rd: into_reg,
-            mem,
-            srcloc: None,
-        },
-        types::B64 | types::I64 | types::R64 => Inst::ULoad64 {
-            rd: into_reg,
-            mem,
-            srcloc: None,
-        },
-        types::F32 => Inst::FpuLoad32 {
-            rd: into_reg,
-            mem,
-            srcloc: None,
-        },
-        types::F64 => Inst::FpuLoad64 {
-            rd: into_reg,
-            mem,
-            srcloc: None,
-        },
-        _ => unimplemented!("load_stack({})", ty),
-    }
-}
-
-fn store_stack(mem: MemArg, from_reg: Reg, ty: Type) -> Inst {
-    match ty {
-        types::B1 | types::B8 | types::I8 => Inst::Store8 {
-            rd: from_reg,
-            mem,
-            srcloc: None,
-        },
-        types::B16 | types::I16 => Inst::Store16 {
-            rd: from_reg,
-            mem,
-            srcloc: None,
-        },
-        types::B32 | types::I32 | types::R32 => Inst::Store32 {
-            rd: from_reg,
-            mem,
-            srcloc: None,
-        },
-        types::B64 | types::I64 | types::R64 => Inst::Store64 {
-            rd: from_reg,
-            mem,
-            srcloc: None,
-        },
-        types::F32 => Inst::FpuStore32 {
-            rd: from_reg,
-            mem,
-            srcloc: None,
-        },
-        types::F64 => Inst::FpuStore64 {
-            rd: from_reg,
-            mem,
-            srcloc: None,
-        },
-        _ => unimplemented!("store_stack({})", ty),
-    }
-}
-
-fn is_callee_save(call_conv: isa::CallConv, r: RealReg) -> bool {
-    if call_conv.extends_baldrdash() {
-        match r.get_class() {
-            RegClass::I64 => {
-                let enc = r.get_hw_encoding();
-                return BALDRDASH_JIT_CALLEE_SAVED_GPR[enc];
-            }
-            RegClass::V128 => {
-                let enc = r.get_hw_encoding();
-                return BALDRDASH_JIT_CALLEE_SAVED_FPU[enc];
-            }
-            _ => unimplemented!("baldrdash callee saved on non-i64 reg classes"),
-        };
+        insts
     }
 
-    match r.get_class() {
-        RegClass::I64 => {
-            // x19 - x28 inclusive are callee-saves.
-            r.get_hw_encoding() >= 19 && r.get_hw_encoding() <= 28
-        }
-        RegClass::V128 => {
-            // v8 - v15 inclusive are callee-saves.
-            r.get_hw_encoding() >= 8 && r.get_hw_encoding() <= 15
-        }
-        _ => panic!("Unexpected RegClass"),
-    }
-}
-
-fn get_callee_saves(
-    call_conv: isa::CallConv,
-    regs: Vec<Writable<RealReg>>,
-) -> (Vec<Writable<RealReg>>, Vec<Writable<RealReg>>) {
-    let mut int_saves = vec![];
-    let mut vec_saves = vec![];
-    for reg in regs.into_iter() {
-        if is_callee_save(call_conv, reg.to_reg()) {
-            match reg.to_reg().get_class() {
-                RegClass::I64 => int_saves.push(reg),
-                RegClass::V128 => vec_saves.push(reg),
-                _ => panic!("Unexpected RegClass"),
-            }
-        }
-    }
-    (int_saves, vec_saves)
-}
-
-fn is_caller_save(call_conv: isa::CallConv, r: RealReg) -> bool {
-    if call_conv.extends_baldrdash() {
-        match r.get_class() {
-            RegClass::I64 => {
-                let enc = r.get_hw_encoding();
-                if !BALDRDASH_JIT_CALLEE_SAVED_GPR[enc] {
-                    return true;
-                }
-                // Otherwise, fall through to preserve native's ABI caller-saved.
-            }
-            RegClass::V128 => {
-                let enc = r.get_hw_encoding();
-                if !BALDRDASH_JIT_CALLEE_SAVED_FPU[enc] {
-                    return true;
-                }
-                // Otherwise, fall through to preserve native's ABI caller-saved.
-            }
-            _ => unimplemented!("baldrdash callee saved on non-i64 reg classes"),
-        };
-    }
-
-    match r.get_class() {
-        RegClass::I64 => {
-            // x0 - x17 inclusive are caller-saves.
-            r.get_hw_encoding() <= 17
-        }
-        RegClass::V128 => {
-            // v0 - v7 inclusive and v16 - v31 inclusive are caller-saves.
-            r.get_hw_encoding() <= 7 || (r.get_hw_encoding() >= 16 && r.get_hw_encoding() <= 31)
-        }
-        _ => panic!("Unexpected RegClass"),
-    }
-}
-
-fn get_caller_saves(call_conv: isa::CallConv) -> Vec<Writable<Reg>> {
-    let mut caller_saved = Vec::new();
-    for i in 0..29 {
-        let x = writable_xreg(i);
-        if is_caller_save(call_conv, x.to_reg().to_real_reg()) {
-            caller_saved.push(x);
-        }
-    }
-    for i in 0..32 {
-        let v = writable_vreg(i);
-        if is_caller_save(call_conv, v.to_reg().to_real_reg()) {
-            caller_saved.push(v);
-        }
-    }
-    caller_saved
-}
-
-fn gen_sp_adjust_insts<F: FnMut(Inst)>(adj: u64, is_sub: bool, mut f: F) {
-    let alu_op = if is_sub { ALUOp::Sub64 } else { ALUOp::Add64 };
-
-    if let Some(imm12) = Imm12::maybe_from_u64(adj) {
-        let adj_inst = Inst::AluRRImm12 {
-            alu_op,
-            rd: writable_stack_reg(),
+    fn gen_stack_lower_bound_trap(limit_reg: Reg) -> SmallVec<[Inst; 2]> {
+        let mut insts = SmallVec::new();
+        insts.push(Inst::AluRRR {
+            alu_op: ALUOp::SubS64XR,
+            rd: writable_zero_reg(),
             rn: stack_reg(),
-            imm12,
-        };
-        f(adj_inst);
-    } else {
-        let tmp = writable_spilltmp_reg();
-        let const_inst = Inst::LoadConst64 {
-            rd: tmp,
-            const_data: adj,
-        };
-        let adj_inst = Inst::AluRRRExtend {
-            alu_op,
-            rd: writable_stack_reg(),
-            rn: stack_reg(),
-            rm: tmp.to_reg(),
-            extendop: ExtendOp::UXTX,
-        };
-        f(const_inst);
-        f(adj_inst);
-    }
-}
-
-impl ABIBody for AArch64ABIBody {
-    type I = Inst;
-
-    fn temp_needed(&self) -> bool {
-        self.sig.stack_ret_arg.is_some()
+            rm: limit_reg,
+        });
+        insts.push(Inst::TrapIf {
+            trap_info: (ir::SourceLoc::default(), ir::TrapCode::StackOverflow),
+            // Here `Lo` == "less than" when interpreting the two
+            // operands as unsigned integers.
+            kind: CondBrKind::Cond(Cond::Lo),
+        });
+        insts
     }
 
-    fn init(&mut self, maybe_tmp: Option<Writable<Reg>>) {
-        if self.sig.stack_ret_arg.is_some() {
-            assert!(maybe_tmp.is_some());
-            self.ret_area_ptr = maybe_tmp;
+    fn gen_epilogue_placeholder() -> Inst {
+        Inst::EpiloguePlaceholder
+    }
+
+    fn gen_get_stack_addr(mem: StackAMode, into_reg: Writable<Reg>, _ty: Type) -> Inst {
+        let mem = mem.into();
+        Inst::LoadAddr { rd: into_reg, mem }
+    }
+
+    fn get_fixed_tmp_reg() -> Reg {
+        spilltmp_reg()
+    }
+
+    fn gen_load_base_offset(into_reg: Writable<Reg>, base: Reg, offset: i64, ty: Type) -> Inst {
+        let mem = AMode::RegOffset(base, offset, ty);
+        Inst::gen_load(into_reg, mem, ty)
+    }
+
+    fn gen_store_base_offset(base: Reg, offset: i64, from_reg: Reg, ty: Type) -> Inst {
+        let mem = AMode::RegOffset(base, offset, ty);
+        Inst::gen_store(mem, from_reg, ty)
+    }
+
+    fn gen_sp_reg_adjust(amount: i64) -> SmallVec<[Inst; 2]> {
+        if amount == 0 {
+            return SmallVec::new();
         }
-    }
 
-    fn flags(&self) -> &settings::Flags {
-        &self.flags
-    }
-
-    fn liveins(&self) -> Set<RealReg> {
-        let mut set: Set<RealReg> = Set::empty();
-        for &arg in &self.sig.args {
-            if let ABIArg::Reg(r, ..) = arg {
-                set.insert(r);
-            }
-        }
-        set
-    }
-
-    fn liveouts(&self) -> Set<RealReg> {
-        let mut set: Set<RealReg> = Set::empty();
-        for &ret in &self.sig.rets {
-            if let ABIArg::Reg(r, ..) = ret {
-                set.insert(r);
-            }
-        }
-        set
-    }
-
-    fn num_args(&self) -> usize {
-        self.sig.args.len()
-    }
-
-    fn num_retvals(&self) -> usize {
-        self.sig.rets.len()
-    }
-
-    fn num_stackslots(&self) -> usize {
-        self.stackslots.len()
-    }
-
-    fn gen_copy_arg_to_reg(&self, idx: usize, into_reg: Writable<Reg>) -> Inst {
-        match &self.sig.args[idx] {
-            // Extension mode doesn't matter (we're copying out, not in; we
-            // ignore high bits by convention).
-            &ABIArg::Reg(r, ty, _) => Inst::gen_move(into_reg, r.to_reg(), ty),
-            &ABIArg::Stack(off, ty, _) => load_stack(
-                MemArg::FPOffset(self.fp_to_arg_offset() + off, ty),
-                into_reg,
-                ty,
-            ),
-        }
-    }
-
-    fn gen_retval_area_setup(&self) -> Option<Inst> {
-        if let Some(i) = self.sig.stack_ret_arg {
-            let inst = self.gen_copy_arg_to_reg(i, self.ret_area_ptr.unwrap());
-            trace!(
-                "gen_retval_area_setup: inst {:?}; ptr reg is {:?}",
-                inst,
-                self.ret_area_ptr.unwrap().to_reg()
-            );
-            Some(inst)
+        let (amount, is_sub) = if amount > 0 {
+            (u64::try_from(amount).unwrap(), false)
         } else {
-            trace!("gen_retval_area_setup: not needed");
-            None
-        }
-    }
+            (u64::try_from(-amount).unwrap(), true)
+        };
 
-    fn gen_copy_reg_to_retval(&self, idx: usize, from_reg: Writable<Reg>) -> Vec<Inst> {
-        let mut ret = Vec::new();
-        match &self.sig.rets[idx] {
-            &ABIArg::Reg(r, ty, ext) => {
-                let from_bits = ty_bits(ty) as u8;
-                let dest_reg = Writable::from_reg(r.to_reg());
-                match (ext, from_bits) {
-                    (ArgumentExtension::Uext, n) if n < 64 => {
-                        ret.push(Inst::Extend {
-                            rd: dest_reg,
-                            rn: from_reg.to_reg(),
-                            signed: false,
-                            from_bits,
-                            to_bits: 64,
-                        });
-                    }
-                    (ArgumentExtension::Sext, n) if n < 64 => {
-                        ret.push(Inst::Extend {
-                            rd: dest_reg,
-                            rn: from_reg.to_reg(),
-                            signed: true,
-                            from_bits,
-                            to_bits: 64,
-                        });
-                    }
-                    _ => ret.push(Inst::gen_move(dest_reg, from_reg.to_reg(), ty)),
-                };
-            }
-            &ABIArg::Stack(off, ty, ext) => {
-                let from_bits = ty_bits(ty) as u8;
-                // Trash the from_reg; it should be its last use.
-                match (ext, from_bits) {
-                    (ArgumentExtension::Uext, n) if n < 64 => {
-                        ret.push(Inst::Extend {
-                            rd: from_reg,
-                            rn: from_reg.to_reg(),
-                            signed: false,
-                            from_bits,
-                            to_bits: 64,
-                        });
-                    }
-                    (ArgumentExtension::Sext, n) if n < 64 => {
-                        ret.push(Inst::Extend {
-                            rd: from_reg,
-                            rn: from_reg.to_reg(),
-                            signed: true,
-                            from_bits,
-                            to_bits: 64,
-                        });
-                    }
-                    _ => {}
-                };
-                let mem = MemArg::RegOffset(self.ret_area_ptr.unwrap().to_reg(), off, ty);
-                ret.push(store_stack(mem, from_reg.to_reg(), ty))
-            }
+        let alu_op = if is_sub { ALUOp::Sub64 } else { ALUOp::Add64 };
+
+        let mut ret = SmallVec::new();
+        if let Some(imm12) = Imm12::maybe_from_u64(amount) {
+            let adj_inst = Inst::AluRRImm12 {
+                alu_op,
+                rd: writable_stack_reg(),
+                rn: stack_reg(),
+                imm12,
+            };
+            ret.push(adj_inst);
+        } else {
+            let tmp = writable_spilltmp_reg();
+            let const_inst = Inst::LoadConst64 {
+                rd: tmp,
+                const_data: amount,
+            };
+            let adj_inst = Inst::AluRRRExtend {
+                alu_op,
+                rd: writable_stack_reg(),
+                rn: stack_reg(),
+                rm: tmp.to_reg(),
+                extendop: ExtendOp::UXTX,
+            };
+            ret.push(const_inst);
+            ret.push(adj_inst);
         }
         ret
     }
 
-    fn gen_ret(&self) -> Inst {
-        Inst::Ret {}
+    fn gen_nominal_sp_adj(offset: i64) -> Inst {
+        Inst::VirtualSPOffsetAdj { offset }
     }
 
-    fn gen_epilogue_placeholder(&self) -> Inst {
-        Inst::EpiloguePlaceholder {}
+    fn gen_prologue_frame_setup() -> SmallVec<[Inst; 2]> {
+        let mut insts = SmallVec::new();
+        // stp fp (x29), lr (x30), [sp, #-16]!
+        insts.push(Inst::StoreP64 {
+            rt: fp_reg(),
+            rt2: link_reg(),
+            mem: PairAMode::PreIndexed(
+                writable_stack_reg(),
+                SImm7Scaled::maybe_from_i64(-16, types::I64).unwrap(),
+            ),
+        });
+        // mov fp (x29), sp. This uses the ADDI rd, rs, 0 form of `MOV` because
+        // the usual encoding (`ORR`) does not work with SP.
+        insts.push(Inst::AluRRImm12 {
+            alu_op: ALUOp::Add64,
+            rd: writable_fp_reg(),
+            rn: stack_reg(),
+            imm12: Imm12 {
+                bits: 0,
+                shift12: false,
+            },
+        });
+        insts
     }
 
-    fn set_num_spillslots(&mut self, slots: usize) {
-        self.spillslots = Some(slots);
+    fn gen_epilogue_frame_restore() -> SmallVec<[Inst; 2]> {
+        let mut insts = SmallVec::new();
+
+        // MOV (alias of ORR) interprets x31 as XZR, so use an ADD here.
+        // MOV to SP is an alias of ADD.
+        insts.push(Inst::AluRRImm12 {
+            alu_op: ALUOp::Add64,
+            rd: writable_stack_reg(),
+            rn: fp_reg(),
+            imm12: Imm12 {
+                bits: 0,
+                shift12: false,
+            },
+        });
+        insts.push(Inst::LoadP64 {
+            rt: writable_fp_reg(),
+            rt2: writable_link_reg(),
+            mem: PairAMode::PostIndexed(
+                writable_stack_reg(),
+                SImm7Scaled::maybe_from_i64(16, types::I64).unwrap(),
+            ),
+        });
+
+        insts
     }
 
-    fn set_clobbered(&mut self, clobbered: Set<Writable<RealReg>>) {
-        self.clobbered = clobbered;
-    }
-
-    /// Load from a stackslot.
-    fn load_stackslot(
-        &self,
-        slot: StackSlot,
-        offset: u32,
-        ty: Type,
-        into_reg: Writable<Reg>,
-    ) -> Inst {
-        // Offset from beginning of stackslot area, which is at nominal-SP (see
-        // [MemArg::NominalSPOffset] for more details on nominal-SP tracking).
-        let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
-        let sp_off: i64 = stack_off + (offset as i64);
-        trace!("load_stackslot: slot {} -> sp_off {}", slot, sp_off);
-        load_stack(MemArg::NominalSPOffset(sp_off, ty), into_reg, ty)
-    }
-
-    /// Store to a stackslot.
-    fn store_stackslot(&self, slot: StackSlot, offset: u32, ty: Type, from_reg: Reg) -> Inst {
-        // Offset from beginning of stackslot area, which is at nominal-SP (see
-        // [MemArg::NominalSPOffset] for more details on nominal-SP tracking).
-        let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
-        let sp_off: i64 = stack_off + (offset as i64);
-        trace!("store_stackslot: slot {} -> sp_off {}", slot, sp_off);
-        store_stack(MemArg::NominalSPOffset(sp_off, ty), from_reg, ty)
-    }
-
-    /// Produce an instruction that computes a stackslot address.
-    fn stackslot_addr(&self, slot: StackSlot, offset: u32, into_reg: Writable<Reg>) -> Inst {
-        // Offset from beginning of stackslot area, which is at nominal-SP (see
-        // [MemArg::NominalSPOffset] for more details on nominal-SP tracking).
-        let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
-        let sp_off: i64 = stack_off + (offset as i64);
-        Inst::LoadAddr {
-            rd: into_reg,
-            mem: MemArg::NominalSPOffset(sp_off, I8),
-        }
-    }
-
-    /// Load from a spillslot.
-    fn load_spillslot(&self, slot: SpillSlot, ty: Type, into_reg: Writable<Reg>) -> Inst {
-        // Offset from beginning of spillslot area, which is at nominal-SP + stackslots_size.
-        let islot = slot.get() as i64;
-        let spill_off = islot * 8;
-        let sp_off = self.stackslots_size as i64 + spill_off;
-        trace!("load_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
-        load_stack(MemArg::NominalSPOffset(sp_off, ty), into_reg, ty)
-    }
-
-    /// Store to a spillslot.
-    fn store_spillslot(&self, slot: SpillSlot, ty: Type, from_reg: Reg) -> Inst {
-        // Offset from beginning of spillslot area, which is at nominal-SP + stackslots_size.
-        let islot = slot.get() as i64;
-        let spill_off = islot * 8;
-        let sp_off = self.stackslots_size as i64 + spill_off;
-        trace!("store_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
-        store_stack(MemArg::NominalSPOffset(sp_off, ty), from_reg, ty)
-    }
-
-    fn spillslots_to_stack_map(&self, slots: &[SpillSlot], state: &EmitState) -> StackMap {
-        assert!(state.virtual_sp_offset >= 0);
-        trace!(
-            "spillslots_to_stack_map: slots = {:?}, state = {:?}",
-            slots,
-            state
-        );
-        let map_size = (state.virtual_sp_offset + state.nominal_sp_to_fp) as u32;
-        let map_words = (map_size + 7) / 8;
-        let mut bits = std::iter::repeat(false)
-            .take(map_words as usize)
-            .collect::<Vec<bool>>();
-
-        let first_spillslot_word =
-            ((self.stackslots_size + state.virtual_sp_offset as u32) / 8) as usize;
-        for &slot in slots {
-            let slot = slot.get() as usize;
-            bits[first_spillslot_word + slot] = true;
-        }
-
-        StackMap::from_slice(&bits[..])
-    }
-
-    fn gen_prologue(&mut self) -> Vec<Inst> {
-        let mut insts = vec![];
-        if !self.call_conv.extends_baldrdash() {
-            // stp fp (x29), lr (x30), [sp, #-16]!
-            insts.push(Inst::StoreP64 {
-                rt: fp_reg(),
-                rt2: link_reg(),
-                mem: PairMemArg::PreIndexed(
-                    writable_stack_reg(),
-                    SImm7Scaled::maybe_from_i64(-16, types::I64).unwrap(),
-                ),
-            });
-            // mov fp (x29), sp. This uses the ADDI rd, rs, 0 form of `MOV` because
-            // the usual encoding (`ORR`) does not work with SP.
-            insts.push(Inst::AluRRImm12 {
-                alu_op: ALUOp::Add64,
-                rd: writable_fp_reg(),
-                rn: stack_reg(),
-                imm12: Imm12 {
-                    bits: 0,
-                    shift12: false,
-                },
-            });
-        }
-
-        let mut total_stacksize = self.stackslots_size + 8 * self.spillslots.unwrap() as u32;
-        if self.call_conv.extends_baldrdash() {
-            debug_assert!(
-                !self.flags.enable_probestack(),
-                "baldrdash does not expect cranelift to emit stack probes"
-            );
-            total_stacksize += self.flags.baldrdash_prologue_words() as u32 * 8;
-        }
-        let total_stacksize = (total_stacksize + 15) & !15; // 16-align the stack.
-
-        let mut total_sp_adjust = 0;
-        let mut nominal_sp_to_real_sp = 0;
-
-        if !self.call_conv.extends_baldrdash() {
-            // Leaf functions with zero stack don't need a stack check if one's
-            // specified, otherwise always insert the stack check.
-            if total_stacksize > 0 || !self.is_leaf {
-                if let Some((reg, stack_limit_load)) = &self.stack_limit {
-                    insts.extend_from_slice(stack_limit_load);
-                    self.insert_stack_check(*reg, total_stacksize, &mut insts);
-                }
-            }
-            if total_stacksize > 0 {
-                total_sp_adjust += total_stacksize as u64;
-            }
-        }
-
-        // N.B.: "nominal SP", which we use to refer to stackslots and
-        // spillslots, is defined to be equal to the stack pointer at this point
-        // in the prologue.
-        //
-        // If we push any clobbers below, we emit a virtual-SP adjustment
-        // meta-instruction so that the nominal-SP references behave as if SP
-        // were still at this point. See documentation for
-        // [crate::isa::aarch64::abi](this module) for more details on
-        // stackframe layout and nominal-SP maintenance.
-
-        if total_sp_adjust > 0 {
-            // sub sp, sp, #total_stacksize
-            gen_sp_adjust_insts(
-                total_sp_adjust,
-                /* is_sub = */ true,
-                |inst| insts.push(inst),
-            );
-        }
-
-        // Save clobbered registers.
-        let (clobbered_int, clobbered_vec) =
-            get_callee_saves(self.call_conv, self.clobbered.to_vec());
+    // Returns stack bytes used as well as instructions. Does not adjust
+    // nominal SP offset; abi_impl generic code will do that.
+    fn gen_clobber_save(
+        call_conv: isa::CallConv,
+        clobbers: &Set<Writable<RealReg>>,
+    ) -> (u64, SmallVec<[Inst; 16]>) {
+        let mut insts = SmallVec::new();
+        let (clobbered_int, clobbered_vec) = get_callee_saves(call_conv, clobbers);
         let mut clobber_size = 0;
         for reg_pair in clobbered_int.chunks(2) {
             let (r1, r2) = if reg_pair.len() == 2 {
@@ -1187,7 +459,7 @@ impl ABIBody for AArch64ABIBody {
             insts.push(Inst::StoreP64 {
                 rt: r1,
                 rt2: r2,
-                mem: PairMemArg::PreIndexed(
+                mem: PairAMode::PreIndexed(
                     writable_stack_reg(),
                     SImm7Scaled::maybe_from_i64(-16, types::I64).unwrap(),
                 ),
@@ -1207,33 +479,25 @@ impl ABIBody for AArch64ABIBody {
         for (i, reg) in clobbered_vec.iter().enumerate() {
             insts.push(Inst::FpuStore128 {
                 rd: reg.to_reg().to_reg(),
-                mem: MemArg::Unscaled(stack_reg(), SImm9::maybe_from_i64((i * 16) as i64).unwrap()),
+                mem: AMode::Unscaled(stack_reg(), SImm9::maybe_from_i64((i * 16) as i64).unwrap()),
                 srcloc: None,
             });
         }
-        nominal_sp_to_real_sp += clobber_size as i64;
 
-        if clobber_size > 0 {
-            insts.push(Inst::VirtualSPOffsetAdj {
-                offset: nominal_sp_to_real_sp,
-            });
-        }
-
-        self.total_frame_size = Some(total_stacksize);
-        insts
+        (clobber_size as u64, insts)
     }
 
-    fn gen_epilogue(&self) -> Vec<Inst> {
-        let mut insts = vec![];
-
-        // Restore clobbered registers.
-        let (clobbered_int, clobbered_vec) =
-            get_callee_saves(self.call_conv, self.clobbered.to_vec());
+    fn gen_clobber_restore(
+        call_conv: isa::CallConv,
+        clobbers: &Set<Writable<RealReg>>,
+    ) -> SmallVec<[Inst; 16]> {
+        let mut insts = SmallVec::new();
+        let (clobbered_int, clobbered_vec) = get_callee_saves(call_conv, clobbers);
 
         for (i, reg) in clobbered_vec.iter().enumerate() {
             insts.push(Inst::FpuLoad128 {
                 rd: Writable::from_reg(reg.to_reg().to_reg()),
-                mem: MemArg::Unscaled(stack_reg(), SImm9::maybe_from_i64((i * 16) as i64).unwrap()),
+                mem: AMode::Unscaled(stack_reg(), SImm9::maybe_from_i64((i * 16) as i64).unwrap()),
                 srcloc: None,
             });
         }
@@ -1264,56 +528,78 @@ impl ABIBody for AArch64ABIBody {
             insts.push(Inst::LoadP64 {
                 rt: r1,
                 rt2: r2,
-                mem: PairMemArg::PostIndexed(
+                mem: PairAMode::PostIndexed(
                     writable_stack_reg(),
                     SImm7Scaled::maybe_from_i64(16, types::I64).unwrap(),
                 ),
             });
         }
 
-        // N.B.: we do *not* emit a nominal-SP adjustment here, because (i) there will be no
-        // references to nominal-SP offsets before the return below, and (ii) the instruction
-        // emission tracks running SP offset linearly (in straight-line order), not according to
-        // the CFG, so early returns in the middle of function bodies would cause an incorrect
-        // offset for the rest of the body.
-
-        if !self.call_conv.extends_baldrdash() {
-            // The MOV (alias of ORR) interprets x31 as XZR, so use an ADD here.
-            // MOV to SP is an alias of ADD.
-            insts.push(Inst::AluRRImm12 {
-                alu_op: ALUOp::Add64,
-                rd: writable_stack_reg(),
-                rn: fp_reg(),
-                imm12: Imm12 {
-                    bits: 0,
-                    shift12: false,
-                },
-            });
-            insts.push(Inst::LoadP64 {
-                rt: writable_fp_reg(),
-                rt2: writable_link_reg(),
-                mem: PairMemArg::PostIndexed(
-                    writable_stack_reg(),
-                    SImm7Scaled::maybe_from_i64(16, types::I64).unwrap(),
-                ),
-            });
-            insts.push(Inst::Ret {});
-        }
-
-        debug!("Epilogue: {:?}", insts);
         insts
     }
 
-    fn frame_size(&self) -> u32 {
-        self.total_frame_size
-            .expect("frame size not computed before prologue generation")
+    fn gen_call(
+        dest: &CallDest,
+        uses: Vec<Reg>,
+        defs: Vec<Writable<Reg>>,
+        loc: SourceLoc,
+        opcode: ir::Opcode,
+    ) -> SmallVec<[(/* is_safepoint = */ bool, Inst); 2]> {
+        let mut insts = SmallVec::new();
+        match &dest {
+            &CallDest::ExtName(ref name, RelocDistance::Near) => insts.push((
+                true,
+                Inst::Call {
+                    info: Box::new(CallInfo {
+                        dest: name.clone(),
+                        uses,
+                        defs,
+                        loc,
+                        opcode,
+                    }),
+                },
+            )),
+            &CallDest::ExtName(ref name, RelocDistance::Far) => {
+                insts.push((
+                    false,
+                    Inst::LoadExtName {
+                        rd: writable_spilltmp_reg(),
+                        name: Box::new(name.clone()),
+                        offset: 0,
+                        srcloc: loc,
+                    },
+                ));
+                insts.push((
+                    true,
+                    Inst::CallInd {
+                        info: Box::new(CallIndInfo {
+                            rn: spilltmp_reg(),
+                            uses,
+                            defs,
+                            loc,
+                            opcode,
+                        }),
+                    },
+                ));
+            }
+            &CallDest::Reg(reg) => insts.push((
+                true,
+                Inst::CallInd {
+                    info: Box::new(CallIndInfo {
+                        rn: *reg,
+                        uses,
+                        defs,
+                        loc,
+                        opcode,
+                    }),
+                },
+            )),
+        }
+
+        insts
     }
 
-    fn stack_args_size(&self) -> u32 {
-        self.sig.stack_arg_space as u32
-    }
-
-    fn get_spillslot_size(&self, rc: RegClass, ty: Type) -> u32 {
+    fn get_spillslot_size(rc: RegClass, ty: Type) -> u32 {
         // We allocate in terms of 8-byte slots.
         match (rc, ty) {
             (RegClass::I64, _) => 1,
@@ -1323,286 +609,122 @@ impl ABIBody for AArch64ABIBody {
         }
     }
 
-    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, ty: Option<Type>) -> Inst {
-        let ty = ty_from_ty_hint_or_reg_class(from_reg.to_reg(), ty);
-        self.store_spillslot(to_slot, ty, from_reg.to_reg())
+    /// Get the current virtual-SP offset from an instruction-emission state.
+    fn get_virtual_sp_offset_from_state(s: &EmitState) -> i64 {
+        s.virtual_sp_offset
     }
 
-    fn gen_reload(
-        &self,
-        to_reg: Writable<RealReg>,
-        from_slot: SpillSlot,
-        ty: Option<Type>,
-    ) -> Inst {
-        let ty = ty_from_ty_hint_or_reg_class(to_reg.to_reg().to_reg(), ty);
-        self.load_spillslot(from_slot, ty, to_reg.map(|r| r.to_reg()))
-    }
-}
-
-/// Return a type either from an optional type hint, or if not, from the default
-/// type associated with the given register's class. This is used to generate
-/// loads/spills appropriately given the type of value loaded/stored (which may
-/// be narrower than the spillslot). We usually have the type because the
-/// regalloc usually provides the vreg being spilled/reloaded, and we know every
-/// vreg's type. However, the regalloc *can* request a spill/reload without an
-/// associated vreg when needed to satisfy a safepoint (which requires all
-/// ref-typed values, even those in real registers in the original vcode, to be
-/// in spillslots).
-fn ty_from_ty_hint_or_reg_class(r: Reg, ty: Option<Type>) -> Type {
-    match (ty, r.get_class()) {
-        // If the type is provided
-        (Some(t), _) => t,
-        // If no type is provided, this should be a register spill for a
-        // safepoint, so we only expect I64 (integer) registers.
-        (None, RegClass::I64) => I64,
-        _ => panic!("Unexpected register class!"),
-    }
-}
-
-enum CallDest {
-    ExtName(ir::ExternalName, RelocDistance),
-    Reg(Reg),
-}
-
-/// AArch64 ABI object for a function call.
-pub struct AArch64ABICall {
-    sig: ABISig,
-    uses: Vec<Reg>,
-    defs: Vec<Writable<Reg>>,
-    dest: CallDest,
-    loc: ir::SourceLoc,
-    opcode: ir::Opcode,
-}
-
-fn abisig_to_uses_and_defs(sig: &ABISig) -> (Vec<Reg>, Vec<Writable<Reg>>) {
-    // Compute uses: all arg regs.
-    let mut uses = Vec::new();
-    for arg in &sig.args {
-        match arg {
-            &ABIArg::Reg(reg, ..) => uses.push(reg.to_reg()),
-            _ => {}
-        }
+    /// Get the nominal-SP-to-FP offset from an instruction-emission state.
+    fn get_nominal_sp_to_fp(s: &EmitState) -> i64 {
+        s.nominal_sp_to_fp
     }
 
-    // Compute defs: all retval regs, and all caller-save (clobbered) regs.
-    let mut defs = get_caller_saves(sig.call_conv);
-    for ret in &sig.rets {
-        match ret {
-            &ABIArg::Reg(reg, ..) => defs.push(Writable::from_reg(reg.to_reg())),
-            _ => {}
-        }
-    }
-
-    (uses, defs)
-}
-
-impl AArch64ABICall {
-    /// Create a callsite ABI object for a call directly to the specified function.
-    pub fn from_func(
-        sig: &ir::Signature,
-        extname: &ir::ExternalName,
-        dist: RelocDistance,
-        loc: ir::SourceLoc,
-    ) -> CodegenResult<AArch64ABICall> {
-        let sig = ABISig::from_func_sig(sig)?;
-        let (uses, defs) = abisig_to_uses_and_defs(&sig);
-        Ok(AArch64ABICall {
-            sig,
-            uses,
-            defs,
-            dest: CallDest::ExtName(extname.clone(), dist),
-            loc,
-            opcode: ir::Opcode::Call,
-        })
-    }
-
-    /// Create a callsite ABI object for a call to a function pointer with the
-    /// given signature.
-    pub fn from_ptr(
-        sig: &ir::Signature,
-        ptr: Reg,
-        loc: ir::SourceLoc,
-        opcode: ir::Opcode,
-    ) -> CodegenResult<AArch64ABICall> {
-        let sig = ABISig::from_func_sig(sig)?;
-        let (uses, defs) = abisig_to_uses_and_defs(&sig);
-        Ok(AArch64ABICall {
-            sig,
-            uses,
-            defs,
-            dest: CallDest::Reg(ptr),
-            loc,
-            opcode,
-        })
-    }
-}
-
-fn adjust_stack_and_nominal_sp<C: LowerCtx<I = Inst>>(ctx: &mut C, amount: u64, is_sub: bool) {
-    if amount == 0 {
-        return;
-    }
-
-    let sp_adjustment = if is_sub {
-        amount as i64
-    } else {
-        -(amount as i64)
-    };
-    ctx.emit(Inst::VirtualSPOffsetAdj {
-        offset: sp_adjustment,
-    });
-
-    gen_sp_adjust_insts(amount, is_sub, |inst| {
-        ctx.emit(inst);
-    });
-}
-
-impl ABICall for AArch64ABICall {
-    type I = Inst;
-
-    fn num_args(&self) -> usize {
-        if self.sig.stack_ret_arg.is_some() {
-            self.sig.args.len() - 1
-        } else {
-            self.sig.args.len()
-        }
-    }
-
-    fn emit_stack_pre_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
-        let off = self.sig.stack_arg_space + self.sig.stack_ret_space;
-        adjust_stack_and_nominal_sp(ctx, off as u64, /* is_sub = */ true)
-    }
-
-    fn emit_stack_post_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
-        let off = self.sig.stack_arg_space + self.sig.stack_ret_space;
-        adjust_stack_and_nominal_sp(ctx, off as u64, /* is_sub = */ false)
-    }
-
-    fn emit_copy_reg_to_arg<C: LowerCtx<I = Self::I>>(
-        &self,
-        ctx: &mut C,
-        idx: usize,
-        from_reg: Reg,
-    ) {
-        match &self.sig.args[idx] {
-            &ABIArg::Reg(reg, ty, ext)
-                if ext != ir::ArgumentExtension::None && ty_bits(ty) < 64 =>
-            {
-                assert_eq!(RegClass::I64, reg.get_class());
-                let signed = match ext {
-                    ir::ArgumentExtension::Uext => false,
-                    ir::ArgumentExtension::Sext => true,
-                    _ => unreachable!(),
-                };
-                ctx.emit(Inst::Extend {
-                    rd: Writable::from_reg(reg.to_reg()),
-                    rn: from_reg,
-                    signed,
-                    from_bits: ty_bits(ty) as u8,
-                    to_bits: 64,
-                });
+    fn get_caller_saves(call_conv: isa::CallConv) -> Vec<Writable<Reg>> {
+        let mut caller_saved = Vec::new();
+        for i in 0..29 {
+            let x = writable_xreg(i);
+            if is_caller_save_reg(call_conv, x.to_reg().to_real_reg()) {
+                caller_saved.push(x);
             }
-            &ABIArg::Reg(reg, ty, _) => {
-                ctx.emit(Inst::gen_move(
-                    Writable::from_reg(reg.to_reg()),
-                    from_reg,
-                    ty,
-                ));
+        }
+        for i in 0..32 {
+            let v = writable_vreg(i);
+            if is_caller_save_reg(call_conv, v.to_reg().to_real_reg()) {
+                caller_saved.push(v);
             }
-            &ABIArg::Stack(off, ty, ext) => {
-                if ext != ir::ArgumentExtension::None && ty_bits(ty) < 64 {
-                    assert_eq!(RegClass::I64, from_reg.get_class());
-                    let signed = match ext {
-                        ir::ArgumentExtension::Uext => false,
-                        ir::ArgumentExtension::Sext => true,
-                        _ => unreachable!(),
-                    };
-                    // Extend in place in the source register. Our convention is to
-                    // treat high bits as undefined for values in registers, so this
-                    // is safe, even for an argument that is nominally read-only.
-                    ctx.emit(Inst::Extend {
-                        rd: Writable::from_reg(from_reg),
-                        rn: from_reg,
-                        signed,
-                        from_bits: ty_bits(ty) as u8,
-                        to_bits: 64,
-                    });
+        }
+        caller_saved
+    }
+}
+
+/// Is this type supposed to be seen on this machine? E.g. references of the
+/// wrong width are invalid.
+fn legal_type_for_machine(ty: Type) -> bool {
+    match ty {
+        R32 => false,
+        _ => true,
+    }
+}
+
+fn is_callee_save_reg(call_conv: isa::CallConv, r: RealReg) -> bool {
+    if call_conv.extends_baldrdash() {
+        match r.get_class() {
+            RegClass::I64 => {
+                let enc = r.get_hw_encoding();
+                return BALDRDASH_JIT_CALLEE_SAVED_GPR[enc];
+            }
+            RegClass::V128 => {
+                let enc = r.get_hw_encoding();
+                return BALDRDASH_JIT_CALLEE_SAVED_FPU[enc];
+            }
+            _ => unimplemented!("baldrdash callee saved on non-i64 reg classes"),
+        };
+    }
+
+    match r.get_class() {
+        RegClass::I64 => {
+            // x19 - x28 inclusive are callee-saves.
+            r.get_hw_encoding() >= 19 && r.get_hw_encoding() <= 28
+        }
+        RegClass::V128 => {
+            // v8 - v15 inclusive are callee-saves.
+            r.get_hw_encoding() >= 8 && r.get_hw_encoding() <= 15
+        }
+        _ => panic!("Unexpected RegClass"),
+    }
+}
+
+fn get_callee_saves(
+    call_conv: isa::CallConv,
+    regs: &Set<Writable<RealReg>>,
+) -> (Vec<Writable<RealReg>>, Vec<Writable<RealReg>>) {
+    let mut int_saves = vec![];
+    let mut vec_saves = vec![];
+    for &reg in regs.iter() {
+        if is_callee_save_reg(call_conv, reg.to_reg()) {
+            match reg.to_reg().get_class() {
+                RegClass::I64 => int_saves.push(reg),
+                RegClass::V128 => vec_saves.push(reg),
+                _ => panic!("Unexpected RegClass"),
+            }
+        }
+    }
+    // Sort registers for deterministic code output.
+    int_saves.sort_by_key(|r| r.to_reg().get_index());
+    vec_saves.sort_by_key(|r| r.to_reg().get_index());
+    (int_saves, vec_saves)
+}
+
+fn is_caller_save_reg(call_conv: isa::CallConv, r: RealReg) -> bool {
+    if call_conv.extends_baldrdash() {
+        match r.get_class() {
+            RegClass::I64 => {
+                let enc = r.get_hw_encoding();
+                if !BALDRDASH_JIT_CALLEE_SAVED_GPR[enc] {
+                    return true;
                 }
-                ctx.emit(store_stack(MemArg::SPOffset(off, ty), from_reg, ty))
+                // Otherwise, fall through to preserve native's ABI caller-saved.
             }
-        }
+            RegClass::V128 => {
+                let enc = r.get_hw_encoding();
+                if !BALDRDASH_JIT_CALLEE_SAVED_FPU[enc] {
+                    return true;
+                }
+                // Otherwise, fall through to preserve native's ABI caller-saved.
+            }
+            _ => unimplemented!("baldrdash callee saved on non-i64 reg classes"),
+        };
     }
 
-    fn emit_copy_retval_to_reg<C: LowerCtx<I = Self::I>>(
-        &self,
-        ctx: &mut C,
-        idx: usize,
-        into_reg: Writable<Reg>,
-    ) {
-        match &self.sig.rets[idx] {
-            // Extension mode doesn't matter because we're copying out, not in,
-            // and we ignore high bits in our own registers by convention.
-            &ABIArg::Reg(reg, ty, _) => ctx.emit(Inst::gen_move(into_reg, reg.to_reg(), ty)),
-            &ABIArg::Stack(off, ty, _) => {
-                let ret_area_base = self.sig.stack_arg_space;
-                ctx.emit(load_stack(
-                    MemArg::SPOffset(off + ret_area_base, ty),
-                    into_reg,
-                    ty,
-                ));
-            }
+    match r.get_class() {
+        RegClass::I64 => {
+            // x0 - x17 inclusive are caller-saves.
+            r.get_hw_encoding() <= 17
         }
-    }
-
-    fn emit_call<C: LowerCtx<I = Self::I>>(&mut self, ctx: &mut C) {
-        let (uses, defs) = (
-            mem::replace(&mut self.uses, Default::default()),
-            mem::replace(&mut self.defs, Default::default()),
-        );
-        if let Some(i) = self.sig.stack_ret_arg {
-            let rd = ctx.alloc_tmp(RegClass::I64, I64);
-            let ret_area_base = self.sig.stack_arg_space;
-            ctx.emit(Inst::LoadAddr {
-                rd,
-                mem: MemArg::SPOffset(ret_area_base, I8),
-            });
-            self.emit_copy_reg_to_arg(ctx, i, rd.to_reg());
+        RegClass::V128 => {
+            // v0 - v7 inclusive and v16 - v31 inclusive are caller-saves.
+            r.get_hw_encoding() <= 7 || (r.get_hw_encoding() >= 16 && r.get_hw_encoding() <= 31)
         }
-        match &self.dest {
-            &CallDest::ExtName(ref name, RelocDistance::Near) => ctx.emit_safepoint(Inst::Call {
-                info: Box::new(CallInfo {
-                    dest: name.clone(),
-                    uses,
-                    defs,
-                    loc: self.loc,
-                    opcode: self.opcode,
-                }),
-            }),
-            &CallDest::ExtName(ref name, RelocDistance::Far) => {
-                ctx.emit(Inst::LoadExtName {
-                    rd: writable_spilltmp_reg(),
-                    name: Box::new(name.clone()),
-                    offset: 0,
-                    srcloc: self.loc,
-                });
-                ctx.emit_safepoint(Inst::CallInd {
-                    info: Box::new(CallIndInfo {
-                        rn: spilltmp_reg(),
-                        uses,
-                        defs,
-                        loc: self.loc,
-                        opcode: self.opcode,
-                    }),
-                });
-            }
-            &CallDest::Reg(reg) => ctx.emit_safepoint(Inst::CallInd {
-                info: Box::new(CallIndInfo {
-                    rn: reg,
-                    uses,
-                    defs,
-                    loc: self.loc,
-                    opcode: self.opcode,
-                }),
-            }),
-        }
+        _ => panic!("Unexpected RegClass"),
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1079,7 +1079,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad8 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "41004038",
@@ -1088,7 +1088,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad8 {
             rd: writable_xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::zero(I8)),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::zero(I8)),
             srcloc: None,
         },
         "41004039",
@@ -1097,7 +1097,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad8 {
             rd: writable_xreg(1),
-            mem: MemArg::RegReg(xreg(2), xreg(5)),
+            mem: AMode::RegReg(xreg(2), xreg(5)),
             srcloc: None,
         },
         "41686538",
@@ -1106,7 +1106,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad8 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "41008038",
@@ -1115,7 +1115,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad8 {
             rd: writable_xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(63, I8).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(63, I8).unwrap()),
             srcloc: None,
         },
         "41FC8039",
@@ -1124,7 +1124,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad8 {
             rd: writable_xreg(1),
-            mem: MemArg::RegReg(xreg(2), xreg(5)),
+            mem: AMode::RegReg(xreg(2), xreg(5)),
             srcloc: None,
         },
         "4168A538",
@@ -1133,7 +1133,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad16 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::maybe_from_i64(5).unwrap()),
+            mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(5).unwrap()),
             srcloc: None,
         },
         "41504078",
@@ -1142,7 +1142,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad16 {
             rd: writable_xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8, I16).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8, I16).unwrap()),
             srcloc: None,
         },
         "41104079",
@@ -1151,7 +1151,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad16 {
             rd: writable_xreg(1),
-            mem: MemArg::RegScaled(xreg(2), xreg(3), I16),
+            mem: AMode::RegScaled(xreg(2), xreg(3), I16),
             srcloc: None,
         },
         "41786378",
@@ -1160,7 +1160,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad16 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "41008078",
@@ -1169,7 +1169,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad16 {
             rd: writable_xreg(28),
-            mem: MemArg::UnsignedOffset(xreg(20), UImm12Scaled::maybe_from_i64(24, I16).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(20), UImm12Scaled::maybe_from_i64(24, I16).unwrap()),
             srcloc: None,
         },
         "9C328079",
@@ -1178,7 +1178,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad16 {
             rd: writable_xreg(28),
-            mem: MemArg::RegScaled(xreg(20), xreg(20), I16),
+            mem: AMode::RegScaled(xreg(20), xreg(20), I16),
             srcloc: None,
         },
         "9C7AB478",
@@ -1187,7 +1187,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad32 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "410040B8",
@@ -1196,7 +1196,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad32 {
             rd: writable_xreg(12),
-            mem: MemArg::UnsignedOffset(xreg(0), UImm12Scaled::maybe_from_i64(204, I32).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(0), UImm12Scaled::maybe_from_i64(204, I32).unwrap()),
             srcloc: None,
         },
         "0CCC40B9",
@@ -1205,7 +1205,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad32 {
             rd: writable_xreg(1),
-            mem: MemArg::RegScaled(xreg(2), xreg(12), I32),
+            mem: AMode::RegScaled(xreg(2), xreg(12), I32),
             srcloc: None,
         },
         "41786CB8",
@@ -1214,7 +1214,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad32 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "410080B8",
@@ -1223,7 +1223,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad32 {
             rd: writable_xreg(12),
-            mem: MemArg::UnsignedOffset(xreg(1), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(1), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
             srcloc: None,
         },
         "2CFCBFB9",
@@ -1232,7 +1232,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad32 {
             rd: writable_xreg(1),
-            mem: MemArg::RegScaled(xreg(5), xreg(1), I32),
+            mem: AMode::RegScaled(xreg(5), xreg(1), I32),
             srcloc: None,
         },
         "A178A1B8",
@@ -1241,7 +1241,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "410040F8",
@@ -1250,7 +1250,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::maybe_from_i64(-256).unwrap()),
+            mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(-256).unwrap()),
             srcloc: None,
         },
         "410050F8",
@@ -1259,7 +1259,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::maybe_from_i64(255).unwrap()),
+            mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(255).unwrap()),
             srcloc: None,
         },
         "41F04FF8",
@@ -1268,7 +1268,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
             srcloc: None,
         },
         "41FC7FF9",
@@ -1277,7 +1277,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::RegReg(xreg(2), xreg(3)),
+            mem: AMode::RegReg(xreg(2), xreg(3)),
             srcloc: None,
         },
         "416863F8",
@@ -1286,7 +1286,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::RegScaled(xreg(2), xreg(3), I64),
+            mem: AMode::RegScaled(xreg(2), xreg(3), I64),
             srcloc: None,
         },
         "417863F8",
@@ -1295,7 +1295,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::SXTW),
+            mem: AMode::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::SXTW),
             srcloc: None,
         },
         "41D863F8",
@@ -1304,7 +1304,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::RegExtended(xreg(2), xreg(3), ExtendOp::SXTW),
+            mem: AMode::RegExtended(xreg(2), xreg(3), ExtendOp::SXTW),
             srcloc: None,
         },
         "41C863F8",
@@ -1313,7 +1313,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::Label(MemLabel::PCRel(64)),
+            mem: AMode::Label(MemLabel::PCRel(64)),
             srcloc: None,
         },
         "01020058",
@@ -1322,7 +1322,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
+            mem: AMode::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
             srcloc: None,
         },
         "410C41F8",
@@ -1331,7 +1331,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
+            mem: AMode::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
             srcloc: None,
         },
         "410441F8",
@@ -1340,7 +1340,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(32768, I8),
+            mem: AMode::FPOffset(32768, I8),
             srcloc: None,
         },
         "100090D2B063308B010240F9",
@@ -1349,7 +1349,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(-32768, I8),
+            mem: AMode::FPOffset(-32768, I8),
             srcloc: None,
         },
         "F0FF8F92B063308B010240F9",
@@ -1358,7 +1358,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(1048576, I8), // 2^20
+            mem: AMode::FPOffset(1048576, I8), // 2^20
             srcloc: None,
         },
         "1002A0D2B063308B010240F9",
@@ -1367,7 +1367,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::FPOffset(1048576 + 1, I8), // 2^20 + 1
+            mem: AMode::FPOffset(1048576 + 1, I8), // 2^20 + 1
             srcloc: None,
         },
         "300080D21002A0F2B063308B010240F9",
@@ -1377,7 +1377,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::RegOffset(xreg(7), 8, I64),
+            mem: AMode::RegOffset(xreg(7), 8, I64),
             srcloc: None,
         },
         "E18040F8",
@@ -1387,7 +1387,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::RegOffset(xreg(7), 1024, I64),
+            mem: AMode::RegOffset(xreg(7), 1024, I64),
             srcloc: None,
         },
         "E10042F9",
@@ -1397,7 +1397,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: MemArg::RegOffset(xreg(7), 1048576, I64),
+            mem: AMode::RegOffset(xreg(7), 1048576, I64),
             srcloc: None,
         },
         "1002A0D2F060308B010240F9",
@@ -1407,7 +1407,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store8 {
             rd: xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "41000038",
@@ -1416,7 +1416,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store8 {
             rd: xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(4095, I8).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(4095, I8).unwrap()),
             srcloc: None,
         },
         "41FC3F39",
@@ -1425,7 +1425,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store16 {
             rd: xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "41000078",
@@ -1434,7 +1434,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store16 {
             rd: xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8190, I16).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8190, I16).unwrap()),
             srcloc: None,
         },
         "41FC3F79",
@@ -1443,7 +1443,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store32 {
             rd: xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "410000B8",
@@ -1452,7 +1452,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store32 {
             rd: xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
             srcloc: None,
         },
         "41FC3FB9",
@@ -1461,7 +1461,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
             srcloc: None,
         },
         "410000F8",
@@ -1470,7 +1470,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
+            mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
             srcloc: None,
         },
         "41FC3FF9",
@@ -1479,7 +1479,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::RegReg(xreg(2), xreg(3)),
+            mem: AMode::RegReg(xreg(2), xreg(3)),
             srcloc: None,
         },
         "416823F8",
@@ -1488,7 +1488,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::RegScaled(xreg(2), xreg(3), I64),
+            mem: AMode::RegScaled(xreg(2), xreg(3), I64),
             srcloc: None,
         },
         "417823F8",
@@ -1497,7 +1497,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::UXTW),
+            mem: AMode::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::UXTW),
             srcloc: None,
         },
         "415823F8",
@@ -1506,7 +1506,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::RegExtended(xreg(2), xreg(3), ExtendOp::UXTW),
+            mem: AMode::RegExtended(xreg(2), xreg(3), ExtendOp::UXTW),
             srcloc: None,
         },
         "414823F8",
@@ -1515,7 +1515,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
+            mem: AMode::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
             srcloc: None,
         },
         "410C01F8",
@@ -1524,7 +1524,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: MemArg::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
+            mem: AMode::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
             srcloc: None,
         },
         "410401F8",
@@ -1535,7 +1535,7 @@ fn test_aarch64_binemit() {
         Inst::StoreP64 {
             rt: xreg(8),
             rt2: xreg(9),
-            mem: PairMemArg::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
+            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
         },
         "482500A9",
         "stp x8, x9, [x10]",
@@ -1544,7 +1544,7 @@ fn test_aarch64_binemit() {
         Inst::StoreP64 {
             rt: xreg(8),
             rt2: xreg(9),
-            mem: PairMemArg::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(504, I64).unwrap()),
+            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(504, I64).unwrap()),
         },
         "48A51FA9",
         "stp x8, x9, [x10, #504]",
@@ -1553,7 +1553,7 @@ fn test_aarch64_binemit() {
         Inst::StoreP64 {
             rt: xreg(8),
             rt2: xreg(9),
-            mem: PairMemArg::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-64, I64).unwrap()),
+            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-64, I64).unwrap()),
         },
         "48253CA9",
         "stp x8, x9, [x10, #-64]",
@@ -1562,7 +1562,7 @@ fn test_aarch64_binemit() {
         Inst::StoreP64 {
             rt: xreg(21),
             rt2: xreg(28),
-            mem: PairMemArg::SignedOffset(xreg(1), SImm7Scaled::maybe_from_i64(-512, I64).unwrap()),
+            mem: PairAMode::SignedOffset(xreg(1), SImm7Scaled::maybe_from_i64(-512, I64).unwrap()),
         },
         "357020A9",
         "stp x21, x28, [x1, #-512]",
@@ -1571,7 +1571,7 @@ fn test_aarch64_binemit() {
         Inst::StoreP64 {
             rt: xreg(8),
             rt2: xreg(9),
-            mem: PairMemArg::PreIndexed(
+            mem: PairAMode::PreIndexed(
                 writable_xreg(10),
                 SImm7Scaled::maybe_from_i64(-64, I64).unwrap(),
             ),
@@ -1583,7 +1583,7 @@ fn test_aarch64_binemit() {
         Inst::StoreP64 {
             rt: xreg(15),
             rt2: xreg(16),
-            mem: PairMemArg::PostIndexed(
+            mem: PairAMode::PostIndexed(
                 writable_xreg(20),
                 SImm7Scaled::maybe_from_i64(504, I64).unwrap(),
             ),
@@ -1596,7 +1596,7 @@ fn test_aarch64_binemit() {
         Inst::LoadP64 {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
-            mem: PairMemArg::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
+            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
         },
         "482540A9",
         "ldp x8, x9, [x10]",
@@ -1605,7 +1605,7 @@ fn test_aarch64_binemit() {
         Inst::LoadP64 {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
-            mem: PairMemArg::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(504, I64).unwrap()),
+            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(504, I64).unwrap()),
         },
         "48A55FA9",
         "ldp x8, x9, [x10, #504]",
@@ -1614,7 +1614,7 @@ fn test_aarch64_binemit() {
         Inst::LoadP64 {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
-            mem: PairMemArg::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-64, I64).unwrap()),
+            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-64, I64).unwrap()),
         },
         "48257CA9",
         "ldp x8, x9, [x10, #-64]",
@@ -1623,10 +1623,7 @@ fn test_aarch64_binemit() {
         Inst::LoadP64 {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
-            mem: PairMemArg::SignedOffset(
-                xreg(10),
-                SImm7Scaled::maybe_from_i64(-512, I64).unwrap(),
-            ),
+            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-512, I64).unwrap()),
         },
         "482560A9",
         "ldp x8, x9, [x10, #-512]",
@@ -1635,7 +1632,7 @@ fn test_aarch64_binemit() {
         Inst::LoadP64 {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
-            mem: PairMemArg::PreIndexed(
+            mem: PairAMode::PreIndexed(
                 writable_xreg(10),
                 SImm7Scaled::maybe_from_i64(-64, I64).unwrap(),
             ),
@@ -1647,7 +1644,7 @@ fn test_aarch64_binemit() {
         Inst::LoadP64 {
             rt: writable_xreg(8),
             rt2: writable_xreg(25),
-            mem: PairMemArg::PostIndexed(
+            mem: PairAMode::PostIndexed(
                 writable_xreg(12),
                 SImm7Scaled::maybe_from_i64(504, I64).unwrap(),
             ),
@@ -4143,7 +4140,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuLoad32 {
             rd: writable_vreg(16),
-            mem: MemArg::RegScaled(xreg(8), xreg(9), F32),
+            mem: AMode::RegScaled(xreg(8), xreg(9), F32),
             srcloc: None,
         },
         "107969BC",
@@ -4153,7 +4150,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuLoad64 {
             rd: writable_vreg(16),
-            mem: MemArg::RegScaled(xreg(8), xreg(9), F64),
+            mem: AMode::RegScaled(xreg(8), xreg(9), F64),
             srcloc: None,
         },
         "107969FC",
@@ -4163,7 +4160,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuLoad128 {
             rd: writable_vreg(16),
-            mem: MemArg::RegScaled(xreg(8), xreg(9), I128),
+            mem: AMode::RegScaled(xreg(8), xreg(9), I128),
             srcloc: None,
         },
         "1079E93C",
@@ -4173,7 +4170,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuLoad32 {
             rd: writable_vreg(16),
-            mem: MemArg::Label(MemLabel::PCRel(8)),
+            mem: AMode::Label(MemLabel::PCRel(8)),
             srcloc: None,
         },
         "5000001C",
@@ -4183,7 +4180,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuLoad64 {
             rd: writable_vreg(16),
-            mem: MemArg::Label(MemLabel::PCRel(8)),
+            mem: AMode::Label(MemLabel::PCRel(8)),
             srcloc: None,
         },
         "5000005C",
@@ -4193,7 +4190,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuLoad128 {
             rd: writable_vreg(16),
-            mem: MemArg::Label(MemLabel::PCRel(8)),
+            mem: AMode::Label(MemLabel::PCRel(8)),
             srcloc: None,
         },
         "5000009C",
@@ -4203,7 +4200,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuStore32 {
             rd: vreg(16),
-            mem: MemArg::RegScaled(xreg(8), xreg(9), F32),
+            mem: AMode::RegScaled(xreg(8), xreg(9), F32),
             srcloc: None,
         },
         "107929BC",
@@ -4213,7 +4210,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuStore64 {
             rd: vreg(16),
-            mem: MemArg::RegScaled(xreg(8), xreg(9), F64),
+            mem: AMode::RegScaled(xreg(8), xreg(9), F64),
             srcloc: None,
         },
         "107929FC",
@@ -4223,7 +4220,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::FpuStore128 {
             rd: vreg(16),
-            mem: MemArg::RegScaled(xreg(8), xreg(9), I128),
+            mem: AMode::RegScaled(xreg(8), xreg(9), I128),
             srcloc: None,
         },
         "1079A93C",

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -663,7 +663,7 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
     elem_ty: Type,
     roots: &[InsnInput],
     offset: i32,
-) -> MemArg {
+) -> AMode {
     // TODO: support base_reg + scale * index_reg. For this, we would need to pattern-match shl or
     // mul instructions (Load/StoreComplex don't include scale factors).
 
@@ -680,26 +680,26 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
         offset
     );
 
-    // First, decide what the `MemArg` will be. Take one extendee and one 64-bit
+    // First, decide what the `AMode` will be. Take one extendee and one 64-bit
     // reg, or two 64-bit regs, or a 64-bit reg and a 32-bit reg with extension,
     // or some other combination as appropriate.
     let memarg = if addends64.len() > 0 {
         if addends32.len() > 0 {
             let (reg32, extendop) = addends32.pop().unwrap();
             let reg64 = addends64.pop().unwrap();
-            MemArg::RegExtended(reg64, reg32, extendop)
+            AMode::RegExtended(reg64, reg32, extendop)
         } else if offset > 0 && offset < 0x1000 {
             let reg64 = addends64.pop().unwrap();
             let off = offset;
             offset = 0;
-            MemArg::RegOffset(reg64, off, elem_ty)
+            AMode::RegOffset(reg64, off, elem_ty)
         } else if addends64.len() >= 2 {
             let reg1 = addends64.pop().unwrap();
             let reg2 = addends64.pop().unwrap();
-            MemArg::RegReg(reg1, reg2)
+            AMode::RegReg(reg1, reg2)
         } else {
             let reg1 = addends64.pop().unwrap();
-            MemArg::reg(reg1)
+            AMode::reg(reg1)
         }
     } else
     /* addends64.len() == 0 */
@@ -720,9 +720,9 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
                 to_bits: 64,
             });
             if let Some((reg2, extendop)) = addends32.pop() {
-                MemArg::RegExtended(tmp.to_reg(), reg2, extendop)
+                AMode::RegExtended(tmp.to_reg(), reg2, extendop)
             } else {
-                MemArg::reg(tmp.to_reg())
+                AMode::reg(tmp.to_reg())
             }
         } else
         /* addends32.len() == 0 */
@@ -730,32 +730,32 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
             let off_reg = ctx.alloc_tmp(RegClass::I64, I64);
             lower_constant_u64(ctx, off_reg, offset as u64);
             offset = 0;
-            MemArg::reg(off_reg.to_reg())
+            AMode::reg(off_reg.to_reg())
         }
     };
 
     // At this point, if we have any remaining components, we need to allocate a
-    // temp, replace one of the registers in the MemArg with the temp, and emit
+    // temp, replace one of the registers in the AMode with the temp, and emit
     // instructions to add together the remaining components. Return immediately
     // if this is *not* the case.
     if offset == 0 && addends32.len() == 0 && addends64.len() == 0 {
         return memarg;
     }
 
-    // Allocate the temp and shoehorn it into the MemArg.
+    // Allocate the temp and shoehorn it into the AMode.
     let addr = ctx.alloc_tmp(RegClass::I64, I64);
     let (reg, memarg) = match memarg {
-        MemArg::RegExtended(r1, r2, extendop) => {
-            (r1, MemArg::RegExtended(addr.to_reg(), r2, extendop))
+        AMode::RegExtended(r1, r2, extendop) => {
+            (r1, AMode::RegExtended(addr.to_reg(), r2, extendop))
         }
-        MemArg::RegOffset(r, off, ty) => (r, MemArg::RegOffset(addr.to_reg(), off, ty)),
-        MemArg::RegReg(r1, r2) => (r2, MemArg::RegReg(addr.to_reg(), r1)),
-        MemArg::UnsignedOffset(r, imm) => (r, MemArg::UnsignedOffset(addr.to_reg(), imm)),
+        AMode::RegOffset(r, off, ty) => (r, AMode::RegOffset(addr.to_reg(), off, ty)),
+        AMode::RegReg(r1, r2) => (r2, AMode::RegReg(addr.to_reg(), r1)),
+        AMode::UnsignedOffset(r, imm) => (r, AMode::UnsignedOffset(addr.to_reg(), imm)),
         _ => unreachable!(),
     };
 
     // If there is any offset, load that first into `addr`, and add the `reg`
-    // that we kicked out of the `MemArg`; otherwise, start with that reg.
+    // that we kicked out of the `AMode`; otherwise, start with that reg.
     if offset != 0 {
         // If we can fit offset or -offset in an imm12, use an add-imm
         // to combine the reg and offset. Otherwise, load value first then add.
@@ -993,37 +993,6 @@ pub(crate) fn condcode_is_signed(cc: IntCC) -> bool {
 
 //=============================================================================
 // Helpers for instruction lowering.
-
-/// Returns the size (in bits) of a given type.
-pub fn ty_bits(ty: Type) -> usize {
-    match ty {
-        B1 => 1,
-        B8 | I8 => 8,
-        B16 | I16 => 16,
-        B32 | I32 | F32 | R32 => 32,
-        B64 | I64 | F64 | R64 => 64,
-        B128 | I128 => 128,
-        IFLAGS | FFLAGS => 32,
-        B8X8 | I8X8 | B16X4 | I16X4 | B32X2 | I32X2 => 64,
-        B8X16 | I8X16 | B16X8 | I16X8 | B32X4 | I32X4 | B64X2 | I64X2 => 128,
-        F32X4 | F64X2 => 128,
-        _ => panic!("ty_bits() on unknown type: {:?}", ty),
-    }
-}
-
-pub(crate) fn ty_is_int(ty: Type) -> bool {
-    match ty {
-        B1 | B8 | I8 | B16 | I16 | B32 | I32 | B64 | I64 | R32 | R64 => true,
-        F32 | F64 | B128 | F32X2 | F32X4 | F64X2 | I128 | I8X8 | I8X16 | I16X4 | I16X8 | I32X2
-        | I32X4 | I64X2 => false,
-        IFLAGS | FFLAGS => panic!("Unexpected flags type"),
-        _ => panic!("ty_is_int() on unknown type: {:?}", ty),
-    }
-}
-
-pub(crate) fn ty_is_float(ty: Type) -> bool {
-    !ty_is_int(ty)
-}
 
 pub(crate) fn choose_32_64<T: Copy>(ty: Type, op32: T, op64: T) -> T {
     let bits = ty_bits(ty);

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -1,0 +1,1160 @@
+//! Implementation of a vanilla ABI, shared between several machines. The
+//! implementation here assumes that arguments will be passed in registers
+//! first, then additional args on the stack; that the stack grows downward,
+//! contains a standard frame (return address and frame pointer), and the
+//! compiler is otherwise free to allocate space below that with its choice of
+//! layout; and that the machine has some notion of caller- and callee-save
+//! registers. Most modern machines, e.g. x86-64 and AArch64, should fit this
+//! mold and thus both of these backends use this shared implementation.
+//!
+//! See the documentation in specific machine backends for the "instantiation"
+//! of this generic ABI, i.e., which registers are caller/callee-save, arguments
+//! and return values, and any other special requirements.
+//!
+//! For now the implementation here assumes a 64-bit machine, but we intend to
+//! make this 32/64-bit-generic shortly.
+//!
+//! # Vanilla ABI
+//!
+//! First, arguments and return values are passed in registers up to a certain
+//! fixed count, after which they overflow onto the stack. Multiple return
+//! values either fit in registers, or are returned in a separate return-value
+//! area on the stack, given by a hidden extra parameter.
+//!
+//! Note that the exact stack layout is up to us. We settled on the
+//! below design based on several requirements. In particular, we need to be
+//! able to generate instructions (or instruction sequences) to access
+//! arguments, stack slots, and spill slots before we know how many spill slots
+//! or clobber-saves there will be, because of our pass structure. We also
+//! prefer positive offsets to negative offsets because of an asymmetry in
+//! some machines' addressing modes (e.g., on AArch64, positive offsets have a
+//! larger possible range without a long-form sequence to synthesize an
+//! arbitrary offset). Finally, it is not allowed to access memory below the
+//! current SP value.
+//!
+//! We assume that a prologue first pushes the frame pointer (and return address
+//! above that, if the machine does not do that in hardware). We set FP to point
+//! to this two-word frame record. We store all other frame slots below this
+//! two-word frame record, with the stack pointer remaining at or below this
+//! fixed frame storage for the rest of the function. We can then access frame
+//! storage slots using positive offsets from SP. In order to allow codegen for
+//! the latter before knowing how many clobber-saves we have, and also allow it
+//! while SP is being adjusted to set up a call, we implement a "nominal SP"
+//! tracking feature by which a fixup (distance between actual SP and a
+//! "nominal" SP) is known at each instruction.
+//!
+//! # Stack Layout
+//!
+//! The stack looks like:
+//!
+//! ```plain
+//!   (high address)
+//!
+//!                              +---------------------------+
+//!                              |          ...              |
+//!                              | stack args                |
+//!                              | (accessed via FP)         |
+//!                              +---------------------------+
+//! SP at function entry ----->  | return address            |
+//!                              +---------------------------+
+//! FP after prologue -------->  | FP (pushed by prologue)   |
+//!                              +---------------------------+
+//!                              |          ...              |
+//!                              | spill slots               |
+//!                              | (accessed via nominal SP) |
+//!                              |          ...              |
+//!                              | stack slots               |
+//!                              | (accessed via nominal SP) |
+//! nominal SP --------------->  | (alloc'd by prologue)     |
+//!                              +---------------------------+
+//!                              |          ...              |
+//!                              | clobbered callee-saves    |
+//! SP at end of prologue ---->  | (pushed by prologue)      |
+//!                              +---------------------------+
+//!                              | [alignment as needed]     |
+//!                              |          ...              |
+//!                              | args for call             |
+//! SP before making a call -->  | (pushed at callsite)      |
+//!                              +---------------------------+
+//!
+//!   (low address)
+//! ```
+//!
+//! # Multi-value Returns
+//!
+//! Note that we support multi-value returns in two ways. First, we allow for
+//! multiple return-value registers. Second, if teh appropriate flag is set, we
+//! support the SpiderMonkey Wasm ABI.  For details of the multi-value return
+//! ABI, see:
+//!
+//! https://searchfox.org/mozilla-central/rev/bc3600def806859c31b2c7ac06e3d69271052a89/js/src/wasm/WasmStubs.h#134
+//!
+//! In brief:
+//! - Return values are processed in *reverse* order.
+//! - The first return value in this order (so the last return) goes into the
+//!   ordinary return register.
+//! - Any further returns go in a struct-return area, allocated upwards (in
+//!   address order) during the reverse traversal.
+//! - This struct-return area is provided by the caller, and a pointer to its
+//!   start is passed as an invisible last (extra) argument. Normally the caller
+//!   will allocate this area on the stack. When we generate calls, we place it
+//!   just above the on-stack argument area.
+//! - So, for example, a function returning 4 i64's (v0, v1, v2, v3), with no
+//!   formal arguments, would:
+//!   - Accept a pointer `P` to the struct return area as a hidden argument in the
+//!     first argument register on entry.
+//!   - Return v3 in the one and only return-value register.
+//!   - Return v2 in memory at `[P]`.
+//!   - Return v1 in memory at `[P+8]`.
+//!   - Return v0 in memory at `[P+16]`.
+
+use super::abi::*;
+use crate::binemit::StackMap;
+use crate::ir::types::*;
+use crate::ir::{ArgumentExtension, SourceLoc, StackSlot};
+use crate::machinst::*;
+use crate::settings;
+use crate::CodegenResult;
+use crate::{ir, isa};
+use alloc::vec::Vec;
+use log::{debug, trace};
+use regalloc::{RealReg, Reg, RegClass, Set, SpillSlot, Writable};
+use std::marker::PhantomData;
+use std::mem;
+
+/// A location for an argument or return value.
+#[derive(Clone, Copy, Debug)]
+pub enum ABIArg {
+    /// In a real register.
+    Reg(RealReg, ir::Type, ir::ArgumentExtension),
+    /// Arguments only: on stack, at given offset from SP at entry.
+    Stack(i64, ir::Type, ir::ArgumentExtension),
+}
+
+/// Are we computing information about arguments or return values? Much of the
+/// handling is factored out into common routines; this enum allows us to
+/// distinguish which case we're handling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArgsOrRets {
+    /// Arguments.
+    Args,
+    /// Return values.
+    Rets,
+}
+
+/// Abstract location for a machine-specific ABI impl to translate into the
+/// appropriate addressing mode.
+#[derive(Clone, Copy, Debug)]
+pub enum StackAMode {
+    /// Offset from the frame pointer, possibly making use of a specific type
+    /// for a scaled indexing operation.
+    FPOffset(i64, ir::Type),
+    /// Offset from the nominal stack pointer, possibly making use of a specific
+    /// type for a scaled indexing operation.
+    NominalSPOffset(i64, ir::Type),
+    /// Offset from the real stack pointer, possibly making use of a specific
+    /// type for a scaled indexing operation.
+    SPOffset(i64, ir::Type),
+}
+
+/// Trait implemented by machine-specific backend to provide information about
+/// register assignments and to allow generating the specific instructions for
+/// stack loads/saves, prologues/epilogues, etc.
+pub trait ABIMachineImpl {
+    /// The instruction type.
+    type I: VCodeInst;
+
+    /// Process a list of parameters or return values and allocate them to registers
+    /// and stack slots.
+    ///
+    /// Returns the list of argument locations, the stack-space used (rounded up
+    /// to as alignment requires), and if `add_ret_area_ptr` was passed, the
+    /// index of the extra synthetic arg that was added.
+    fn compute_arg_locs(
+        call_conv: isa::CallConv,
+        params: &[ir::AbiParam],
+        args_or_rets: ArgsOrRets,
+        add_ret_area_ptr: bool,
+    ) -> CodegenResult<(Vec<ABIArg>, i64, Option<usize>)>;
+
+    /// Returns the offset from FP to the argument area, i.e., jumping over the saved FP, return
+    /// address, and maybe other standard elements depending on ABI (e.g. Wasm TLS reg).
+    fn fp_to_arg_offset(call_conv: isa::CallConv, flags: &settings::Flags) -> i64;
+
+    /// Generate a load from the stack.
+    fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Self::I;
+
+    /// Generate a store to the stack.
+    fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type) -> Self::I;
+
+    /// Generate a move.
+    fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Self::I;
+
+    /// Generate an integer-extend operation.
+    fn gen_extend(
+        to_reg: Writable<Reg>,
+        from_reg: Reg,
+        is_signed: bool,
+        from_bits: u8,
+        to_bits: u8,
+    ) -> Self::I;
+
+    /// Generate a return instruction.
+    fn gen_ret() -> Self::I;
+
+    /// Generate an "epilogue placeholder" instruction, recognized by lowering
+    /// when using the Baldrdash ABI.
+    fn gen_epilogue_placeholder() -> Self::I;
+
+    /// Generate an add-with-immediate. Note that even if this uses a scratch
+    /// register, the sequence must still be correct if the given source or dest
+    /// is the register returned by `get_fixed_tmp_reg()`; hence, for machines
+    /// that may need a scratch register to synthesize an arbitrary constant,
+    /// the machine backend should reserve *another* fixed temp register for
+    /// this purpose. (E.g., on AArch64, x16 is the ordinary fixed tmp, and x17
+    /// is the secondary fixed tmp used to implement this.)
+    fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u64) -> SmallVec<[Self::I; 4]>;
+
+    /// Generate a sequence that traps with a `TrapCode::StackOverflow` code if
+    /// the stack pointer is less than the given limit register (assuming the
+    /// stack grows downward).
+    fn gen_stack_lower_bound_trap(limit_reg: Reg) -> SmallVec<[Self::I; 2]>;
+
+    /// Generate an instruction to compute an address of a stack slot (FP- or
+    /// SP-based offset).
+    fn gen_get_stack_addr(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Self::I;
+
+    /// Get a fixed (not used by regalloc) temp. This is needed for certain
+    /// sequences generated after the register allocator has already run.
+    fn get_fixed_tmp_reg() -> Reg;
+
+    /// Generate a store to the given [base+offset] address.
+    fn gen_load_base_offset(into_reg: Writable<Reg>, base: Reg, offset: i64, ty: Type) -> Self::I;
+
+    /// Generate a load from the given [base+offset] address.
+    fn gen_store_base_offset(base: Reg, offset: i64, from_reg: Reg, ty: Type) -> Self::I;
+
+    /// Adjust the stack pointer up or down.
+    fn gen_sp_reg_adjust(amount: i64) -> SmallVec<[Self::I; 2]>;
+
+    /// Generate a meta-instruction that adjusts the nominal SP offset.
+    fn gen_nominal_sp_adj(amount: i64) -> Self::I;
+
+    /// Generate the usual frame-setup sequence for this architecture: e.g.,
+    /// `push rbp / mov rbp, rsp` on x86-64, or `stp fp, lr, [sp, #-16]!` on
+    /// AArch64.
+    fn gen_prologue_frame_setup() -> SmallVec<[Self::I; 2]>;
+
+    /// Generate the usual frame-restore sequence for this architecture.
+    fn gen_epilogue_frame_restore() -> SmallVec<[Self::I; 2]>;
+
+    /// Generate a clobber-save sequence. This takes the list of *all* registers
+    /// written/modified by the function body. The implementation here is
+    /// responsible for determining which of these are callee-saved according to
+    /// the ABI. It should return a sequence of instructions that "push" or
+    /// otherwise save these values to the stack. The sequence of instructions
+    /// should adjust the stack pointer downward, and should align as necessary
+    /// according to ABI requirements.
+    ///
+    /// Returns stack bytes used as well as instructions. Does not adjust
+    /// nominal SP offset; caller will do that.
+    fn gen_clobber_save(
+        call_conv: isa::CallConv,
+        clobbers: &Set<Writable<RealReg>>,
+    ) -> (u64, SmallVec<[Self::I; 16]>);
+
+    /// Generate a clobber-restore sequence. This sequence should perform the
+    /// opposite of the clobber-save sequence generated above, assuming that SP
+    /// going into the sequence is at the same point that it was left when the
+    /// clobber-save sequence finished.
+    fn gen_clobber_restore(
+        call_conv: isa::CallConv,
+        clobbers: &Set<Writable<RealReg>>,
+    ) -> SmallVec<[Self::I; 16]>;
+
+    /// Generate a call instruction/sequence.
+    fn gen_call(
+        dest: &CallDest,
+        uses: Vec<Reg>,
+        defs: Vec<Writable<Reg>>,
+        loc: SourceLoc,
+        opcode: ir::Opcode,
+    ) -> SmallVec<[(/* is_safepoint = */ bool, Self::I); 2]>;
+
+    /// Get the number of spillslots required for the given register-class and
+    /// type.
+    fn get_spillslot_size(rc: RegClass, ty: Type) -> u32;
+
+    /// Get the current virtual-SP offset from an instruction-emission state.
+    fn get_virtual_sp_offset_from_state(s: &<Self::I as MachInstEmit>::State) -> i64;
+
+    /// Get the "nominal SP to FP" offset from an instruction-emission state.
+    fn get_nominal_sp_to_fp(s: &<Self::I as MachInstEmit>::State) -> i64;
+
+    /// Get all caller-save registers.
+    fn get_caller_saves(call_conv: isa::CallConv) -> Vec<Writable<Reg>>;
+}
+
+/// ABI information shared between body (callee) and caller.
+struct ABISig {
+    /// Argument locations (regs or stack slots). Stack offsets are relative to
+    /// SP on entry to function.
+    args: Vec<ABIArg>,
+    /// Return-value locations. Stack offsets are relative to the return-area
+    /// pointer.
+    rets: Vec<ABIArg>,
+    /// Space on stack used to store arguments.
+    stack_arg_space: i64,
+    /// Space on stack used to store return values.
+    stack_ret_space: i64,
+    /// Index in `args` of the stack-return-value-area argument.
+    stack_ret_arg: Option<usize>,
+    /// Calling convention used.
+    call_conv: isa::CallConv,
+}
+
+impl ABISig {
+    fn from_func_sig<M: ABIMachineImpl>(sig: &ir::Signature) -> CodegenResult<ABISig> {
+        // Compute args and retvals from signature. Handle retvals first,
+        // because we may need to add a return-area arg to the args.
+        let (rets, stack_ret_space, _) = M::compute_arg_locs(
+            sig.call_conv,
+            &sig.returns,
+            ArgsOrRets::Rets,
+            /* extra ret-area ptr = */ false,
+        )?;
+        let need_stack_return_area = stack_ret_space > 0;
+        let (args, stack_arg_space, stack_ret_arg) = M::compute_arg_locs(
+            sig.call_conv,
+            &sig.params,
+            ArgsOrRets::Args,
+            need_stack_return_area,
+        )?;
+
+        trace!(
+            "ABISig: sig {:?} => args = {:?} rets = {:?} arg stack = {} ret stack = {} stack_ret_arg = {:?}",
+            sig,
+            args,
+            rets,
+            stack_arg_space,
+            stack_ret_space,
+            stack_ret_arg
+        );
+
+        Ok(ABISig {
+            args,
+            rets,
+            stack_arg_space,
+            stack_ret_space,
+            stack_ret_arg,
+            call_conv: sig.call_conv,
+        })
+    }
+}
+
+/// ABI object for a function body.
+pub struct ABIBodyImpl<M: ABIMachineImpl> {
+    /// Signature: arg and retval regs.
+    sig: ABISig,
+    /// Offsets to each stackslot.
+    stackslots: Vec<u32>,
+    /// Total stack size of all stackslots.
+    stackslots_size: u32,
+    /// Clobbered registers, from regalloc.
+    clobbered: Set<Writable<RealReg>>,
+    /// Total number of spillslots, from regalloc.
+    spillslots: Option<usize>,
+    /// "Total frame size", as defined by "distance between FP and nominal SP".
+    /// Some items are pushed below nominal SP, so the function may actually use
+    /// more stack than this would otherwise imply. It is simply the initial
+    /// frame/allocation size needed for stackslots and spillslots.
+    total_frame_size: Option<u32>,
+    /// The register holding the return-area pointer, if needed.
+    ret_area_ptr: Option<Writable<Reg>>,
+    /// Calling convention this function expects.
+    call_conv: isa::CallConv,
+    /// The settings controlling this function's compilation.
+    flags: settings::Flags,
+    /// Whether or not this function is a "leaf", meaning it calls no other
+    /// functions
+    is_leaf: bool,
+    /// If this function has a stack limit specified, then `Reg` is where the
+    /// stack limit will be located after the instructions specified have been
+    /// executed.
+    ///
+    /// Note that this is intended for insertion into the prologue, if
+    /// present. Also note that because the instructions here execute in the
+    /// prologue this happens after legalization/register allocation/etc so we
+    /// need to be extremely careful with each instruction. The instructions are
+    /// manually register-allocated and carefully only use caller-saved
+    /// registers and keep nothing live after this sequence of instructions.
+    stack_limit: Option<(Reg, Vec<M::I>)>,
+
+    _mach: PhantomData<M>,
+}
+
+fn get_special_purpose_param_register(
+    f: &ir::Function,
+    abi: &ABISig,
+    purpose: ir::ArgumentPurpose,
+) -> Option<Reg> {
+    let idx = f.signature.special_param_index(purpose)?;
+    match abi.args[idx] {
+        ABIArg::Reg(reg, ..) => Some(reg.to_reg()),
+        ABIArg::Stack(..) => None,
+    }
+}
+
+impl<M: ABIMachineImpl> ABIBodyImpl<M> {
+    /// Create a new body ABI instance.
+    pub fn new(f: &ir::Function, flags: settings::Flags) -> CodegenResult<Self> {
+        debug!("ABI: func signature {:?}", f.signature);
+
+        let sig = ABISig::from_func_sig::<M>(&f.signature)?;
+
+        let call_conv = f.signature.call_conv;
+        // Only these calling conventions are supported.
+        debug_assert!(
+            call_conv == isa::CallConv::SystemV
+                || call_conv == isa::CallConv::Fast
+                || call_conv == isa::CallConv::Cold
+                || call_conv.extends_baldrdash(),
+            "Unsupported calling convention: {:?}",
+            call_conv
+        );
+
+        // Compute stackslot locations and total stackslot size.
+        let mut stack_offset: u32 = 0;
+        let mut stackslots = vec![];
+        for (stackslot, data) in f.stack_slots.iter() {
+            let off = stack_offset;
+            stack_offset += data.size;
+            stack_offset = (stack_offset + 7) & !7;
+            debug_assert_eq!(stackslot.as_u32() as usize, stackslots.len());
+            stackslots.push(off);
+        }
+
+        // Figure out what instructions, if any, will be needed to check the
+        // stack limit. This can either be specified as a special-purpose
+        // argument or as a global value which often calculates the stack limit
+        // from the arguments.
+        let stack_limit =
+            get_special_purpose_param_register(f, &sig, ir::ArgumentPurpose::StackLimit)
+                .map(|reg| (reg, Vec::new()))
+                .or_else(|| f.stack_limit.map(|gv| gen_stack_limit::<M>(f, &sig, gv)));
+
+        Ok(Self {
+            sig,
+            stackslots,
+            stackslots_size: stack_offset,
+            clobbered: Set::empty(),
+            spillslots: None,
+            total_frame_size: None,
+            ret_area_ptr: None,
+            call_conv,
+            flags,
+            is_leaf: f.is_leaf(),
+            stack_limit,
+            _mach: PhantomData,
+        })
+    }
+
+    /// Inserts instructions necessary for checking the stack limit into the
+    /// prologue.
+    ///
+    /// This function will generate instructions necessary for perform a stack
+    /// check at the header of a function. The stack check is intended to trap
+    /// if the stack pointer goes below a particular threshold, preventing stack
+    /// overflow in wasm or other code. The `stack_limit` argument here is the
+    /// register which holds the threshold below which we're supposed to trap.
+    /// This function is known to allocate `stack_size` bytes and we'll push
+    /// instructions onto `insts`.
+    ///
+    /// Note that the instructions generated here are special because this is
+    /// happening so late in the pipeline (e.g. after register allocation). This
+    /// means that we need to do manual register allocation here and also be
+    /// careful to not clobber any callee-saved or argument registers. For now
+    /// this routine makes do with the `spilltmp_reg` as one temporary
+    /// register, and a second register of `tmp2` which is caller-saved. This
+    /// should be fine for us since no spills should happen in this sequence of
+    /// instructions, so our register won't get accidentally clobbered.
+    ///
+    /// No values can be live after the prologue, but in this case that's ok
+    /// because we just need to perform a stack check before progressing with
+    /// the rest of the function.
+    fn insert_stack_check(&self, stack_limit: Reg, stack_size: u32, insts: &mut Vec<M::I>) {
+        // With no explicit stack allocated we can just emit the simple check of
+        // the stack registers against the stack limit register, and trap if
+        // it's out of bounds.
+        if stack_size == 0 {
+            insts.extend(M::gen_stack_lower_bound_trap(stack_limit));
+            return;
+        }
+
+        // Note that the 32k stack size here is pretty special. See the
+        // documentation in x86/abi.rs for why this is here. The general idea is
+        // that we're protecting against overflow in the addition that happens
+        // below.
+        if stack_size >= 32 * 1024 {
+            insts.extend(M::gen_stack_lower_bound_trap(stack_limit));
+        }
+
+        // Add the `stack_size` to `stack_limit`, placing the result in
+        // `scratch`.
+        //
+        // Note though that `stack_limit`'s register may be the same as
+        // `scratch`. If our stack size doesn't fit into an immediate this
+        // means we need a second scratch register for loading the stack size
+        // into a register.
+        let scratch = Writable::from_reg(M::get_fixed_tmp_reg());
+        let stack_size = u64::from(stack_size);
+        insts.extend(M::gen_add_imm(scratch, stack_limit, stack_size).into_iter());
+        insts.extend(M::gen_stack_lower_bound_trap(scratch.to_reg()));
+    }
+}
+
+/// Generates the instructions necessary for the `gv` to be materialized into a
+/// register.
+///
+/// This function will return a register that will contain the result of
+/// evaluating `gv`. It will also return any instructions necessary to calculate
+/// the value of the register.
+///
+/// Note that global values are typically lowered to instructions via the
+/// standard legalization pass. Unfortunately though prologue generation happens
+/// so late in the pipeline that we can't use these legalization passes to
+/// generate the instructions for `gv`. As a result we duplicate some lowering
+/// of `gv` here and support only some global values. This is similar to what
+/// the x86 backend does for now, and hopefully this can be somewhat cleaned up
+/// in the future too!
+///
+/// Also note that this function will make use of `writable_spilltmp_reg()` as a
+/// temporary register to store values in if necessary. Currently after we write
+/// to this register there's guaranteed to be no spilled values between where
+/// it's used, because we're not participating in register allocation anyway!
+fn gen_stack_limit<M: ABIMachineImpl>(
+    f: &ir::Function,
+    abi: &ABISig,
+    gv: ir::GlobalValue,
+) -> (Reg, Vec<M::I>) {
+    let mut insts = Vec::new();
+    let reg = generate_gv::<M>(f, abi, gv, &mut insts);
+    return (reg, insts);
+}
+
+fn generate_gv<M: ABIMachineImpl>(
+    f: &ir::Function,
+    abi: &ABISig,
+    gv: ir::GlobalValue,
+    insts: &mut Vec<M::I>,
+) -> Reg {
+    match f.global_values[gv] {
+        // Return the direct register the vmcontext is in
+        ir::GlobalValueData::VMContext => {
+            get_special_purpose_param_register(f, abi, ir::ArgumentPurpose::VMContext)
+                .expect("no vmcontext parameter found")
+        }
+        // Load our base value into a register, then load from that register
+        // in to a temporary register.
+        ir::GlobalValueData::Load {
+            base,
+            offset,
+            global_type: _,
+            readonly: _,
+        } => {
+            let base = generate_gv::<M>(f, abi, base, insts);
+            let into_reg = Writable::from_reg(M::get_fixed_tmp_reg());
+            insts.push(M::gen_load_base_offset(into_reg, base, offset.into(), I64));
+            return into_reg.to_reg();
+        }
+        ref other => panic!("global value for stack limit not supported: {}", other),
+    }
+}
+
+/// Return a type either from an optional type hint, or if not, from the default
+/// type associated with the given register's class. This is used to generate
+/// loads/spills appropriately given the type of value loaded/stored (which may
+/// be narrower than the spillslot). We usually have the type because the
+/// regalloc usually provides the vreg being spilled/reloaded, and we know every
+/// vreg's type. However, the regalloc *can* request a spill/reload without an
+/// associated vreg when needed to satisfy a safepoint (which requires all
+/// ref-typed values, even those in real registers in the original vcode, to be
+/// in spillslots).
+fn ty_from_ty_hint_or_reg_class(r: Reg, ty: Option<Type>) -> Type {
+    match (ty, r.get_class()) {
+        // If the type is provided
+        (Some(t), _) => t,
+        // If no type is provided, this should be a register spill for a
+        // safepoint, so we only expect I64 (integer) registers.
+        (None, RegClass::I64) => I64,
+        _ => panic!("Unexpected register class!"),
+    }
+}
+
+impl<M: ABIMachineImpl> ABIBody for ABIBodyImpl<M> {
+    type I = M::I;
+
+    fn temp_needed(&self) -> bool {
+        self.sig.stack_ret_arg.is_some()
+    }
+
+    fn init(&mut self, maybe_tmp: Option<Writable<Reg>>) {
+        if self.sig.stack_ret_arg.is_some() {
+            assert!(maybe_tmp.is_some());
+            self.ret_area_ptr = maybe_tmp;
+        }
+    }
+
+    fn flags(&self) -> &settings::Flags {
+        &self.flags
+    }
+
+    fn liveins(&self) -> Set<RealReg> {
+        let mut set: Set<RealReg> = Set::empty();
+        for &arg in &self.sig.args {
+            if let ABIArg::Reg(r, ..) = arg {
+                set.insert(r);
+            }
+        }
+        set
+    }
+
+    fn liveouts(&self) -> Set<RealReg> {
+        let mut set: Set<RealReg> = Set::empty();
+        for &ret in &self.sig.rets {
+            if let ABIArg::Reg(r, ..) = ret {
+                set.insert(r);
+            }
+        }
+        set
+    }
+
+    fn num_args(&self) -> usize {
+        self.sig.args.len()
+    }
+
+    fn num_retvals(&self) -> usize {
+        self.sig.rets.len()
+    }
+
+    fn num_stackslots(&self) -> usize {
+        self.stackslots.len()
+    }
+
+    fn gen_copy_arg_to_reg(&self, idx: usize, into_reg: Writable<Reg>) -> Self::I {
+        match &self.sig.args[idx] {
+            // Extension mode doesn't matter (we're copying out, not in; we
+            // ignore high bits by convention).
+            &ABIArg::Reg(r, ty, _) => M::gen_move(into_reg, r.to_reg(), ty),
+            &ABIArg::Stack(off, ty, _) => M::gen_load_stack(
+                StackAMode::FPOffset(M::fp_to_arg_offset(self.call_conv, &self.flags) + off, ty),
+                into_reg,
+                ty,
+            ),
+        }
+    }
+
+    fn gen_copy_reg_to_retval(&self, idx: usize, from_reg: Writable<Reg>) -> Vec<Self::I> {
+        let mut ret = Vec::new();
+        match &self.sig.rets[idx] {
+            &ABIArg::Reg(r, ty, ext) => {
+                let from_bits = ty_bits(ty) as u8;
+                let dest_reg = Writable::from_reg(r.to_reg());
+                match (ext, from_bits) {
+                    (ArgumentExtension::Uext, n) | (ArgumentExtension::Sext, n) if n < 64 => {
+                        let signed = ext == ArgumentExtension::Sext;
+                        ret.push(M::gen_extend(
+                            dest_reg,
+                            from_reg.to_reg(),
+                            signed,
+                            from_bits,
+                            /* to_bits = */ 64,
+                        ));
+                    }
+                    _ => ret.push(M::gen_move(dest_reg, from_reg.to_reg(), ty)),
+                };
+            }
+            &ABIArg::Stack(off, ty, ext) => {
+                let from_bits = ty_bits(ty) as u8;
+                // Trash the from_reg; it should be its last use.
+                match (ext, from_bits) {
+                    (ArgumentExtension::Uext, n) | (ArgumentExtension::Sext, n) if n < 64 => {
+                        let signed = ext == ArgumentExtension::Sext;
+                        ret.push(M::gen_extend(
+                            from_reg,
+                            from_reg.to_reg(),
+                            signed,
+                            from_bits,
+                            /* to_bits = */ 64,
+                        ));
+                    }
+                    _ => {}
+                };
+                ret.push(M::gen_store_base_offset(
+                    self.ret_area_ptr.unwrap().to_reg(),
+                    off,
+                    from_reg.to_reg(),
+                    ty,
+                ));
+            }
+        }
+        ret
+    }
+
+    fn gen_retval_area_setup(&self) -> Option<Self::I> {
+        if let Some(i) = self.sig.stack_ret_arg {
+            let inst = self.gen_copy_arg_to_reg(i, self.ret_area_ptr.unwrap());
+            trace!(
+                "gen_retval_area_setup: inst {:?}; ptr reg is {:?}",
+                inst,
+                self.ret_area_ptr.unwrap().to_reg()
+            );
+            Some(inst)
+        } else {
+            trace!("gen_retval_area_setup: not needed");
+            None
+        }
+    }
+
+    fn gen_ret(&self) -> Self::I {
+        M::gen_ret()
+    }
+
+    fn gen_epilogue_placeholder(&self) -> Self::I {
+        M::gen_epilogue_placeholder()
+    }
+
+    fn set_num_spillslots(&mut self, slots: usize) {
+        self.spillslots = Some(slots);
+    }
+
+    fn set_clobbered(&mut self, clobbered: Set<Writable<RealReg>>) {
+        self.clobbered = clobbered;
+    }
+
+    /// Load from a stackslot.
+    fn load_stackslot(
+        &self,
+        slot: StackSlot,
+        offset: u32,
+        ty: Type,
+        into_reg: Writable<Reg>,
+    ) -> Self::I {
+        // Offset from beginning of stackslot area, which is at nominal SP (see
+        // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
+        let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
+        let sp_off: i64 = stack_off + (offset as i64);
+        trace!("load_stackslot: slot {} -> sp_off {}", slot, sp_off);
+        M::gen_load_stack(StackAMode::NominalSPOffset(sp_off, ty), into_reg, ty)
+    }
+
+    /// Store to a stackslot.
+    fn store_stackslot(&self, slot: StackSlot, offset: u32, ty: Type, from_reg: Reg) -> Self::I {
+        // Offset from beginning of stackslot area, which is at nominal SP (see
+        // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
+        let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
+        let sp_off: i64 = stack_off + (offset as i64);
+        trace!("store_stackslot: slot {} -> sp_off {}", slot, sp_off);
+        M::gen_store_stack(StackAMode::NominalSPOffset(sp_off, ty), from_reg, ty)
+    }
+
+    /// Produce an instruction that computes a stackslot address.
+    fn stackslot_addr(&self, slot: StackSlot, offset: u32, into_reg: Writable<Reg>) -> Self::I {
+        // Offset from beginning of stackslot area, which is at nominal SP (see
+        // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
+        let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
+        let sp_off: i64 = stack_off + (offset as i64);
+        M::gen_get_stack_addr(StackAMode::NominalSPOffset(sp_off, I8), into_reg, I8)
+    }
+
+    /// Load from a spillslot.
+    fn load_spillslot(&self, slot: SpillSlot, ty: Type, into_reg: Writable<Reg>) -> Self::I {
+        // Offset from beginning of spillslot area, which is at nominal SP + stackslots_size.
+        let islot = slot.get() as i64;
+        let spill_off = islot * 8; // FIXME: 64-bit machine assumed.
+        let sp_off = self.stackslots_size as i64 + spill_off;
+        trace!("load_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
+        M::gen_load_stack(StackAMode::NominalSPOffset(sp_off, ty), into_reg, ty)
+    }
+
+    /// Store to a spillslot.
+    fn store_spillslot(&self, slot: SpillSlot, ty: Type, from_reg: Reg) -> Self::I {
+        // Offset from beginning of spillslot area, which is at nominal SP + stackslots_size.
+        let islot = slot.get() as i64;
+        let spill_off = islot * 8; // FIXME: 64-bit machine assumed.
+        let sp_off = self.stackslots_size as i64 + spill_off;
+        trace!("store_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
+        M::gen_store_stack(StackAMode::NominalSPOffset(sp_off, ty), from_reg, ty)
+    }
+
+    fn spillslots_to_stack_map(
+        &self,
+        slots: &[SpillSlot],
+        state: &<Self::I as MachInstEmit>::State,
+    ) -> StackMap {
+        let virtual_sp_offset = M::get_virtual_sp_offset_from_state(state);
+        let nominal_sp_to_fp = M::get_nominal_sp_to_fp(state);
+        assert!(virtual_sp_offset >= 0);
+        trace!(
+            "spillslots_to_stackmap: slots = {:?}, state = {:?}",
+            slots,
+            state
+        );
+        let map_size = (virtual_sp_offset + nominal_sp_to_fp) as u32;
+        let map_words = (map_size + 7) / 8; // FIXME: 64-bit machine assumed.
+        let mut bits = std::iter::repeat(false)
+            .take(map_words as usize)
+            .collect::<Vec<bool>>();
+
+        let first_spillslot_word = ((self.stackslots_size + virtual_sp_offset as u32) / 8) as usize;
+        for &slot in slots {
+            let slot = slot.get() as usize;
+            bits[first_spillslot_word + slot] = true;
+        }
+
+        StackMap::from_slice(&bits[..])
+    }
+
+    fn gen_prologue(&mut self) -> Vec<Self::I> {
+        let mut insts = vec![];
+        if !self.call_conv.extends_baldrdash() {
+            // set up frame
+            insts.extend(M::gen_prologue_frame_setup().into_iter());
+        }
+
+        let mut total_stacksize = self.stackslots_size + 8 * self.spillslots.unwrap() as u32;
+        if self.call_conv.extends_baldrdash() {
+            debug_assert!(
+                !self.flags.enable_probestack(),
+                "baldrdash does not expect cranelift to emit stack probes"
+            );
+            // FIXME: 64-bit machine assumed.
+            total_stacksize += self.flags.baldrdash_prologue_words() as u32 * 8;
+        }
+        let total_stacksize = (total_stacksize + 15) & !15; // 16-align the stack.
+
+        let mut total_sp_adjust = 0;
+
+        if !self.call_conv.extends_baldrdash() {
+            // Leaf functions with zero stack don't need a stack check if one's
+            // specified, otherwise always insert the stack check.
+            if total_stacksize > 0 || !self.is_leaf {
+                if let Some((reg, stack_limit_load)) = &self.stack_limit {
+                    insts.extend_from_slice(stack_limit_load);
+                    self.insert_stack_check(*reg, total_stacksize, &mut insts);
+                }
+            }
+            if total_stacksize > 0 {
+                total_sp_adjust += total_stacksize as u64;
+            }
+        }
+
+        // N.B.: "nominal SP", which we use to refer to stackslots and
+        // spillslots, is defined to be equal to the stack pointer at this point
+        // in the prologue.
+        //
+        // If we push any clobbers below, we emit a virtual-SP adjustment
+        // meta-instruction so that the nominal SP references behave as if SP
+        // were still at this point. See documentation for
+        // [crate::machinst::abi_impl](this module) for more details on
+        // stackframe layout and nominal SP maintenance.
+
+        if total_sp_adjust > 0 {
+            // sub sp, sp, #total_stacksize
+            let adj = total_sp_adjust as i64;
+            insts.extend(M::gen_sp_reg_adjust(-adj));
+        }
+
+        // Save clobbered registers.
+        let (clobber_size, clobber_insts) = M::gen_clobber_save(self.call_conv, &self.clobbered);
+        insts.extend(clobber_insts);
+
+        if clobber_size > 0 {
+            insts.push(M::gen_nominal_sp_adj(clobber_size as i64));
+        }
+
+        self.total_frame_size = Some(total_stacksize);
+        insts
+    }
+
+    fn gen_epilogue(&self) -> Vec<M::I> {
+        let mut insts = vec![];
+
+        // Restore clobbered registers.
+        insts.extend(M::gen_clobber_restore(self.call_conv, &self.clobbered));
+
+        // N.B.: we do *not* emit a nominal SP adjustment here, because (i) there will be no
+        // references to nominal SP offsets before the return below, and (ii) the instruction
+        // emission tracks running SP offset linearly (in straight-line order), not according to
+        // the CFG, so early returns in the middle of function bodies would cause an incorrect
+        // offset for the rest of the body.
+
+        if !self.call_conv.extends_baldrdash() {
+            insts.extend(M::gen_epilogue_frame_restore());
+            insts.push(M::gen_ret());
+        }
+
+        debug!("Epilogue: {:?}", insts);
+        insts
+    }
+
+    fn frame_size(&self) -> u32 {
+        self.total_frame_size
+            .expect("frame size not computed before prologue generation")
+    }
+
+    fn stack_args_size(&self) -> u32 {
+        self.sig.stack_arg_space as u32
+    }
+
+    fn get_spillslot_size(&self, rc: RegClass, ty: Type) -> u32 {
+        M::get_spillslot_size(rc, ty)
+    }
+
+    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, ty: Option<Type>) -> Self::I {
+        let ty = ty_from_ty_hint_or_reg_class(from_reg.to_reg(), ty);
+        self.store_spillslot(to_slot, ty, from_reg.to_reg())
+    }
+
+    fn gen_reload(
+        &self,
+        to_reg: Writable<RealReg>,
+        from_slot: SpillSlot,
+        ty: Option<Type>,
+    ) -> Self::I {
+        let ty = ty_from_ty_hint_or_reg_class(to_reg.to_reg().to_reg(), ty);
+        self.load_spillslot(from_slot, ty, to_reg.map(|r| r.to_reg()))
+    }
+}
+
+fn abisig_to_uses_and_defs<M: ABIMachineImpl>(sig: &ABISig) -> (Vec<Reg>, Vec<Writable<Reg>>) {
+    // Compute uses: all arg regs.
+    let mut uses = Vec::new();
+    for arg in &sig.args {
+        match arg {
+            &ABIArg::Reg(reg, ..) => uses.push(reg.to_reg()),
+            _ => {}
+        }
+    }
+
+    // Compute defs: all retval regs, and all caller-save (clobbered) regs.
+    let mut defs = M::get_caller_saves(sig.call_conv);
+    for ret in &sig.rets {
+        match ret {
+            &ABIArg::Reg(reg, ..) => defs.push(Writable::from_reg(reg.to_reg())),
+            _ => {}
+        }
+    }
+
+    (uses, defs)
+}
+
+/// ABI object for a callsite.
+pub struct ABICallImpl<M: ABIMachineImpl> {
+    /// The called function's signature.
+    sig: ABISig,
+    /// All uses for the callsite, i.e., function args.
+    uses: Vec<Reg>,
+    /// All defs for the callsite, i.e., return values and caller-saves.
+    defs: Vec<Writable<Reg>>,
+    /// Call destination.
+    dest: CallDest,
+    /// Location of callsite.
+    loc: ir::SourceLoc,
+    /// Actuall call opcode; used to distinguish various types of calls.
+    opcode: ir::Opcode,
+
+    _mach: PhantomData<M>,
+}
+
+/// Destination for a call.
+#[derive(Debug, Clone)]
+pub enum CallDest {
+    /// Call to an ExtName (named function symbol).
+    ExtName(ir::ExternalName, RelocDistance),
+    /// Indirect call to a function pointer in a register.
+    Reg(Reg),
+}
+
+impl<M: ABIMachineImpl> ABICallImpl<M> {
+    /// Create a callsite ABI object for a call directly to the specified function.
+    pub fn from_func(
+        sig: &ir::Signature,
+        extname: &ir::ExternalName,
+        dist: RelocDistance,
+        loc: ir::SourceLoc,
+    ) -> CodegenResult<ABICallImpl<M>> {
+        let sig = ABISig::from_func_sig::<M>(sig)?;
+        let (uses, defs) = abisig_to_uses_and_defs::<M>(&sig);
+        Ok(ABICallImpl {
+            sig,
+            uses,
+            defs,
+            dest: CallDest::ExtName(extname.clone(), dist),
+            loc,
+            opcode: ir::Opcode::Call,
+            _mach: PhantomData,
+        })
+    }
+
+    /// Create a callsite ABI object for a call to a function pointer with the
+    /// given signature.
+    pub fn from_ptr(
+        sig: &ir::Signature,
+        ptr: Reg,
+        loc: ir::SourceLoc,
+        opcode: ir::Opcode,
+    ) -> CodegenResult<ABICallImpl<M>> {
+        let sig = ABISig::from_func_sig::<M>(sig)?;
+        let (uses, defs) = abisig_to_uses_and_defs::<M>(&sig);
+        Ok(ABICallImpl {
+            sig,
+            uses,
+            defs,
+            dest: CallDest::Reg(ptr),
+            loc,
+            opcode,
+            _mach: PhantomData,
+        })
+    }
+}
+
+fn adjust_stack_and_nominal_sp<M: ABIMachineImpl, C: LowerCtx<I = M::I>>(
+    ctx: &mut C,
+    off: u64,
+    is_sub: bool,
+) {
+    if off == 0 {
+        return;
+    }
+    let off = off as i64;
+    let amt = if is_sub { -off } else { off };
+    for inst in M::gen_sp_reg_adjust(amt) {
+        ctx.emit(inst);
+    }
+    ctx.emit(M::gen_nominal_sp_adj(-amt));
+}
+
+impl<M: ABIMachineImpl> ABICall for ABICallImpl<M> {
+    type I = M::I;
+
+    fn num_args(&self) -> usize {
+        if self.sig.stack_ret_arg.is_some() {
+            self.sig.args.len() - 1
+        } else {
+            self.sig.args.len()
+        }
+    }
+
+    fn emit_stack_pre_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
+        let off = self.sig.stack_arg_space + self.sig.stack_ret_space;
+        adjust_stack_and_nominal_sp::<M, C>(ctx, off as u64, /* is_sub = */ true)
+    }
+
+    fn emit_stack_post_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
+        let off = self.sig.stack_arg_space + self.sig.stack_ret_space;
+        adjust_stack_and_nominal_sp::<M, C>(ctx, off as u64, /* is_sub = */ false)
+    }
+
+    fn emit_copy_reg_to_arg<C: LowerCtx<I = Self::I>>(
+        &self,
+        ctx: &mut C,
+        idx: usize,
+        from_reg: Reg,
+    ) {
+        match &self.sig.args[idx] {
+            &ABIArg::Reg(reg, ty, ext)
+                if ext != ir::ArgumentExtension::None && ty_bits(ty) < 64 =>
+            {
+                assert_eq!(RegClass::I64, reg.get_class());
+                let signed = match ext {
+                    ir::ArgumentExtension::Uext => false,
+                    ir::ArgumentExtension::Sext => true,
+                    _ => unreachable!(),
+                };
+                ctx.emit(M::gen_extend(
+                    Writable::from_reg(reg.to_reg()),
+                    from_reg,
+                    signed,
+                    ty_bits(ty) as u8,
+                    64,
+                ));
+            }
+            &ABIArg::Reg(reg, ty, _) => {
+                ctx.emit(M::gen_move(Writable::from_reg(reg.to_reg()), from_reg, ty));
+            }
+            &ABIArg::Stack(off, ty, ext) => {
+                if ext != ir::ArgumentExtension::None && ty_bits(ty) < 64 {
+                    assert_eq!(RegClass::I64, from_reg.get_class());
+                    let signed = match ext {
+                        ir::ArgumentExtension::Uext => false,
+                        ir::ArgumentExtension::Sext => true,
+                        _ => unreachable!(),
+                    };
+                    // Extend in place in the source register. Our convention is to
+                    // treat high bits as undefined for values in registers, so this
+                    // is safe, even for an argument that is nominally read-only.
+                    ctx.emit(M::gen_extend(
+                        Writable::from_reg(from_reg),
+                        from_reg,
+                        signed,
+                        ty_bits(ty) as u8,
+                        64,
+                    ));
+                }
+                ctx.emit(M::gen_store_stack(
+                    StackAMode::SPOffset(off, ty),
+                    from_reg,
+                    ty,
+                ));
+            }
+        }
+    }
+
+    fn emit_copy_retval_to_reg<C: LowerCtx<I = Self::I>>(
+        &self,
+        ctx: &mut C,
+        idx: usize,
+        into_reg: Writable<Reg>,
+    ) {
+        match &self.sig.rets[idx] {
+            // Extension mode doesn't matter because we're copying out, not in,
+            // and we ignore high bits in our own registers by convention.
+            &ABIArg::Reg(reg, ty, _) => ctx.emit(M::gen_move(into_reg, reg.to_reg(), ty)),
+            &ABIArg::Stack(off, ty, _) => {
+                let ret_area_base = self.sig.stack_arg_space;
+                ctx.emit(M::gen_load_stack(
+                    StackAMode::SPOffset(off + ret_area_base, ty),
+                    into_reg,
+                    ty,
+                ));
+            }
+        }
+    }
+
+    fn emit_call<C: LowerCtx<I = Self::I>>(&mut self, ctx: &mut C) {
+        let (uses, defs) = (
+            mem::replace(&mut self.uses, Default::default()),
+            mem::replace(&mut self.defs, Default::default()),
+        );
+        if let Some(i) = self.sig.stack_ret_arg {
+            let rd = ctx.alloc_tmp(RegClass::I64, I64);
+            let ret_area_base = self.sig.stack_arg_space;
+            ctx.emit(M::gen_get_stack_addr(
+                StackAMode::SPOffset(ret_area_base, I8),
+                rd,
+                I8,
+            ));
+            self.emit_copy_reg_to_arg(ctx, i, rd.to_reg());
+        }
+        for (is_safepoint, inst) in
+            M::gen_call(&self.dest, uses, defs, self.loc, self.opcode).into_iter()
+        {
+            if is_safepoint {
+                ctx.emit_safepoint(inst);
+            } else {
+                ctx.emit(inst);
+            }
+        }
+    }
+}

--- a/cranelift/codegen/src/machinst/helpers.rs
+++ b/cranelift/codegen/src/machinst/helpers.rs
@@ -1,0 +1,18 @@
+//! Miscellaneous helpers for machine backends.
+
+use crate::ir::Type;
+
+/// Returns the size (in bits) of a given type.
+pub fn ty_bits(ty: Type) -> usize {
+    usize::from(ty.bits())
+}
+
+/// Is the type represented by an integer (not float) at the machine level?
+pub(crate) fn ty_has_int_representation(ty: Type) -> bool {
+    ty.is_int() || ty.is_bool() || ty.is_ref()
+}
+
+/// Is the type represented by a float or vector value at the machine level?
+pub(crate) fn ty_has_float_or_vec_representation(ty: Type) -> bool {
+    ty.is_vector() || ty.is_float()
+}

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -123,12 +123,16 @@ pub mod blockorder;
 pub use blockorder::*;
 pub mod abi;
 pub use abi::*;
+pub mod abi_impl;
+pub use abi_impl::*;
 pub mod pretty_print;
 pub use pretty_print::*;
 pub mod buffer;
 pub use buffer::*;
 pub mod adapter;
 pub use adapter::*;
+pub mod helpers;
+pub use helpers::*;
 
 /// A machine instruction.
 pub trait MachInst: Clone + Debug {


### PR DESCRIPTION
We have observed that the ABI implementations for AArch64 and x64 are
very similar; in fact, x64's implementation started as a modified copy
of AArch64's implementation. This is an artifact of both a similar ABI
(both machines pass args and return values in registers first, then the
stack, and both machines give considerable freedom with stack-frame
layout) and a too-low-level ABI abstraction in the existing design. For
machines that fit the mainstream or most common ABI-design idioms, we
should be able to do much better.

This commit factors AArch64 into machine-specific and
machine-independent parts, but does not yet modify x64; that will come
next.

This should be completely neutral with respect to compile time and
generated code performance.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
