### PR TITLE
Remove dead code

### DIFF
--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -276,11 +276,11 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     }
 
     fn gen_ret() -> Self::I {
-        Inst::Ret
+        Inst::ret()
     }
 
     fn gen_epilogue_placeholder() -> Self::I {
-        Inst::EpiloguePlaceholder
+        Inst::epilogue_placeholder()
     }
 
     fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u32) -> SmallVec<[Self::I; 4]> {

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1766,17 +1766,9 @@ fn test_x64_emit() {
         "lea     179(%r10,%r9,1), %r8",
     ));
     insns.push((
-        Inst::lea(Amode::rip_relative(BranchTarget::ResolvedOffset(0)), w_rdi),
+        Inst::lea(Amode::rip_relative(MachLabel::from_block(0)), w_rdi),
         "488D3D00000000",
-        "lea     0(%rip), %rdi",
-    ));
-    insns.push((
-        Inst::lea(
-            Amode::rip_relative(BranchTarget::ResolvedOffset(1337)),
-            w_r15,
-        ),
-        "4C8D3D39050000",
-        "lea     1337(%rip), %r15",
+        "lea     label0(%rip), %rdi",
     ));
 
     // ========================================================
@@ -3676,7 +3668,13 @@ fn test_x64_emit() {
         assert_eq!(expected_printing, actual_printing);
         let mut sink = test_utils::TestCodeSink::new();
         let mut buffer = MachBuffer::new();
+
         insn.emit(&mut buffer, &emit_info, &mut Default::default());
+
+        // Allow one label just after the instruction (so the offset is 0).
+        let label = buffer.get_label();
+        buffer.bind_label(label);
+
         let buffer = buffer.finish();
         buffer.emit(&mut sink);
         let actual_encoding = &sink.stringify();

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2487,7 +2487,7 @@ impl MachInst for Inst {
     }
 
     fn gen_nop(preferred_size: usize) -> Inst {
-        Inst::nop(preferred_size as u8)
+        Inst::nop((preferred_size % 16) as u8)
     }
 
     fn maybe_direct_reload(&self, _reg: VirtualReg, _slot: SpillSlot) -> Option<Inst> {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1,5 +1,4 @@
 //! This module defines x86_64-specific machine instruction types.
-#![allow(dead_code)]
 
 use crate::binemit::{CodeOffset, StackMap};
 use crate::ir::{types, ExternalName, Opcode, SourceLoc, TrapCode, Type};
@@ -369,7 +368,7 @@ pub enum Inst {
     EpiloguePlaceholder,
 
     /// Jump to a known target: jmp simm32.
-    JmpKnown { dst: BranchTarget },
+    JmpKnown { dst: MachLabel },
 
     /// One-way conditional branch: jcond cond target.
     ///
@@ -379,14 +378,14 @@ pub enum Inst {
     /// A note of caution: in contexts where the branch target is another block, this has to be the
     /// same successor as the one specified in the terminator branch of the current block.
     /// Otherwise, this might confuse register allocation by creating new invisible edges.
-    JmpIf { cc: CC, taken: BranchTarget },
+    JmpIf { cc: CC, taken: MachLabel },
 
     /// Two-way conditional branch: jcond cond target target.
     /// Emitted as a compound sequence; the MachBuffer will shrink it as appropriate.
     JmpCond {
         cc: CC,
-        taken: BranchTarget,
-        not_taken: BranchTarget,
+        taken: MachLabel,
+        not_taken: MachLabel,
     },
 
     /// Jump-table sequence, as one compound instruction (see note in lower.rs for rationale).
@@ -397,8 +396,8 @@ pub enum Inst {
         idx: Reg,
         tmp1: Writable<Reg>,
         tmp2: Writable<Reg>,
-        default_target: BranchTarget,
-        targets: Vec<BranchTarget>,
+        default_target: MachLabel,
+        targets: Vec<MachLabel>,
         targets_for_term: Vec<MachLabel>,
     },
 
@@ -1077,15 +1076,15 @@ impl Inst {
         Inst::EpiloguePlaceholder
     }
 
-    pub(crate) fn jmp_known(dst: BranchTarget) -> Inst {
+    pub(crate) fn jmp_known(dst: MachLabel) -> Inst {
         Inst::JmpKnown { dst }
     }
 
-    pub(crate) fn jmp_if(cc: CC, taken: BranchTarget) -> Inst {
+    pub(crate) fn jmp_if(cc: CC, taken: MachLabel) -> Inst {
         Inst::JmpIf { cc, taken }
     }
 
-    pub(crate) fn jmp_cond(cc: CC, taken: BranchTarget, not_taken: BranchTarget) -> Inst {
+    pub(crate) fn jmp_cond(cc: CC, taken: MachLabel, not_taken: MachLabel) -> Inst {
         Inst::JmpCond {
             cc,
             taken,
@@ -1679,13 +1678,13 @@ impl PrettyPrint for Inst {
             Inst::EpiloguePlaceholder => "epilogue placeholder".to_string(),
 
             Inst::JmpKnown { dst } => {
-                format!("{} {}", ljustify("jmp".to_string()), dst.show_rru(mb_rru))
+                format!("{} {}", ljustify("jmp".to_string()), dst.to_string())
             }
 
             Inst::JmpIf { cc, taken } => format!(
                 "{} {}",
                 ljustify2("j".to_string(), cc.to_string()),
-                taken.show_rru(mb_rru),
+                taken.to_string(),
             ),
 
             Inst::JmpCond {
@@ -1695,8 +1694,8 @@ impl PrettyPrint for Inst {
             } => format!(
                 "{} {}; j {}",
                 ljustify2("j".to_string(), cc.to_string()),
-                taken.show_rru(mb_rru),
-                not_taken.show_rru(mb_rru)
+                taken.to_string(),
+                not_taken.to_string()
             ),
 
             Inst::JmpTableSeq { idx, .. } => {
@@ -2446,10 +2445,10 @@ impl MachInst for Inst {
         match self {
             // Interesting cases.
             &Self::Ret | &Self::EpiloguePlaceholder => MachTerminator::Ret,
-            &Self::JmpKnown { dst } => MachTerminator::Uncond(dst.as_label().unwrap()),
+            &Self::JmpKnown { dst } => MachTerminator::Uncond(dst),
             &Self::JmpCond {
                 taken, not_taken, ..
-            } => MachTerminator::Cond(taken.as_label().unwrap(), not_taken.as_label().unwrap()),
+            } => MachTerminator::Cond(taken, not_taken),
             &Self::JmpTableSeq {
                 ref targets_for_term,
                 ..
@@ -2487,8 +2486,8 @@ impl MachInst for Inst {
         Inst::Nop { len: 0 }
     }
 
-    fn gen_nop(_preferred_size: usize) -> Inst {
-        unimplemented!()
+    fn gen_nop(preferred_size: usize) -> Inst {
+        Inst::nop(preferred_size as u8)
     }
 
     fn maybe_direct_reload(&self, _reg: VirtualReg, _slot: SpillSlot) -> Option<Inst> {
@@ -2519,7 +2518,7 @@ impl MachInst for Inst {
     }
 
     fn gen_jump(label: MachLabel) -> Inst {
-        Inst::jmp_known(BranchTarget::Label(label))
+        Inst::jmp_known(label)
     }
 
     fn gen_constant<F: FnMut(RegClass, Type) -> Writable<Reg>>(

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -3315,10 +3315,10 @@ impl LowerBackend for X64Backend {
             );
             assert!(op1 == Opcode::Jump || op1 == Opcode::Fallthrough);
 
-            let taken = BranchTarget::Label(targets[0]);
+            let taken = targets[0];
             let not_taken = match op1 {
-                Opcode::Jump => BranchTarget::Label(targets[1]),
-                Opcode::Fallthrough => BranchTarget::Label(fallthrough.unwrap()),
+                Opcode::Jump => targets[1],
+                Opcode::Fallthrough => fallthrough.unwrap(),
                 _ => unreachable!(), // assert above.
             };
 
@@ -3422,7 +3422,7 @@ impl LowerBackend for X64Backend {
             let op = ctx.data(branches[0]).opcode();
             match op {
                 Opcode::Jump | Opcode::Fallthrough => {
-                    ctx.emit(Inst::jmp_known(BranchTarget::Label(targets[0])));
+                    ctx.emit(Inst::jmp_known(targets[0]));
                 }
 
                 Opcode::BrTable => {
@@ -3465,13 +3465,9 @@ impl LowerBackend for X64Backend {
                     let tmp2 = ctx.alloc_tmp(RegClass::I64, types::I64);
 
                     let targets_for_term: Vec<MachLabel> = targets.to_vec();
-                    let default_target = BranchTarget::Label(targets[0]);
+                    let default_target = targets[0];
 
-                    let jt_targets: Vec<BranchTarget> = targets
-                        .iter()
-                        .skip(1)
-                        .map(|bix| BranchTarget::Label(*bix))
-                        .collect();
+                    let jt_targets: Vec<MachLabel> = targets.iter().skip(1).cloned().collect();
 
                     ctx.emit(Inst::JmpTableSeq {
                         idx,

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -148,6 +148,7 @@ use crate::timing;
 use log::trace;
 use smallvec::SmallVec;
 use std::mem;
+use std::string::String;
 
 /// A buffer of output to be produced, fixed up, and then emitted to a CodeSink
 /// in bulk.
@@ -258,6 +259,11 @@ impl MachLabel {
     /// Get the numeric label index.
     pub fn get(self) -> u32 {
         self.0
+    }
+
+    /// Creates a string representing this label, for convenience.
+    pub fn to_string(&self) -> String {
+        format!("label{}", self.0)
     }
 }
 


### PR DESCRIPTION
Building on top of #2258 (2 additional commits), this removes dead code. Also as a bonus, adds the ability to emit NOP instructions of variable sizes, since this had not been done yet; this can be used to e.g. align loop headers on code cache boundaries, which showed a small performance benefits for tight loops in Spidermonkey. I didn't find a marker for blocks that are loop headers in the lowering code, so this is left as an exercise to the reader/@cfallin if he's interested :-)