### PR TITLE
fix sa_sigaction signature

### DIFF
--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -147,9 +147,9 @@ cfg_if::cfg_if! {
             {
                 libc::sigaction(signum, previous, ptr::null_mut());
             } else {
-                mem::transmute::<usize, extern "C" fn(libc::c_int)>(
+                mem::transmute::<usize, extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void)>(
                     previous.sa_sigaction
-                )(signum)
+                )(signum, siginfo, context)
             }
         }
 


### PR DESCRIPTION
The signature for `sa_sigaction` shoud be `extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void)`.