### PR TITLE
clif-util: add the `souper-to-peepmatic` subcommand

### DIFF
--- a/cranelift/src/souper_to_peepmatic.rs
+++ b/cranelift/src/souper_to_peepmatic.rs
@@ -1,0 +1,32 @@
+use std::io::{Read, Write};
+use std::path::Path;
+
+pub fn run(input: &Path, output: &Path) -> Result<(), String> {
+    let peepmatic_dsl = if input == Path::new("-") {
+        let stdin = std::io::stdin();
+        let mut stdin = stdin.lock();
+        let mut souper_dsl = vec![];
+        stdin
+            .read_to_end(&mut souper_dsl)
+            .map_err(|e| format!("failed to read from stdin: {}", e))?;
+        let souper_dsl =
+            String::from_utf8(souper_dsl).map_err(|e| format!("stdin is not UTF-8: {}", e))?;
+        peepmatic_souper::convert_str(&souper_dsl, Some(Path::new("stdin")))
+            .map_err(|e| e.to_string())?
+    } else {
+        peepmatic_souper::convert_file(input).map_err(|e| e.to_string())?
+    };
+
+    if output == Path::new("-") {
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        stdout
+            .write_all(peepmatic_dsl.as_bytes())
+            .map_err(|e| format!("error writing to stdout: {}", e))?;
+    } else {
+        std::fs::write(output, peepmatic_dsl.as_bytes())
+            .map_err(|e| format!("error writing to {}: {}", output.display(), e))?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a subcommand to the `clif-util` CLI for exposing the Souper->Peepmatic
translation machinery that was introduced in #2192.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
