### PR TITLE
wasm->CLIF translation: consistently bitcast V128 values that are blo…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "itertools 0.9.0",
  "log",
  "serde",
+ "smallvec",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.63.0",

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -20,6 +20,7 @@ hashbrown = { version = "0.7", optional = true }
 itertools = "0.9.0"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
+smallvec = "1.0.0"
 thiserror = "1.0.4"
 
 [dev-dependencies]

--- a/cranelift/wasmtests/pr2303.wat
+++ b/cranelift/wasmtests/pr2303.wat
@@ -1,0 +1,15 @@
+(module
+    (memory (export "mem") 1 1)
+    (func (export "runif") (param $cond i32)
+      i32.const 48
+      (v128.load (i32.const 0))
+      (v128.load (i32.const 16))
+      (if (param v128) (param v128) (result v128 v128)
+          (local.get $cond)
+          (then i64x2.add
+                (v128.load (i32.const 32)))
+          (else i32x4.sub
+                (v128.load (i32.const 0))))
+      i16x8.mul
+      v128.store)
+)


### PR DESCRIPTION
…ck formal parameters.

In the current translation of wasm (128-bit) SIMD into CLIF, we work around differences in the
type system models of wasm vs CLIF by inserting `bitcast` (no-op casts) CLIF instructions before
more or less every use of a SIMD value.  Unfortunately this was not being done consistently and
even small examples with a single if-then-else diamond that produces a SIMD value, could cause a
verification failure downstream.  In this case, the jump out of the "else" block needed a
bitcast, but didn't have one.

This patch wraps creation of CLIF jumps and conditional branches up into a pair of functions,
`canonicalise_then_jump` and `canonicalise_then_br_z_or_nz`, and uses them consistently.  They
first cast the relevant block formal parameters, then generate the relevant kind of branch/jump.
Hence, provided they are also used consistently in future to generate branches/jumps in this
file, we are protected against such failures.

The patch also adds a large(ish) comment at the top explaining this in more detail.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
