### PR TITLE
Revert "Introduce the Cranelift IR instruction `LoadSplat`" for build failures.

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift/codegen/meta/src/isa/x86/legalize.rs
@@ -396,7 +396,6 @@ fn define_simd(
     let insertlane = insts.by_name("insertlane");
     let ishl = insts.by_name("ishl");
     let ishl_imm = insts.by_name("ishl_imm");
-    let load_splat = insts.by_name("load_splat");
     let raw_bitcast = insts.by_name("raw_bitcast");
     let scalar_to_vector = insts.by_name("scalar_to_vector");
     let splat = insts.by_name("splat");
@@ -821,7 +820,6 @@ fn define_simd(
     narrow.custom_legalize(fcvt_to_sint_sat, "expand_fcvt_to_sint_sat_vector");
     narrow.custom_legalize(fmin, "expand_minmax_vector");
     narrow.custom_legalize(fmax, "expand_minmax_vector");
-    narrow.custom_legalize(load_splat, "expand_load_splat");
 
     narrow_avx.custom_legalize(imul, "convert_i64x2_imul");
     narrow_avx.custom_legalize(fcvt_from_uint, "expand_fcvt_from_uint_vector");

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -4459,24 +4459,5 @@ pub(crate) fn define(
         .other_side_effects(true),
     );
 
-    let Offset = &Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address");
-    let a = &Operand::new("a", TxN);
-
-    ig.push(
-        Inst::new(
-            "load_splat",
-            r#"
-        Load an element from memory at ``p + Offset`` and return a vector
-        whose lanes are all set to that element.
-
-        This is equivalent to ``load`` followed by ``splat``.
-        "#,
-            &formats.load,
-        )
-        .operands_in(vec![MemFlags, p, Offset])
-        .operands_out(vec![a])
-        .can_load(true),
-    );
-
     ig.build()
 }

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -680,19 +680,4 @@ impl VectorSize {
             _ => *self,
         }
     }
-
-    /// Return the encoding bits that are used by some SIMD instructions
-    /// for a particular operand size.
-    pub fn enc_size(&self) -> (u32, u32) {
-        let q = self.is_128bits() as u32;
-        let size = match self.lane_size() {
-            ScalarSize::Size8 => 0b00,
-            ScalarSize::Size16 => 0b01,
-            ScalarSize::Size32 => 0b10,
-            ScalarSize::Size64 => 0b11,
-            _ => unreachable!(),
-        };
-
-        (q, size)
-    }
 }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -248,16 +248,6 @@ fn enc_ldst_imm19(op_31_24: u32, imm19: u32, rd: Reg) -> u32 {
     (op_31_24 << 24) | (imm19 << 5) | machreg_to_gpr_or_vec(rd)
 }
 
-fn enc_ldst_vec(q: u32, size: u32, rn: Reg, rt: Writable<Reg>) -> u32 {
-    debug_assert_eq!(q & 0b1, q);
-    debug_assert_eq!(size & 0b11, size);
-    0b0_0_0011010_10_00000_110_0_00_00000_00000
-        | q << 30
-        | size << 10
-        | machreg_to_gpr(rn) << 5
-        | machreg_to_vec(rt.to_reg())
-}
-
 fn enc_extend(top22: u32, rd: Writable<Reg>, rn: Reg) -> u32 {
     (top22 << 10) | (machreg_to_gpr(rn) << 5) | machreg_to_gpr(rd.to_reg())
 }
@@ -1391,7 +1381,14 @@ impl MachInstEmit for Inst {
                 sink.put4(enc_fpurrrr(top17, rd, rn, rm, ra));
             }
             &Inst::VecMisc { op, rd, rn, size } => {
-                let (q, enc_size) = size.enc_size();
+                let enc_size = match size.lane_size() {
+                    ScalarSize::Size8 => 0b00,
+                    ScalarSize::Size16 => 0b01,
+                    ScalarSize::Size32 => 0b10,
+                    ScalarSize::Size64 => 0b11,
+                    _ => unreachable!(),
+                };
+                let q = if size.is_128bits() { 1 } else { 0 };
                 let (u, bits_12_16, size) = match op {
                     VecMisc2::Not => (0b1, 0b00101, 0b00),
                     VecMisc2::Neg => (0b1, 0b01011, enc_size),
@@ -1834,7 +1831,13 @@ impl MachInstEmit for Inst {
                 alu_op,
                 size,
             } => {
-                let (q, enc_size) = size.enc_size();
+                let enc_size = match size.lane_size() {
+                    ScalarSize::Size8 => 0b00,
+                    ScalarSize::Size16 => 0b01,
+                    ScalarSize::Size32 => 0b10,
+                    ScalarSize::Size64 => 0b11,
+                    _ => unreachable!(),
+                };
                 let is_float = match alu_op {
                     VecALUOp::Fcmeq
                     | VecALUOp::Fcmgt
@@ -1848,7 +1851,6 @@ impl MachInstEmit for Inst {
                     _ => false,
                 };
                 let enc_float_size = match (is_float, size) {
-                    (true, VectorSize::Size32x2) => 0b0,
                     (true, VectorSize::Size32x4) => 0b0,
                     (true, VectorSize::Size64x2) => 0b1,
                     (true, _) => unimplemented!(),
@@ -1856,46 +1858,46 @@ impl MachInstEmit for Inst {
                 };
 
                 let (top11, bit15_10) = match alu_op {
-                    VecALUOp::Sqadd => (0b000_01110_00_1 | enc_size << 1, 0b000011),
-                    VecALUOp::Sqsub => (0b000_01110_00_1 | enc_size << 1, 0b001011),
-                    VecALUOp::Uqadd => (0b001_01110_00_1 | enc_size << 1, 0b000011),
-                    VecALUOp::Uqsub => (0b001_01110_00_1 | enc_size << 1, 0b001011),
-                    VecALUOp::Cmeq => (0b001_01110_00_1 | enc_size << 1, 0b100011),
-                    VecALUOp::Cmge => (0b000_01110_00_1 | enc_size << 1, 0b001111),
-                    VecALUOp::Cmgt => (0b000_01110_00_1 | enc_size << 1, 0b001101),
-                    VecALUOp::Cmhi => (0b001_01110_00_1 | enc_size << 1, 0b001101),
-                    VecALUOp::Cmhs => (0b001_01110_00_1 | enc_size << 1, 0b001111),
-                    VecALUOp::Fcmeq => (0b000_01110_00_1, 0b111001),
-                    VecALUOp::Fcmgt => (0b001_01110_10_1, 0b111001),
-                    VecALUOp::Fcmge => (0b001_01110_00_1, 0b111001),
+                    VecALUOp::Sqadd => (0b010_01110_00_1 | enc_size << 1, 0b000011),
+                    VecALUOp::Sqsub => (0b010_01110_00_1 | enc_size << 1, 0b001011),
+                    VecALUOp::Uqadd => (0b011_01110_00_1 | enc_size << 1, 0b000011),
+                    VecALUOp::Uqsub => (0b011_01110_00_1 | enc_size << 1, 0b001011),
+                    VecALUOp::Cmeq => (0b011_01110_00_1 | enc_size << 1, 0b100011),
+                    VecALUOp::Cmge => (0b010_01110_00_1 | enc_size << 1, 0b001111),
+                    VecALUOp::Cmgt => (0b010_01110_00_1 | enc_size << 1, 0b001101),
+                    VecALUOp::Cmhi => (0b011_01110_00_1 | enc_size << 1, 0b001101),
+                    VecALUOp::Cmhs => (0b011_01110_00_1 | enc_size << 1, 0b001111),
+                    VecALUOp::Fcmeq => (0b010_01110_00_1, 0b111001),
+                    VecALUOp::Fcmgt => (0b011_01110_10_1, 0b111001),
+                    VecALUOp::Fcmge => (0b011_01110_00_1, 0b111001),
                     // The following logical instructions operate on bytes, so are not encoded differently
                     // for the different vector types.
-                    VecALUOp::And => (0b000_01110_00_1, 0b000111),
-                    VecALUOp::Bic => (0b000_01110_01_1, 0b000111),
-                    VecALUOp::Orr => (0b000_01110_10_1, 0b000111),
-                    VecALUOp::Eor => (0b001_01110_00_1, 0b000111),
-                    VecALUOp::Bsl => (0b001_01110_01_1, 0b000111),
-                    VecALUOp::Umaxp => (0b001_01110_00_1 | enc_size << 1, 0b101001),
-                    VecALUOp::Add => (0b000_01110_00_1 | enc_size << 1, 0b100001),
-                    VecALUOp::Sub => (0b001_01110_00_1 | enc_size << 1, 0b100001),
+                    VecALUOp::And => (0b010_01110_00_1, 0b000111),
+                    VecALUOp::Bic => (0b010_01110_01_1, 0b000111),
+                    VecALUOp::Orr => (0b010_01110_10_1, 0b000111),
+                    VecALUOp::Eor => (0b011_01110_00_1, 0b000111),
+                    VecALUOp::Bsl => (0b011_01110_01_1, 0b000111),
+                    VecALUOp::Umaxp => (0b011_01110_00_1 | enc_size << 1, 0b101001),
+                    VecALUOp::Add => (0b010_01110_00_1 | enc_size << 1, 0b100001),
+                    VecALUOp::Sub => (0b011_01110_00_1 | enc_size << 1, 0b100001),
                     VecALUOp::Mul => {
                         debug_assert_ne!(size, VectorSize::Size64x2);
-                        (0b000_01110_00_1 | enc_size << 1, 0b100111)
+                        (0b010_01110_00_1 | enc_size << 1, 0b100111)
                     }
-                    VecALUOp::Sshl => (0b000_01110_00_1 | enc_size << 1, 0b010001),
-                    VecALUOp::Ushl => (0b001_01110_00_1 | enc_size << 1, 0b010001),
-                    VecALUOp::Umin => (0b001_01110_00_1 | enc_size << 1, 0b011011),
-                    VecALUOp::Smin => (0b000_01110_00_1 | enc_size << 1, 0b011011),
-                    VecALUOp::Umax => (0b001_01110_00_1 | enc_size << 1, 0b011001),
-                    VecALUOp::Smax => (0b000_01110_00_1 | enc_size << 1, 0b011001),
-                    VecALUOp::Urhadd => (0b001_01110_00_1 | enc_size << 1, 0b000101),
-                    VecALUOp::Fadd => (0b000_01110_00_1, 0b110101),
-                    VecALUOp::Fsub => (0b000_01110_10_1, 0b110101),
-                    VecALUOp::Fdiv => (0b001_01110_00_1, 0b111111),
-                    VecALUOp::Fmax => (0b000_01110_00_1, 0b111101),
-                    VecALUOp::Fmin => (0b000_01110_10_1, 0b111101),
-                    VecALUOp::Fmul => (0b001_01110_00_1, 0b110111),
-                    VecALUOp::Addp => (0b000_01110_00_1 | enc_size << 1, 0b101111),
+                    VecALUOp::Sshl => (0b010_01110_00_1 | enc_size << 1, 0b010001),
+                    VecALUOp::Ushl => (0b011_01110_00_1 | enc_size << 1, 0b010001),
+                    VecALUOp::Umin => (0b011_01110_00_1 | enc_size << 1, 0b011011),
+                    VecALUOp::Smin => (0b010_01110_00_1 | enc_size << 1, 0b011011),
+                    VecALUOp::Umax => (0b011_01110_00_1 | enc_size << 1, 0b011001),
+                    VecALUOp::Smax => (0b010_01110_00_1 | enc_size << 1, 0b011001),
+                    VecALUOp::Urhadd => (0b011_01110_00_1 | enc_size << 1, 0b000101),
+                    VecALUOp::Fadd => (0b010_01110_00_1, 0b110101),
+                    VecALUOp::Fsub => (0b010_01110_10_1, 0b110101),
+                    VecALUOp::Fdiv => (0b011_01110_00_1, 0b111111),
+                    VecALUOp::Fmax => (0b010_01110_00_1, 0b111101),
+                    VecALUOp::Fmin => (0b010_01110_10_1, 0b111101),
+                    VecALUOp::Fmul => (0b011_01110_00_1, 0b110111),
+                    VecALUOp::Addp => (0b010_01110_00_1 | enc_size << 1, 0b101111),
                     VecALUOp::Umlal => {
                         debug_assert!(!size.is_128bits());
                         (0b001_01110_00_1 | enc_size << 1, 0b100000)
@@ -1903,26 +1905,11 @@ impl MachInstEmit for Inst {
                     VecALUOp::Zip1 => (0b01001110_00_0 | enc_size << 1, 0b001110),
                 };
                 let top11 = if is_float {
-                    top11 | (q << 9) | enc_float_size << 1
+                    top11 | enc_float_size << 1
                 } else {
-                    top11 | (q << 9)
+                    top11
                 };
                 sink.put4(enc_vec_rrr(top11, rm, bit15_10, rn, rd));
-            }
-            &Inst::VecLoadReplicate {
-                rd,
-                rn,
-                size,
-                srcloc,
-            } => {
-                let (q, size) = size.enc_size();
-
-                if let Some(srcloc) = srcloc {
-                    // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
-                }
-
-                sink.put4(enc_ldst_vec(q, size, rn, rd));
             }
             &Inst::MovToNZCV { rn } => {
                 sink.put4(0xd51b4200 | machreg_to_gpr(rn));
@@ -2208,12 +2195,9 @@ impl MachInstEmit for Inst {
                     inst.emit(sink, emit_info, state);
                 }
 
-                let (reg, index_reg, offset) = match mem {
-                    AMode::RegExtended(r, idx, extendop) => (r, Some((idx, extendop)), 0),
-                    AMode::Unscaled(r, simm9) => (r, None, simm9.value()),
-                    AMode::UnsignedOffset(r, uimm12scaled) => {
-                        (r, None, uimm12scaled.value() as i32)
-                    }
+                let (reg, offset) = match mem {
+                    AMode::Unscaled(r, simm9) => (r, simm9.value()),
+                    AMode::UnsignedOffset(r, uimm12scaled) => (r, uimm12scaled.value() as i32),
                     _ => panic!("Unsupported case for LoadAddr: {:?}", mem),
                 };
                 let abs_offset = if offset < 0 {
@@ -2227,22 +2211,9 @@ impl MachInstEmit for Inst {
                     ALUOp::Add64
                 };
 
-                if let Some((idx, extendop)) = index_reg {
-                    let add = Inst::AluRRRExtend {
-                        alu_op: ALUOp::Add64,
-                        rd,
-                        rn: reg,
-                        rm: idx,
-                        extendop,
-                    };
-
-                    add.emit(sink, emit_info, state);
-                } else if offset == 0 {
-                    if reg != rd.to_reg() {
-                        let mov = Inst::mov(rd, reg);
-
-                        mov.emit(sink, emit_info, state);
-                    }
+                if offset == 0 {
+                    let mov = Inst::mov(rd, reg);
+                    mov.emit(sink, emit_info, state);
                 } else if let Some(imm12) = Imm12::maybe_from_u64(abs_offset) {
                     let add = Inst::AluRRImm12 {
                         alu_op,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -2533,10 +2533,10 @@ fn test_aarch64_binemit() {
             rd: writable_vreg(28),
             rn: vreg(12),
             rm: vreg(4),
-            size: VectorSize::Size32x2,
+            size: VectorSize::Size32x4,
         },
-        "9CE5240E",
-        "fcmeq v28.2s, v12.2s, v4.2s",
+        "9CE5244E",
+        "fcmeq v28.4s, v12.4s, v4.4s",
     ));
 
     insns.push((
@@ -2965,10 +2965,10 @@ fn test_aarch64_binemit() {
             rd: writable_vreg(6),
             rn: vreg(9),
             rm: vreg(8),
-            size: VectorSize::Size8x8,
+            size: VectorSize::Size8x16,
         },
-        "2665282E",
-        "umax v6.8b, v9.8b, v8.8b",
+        "2665286E",
+        "umax v6.16b, v9.16b, v8.16b",
     ));
 
     insns.push((
@@ -3803,28 +3803,6 @@ fn test_aarch64_binemit() {
         },
         "6331134E",
         "tbx v3.16b, { v11.16b, v12.16b }, v19.16b",
-    ));
-
-    insns.push((
-        Inst::VecLoadReplicate {
-            rd: writable_vreg(31),
-            rn: xreg(0),
-            srcloc: None,
-            size: VectorSize::Size64x2,
-        },
-        "1FCC404D",
-        "ld1r { v31.2d }, [x0]",
-    ));
-
-    insns.push((
-        Inst::VecLoadReplicate {
-            rd: writable_vreg(0),
-            rn: xreg(25),
-            srcloc: None,
-            size: VectorSize::Size8x8,
-        },
-        "20C3400D",
-        "ld1r { v0.8b }, [x25]",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1021,14 +1021,6 @@ pub enum Inst {
         is_extension: bool,
     },
 
-    /// Load an element and replicate to all lanes of a vector.
-    VecLoadReplicate {
-        rd: Writable<Reg>,
-        rn: Reg,
-        size: VectorSize,
-        srcloc: Option<SourceLoc>,
-    },
-
     /// Move to the NZCV flags (actually a `MSR NZCV, Xn` insn).
     MovToNZCV {
         rn: Reg,
@@ -1672,10 +1664,7 @@ fn aarch64_get_regs(inst: &Inst, collector: &mut RegUsageCollector) {
                 collector.add_def(rd);
             }
         }
-        &Inst::VecLoadReplicate { rd, rn, .. } => {
-            collector.add_def(rd);
-            collector.add_use(rn);
-        }
+
         &Inst::FpuCmp32 { rn, rm } | &Inst::FpuCmp64 { rn, rm } => {
             collector.add_use(rn);
             collector.add_use(rm);
@@ -1828,9 +1817,8 @@ fn aarch64_get_regs(inst: &Inst, collector: &mut RegUsageCollector) {
         &Inst::LoadExtName { rd, .. } => {
             collector.add_def(rd);
         }
-        &Inst::LoadAddr { rd, ref mem } => {
+        &Inst::LoadAddr { rd, mem: _ } => {
             collector.add_def(rd);
-            memarg_regs(mem, collector);
         }
         &Inst::VirtualSPOffsetAdj { .. } => {}
         &Inst::EmitIsland { .. } => {}
@@ -2273,14 +2261,6 @@ fn aarch64_map_regs<RUM: RegUsageMapper>(inst: &mut Inst, mapper: &RUM) {
             } else {
                 map_def(mapper, rd);
             }
-        }
-        &mut Inst::VecLoadReplicate {
-            ref mut rd,
-            ref mut rn,
-            ..
-        } => {
-            map_def(mapper, rd);
-            map_use(mapper, rn);
         }
         &mut Inst::FpuCmp32 {
             ref mut rn,
@@ -3526,12 +3506,6 @@ impl Inst {
                 let rn2 = show_vreg_vector(rn2, mb_rru, VectorSize::Size8x16);
                 let rm = show_vreg_vector(rm, mb_rru, VectorSize::Size8x16);
                 format!("{} {}, {{ {}, {} }}, {}", op, rd, rn, rn2, rm)
-            }
-            &Inst::VecLoadReplicate { rd, rn, size, .. } => {
-                let rd = show_vreg_vector(rd.to_reg(), mb_rru, size);
-                let rn = rn.show_rru(mb_rru);
-
-                format!("ld1r {{ {} }}, [{}]", rd, rn)
             }
             &Inst::MovToNZCV { rn } => {
                 let rn = rn.show_rru(mb_rru);

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1197,29 +1197,6 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         }
 
-        Opcode::LoadSplat => {
-            let off = ctx.data(insn).load_store_offset().unwrap();
-            let ty = ty.unwrap();
-            let mem = lower_address(ctx, ty.lane_type(), &inputs[..], off);
-            let memflags = ctx.memflags(insn).expect("memory flags");
-            let rd = get_output_reg(ctx, outputs[0]);
-            let size = VectorSize::from_ty(ty);
-            let srcloc = if memflags.notrap() {
-                None
-            } else {
-                Some(ctx.srcloc(insn))
-            };
-            let tmp = ctx.alloc_tmp(RegClass::I64, I64);
-
-            ctx.emit(Inst::LoadAddr { rd: tmp, mem });
-            ctx.emit(Inst::VecLoadReplicate {
-                rd,
-                rn: tmp.to_reg(),
-                size,
-                srcloc,
-            });
-        }
-
         Opcode::Store
         | Opcode::Istore8
         | Opcode::Istore16

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -2983,12 +2983,12 @@ fn test_x64_emit() {
     // XMM_RM_R: float binary ops
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm1), w_xmm0, None),
+        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm1), w_xmm0),
         "F30F58C1",
         "addss   %xmm1, %xmm0",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm11), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm11), w_xmm13),
         "F3450F58EB",
         "addss   %xmm11, %xmm13",
     ));
@@ -2997,24 +2997,23 @@ fn test_x64_emit() {
             SseOpcode::Addss,
             RegMem::mem(Amode::imm_reg_reg_shift(123, r10, rdx, 2)),
             w_xmm0,
-            None,
         ),
         "F3410F5844927B",
         "addss   123(%r10,%rdx,4), %xmm0",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Addsd, RegMem::reg(xmm15), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Addsd, RegMem::reg(xmm15), w_xmm4),
         "F2410F58E7",
         "addsd   %xmm15, %xmm4",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm0), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm0), w_xmm1),
         "F30F5CC8",
         "subss   %xmm0, %xmm1",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm12), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm12), w_xmm1),
         "F3410F5CCC",
         "subss   %xmm12, %xmm1",
     ));
@@ -3023,58 +3022,57 @@ fn test_x64_emit() {
             SseOpcode::Subss,
             RegMem::mem(Amode::imm_reg_reg_shift(321, r10, rax, 3)),
             w_xmm10,
-            None,
         ),
         "F3450F5C94C241010000",
         "subss   321(%r10,%rax,8), %xmm10",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Subsd, RegMem::reg(xmm5), w_xmm14, None),
+        Inst::xmm_rm_r(SseOpcode::Subsd, RegMem::reg(xmm5), w_xmm14),
         "F2440F5CF5",
         "subsd   %xmm5, %xmm14",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Mulss, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Mulss, RegMem::reg(xmm5), w_xmm4),
         "F30F59E5",
         "mulss   %xmm5, %xmm4",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Mulsd, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Mulsd, RegMem::reg(xmm5), w_xmm4),
         "F20F59E5",
         "mulsd   %xmm5, %xmm4",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Divss, RegMem::reg(xmm8), w_xmm7, None),
+        Inst::xmm_rm_r(SseOpcode::Divss, RegMem::reg(xmm8), w_xmm7),
         "F3410F5EF8",
         "divss   %xmm8, %xmm7",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Divsd, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Divsd, RegMem::reg(xmm5), w_xmm4),
         "F20F5EE5",
         "divsd   %xmm5, %xmm4",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Andps, RegMem::reg(xmm3), w_xmm12, None),
+        Inst::xmm_rm_r(SseOpcode::Andps, RegMem::reg(xmm3), w_xmm12),
         "440F54E3",
         "andps   %xmm3, %xmm12",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Andnps, RegMem::reg(xmm4), w_xmm11, None),
+        Inst::xmm_rm_r(SseOpcode::Andnps, RegMem::reg(xmm4), w_xmm11),
         "440F55DC",
         "andnps  %xmm4, %xmm11",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm1), w_xmm15, None),
+        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm1), w_xmm15),
         "440F56F9",
         "orps    %xmm1, %xmm15",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm5), w_xmm4),
         "0F56E5",
         "orps    %xmm5, %xmm4",
     ));
@@ -3083,211 +3081,211 @@ fn test_x64_emit() {
     // XMM_RM_R: Integer Packed
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddb, RegMem::reg(xmm9), w_xmm5, None),
+        Inst::xmm_rm_r(SseOpcode::Paddb, RegMem::reg(xmm9), w_xmm5),
         "66410FFCE9",
         "paddb   %xmm9, %xmm5",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddw, RegMem::reg(xmm7), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Paddw, RegMem::reg(xmm7), w_xmm6),
         "660FFDF7",
         "paddw   %xmm7, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddd, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Paddd, RegMem::reg(xmm12), w_xmm13),
         "66450FFEEC",
         "paddd   %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddq, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Paddq, RegMem::reg(xmm1), w_xmm8),
         "66440FD4C1",
         "paddq   %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddsb, RegMem::reg(xmm9), w_xmm5, None),
+        Inst::xmm_rm_r(SseOpcode::Paddsb, RegMem::reg(xmm9), w_xmm5),
         "66410FECE9",
         "paddsb  %xmm9, %xmm5",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddsw, RegMem::reg(xmm7), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Paddsw, RegMem::reg(xmm7), w_xmm6),
         "660FEDF7",
         "paddsw  %xmm7, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddusb, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Paddusb, RegMem::reg(xmm12), w_xmm13),
         "66450FDCEC",
         "paddusb %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddusw, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Paddusw, RegMem::reg(xmm1), w_xmm8),
         "66440FDDC1",
         "paddusw %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubsb, RegMem::reg(xmm9), w_xmm5, None),
+        Inst::xmm_rm_r(SseOpcode::Psubsb, RegMem::reg(xmm9), w_xmm5),
         "66410FE8E9",
         "psubsb  %xmm9, %xmm5",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubsw, RegMem::reg(xmm7), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Psubsw, RegMem::reg(xmm7), w_xmm6),
         "660FE9F7",
         "psubsw  %xmm7, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubusb, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Psubusb, RegMem::reg(xmm12), w_xmm13),
         "66450FD8EC",
         "psubusb %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubusw, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Psubusw, RegMem::reg(xmm1), w_xmm8),
         "66440FD9C1",
         "psubusw %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pavgb, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Pavgb, RegMem::reg(xmm12), w_xmm13),
         "66450FE0EC",
         "pavgb   %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pavgw, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Pavgw, RegMem::reg(xmm1), w_xmm8),
         "66440FE3C1",
         "pavgw   %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubb, RegMem::reg(xmm5), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Psubb, RegMem::reg(xmm5), w_xmm9),
         "66440FF8CD",
         "psubb   %xmm5, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubw, RegMem::reg(xmm6), w_xmm7, None),
+        Inst::xmm_rm_r(SseOpcode::Psubw, RegMem::reg(xmm6), w_xmm7),
         "660FF9FE",
         "psubw   %xmm6, %xmm7",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubd, RegMem::reg(xmm13), w_xmm12, None),
+        Inst::xmm_rm_r(SseOpcode::Psubd, RegMem::reg(xmm13), w_xmm12),
         "66450FFAE5",
         "psubd   %xmm13, %xmm12",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubq, RegMem::reg(xmm8), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Psubq, RegMem::reg(xmm8), w_xmm1),
         "66410FFBC8",
         "psubq   %xmm8, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmulld, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmulld, RegMem::reg(xmm15), w_xmm6),
         "66410F3840F7",
         "pmulld  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmullw, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmullw, RegMem::reg(xmm14), w_xmm1),
         "66410FD5CE",
         "pmullw  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmuludq, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pmuludq, RegMem::reg(xmm8), w_xmm9),
         "66450FF4C8",
         "pmuludq %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxsb, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxsb, RegMem::reg(xmm15), w_xmm6),
         "66410F383CF7",
         "pmaxsb  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxsw, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxsw, RegMem::reg(xmm15), w_xmm6),
         "66410FEEF7",
         "pmaxsw  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxsd, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxsd, RegMem::reg(xmm15), w_xmm6),
         "66410F383DF7",
         "pmaxsd  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxub, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxub, RegMem::reg(xmm14), w_xmm1),
         "66410FDECE",
         "pmaxub  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxuw, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxuw, RegMem::reg(xmm14), w_xmm1),
         "66410F383ECE",
         "pmaxuw  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxud, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxud, RegMem::reg(xmm14), w_xmm1),
         "66410F383FCE",
         "pmaxud  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminsb, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pminsb, RegMem::reg(xmm8), w_xmm9),
         "66450F3838C8",
         "pminsb  %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminsw, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pminsw, RegMem::reg(xmm8), w_xmm9),
         "66450FEAC8",
         "pminsw  %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminsd, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pminsd, RegMem::reg(xmm8), w_xmm9),
         "66450F3839C8",
         "pminsd  %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminub, RegMem::reg(xmm3), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pminub, RegMem::reg(xmm3), w_xmm2),
         "660FDAD3",
         "pminub  %xmm3, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminuw, RegMem::reg(xmm3), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pminuw, RegMem::reg(xmm3), w_xmm2),
         "660F383AD3",
         "pminuw  %xmm3, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminud, RegMem::reg(xmm3), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pminud, RegMem::reg(xmm3), w_xmm2),
         "660F383BD3",
         "pminud  %xmm3, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::reg(xmm11), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::reg(xmm11), w_xmm2),
         "66410FEFD3",
         "pxor    %xmm11, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pshufb, RegMem::reg(xmm11), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pshufb, RegMem::reg(xmm11), w_xmm2),
         "66410F3800D3",
         "pshufb  %xmm11, %xmm2",
     ));
@@ -3504,12 +3502,12 @@ fn test_x64_emit() {
     // ========================================================
     // XmmRmRImm
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Cmppd, RegMem::reg(xmm5), w_xmm1, 2, false, None),
+        Inst::xmm_rm_r_imm(SseOpcode::Cmppd, RegMem::reg(xmm5), w_xmm1, 2, false),
         "660FC2CD02",
         "cmppd   $2, %xmm5, %xmm1",
     ));
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Cmpps, RegMem::reg(xmm15), w_xmm7, 0, false, None),
+        Inst::xmm_rm_r_imm(SseOpcode::Cmpps, RegMem::reg(xmm15), w_xmm7, 0, false),
         "410FC2FF00",
         "cmpps   $0, %xmm15, %xmm7",
     ));

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -213,7 +213,6 @@ pub enum Inst {
         op: SseOpcode,
         src: RegMem,
         dst: Writable<Reg>,
-        srcloc: Option<SourceLoc>,
     },
 
     /// XMM (scalar or vector) unary op: mov between XMM registers (32 64) (reg addr) reg, sqrt,
@@ -340,7 +339,6 @@ pub enum Inst {
         dst: Writable<Reg>,
         imm: u8,
         is64: bool,
-        srcloc: Option<SourceLoc>,
     },
 
     // =====================================
@@ -714,20 +712,10 @@ impl Inst {
         }
     }
 
-    pub(crate) fn xmm_rm_r(
-        op: SseOpcode,
-        src: RegMem,
-        dst: Writable<Reg>,
-        srcloc: Option<SourceLoc>,
-    ) -> Self {
+    pub(crate) fn xmm_rm_r(op: SseOpcode, src: RegMem, dst: Writable<Reg>) -> Self {
         src.assert_regclass_is(RegClass::V128);
         debug_assert!(dst.to_reg().get_class() == RegClass::V128);
-        Inst::XmmRmR {
-            op,
-            src,
-            dst,
-            srcloc,
-        }
+        Inst::XmmRmR { op, src, dst }
     }
 
     pub(crate) fn xmm_uninit_value(dst: Writable<Reg>) -> Self {
@@ -882,7 +870,6 @@ impl Inst {
         dst: Writable<Reg>,
         imm: u8,
         is64: bool,
-        srcloc: Option<SourceLoc>,
     ) -> Inst {
         Inst::XmmRmRImm {
             op,
@@ -890,7 +877,6 @@ impl Inst {
             dst,
             imm,
             is64,
-            srcloc,
         }
     }
 
@@ -1248,26 +1234,16 @@ impl Inst {
     /// Choose which instruction to use for comparing two values for equality.
     pub(crate) fn equals(ty: Type, from: RegMem, to: Writable<Reg>) -> Inst {
         match ty {
-            types::I8X16 | types::B8X16 => Inst::xmm_rm_r(SseOpcode::Pcmpeqb, from, to, None),
-            types::I16X8 | types::B16X8 => Inst::xmm_rm_r(SseOpcode::Pcmpeqw, from, to, None),
-            types::I32X4 | types::B32X4 => Inst::xmm_rm_r(SseOpcode::Pcmpeqd, from, to, None),
-            types::I64X2 | types::B64X2 => Inst::xmm_rm_r(SseOpcode::Pcmpeqq, from, to, None),
-            types::F32X4 => Inst::xmm_rm_r_imm(
-                SseOpcode::Cmpps,
-                from,
-                to,
-                FcmpImm::Equal.encode(),
-                false,
-                None,
-            ),
-            types::F64X2 => Inst::xmm_rm_r_imm(
-                SseOpcode::Cmppd,
-                from,
-                to,
-                FcmpImm::Equal.encode(),
-                false,
-                None,
-            ),
+            types::I8X16 | types::B8X16 => Inst::xmm_rm_r(SseOpcode::Pcmpeqb, from, to),
+            types::I16X8 | types::B16X8 => Inst::xmm_rm_r(SseOpcode::Pcmpeqw, from, to),
+            types::I32X4 | types::B32X4 => Inst::xmm_rm_r(SseOpcode::Pcmpeqd, from, to),
+            types::I64X2 | types::B64X2 => Inst::xmm_rm_r(SseOpcode::Pcmpeqq, from, to),
+            types::F32X4 => {
+                Inst::xmm_rm_r_imm(SseOpcode::Cmpps, from, to, FcmpImm::Equal.encode(), false)
+            }
+            types::F64X2 => {
+                Inst::xmm_rm_r_imm(SseOpcode::Cmppd, from, to, FcmpImm::Equal.encode(), false)
+            }
             _ => unimplemented!("unimplemented type for Inst::equals: {}", ty),
         }
     }
@@ -1275,11 +1251,9 @@ impl Inst {
     /// Choose which instruction to use for computing a bitwise AND on two values.
     pub(crate) fn and(ty: Type, from: RegMem, to: Writable<Reg>) -> Inst {
         match ty {
-            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Andps, from, to, None),
-            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Andpd, from, to, None),
-            _ if ty.is_vector() && ty.bits() == 128 => {
-                Inst::xmm_rm_r(SseOpcode::Pand, from, to, None)
-            }
+            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Andps, from, to),
+            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Andpd, from, to),
+            _ if ty.is_vector() && ty.bits() == 128 => Inst::xmm_rm_r(SseOpcode::Pand, from, to),
             _ => unimplemented!("unimplemented type for Inst::and: {}", ty),
         }
     }
@@ -1287,11 +1261,9 @@ impl Inst {
     /// Choose which instruction to use for computing a bitwise AND NOT on two values.
     pub(crate) fn and_not(ty: Type, from: RegMem, to: Writable<Reg>) -> Inst {
         match ty {
-            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Andnps, from, to, None),
-            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Andnpd, from, to, None),
-            _ if ty.is_vector() && ty.bits() == 128 => {
-                Inst::xmm_rm_r(SseOpcode::Pandn, from, to, None)
-            }
+            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Andnps, from, to),
+            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Andnpd, from, to),
+            _ if ty.is_vector() && ty.bits() == 128 => Inst::xmm_rm_r(SseOpcode::Pandn, from, to),
             _ => unimplemented!("unimplemented type for Inst::and_not: {}", ty),
         }
     }
@@ -1299,11 +1271,9 @@ impl Inst {
     /// Choose which instruction to use for computing a bitwise OR on two values.
     pub(crate) fn or(ty: Type, from: RegMem, to: Writable<Reg>) -> Inst {
         match ty {
-            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Orps, from, to, None),
-            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Orpd, from, to, None),
-            _ if ty.is_vector() && ty.bits() == 128 => {
-                Inst::xmm_rm_r(SseOpcode::Por, from, to, None)
-            }
+            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Orps, from, to),
+            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Orpd, from, to),
+            _ if ty.is_vector() && ty.bits() == 128 => Inst::xmm_rm_r(SseOpcode::Por, from, to),
             _ => unimplemented!("unimplemented type for Inst::or: {}", ty),
         }
     }
@@ -1311,11 +1281,9 @@ impl Inst {
     /// Choose which instruction to use for computing a bitwise XOR on two values.
     pub(crate) fn xor(ty: Type, from: RegMem, to: Writable<Reg>) -> Inst {
         match ty {
-            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Xorps, from, to, None),
-            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Xorpd, from, to, None),
-            _ if ty.is_vector() && ty.bits() == 128 => {
-                Inst::xmm_rm_r(SseOpcode::Pxor, from, to, None)
-            }
+            types::F32X4 => Inst::xmm_rm_r(SseOpcode::Xorps, from, to),
+            types::F64X2 => Inst::xmm_rm_r(SseOpcode::Xorpd, from, to),
+            _ if ty.is_vector() && ty.bits() == 128 => Inst::xmm_rm_r(SseOpcode::Pxor, from, to),
             _ => unimplemented!("unimplemented type for Inst::xor: {}", ty),
         }
     }
@@ -1462,7 +1430,7 @@ impl PrettyPrint for Inst {
                 dst.show_rru(mb_rru),
             ),
 
-            Inst::XmmRmR { op, src, dst, .. } => format!(
+            Inst::XmmRmR { op, src, dst } => format!(
                 "{} {}, {}",
                 ljustify(op.to_string()),
                 src.show_rru_sized(mb_rru, 8),
@@ -1492,7 +1460,7 @@ impl PrettyPrint for Inst {
                 show_ireg_sized(rhs_dst.to_reg(), mb_rru, 8),
             ),
 
-            Inst::XmmRmRImm { op, src, dst, imm, is64, .. } => format!(
+            Inst::XmmRmRImm { op, src, dst, imm, is64 } => format!(
                 "{} ${}, {}, {}",
                 ljustify(format!("{}{}", op.to_string(), if *is64 { ".w" } else { "" })),
                 imm,
@@ -2628,7 +2596,6 @@ impl MachInst for Inst {
                     SseOpcode::Xorps,
                     RegMem::reg(to_reg.to_reg()),
                     to_reg,
-                    None,
                 ));
             } else {
                 let tmp = alloc_tmp(RegClass::I64, types::I32);
@@ -2647,7 +2614,6 @@ impl MachInst for Inst {
                     SseOpcode::Xorpd,
                     RegMem::reg(to_reg.to_reg()),
                     to_reg,
-                    None,
                 ));
             } else {
                 let tmp = alloc_tmp(RegClass::I64, types::I64);

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -1892,31 +1892,3 @@ fn expand_tls_value(
         unreachable!();
     }
 }
-
-fn expand_load_splat(
-    inst: ir::Inst,
-    func: &mut ir::Function,
-    _cfg: &mut ControlFlowGraph,
-    _isa: &dyn TargetIsa,
-) {
-    let mut pos = FuncCursor::new(func).at_inst(inst);
-
-    pos.use_srcloc(inst);
-
-    let (ptr, offset, flags) = match pos.func.dfg[inst] {
-        ir::InstructionData::Load {
-            opcode: ir::Opcode::LoadSplat,
-            arg,
-            offset,
-            flags,
-        } => (arg, offset, flags),
-        _ => panic!(
-            "Expected load_splat: {}",
-            pos.func.dfg.display_inst(inst, None)
-        ),
-    };
-    let ty = pos.func.dfg.ctrl_typevar(inst);
-    let load = pos.ins().load(ty.lane_type(), flags, ptr, offset);
-
-    pos.func.dfg.replace(inst).splat(ty, load);
-}

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1414,17 +1414,19 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::V128Load16Splat { memarg }
         | Operator::V128Load32Splat { memarg }
         | Operator::V128Load64Splat { memarg } => {
-            let opcode = ir::Opcode::LoadSplat;
-            let result_ty = type_of(op);
-            let (flags, base, offset) = prepare_load(
+            // TODO: For spec compliance, this is initially implemented as a combination of `load +
+            // splat` but could be implemented eventually as a single instruction (`load_splat`).
+            // See https://github.com/bytecodealliance/wasmtime/issues/1175.
+            translate_load(
                 memarg,
-                mem_op_size(opcode, result_ty.lane_type()),
+                ir::Opcode::Load,
+                type_of(op).lane_type(),
                 builder,
                 state,
                 environ,
             )?;
-            let (load, dfg) = builder.ins().Load(opcode, result_ty, flags, offset, base);
-            state.push1(dfg.first_result(load))
+            let splatted = builder.ins().splat(type_of(op), state.pop1());
+            state.push1(splatted)
         }
         Operator::I8x16ExtractLaneS { lane } | Operator::I16x8ExtractLaneS { lane } => {
             let vector = pop1_with_bitcast(state, type_of(op), builder);
@@ -2086,7 +2088,7 @@ fn mem_op_size(opcode: ir::Opcode, ty: Type) -> u32 {
         ir::Opcode::Istore8 | ir::Opcode::Sload8 | ir::Opcode::Uload8 => 1,
         ir::Opcode::Istore16 | ir::Opcode::Sload16 | ir::Opcode::Uload16 => 2,
         ir::Opcode::Istore32 | ir::Opcode::Sload32 | ir::Opcode::Uload32 => 4,
-        ir::Opcode::Store | ir::Opcode::Load | ir::Opcode::LoadSplat => ty.bytes(),
+        ir::Opcode::Store | ir::Opcode::Load => ty.bytes(),
         _ => panic!("unknown size of mem op for {:?}", opcode),
     }
 }


### PR DESCRIPTION
Reverts bytecodealliance/wasmtime#2278