### PR TITLE
Implement emission of constants

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1035,7 +1035,8 @@ impl<I: VCodeInst> MachBuffer<I> {
         );
         let deadline = self.cur_offset().saturating_add(max_distance);
         self.island_worst_case_size += data.len() as CodeOffset;
-        self.island_worst_case_size &= !(I::LabelUse::ALIGN - 1);
+        self.island_worst_case_size =
+            (self.island_worst_case_size + I::LabelUse::ALIGN - 1) & !(I::LabelUse::ALIGN - 1);
         self.pending_constants.push(MachLabelConstant {
             label,
             align,

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -13,7 +13,7 @@ use crate::ir::{
 };
 use crate::machinst::{
     ABICallee, BlockIndex, BlockLoweringOrder, LoweredBlock, MachLabel, VCode, VCodeBuilder,
-    VCodeInst,
+    VCodeConstant, VCodeConstantData, VCodeConstants, VCodeInst,
 };
 use crate::CodegenResult;
 
@@ -162,6 +162,8 @@ pub trait LowerCtx {
     fn is_reg_needed(&self, ir_inst: Inst, reg: Reg) -> bool;
     /// Retrieve constant data given a handle.
     fn get_constant_data(&self, constant_handle: Constant) -> &ConstantData;
+    /// Indicate that a constant should be emitted.
+    fn use_constant(&mut self, constant: VCodeConstantData) -> VCodeConstant;
     /// Retrieve the value immediate from an instruction. This will perform necessary lookups on the
     /// `DataFlowGraph` to retrieve even large immediates.
     fn get_immediate(&self, ir_inst: Inst) -> Option<DataValue>;
@@ -318,7 +320,8 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         emit_info: I::Info,
         block_order: BlockLoweringOrder,
     ) -> CodegenResult<Lower<'func, I>> {
-        let mut vcode = VCodeBuilder::new(abi, emit_info, block_order);
+        let constants = VCodeConstants::with_capacity(f.dfg.constants.len());
+        let mut vcode = VCodeBuilder::new(abi, emit_info, block_order, constants);
 
         let mut next_vreg: u32 = 0;
 
@@ -1008,6 +1011,10 @@ impl<'func, I: VCodeInst> LowerCtx for Lower<'func, I> {
 
     fn get_constant_data(&self, constant_handle: Constant) -> &ConstantData {
         self.f.dfg.constants.get(constant_handle)
+    }
+
+    fn use_constant(&mut self, constant: VCodeConstantData) -> VCodeConstant {
+        self.vcode.constants().insert(constant)
     }
 
     fn get_immediate(&self, ir_inst: Inst) -> Option<DataValue> {

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -12,11 +12,11 @@ block0:
     v2 = shuffle v0, v1, 0x11000000000000000000000000000000     ; pick the second lane of v1, the rest use the first lane of v0
     return v2
 }
-; check:  load_const $$[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], %xmm1
-; nextln: load_const $$[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], %xmm0
-; nextln: load_const $$[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128], %xmm2
+; check:  load_const VCodeConstant(3), %xmm1
+; nextln: load_const VCodeConstant(2), %xmm0
+; nextln: load_const VCodeConstant(0), %xmm2
 ; nextln: pshufb  %xmm2, %xmm1
-; nextln: load_const $$[128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 1], %xmm2
+; nextln: load_const VCodeConstant(1), %xmm2
 ; nextln: pshufb  %xmm2, %xmm0
 ; nextln: orps    %xmm1, %xmm0
 
@@ -27,8 +27,8 @@ block0:
     v2 = shuffle v1, v1, 0x13000000000000000000000000000000     ; pick the fourth lane of v1 and the rest from the first lane of v1
     return v2
 }
-; check:  load_const $$[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], %xmm0
-; nextln: load_const $$[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3], %xmm1
+; check:  load_const VCodeConstant(1), %xmm0
+; nextln: load_const VCodeConstant(0), %xmm1
 ; nextln: pshufb  %xmm1, %xmm0
 
 
@@ -42,9 +42,9 @@ block0:
     v2 = swizzle.i8x16 v0, v1
     return v2
 }
-; check:  load_const $$[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], %xmm1
-; nextln: load_const $$[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], %xmm0
-; nextln: load_const $$[112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112], %xmm2
+; check:  load_const VCodeConstant(1), %xmm1
+; nextln: load_const VCodeConstant(1), %xmm0
+; nextln: load_const VCodeConstant(0), %xmm2
 ; nextln: paddusb %xmm2, %xmm0
 ; nextln: pshufb  %xmm0, %xmm1
 ; nextln: movdqa  %xmm1, %xmm0


### PR DESCRIPTION
@cfallin, based on what we discussed in Zulip and #1385, here's a first pass on a way to emit constants using `MachBuffer::defer_constant`. Note that I had to do two mappings--one from `Constant` to `UsedConstant` and another from `UsedConstant` to `MachLabel`--in order to make this work ("work" is too strong--"compile"). I'm interested in your feedback before I fix this up and improve `gen_constant`.