### PR TITLE
CI: fix rebuilding peepmatic peephole optimizers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,9 +168,9 @@ jobs:
     - name: Rebuild Peepmatic-based peephole optimizers and test them
       run: |
         cargo test \
-          --features 'enable-peepmatic cranelift-codegen/rebuild-peephole-optimizers' \
+          --features 'enable-peepmatic rebuild-peephole-optimizers' \
           peepmatic
-      working-directory: ./cranelift
+      working-directory: ./cranelift/codegen
     - name: Check that built peephole optimizers are up to date
       run: git diff --exit-code
     - name: Test with Peepmatic-based peephole optimizers


### PR DESCRIPTION
The test that triggers the rebuild of the peephole optimizers is in the `cranelift-codegen` crate, not the umbrella cranelift crate. This was previously successfully running zero tests, and then successfully reporting no `git diff` because no peephole optimizers were ever rebuilt.

This change fixes it so that we run the correct test that triggers the rebuilding of the peephole optimizers.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
