### PR TITLE
rm misleading comment

### DIFF
--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -517,7 +517,7 @@ impl SSABuilder {
             ZeroOneOrMore::Zero => {
                 // The variable is used but never defined before. This is an irregularity in the
                 // code, but rather than throwing an error we silently initialize the variable to
-                // 0. This will have no effect since this situation happens in unreachable code.
+                // 0.
                 if !func.layout.is_block_inserted(dest_block) {
                     func.layout.append_block(dest_block);
                 }


### PR DESCRIPTION
`emit_zero` is called if `use_var` is called without `def_var`, this comment is misleading .