### PR TITLE
machinst x64 (cleanup): remove unnecessary allow directives

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -476,7 +476,7 @@ pub(crate) fn emit(
     state: &mut EmitState,
 ) {
     match inst {
-        Inst::Alu_RMI_R {
+        Inst::AluRmiR {
             is_64,
             op,
             src,
@@ -891,7 +891,7 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::Mov_R_R { is_64, src, dst } => {
+        Inst::MovRR { is_64, src, dst } => {
             let rex = if *is_64 {
                 RexFlags::set_w()
             } else {
@@ -900,7 +900,7 @@ pub(crate) fn emit(
             emit_std_reg_reg(sink, LegacyPrefixes::None, 0x89, 1, *src, dst.to_reg(), rex);
         }
 
-        Inst::MovZX_RM_R {
+        Inst::MovzxRmR {
             ext_mode,
             src,
             dst,
@@ -981,7 +981,7 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::Mov64_M_R { src, dst, srcloc } => {
+        Inst::Mov64MR { src, dst, srcloc } => {
             let src = &src.finalize(state);
 
             if let Some(srcloc) = *srcloc {
@@ -1010,7 +1010,7 @@ pub(crate) fn emit(
             RexFlags::set_w(),
         ),
 
-        Inst::MovSX_RM_R {
+        Inst::MovsxRmR {
             ext_mode,
             src,
             dst,
@@ -1083,7 +1083,7 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::Mov_R_M {
+        Inst::MovRM {
             size,
             src,
             dst,
@@ -1155,7 +1155,7 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::Shift_R {
+        Inst::ShiftR {
             size,
             kind,
             num_bits,
@@ -1255,7 +1255,7 @@ pub(crate) fn emit(
             };
         }
 
-        Inst::Cmp_RMI_R {
+        Inst::CmpRmiR {
             size,
             src: src_e,
             dst: reg_g,
@@ -1740,7 +1740,7 @@ pub(crate) fn emit(
             };
         }
 
-        Inst::XMM_RM_R {
+        Inst::XmmRmR {
             op,
             src: src_e,
             dst: reg_g,
@@ -2007,7 +2007,7 @@ pub(crate) fn emit(
             // emitted.
         }
 
-        Inst::Xmm_Mov_R_M {
+        Inst::XmmMovRM {
             op,
             src,
             dst,
@@ -2089,7 +2089,7 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::XMM_Cmp_RM_R { op, src, dst } => {
+        Inst::XmmCmpRmR { op, src, dst } => {
             let rex = RexFlags::clear_w();
             let (prefix, opcode, len) = match op {
                 SseOpcode::Ptest => (LegacyPrefixes::_66, 0x0F3817, 3),

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -517,8 +517,8 @@ pub(crate) fn emit(
                     }
 
                     RegMemImm::Imm { simm32 } => {
-                        let useImm8 = low8_will_sign_extend_to_32(*simm32);
-                        let opcode = if useImm8 { 0x6B } else { 0x69 };
+                        let use_imm8 = low8_will_sign_extend_to_32(*simm32);
+                        let opcode = if use_imm8 { 0x6B } else { 0x69 };
                         // Yes, really, reg_g twice.
                         emit_std_reg_reg(
                             sink,
@@ -529,7 +529,7 @@ pub(crate) fn emit(
                             reg_g.to_reg(),
                             rex,
                         );
-                        emit_simm(sink, if useImm8 { 1 } else { 4 }, *simm32);
+                        emit_simm(sink, if use_imm8 { 1 } else { 4 }, *simm32);
                     }
                 }
             } else {
@@ -1424,13 +1424,12 @@ pub(crate) fn emit(
         }
 
         Inst::Pop64 { dst } => {
-            let encDst = int_reg_enc(dst.to_reg());
-            if encDst >= 8 {
-                // 0x41 == REX.{W=0, B=1}.  It seems that REX.W is irrelevant
-                // here.
+            let enc_dst = int_reg_enc(dst.to_reg());
+            if enc_dst >= 8 {
+                // 0x41 == REX.{W=0, B=1}.  It seems that REX.W is irrelevant here.
                 sink.put1(0x41);
             }
-            sink.put1(0x58 + (encDst & 7));
+            sink.put1(0x58 + (enc_dst & 7));
         }
 
         Inst::CallKnown {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1,6 +1,5 @@
 //! This module defines x86_64-specific machine instruction types.
 #![allow(dead_code)]
-#![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
 use crate::binemit::{CodeOffset, StackMap};
@@ -1183,11 +1182,11 @@ impl ShowWithRRU for Inst {
             ljustify(s1 + &s2)
         }
 
-        fn suffixLQ(is_64: bool) -> String {
+        fn suffix_lq(is_64: bool) -> String {
             (if is_64 { "q" } else { "l" }).to_string()
         }
 
-        fn sizeLQ(is_64: bool) -> u8 {
+        fn size_lq(is_64: bool) -> u8 {
             if is_64 {
                 8
             } else {
@@ -1195,7 +1194,7 @@ impl ShowWithRRU for Inst {
             }
         }
 
-        fn suffixBWLQ(size: u8) -> String {
+        fn suffix_bwlq(size: u8) -> String {
             match size {
                 1 => "b".to_string(),
                 2 => "w".to_string(),
@@ -1215,27 +1214,27 @@ impl ShowWithRRU for Inst {
                 dst,
             } => format!(
                 "{} {}, {}",
-                ljustify2(op.to_string(), suffixLQ(*is_64)),
-                src.show_rru_sized(mb_rru, sizeLQ(*is_64)),
-                show_ireg_sized(dst.to_reg(), mb_rru, sizeLQ(*is_64)),
+                ljustify2(op.to_string(), suffix_lq(*is_64)),
+                src.show_rru_sized(mb_rru, size_lq(*is_64)),
+                show_ireg_sized(dst.to_reg(), mb_rru, size_lq(*is_64)),
             ),
 
             Inst::UnaryRmR { src, dst, op, size } => format!(
                 "{} {}, {}",
-                ljustify2(op.to_string(), suffixBWLQ(*size)),
+                ljustify2(op.to_string(), suffix_bwlq(*size)),
                 src.show_rru_sized(mb_rru, *size),
                 show_ireg_sized(dst.to_reg(), mb_rru, *size),
             ),
 
             Inst::Not { size, src } => format!(
                 "{} {}",
-                ljustify2("not".to_string(), suffixBWLQ(*size)),
+                ljustify2("not".to_string(), suffix_bwlq(*size)),
                 show_ireg_sized(src.to_reg(), mb_rru, *size)
             ),
 
             Inst::Neg { size, src } => format!(
                 "{} {}",
-                ljustify2("neg".to_string(), suffixBWLQ(*size)),
+                ljustify2("neg".to_string(), suffix_bwlq(*size)),
                 show_ireg_sized(src.to_reg(), mb_rru, *size)
             ),
 
@@ -1476,9 +1475,9 @@ impl ShowWithRRU for Inst {
 
             Inst::Mov_R_R { is_64, src, dst } => format!(
                 "{} {}, {}",
-                ljustify2("mov".to_string(), suffixLQ(*is_64)),
-                show_ireg_sized(*src, mb_rru, sizeLQ(*is_64)),
-                show_ireg_sized(dst.to_reg(), mb_rru, sizeLQ(*is_64))
+                ljustify2("mov".to_string(), suffix_lq(*is_64)),
+                show_ireg_sized(*src, mb_rru, size_lq(*is_64)),
+                show_ireg_sized(dst.to_reg(), mb_rru, size_lq(*is_64))
             ),
 
             Inst::MovZX_RM_R {
@@ -1526,7 +1525,7 @@ impl ShowWithRRU for Inst {
 
             Inst::Mov_R_M { size, src, dst, .. } => format!(
                 "{} {}, {}",
-                ljustify2("mov".to_string(), suffixBWLQ(*size)),
+                ljustify2("mov".to_string(), suffix_bwlq(*size)),
                 show_ireg_sized(*src, mb_rru, *size),
                 dst.show_rru(mb_rru)
             ),
@@ -1539,13 +1538,13 @@ impl ShowWithRRU for Inst {
             } => match num_bits {
                 None => format!(
                     "{} %cl, {}",
-                    ljustify2(kind.to_string(), suffixBWLQ(*size)),
+                    ljustify2(kind.to_string(), suffix_bwlq(*size)),
                     show_ireg_sized(dst.to_reg(), mb_rru, *size)
                 ),
 
                 Some(num_bits) => format!(
                     "{} ${}, {}",
-                    ljustify2(kind.to_string(), suffixBWLQ(*size)),
+                    ljustify2(kind.to_string(), suffix_bwlq(*size)),
                     num_bits,
                     show_ireg_sized(dst.to_reg(), mb_rru, *size)
                 ),
@@ -1560,7 +1559,7 @@ impl ShowWithRRU for Inst {
 
             Inst::Cmp_RMI_R { size, src, dst } => format!(
                 "{} {}, {}",
-                ljustify2("cmp".to_string(), suffixBWLQ(*size)),
+                ljustify2("cmp".to_string(), suffix_bwlq(*size)),
                 src.show_rru_sized(mb_rru, *size),
                 show_ireg_sized(*dst, mb_rru, *size)
             ),
@@ -1573,7 +1572,7 @@ impl ShowWithRRU for Inst {
 
             Inst::Cmove { size, cc, src, dst } => format!(
                 "{} {}, {}",
-                ljustify(format!("cmov{}{}", cc.to_string(), suffixBWLQ(*size))),
+                ljustify(format!("cmov{}{}", cc.to_string(), suffix_bwlq(*size))),
                 src.show_rru_sized(mb_rru, *size),
                 show_ireg_sized(dst.to_reg(), mb_rru, *size)
             ),
@@ -1662,7 +1661,7 @@ impl ShowWithRRU for Inst {
             Inst::LockCmpxchg { ty, src, dst, .. } => {
                 let size = ty.bytes() as u8;
                 format!("lock cmpxchg{} {}, {}",
-                        suffixBWLQ(size), show_ireg_sized(*src, mb_rru, size), dst.show_rru(mb_rru))
+                        suffix_bwlq(size), show_ireg_sized(*src, mb_rru, size), dst.show_rru(mb_rru))
             }
 
             Inst::AtomicRmwSeq { ty, op, .. } => {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -1,7 +1,5 @@
 //! Lowering rules for X64.
 
-#![allow(non_snake_case)]
-
 use crate::ir::{
     condcodes::FloatCC, condcodes::IntCC, types, AbiParam, ArgumentPurpose, ExternalName,
     Inst as IRInst, InstructionData, LibCall, Opcode, Signature, Type,


### PR DESCRIPTION
This is in preparation for `Inst` refactorings suggested by #2252. I didn't remove the directive allowing dead code yet, because one thing it flags I'd like to use in a subsequent PR.