### PR TITLE
Log level to "debug!" in translate_from_reader

### DIFF
--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -14,7 +14,6 @@ use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, Block, InstBuilder, ValueLabel};
 use cranelift_codegen::timing;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
-use log::info;
 use wasmparser::{self, BinaryReader};
 
 /// WebAssembly to Cranelift IR function translator.
@@ -79,7 +78,7 @@ impl FuncTranslator {
         environ: &mut FE,
     ) -> WasmResult<()> {
         let _tt = timing::wasm_translate_function();
-        debug!(
+        log::debug!(
             "translate({} bytes, {}{})",
             reader.bytes_remaining(),
             func.name,

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -79,7 +79,7 @@ impl FuncTranslator {
         environ: &mut FE,
     ) -> WasmResult<()> {
         let _tt = timing::wasm_translate_function();
-        info!(
+        debug!(
             "translate({} bytes, {}{})",
             reader.bytes_remaining(),
             func.name,


### PR DESCRIPTION
Default logger floods the console otherwise:

```
Sep 22 22:41:02.525 INFO translate(181 bytes, u0:1353(i64 vmctx, i64, i32, i32) -> i32 system_v)
Sep 22 22:41:02.526 INFO translate(394 bytes, u0:1354(i64 vmctx, i64, i32) system_v)
Sep 22 22:41:02.527 INFO translate(16307 bytes, u0:944(i64 vmctx, i64, i32, i32, i32) system_v)
Sep 22 22:41:02.528 INFO translate(269 bytes, u0:382(i64 vmctx, i64, i32, i32) system_v)
Sep 22 22:41:02.528 INFO translate(220 bytes, u0:283(i64 vmctx, i64, i32, i32) system_v)
Sep 22 22:41:02.528 INFO translate(603 bytes, u0:383(i64 vmctx, i64, i32, i32) system_v)
Sep 22 22:41:02.528 INFO translate(1470 bytes, u0:284(i64 vmctx, i64, i32, i32) system_v)
Sep 22 22:41:02.529 INFO translate(189 bytes, u0:387(i64 vmctx, i64, i32, i32) -> i32 system_v)
Sep 22 22:41:02.529 INFO translate(14 bytes, u0:388(i64 vmctx, i64, i32, i32) system_v)
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
