### PR TITLE
Upgrade to target-lexicon 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
+checksum = "fe2635952a442a01fd4cb53d98858b5e4bb461b02c0d111f22f31772e3e7a8b2"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ wasi-common = { path = "crates/wasi-common", version = "0.19.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
 object = { version = "0.21.1", default-features = false, features = ["write"] }
 anyhow = "1.0.19"
-target-lexicon = { version = "0.10.0", default-features = false }
+target-lexicon = { version = "0.11.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
 wat = "1.0.23"

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -34,7 +34,7 @@ log = "0.4.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
 wat = { version = "1.0.18", optional = true }
-target-lexicon = { version = "0.10", features = ["std"] }
+target-lexicon = { version = "0.11", features = ["std"] }
 peepmatic-souper = { path = "./peepmatic/crates/souper", version = "0.66.0", optional = true }
 pretty_env_logger = "0.4.0"
 rayon = { version = "1", optional = true }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -17,7 +17,7 @@ cranelift-codegen-shared = { path = "./shared", version = "0.66.0" }
 cranelift-entity = { path = "../entity", version = "0.66.0" }
 cranelift-bforest = { path = "../bforest", version = "0.66.0" }
 hashbrown = { version = "0.7", optional = true }
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -119,8 +119,10 @@ macro_rules! isa_builder {
 /// Return a builder that can create a corresponding `TargetIsa`.
 pub fn lookup(triple: Triple) -> Result<Builder, LookupError> {
     match triple.architecture {
-        Architecture::Riscv32 | Architecture::Riscv64 => isa_builder!(riscv, "riscv", triple),
-        Architecture::I386 | Architecture::I586 | Architecture::I686 | Architecture::X86_64 => {
+        Architecture::Riscv32 { .. } | Architecture::Riscv64 { .. } => {
+            isa_builder!(riscv, "riscv", triple)
+        }
+        Architecture::X86_32 { .. } | Architecture::X86_64 => {
             if cfg!(feature = "x64") {
                 isa_builder!(x64, "x64", triple)
             } else {

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -23,7 +23,7 @@ gimli = { version = "0.21.0", default-features = false, features = ["read"] }
 log = "0.4.6"
 memmap = "0.7.0"
 num_cpus = "1.8.0"
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 thiserror = "1.0.15"
 anyhow = "1.0.32"
 

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 log = { version = "0.4.6", default-features = false }
 hashbrown = { version = "0.7", optional = true }
 smallvec = { version = "1.0.0" }

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false }
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "7.0.3"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 cranelift-module = { path = "../module", version = "0.66.0" }
 cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["std"] }
 object = { version = "0.21.1", default-features = false, features = ["write"] }
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 anyhow = "1.0"
 
 [badges]

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -57,11 +57,15 @@ impl ObjectBuilder {
             target_lexicon::BinaryFormat::Unknown => {
                 return Err(ModuleError::Backend(anyhow!("binary format is unknown")))
             }
+            other => {
+                return Err(ModuleError::Backend(anyhow!(
+                    "binary format {} not recognized",
+                    other
+                )))
+            }
         };
         let architecture = match isa.triple().architecture {
-            target_lexicon::Architecture::I386
-            | target_lexicon::Architecture::I586
-            | target_lexicon::Architecture::I686 => object::Architecture::I386,
+            target_lexicon::Architecture::X86_32(_) => object::Architecture::I386,
             target_lexicon::Architecture::X86_64 => object::Architecture::X86_64,
             target_lexicon::Architecture::Arm(_) => object::Architecture::Arm,
             target_lexicon::Architecture::Aarch64(_) => object::Architecture::Aarch64,

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 cranelift-codegen = { path = "../codegen", version = "0.66.0" }
 smallvec = "1.0.0"
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 thiserror = "1.0.15"
 
 [badges]

--- a/cranelift/simplejit/Cargo.toml
+++ b/cranelift/simplejit/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features 
 region = "2.2.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 memmap = { version = "0.7.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -127,10 +127,10 @@ cfg_if! {
 
         fn get_disassembler(isa: &dyn TargetIsa) -> Result<Capstone> {
             let cs = match isa.triple().architecture {
-                Architecture::Riscv32 | Architecture::Riscv64 => {
+                Architecture::Riscv32(_) | Architecture::Riscv64(_) => {
                     anyhow::bail!("No disassembler for RiscV");
                 }
-                Architecture::I386 | Architecture::I586 | Architecture::I686 => Capstone::new()
+                Architecture::X86_32(_) => Capstone::new()
                     .x86()
                     .mode(arch::x86::ArchMode::Mode32)
                     .build()?,

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0.4"
 
 [dev-dependencies]
 wat = "1.0.23"
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 # Enable the riscv feature for cranelift-codegen, as some tests require it
 cranelift-codegen = { path = "../codegen", version = "0.66.0", default-features = false, features = ["riscv"] }
 

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -16,7 +16,7 @@ gimli = "0.21.0"
 wasmparser = "0.59.0"
 object = { version = "0.21.1", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.19.0" }
-target-lexicon = { version = "0.10.0", default-features = false }
+target-lexicon = { version = "0.11.0", default-features = false }
 anyhow = "1.0"
 thiserror = "1.0.4"
 more-asserts = "0.2.1"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -27,7 +27,7 @@ wasmtime-obj = { path = "../obj", version = "0.19.0" }
 rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"
-target-lexicon = { version = "0.10.0", default-features = false }
+target-lexicon = { version = "0.11.0", default-features = false }
 wasmparser = "0.59.0"
 more-asserts = "0.2.1"
 anyhow = "1.0"

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 wasmtime-environ = { path = "../environ", version = "0.19.0" }
 object = { version = "0.21.1", default-features = false, features = ["write"] }
 more-asserts = "0.2.1"
-target-lexicon = { version = "0.10.0", default-features = false }
+target-lexicon = { version = "0.11.0", default-features = false }
 wasmtime-debug = { path = "../debug", version = "0.19.0" }
 
 [badges]

--- a/crates/obj/src/builder.rs
+++ b/crates/obj/src/builder.rs
@@ -98,7 +98,7 @@ fn to_object_architecture(
 ) -> Result<Architecture, anyhow::Error> {
     use target_lexicon::Architecture::*;
     Ok(match arch {
-        I386 | I586 | I686 => Architecture::I386,
+        X86_32(_) => Architecture::I386,
         X86_64 => Architecture::X86_64,
         Arm(_) => Architecture::Arm,
         Aarch64(_) => Architecture::Aarch64,
@@ -238,6 +238,7 @@ impl ObjectBuilderTarget {
             target_lexicon::BinaryFormat::Unknown => {
                 bail!("binary format is unknown");
             }
+            other => bail!("binary format {} is unsupported", other),
         };
         let architecture = to_object_architecture(triple.architecture)?;
         let endianness = match triple.endianness().unwrap() {

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4"
 libc = { version = "0.2.60", default-features = false }
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
 serde = { version = "1.0.99", features = ["derive"] }
-target-lexicon = "0.10.0"
+target-lexicon = "0.11.0"
 wasmtime-environ = { path = "../environ", version = "0.19.0" }
 wasmtime-runtime = { path = "../runtime", version = "0.19.0" }
 ittapi-rs = { version = "0.1.5", optional = true }

--- a/crates/profiling/src/jitdump_linux.rs
+++ b/crates/profiling/src/jitdump_linux.rs
@@ -238,7 +238,7 @@ impl State {
     fn get_e_machine(&self) -> u32 {
         match target_lexicon::HOST.architecture {
             Architecture::X86_64 => elf::EM_X86_64 as u32,
-            Architecture::I686 => elf::EM_386 as u32,
+            Architecture::X86_32(_) => elf::EM_386 as u32,
             Architecture::Arm(_) => elf::EM_ARM as u32,
             Architecture::Aarch64(_) => elf::EM_AARCH64 as u32,
             _ => unimplemented!("unrecognized architecture"),

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -13,7 +13,7 @@ cfg-if = "0.1.9"
 wasi-common = { path = "../wasi-common", version = "0.19.0" }
 wasmtime-wasi = { path = "../wasi", version = "0.19.0" }
 wasmtime = { path = "../wasmtime", version = "0.19.0" }
-target-lexicon = "0.10.0"
+target-lexicon = "0.11.0"
 pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"
 os_pipe = "0.9"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -16,7 +16,7 @@ wasmtime-jit = { path = "../jit", version = "0.19.0" }
 wasmtime-cache = { path = "../cache", version = "0.19.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.19.0" }
 wasmparser = "0.59.0"
-target-lexicon = { version = "0.10.0", default-features = false }
+target-lexicon = { version = "0.11.0", default-features = false }
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cranelift-codegen = { path = "../cranelift/codegen" }
 cranelift-reader = { path = "../cranelift/reader" }
 cranelift-wasm = { path = "../cranelift/wasm" }
 libfuzzer-sys = "0.3.3"
-target-lexicon = "0.10"
+target-lexicon = "0.11"
 peepmatic-fuzzing = { path = "../cranelift/peepmatic/crates/fuzzing", optional = true }
 wasmtime = { path = "../crates/wasmtime" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }


### PR DESCRIPTION
- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.

This upgrades a dependency, without changing runtime behavior.

- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.

This allows downstream library users to use `CDataModel` without having
to install two different versions of target-lexicon.

- [ ] This PR contains test cases, if meaningful.

N/A

- [ ] A reviewer from the core maintainer team has been assigned for this PR.

r? @sunfishcode 