### PR TITLE
Some SimpleJIT improvements

### DIFF
--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -122,6 +122,7 @@ impl From<FuncOrDataId> for ir::ExternalName {
 }
 
 /// Information about a function which can be called.
+#[derive(Debug)]
 pub struct FunctionDeclaration {
     pub name: String,
     pub linkage: Linkage,
@@ -176,6 +177,7 @@ pub enum ModuleError {
 pub type ModuleResult<T> = Result<T, ModuleError>;
 
 /// Information about a data object which can be accessed.
+#[derive(Debug)]
 pub struct DataDeclaration {
     pub name: String,
     pub linkage: Linkage,
@@ -196,7 +198,7 @@ impl DataDeclaration {
 
 /// This provides a view to the state of a module which allows `ir::ExternalName`s to be translated
 /// into `FunctionDeclaration`s and `DataDeclaration`s.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ModuleDeclarations {
     names: HashMap<String, FuncOrDataId>,
     functions: PrimaryMap<FuncId, FunctionDeclaration>,

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -151,14 +151,14 @@ struct StackMapRecord {
 }
 
 #[derive(Clone)]
-pub struct SimpleJITCompiledFunction {
+struct SimpleJITCompiledFunction {
     code: *mut u8,
     size: usize,
     relocs: Vec<RelocRecord>,
 }
 
 #[derive(Clone)]
-pub struct SimpleJITCompiledData {
+struct SimpleJITCompiledData {
     storage: *mut u8,
     size: usize,
     relocs: Vec<RelocRecord>,
@@ -451,8 +451,8 @@ impl<'simple_jit_backend> Module for SimpleJITModule {
 
         self.record_function_for_perf(ptr, size, &decl.name);
 
-        let mut reloc_sink = SimpleJITRelocSink::new();
-        let mut stack_map_sink = SimpleJITStackMapSink::new();
+        let mut reloc_sink = SimpleJITRelocSink::default();
+        let mut stack_map_sink = SimpleJITStackMapSink::default();
         unsafe {
             ctx.emit_to_memory(
                 &*self.isa,
@@ -673,14 +673,9 @@ fn lookup_with_dlsym(name: &str) -> *const u8 {
     }
 }
 
+#[derive(Default)]
 struct SimpleJITRelocSink {
-    pub relocs: Vec<RelocRecord>,
-}
-
-impl SimpleJITRelocSink {
-    pub fn new() -> Self {
-        Self { relocs: Vec::new() }
-    }
+    relocs: Vec<RelocRecord>,
 }
 
 impl RelocSink for SimpleJITRelocSink {
@@ -729,16 +724,9 @@ impl RelocSink for SimpleJITRelocSink {
     }
 }
 
+#[derive(Default)]
 struct SimpleJITStackMapSink {
-    pub stack_maps: Vec<StackMapRecord>,
-}
-
-impl SimpleJITStackMapSink {
-    pub fn new() -> Self {
-        Self {
-            stack_maps: Vec::new(),
-        }
-    }
+    stack_maps: Vec<StackMapRecord>,
 }
 
 impl StackMapSink for SimpleJITStackMapSink {


### PR DESCRIPTION
Follow up to #2249. This re-introduces the `finalize_definitions` and `get_finalized_*` methods, but only for SimpleJIT. This also implements `Linkage::Preemptible` for SimpleJIT.