### PR TITLE
Deduplicate for_each_libcall, assert, provide mock impl

### DIFF
--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -73,7 +73,6 @@ macro_rules! for_each_libcall {
     ($op:ident) => {
         $op![
             (UdivI64, wasmtime_i64_udiv),
-            (UdivI64, wasmtime_i64_udiv),
             (SdivI64, wasmtime_i64_sdiv),
             (UremI64, wasmtime_i64_urem),
             (SremI64, wasmtime_i64_srem),
@@ -87,7 +86,26 @@ macro_rules! for_each_libcall {
             (CeilF64, wasmtime_f64_ceil),
             (FloorF64, wasmtime_f64_floor),
             (TruncF64, wasmtime_f64_trunc),
-            (NearestF64, wasmtime_f64_nearest)
+            (NearestF64, wasmtime_f64_nearest),
+            (Probestack, wasmtime_probestack),
+            (Memcpy, wasmtime_memcpy),
+            (Memset, wasmtime_memset),
+            (Memmove, wasmtime_memmove),
+            (ElfTlsGetAddr, wasmtime_tls_get_addr)
         ];
     };
+}
+
+fn __assert_all_for_each_libcalls(libcall: crate::ir::LibCall) {
+    use crate::ir::LibCall;
+    macro_rules! assert_libcalls {
+        [$(($libcall:ident, $export:ident)),*] => {
+            match libcall {
+                $(
+                   | LibCall::$libcall
+                )+ => (),
+            }
+        };
+    }
+    for_each_libcall!(assert_libcalls)
 }

--- a/crates/obj/src/builder.rs
+++ b/crates/obj/src/builder.rs
@@ -31,7 +31,9 @@ use wasmtime_environ::entity::{EntityRef, PrimaryMap};
 use wasmtime_environ::ir::{LibCall, Reloc};
 use wasmtime_environ::isa::unwind::UnwindInfo;
 use wasmtime_environ::wasm::{DefinedFuncIndex, FuncIndex, SignatureIndex};
-use wasmtime_environ::{CompiledFunction, CompiledFunctions, Module, Relocation, RelocationTarget};
+use wasmtime_environ::{
+    for_each_libcall, CompiledFunction, CompiledFunctions, Module, Relocation, RelocationTarget,
+};
 
 fn to_object_relocations<'a>(
     it: impl Iterator<Item = &'a Relocation> + 'a,
@@ -126,31 +128,6 @@ fn process_unwind_info(info: &UnwindInfo, obj: &mut Object, code_section: Sectio
 //     isa.triple().architecture.endianness(),
 //     Ok(target_lexicon::Endianness::Little)
 // );
-
-/// Iterates through all `LibCall` members and all runtime exported functions.
-#[macro_export]
-macro_rules! for_each_libcall {
-    ($op:ident) => {
-        $op![
-            (UdivI64, wasmtime_i64_udiv),
-            (UdivI64, wasmtime_i64_udiv),
-            (SdivI64, wasmtime_i64_sdiv),
-            (UremI64, wasmtime_i64_urem),
-            (SremI64, wasmtime_i64_srem),
-            (IshlI64, wasmtime_i64_ishl),
-            (UshrI64, wasmtime_i64_ushr),
-            (SshrI64, wasmtime_i64_sshr),
-            (CeilF32, wasmtime_f32_ceil),
-            (FloorF32, wasmtime_f32_floor),
-            (TruncF32, wasmtime_f32_trunc),
-            (NearestF32, wasmtime_f32_nearest),
-            (CeilF64, wasmtime_f64_ceil),
-            (FloorF64, wasmtime_f64_floor),
-            (TruncF64, wasmtime_f64_trunc),
-            (NearestF64, wasmtime_f64_nearest)
-        ];
-    };
-}
 
 fn write_libcall_symbols(obj: &mut Object) -> HashMap<LibCall, SymbolId> {
     let mut libcalls = HashMap::new();

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -184,6 +184,35 @@ pub extern "C" fn wasmtime_f64_nearest(x: f64) -> f64 {
     }
 }
 
+/// Implementation of probestack
+pub unsafe extern "C" fn wasmtime_probestack() {
+    // TODO forward to __rust_probestack ?
+    panic!("TODO probestack")
+}
+
+/// Implementation of elf_tls_get_addr
+pub unsafe extern "C" fn wasmtime_tls_get_addr() {
+    panic!("TODO elf_tls_get_addr")
+}
+
+/// Implementation of memcpy
+pub unsafe extern "C" fn wasmtime_memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    use std::ffi::c_void;
+    libc::memcpy(dest as *mut c_void, src as *const c_void, n) as *mut u8
+}
+
+/// Implementation of memmove
+pub unsafe extern "C" fn wasmtime_memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    use std::ffi::c_void;
+    libc::memmove(dest as *mut c_void, src as *const c_void, n) as *mut u8
+}
+
+/// Implementation of memset
+pub unsafe extern "C" fn wasmtime_memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
+    use std::ffi::c_void;
+    libc::memset(s as *mut c_void, c, n) as *mut u8
+}
+
 /// Implementation of memory.grow for locally-defined 32-bit memories.
 pub unsafe extern "C" fn wasmtime_memory32_grow(
     vmctx: *mut VMContext,


### PR DESCRIPTION
We don't have listed all Libcalls in the `for_each_libcall` at the moment. (And I noticed `Libcall::Probestack` reloc record in one of the large WASI programs)

This patch:
- [x] removes for_each_libcall macro from the obj crate
- [x] adds __assert_all_for_each_libcalls to catch missing Libcall (and warns for duplicate)
- [x] Implement wasmtime_memXXX and stub rest

Not sure what are the plans. Can we use stuff from the compiler-builtins crate here?
