### PR TITLE
Fix relocated readonly data in custom sections

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -335,8 +335,10 @@ impl Backend for ObjectBackend {
                 sec.clone().into_bytes(),
                 if writable {
                     SectionKind::Data
-                } else {
+                } else if relocs.is_empty() {
                     SectionKind::ReadOnlyData
+                } else {
+                    SectionKind::Data
                 },
             )
         };


### PR DESCRIPTION
Lld doesn't allow relocations in readonly sections

This is required for https://github.com/bjorn3/rustc_codegen_cranelift/issues/1055.