### PR TITLE
[machinst x64]: assert lane is correct size for extractlane

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2817,6 +2817,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             } else {
                 unreachable!();
             };
+            debug_assert!(lane < src_ty.lane_count() as u8);
 
             if !ty.is_float() {
                 let (sse_op, w_bit) = match ty.lane_bits() {


### PR DESCRIPTION
This change applies a good suggestion @bjorn3 made in #2230 that I forgot to implement there.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
