### PR TITLE
Don't implicitly create empty files in VirtualDir::openat

### DIFF
--- a/crates/test-programs/README.md
+++ b/crates/test-programs/README.md
@@ -1,2 +1,7 @@
 This is the `test-programs` crate, which builds and runs whole programs
 compiled to wasm32-wasi.
+
+To actually run these tests, the test-programs feature must be enabled, e.g.:
+```
+cargo test --features test-programs/test_programs --package test-programs
+```

--- a/crates/test-programs/wasi-tests/src/bin/path_open_missing.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_missing.rs
@@ -1,0 +1,43 @@
+use std::{env, process};
+use wasi_tests::{open_scratch_directory};
+
+unsafe fn test_path_open_missing(dir_fd: wasi::Fd) {
+    assert_eq!(
+        wasi::path_open(
+            dir_fd,
+            0,
+            "file",
+            0, // not passing O_CREAT here
+            0,
+            0,
+            0,
+        )
+        .expect_err("trying to open a file that doesn't exist")
+        .raw_error(),
+        wasi::ERRNO_NOENT,
+        "errno should be ERRNO_NOENT"
+    );
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_path_open_missing(dir_fd) }
+}


### PR DESCRIPTION
Prior to this change, non-existent files opened inside the wasi/wasm binary via `std::fs::read_to_string()` would show up as existing and empty. Added a test that demonstrates the issue.