### PR TITLE
Update Github Actions CI set-env/add-path

### DIFF
--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -2,19 +2,24 @@
 
 const child_process = require('child_process');
 const stdio = { stdio: 'inherit' };
+const fs = require('fs');
+
+function set_env(name, val) {
+  fs.appendFileSync(process.env['GITHUB_ENV'], `${name}=${val}\n`)
+}
 
 // On OSX all we need to do is configure our deployment target as old as
 // possible. For now 10.9 is the limit.
 if (process.platform == 'darwin') {
-  console.log("::set-env name=MACOSX_DEPLOYMENT_TARGET::10.9");
-  console.log("::set-env name=python::python3");
+  set_env("MACOSX_DEPLOYMENT_TARGET", "10.9");
+  set_env("python", "python3");
   return;
 }
 
 // On Windows we build against the static CRT to reduce dll dependencies
 if (process.platform == 'win32') {
-  console.log("::set-env name=RUSTFLAGS::-Ctarget-feature=+crt-static");
-  console.log("::set-env name=python::python");
+  set_env("RUSTFLAGS", "-Ctarget-feature=+crt-static");
+  set_env("python", "python");
   return;
 }
 
@@ -51,7 +56,7 @@ child_process.execFileSync('docker', [
 ], stdio);
 
 // Use ourselves to run future commands
-console.log(`::set-env name=CENTOS::${__filename}`)
+set_env("CENTOS", __filename);
 
 // See https://edwards.sdsu.edu/research/c11-on-centos-6/ for where these
 const exec = s => {
@@ -66,4 +71,4 @@ exec('yum install -y git');
 // This is a hack and not the right way to do this, but it ends up doing the
 // right thing for now.
 exec('rm -f /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so');
-console.log("::set-env name=python::python3");
+set_env("python", "python3");

--- a/.github/actions/define-llvm-env/main.js
+++ b/.github/actions/define-llvm-env/main.js
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 
+const fs = require('fs');
+
+function set_env(name, val) {
+  fs.appendFileSync(process.env['GITHUB_ENV'], `${name}=${val}\n`)
+}
+
 // On OSX pointing to brew's LLVM location.
 if (process.platform == 'darwin') {
-  console.log("::set-env name=DWARFDUMP::/usr/local/opt/llvm/bin/llvm-dwarfdump");
-  console.log("::set-env name=LLDB::/usr/local/opt/llvm/bin/lldb");
+  set_env("DWARFDUMP", "/usr/local/opt/llvm/bin/llvm-dwarfdump");
+  set_env("LLDB", "/usr/local/opt/llvm/bin/lldb");
 }
 
 // On Linux pointing to specific version
 if (process.platform == 'linux') {
-  console.log("::set-env name=DWARFDUMP::/usr/bin/llvm-dwarfdump-9");
-  console.log("::set-env name=LLDB::/usr/bin/lldb-9");
+  set_env("DWARFDUMP", "/usr/bin/llvm-dwarfdump-9");
+  set_env("LLDB", "/usr/bin/lldb-9");
 }

--- a/.github/actions/install-rust/main.js
+++ b/.github/actions/install-rust/main.js
@@ -1,10 +1,15 @@
 const child_process = require('child_process');
 const toolchain = process.env.INPUT_TOOLCHAIN;
+const fs = require('fs');
+
+function set_env(name, val) {
+  fs.appendFileSync(process.env['GITHUB_ENV'], `${name}=${val}\n`)
+}
 
 if (process.platform === 'darwin') {
   child_process.execSync(`curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=none --profile=minimal`);
   const bindir = `${process.env.HOME}/.cargo/bin`;
-  console.log(`::add-path::${bindir}`);
+  fs.appendFileSync(process.env['GITHUB_PATH'], `${bindir}\n`);
   process.env.PATH = `${process.env.PATH}:${bindir}`;
 }
 
@@ -15,13 +20,13 @@ child_process.execFileSync('rustup', ['default', toolchain]);
 // Deny warnings on CI to keep our code warning-free as it lands in-tree. Don't
 // do this on nightly though since there's a fair amount of warning churn there.
 if (!toolchain.startsWith('nightly')) {
-  console.log(`::set-env name=RUSTFLAGS::-D warnings`);
+  set_env("RUSTFLAGS", "-D warnings");
 }
 
 // Save disk space by avoiding incremental compilation, and also we don't use
 // any caching so incremental wouldn't help anyway.
-console.log(`::set-env name=CARGO_INCREMENTAL::0`);
+set_env("CARGO_INCREMENTAL", "0");
 
 // Turn down debuginfo from 2 to 1 to help save disk space
-console.log(`::set-env name=CARGO_PROFILE_DEV_DEBUG::1`);
-console.log(`::set-env name=CARGO_PROFILE_TEST_DEBUG::1`);
+set_env("CARGO_PROFILE_DEV_DEBUG", "1");
+set_env("CARGO_PROFILE_TEST_DEBUG", "1");

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     - run: |
         set -e
         curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
-        echo ::add-path::`pwd`
+        echo `pwd` >> $GITHUB_PATH
     - run: (cd docs && mdbook build)
     - run: cargo build -p wasmtime
     - run: (cd docs && mdbook test -L ../target/debug/deps)
@@ -216,8 +216,8 @@ jobs:
       run: |
         curl https://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe -o llvm-installer.exe
         7z x llvm-installer.exe -oC:/llvm-binary
-        echo ::set-env name=LIBCLANG_PATH::C:/llvm-binary/bin/libclang.dll
-        echo ::add-path::C:/llvm-binary/bin
+        echo LIBCLANG_PATH=C:/llvm-binary/bin/libclang.dll >> $GITHUB_ENV
+        echo C:/llvm-binary/bin >> $GITHUB_PATH
 
     - name: Query Clang Version
       if: matrix.os == 'windows-latest'
@@ -354,7 +354,7 @@ jobs:
 
     - name: Configure Cargo target
       run: |
-        echo ::set-env name=CARGO_BUILD_TARGET::${{ matrix.target }}
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
@@ -376,12 +376,12 @@ jobs:
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo ::set-env name=CARGO_TARGET_${upcase}_RUNNER::$HOME/qemu/bin/${{ matrix.qemu }}
-        echo ::set-env name=CARGO_TARGET_${upcase}_LINKER::${{ matrix.gcc }}
+        echo CARGO_TARGET_${upcase}_RUNNER=$HOME/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
+        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
 
         # See comments in the source for why we enable this during QEMU
         # emulation.
-        echo ::set-env name=WASMTIME_TEST_NO_HOG_MEMORY::1
+        echo WASMTIME_TEST_NO_HOG_MEMORY=1 >> $GITHUB_ENV
       if: matrix.target != '' && matrix.os == 'ubuntu-latest'
 
     # Install wasm32-wasi target in order to build wasi-common's integration
@@ -538,7 +538,7 @@ jobs:
           name=${GITHUB_REF:10}
         fi
         echo ::set-output name=val::$name
-        echo ::set-env name=TAG::$name
+        echo TAG=$name >> $GITHUB_ENV
       id: tagname
 
     # Assemble all the build artifacts into tarballs and zip archives.
@@ -588,7 +588,7 @@ jobs:
       with:
         path: ${{ runner.tool_cache }}/cargo-audit
         key: cargo-audit-bin-${{ env.CARGO_AUDIT_VERSION }}
-    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-audit/bin"
+    - run: echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
     - run: |
         cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
         cargo audit
@@ -603,8 +603,8 @@ jobs:
     - run: |
         cd ${{ runner.tool_cache }}
         curl -L https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz | tar xzf -
-        echo "::add-path::`pwd`/sccache-0.2.13-x86_64-unknown-linux-musl"
-        echo ::set-env name=RUSTC_WRAPPER::sccache
+        echo "`pwd`/sccache-0.2.13-x86_64-unknown-linux-musl" >> $GITHUB_PATH
+        echo RUSTC_WRAPPER=sccache >> $GITHUB_ENV
     - run: |
         rustc scripts/publish.rs
         ./publish verify


### PR DESCRIPTION
In accordance with [this
advisory](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
it's recommended we moved to a different scheme of setting env vars and
updating PATH.
