### PR TITLE
Upgrade to regalloc 0.0.29.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.28"
+version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3598bed0895fe0f72a9e0b00ef9e3a3c8af978a8401b2f2046dec5927de6364a"
+checksum = "c178c51068338acd359c6e1ed356fcffe6b6cb3c162f68f70e251ca29bfe0eba"
 dependencies = [
  "log",
  "rustc-hash",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = { version = "1.3.2", default-features = false }
 peepmatic = { path = "../peepmatic", optional = true, version = "0.66.0" }
 peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, version = "0.66.0" }
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.66.0" }
-regalloc = "0.0.28"
+regalloc = "0.0.29"
 wast = { version = "22.0.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary


### PR DESCRIPTION
This upgrade pulls in several recent changes in regalloc that should
improve compile-time performance in the AArch64 and new x64 backends.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
