### PR TITLE
dep gardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli 0.22.0",
+ "gimli",
 ]
 
 [[package]]
@@ -381,7 +381,7 @@ dependencies = [
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.21.0",
+ "gimli",
  "hashbrown 0.7.2",
  "log",
  "peepmatic",
@@ -429,7 +429,7 @@ dependencies = [
  "cranelift-reader",
  "file-per-thread-logger",
  "filecheck",
- "gimli 0.21.0",
+ "gimli",
  "log",
  "memmap",
  "num_cpus",
@@ -907,20 +907,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "glob"
@@ -1215,12 +1209,6 @@ name = "number_prefix"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
-
-[[package]]
-name = "object"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
 name = "object"
@@ -2482,7 +2470,7 @@ name = "wasmtime-debug"
 version = "0.20.0"
 dependencies = [
  "anyhow",
- "gimli 0.21.0",
+ "gimli",
  "more-asserts",
  "object 0.21.1",
  "target-lexicon",
@@ -2500,7 +2488,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-wasm",
- "gimli 0.21.0",
+ "gimli",
  "indexmap",
  "log",
  "more-asserts",
@@ -2552,7 +2540,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli 0.21.0",
+ "gimli",
  "log",
  "more-asserts",
  "object 0.21.1",
@@ -2600,11 +2588,11 @@ version = "0.20.0"
 dependencies = [
  "anyhow",
  "cfg-if",
- "gimli 0.21.0",
+ "gimli",
  "ittapi-rs",
  "lazy_static",
  "libc",
- "object 0.19.0",
+ "object 0.21.1",
  "scroll",
  "serde",
  "target-lexicon",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -21,7 +21,7 @@ target-lexicon = "0.11"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
-gimli = { version = "0.21.0", default-features = false, features = ["write"], optional = true }
+gimli = { version = "0.22.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -19,7 +19,7 @@ cranelift-preopt = { path = "../preopt", version = "0.67.0" }
 byteorder = { version = "1.3.2", default-features = false }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"
-gimli = { version = "0.21.0", default-features = false, features = ["read"] }
+gimli = { version = "0.22.0", default-features = false, features = ["read"] }
 log = "0.4.6"
 memmap = "0.7.0"
 num_cpus = "1.8.0"

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-gimli = "0.21.0"
+gimli = "0.22.0"
 wasmparser = "0.59.0"
 object = { version = "0.21.1", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.20.0" }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
 more-asserts = "0.2.1"
 cfg-if = "0.1.9"
-gimli = "0.21"
+gimli = "0.22"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -33,7 +33,7 @@ more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "0.1.9"
 log = "0.4"
-gimli = { version = "0.21.0", default-features = false, features = ["write"] }
+gimli = { version = "0.22.0", default-features = false, features = ["write"] }
 object = { version = "0.21.1", default-features = false, features = ["write"] }
 serde = { version = "1.0.94", features = ["derive"] }
 

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 cfg-if = "0.1"
-gimli = { version = "0.21.0", optional = true }
+gimli = { version = "0.22.0", optional = true }
 lazy_static = "1.4"
 libc = { version = "0.2.60", default-features = false }
 scroll = { version = "0.10.1", features = ["derive"], optional = true }

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime-runtime = { path = "../runtime", version = "0.20.0" }
 ittapi-rs = { version = "0.1.5", optional = true }
 
 [dependencies.object]
-version = "0.19.0"
+version = "0.21.1"
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'std']


### PR DESCRIPTION
Thank you @maxded and @bjorn3 in #2225 - `cargo deny` helped us identify that these deps can be consolidated:

* gimli goes to 0.22.0
* object goes to 0.21.1

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
