### PR TITLE
Optimize cranelift-reader a bit

### DIFF
--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -445,7 +445,7 @@ impl<'a> Parser<'a> {
         // running. I don't think this is true - self.lookahead is mutated in the loop body - so
         // maybe this is a clippy bug? Either way, disable clippy for this.
         #[cfg_attr(feature = "cargo-clippy", allow(clippy::while_immutable_condition))]
-        while self.lookahead == None {
+        while self.lookahead.is_none() {
             match self.lex.next() {
                 Some(Ok(LocatedToken { token, location })) => {
                     match token {


### PR DESCRIPTION
```
before
instructions:u 131061201966
cycles:u        60881656295

after
instructions:u 128897387028
cycles:u        60018494856
```

See the commit messages for more information.