### PR TITLE
Fix remaining failures and re-enable x64 new backend CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,6 +271,32 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+  # Perform all tests (debug mode) for `wasmtime` with the experimental x64
+  # backend. This runs on the nightly channel of Rust (because of issues with
+  # unifying Cargo features on stable) on Ubuntu.
+  test_x64:
+    name: Test x64 new backend
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly-2020-08-25
+    - uses: ./.github/actions/define-llvm-env
+
+    # Install wasm32 targets in order to build various tests throughout the
+    # repo.
+    - run: rustup target add wasm32-wasi
+    - run: rustup target add wasm32-unknown-unknown
+
+    # Run the x64 CI script.
+    - run: ./ci/run-experimental-x64-ci.sh
+      env:
+        CARGO_VERSION: "+nightly-2020-08-25"
+        RUST_BACKTRACE: 1
+
   # Verify that cranelift's code generation is deterministic
   meta_determinist_check:
     name: Meta deterministic check

--- a/build.rs
+++ b/build.rs
@@ -182,6 +182,10 @@ fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str
     match (testsuite, testname) {
         ("simd", "simd_address") => return false,
         ("simd", "simd_const") => return false,
+        ("simd", "simd_i8x16_arith") => return false,
+        ("simd", "simd_i16x8_arith") => return false,
+        ("simd", "simd_i32x4_arith") => return false,
+        ("simd", "simd_i64x2_arith") => return false,
         ("simd", "simd_f32x4_arith") => return false,
         ("simd", "simd_f32x4_cmp") => return false,
         ("simd", "simd_f64x2_arith") => return false,

--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-cargo +nightly \
+# Use the Nightly variant of the compiler to properly unify the
+# experimental_x64 feature across all crates.  Once the feature has stabilized
+# and become the default, we can remove this.
+CARGO_VERSION=${CARGO_VERSION:-"+nightly"}
+
+cargo $CARGO_VERSION \
             -Zfeatures=all -Zpackage-features \
             test \
             --features test-programs/test_programs \

--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -14,4 +14,5 @@ cargo +nightly \
             --exclude peepmatic-runtime \
             --exclude peepmatic-test \
             --exclude peepmatic-souper \
-            --exclude lightbeam
+            --exclude lightbeam \
+            $@


### PR DESCRIPTION
See commit messages for details.

The interesting failure was actually in the implementation of nearest; the error was hidden in the old backend by the fact that the old backend uses native x86 instructions for nearest, and not the runtime intrinsic. There's a todo for this in the new backend, fwiw.