### PR TITLE
Remove the `finished_functions` field in `Instance`

### DIFF
--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -36,7 +36,7 @@ pub(crate) fn create_handle(
         let handle = InstanceHandle::new(
             Arc::new(module),
             Arc::new(()),
-            finished_functions.into_boxed_slice(),
+            &finished_functions,
             trampolines,
             imports,
             store.memory_creator(),


### PR DESCRIPTION
Turns out we don't actually need it anywhere any more! This removes an
allocation when instantiating.

This is hopefully a slight improvement with https://github.com/bytecodealliance/wasmtime/issues/2295