### PR TITLE
machinst x64: check SSE requirements for instructions

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -463,10 +463,26 @@ impl EmitState {
     }
 }
 
+/// Constant state used during function compilation.
+pub struct EmitInfo(settings::Flags);
+
+impl EmitInfo {
+    pub(crate) fn new(flags: settings::Flags) -> Self {
+        Self(flags)
+    }
+}
+
+impl MachInstEmitInfo for EmitInfo {
+    fn flags(&self) -> &settings::Flags {
+        &self.0
+    }
+}
+
 impl MachInstEmit for Inst {
     type State = EmitState;
+    type Info = EmitInfo;
 
-    fn emit(&self, sink: &mut MachBuffer<Inst>, flags: &settings::Flags, state: &mut EmitState) {
+    fn emit(&self, sink: &mut MachBuffer<Inst>, emit_info: &Self::Info, state: &mut EmitState) {
         // N.B.: we *must* not exceed the "worst-case size" used to compute
         // where to insert islands, except when islands are explicitly triggered
         // (with an `EmitIsland`). We check this in debug builds. This is `mut`
@@ -742,7 +758,7 @@ impl MachInstEmit for Inst {
                 let (mem_insts, mem) = mem_finalize(sink.cur_offset(), mem, state);
 
                 for inst in mem_insts.into_iter() {
-                    inst.emit(sink, flags, state);
+                    inst.emit(sink, emit_info, state);
                 }
 
                 // ldst encoding helpers take Reg, not Writable<Reg>.
@@ -887,7 +903,7 @@ impl MachInstEmit for Inst {
                 let (mem_insts, mem) = mem_finalize(sink.cur_offset(), mem, state);
 
                 for inst in mem_insts.into_iter() {
-                    inst.emit(sink, flags, state);
+                    inst.emit(sink, emit_info, state);
                 }
 
                 let (op, bits) = match self {
@@ -1500,11 +1516,11 @@ impl MachInstEmit for Inst {
                     mem: AMode::Label(MemLabel::PCRel(8)),
                     srcloc: None,
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 let inst = Inst::Jump {
                     dest: BranchTarget::ResolvedOffset(8),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 sink.put4(const_data.to_bits());
             }
             &Inst::LoadFpuConst64 { rd, const_data } => {
@@ -1513,11 +1529,11 @@ impl MachInstEmit for Inst {
                     mem: AMode::Label(MemLabel::PCRel(8)),
                     srcloc: None,
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 let inst = Inst::Jump {
                     dest: BranchTarget::ResolvedOffset(12),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 sink.put8(const_data.to_bits());
             }
             &Inst::LoadFpuConst128 { rd, const_data } => {
@@ -1526,11 +1542,11 @@ impl MachInstEmit for Inst {
                     mem: AMode::Label(MemLabel::PCRel(8)),
                     srcloc: None,
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 let inst = Inst::Jump {
                     dest: BranchTarget::ResolvedOffset(20),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
 
                 for i in const_data.to_le_bytes().iter() {
                     sink.put1(*i);
@@ -1854,7 +1870,7 @@ impl MachInstEmit for Inst {
                 if top22 != 0 {
                     sink.put4(enc_extend(top22, rd, rn));
                 } else {
-                    Inst::mov32(rd, rn).emit(sink, flags, state);
+                    Inst::mov32(rd, rn).emit(sink, emit_info, state);
                 }
             }
             &Inst::Extend {
@@ -1877,7 +1893,7 @@ impl MachInstEmit for Inst {
                     rn: zero_reg(),
                     rm: rd.to_reg(),
                 };
-                sub_inst.emit(sink, flags, state);
+                sub_inst.emit(sink, emit_info, state);
             }
             &Inst::Extend {
                 rd,
@@ -1964,7 +1980,7 @@ impl MachInstEmit for Inst {
                 sink.use_label_at_offset(off, label, LabelUse::Branch19);
                 // udf
                 let trap = Inst::Udf { trap_info };
-                trap.emit(sink, flags, state);
+                trap.emit(sink, emit_info, state);
                 // LABEL:
                 sink.bind_label(label);
             }
@@ -2022,10 +2038,10 @@ impl MachInstEmit for Inst {
                 // Save index in a tmp (the live range of ridx only goes to start of this
                 // sequence; rtmp1 or rtmp2 may overwrite it).
                 let inst = Inst::gen_move(rtmp2, ridx, I64);
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 // Load address of jump table
                 let inst = Inst::Adr { rd: rtmp1, off: 16 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 // Load value out of jump table
                 let inst = Inst::SLoad32 {
                     rd: rtmp2,
@@ -2037,7 +2053,7 @@ impl MachInstEmit for Inst {
                     ),
                     srcloc: None, // can't cause a user trap.
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 // Add base of jump table to jump-table-sourced block offset
                 let inst = Inst::AluRRR {
                     alu_op: ALUOp::Add64,
@@ -2045,14 +2061,14 @@ impl MachInstEmit for Inst {
                     rn: rtmp1.to_reg(),
                     rm: rtmp2.to_reg(),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 // Branch to computed address. (`targets` here is only used for successor queries
                 // and is not needed for emission.)
                 let inst = Inst::IndirectBr {
                     rn: rtmp1.to_reg(),
                     targets: vec![],
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 // Emit jump table (table of 32-bit offsets).
                 let jt_off = sink.cur_offset();
                 for &target in info.targets.iter() {
@@ -2085,13 +2101,13 @@ impl MachInstEmit for Inst {
                     mem: AMode::Label(MemLabel::PCRel(8)),
                     srcloc: None, // can't cause a user trap.
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 let inst = Inst::Jump {
                     dest: BranchTarget::ResolvedOffset(12),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
                 sink.add_reloc(srcloc, Reloc::Abs8, name, offset);
-                if flags.emit_all_ones_funcaddrs() {
+                if emit_info.flags().emit_all_ones_funcaddrs() {
                     sink.put8(u64::max_value());
                 } else {
                     sink.put8(0);
@@ -2100,7 +2116,7 @@ impl MachInstEmit for Inst {
             &Inst::LoadAddr { rd, ref mem } => {
                 let (mem_insts, mem) = mem_finalize(sink.cur_offset(), mem, state);
                 for inst in mem_insts.into_iter() {
-                    inst.emit(sink, flags, state);
+                    inst.emit(sink, emit_info, state);
                 }
 
                 let (reg, offset) = match mem {
@@ -2121,7 +2137,7 @@ impl MachInstEmit for Inst {
 
                 if offset == 0 {
                     let mov = Inst::mov(rd, reg);
-                    mov.emit(sink, flags, state);
+                    mov.emit(sink, emit_info, state);
                 } else if let Some(imm12) = Imm12::maybe_from_u64(abs_offset) {
                     let add = Inst::AluRRImm12 {
                         alu_op,
@@ -2129,7 +2145,7 @@ impl MachInstEmit for Inst {
                         rn: reg,
                         imm12,
                     };
-                    add.emit(sink, flags, state);
+                    add.emit(sink, emit_info, state);
                 } else {
                     // Use `tmp2` here: `reg` may be `spilltmp` if the `AMode` on this instruction
                     // was initially an `SPOffset`. Assert that `tmp2` is truly free to use. Note
@@ -2140,7 +2156,7 @@ impl MachInstEmit for Inst {
                     debug_assert!(reg != tmp2_reg());
                     let tmp = writable_tmp2_reg();
                     for insn in Inst::load_constant(tmp, abs_offset).into_iter() {
-                        insn.emit(sink, flags, state);
+                        insn.emit(sink, emit_info, state);
                     }
                     let add = Inst::AluRRR {
                         alu_op,
@@ -2148,7 +2164,7 @@ impl MachInstEmit for Inst {
                         rn: reg,
                         rm: tmp.to_reg(),
                     };
-                    add.emit(sink, flags, state);
+                    add.emit(sink, emit_info, state);
                 }
             }
             &Inst::VirtualSPOffsetAdj { offset } => {
@@ -2165,7 +2181,7 @@ impl MachInstEmit for Inst {
                     let jmp = Inst::Jump {
                         dest: BranchTarget::Label(jump_around_label),
                     };
-                    jmp.emit(sink, flags, state);
+                    jmp.emit(sink, emit_info, state);
                     sink.emit_island();
                     sink.bind_label(jump_around_label);
                 }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -9,7 +9,6 @@ use alloc::vec::Vec;
 
 #[test]
 fn test_aarch64_binemit() {
-    let flags = settings::Flags::new(settings::builder());
     let mut insns = Vec::<(Inst, &str, &str)>::new();
 
     // N.B.: the architecture is little-endian, so when transcribing the 32-bit
@@ -4668,7 +4667,9 @@ fn test_aarch64_binemit() {
 
     insns.push((Inst::Fence {}, "BF3B03D5", "dmb ish"));
 
-    let rru = create_reg_universe(&settings::Flags::new(settings::builder()));
+    let flags = settings::Flags::new(settings::builder());
+    let rru = create_reg_universe(&flags);
+    let emit_info = EmitInfo::new(flags);
     for (insn, expected_encoding, expected_printing) in insns {
         println!(
             "AArch64: {:?}, {}, {}",
@@ -4681,7 +4682,7 @@ fn test_aarch64_binemit() {
 
         let mut sink = test_utils::TestCodeSink::new();
         let mut buffer = MachBuffer::new();
-        insn.emit(&mut buffer, &flags, &mut Default::default());
+        insn.emit(&mut buffer, &emit_info, &mut Default::default());
         let buffer = buffer.finish();
         buffer.emit(&mut sink);
         let actual_encoding = &sink.stringify();

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -20,6 +20,8 @@ mod lower_inst;
 
 use inst::create_reg_universe;
 
+use self::inst::EmitInfo;
+
 /// An AArch64 backend.
 pub struct AArch64Backend {
     triple: Triple,
@@ -45,8 +47,9 @@ impl AArch64Backend {
         func: &Function,
         flags: settings::Flags,
     ) -> CodegenResult<VCode<inst::Inst>> {
+        let emit_info = EmitInfo::new(flags.clone());
         let abi = Box::new(abi::AArch64ABICallee::new(func, flags)?);
-        compile::compile::<AArch64Backend>(func, self, abi)
+        compile::compile::<AArch64Backend>(func, self, abi, emit_info)
     }
 }
 
@@ -58,6 +61,7 @@ impl MachBackend for AArch64Backend {
     ) -> CodegenResult<MachCompileResult> {
         let flags = self.flags();
         let vcode = self.compile_vcode(func, flags.clone())?;
+
         let buffer = vcode.emit();
         let frame_size = vcode.frame_size();
 

--- a/cranelift/codegen/src/isa/arm32/inst/emit.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/emit.rs
@@ -255,10 +255,27 @@ impl EmitState {
     }
 }
 
+pub struct EmitInfo {
+    flags: settings::Flags,
+}
+
+impl EmitInfo {
+    pub(crate) fn new(flags: settings::Flags) -> Self {
+        EmitInfo { flags }
+    }
+}
+
+impl MachInstEmitInfo for EmitInfo {
+    fn flags(&self) -> &settings::Flags {
+        &self.flags
+    }
+}
+
 impl MachInstEmit for Inst {
+    type Info = EmitInfo;
     type State = EmitState;
 
-    fn emit(&self, sink: &mut MachBuffer<Inst>, flags: &settings::Flags, state: &mut EmitState) {
+    fn emit(&self, sink: &mut MachBuffer<Inst>, emit_info: &Self::Info, state: &mut EmitState) {
         let start_off = sink.cur_offset();
 
         match self {
@@ -446,7 +463,7 @@ impl MachInstEmit for Inst {
             } => {
                 let (mem_insts, mem) = mem_finalize(mem, state);
                 for inst in mem_insts.into_iter() {
-                    inst.emit(sink, flags, state);
+                    inst.emit(sink, emit_info, state);
                 }
                 if let Some(srcloc) = srcloc {
                     // Register the offset at which the store instruction starts.
@@ -484,7 +501,7 @@ impl MachInstEmit for Inst {
             } => {
                 let (mem_insts, mem) = mem_finalize(mem, state);
                 for inst in mem_insts.into_iter() {
-                    inst.emit(sink, flags, state);
+                    inst.emit(sink, emit_info, state);
                 }
                 if let Some(srcloc) = srcloc {
                     // Register the offset at which the load instruction starts.
@@ -537,7 +554,7 @@ impl MachInstEmit for Inst {
             &Inst::LoadAddr { rd, ref mem } => {
                 let (mem_insts, mem) = mem_finalize(mem, state);
                 for inst in mem_insts.into_iter() {
-                    inst.emit(sink, flags, state);
+                    inst.emit(sink, emit_info, state);
                 }
                 let inst = match mem {
                     AMode::RegReg(reg1, reg2, shift) => {
@@ -574,7 +591,7 @@ impl MachInstEmit for Inst {
                     }
                     _ => unreachable!(),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
             }
             &Inst::Extend {
                 rd,
@@ -617,7 +634,7 @@ impl MachInstEmit for Inst {
                     rn: rm,
                     imm8: UImm8::maybe_from_i64(1).unwrap(),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
 
                 if signed {
                     let inst = Inst::AluRRImm8 {
@@ -626,7 +643,7 @@ impl MachInstEmit for Inst {
                         rn: rd.to_reg(),
                         imm8: UImm8::maybe_from_i64(1).unwrap(),
                     };
-                    inst.emit(sink, flags, state);
+                    inst.emit(sink, emit_info, state);
                 }
             }
             &Inst::Extend { .. } => {
@@ -638,7 +655,7 @@ impl MachInstEmit for Inst {
 
                 sink.put2(enc_16_it(cond, insts));
                 for inst in insts.iter() {
-                    inst.inst.emit(sink, flags, state);
+                    inst.inst.emit(sink, emit_info, state);
                 }
             }
             &Inst::Push { ref reg_list } => match reg_list.len() {
@@ -703,7 +720,7 @@ impl MachInstEmit for Inst {
                 // continue:
                 //
                 if start_off & 0x3 != 0 {
-                    Inst::Nop2.emit(sink, flags, state);
+                    Inst::Nop2.emit(sink, emit_info, state);
                 }
                 assert_eq!(sink.cur_offset() & 0x3, 0);
 
@@ -715,12 +732,12 @@ impl MachInstEmit for Inst {
                     bits: 32,
                     sign_extend: false,
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
 
                 let inst = Inst::Jump {
                     dest: BranchTarget::ResolvedOffset(4),
                 };
-                inst.emit(sink, flags, state);
+                inst.emit(sink, emit_info, state);
 
                 sink.add_reloc(srcloc, Reloc::Abs4, name, offset.into());
                 sink.put4(0);
@@ -779,7 +796,7 @@ impl MachInstEmit for Inst {
                 emit_32(enc_32_cond_branch(cond, dest), sink);
 
                 let trap = Inst::Udf { trap_info };
-                trap.emit(sink, flags, state);
+                trap.emit(sink, emit_info, state);
             }
             &Inst::VirtualSPOffsetAdj { offset } => {
                 debug!(

--- a/cranelift/codegen/src/isa/arm32/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/mod.rs
@@ -17,7 +17,7 @@ mod inst;
 mod lower;
 mod lower_inst;
 
-use inst::create_reg_universe;
+use inst::{create_reg_universe, EmitInfo};
 
 /// An ARM32 backend.
 pub struct Arm32Backend {
@@ -44,8 +44,9 @@ impl Arm32Backend {
     ) -> CodegenResult<VCode<inst::Inst>> {
         // This performs lowering to VCode, register-allocates the code, computes
         // block layout and finalizes branches. The result is ready for binary emission.
+        let emit_info = EmitInfo::new(flags.clone());
         let abi = Box::new(abi::Arm32ABICallee::new(func, flags)?);
-        compile::compile::<Arm32Backend>(func, self, abi)
+        compile::compile::<Arm32Backend>(func, self, abi, emit_info)
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -475,6 +475,16 @@ pub(crate) fn emit(
     info: &EmitInfo,
     state: &mut EmitState,
 ) {
+    if let Some(iset_requirement) = inst.isa_requirement() {
+        match iset_requirement {
+            // Cranelift assumes SSE2 at least.
+            InstructionSet::SSE | InstructionSet::SSE2 => {}
+            InstructionSet::SSSE3 => assert!(info.isa_flags.has_ssse3()),
+            InstructionSet::SSE41 => assert!(info.isa_flags.has_sse41()),
+            InstructionSet::SSE42 => assert!(info.isa_flags.has_sse42()),
+        }
+    }
+
     match inst {
         Inst::AluRmiR {
             is_64,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -502,6 +502,71 @@ pub(crate) fn low32_will_sign_extend_to_64(x: u64) -> bool {
     xs == ((xs << 32) >> 32)
 }
 
+impl Inst {
+    fn isa_requirement(&self) -> Option<InstructionSet> {
+        match self {
+            // These instructions are part of SSE2, which is a basic requirement in Cranelift, and
+            // don't have to be checked.
+            Inst::AluRmiR { .. }
+            | Inst::AtomicRmwSeq { .. }
+            | Inst::CallKnown { .. }
+            | Inst::CallUnknown { .. }
+            | Inst::CheckedDivOrRemSeq { .. }
+            | Inst::Cmove { .. }
+            | Inst::CmpRmiR { .. }
+            | Inst::CvtFloatToSintSeq { .. }
+            | Inst::CvtFloatToUintSeq { .. }
+            | Inst::CvtUint64ToFloatSeq { .. }
+            | Inst::Div { .. }
+            | Inst::EpiloguePlaceholder
+            | Inst::Fence { .. }
+            | Inst::Hlt
+            | Inst::Imm { .. }
+            | Inst::JmpCond { .. }
+            | Inst::JmpIf { .. }
+            | Inst::JmpKnown { .. }
+            | Inst::JmpTableSeq { .. }
+            | Inst::JmpUnknown { .. }
+            | Inst::LoadEffectiveAddress { .. }
+            | Inst::LoadExtName { .. }
+            | Inst::LockCmpxchg { .. }
+            | Inst::Mov64MR { .. }
+            | Inst::MovRM { .. }
+            | Inst::MovRR { .. }
+            | Inst::MovsxRmR { .. }
+            | Inst::MovzxRmR { .. }
+            | Inst::MulHi { .. }
+            | Inst::Neg { .. }
+            | Inst::Not { .. }
+            | Inst::Nop { .. }
+            | Inst::Pop64 { .. }
+            | Inst::Push64 { .. }
+            | Inst::Ret
+            | Inst::Setcc { .. }
+            | Inst::ShiftR { .. }
+            | Inst::SignExtendData { .. }
+            | Inst::TrapIf { .. }
+            | Inst::Ud2 { .. }
+            | Inst::UnaryRmR { .. }
+            | Inst::VirtualSPOffsetAdj { .. }
+            | Inst::XmmCmove { .. }
+            | Inst::XmmCmpRmR { .. }
+            | Inst::XmmLoadConstSeq { .. }
+            | Inst::XmmMinMaxSeq { .. }
+            | Inst::XmmUninitializedValue { .. } => None,
+
+            // These use dynamic SSE opcodes.
+            Inst::GprToXmm { op, .. }
+            | Inst::XmmMovRM { op, .. }
+            | Inst::XmmRmiReg { opcode: op, .. }
+            | Inst::XmmRmR { op, .. }
+            | Inst::XmmRmRImm { op, .. }
+            | Inst::XmmToGpr { op, .. }
+            | Inst::XmmUnaryRmR { op, .. } => Some(op.available_from()),
+        }
+    }
+}
+
 // Handy constructors for Insts.
 
 impl Inst {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::binemit::{CodeOffset, StackMap};
 use crate::ir::{types, ExternalName, Opcode, SourceLoc, TrapCode, Type};
+use crate::isa::x64::settings as x64_settings;
 use crate::machinst::*;
 use crate::{settings, settings::Flags, CodegenError, CodegenResult};
 use alloc::boxed::Box;
@@ -2557,11 +2558,30 @@ pub struct EmitState {
     stack_map: Option<StackMap>,
 }
 
+/// Constant state used during emissions of a sequence of instructions.
+pub struct EmitInfo {
+    flags: settings::Flags,
+    isa_flags: x64_settings::Flags,
+}
+
+impl EmitInfo {
+    pub(crate) fn new(flags: settings::Flags, isa_flags: x64_settings::Flags) -> Self {
+        Self { flags, isa_flags }
+    }
+}
+
+impl MachInstEmitInfo for EmitInfo {
+    fn flags(&self) -> &Flags {
+        &self.flags
+    }
+}
+
 impl MachInstEmit for Inst {
     type State = EmitState;
+    type Info = EmitInfo;
 
-    fn emit(&self, sink: &mut MachBuffer<Inst>, flags: &settings::Flags, state: &mut Self::State) {
-        emit::emit(self, sink, flags, state);
+    fn emit(&self, sink: &mut MachBuffer<Inst>, info: &Self::Info, state: &mut Self::State) {
+        emit::emit(self, sink, info, state);
     }
 
     fn pretty_print(&self, mb_rru: Option<&RealRegUniverse>, _: &mut Self::State) -> String {

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -14,6 +14,7 @@ pub fn compile<B: LowerBackend + MachBackend>(
     f: &Function,
     b: &B,
     abi: Box<dyn ABICallee<I = B::MInst>>,
+    emit_info: <B::MInst as MachInstEmit>::Info,
 ) -> CodegenResult<VCode<B::MInst>>
 where
     B::MInst: PrettyPrint,
@@ -21,7 +22,7 @@ where
     // Compute lowered block order.
     let block_order = BlockLoweringOrder::new(f);
     // Build the lowering context.
-    let lower = Lower::new(f, abi, block_order)?;
+    let lower = Lower::new(f, abi, emit_info, block_order)?;
     // Lower the IR.
     let (mut vcode, stack_map_request_info) = {
         let _tt = timing::vcode_lower();

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -313,9 +313,10 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
     pub fn new(
         f: &'func Function,
         abi: Box<dyn ABICallee<I = I>>,
+        emit_info: I::Info,
         block_order: BlockLoweringOrder,
     ) -> CodegenResult<Lower<'func, I>> {
-        let mut vcode = VCodeBuilder::new(abi, block_order);
+        let mut vcode = VCodeBuilder::new(abi, emit_info, block_order);
 
         let mut next_vreg: u32 = 0;
 

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -275,10 +275,19 @@ pub enum MachTerminator<'a> {
 pub trait MachInstEmit: MachInst {
     /// Persistent state carried across `emit` invocations.
     type State: MachInstEmitState<Self>;
+    /// Constant information used in `emit` invocations.
+    type Info: MachInstEmitInfo;
     /// Emit the instruction.
-    fn emit(&self, code: &mut MachBuffer<Self>, flags: &Flags, state: &mut Self::State);
+    fn emit(&self, code: &mut MachBuffer<Self>, info: &Self::Info, state: &mut Self::State);
     /// Pretty-print the instruction.
     fn pretty_print(&self, mb_rru: Option<&RealRegUniverse>, state: &mut Self::State) -> String;
+}
+
+/// Constant information used to emit an instruction.
+pub trait MachInstEmitInfo {
+    /// Return the target-independent settings used for the compilation of this
+    /// particular function.
+    fn flags(&self) -> &Flags;
 }
 
 /// A trait describing the emission state carried between MachInsts when

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -1,6 +1,6 @@
 test compile
 set enable_simd
-target x86_64
+target x86_64 has_ssse3 has_sse41
 feature "experimental_x64"
 
 ;; shuffle


### PR DESCRIPTION
This builds on top of #2255 (two commits), and adds a dynamic check that every time we emit an instruction that uses SSE features, the features were enabled by the configuration. This avoids cases where we could use e.g. SSE4.1 on a machine that doesn't have it.

The way to pass the ISA flags is a bit tricky; please see commit message for the explanation of why it was done this way. Happy to try a different way if anybody has better suggestions!