### PR TITLE
Update wasmparser, wast, and spec test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "souper-ir",
  "target-lexicon",
  "thiserror",
- "wast",
+ "wast 25.0.0",
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wat",
 ]
 
@@ -1103,7 +1103,7 @@ dependencies = [
  "staticvec",
  "thiserror",
  "typemap",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wat",
 ]
 
@@ -1274,7 +1274,7 @@ dependencies = [
  "peepmatic-test-operator",
  "peepmatic-traits",
  "serde",
- "wast",
+ "wast 25.0.0",
  "z3",
 ]
 
@@ -1302,7 +1302,7 @@ dependencies = [
  "peepmatic-traits",
  "rand 0.7.3",
  "serde",
- "wast",
+ "wast 25.0.0",
 ]
 
 [[package]]
@@ -1327,7 +1327,7 @@ dependencies = [
  "serde",
  "serde_test",
  "thiserror",
- "wast",
+ "wast 25.0.0",
 ]
 
 [[package]]
@@ -1339,7 +1339,7 @@ dependencies = [
  "peepmatic",
  "peepmatic-test-operator",
  "souper-ir",
- "wast",
+ "wast 25.0.0",
 ]
 
 [[package]]
@@ -1360,7 +1360,7 @@ version = "0.67.0"
 dependencies = [
  "peepmatic-traits",
  "serde",
- "wast",
+ "wast 25.0.0",
 ]
 
 [[package]]
@@ -2337,18 +2337,18 @@ checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmparser"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36b5b8441a5d83ea606c9eb904a3ee3889ebfeda1df1a5c48b84725239d93ce"
+checksum = "57da5d7300428d75d8b3cdfb736e41ee6af8926d69c1de2f201a1a22f234b7b5"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc9e10f7145e1c15f16c809d6c0937ab51a79478f53458fb78ded3491819a94"
+checksum = "fd1fea2e86fb107de33db6538db99f73e8d058f6fda2bbd8cceafff847dd9266"
 dependencies = [
  "anyhow",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
 ]
 
 [[package]]
@@ -2368,7 +2368,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -2446,7 +2446,7 @@ dependencies = [
  "test-programs",
  "tracing-subscriber",
  "wasi-common",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-debug",
@@ -2481,7 +2481,7 @@ dependencies = [
  "object 0.21.1",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wasmtime-environ",
 ]
 
@@ -2500,7 +2500,7 @@ dependencies = [
  "more-asserts",
  "serde",
  "thiserror",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
 ]
 
 [[package]]
@@ -2528,7 +2528,7 @@ dependencies = [
  "env_logger",
  "log",
  "rayon",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -2555,7 +2555,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -2572,7 +2572,7 @@ version = "0.20.0"
 dependencies = [
  "cranelift-codegen",
  "lightbeam",
- "wasmparser 0.62.0",
+ "wasmparser 0.63.0",
  "wasmtime-environ",
 ]
 
@@ -2664,7 +2664,7 @@ version = "0.20.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast",
+ "wast 25.0.0",
 ]
 
 [[package]]
@@ -2698,12 +2698,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.0.23"
+name = "wast"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f888158d9a4b7c39b859f72a435019835b64097c749f4f28d319004ca5a520b8"
+checksum = "d8c67a4386e4efe10563552848d8c6a4b7f941e69924a935495645c3f52b32d0"
 dependencies = [
- "wast",
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4766d466249e23279e92c52033429eb91141c5efea1c4478138fa6f6ef4efe3e"
+dependencies = [
+ "wast 25.0.0",
 ]
 
 [[package]]
@@ -2814,7 +2823,7 @@ dependencies = [
  "pretty_env_logger",
  "structopt",
  "thiserror",
- "wast",
+ "wast 22.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,12 @@ anyhow = "1.0.19"
 target-lexicon = { version = "0.11.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.23"
+wat = "1.0.26"
 libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"
 humantime = "1.3.0"
-wasmparser = "0.62"
+wasmparser = "0.63"
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/build.rs
+++ b/build.rs
@@ -39,7 +39,6 @@ fn main() -> anyhow::Result<()> {
             // out.
             if spec_tests > 0 {
                 test_directory_module(out, "tests/spec_testsuite/proposals/simd", strategy)?;
-                test_directory_module(out, "tests/spec_testsuite/proposals/multi-value", strategy)?;
                 test_directory_module(
                     out,
                     "tests/spec_testsuite/proposals/reference-types",
@@ -225,6 +224,13 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", _) => {
                 return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
             }
+
+            // These tests have simd operators which aren't implemented yet.
+            ("simd", "simd_boolean") => return true,
+            ("simd", "simd_f32x4_pmin_pmax") => return true,
+            ("simd", "simd_f32x4_rounding") => return true,
+            ("simd", "simd_f64x2_pmin_pmax") => return true,
+            ("simd", "simd_f64x2_rounding") => return true,
 
             _ => {}
         },

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -30,7 +30,7 @@ peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, versi
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.67.0" }
 regalloc = "0.0.30"
 souper-ir = { version = "1", optional = true }
-wast = { version = "22.0.0", optional = true }
+wast = { version = "25.0.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/peepmatic/Cargo.toml
+++ b/cranelift/peepmatic/Cargo.toml
@@ -15,7 +15,7 @@ peepmatic-macro = { version = "0.67.0", path = "crates/macro" }
 peepmatic-runtime = { version = "0.67.0", path = "crates/runtime", features = ["construct"] }
 peepmatic-traits = { version = "0.67.0", path = "crates/traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "22.0.0"
+wast = "25.0.0"
 z3 = { version = "0.6.0", features = ["static-link-z3"] }
 
 [dev-dependencies]

--- a/cranelift/peepmatic/crates/fuzzing/Cargo.toml
+++ b/cranelift/peepmatic/crates/fuzzing/Cargo.toml
@@ -21,4 +21,4 @@ peepmatic-test-operator = { path = "../test-operator" }
 peepmatic-traits = { path = "../traits" }
 rand = { version = "0.7.3", features = ["small_rng"] }
 serde = "1.0.106"
-wast = "22.0.0"
+wast = "25.0.0"

--- a/cranelift/peepmatic/crates/runtime/Cargo.toml
+++ b/cranelift/peepmatic/crates/runtime/Cargo.toml
@@ -16,7 +16,7 @@ peepmatic-automata = { version = "0.67.0", path = "../automata", features = ["se
 peepmatic-traits = { version = "0.67.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
 thiserror = "1.0.15"
-wast = { version = "22.0.0", optional = true }
+wast = { version = "25.0.0", optional = true }
 
 [dev-dependencies]
 peepmatic-test-operator = { version = "0.67.0", path = "../test-operator" }

--- a/cranelift/peepmatic/crates/souper/Cargo.toml
+++ b/cranelift/peepmatic/crates/souper/Cargo.toml
@@ -16,4 +16,4 @@ log = "0.4.8"
 [dev-dependencies]
 peepmatic = { path = "../..", version = "0.67.0" }
 peepmatic-test-operator = { version = "0.67.0", path = "../test-operator" }
-wast = "22.0.0"
+wast = "25.0.0"

--- a/cranelift/peepmatic/crates/test-operator/Cargo.toml
+++ b/cranelift/peepmatic/crates/test-operator/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 [dependencies]
 peepmatic-traits = { version = "0.67.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "22.0.0"
+wast = "25.0.0"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.62.0", default-features = false }
+wasmparser = { version = "0.63.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.67.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.67.0" }
 cranelift-frontend = { path = "../frontend", version = "0.67.0", default-features = false }

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -634,32 +634,32 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::V128Load { memarg } => {
             translate_load(memarg, ir::Opcode::Load, I8X16, builder, state, environ)?;
         }
-        Operator::I16x8Load8x8S { memarg } => {
+        Operator::V128Load8x8S { memarg } => {
             let (flags, base, offset) = prepare_load(memarg, 8, builder, state, environ)?;
             let loaded = builder.ins().sload8x8(flags, base, offset);
             state.push1(loaded);
         }
-        Operator::I16x8Load8x8U { memarg } => {
+        Operator::V128Load8x8U { memarg } => {
             let (flags, base, offset) = prepare_load(memarg, 8, builder, state, environ)?;
             let loaded = builder.ins().uload8x8(flags, base, offset);
             state.push1(loaded);
         }
-        Operator::I32x4Load16x4S { memarg } => {
+        Operator::V128Load16x4S { memarg } => {
             let (flags, base, offset) = prepare_load(memarg, 8, builder, state, environ)?;
             let loaded = builder.ins().sload16x4(flags, base, offset);
             state.push1(loaded);
         }
-        Operator::I32x4Load16x4U { memarg } => {
+        Operator::V128Load16x4U { memarg } => {
             let (flags, base, offset) = prepare_load(memarg, 8, builder, state, environ)?;
             let loaded = builder.ins().uload16x4(flags, base, offset);
             state.push1(loaded);
         }
-        Operator::I64x2Load32x2S { memarg } => {
+        Operator::V128Load32x2S { memarg } => {
             let (flags, base, offset) = prepare_load(memarg, 8, builder, state, environ)?;
             let loaded = builder.ins().sload32x2(flags, base, offset);
             state.push1(loaded);
         }
-        Operator::I64x2Load32x2U { memarg } => {
+        Operator::V128Load32x2U { memarg } => {
             let (flags, base, offset) = prepare_load(memarg, 8, builder, state, environ)?;
             let loaded = builder.ins().uload32x2(flags, base, offset);
             state.push1(loaded);
@@ -1372,10 +1372,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let splatted = builder.ins().splat(type_of(op), state.pop1());
             state.push1(splatted)
         }
-        Operator::V8x16LoadSplat { memarg }
-        | Operator::V16x8LoadSplat { memarg }
-        | Operator::V32x4LoadSplat { memarg }
-        | Operator::V64x2LoadSplat { memarg } => {
+        Operator::V128Load8Splat { memarg }
+        | Operator::V128Load16Splat { memarg }
+        | Operator::V128Load32Splat { memarg }
+        | Operator::V128Load64Splat { memarg } => {
             // TODO: For spec compliance, this is initially implemented as a combination of `load +
             // splat` but could be implemented eventually as a single instruction (`load_splat`).
             // See https://github.com/bytecodealliance/wasmtime/issues/1175.
@@ -1425,7 +1425,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let vector = optionally_bitcast_vector(vector, type_of(op), builder);
             state.push1(builder.ins().insertlane(vector, replacement, *lane))
         }
-        Operator::V8x16Shuffle { lanes, .. } => {
+        Operator::I8x16Shuffle { lanes, .. } => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
             let lanes = ConstantData::from(lanes.as_ref());
             let mask = builder.func.dfg.immediates.push(lanes);
@@ -1436,7 +1436,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             // to WASM using the less specific v128 type for certain operations and more specific
             // types (e.g. i8x16) for others.
         }
-        Operator::V8x16Swizzle => {
+        Operator::I8x16Swizzle => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
             state.push1(builder.ins().swizzle(I8X16, a, b))
         }
@@ -1444,11 +1444,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().iadd(a, b))
         }
-        Operator::I8x16AddSaturateS | Operator::I16x8AddSaturateS => {
+        Operator::I8x16AddSatS | Operator::I16x8AddSatS => {
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().sadd_sat(a, b))
         }
-        Operator::I8x16AddSaturateU | Operator::I16x8AddSaturateU => {
+        Operator::I8x16AddSatU | Operator::I16x8AddSatU => {
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().uadd_sat(a, b))
         }
@@ -1456,11 +1456,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().isub(a, b))
         }
-        Operator::I8x16SubSaturateS | Operator::I16x8SubSaturateS => {
+        Operator::I8x16SubSatS | Operator::I16x8SubSatS => {
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().ssub_sat(a, b))
         }
-        Operator::I8x16SubSaturateU | Operator::I16x8SubSaturateU => {
+        Operator::I8x16SubSatU | Operator::I16x8SubSatU => {
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().usub_sat(a, b))
         }
@@ -1713,7 +1713,22 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, I16X8, builder);
             state.push1(builder.ins().uwiden_high(a))
         }
-        Operator::I8x16Bitmask | Operator::I16x8Bitmask | Operator::I32x4Bitmask => {
+
+        Operator::F32x4Ceil
+        | Operator::F32x4Floor
+        | Operator::F32x4Trunc
+        | Operator::F32x4Nearest
+        | Operator::F32x4PMin
+        | Operator::F32x4PMax
+        | Operator::F64x2Ceil
+        | Operator::F64x2Floor
+        | Operator::F64x2Trunc
+        | Operator::F64x2PMin
+        | Operator::F64x2PMax
+        | Operator::F64x2Nearest
+        | Operator::I8x16Bitmask
+        | Operator::I16x8Bitmask
+        | Operator::I32x4Bitmask => {
             return Err(wasm_unsupported!("proposed SIMD operator {:?}", op));
         }
 
@@ -2345,9 +2360,9 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::V128Xor
         | Operator::V128Bitselect => I8X16, // default type representing V128
 
-        Operator::V8x16Shuffle { .. }
+        Operator::I8x16Shuffle { .. }
         | Operator::I8x16Splat
-        | Operator::V8x16LoadSplat { .. }
+        | Operator::V128Load8Splat { .. }
         | Operator::I8x16ExtractLaneS { .. }
         | Operator::I8x16ExtractLaneU { .. }
         | Operator::I8x16ReplaceLane { .. }
@@ -2369,11 +2384,11 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I8x16ShrS
         | Operator::I8x16ShrU
         | Operator::I8x16Add
-        | Operator::I8x16AddSaturateS
-        | Operator::I8x16AddSaturateU
+        | Operator::I8x16AddSatS
+        | Operator::I8x16AddSatU
         | Operator::I8x16Sub
-        | Operator::I8x16SubSaturateS
-        | Operator::I8x16SubSaturateU
+        | Operator::I8x16SubSatS
+        | Operator::I8x16SubSatU
         | Operator::I8x16MinS
         | Operator::I8x16MinU
         | Operator::I8x16MaxS
@@ -2382,7 +2397,7 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I8x16Bitmask => I8X16,
 
         Operator::I16x8Splat
-        | Operator::V16x8LoadSplat { .. }
+        | Operator::V128Load16Splat { .. }
         | Operator::I16x8ExtractLaneS { .. }
         | Operator::I16x8ExtractLaneU { .. }
         | Operator::I16x8ReplaceLane { .. }
@@ -2404,11 +2419,11 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I16x8ShrS
         | Operator::I16x8ShrU
         | Operator::I16x8Add
-        | Operator::I16x8AddSaturateS
-        | Operator::I16x8AddSaturateU
+        | Operator::I16x8AddSatS
+        | Operator::I16x8AddSatU
         | Operator::I16x8Sub
-        | Operator::I16x8SubSaturateS
-        | Operator::I16x8SubSaturateU
+        | Operator::I16x8SubSatS
+        | Operator::I16x8SubSatU
         | Operator::I16x8MinS
         | Operator::I16x8MinU
         | Operator::I16x8MaxS
@@ -2418,7 +2433,7 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I16x8Bitmask => I16X8,
 
         Operator::I32x4Splat
-        | Operator::V32x4LoadSplat { .. }
+        | Operator::V128Load32Splat { .. }
         | Operator::I32x4ExtractLane { .. }
         | Operator::I32x4ReplaceLane { .. }
         | Operator::I32x4Eq
@@ -2450,7 +2465,7 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I32x4Bitmask => I32X4,
 
         Operator::I64x2Splat
-        | Operator::V64x2LoadSplat { .. }
+        | Operator::V128Load64Splat { .. }
         | Operator::I64x2ExtractLane { .. }
         | Operator::I64x2ReplaceLane { .. }
         | Operator::I64x2Neg

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.22.0"
-wasmparser = "0.62.0"
+wasmparser = "0.63.0"
 object = { version = "0.21.1", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.20.0" }
 target-lexicon = { version = "0.11.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.67.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.67.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.67.0", features = ["enable-serde"] }
-wasmparser = "0.62.0"
+wasmparser = "0.63.0"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,8 +13,8 @@ binaryen = { version = "0.10.0", optional = true }
 env_logger = "0.7.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.62.0"
-wasmprinter = "0.2.8"
+wasmparser = "0.63.0"
+wasmprinter = "0.2.10"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -28,7 +28,7 @@ rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.62.0"
+wasmparser = "0.63.0"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "0.1.9"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "1.0.0"
 staticvec = "0.10"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.62.0"
+wasmparser = "0.63.0"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 lightbeam = { path = "..", version = "0.20.0" }
-wasmparser = "0.62"
+wasmparser = "0.63"
 cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.67.0" }
 wasmtime-environ = { path = "../../environ", version = "0.20.0" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -16,7 +16,7 @@ wasmtime-jit = { path = "../jit", version = "0.20.0" }
 wasmtime-cache = { path = "../cache", version = "0.20.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.20.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.62.0"
+wasmparser = "0.63.0"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.20.0", default-features = false }
-wast = "22.0.0"
+wast = "25.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION


This brings in a number of SIMD opcode renames, various other test suite
updates, as well as some new proposed SIMD opcodes too.

