### PR TITLE
arm64: Use SignedOffset rather than PreIndexed addressing mode for ca…

### DIFF
--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -179,7 +179,6 @@ block0:
 ; nextln:  ldr q8, [sp]
 ; nextln:  ldr q9, [sp, #16]
 ; nextln:  ldr q10, [sp, #32]
-; nextln:  add sp, sp, #48
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
@@ -230,7 +229,6 @@ block0:
 ; nextln:  ldr q8, [sp]
 ; nextln:  ldr q9, [sp, #16]
 ; nextln:  ldr q10, [sp, #32]
-; nextln:  add sp, sp, #48
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
@@ -285,7 +283,6 @@ block0:
 ; nextln:  ldr q8, [sp]
 ; nextln:  ldr q9, [sp, #16]
 ; nextln:  ldr q10, [sp, #32]
-; nextln:  add sp, sp, #48
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -77,8 +77,8 @@ block3(v7: r64, v8: r64):
 ; check: Block 0:
 ; check: stp fp, lr, [sp, #-16]!
 ; nextln: mov fp, sp
-; nextln: sub sp, sp, #32
-; nextln: stp x19, x20, [sp, #-16]!
+; nextln: sub sp, sp, #48
+; nextln: stp x19, x20, [sp]
 ; nextln: virtual_sp_offset_adjust 16
 ; nextln: mov x19, x0
 ; nextln: mov x20, x1
@@ -111,7 +111,7 @@ block3(v7: r64, v8: r64):
 ; nextln: ldr x1, [x1]
 ; nextln: mov x2, x1
 ; nextln: mov x1, x19
-; nextln: ldp x19, x20, [sp], #16
+; nextln: ldp x19, x20, [sp]
 ; nextln: mov sp, fp
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret


### PR DESCRIPTION
…llee-saved registers

This also passes `fixed_frame_storage_size` (previously `total_sp_adjust`)
into `gen_clobber_save` so that it can be combined with other stack
adjustments.

Copyright (c) 2020, Arm Limited.


NOTE: I haven't tested this on x86, hopefully CI will be enough.