### PR TITLE
Further compress the in-memory representation of address maps

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -1145,14 +1145,21 @@ mod tests {
                     InstructionAddressMap {
                         srcloc: SourceLoc::new(code_section_offset + 12),
                         code_offset: 5,
-                        code_len: 3,
+                    },
+                    InstructionAddressMap {
+                        srcloc: SourceLoc::default(),
+                        code_offset: 8,
                     },
                     InstructionAddressMap {
                         srcloc: SourceLoc::new(code_section_offset + 17),
                         code_offset: 15,
-                        code_len: 8,
                     },
-                ],
+                    InstructionAddressMap {
+                        srcloc: SourceLoc::default(),
+                        code_offset: 23,
+                    },
+                ]
+                .into(),
                 start_srcloc: SourceLoc::new(code_section_offset + 10),
                 end_srcloc: SourceLoc::new(code_section_offset + 20),
                 body_offset: 0,

--- a/crates/environ/src/address_map.rs
+++ b/crates/environ/src/address_map.rs
@@ -7,22 +7,24 @@ use serde::{Deserialize, Serialize};
 /// Single source location to generated address mapping.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InstructionAddressMap {
-    /// Original source location.
+    /// Where in the source this instruction comes from.
     pub srcloc: ir::SourceLoc,
 
-    /// Generated instructions offset.
-    pub code_offset: usize,
-
-    /// Generated instructions length.
-    pub code_len: usize,
+    /// Offset from the start of the function's compiled code to where this
+    /// instruction is located, or the region where it starts.
+    pub code_offset: u32,
 }
 
 /// Function and its instructions addresses mappings.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub struct FunctionAddressMap {
-    /// Instructions maps.
-    /// The array is sorted by the InstructionAddressMap::code_offset field.
-    pub instructions: Vec<InstructionAddressMap>,
+    /// An array of data for the instructions in this function, indicating where
+    /// each instruction maps back to in the original function.
+    ///
+    /// This array is sorted least-to-greatest by the `code_offset` field.
+    /// Additionally the span of each `InstructionAddressMap` is implicitly the
+    /// gap between it and the next item in the array.
+    pub instructions: Box<[InstructionAddressMap]>,
 
     /// Function start source location (normally declaration).
     pub start_srcloc: ir::SourceLoc,
@@ -34,7 +36,7 @@ pub struct FunctionAddressMap {
     pub body_offset: usize,
 
     /// Generated function body length.
-    pub body_len: usize,
+    pub body_len: u32,
 }
 
 /// Memory definition offset in the VMContext structure.

--- a/crates/wasmtime/src/frame_info.rs
+++ b/crates/wasmtime/src/frame_info.rs
@@ -64,7 +64,7 @@ impl GlobalFrameInfo {
         // Use our relative position from the start of the function to find the
         // machine instruction that corresponds to `pc`, which then allows us to
         // map that to a wasm original source location.
-        let rel_pos = pc - func.start;
+        let rel_pos = (pc - func.start) as u32;
         let pos = match func
             .instr_map
             .instructions
@@ -77,19 +77,8 @@ impl GlobalFrameInfo {
             // instructions cover `pc`.
             Err(0) => None,
 
-            // This would be at the `nth` slot, so check `n-1` to see if we're
-            // part of that instruction. This happens due to the minus one when
-            // this function is called form trap symbolication, where we don't
-            // always get called with a `pc` that's an exact instruction
-            // boundary.
-            Err(n) => {
-                let instr = &func.instr_map.instructions[n - 1];
-                if instr.code_offset <= rel_pos && rel_pos < instr.code_offset + instr.code_len {
-                    Some(n - 1)
-                } else {
-                    None
-                }
-            }
+            // This would be at the `nth` slot, so we're at the `n-1`th slot.
+            Err(n) => Some(n - 1),
         };
 
         // In debug mode for now assert that we found a mapping for `pc` within


### PR DESCRIPTION
This commit reduces the size of `InstructionAddressMap` from 24 bytes to
8 bytes by dropping the `code_len` field and reducing `code_offset` to
`u32` instead of `usize`. The intention is to primarily make the
in-memory version take up less space, and the hunch is that the
`code_len` is largely not necessary since most entries in this map are
always adjacent to one another. The `code_len` field is now implied by
the `code_offset` field of the next entry in the map.

This isn't as big of an improvement to serialized module size as #2321
or #2322, primarily because of the switch to variable-length encoding.
Despite this though it shaves about 10MB off the encoded size of the
module from #2318


