### PR TITLE
Expand modules instantiated in instantiate-wasm-smith

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282c6162f6e30c663bf473bba323950eb494d7de1899e259024ffeb127cf5733"
+checksum = "5ff896bbe4adf62d6a909708c34db3ad94ce2103daa9673f64fe15e60ba70dad"
 dependencies = [
  "arbitrary",
  "leb128",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ target-lexicon = "0.10"
 peepmatic-fuzzing = { path = "../cranelift/peepmatic/crates/fuzzing", optional = true }
 wasmtime = { path = "../crates/wasmtime" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }
-wasm-smith = "0.1.3"
+wasm-smith = "0.1.5"
 
 [[bin]]
 name = "compile"

--- a/fuzz/fuzz_targets/instantiate-maybe-invalid.rs
+++ b/fuzz/fuzz_targets/instantiate-maybe-invalid.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::time::Duration;
+use wasm_smith::Module;
+use wasmtime::Strategy;
+use wasmtime_fuzzing::oracles;
+
+fuzz_target!(|module: MaybeInvalidModule| {
+    oracles::instantiate_with_config(
+        &module.to_bytes(),
+        wasmtime_fuzzing::fuzz_default_config(Strategy::Auto),
+        Some(Duration::from_secs(20)),
+    );
+});

--- a/tests/all/fuzzing.rs
+++ b/tests/all/fuzzing.rs
@@ -26,5 +26,5 @@ fn instantiate_module_that_compiled_to_x64_has_register_32() {
     let mut config = Config::new();
     config.debug_info(true);
     let data = wat::parse_str(include_str!("./fuzzing/issue694.wat")).unwrap();
-    oracles::instantiate_with_config(&data, config);
+    oracles::instantiate_with_config(&data, config, None);
 }


### PR DESCRIPTION
This commit uses the new `MaybeInvalidModule` type in `wasm-smith` to
try to explore more points in the fuzz target space in the
`instantiate-wasm-smith` fuzz target. The goal here is to use the raw
fuzz input as the body of a function to stress the validator/decoder a
bit more, and try to get inputs we might not otherwise generate.

This also removes the reliance on inherent termination of the wasm
module, instead using the timeout mechanism in wasmtime to ensure that
wasm runs for a limited amount of time.
