### PR TITLE
optimize register_jit_code

### DIFF
--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -163,7 +163,7 @@ impl Instance {
 
         let host_info = Box::new({
             let frame_info_registration = module.register_frame_info();
-            store.register_jit_code(module.compiled_module().jit_code_ranges());
+            store.register_jit_code(&module);
             store.register_stack_maps(&module);
             frame_info_registration
         });

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -963,7 +963,8 @@ impl Store {
             .any(|(start, end)| *start <= addr && addr < *end)
     }
 
-    pub(crate) fn register_jit_code(&self, mut ranges: impl Iterator<Item = (usize, usize)>) {
+    pub(crate) fn register_jit_code(&self, module: &Module) {
+        let mut ranges = module.compiled_module().jit_code_ranges();
         // Checking of we already registered JIT code ranges by searching
         // first range start.
         match ranges.next() {


### PR DESCRIPTION
Make `register_jit_code` take `&Module` as parameter, the same as `register_stack_maps`.