### PR TITLE
Avoid allocations in trampoline shims

### DIFF
--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -230,7 +230,7 @@ pub fn create_handle_with_function(
     let func_id = module.functions.push(sig_id);
     module
         .exports
-        .insert("trampoline".to_string(), EntityIndex::Function(func_id));
+        .insert(String::new(), EntityIndex::Function(func_id));
     let trampoline = make_trampoline(isa.as_ref(), &mut code_memory, &mut fn_builder_ctx, &sig);
     finished_functions.push(trampoline);
 
@@ -289,7 +289,7 @@ pub unsafe fn create_handle_with_raw_function(
     let func_id = module.functions.push(sig_id);
     module
         .exports
-        .insert("trampoline".to_string(), EntityIndex::Function(func_id));
+        .insert(String::new(), EntityIndex::Function(func_id));
     finished_functions.push(func);
     let sig_id = store.register_signature(ft.to_wasm_func_type(), sig);
     trampolines.insert(sig_id, trampoline);

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -61,7 +61,7 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
     let global_id = module.globals.push(global);
     module
         .exports
-        .insert("global".to_string(), EntityIndex::Global(global_id));
+        .insert(String::new(), EntityIndex::Global(global_id));
     let handle = create_handle(
         module,
         store,
@@ -72,7 +72,7 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
     )?;
 
     if let Some(x) = externref_init {
-        match handle.lookup("global").unwrap() {
+        match handle.lookup("").unwrap() {
             wasmtime_runtime::Export::Global(g) => unsafe {
                 *(*g.definition).as_externref_mut() = Some(x.inner);
             },

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -27,7 +27,7 @@ pub fn create_handle_with_memory(
     let memory_id = module.memory_plans.push(memory_plan);
     module
         .exports
-        .insert("memory".to_string(), EntityIndex::Memory(memory_id));
+        .insert(String::new(), EntityIndex::Memory(memory_id));
 
     create_handle(
         module,

--- a/crates/wasmtime/src/trampoline/mod.rs
+++ b/crates/wasmtime/src/trampoline/mod.rs
@@ -55,7 +55,7 @@ pub fn generate_func_export(
     VMTrampoline,
 )> {
     let (instance, trampoline) = create_handle_with_function(ft, func, store)?;
-    match instance.lookup("trampoline").expect("trampoline export") {
+    match instance.lookup("").expect("trampoline export") {
         wasmtime_runtime::Export::Function(f) => Ok((instance, f, trampoline)),
         _ => unreachable!(),
     }
@@ -72,7 +72,7 @@ pub unsafe fn generate_raw_func_export(
     state: Box<dyn Any>,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportFunction)> {
     let instance = func::create_handle_with_raw_function(ft, func, trampoline, store, state)?;
-    match instance.lookup("trampoline").expect("trampoline export") {
+    match instance.lookup("").expect("trampoline export") {
         wasmtime_runtime::Export::Function(f) => Ok((instance, f)),
         _ => unreachable!(),
     }
@@ -84,7 +84,7 @@ pub fn generate_global_export(
     val: Val,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportGlobal)> {
     let instance = create_global(store, gt, val)?;
-    match instance.lookup("global").expect("global export") {
+    match instance.lookup("").expect("global export") {
         wasmtime_runtime::Export::Global(g) => Ok((instance, g)),
         _ => unreachable!(),
     }
@@ -95,7 +95,7 @@ pub fn generate_memory_export(
     m: &MemoryType,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportMemory)> {
     let instance = create_handle_with_memory(store, m)?;
-    match instance.lookup("memory").expect("memory export") {
+    match instance.lookup("").expect("memory export") {
         wasmtime_runtime::Export::Memory(m) => Ok((instance, m)),
         _ => unreachable!(),
     }
@@ -106,7 +106,7 @@ pub fn generate_table_export(
     t: &TableType,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportTable)> {
     let instance = create_handle_with_table(store, t)?;
-    match instance.lookup("table").expect("table export") {
+    match instance.lookup("").expect("table export") {
         wasmtime_runtime::Export::Table(t) => Ok((instance, t)),
         _ => unreachable!(),
     }

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -25,7 +25,7 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Stor
     let table_id = module.table_plans.push(table_plan);
     module
         .exports
-        .insert("table".to_string(), EntityIndex::Table(table_id));
+        .insert(String::new(), EntityIndex::Table(table_id));
 
     create_handle(
         module,


### PR DESCRIPTION
There's no need to name each export since each synthetic instance we're
creating only has one export, so let's use the empty string which
doesn't require any allocations.
