### PR TITLE
AArch64: Add various missing SIMD bits

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -575,7 +575,7 @@ impl ScalarSize {
             32 => ScalarSize::Size32,
             64 => ScalarSize::Size64,
             128 => ScalarSize::Size128,
-            _ => panic!("Unexpected type width"),
+            w => panic!("Unexpected type width: {}", w),
         }
     }
 
@@ -591,7 +591,7 @@ impl ScalarSize {
             ScalarSize::Size16 => 0b11,
             ScalarSize::Size32 => 0b00,
             ScalarSize::Size64 => 0b01,
-            _ => panic!("Unexpected scalar FP operand size"),
+            _ => panic!("Unexpected scalar FP operand size: {:?}", self),
         }
     }
 }
@@ -612,6 +612,7 @@ impl VectorSize {
     /// Convert from a type into a vector operand size.
     pub fn from_ty(ty: Type) -> VectorSize {
         match ty {
+            B32X4 => VectorSize::Size32x4,
             F32X2 => VectorSize::Size32x2,
             F32X4 => VectorSize::Size32x4,
             F64X2 => VectorSize::Size64x2,
@@ -622,7 +623,7 @@ impl VectorSize {
             I32X2 => VectorSize::Size32x2,
             I32X4 => VectorSize::Size32x4,
             I64X2 => VectorSize::Size64x2,
-            _ => unimplemented!(),
+            _ => unimplemented!("Unsupported type: {}", ty),
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -777,14 +777,15 @@ fn test_aarch64_binemit() {
     ));
 
     insns.push((
-        Inst::AluRRR {
-            alu_op: ALUOp::SubS64XR,
+        Inst::AluRRRExtend {
+            alu_op: ALUOp::SubS64,
             rd: writable_zero_reg(),
             rn: stack_reg(),
             rm: xreg(12),
+            extendop: ExtendOp::UXTX,
         },
         "FF632CEB",
-        "subs xzr, sp, x12",
+        "subs xzr, sp, x12, UXTX",
     ));
 
     insns.push((

--- a/cranelift/filetests/filetests/vcode/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/stack-limit.clif
@@ -105,7 +105,8 @@ block0(v0: i64):
 ; nextln:     add x16, x0, x17, UXTX
 ; nextln:     subs xzr, sp, x16
 ; nextln:     b.hs 8 ; udf
-; nextln:     ldr x16, 8 ; b 12 ; data 400000
+; nextln:     movz w16, #6784
+; nextln:     movk w16, #6, LSL #16
 ; nextln:     sub sp, sp, x16, UXTX
 ; nextln:     mov sp, fp
 ; nextln:     ldp fp, lr, [sp], #16
@@ -154,7 +155,8 @@ block0(v0: i64):
 ; nextln:     add x16, x16, x17, UXTX
 ; nextln:     subs xzr, sp, x16
 ; nextln:     b.hs 8 ; udf
-; nextln:     ldr x16, 8 ; b 12 ; data 400000
+; nextln:     movz w16, #6784
+; nextln:     movk w16, #6, LSL #16
 ; nextln:     sub sp, sp, x16, UXTX
 ; nextln:     mov sp, fp
 ; nextln:     ldp fp, lr, [sp], #16

--- a/cranelift/filetests/filetests/vcode/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/vcode/aarch64/stack.clif
@@ -29,7 +29,8 @@ block0:
 
 ; check: stp fp, lr, [sp, #-16]!
 ; nextln: mov fp, sp
-; nextln: ldr x16, 8 ; b 12 ; data 100016
+; nextln: movz w16, #34480
+; nextln: movk w16, #1, LSL #16
 ; nextln: sub sp, sp, x16, UXTX
 ; nextln: mov x0, sp
 ; nextln: mov sp, fp
@@ -68,7 +69,8 @@ block0:
 
 ; check: stp fp, lr, [sp, #-16]!
 ; nextln: mov fp, sp
-; nextln: ldr x16, 8 ; b 12 ; data 100016
+; nextln: movz w16, #34480
+; nextln: movk w16, #1, LSL #16
 ; nextln: sub sp, sp, x16, UXTX
 ; nextln: mov x0, sp
 ; nextln: ldr x0, [x0]
@@ -106,7 +108,8 @@ block0(v0: i64):
 
 ; check: stp fp, lr, [sp, #-16]!
 ; nextln: mov fp, sp
-; nextln: ldr x16, 8 ; b 12 ; data 100016
+; nextln: movz w16, #34480
+; nextln: movk w16, #1, LSL #16
 ; nextln: sub sp, sp, x16, UXTX
 ; nextln: mov x1, sp
 ; nextln: str x0, [x1]


### PR DESCRIPTION
Add various missing SIMD bits into the AArch64 backend and improve the code for stack pointer manipulation.

Now it is possible to compile a SIMD-enabled build of Doom 3 (the [D3wasm](http://www.continuation-labs.com/projects/d3wasm) port).