### PR TITLE
AArch64: Add test cases for callee-saved SIMD & FP registers

### DIFF
--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -130,3 +130,162 @@ block0(v0: i8):
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
+
+function %f8() {
+    fn0 = %g0() -> f32
+    fn1 = %g1() -> f64
+    fn2 = %g2()
+    fn3 = %g3(f32)
+    fn4 = %g4(f64)
+
+block0:
+    v0 = call fn0()
+    v1 = call fn1()
+    v2 = call fn1()
+    call fn2()
+    call fn3(v0)
+    call fn4(v1)
+    call fn4(v2)
+    return
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  sub sp, sp, #48
+; nextln:  str q8, [sp]
+; nextln:  str q9, [sp, #16]
+; nextln:  str q10, [sp, #32]
+; nextln:  virtual_sp_offset_adjust 48
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v8.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v9.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v10.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v8.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v9.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v10.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  ldr q8, [sp]
+; nextln:  ldr q9, [sp, #16]
+; nextln:  ldr q10, [sp, #32]
+; nextln:  add sp, sp, #48
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret
+
+function %f9() {
+    fn0 = %g0() -> i8x16
+    fn1 = %g1()
+    fn2 = %g2(i8x16)
+
+block0:
+    v0 = call fn0()
+    v1 = call fn0()
+    v2 = call fn0()
+    call fn1()
+    call fn2(v0)
+    call fn2(v1)
+    call fn2(v2)
+    return
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  sub sp, sp, #48
+; nextln:  str q8, [sp]
+; nextln:  str q9, [sp, #16]
+; nextln:  str q10, [sp, #32]
+; nextln:  virtual_sp_offset_adjust 48
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v8.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v9.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v10.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v8.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v9.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v10.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  ldr q8, [sp]
+; nextln:  ldr q9, [sp, #16]
+; nextln:  ldr q10, [sp, #32]
+; nextln:  add sp, sp, #48
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret
+
+function %f10() {
+    fn0 = %g0() -> f32
+    fn1 = %g1() -> f64
+    fn2 = %g2() -> i8x16
+    fn3 = %g3()
+    fn4 = %g4(f32)
+    fn5 = %g5(f64)
+    fn6 = %g6(i8x16)
+
+block0:
+    v0 = call fn0()
+    v1 = call fn1()
+    v2 = call fn2()
+    call fn3()
+    call fn4(v0)
+    call fn5(v1)
+    call fn6(v2)
+    return
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  sub sp, sp, #48
+; nextln:  str q8, [sp]
+; nextln:  str q9, [sp, #16]
+; nextln:  str q10, [sp, #32]
+; nextln:  virtual_sp_offset_adjust 48
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v8.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v9.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v10.16b, v0.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v8.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v9.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  mov v0.16b, v10.16b
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  ldr q8, [sp]
+; nextln:  ldr q9, [sp, #16]
+; nextln:  ldr q10, [sp, #32]
+; nextln:  add sp, sp, #48
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret


### PR DESCRIPTION
This PR adds a test case for a function that saves clobbered vector registers on the stack.

Its purpose is to demonstrate that Cranelift deviates from the Procedure Call Standard for the Arm 64-bit Architecture (AAPCS64). The AAPCS64 [specifies](https://github.com/ARM-software/abi-aa/blob/2019Q4/aapcs64/aapcs64.rst#simd-and-floating-point-registers) that a callee is only responsible for saving the bottom 64 bits of a vector register, so it is not possible to preserve a vector value across a function call by keeping it in a callee-saved register (let's ignore the Scalable Vector Extension for the time being, but keep in mind that it makes the rules more complicated).

Due to another deviation from AAPCS64 (the whole vector register is saved instead of only the bottom half), Cranelift effectively implements its own custom calling convention, so there are no correctness issues as long as the generated code calls only functions with the same behaviour.

The wider question is - are we striving for strict AAPCS64 compliance? That's in the non-baldrdash case, of course. I can also open an issue if a longer discussion would be necessary.

cc @cfallin @julian-seward1