### PR TITLE
wasi-common: remove unnecessary check - fixed in std since Rust 1.38

### DIFF
--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -172,10 +172,6 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
     fn fd_filestat_set_size(&self, fd: types::Fd, size: types::Filesize) -> Result<()> {
         let required_rights = HandleRights::from_base(types::Rights::FD_FILESTAT_SET_SIZE);
         let entry = self.get_entry(fd)?;
-        // This check will be unnecessary when rust-lang/rust#63326 is fixed
-        if size > i64::max_value() as u64 {
-            return Err(Errno::TooBig);
-        }
         entry.as_handle(&required_rights)?.filestat_set_size(size)
     }
 


### PR DESCRIPTION
issue now closed: https://github.com/rust-lang/rust/issues/63326
fix landed in a rollup: https://github.com/rust-lang/rust/pull/63380 merged aug 8, 2019
rust 1.38 beta cut on aug 15, 2019: https://blog.rust-lang.org/2019/08/15/Rust-1.37.0.html
minimum supported rust version for this repo is currently 1.41.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
