### PR TITLE
Revert #2137, the extra (seemingly leftover) DW_OP_deref is in fact essential

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -458,6 +458,8 @@ where
                 Operation::Deref { .. } => {
                     flush_code_chunk!();
                     parts.push(CompiledExpressionPart::Deref);
+                    // Don't re-enter the loop here (i.e. continue), because the
+                    // DW_OP_deref still needs to be kept.
                 }
                 _ => {
                     return Ok(None);


### PR DESCRIPTION
This corrects my mistake (by reverting #2137) and adds a comment so that I don't make the same error again.

A possibility to test for this (e.g. by `wasm2obj` or such) would be awesome.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
