### PR TITLE
Minor fixes in wiggle/wasi-common

### DIFF
--- a/crates/wiggle/generate/src/types/struct.rs
+++ b/crates/wiggle/generate/src/types/struct.rs
@@ -33,7 +33,7 @@ pub(super) fn define_struct(
                     let pointee_type = names.type_ref(&pointee, quote!('a));
                     quote!(#rt::GuestPtr<'a, #pointee_type>)
                 }
-                _ => unimplemented!("other anonymous struct members"),
+                _ => unimplemented!("other anonymous struct members: {:?}", m.tref),
             },
         };
         quote!(pub #name: #type_)
@@ -63,7 +63,7 @@ pub(super) fn define_struct(
                         let #name = <#rt::GuestPtr::<#pointee_type> as #rt::GuestType>::read(&#location)?;
                     }
                 }
-                _ => unimplemented!("other anonymous struct members"),
+                _ => unimplemented!("other anonymous struct members: {:?}", ty),
             },
         }
     });

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -11,7 +11,7 @@ use syn::parse_macro_input;
 ///   CamelCase.
 ///
 /// * For each `module` defined in the witx document, a Rust module is defined
-///   containing definitions for that module. Module names are teanslated to the
+///   containing definitions for that module. Module names are translated to the
 ///   Rust-idiomatic snake\_case.
 ///
 ///     * For each `@interface func` defined in a witx module, an abi-level


### PR DESCRIPTION
These changes fix a typo and make it easier to debug unimplemented types in wiggle.