### PR TITLE
wiggle-wasmtime: witx paths should be relative to CARGO_MANIFEST_DIR,…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,6 +1906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2709,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+ "shellexpand",
  "syn",
  "witx",
 ]

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -4,7 +4,7 @@
 use crate::WasiCtx;
 
 wiggle::from_witx!({
-    witx: ["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
+    witx: ["$WASI_ROOT/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -10,7 +10,7 @@ wasmtime_wiggle::wasmtime_integration!({
     // The wiggle code to integrate with lives here:
     target: wasi_common::wasi,
     // This must be the same witx document as used above:
-    witx: ["phases/snapshot/witx/wasi_snapshot_preview1.witx"],
+    witx: ["../wasi-common/WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
     // This must be the same ctx type as used for the target:
     ctx: WasiCtx,
     // This macro will emit a struct to represent the instance,

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -9,8 +9,9 @@ pub use wasi_common::{WasiCtx, WasiCtxBuilder};
 wasmtime_wiggle::wasmtime_integration!({
     // The wiggle code to integrate with lives here:
     target: wasi_common::wasi,
-    // This must be the same witx document as used above:
-    witx: ["../wasi-common/WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
+    // This must be the same witx document as used above. This should be ensured by
+    // the `WASI_ROOT` env variable, which is set in wasi-common's `build.rs`.
+    witx: ["$WASI_ROOT/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
     // This must be the same ctx type as used for the target:
     ctx: WasiCtx,
     // This macro will emit a struct to represent the instance,

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro2 = "1.0"
 heck = "0.3"
 anyhow = "1"
 syn = { version = "1.0", features = ["full"] }
+shellexpand = "2.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -147,6 +147,7 @@ impl WitxConf {
     /// If using the [`Paths`][paths] syntax, make all paths relative to a root directory.
     ///
     /// [paths]: enum.WitxConf.html#variant.Paths
+    // FIXME this can be deleted once we have env var interpolation
     pub fn make_paths_relative_to<P: AsRef<Path>>(&mut self, root: P) {
         if let Self::Paths(paths) = self {
             paths.as_mut().iter_mut().for_each(|p| {
@@ -201,6 +202,29 @@ impl Parse for Paths {
         let content;
         let _ = bracketed!(content in input);
         let path_lits: Punctuated<LitStr, Token![,]> = content.parse_terminated(Parse::parse)?;
+
+        /* TODO interpolate env variables here!!!
+                        fn main() {
+            let p = "foo/$BAR/baz";
+            let buf = PathBuf::from(p);
+            let components = buf
+                .iter()
+                .map(|osstr| interpolate(osstr.to_str().expect("always a str")))
+                .collect::<Vec<String>>();
+
+            println!("{:?}", components);
+        }
+
+        fn interpolate(v: &str) -> String {
+            if let Some('$') = v.chars().nth(0) {
+                let var = &v[1..];
+                std::env::var(var).unwrap_or(String::new())
+            } else {
+                v.to_owned()
+            }
+        }
+        */
+
         Ok(path_lits
             .iter()
             .map(|lit| PathBuf::from(lit.value()))

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -90,10 +90,7 @@ use syn::parse_macro_input;
 /// ```
 #[proc_macro]
 pub fn from_witx(args: TokenStream) -> TokenStream {
-    let mut config = parse_macro_input!(args as wiggle_generate::Config);
-    config.witx.make_paths_relative_to(
-        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR env var"),
-    );
+    let config = parse_macro_input!(args as wiggle_generate::Config);
 
     let doc = config.load_document();
     let names = wiggle_generate::Names::new(&config.ctx.name, quote!(wiggle));

--- a/crates/wiggle/tests/arrays.rs
+++ b/crates/wiggle/tests/arrays.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/arrays.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/arrays.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/atoms.rs
+++ b/crates/wiggle/tests/atoms.rs
@@ -3,7 +3,7 @@ use wiggle::GuestMemory;
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/atoms.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/flags.rs
+++ b/crates/wiggle/tests/flags.rs
@@ -4,7 +4,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/flags.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/flags.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/handles.rs
+++ b/crates/wiggle/tests/handles.rs
@@ -5,7 +5,7 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 const FD_VAL: u32 = 123;
 
 wiggle::from_witx!({
-    witx: ["tests/handles.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/handles.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/ints.rs
+++ b/crates/wiggle/tests/ints.rs
@@ -4,7 +4,7 @@ use wiggle::GuestMemory;
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/ints.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/ints.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/keywords.rs
+++ b/crates/wiggle/tests/keywords.rs
@@ -58,7 +58,7 @@ mod struct_test {
 /// Test that a union variant that conflicts with a Rust keyword can be compiled properly.
 mod union_test {
     wiggle::from_witx!({
-        witx: ["tests/keywords_union.witx"],
+        witx: ["$CARGO_MANIFEST_DIR/tests/keywords_union.witx"],
         ctx: DummyCtx,
     });
 }

--- a/crates/wiggle/tests/pointers.rs
+++ b/crates/wiggle/tests/pointers.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/pointers.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/pointers.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/strings.rs
+++ b/crates/wiggle/tests/strings.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/strings.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/strings.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/structs.rs
+++ b/crates/wiggle/tests/structs.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/structs.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/structs.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/union.rs
+++ b/crates/wiggle/tests/union.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["tests/union.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/union.witx"],
     ctx: WasiCtx,
 });
 

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -7,7 +7,7 @@ use wiggle_test::WasiCtx;
 // witx is exposed with the type signatures that we expect.
 
 wiggle::from_witx!({
-    witx: ["tests/wasi.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/wasi.witx"],
     ctx: WasiCtx,
 });
 
@@ -16,7 +16,8 @@ wiggle::from_witx!({
 #[test]
 fn document_equivalent() {
     let macro_doc = metadata::document();
-    let disk_doc = witx::load(&["tests/wasi.witx"]).expect("load wasi.witx from disk");
+    let disk_doc =
+        witx::load(&["$CARGO_MANIFEST_DIR/tests/wasi.witx"]).expect("load wasi.witx from disk");
 
     assert_eq!(macro_doc, disk_doc);
 }

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -16,8 +16,10 @@ wiggle::from_witx!({
 #[test]
 fn document_equivalent() {
     let macro_doc = metadata::document();
-    let disk_doc =
-        witx::load(&["$CARGO_MANIFEST_DIR/tests/wasi.witx"]).expect("load wasi.witx from disk");
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("wasi.witx");
+    let disk_doc = witx::load(&[path]).expect("load wasi.witx from disk");
 
     assert_eq!(macro_doc, disk_doc);
 }

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -47,10 +47,7 @@ use config::{MissingMemoryConf, ModuleConf, TargetConf};
 ///
 #[proc_macro]
 pub fn wasmtime_integration(args: TokenStream) -> TokenStream {
-    let mut config = parse_macro_input!(args as config::Config);
-    config.witx.make_paths_relative_to(
-        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR env var"),
-    );
+    let config = parse_macro_input!(args as config::Config);
     let doc = config.load_document();
     let names = Names::new(&config.ctx.name, quote!(wasmtime_wiggle));
 

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -48,9 +48,9 @@ use config::{MissingMemoryConf, ModuleConf, TargetConf};
 #[proc_macro]
 pub fn wasmtime_integration(args: TokenStream) -> TokenStream {
     let mut config = parse_macro_input!(args as config::Config);
-    config
-        .witx
-        .make_paths_relative_to(std::env::var("WASI_ROOT").expect("WASI_ROOT env var"));
+    config.witx.make_paths_relative_to(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR env var"),
+    );
     let doc = config.load_document();
     let names = Names::new(&config.ctx.name, quote!(wasmtime_wiggle));
 


### PR DESCRIPTION
… not WASI_ROOT

the WASI_ROOT was leftover from when this code was part of `wig`.

Thank you @aturon for bug report.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
