### PR TITLE
Bump object to 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
- "object 0.20.0",
+ "object 0.21.1",
  "target-lexicon",
 ]
 
@@ -1255,6 +1255,12 @@ name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
+
+[[package]]
+name = "object"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 dependencies = [
  "crc32fast",
  "indexmap",
@@ -2441,7 +2447,7 @@ dependencies = [
  "libc",
  "log",
  "more-asserts",
- "object 0.20.0",
+ "object 0.21.1",
  "pretty_env_logger",
  "rayon",
  "structopt",
@@ -2469,7 +2475,7 @@ dependencies = [
  "anyhow",
  "gimli 0.21.0",
  "more-asserts",
- "object 0.20.0",
+ "object 0.21.1",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.59.0",
@@ -2541,7 +2547,7 @@ dependencies = [
  "gimli 0.21.0",
  "log",
  "more-asserts",
- "object 0.20.0",
+ "object 0.21.1",
  "rayon",
  "region",
  "serde",
@@ -2562,7 +2568,7 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object 0.20.0",
+ "object 0.21.1",
  "target-lexicon",
  "wasmtime-debug",
  "wasmtime-environ",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ wasmtime-wast = { path = "crates/wast", version = "0.19.0" }
 wasmtime-wasi = { path = "crates/wasi", version = "0.19.0" }
 wasi-common = { path = "crates/wasi-common", version = "0.19.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
-object = { version = "0.20", default-features = false, features = ["write"] }
+object = { version = "0.21.1", default-features = false, features = ["write"] }
 anyhow = "1.0.19"
 target-lexicon = { version = "0.10.0", default-features = false }
 pretty_env_logger = "0.4.0"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 cranelift-module = { path = "../module", version = "0.66.0" }
 cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["std"] }
-object = { version = "0.20", default-features = false, features = ["write"] }
+object = { version = "0.21.1", default-features = false, features = ["write"] }
 target-lexicon = "0.10"
 anyhow = "1.0"
 

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 gimli = "0.21.0"
 wasmparser = "0.59.0"
-object = { version = "0.20", default-features = false, features = ["read", "write"] }
+object = { version = "0.21.1", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.19.0" }
 target-lexicon = { version = "0.10.0", default-features = false }
 anyhow = "1.0"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0"
 cfg-if = "0.1.9"
 log = "0.4"
 gimli = { version = "0.21.0", default-features = false, features = ["write"] }
-object = { version = "0.20", default-features = false, features = ["write"] }
+object = { version = "0.21.1", default-features = false, features = ["write"] }
 serde = { version = "1.0.94", features = ["derive"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 wasmtime-environ = { path = "../environ", version = "0.19.0" }
-object = { version = "0.20", default-features = false, features = ["write"] }
+object = { version = "0.21.1", default-features = false, features = ["write"] }
 more-asserts = "0.2.1"
 target-lexicon = { version = "0.10.0", default-features = false }
 wasmtime-debug = { path = "../debug", version = "0.19.0" }


### PR DESCRIPTION
All changes: https://github.com/gimli-rs/object/compare/0.20.0...0.21.1

### Changelog for 0.21.0

* Use WritableBuffer to emit object file (https://github.com/gimli-rs/object/pull/241)
* Make everything in crate::elf public (https://github.com/gimli-rs/object/pull/242)
* Implement COMDAT support (https://github.com/gimli-rs/object/pull/243)
* Add support for s390x (https://github.com/gimli-rs/object/pull/245)

### Changelog for 0.21.1

* write/elf: Check symbol.weak before symbol.is_undefined() (https://github.com/gimli-rs/object/pull/247)