### PR TITLE
refactor: retrieve immediates in new backend

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -1,0 +1,180 @@
+//! This module gives users to instantiate values that Cranelift understands. These values are used,
+//! for example, during interpretation and for wrapping immediates.
+use crate::ir::immediates::{Ieee32, Ieee64, Imm64};
+use crate::ir::{types, ConstantData, Type};
+use core::convert::TryInto;
+use core::fmt::{self, Display, Formatter};
+use thiserror::Error;
+
+/// Represent a data value. Where [Value] is an SSA reference, [DataValue] is the type + value
+/// that would be referred to by a [Value].
+///
+/// [Value]: crate::ir::Value
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DataValue {
+    B(bool),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64),
+    V128([u8; 16]),
+}
+
+impl DataValue {
+    /// Try to cast an immediate integer ([Imm64]) to the given Cranelift [Type].
+    pub fn from_integer(imm: Imm64, ty: Type) -> Result<DataValue, DataValueCastFailure> {
+        match ty {
+            types::I8 => Ok(DataValue::I8(imm.bits() as i8)),
+            types::I16 => Ok(DataValue::I16(imm.bits() as i16)),
+            types::I32 => Ok(DataValue::I32(imm.bits() as i32)),
+            types::I64 => Ok(DataValue::I64(imm.bits())),
+            _ => Err(DataValueCastFailure::FromImm64(imm, ty)),
+        }
+    }
+
+    /// Return the Cranelift IR [Type] for this [DataValue].
+    pub fn ty(&self) -> Type {
+        match self {
+            DataValue::B(_) => types::B8, // A default type.
+            DataValue::I8(_) => types::I8,
+            DataValue::I16(_) => types::I16,
+            DataValue::I32(_) => types::I32,
+            DataValue::I64(_) => types::I64,
+            DataValue::F32(_) => types::F32,
+            DataValue::F64(_) => types::F64,
+            DataValue::V128(_) => types::I8X16, // A default type.
+        }
+    }
+
+    /// Return true if the value is a vector (i.e. `DataValue::V128`).
+    pub fn is_vector(&self) -> bool {
+        match self {
+            DataValue::V128(_) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Record failures to cast [DataValue].
+#[derive(Error, Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum DataValueCastFailure {
+    #[error("unable to cast data value of type {0} to type {1}")]
+    TryInto(Type, Type),
+    #[error("unable to cast Imm64({0}) to a data value of type {1}")]
+    FromImm64(Imm64, Type),
+}
+
+/// Helper for creating conversion implementations for [DataValue].
+macro_rules! build_conversion_impl {
+    ( $rust_ty:ty, $data_value_ty:ident, $cranelift_ty:ident ) => {
+        impl From<$rust_ty> for DataValue {
+            fn from(data: $rust_ty) -> Self {
+                DataValue::$data_value_ty(data)
+            }
+        }
+
+        impl TryInto<$rust_ty> for DataValue {
+            type Error = DataValueCastFailure;
+            fn try_into(self) -> Result<$rust_ty, Self::Error> {
+                if let DataValue::$data_value_ty(v) = self {
+                    Ok(v)
+                } else {
+                    Err(DataValueCastFailure::TryInto(
+                        self.ty(),
+                        types::$cranelift_ty,
+                    ))
+                }
+            }
+        }
+    };
+}
+build_conversion_impl!(bool, B, B8);
+build_conversion_impl!(i8, I8, I8);
+build_conversion_impl!(i16, I16, I16);
+build_conversion_impl!(i32, I32, I32);
+build_conversion_impl!(i64, I64, I64);
+build_conversion_impl!(f32, F32, F32);
+build_conversion_impl!(f64, F64, F64);
+build_conversion_impl!([u8; 16], V128, I8X16);
+
+impl Display for DataValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            DataValue::B(dv) => write!(f, "{}", dv),
+            DataValue::I8(dv) => write!(f, "{}", dv),
+            DataValue::I16(dv) => write!(f, "{}", dv),
+            DataValue::I32(dv) => write!(f, "{}", dv),
+            DataValue::I64(dv) => write!(f, "{}", dv),
+            // Use the Ieee* wrappers here to maintain a consistent syntax.
+            DataValue::F32(dv) => write!(f, "{}", Ieee32::from(*dv)),
+            DataValue::F64(dv) => write!(f, "{}", Ieee64::from(*dv)),
+            // Again, for syntax consistency, use ConstantData, which in this case displays as hex.
+            DataValue::V128(dv) => write!(f, "{}", ConstantData::from(&dv[..])),
+        }
+    }
+}
+
+/// Helper structure for printing bracket-enclosed vectors of [DataValue]s.
+/// - for empty vectors, display `[]`
+/// - for single item vectors, display `42`, e.g.
+/// - for multiple item vectors, display `[42, 43, 44]`, e.g.
+pub struct DisplayDataValues<'a>(pub &'a [DataValue]);
+
+impl<'a> Display for DisplayDataValues<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.0.len() == 1 {
+            write!(f, "{}", self.0[0])
+        } else {
+            write!(f, "[")?;
+            write_data_value_list(f, &self.0)?;
+            write!(f, "]")
+        }
+    }
+}
+
+/// Helper function for displaying `Vec<DataValue>`.
+pub fn write_data_value_list(f: &mut Formatter<'_>, list: &[DataValue]) -> fmt::Result {
+    match list.len() {
+        0 => Ok(()),
+        1 => write!(f, "{}", list[0]),
+        _ => {
+            write!(f, "{}", list[0])?;
+            for dv in list.iter().skip(1) {
+                write!(f, ", {}", dv)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn type_conversions() {
+        assert_eq!(DataValue::B(true).ty(), types::B8);
+        assert_eq!(
+            TryInto::<bool>::try_into(DataValue::B(false)).unwrap(),
+            false
+        );
+        assert_eq!(
+            TryInto::<i32>::try_into(DataValue::B(false)).unwrap_err(),
+            DataValueCastFailure::TryInto(types::B8, types::I32)
+        );
+
+        assert_eq!(DataValue::V128([0; 16]).ty(), types::I8X16);
+        assert_eq!(
+            TryInto::<[u8; 16]>::try_into(DataValue::V128([0; 16])).unwrap(),
+            [0; 16]
+        );
+        assert_eq!(
+            TryInto::<i32>::try_into(DataValue::V128([0; 16])).unwrap_err(),
+            DataValueCastFailure::TryInto(types::I8X16, types::I32)
+        );
+    }
+}

--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -1,6 +1,6 @@
 //! This module gives users to instantiate values that Cranelift understands. These values are used,
 //! for example, during interpretation and for wrapping immediates.
-use crate::ir::immediates::{Ieee32, Ieee64, Imm64};
+use crate::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32};
 use crate::ir::{types, ConstantData, Type};
 use core::convert::TryInto;
 use core::fmt::{self, Display, Formatter};
@@ -100,6 +100,21 @@ build_conversion_impl!(i64, I64, I64);
 build_conversion_impl!(f32, F32, F32);
 build_conversion_impl!(f64, F64, F64);
 build_conversion_impl!([u8; 16], V128, I8X16);
+impl From<Ieee64> for DataValue {
+    fn from(f: Ieee64) -> Self {
+        DataValue::from(f64::from_bits(f.bits()))
+    }
+}
+impl From<Ieee32> for DataValue {
+    fn from(f: Ieee32) -> Self {
+        DataValue::from(f32::from_bits(f.bits()))
+    }
+}
+impl From<Offset32> for DataValue {
+    fn from(o: Offset32) -> Self {
+        DataValue::from(Into::<i32>::into(o))
+    }
+}
 
 impl Display for DataValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -18,8 +18,8 @@ pub enum DataValue {
     I16(i16),
     I32(i32),
     I64(i64),
-    F32(f32),
-    F64(f64),
+    F32(Ieee32),
+    F64(Ieee64),
     V128([u8; 16]),
 }
 
@@ -97,19 +97,9 @@ build_conversion_impl!(i8, I8, I8);
 build_conversion_impl!(i16, I16, I16);
 build_conversion_impl!(i32, I32, I32);
 build_conversion_impl!(i64, I64, I64);
-build_conversion_impl!(f32, F32, F32);
-build_conversion_impl!(f64, F64, F64);
+build_conversion_impl!(Ieee32, F32, F32);
+build_conversion_impl!(Ieee64, F64, F64);
 build_conversion_impl!([u8; 16], V128, I8X16);
-impl From<Ieee64> for DataValue {
-    fn from(f: Ieee64) -> Self {
-        DataValue::from(f64::from_bits(f.bits()))
-    }
-}
-impl From<Ieee32> for DataValue {
-    fn from(f: Ieee32) -> Self {
-        DataValue::from(f32::from_bits(f.bits()))
-    }
-}
 impl From<Offset32> for DataValue {
     fn from(o: Offset32) -> Self {
         DataValue::from(Into::<i32>::into(o))
@@ -124,9 +114,9 @@ impl Display for DataValue {
             DataValue::I16(dv) => write!(f, "{}", dv),
             DataValue::I32(dv) => write!(f, "{}", dv),
             DataValue::I64(dv) => write!(f, "{}", dv),
-            // Use the Ieee* wrappers here to maintain a consistent syntax.
-            DataValue::F32(dv) => write!(f, "{}", Ieee32::from(*dv)),
-            DataValue::F64(dv) => write!(f, "{}", Ieee64::from(*dv)),
+            // The Ieee* wrappers here print the expected syntax.
+            DataValue::F32(dv) => write!(f, "{}", dv),
+            DataValue::F64(dv) => write!(f, "{}", dv),
             // Again, for syntax consistency, use ConstantData, which in this case displays as hex.
             DataValue::V128(dv) => write!(f, "{}", ConstantData::from(&dv[..])),
         }

--- a/cranelift/codegen/src/ir/constant.rs
+++ b/cranelift/codegen/src/ir/constant.rs
@@ -63,6 +63,11 @@ impl ConstantData {
         self.0.is_empty()
     }
 
+    /// Return the data as a slice.
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
     /// Convert the data to a vector.
     pub fn into_vec(self) -> Vec<u8> {
         self.0

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -450,6 +450,7 @@ impl FromStr for Offset32 {
 ///
 /// All bit patterns are allowed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[repr(C)]
 pub struct Ieee32(u32);
 
 /// An IEEE binary64 immediate floating point value, represented as a u64
@@ -457,6 +458,7 @@ pub struct Ieee32(u32);
 ///
 /// All bit patterns are allowed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[repr(C)]
 pub struct Ieee64(u64);
 
 /// Format a floating point number in a way that is reasonably human-readable, and that can be

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -71,6 +71,7 @@ pub use cranelift_entity as entity;
 pub mod binemit;
 pub mod cfg_printer;
 pub mod cursor;
+pub mod data_value;
 pub mod dbg;
 pub mod dominator_tree;
 pub mod flowgraph;

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -1,12 +1,12 @@
 //! Provides functionality for compiling and running CLIF IR for `run` tests.
 use core::{mem, ptr};
 use cranelift_codegen::binemit::{NullRelocSink, NullStackMapSink, NullTrapSink};
+use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::{condcodes::IntCC, Function, InstBuilder, Signature, Type};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::{ir, settings, CodegenError, Context};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_native::builder as host_isa_builder;
-use cranelift_reader::DataValue;
 use log::trace;
 use memmap::{Mmap, MmapMut};
 use std::cmp::max;
@@ -126,7 +126,8 @@ impl Trampoline {
 ///
 /// ```
 /// use cranelift_filetests::SingleFunctionCompiler;
-/// use cranelift_reader::{parse_functions, DataValue};
+/// use cranelift_reader::parse_functions;
+/// use cranelift_codegen::data_value::DataValue;
 ///
 /// let code = "test run \n function %add(i32, i32) -> i32 {  block0(v0:i32, v1:i32):  v2 = iadd v0, v1  return v2 }".into();
 /// let func = parse_functions(code).unwrap().into_iter().nth(0).unwrap();

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -2,6 +2,7 @@
 use core::{mem, ptr};
 use cranelift_codegen::binemit::{NullRelocSink, NullStackMapSink, NullTrapSink};
 use cranelift_codegen::data_value::DataValue;
+use cranelift_codegen::ir::immediates::{Ieee32, Ieee64};
 use cranelift_codegen::ir::{condcodes::IntCC, Function, InstBuilder, Signature, Type};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::{ir, settings, CodegenError, Context};
@@ -233,8 +234,8 @@ impl UnboxedValues {
             DataValue::I16(i) => ptr::write(p as *mut i16, *i),
             DataValue::I32(i) => ptr::write(p as *mut i32, *i),
             DataValue::I64(i) => ptr::write(p as *mut i64, *i),
-            DataValue::F32(f) => ptr::write(p as *mut f32, *f),
-            DataValue::F64(f) => ptr::write(p as *mut f64, *f),
+            DataValue::F32(f) => ptr::write(p as *mut Ieee32, *f),
+            DataValue::F64(f) => ptr::write(p as *mut Ieee64, *f),
             DataValue::V128(b) => ptr::write(p as *mut [u8; 16], *b),
         }
     }
@@ -246,8 +247,8 @@ impl UnboxedValues {
             ir::types::I16 => DataValue::I16(ptr::read(p as *const i16)),
             ir::types::I32 => DataValue::I32(ptr::read(p as *const i32)),
             ir::types::I64 => DataValue::I64(ptr::read(p as *const i64)),
-            ir::types::F32 => DataValue::F32(ptr::read(p as *const f32)),
-            ir::types::F64 => DataValue::F64(ptr::read(p as *const f64)),
+            ir::types::F32 => DataValue::F32(ptr::read(p as *const Ieee32)),
+            ir::types::F64 => DataValue::F64(ptr::read(p as *const Ieee64)),
             _ if ty.is_bool() => DataValue::B(ptr::read(p as *const bool)),
             _ if ty.is_vector() && ty.bytes() == 16 => {
                 DataValue::V128(ptr::read(p as *const [u8; 16]))

--- a/cranelift/interpreter/src/frame.rs
+++ b/cranelift/interpreter/src/frame.rs
@@ -1,7 +1,7 @@
 //! Implements a call frame (activation record) for the Cranelift interpreter.
 
+use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::{Function, Value as ValueRef};
-use cranelift_reader::DataValue;
 use log::trace;
 use std::collections::HashMap;
 
@@ -78,9 +78,9 @@ impl<'a> Frame<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cranelift_codegen::data_value::DataValue;
     use cranelift_codegen::ir::InstBuilder;
     use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-    use cranelift_reader::DataValue;
 
     /// Build an empty function with a single return.
     fn empty_function() -> Function {

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -5,12 +5,12 @@
 use crate::environment::Environment;
 use crate::frame::Frame;
 use crate::interpreter::Trap::InvalidType;
+use cranelift_codegen::data_value::{DataValue, DataValueCastFailure};
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{
     Block, FuncRef, Function, Inst, InstructionData, InstructionData::*, Opcode, Opcode::*, Type,
     Value as ValueRef, ValueList,
 };
-use cranelift_reader::{DataValue, DataValueCastFailure};
 use log::trace;
 use std::ops::{Add, Div, Mul, Sub};
 use thiserror::Error;

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -12,7 +12,7 @@ use cranelift_codegen::ir::{
     Value as ValueRef, ValueList,
 };
 use log::trace;
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, Mul, Sub};
 use thiserror::Error;
 
 /// The valid control flow states.
@@ -153,10 +153,11 @@ impl Interpreter {
                     Iadd => binary_op!(Add::add[arg1, arg2]; [I8, I16, I32, I64]; inst),
                     Isub => binary_op!(Sub::sub[arg1, arg2]; [I8, I16, I32, I64]; inst),
                     Imul => binary_op!(Mul::mul[arg1, arg2]; [I8, I16, I32, I64]; inst),
-                    Fadd => binary_op!(Add::add[arg1, arg2]; [F32, F64]; inst),
-                    Fsub => binary_op!(Sub::sub[arg1, arg2]; [F32, F64]; inst),
-                    Fmul => binary_op!(Mul::mul[arg1, arg2]; [F32, F64]; inst),
-                    Fdiv => binary_op!(Div::div[arg1, arg2]; [F32, F64]; inst),
+                    // TODO re-enable by importing something like rustc_apfloat for correctness.
+                    // Fadd => binary_op!(Add::add[arg1, arg2]; [F32, F64]; inst),
+                    // Fsub => binary_op!(Sub::sub[arg1, arg2]; [F32, F64]; inst),
+                    // Fmul => binary_op!(Mul::mul[arg1, arg2]; [F32, F64]; inst),
+                    // Fdiv => binary_op!(Div::div[arg1, arg2]; [F32, F64]; inst),
                     _ => unimplemented!("interpreter does not support opcode yet: {}", opcode),
                 }?;
                 frame.set(first_result(frame.function, inst), result);

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -29,7 +29,7 @@
 pub use crate::error::{Location, ParseError, ParseResult};
 pub use crate::isaspec::{parse_options, IsaSpec, ParseOptionError};
 pub use crate::parser::{parse_functions, parse_run_command, parse_test, ParseOptions};
-pub use crate::run_command::{Comparison, DataValue, DataValueCastFailure, Invocation, RunCommand};
+pub use crate::run_command::{Comparison, Invocation, RunCommand};
 pub use crate::sourcemap::SourceMap;
 pub use crate::testcommand::{TestCommand, TestOption};
 pub use crate::testfile::{Comment, Details, Feature, TestFile};

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -3,10 +3,11 @@
 use crate::error::{Location, ParseError, ParseResult};
 use crate::isaspec;
 use crate::lexer::{LexError, Lexer, LocatedError, LocatedToken, Token};
-use crate::run_command::{Comparison, DataValue, Invocation, RunCommand};
+use crate::run_command::{Comparison, Invocation, RunCommand};
 use crate::sourcemap::SourceMap;
 use crate::testcommand::TestCommand;
 use crate::testfile::{Comment, Details, Feature, TestFile};
+use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::entities::AnyEntity;

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2700,8 +2700,8 @@ impl<'a> Parser<'a> {
             I16 => DataValue::from(self.match_imm16("expected an i16")?),
             I32 => DataValue::from(self.match_imm32("expected an i32")?),
             I64 => DataValue::from(Into::<i64>::into(self.match_imm64("expected an i64")?)),
-            F32 => DataValue::from(f32::from_bits(self.match_ieee32("expected an f32")?.bits())),
-            F64 => DataValue::from(f64::from_bits(self.match_ieee64("expected an f64")?.bits())),
+            F32 => DataValue::from(self.match_ieee32("expected an f32")?),
+            F64 => DataValue::from(self.match_ieee64("expected an f64")?),
             _ if ty.is_vector() => {
                 let as_vec = self.match_uimm128(ty)?.into_vec();
                 if as_vec.len() == 16 {

--- a/cranelift/reader/src/run_command.rs
+++ b/cranelift/reader/src/run_command.rs
@@ -6,11 +6,8 @@
 //! - `; run`: this assumes the function has a signature like `() -> b*`.
 //! - `; run: %fn(42, 4.2) == false`: this syntax specifies the parameters and return values.
 
-use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64};
-use cranelift_codegen::ir::{self, types, ConstantData, Type};
-use std::convert::TryInto;
+use cranelift_codegen::data_value::{self, DataValue, DisplayDataValues};
 use std::fmt::{self, Display, Formatter};
-use thiserror::Error;
 
 /// A run command appearing in a test file.
 ///
@@ -88,153 +85,8 @@ impl Invocation {
 impl Display for Invocation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "%{}(", self.func)?;
-        write_data_value_list(f, &self.args)?;
+        data_value::write_data_value_list(f, &self.args)?;
         write!(f, ")")
-    }
-}
-
-/// Represent a data value. Where [Value] is an SSA reference, [DataValue] is the type + value
-/// that would be referred to by a [Value].
-///
-/// [Value]: cranelift_codegen::ir::Value
-#[allow(missing_docs)]
-#[derive(Clone, Debug, PartialEq)]
-pub enum DataValue {
-    B(bool),
-    I8(i8),
-    I16(i16),
-    I32(i32),
-    I64(i64),
-    F32(f32),
-    F64(f64),
-    V128([u8; 16]),
-}
-
-impl DataValue {
-    /// Try to cast an immediate integer ([Imm64]) to the given Cranelift [Type].
-    pub fn from_integer(imm: Imm64, ty: Type) -> Result<DataValue, DataValueCastFailure> {
-        match ty {
-            types::I8 => Ok(DataValue::I8(imm.bits() as i8)),
-            types::I16 => Ok(DataValue::I16(imm.bits() as i16)),
-            types::I32 => Ok(DataValue::I32(imm.bits() as i32)),
-            types::I64 => Ok(DataValue::I64(imm.bits())),
-            _ => Err(DataValueCastFailure::FromImm64(imm, ty)),
-        }
-    }
-
-    /// Return the Cranelift IR [Type] for this [DataValue].
-    pub fn ty(&self) -> Type {
-        match self {
-            DataValue::B(_) => ir::types::B8, // A default type.
-            DataValue::I8(_) => ir::types::I8,
-            DataValue::I16(_) => ir::types::I16,
-            DataValue::I32(_) => ir::types::I32,
-            DataValue::I64(_) => ir::types::I64,
-            DataValue::F32(_) => ir::types::F32,
-            DataValue::F64(_) => ir::types::F64,
-            DataValue::V128(_) => ir::types::I8X16, // A default type.
-        }
-    }
-
-    /// Return true if the value is a vector (i.e. `DataValue::V128`).
-    pub fn is_vector(&self) -> bool {
-        match self {
-            DataValue::V128(_) => true,
-            _ => false,
-        }
-    }
-}
-
-/// Record failures to cast [DataValue].
-#[derive(Error, Debug, PartialEq)]
-#[allow(missing_docs)]
-pub enum DataValueCastFailure {
-    #[error("unable to cast data value of type {0} to type {1}")]
-    TryInto(Type, Type),
-    #[error("unable to cast Imm64({0}) to a data value of type {1}")]
-    FromImm64(Imm64, Type),
-}
-
-/// Helper for creating conversion implementations for [DataValue].
-macro_rules! build_conversion_impl {
-    ( $rust_ty:ty, $data_value_ty:ident, $cranelift_ty:ident ) => {
-        impl From<$rust_ty> for DataValue {
-            fn from(data: $rust_ty) -> Self {
-                DataValue::$data_value_ty(data)
-            }
-        }
-
-        impl TryInto<$rust_ty> for DataValue {
-            type Error = DataValueCastFailure;
-            fn try_into(self) -> Result<$rust_ty, Self::Error> {
-                if let DataValue::$data_value_ty(v) = self {
-                    Ok(v)
-                } else {
-                    Err(DataValueCastFailure::TryInto(
-                        self.ty(),
-                        types::$cranelift_ty,
-                    ))
-                }
-            }
-        }
-    };
-}
-build_conversion_impl!(bool, B, B8);
-build_conversion_impl!(i8, I8, I8);
-build_conversion_impl!(i16, I16, I16);
-build_conversion_impl!(i32, I32, I32);
-build_conversion_impl!(i64, I64, I64);
-build_conversion_impl!(f32, F32, F32);
-build_conversion_impl!(f64, F64, F64);
-build_conversion_impl!([u8; 16], V128, I8X16);
-
-impl Display for DataValue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            DataValue::B(dv) => write!(f, "{}", dv),
-            DataValue::I8(dv) => write!(f, "{}", dv),
-            DataValue::I16(dv) => write!(f, "{}", dv),
-            DataValue::I32(dv) => write!(f, "{}", dv),
-            DataValue::I64(dv) => write!(f, "{}", dv),
-            // Use the Ieee* wrappers here to maintain a consistent syntax.
-            DataValue::F32(dv) => write!(f, "{}", Ieee32::from(*dv)),
-            DataValue::F64(dv) => write!(f, "{}", Ieee64::from(*dv)),
-            // Again, for syntax consistency, use ConstantData, which in this case displays as hex.
-            DataValue::V128(dv) => write!(f, "{}", ConstantData::from(&dv[..])),
-        }
-    }
-}
-
-/// Helper structure for printing bracket-enclosed vectors of [DataValue]s.
-/// - for empty vectors, display `[]`
-/// - for single item vectors, display `42`, e.g.
-/// - for multiple item vectors, display `[42, 43, 44]`, e.g.
-struct DisplayDataValues<'a>(&'a [DataValue]);
-
-impl<'a> Display for DisplayDataValues<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if self.0.len() == 1 {
-            write!(f, "{}", self.0[0])
-        } else {
-            write!(f, "[")?;
-            write_data_value_list(f, &self.0)?;
-            write!(f, "]")
-        }
-    }
-}
-
-/// Helper function for displaying `Vec<DataValue>`.
-fn write_data_value_list(f: &mut Formatter<'_>, list: &[DataValue]) -> fmt::Result {
-    match list.len() {
-        0 => Ok(()),
-        1 => write!(f, "{}", list[0]),
-        _ => {
-            write!(f, "{}", list[0])?;
-            for dv in list.iter().skip(1) {
-                write!(f, ", {}", dv)?;
-            }
-            Ok(())
-        }
     }
 }
 
@@ -272,28 +124,5 @@ mod test {
 
         assert!(command.run(|_, _| Ok(vec![DataValue::I32(42)])).is_ok());
         assert!(command.run(|_, _| Ok(vec![DataValue::I32(43)])).is_err());
-    }
-
-    #[test]
-    fn type_conversions() {
-        assert_eq!(DataValue::B(true).ty(), types::B8);
-        assert_eq!(
-            TryInto::<bool>::try_into(DataValue::B(false)).unwrap(),
-            false
-        );
-        assert_eq!(
-            TryInto::<i32>::try_into(DataValue::B(false)).unwrap_err(),
-            DataValueCastFailure::TryInto(types::B8, types::I32)
-        );
-
-        assert_eq!(DataValue::V128([0; 16]).ty(), types::I8X16);
-        assert_eq!(
-            TryInto::<[u8; 16]>::try_into(DataValue::V128([0; 16])).unwrap(),
-            [0; 16]
-        );
-        assert_eq!(
-            TryInto::<i32>::try_into(DataValue::V128([0; 16])).unwrap_err(),
-            DataValueCastFailure::TryInto(types::I8X16, types::I32)
-        );
     }
 }


### PR DESCRIPTION
@cfallin, here is what I came up with after we discussed this last week. This change:
 - moves `DataValue` into cranelift-codegen so that I can use it as a value wrapper
 - gives `InstructionData` the ability to find immediate values in the format structures
 - reworks `LowerCtx::get_immediate` to grab the value from the instruction (and the DataFlowGraph for vector immediates)

I felt like this approach provides the new backend a more abstract view of immediates instead of munging directly in the `InstructionData` but I didn't perform the refactor on the rest of the places the new backend grabs immediates because I wanted to get some feedback first.