### PR TITLE
Dependency version gardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,7 +2644,7 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 21.0.0",
+ "wast 22.0.0",
 ]
 
 [[package]]
@@ -2666,15 +2666,6 @@ dependencies = [
  "syn",
  "wiggle-generate",
  "witx",
-]
-
-[[package]]
-name = "wast"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4d67ba9266f4fcaf2e8a1afadc5e2a959e51aecc07b1ecbdf85a6ddaf08bde"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -2803,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.8.5"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "diff",
@@ -2811,7 +2802,7 @@ dependencies = [
  "pretty_env_logger",
  "structopt",
  "thiserror",
- "wast 11.0.0",
+ "wast 22.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wast 22.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -1303,7 +1303,7 @@ dependencies = [
  "peepmatic-test-operator",
  "peepmatic-traits",
  "serde",
- "wast 22.0.0",
+ "wast",
  "z3",
 ]
 
@@ -1331,7 +1331,7 @@ dependencies = [
  "peepmatic-traits",
  "rand 0.7.3",
  "serde",
- "wast 22.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ dependencies = [
  "serde",
  "serde_test",
  "thiserror",
- "wast 22.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -1377,7 +1377,7 @@ version = "0.66.0"
 dependencies = [
  "peepmatic-traits",
  "serde",
- "wast 22.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -2644,7 +2644,7 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 22.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -2670,15 +2670,6 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1844f66a2bc8526d71690104c0e78a8e59ffa1597b7245769d174ebb91deb5"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
 version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe1220ed7f824992b426a76125a3403d048eaf0f627918e97ade0d9b9d510d20"
@@ -2688,11 +2679,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce85d72b74242c340e9e3492cfb602652d7bb324c3172dd441b5577e39a2e18c"
+checksum = "f888158d9a4b7c39b859f72a435019835b64097c749f4f28d319004ca5a520b8"
 dependencies = [
- "wast 21.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -2802,7 +2793,7 @@ dependencies = [
  "pretty_env_logger",
  "structopt",
  "thiserror",
- "wast 22.0.0",
+ "wast",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ anyhow = "1.0.19"
 target-lexicon = { version = "0.10.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.18"
+wat = "1.0.23"
 libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 thiserror = "1.0.4"
 
 [dev-dependencies]
-wat = "1.0.18"
+wat = "1.0.23"
 target-lexicon = "0.10"
 # Enable the riscv feature for cranelift-codegen, as some tests require it
 cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["riscv"] }

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime = { path = "../wasmtime", default-features = false }
 wasmtime-c-api-macros = { path = "macros" }
 
 # Optional dependency for the `wat2wasm` API
-wat = { version = "1.0.18", optional = true }
+wat = { version = "1.0.23", optional = true }
 
 # Optional dependencies for the `wasi` feature
 wasi-common = { path = "../wasi-common", optional = true }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -19,4 +19,4 @@ wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 
 [dev-dependencies]
-wat = "1.0.18"
+wat = "1.0.23"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -28,7 +28,7 @@ wasmparser = "0.59.0"
 
 [dev-dependencies]
 lazy_static = "1.2"
-wat = "1.0.18"
+wat = "1.0.23"
 quickcheck = "0.9.0"
 anyhow = "1.0"
 

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -18,7 +18,7 @@ pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
-wat = "1.0.18"
+wat = "1.0.23"
 
 [features]
 test_programs = []

--- a/crates/wasi-common/wig/Cargo.toml
+++ b/crates/wasi-common/wig/Cargo.toml
@@ -18,7 +18,7 @@ test = false
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 heck = "0.3.1"
-witx = { path = "../WASI/tools/witx", version = "0.8.5" }
+witx = { path = "../WASI/tools/witx", version = "0.8.7" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.19.0", default-features = false }
-wast = "21.0.0"
+wast = "22.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -409,7 +409,7 @@ fn val_matches(actual: &Val, expected: &wast::AssertExpression) -> Result<bool> 
         (Val::F32(a), wast::AssertExpression::F32(b)) => f32_matches(*a, b),
         (Val::F64(a), wast::AssertExpression::F64(b)) => f64_matches(*a, b),
         (Val::V128(a), wast::AssertExpression::V128(b)) => v128_matches(*a, b),
-        (Val::ExternRef(x), wast::AssertExpression::RefNull(HeapType::Extern)) => x.is_none(),
+        (Val::ExternRef(x), wast::AssertExpression::RefNull(Some(HeapType::Extern))) => x.is_none(),
         (Val::ExternRef(x), wast::AssertExpression::RefExtern(y)) => {
             if let Some(x) = x {
                 let x = x
@@ -421,7 +421,7 @@ fn val_matches(actual: &Val, expected: &wast::AssertExpression) -> Result<bool> 
                 false
             }
         }
-        (Val::FuncRef(x), wast::AssertExpression::RefNull(HeapType::Func)) => x.is_none(),
+        (Val::FuncRef(x), wast::AssertExpression::RefNull(_)) => x.is_none(),
         _ => bail!(
             "don't know how to compare {:?} and {:?} yet",
             actual,

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 thiserror = "1"
-witx = { path = "../wasi-common/WASI/tools/witx", version = "0.8.5", optional = true }
+witx = { path = "../wasi-common/WASI/tools/witx", version = "0.8.7", optional = true }
 wiggle-macro = { path = "macro", version = "0.19.0" }
 tracing = "0.1.15"
 

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "LICENSE"]
 [lib]
 
 [dependencies]
-witx = { version = "0.8.5", path = "../../wasi-common/WASI/tools/witx" }
+witx = { version = "0.8.7", path = "../../wasi-common/WASI/tools/witx" }
 quote = "1.0"
 proc-macro2 = "1.0"
 heck = "0.3"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [dependencies]
 wiggle-generate = { path = "../generate", version = "0.19.0" }
-witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.5" }
+witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.7" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 

--- a/crates/wiggle/wasmtime/Cargo.toml
+++ b/crates/wiggle/wasmtime/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*", "LICENSE"]
 [dependencies]
 wasmtime = { path = "../../wasmtime", version = "0.19.0", default-features = false }
 wasmtime-wiggle-macro = { path = "./macro", version = "0.19.0" }
-witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.5", optional = true }
+witx = { path = "../../wasi-common/WASI/tools/witx", version = "0.8.7", optional = true }
 wiggle = { path = "..", version = "0.19.0" }
 
 [badges]

--- a/crates/wiggle/wasmtime/macro/Cargo.toml
+++ b/crates/wiggle/wasmtime/macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 test = false
 
 [dependencies]
-witx = { path = "../../../wasi-common/WASI/tools/witx", version = "0.8.5" }
+witx = { path = "../../../wasi-common/WASI/tools/witx", version = "0.8.7" }
 wiggle-generate = { path = "../../generate", version = "0.19.0" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"]  }


### PR DESCRIPTION
* Upgrade the `WASI` submodule to the latest `master`, which is `witx` crate `0.8.7`
* Upgrade `wasmtime-wast`'s dependency on `wast` to `22.0.0`
* Upgrade all `wat` dependencies to `1.0.23`

Together, these changes trim us from depending on 3 versions of `wast` down to just one (the latest, `22.0.0`).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
