### PR TITLE
Remove `source_loc` from `TrapInformation`

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -195,12 +195,11 @@ impl binemit::TrapSink for TrapSink {
     fn trap(
         &mut self,
         code_offset: binemit::CodeOffset,
-        source_loc: ir::SourceLoc,
+        _source_loc: ir::SourceLoc,
         trap_code: ir::TrapCode,
     ) {
         self.traps.push(TrapInformation {
             code_offset,
-            source_loc,
             trap_code,
         });
     }

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -61,8 +61,6 @@ pub enum RelocationTarget {
 pub struct TrapInformation {
     /// The offset of the trapping instruction in native code. It is relative to the beginning of the function.
     pub code_offset: binemit::CodeOffset,
-    /// Location of trapping instruction in WebAssembly binary module.
-    pub source_loc: ir::SourceLoc,
     /// Code of the trap.
     pub trap_code: ir::TrapCode,
 }

--- a/crates/lightbeam/wasmtime/src/lib.rs
+++ b/crates/lightbeam/wasmtime/src/lib.rs
@@ -165,12 +165,11 @@ impl binemit::TrapSink for TrapSink {
     fn trap(
         &mut self,
         code_offset: binemit::CodeOffset,
-        source_loc: ir::SourceLoc,
+        _source_loc: ir::SourceLoc,
         trap_code: ir::TrapCode,
     ) {
         self.traps.push(TrapInformation {
             code_offset,
-            source_loc,
             trap_code,
         });
     }


### PR DESCRIPTION
Turns out this wasn't needed anywhere! Additionally we can construct it
from `InstructionAddressMap` anyway. There's so many pieces of trap
information that it's best to keep these structures small as well.
 