### PR TITLE
[machinst x64]: implement packed pmin/pmax

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -199,9 +199,11 @@ fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str
         ("simd", "simd_f32x4") => return false,
         ("simd", "simd_f32x4_arith") => return false,
         ("simd", "simd_f32x4_cmp") => return false,
+        ("simd", "simd_f32x4_pmin_pmax") => return false,
         ("simd", "simd_f64x2") => return false,
         ("simd", "simd_f64x2_arith") => return false,
         ("simd", "simd_f64x2_cmp") => return false,
+        ("simd", "simd_f64x2_pmin_pmax") => return false,
         ("simd", "simd_lane") => return false,
         ("simd", "simd_load_splat") => return false,
         ("simd", "simd_store") => return false,
@@ -231,16 +233,15 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             }
 
             // These are only implemented on aarch64 and x64.
-            ("simd", "simd_boolean") => {
+            ("simd", "simd_boolean")
+            | ("simd", "simd_f32x4_pmin_pmax")
+            | ("simd", "simd_f64x2_pmin_pmax") => {
                 return !(cfg!(feature = "experimental_x64")
                     || env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "aarch64")
             }
 
             // These are only implemented on aarch64.
-            ("simd", "simd_f32x4_pmin_pmax")
-            | ("simd", "simd_f32x4_rounding")
-            | ("simd", "simd_f64x2_pmin_pmax")
-            | ("simd", "simd_f64x2_rounding") => {
+            ("simd", "simd_f32x4_rounding") | ("simd", "simd_f64x2_rounding") => {
                 return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "aarch64";
             }
 


### PR DESCRIPTION
This implements the new-ish pseudo-minimum and pseudo-maximum instructions from the [SIMD spec](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#pseudo-minimum). Since this is done only in the new backend, the `build.rs` change is a bit confusing, but this extra logic will go away once the old backend does as well.