### PR TITLE
Add a script to run CI for the new x64 backend

### DIFF
--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cargo +nightly \
+            -Zfeatures=all -Zpackage-features \
+            test \
+            --features test-programs/test_programs \
+            --features experimental_x64 \
+            --all \
+            --exclude wasmtime-lightbeam \
+            --exclude peepmatic \
+            --exclude peepmatic-automata \
+            --exclude peepmatic-fuzzing \
+            --exclude peepmatic-macro \
+            --exclude peepmatic-runtime \
+            --exclude peepmatic-test --exclude lightbeam

--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -12,4 +12,6 @@ cargo +nightly \
             --exclude peepmatic-fuzzing \
             --exclude peepmatic-macro \
             --exclude peepmatic-runtime \
-            --exclude peepmatic-test --exclude lightbeam
+            --exclude peepmatic-test \
+            --exclude peepmatic-souper \
+            --exclude lightbeam


### PR DESCRIPTION
A first step to make it easier to collectively look into x64 CI failures, until we can re-enable CI. This is mostly the content of what was in the `main.yml` file, but as a script that we'll be able to use in the yml configuration, and it's more dev-friendly.