### PR TITLE
Add ARM32 build test to CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,9 +108,11 @@ jobs:
     # Check a few builds of the cranelift backend
     # - only x86 backend support,
     # - only arm64 backend support,
+    # - experimental arm32 support,
     # - no debug_assertions.
     - run: cargo check --manifest-path=./cranelift/Cargo.toml --bin clif-util --no-default-features --features=cranelift-codegen/arm64
     - run: cargo check --manifest-path=./cranelift/Cargo.toml --bin clif-util --no-default-features --features=cranelift-codegen/x86
+    - run: cargo check --manifest-path=./cranelift/Cargo.toml --bin clif-util --no-default-features --features=cranelift-codegen/arm32
     - run: cargo check --manifest-path=./cranelift/Cargo.toml --bin clif-util
       env:
         CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: false


### PR DESCRIPTION
We do not yet want to gate our CI on tests passing, because the backend
is only partially complete; but we want to make sure that it remains
up-to-date as we change internal APIs.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
