### PR TITLE
refactor: Use the obvious DW_OP_const4u for 0xffff_ffff

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -64,6 +64,10 @@ impl ExpressionWriter {
         write::Writer::write_u8(&mut self.0, b)
     }
 
+    pub fn write_u32(&mut self, b: u32) -> write::Result<()> {
+        write::Writer::write_u32(&mut self.0, b)
+    }
+
     pub fn write_uleb128(&mut self, i: u64) -> write::Result<()> {
         write::Writer::write_uleb128(&mut self.0, i)
     }
@@ -196,8 +200,8 @@ fn append_memory_deref(
     }
     writer.write_op(gimli::constants::DW_OP_deref)?;
     writer.write_op(gimli::constants::DW_OP_swap)?;
-    writer.write_op(gimli::constants::DW_OP_constu)?;
-    writer.write_uleb128(0xffff_ffff)?;
+    writer.write_op(gimli::constants::DW_OP_const4u)?;
+    writer.write_u32(0xffff_ffff)?;
     writer.write_op(gimli::constants::DW_OP_and)?;
     writer.write_op(gimli::constants::DW_OP_plus)?;
     buf.extend(writer.into_vec());


### PR DESCRIPTION
No point in resorting to LEB128 encoding for such constants,
using the native `u32` is faster and more compact.

Adds `write_u32` method to facilitate this.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
