### PR TITLE
Account for duplicated if-block params on `end` op in unreachable case.

### DIFF
--- a/cranelift/wasmtests/if-unreachable-else-params-2.wat
+++ b/cranelift/wasmtests/if-unreachable-else-params-2.wat
@@ -1,0 +1,18 @@
+(module
+  (type (;0;) (func (param i32 i32) (result f64)))
+  (func $main (type 0) (param i32 i32) (result f64)
+    f64.const 1.0
+    local.get 0
+    local.get 1
+    if (param i32)  ;; label = @2
+      i64.load16_s align=1
+      drop
+    else
+      unreachable
+    end)
+  (table (;0;) 63 255 funcref)
+  (memory (;0;) 13 16)
+  (export "t1" (table 0))
+  (export "m1" (memory 0))
+  (export "main" (func $main))
+  (export "memory" (memory 0)))


### PR DESCRIPTION
This is a close analogue to @bnjbvr 's fix in commit 518b7a7e. Similar to
that fix, this PR fixes a bug in which the Wasm translator could
misalign its value stack and either mistranslate or cause a panic with a
type-checking error.

Found via fuzzing by :decoder in SpiderMonkey (bug 1664453).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
