### PR TITLE
Fix typo in generated documentation for `entity!`

### DIFF
--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -92,7 +92,7 @@ macro_rules! entity_impl {
         }
 
         impl $entity {
-            /// Create a new instance of entity from a `u32`
+            /// Create a new instance from a `u32`
             #[allow(dead_code)]
             pub fn from_u32(x: u32) -> Self {
                 debug_assert!(x < $crate::__core::u32::MAX);

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -92,7 +92,7 @@ macro_rules! entity_impl {
         }
 
         impl $entity {
-            /// Create a new instance from a `u32`
+            /// Create a new instance from a `u32`.
             #[allow(dead_code)]
             pub fn from_u32(x: u32) -> Self {
                 debug_assert!(x < $crate::__core::u32::MAX);

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -92,7 +92,7 @@ macro_rules! entity_impl {
         }
 
         impl $entity {
-            /// Return the underlying index value as a `u32`.
+            /// Create a new instance of entity from a `u32`
             #[allow(dead_code)]
             pub fn from_u32(x: u32) -> Self {
                 debug_assert!(x < $crate::__core::u32::MAX);


### PR DESCRIPTION
The same function documentation was used for `from_u32()` and `as_u32()`
while their behavior is different. The culprit was the generated documentation from
the `entity!` macro

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
