### PR TITLE
Add WasiCtxBuilder::preopened_handle to allow more flexible VFS usage

### DIFF
--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -268,6 +268,19 @@ impl WasiCtxBuilder {
         self
     }
 
+    pub fn preopened_handle<P: AsRef<Path>>(
+        &mut self,
+        handle: Box<dyn Handle>,
+        guest_path: P,
+    ) -> &mut Self {
+        let preopen = PendingPreopen::new(move || Ok(handle));
+        self.preopens
+            .as_mut()
+            .unwrap()
+            .push((guest_path.as_ref().to_owned(), preopen));
+        self
+    }
+
     /// Build a `WasiCtx`, consuming this `WasiCtxBuilder`.
     ///
     /// If any of the arguments or environment variables in this builder cannot be converted into

--- a/crates/wasi-common/src/virtfs.rs
+++ b/crates/wasi-common/src/virtfs.rs
@@ -423,13 +423,11 @@ impl VirtualDir {
         }
     }
 
-    #[allow(dead_code)]
     pub fn with_dir<P: AsRef<Path>>(mut self, dir: Self, path: P) -> Self {
         self.add_dir(dir, path);
         self
     }
 
-    #[allow(dead_code)]
     pub fn add_dir<P: AsRef<Path>>(&mut self, dir: Self, path: P) {
         let entry = Box::new(dir);
         entry.set_parent(Some(self.try_clone().expect("can clone self")));
@@ -438,13 +436,11 @@ impl VirtualDir {
             .insert(path.as_ref().to_owned(), entry);
     }
 
-    #[allow(dead_code)]
     pub fn with_file<P: AsRef<Path>>(mut self, content: Box<dyn FileContents>, path: P) -> Self {
         self.add_file(content, path);
         self
     }
 
-    #[allow(dead_code)]
     pub fn add_file<P: AsRef<Path>>(&mut self, content: Box<dyn FileContents>, path: P) {
         let entry = Box::new(InMemoryFile::new(content));
         entry.set_parent(Some(self.try_clone().expect("can clone self")));


### PR DESCRIPTION
This will allow third-party libraries to implement their own VFS to expose to a wasi binary,
such as (for example) VFS implemenations that record all reads/writes done from wasi,
or purely user-space implementations of traditional filesystems.

Also modify the wasi-fs example to use this simplified & more powerful system.

(partial fix for #2232)