### PR TITLE
wasm: Remove duplicated parameters when popping an If

### DIFF
--- a/cranelift/wasmtests/multi-17.wat
+++ b/cranelift/wasmtests/multi-17.wat
@@ -1,0 +1,26 @@
+(module
+  (func $main (type 0) (param i32 i32 i32) (result i32)
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    i32.const 0
+
+    i32.const 0
+    if (param i32 i32 i32) (result i32)  ;; label = @1
+      br 0 (;@1;)
+    else
+      call $main
+    end
+
+    i32.const 0
+
+    i32.const 0
+    if (param i32 i32 i32) (result i32)  ;; label = @1
+      drop
+      drop
+    else
+      drop
+      drop
+    end
+  )
+  (export "main" (func $main)))


### PR DESCRIPTION
Parameters are duplicated when pushing an If block, so they're available
to the Else block without an extra heap allocation. However, when
truncating the stack after popping the If control frame, the stack size
at entry doesn't account for the duplicated parameters. That is
intentional: the Else block uses this value to know what's the stack
size when it is entered, so there's nothing to change there.

This patch makes the wasm translation truncates the value stack to the
right size after an If block, by taking those duplicated parameters into
account.