### PR TITLE
Don't leave Deref bytecode for Code chunk

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -454,6 +454,7 @@ where
                 Operation::Deref { .. } => {
                     flush_code_chunk!();
                     parts.push(CompiledExpressionPart::Deref);
+                    continue;
                 }
                 _ => {
                     return Ok(None);
@@ -720,7 +721,7 @@ mod tests {
                     },
                     CompiledExpressionPart::Code(vec![35, 5]),
                     CompiledExpressionPart::Deref,
-                    CompiledExpressionPart::Code(vec![6, 159])
+                    CompiledExpressionPart::Code(vec![159])
                 ],
                 need_deref: false
             }


### PR DESCRIPTION
Re-enter loop after pushing `CompiledExpressionPart::Deref`, so that it
isn't recoded for `CompiledExpressionPart::Code` as well.

Fixed the test case too, which was essentially confirming the bug.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
