### PR TITLE
Update minimum Rust version in CI to 1.43.0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,12 +124,12 @@ jobs:
     - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
     - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
 
-    # Check that codegen and wasm crates typecheck on 1.41.0; this is required
+    # Check that codegen and wasm crates typecheck on 1.43.0; this is required
     # for Firefox.
-    - run: rustup install 1.41.0
-    - run: cargo +1.41.0 check -p cranelift-codegen
-    - run: cargo +1.41.0 check -p cranelift-wasm
-    - run: cargo +1.41.0 check -p cranelift-tools
+    - run: rustup install 1.43.0
+    - run: cargo +1.43.0 check -p cranelift-codegen
+    - run: cargo +1.43.0 check -p cranelift-wasm
+    - run: cargo +1.43.0 check -p cranelift-tools
 
 
   fuzz_targets:


### PR DESCRIPTION
Firefox currently requires vendored Rust code (including Cranelift) to
compile on Rust 1.43.0, according to this line:

https://searchfox.org/mozilla-central/rev/eb9d5c97927aea75f0c8e38bbc5b5d288099e687/python/mozboot/mozboot/util.py#16

Whenever that version is updated, we can bump this CI check's Rust
version accordingly.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
