### PR TITLE
debug: Normalise value prior to right shifts

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -604,6 +604,10 @@ where
                 }
                 Operation::Shr { .. } | Operation::Shra { .. } => {
                     // Insert value normalisation part.
+                    // The semantic value is 32 bits (TODO: check unit)
+                    // but the target architecture is 64-bits. So we'll
+                    // clean out the upper 32 bits (in a sign-correct way)
+                    // to avoid contamination of the result with randomness.
                     let mut writer = ExpressionWriter::new();
                     writer.write_op(gimli::constants::DW_OP_swap)?;
                     writer.write_op(gimli::constants::DW_OP_const1u)?;

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -612,7 +612,7 @@ where
                     writer.write_op(gimli::constants::DW_OP_shl)?;
                     writer.write_op(gimli::constants::DW_OP_const1u)?;
                     writer.write_u8(32)?;
-                   // Extend with the (arithmetic) shift.
+                    // Extend with the (arithmetic) shift.
                     writer.write_u8(buf[pos])?;
                     writer.write_op(gimli::constants::DW_OP_swap)?;
                     code_chunk.extend(writer.into_vec());

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -602,8 +602,7 @@ where
                     // Don't re-enter the loop here (i.e. continue), because the
                     // DW_OP_deref still needs to be kept.
                 }
-                Operation::Shr { .. }
-                | Operation::Shra { .. } => {
+                Operation::Shr { .. } | Operation::Shra { .. } => {
                     // Insert value normalisation part.
                     let mut writer = ExpressionWriter::new();
                     writer.write_op(gimli::constants::DW_OP_swap)?;

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -612,7 +612,7 @@ where
                     writer.write_op(gimli::constants::DW_OP_shl)?;
                     writer.write_op(gimli::constants::DW_OP_const1u)?;
                     writer.write_u8(32)?;
-		    // Extend with the (arithmetic) shift.
+                   // Extend with the (arithmetic) shift.
                     writer.write_u8(buf[pos])?;
                     writer.write_op(gimli::constants::DW_OP_swap)?;
                     code_chunk.extend(writer.into_vec());

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -993,7 +993,7 @@ mod tests {
                         conditionally: true,
                         target: targets[0].clone(),
                     },
-                    CompiledExpressionPart::Code(vec![22, 37]),
+                    CompiledExpressionPart::Code(vec![22, 22, 8, 32, 36, 8, 32, 37, 22, 37]),
                     CompiledExpressionPart::Jump {
                         conditionally: false,
                         target: targets[1].clone(),

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -954,6 +954,31 @@ mod tests {
         );
 
         let e = expression!(
+            DW_OP_WASM_location,
+            0x0,
+            1,
+            DW_OP_lit16,
+            DW_OP_shra,
+            DW_OP_stack_value
+        );
+        let ce = compile_expression(&e, DWARF_ENCODING, None)
+            .expect("non-error")
+            .expect("expression");
+        assert_eq!(
+            ce,
+            CompiledExpression {
+                parts: vec![
+                    CompiledExpressionPart::Local {
+                        label: val1,
+                        trailing: false
+                    },
+                    CompiledExpressionPart::Code(vec![64, 22, 8, 32, 36, 8, 32, 38, 22, 38, 159])
+                ],
+                need_deref: false,
+            }
+        );
+
+        let e = expression!(
             DW_OP_lit1,
             DW_OP_dup,
             DW_OP_WASM_location,

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -609,14 +609,12 @@ where
                     // clean out the upper 32 bits (in a sign-correct way)
                     // to avoid contamination of the result with randomness.
                     let mut writer = ExpressionWriter::new();
+                    writer.write_op(gimli::constants::DW_OP_plus_uconst)?;
+                    writer.write_uleb128(32)?; // increase shift amount
                     writer.write_op(gimli::constants::DW_OP_swap)?;
                     writer.write_op(gimli::constants::DW_OP_const1u)?;
                     writer.write_u8(32)?;
                     writer.write_op(gimli::constants::DW_OP_shl)?;
-                    writer.write_op(gimli::constants::DW_OP_const1u)?;
-                    writer.write_u8(32)?;
-                    // Extend with the (arithmetic) shift.
-                    writer.write_u8(buf[pos])?;
                     writer.write_op(gimli::constants::DW_OP_swap)?;
                     code_chunk.extend(writer.into_vec());
                     // Don't re-enter the loop here (i.e. continue), because the
@@ -976,7 +974,7 @@ mod tests {
                         label: val1,
                         trailing: false
                     },
-                    CompiledExpressionPart::Code(vec![64, 22, 8, 32, 36, 8, 32, 38, 22, 38, 159])
+                    CompiledExpressionPart::Code(vec![64, 35, 32, 22, 8, 32, 36, 22, 38, 159])
                 ],
                 need_deref: false,
             }
@@ -1022,7 +1020,7 @@ mod tests {
                         conditionally: true,
                         target: targets[0].clone(),
                     },
-                    CompiledExpressionPart::Code(vec![22, 22, 8, 32, 36, 8, 32, 37, 22, 37]),
+                    CompiledExpressionPart::Code(vec![22, 35, 32, 22, 8, 32, 36, 22, 37]),
                     CompiledExpressionPart::Jump {
                         conditionally: false,
                         target: targets[1].clone(),


### PR DESCRIPTION
Due to the 32-bit WASM/64-bit wasmtime VM schism, the `DW_OP_shr*` operations end up with random bits frobbed from the upper portion of the 64-bit operand word. This PR fixes up the location translator such that it inserts (something akin to) `DW_OP_lit32; DW_OP_shl; DW_OP_lit32; DW_OP_shrX` in front of `DW_OP_shrX`. The rationale is that this will clean out the upper portion, respecting 32-bit signedness. 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
