### PR TITLE
Refactor how signatures/trampolines are stored in `Store`

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -28,7 +28,6 @@ mod instance;
 mod jit_int;
 mod memory;
 mod mmap;
-mod sig_registry;
 mod table;
 mod traphandlers;
 mod vmcontext;
@@ -43,7 +42,6 @@ pub use crate::instance::{InstanceHandle, InstantiationError, LinkError};
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
-pub use crate::sig_registry::SignatureRegistry;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
     catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, SignalHandler, Trap,

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -492,6 +492,11 @@ impl VMSharedSignatureIndex {
     pub fn new(value: u32) -> Self {
         Self(value)
     }
+
+    /// Returns the underlying bits of the index.
+    pub fn bits(&self) -> u32 {
+        self.0
+    }
 }
 
 impl Default for VMSharedSignatureIndex {

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -540,7 +540,10 @@ impl Func {
     pub fn ty(&self) -> FuncType {
         // Signatures should always be registered in the store's registry of
         // shared signatures, so we should be able to unwrap safely here.
-        let wft = self.instance.store.lookup_signature(self.sig_index());
+        let signatures = self.instance.store.signatures().borrow();
+        let (wft, _, _) = signatures
+            .lookup_shared(self.sig_index())
+            .expect("signature should be registered");
 
         // This is only called with `Export::Function`, and since it's coming
         // from wasmtime_runtime itself we should support all the types coming
@@ -550,19 +553,19 @@ impl Func {
 
     /// Returns the number of parameters that this function takes.
     pub fn param_arity(&self) -> usize {
-        let sig = self
-            .instance
-            .store
-            .lookup_signature(unsafe { self.export.anyfunc.as_ref().type_index });
+        let signatures = self.instance.store.signatures().borrow();
+        let (sig, _, _) = signatures
+            .lookup_shared(self.sig_index())
+            .expect("signature should be registered");
         sig.params.len()
     }
 
     /// Returns the number of results this function produces.
     pub fn result_arity(&self) -> usize {
-        let sig = self
-            .instance
-            .store
-            .lookup_signature(unsafe { self.export.anyfunc.as_ref().type_index });
+        let signatures = self.instance.store.signatures().borrow();
+        let (sig, _, _) = signatures
+            .lookup_shared(self.sig_index())
+            .expect("signature should be registered");
         sig.returns.len()
     }
 
@@ -649,8 +652,12 @@ impl Func {
         // on that module as well, so unwrap the result here since otherwise
         // it's a bug in wasmtime.
         let trampoline = instance
-            .trampoline(unsafe { export.anyfunc.as_ref().type_index })
-            .expect("failed to retrieve trampoline from module");
+            .store
+            .signatures()
+            .borrow()
+            .lookup_shared(unsafe { export.anyfunc.as_ref().type_index })
+            .expect("failed to retrieve trampoline from module")
+            .2;
 
         Func {
             instance,

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -242,6 +242,7 @@ mod linker;
 mod module;
 mod r#ref;
 mod runtime;
+mod sig_registry;
 mod trampoline;
 mod trap;
 mod types;

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -1,4 +1,5 @@
 use crate::externals::MemoryCreator;
+use crate::sig_registry::SignatureRegistry;
 use crate::trampoline::{MemoryCreatorProxy, StoreInstanceHandle};
 use crate::Module;
 use anyhow::{bail, Result};
@@ -16,13 +17,12 @@ use wasmparser::WasmFeatures;
 #[cfg(feature = "cache")]
 use wasmtime_cache::CacheConfig;
 use wasmtime_environ::settings::{self, Configurable, SetError};
-use wasmtime_environ::{ir, isa, isa::TargetIsa, wasm, Tunables};
+use wasmtime_environ::{isa, isa::TargetIsa, wasm, Tunables};
 use wasmtime_jit::{native, CompilationStrategy, Compiler};
 use wasmtime_profiling::{JitDumpAgent, NullProfilerAgent, ProfilingAgent, VTuneAgent};
 use wasmtime_runtime::{
-    debug_builtins, InstanceHandle, RuntimeMemoryCreator, SignalHandler, SignatureRegistry,
-    StackMapRegistry, VMExternRef, VMExternRefActivationsTable, VMInterrupts,
-    VMSharedSignatureIndex,
+    debug_builtins, InstanceHandle, RuntimeMemoryCreator, SignalHandler, StackMapRegistry,
+    VMExternRef, VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex,
 };
 
 // Runtime Environment
@@ -915,38 +915,21 @@ impl Store {
             .map(|x| x as _)
     }
 
-    pub(crate) fn lookup_signature(&self, sig_index: VMSharedSignatureIndex) -> wasm::WasmFuncType {
-        self.inner
-            .signatures
-            .borrow()
-            .lookup_wasm(sig_index)
-            .expect("failed to lookup signature")
+    pub(crate) fn signatures(&self) -> &RefCell<SignatureRegistry> {
+        &self.inner.signatures
     }
 
-    pub(crate) fn lookup_wasm_and_native_signatures(
-        &self,
-        sig_index: VMSharedSignatureIndex,
-    ) -> (wasm::WasmFuncType, ir::Signature) {
-        self.inner
-            .signatures
-            .borrow()
-            .lookup_wasm_and_native_signatures(sig_index)
-            .expect("failed to lookup signature")
-    }
-
-    pub(crate) fn register_signature(
-        &self,
-        wasm_sig: wasm::WasmFuncType,
-        native: ir::Signature,
-    ) -> VMSharedSignatureIndex {
-        self.inner
-            .signatures
-            .borrow_mut()
-            .register(wasm_sig, native)
-    }
-
-    pub(crate) fn signatures_mut(&self) -> std::cell::RefMut<'_, SignatureRegistry> {
-        self.inner.signatures.borrow_mut()
+    pub(crate) fn lookup_shared_signature<'a>(
+        &'a self,
+        module: &'a wasmtime_environ::Module,
+    ) -> impl Fn(wasm::SignatureIndex) -> VMSharedSignatureIndex + 'a {
+        move |index| {
+            let (wasm, _native) = &module.signatures[index];
+            self.signatures()
+                .borrow()
+                .lookup(wasm)
+                .expect("signature not previously registered")
+        }
     }
 
     /// Returns whether or not the given address falls within the JIT code
@@ -959,7 +942,32 @@ impl Store {
             .any(|(start, end)| *start <= addr && addr < *end)
     }
 
-    pub(crate) fn register_jit_code(&self, module: &Module) {
+    pub(crate) fn register_module(&self, module: &Module) {
+        // All modules register their JIT code in a store for two reasons
+        // currently:
+        //
+        // * First we only catch signals/traps if the program counter falls
+        //   within the jit code of an instantiated wasm module. This ensures
+        //   we don't catch accidental Rust/host segfaults.
+        //
+        // * Second when generating a backtrace we'll use this mapping to
+        //   only generate wasm frames for instruction pointers that fall
+        //   within jit code.
+        self.register_jit_code(module);
+
+        // We need to know about all the stack maps of all instantiated modules
+        // so when performing a GC we know about all wasm frames that we find
+        // on the stack.
+        self.register_stack_maps(module);
+
+        // Signatures are loaded into our `SignatureRegistry` here
+        // once-per-module (and once-per-signature). This allows us to create
+        // a `Func` wrapper for any function in the module, which requires that
+        // we know about the signature and trampoline for all instances.
+        self.register_signatures(module);
+    }
+
+    fn register_jit_code(&self, module: &Module) {
         let mut ranges = module.compiled_module().jit_code_ranges();
         // Checking of we already registered JIT code ranges by searching
         // first range start.
@@ -977,7 +985,7 @@ impl Store {
         }
     }
 
-    pub(crate) fn register_stack_maps(&self, module: &Module) {
+    fn register_stack_maps(&self, module: &Module) {
         let module = &module.compiled_module();
         self.stack_map_registry()
             .register_stack_maps(module.stack_maps().map(|(func, stack_maps)| unsafe {
@@ -988,6 +996,15 @@ impl Store {
                 let range = start..end;
                 (range, stack_maps)
             }));
+    }
+
+    fn register_signatures(&self, module: &Module) {
+        let trampolines = module.compiled_module().trampolines();
+        let module = module.compiled_module().module();
+        let mut signatures = self.signatures().borrow_mut();
+        for (index, (wasm, native)) in module.signatures.iter() {
+            signatures.register(wasm, native, trampolines[index]);
+        }
     }
 
     pub(crate) unsafe fn add_instance(&self, handle: InstanceHandle) -> StoreInstanceHandle {

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -4,43 +4,35 @@ use crate::trampoline::StoreInstanceHandle;
 use crate::Store;
 use anyhow::Result;
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::Module;
 use wasmtime_runtime::{
     Imports, InstanceHandle, StackMapRegistry, VMExternRefActivationsTable, VMFunctionBody,
-    VMFunctionImport, VMSharedSignatureIndex, VMTrampoline,
+    VMFunctionImport,
 };
 
 pub(crate) fn create_handle(
     module: Module,
     store: &Store,
     finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
-    trampolines: HashMap<VMSharedSignatureIndex, VMTrampoline>,
     state: Box<dyn Any>,
     func_imports: &[VMFunctionImport],
 ) -> Result<StoreInstanceHandle> {
     let mut imports = Imports::default();
     imports.functions = func_imports;
-
-    // Compute indices into the shared signature table.
-    let signatures = module
-        .signatures
-        .values()
-        .map(|(wasm, native)| store.register_signature(wasm.clone(), native.clone()))
-        .collect::<PrimaryMap<_, _>>();
+    let module = Arc::new(module);
+    let module2 = module.clone();
 
     unsafe {
         let handle = InstanceHandle::new(
-            Arc::new(module),
+            module,
             Arc::new(()),
             &finished_functions,
-            trampolines,
             imports,
             store.memory_creator(),
-            signatures.into_boxed_slice(),
+            &store.lookup_shared_signature(&module2),
             state,
             store.interrupts(),
             store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -35,10 +35,12 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
             Val::FuncRef(Some(f)) => {
                 // Add a function import to the stub module, and then initialize
                 // our global with a `ref.func` to grab that imported function.
+                let signatures = store.signatures().borrow();
                 let shared_sig_index = f.sig_index();
-                let local_sig_index = module
-                    .signatures
-                    .push(store.lookup_wasm_and_native_signatures(shared_sig_index));
+                let (wasm, native, _) = signatures
+                    .lookup_shared(shared_sig_index)
+                    .expect("signature not registered");
+                let local_sig_index = module.signatures.push((wasm.clone(), native.clone()));
                 let func_index = module.functions.push(local_sig_index);
                 module.num_imported_funcs = 1;
                 module
@@ -66,7 +68,6 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
         module,
         store,
         PrimaryMap::new(),
-        Default::default(),
         Box::new(()),
         &func_imports,
     )?;

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -29,14 +29,7 @@ pub fn create_handle_with_memory(
         .exports
         .insert(String::new(), EntityIndex::Memory(memory_id));
 
-    create_handle(
-        module,
-        store,
-        PrimaryMap::new(),
-        Default::default(),
-        Box::new(()),
-        &[],
-    )
+    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[])
 }
 
 struct LinearMemoryProxy {

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -27,12 +27,5 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Stor
         .exports
         .insert(String::new(), EntityIndex::Table(table_id));
 
-    create_handle(
-        module,
-        store,
-        PrimaryMap::new(),
-        Default::default(),
-        Box::new(()),
-        &[],
-    )
+    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[])
 }


### PR DESCRIPTION
This commit refactors where trampolines and signature information is
stored within a `Store`, namely moving them from
`wasmtime_runtime::Instance` instead to `Store` itself. The goal here is
to remove an allocation inside of an `Instance` and make them a bit
cheaper to create. Additionally this should open up future possibilities
like not creating duplicate trampolines for signatures already in the
`Store` when using `Func::new`.
