### PR TITLE
wasi-common: add means to share handles across multiple modules

### DIFF
--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -16,11 +16,11 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         argv: &GuestPtr<'b, GuestPtr<'b, u8>>,
         argv_buf: &GuestPtr<'b, u8>,
     ) -> Result<()> {
-        self.args.write_to_guest(argv_buf, argv)
+        self.args().write_to_guest(argv_buf, argv)
     }
 
     fn args_sizes_get(&self) -> Result<(types::Size, types::Size)> {
-        Ok((self.args.number_elements, self.args.cumulative_size))
+        Ok((self.args().number_elements, self.args().cumulative_size))
     }
 
     fn environ_get<'b>(
@@ -28,11 +28,11 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         environ: &GuestPtr<'b, GuestPtr<'b, u8>>,
         environ_buf: &GuestPtr<'b, u8>,
     ) -> Result<()> {
-        self.env.write_to_guest(environ_buf, environ)
+        self.env().write_to_guest(environ_buf, environ)
     }
 
     fn environ_sizes_get(&self) -> Result<(types::Size, types::Size)> {
-        Ok((self.env.number_elements, self.env.cumulative_size))
+        Ok((self.env().number_elements, self.env().cumulative_size))
     }
 
     fn clock_res_get(&self, id: types::Clockid) -> Result<types::Timestamp> {


### PR DESCRIPTION
I am sure that this is not a good idea and there could be a better approach, but I would like to hear any opinions.

In our project, we want to open an I/O stream in a custom WASI module (or dynamically open it by the host) and somehow inject its handle to the main WASI module, to allow the guest to read/write with the `fd_*` functions. That is currently not possible because the FD management (`EntryTable`) is internal to the wasi-common crate.

I'm wondering if `EntryTable` can be made public, with a couple of registration/lookup methods, so other modules can register FD through it.  A typical usage would be:
```rust
  // Create a centrally managed file descriptor table.
  let entries = EntryTable::new();

  // Create WasiCtx with the table.
  let mut builder = WasiCtxBuilder::new();
  let ctx = builder.entries(entries).build();

  // Create a context of an external WASI module with the same table.
  let mut builder = WasiOtherCtxBuilder::new();
  let ctx = builder.entries(entries).build();
```
The implementation of `WasiOtherCtx` can create a `Handle` internally and register it with `EntryTable::insert_handle`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
