### PR TITLE
Add docs.wasmtime.dev as a CNAME for the Wasmtime docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         submodules: true
     - run: |
         set -e
-        curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
+        curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.4/mdbook-v0.4.4-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
         echo `pwd` >> $GITHUB_PATH
     - run: (cd docs && mdbook build)
     - run: cargo build -p wasmtime

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -3,3 +3,6 @@ authors = ["The Wasmtime Project Developers"]
 multilingual = false
 src = "."
 title = "Wasmtime"
+
+[output.html]
+cname = "docs.wasmtime.dev"


### PR DESCRIPTION
As luck would have it, mdbook [just recently gained support](https://github.com/rust-lang/mdBook/pull/1311) for configuring a CNAME, so we don't need to manually create the `CNAME` file in the CI action.