### PR TITLE
CI: upload built peepholes as artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,12 +165,17 @@ jobs:
           --package peepmatic-runtime \
           --package peepmatic-test \
           --package peepmatic-souper
-    - name: Rebuild Peepmatic-based peephole optimizers and test them
+    - name: Rebuild Peepmatic-based peephole optimizers
       run: |
         cargo test \
           --features 'enable-peepmatic rebuild-peephole-optimizers' \
           peepmatic
       working-directory: ./cranelift/codegen
+    - name: Upload rebuilt peephole optimizers
+      uses: actions/upload-artifact@v2
+      with:
+        name: peephole-optimizers
+        path: cranelift/codegen/src/preopt.serialized
     - name: Check that built peephole optimizers are up to date
       run: git diff --exit-code
     - name: Test with Peepmatic-based peephole optimizers


### PR DESCRIPTION
For people who can't build Z3, this lets them update the peephole optimizers
when necessary.

+cc @julian-seward1 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
