### PR TITLE
Make filetest errors report full context

### DIFF
--- a/cranelift/filetests/src/runner.rs
+++ b/cranelift/filetests/src/runner.rs
@@ -48,7 +48,7 @@ impl Display for QueueEntry {
         let p = self.path.to_string_lossy();
         match self.state {
             State::Done(Ok(dur)) => write!(f, "{}.{:03} {}", dur.as_secs(), dur.subsec_millis(), p),
-            State::Done(Err(ref e)) => write!(f, "FAIL {}: {}", p, e),
+            State::Done(Err(ref e)) => write!(f, "FAIL {}: {:?}", p, e),
             _ => write!(f, "{}", p),
         }
     }

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -161,8 +161,7 @@ fn main() -> anyhow::Result<()> {
                     .iter()
                     .map(|f| f.display().to_string())
                     .collect::<Vec<_>>(),
-            )
-            .map_err(|s| anyhow::anyhow!("{}", s))?;
+            )?;
         }
         Commands::Pass(p) => {
             handle_debug_flag(p.debug);
@@ -172,8 +171,7 @@ fn main() -> anyhow::Result<()> {
                 &p.passes,
                 &p.target,
                 &p.file.display().to_string(),
-            )
-            .map_err(|s| anyhow::anyhow!("{}", s))?;
+            )?;
         }
     }
 


### PR DESCRIPTION
This provides the full error context, not just the source error's message. The `anyhow::Error`'s `Display` implementation just shows the source error's message, not any of its context. The `Debug` implementation shows the full error context (and backtrace, if captured).