### PR TITLE
Remove Windows-specific code for static memory bounds

### DIFF
--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -52,15 +52,6 @@ impl Config {
     /// Creates a new configuration object with the default configuration
     /// specified.
     pub fn new() -> Config {
-        let mut tunables = Tunables::default();
-        if cfg!(windows) {
-            // For now, use a smaller footprint on Windows so that we don't
-            // don't outstrip the paging file.
-            tunables.static_memory_bound = cmp::min(tunables.static_memory_bound, 0x100);
-            tunables.static_memory_offset_guard_size =
-                cmp::min(tunables.static_memory_offset_guard_size, 0x10000);
-        }
-
         let mut flags = settings::builder();
 
         // There are two possible traps for division, and this way
@@ -85,7 +76,7 @@ impl Config {
             .expect("should be valid flag");
 
         Config {
-            tunables,
+            tunables: Tunables::default(),
             flags,
             isa_flags: native::builder(),
             strategy: CompilationStrategy::Auto,


### PR DESCRIPTION
Added in c4e10227de1358d009cf8fb7df55a1c9dfb675d5 I think the original
reason (which I'm not entirely knowledgeable of) may no longer be
applicable? In any case this is a significant difference on Windows from
other platforms because it makes loads/stores of wasm code have manual
checks instead of relying on the guard page, causing runtime and
compile-time slowdowns on Windows-only.

I originally rediscovered this when investigating #2318 and saw that
both the compile time of the module in question and trap information
tables were much larger than they were on Linux. Removing this
Windows-specific configuration fixed the discrepancies and afterwards
Linux and Windows were basically the same.
