### PR TITLE
Don't store `Arc<VMInterrupts>` in instances

### DIFF
--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -250,7 +250,7 @@ impl CompiledModule {
         imports: Imports<'_>,
         signature_registry: &mut SignatureRegistry,
         mem_creator: Option<&dyn RuntimeMemoryCreator>,
-        interrupts: Arc<VMInterrupts>,
+        interrupts: *const VMInterrupts,
         host_state: Box<dyn Any>,
         externref_activations_table: *mut VMExternRefActivationsTable,
         stack_map_registry: *mut StackMapRegistry,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -71,10 +71,6 @@ pub(crate) struct Instance {
     /// Hosts can store arbitrary per-instance information here.
     host_state: Box<dyn Any>,
 
-    /// Externally allocated data indicating how this instance will be
-    /// interrupted.
-    pub(crate) interrupts: Arc<VMInterrupts>,
-
     /// Additional context used by compiled wasm code. This field is last, and
     /// represents a dynamically-sized array that extends beyond the nominal
     /// end of the struct (similar to a flexible array member).
@@ -827,7 +823,7 @@ impl InstanceHandle {
         mem_creator: Option<&dyn RuntimeMemoryCreator>,
         vmshared_signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
         host_state: Box<dyn Any>,
-        interrupts: Arc<VMInterrupts>,
+        interrupts: *const VMInterrupts,
         externref_activations_table: *mut VMExternRefActivationsTable,
         stack_map_registry: *mut StackMapRegistry,
     ) -> Result<Self, InstantiationError> {
@@ -867,7 +863,6 @@ impl InstanceHandle {
                 finished_functions,
                 trampolines,
                 host_state,
-                interrupts,
                 vmctx: VMContext {},
             };
             let layout = instance.alloc_layout();
@@ -934,7 +929,7 @@ impl InstanceHandle {
             instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
             VMBuiltinFunctionsArray::initialized(),
         );
-        *instance.interrupts() = &*instance.interrupts;
+        *instance.interrupts() = interrupts;
         *instance.externref_activations_table() = externref_activations_table;
         *instance.stack_map_registry() = stack_map_registry;
 

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -453,8 +453,8 @@ impl<'a> CallThreadState<'a> {
             UnwindReason::JitTrap { backtrace, pc } => {
                 debug_assert_eq!(ret, 0);
                 let maybe_interrupted = unsafe {
-                    (*self.vmctx).instance().interrupts.stack_limit.load(SeqCst)
-                        == wasmtime_environ::INTERRUPTED
+                    let interrupts = (*self.vmctx).instance().interrupts();
+                    (**interrupts).stack_limit.load(SeqCst) == wasmtime_environ::INTERRUPTED
                 };
                 Err(Trap::Jit {
                     pc,

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -22,7 +22,7 @@ fn instantiate(
             imports,
             &mut store.signatures_mut(),
             config.memory_creator.as_ref().map(|a| a as _),
-            store.interrupts().clone(),
+            store.interrupts(),
             host,
             store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
             store.stack_map_registry() as *const StackMapRegistry as *mut _,

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -1030,7 +1030,7 @@ impl Store {
         self.inner.signal_handler.borrow_mut()
     }
 
-    pub(crate) fn interrupts(&self) -> &Arc<VMInterrupts> {
+    pub(crate) fn interrupts(&self) -> &VMInterrupts {
         &self.inner.interrupts
     }
 
@@ -1128,7 +1128,7 @@ impl Store {
     pub fn interrupt_handle(&self) -> Result<InterruptHandle> {
         if self.engine().config().tunables.interruptable {
             Ok(InterruptHandle {
-                interrupts: self.interrupts().clone(),
+                interrupts: self.inner.interrupts.clone(),
             })
         } else {
             bail!("interrupts aren't enabled for this `Store`")

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -42,7 +42,7 @@ pub(crate) fn create_handle(
             store.memory_creator(),
             signatures.into_boxed_slice(),
             state,
-            store.interrupts().clone(),
+            store.interrupts(),
             store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
             store.stack_map_registry() as *const StackMapRegistry as *mut _,
         )?;


### PR DESCRIPTION
Similar to other data structures owned by the `Store` there's no need
for `Instance` to have a strong `Arc` reference, instead it's sufficient
for `Store` to have the owning reference.

This is hopefully a slight improvement with https://github.com/bytecodealliance/wasmtime/issues/2295