### PR TITLE
Add metadata to peepmatic crates

### DIFF
--- a/cranelift/peepmatic/crates/traits/Cargo.toml
+++ b/cranelift/peepmatic/crates/traits/Cargo.toml
@@ -3,6 +3,8 @@ name = "peepmatic-traits"
 version = "0.67.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0 WITH LLVM-exception"
+description = 'Common traits for peepmatic'
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Forgot that I needed this to publish the last release of wasmtime