### PR TITLE
Add missing `SourceLoc` to newly-emitted instructions

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3295,13 +3295,13 @@ fn test_x64_emit() {
     // ========================================================
     // XMM_RM_R: Integer Conversion
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Cvtdq2ps, RegMem::reg(xmm1), w_xmm8),
+        Inst::xmm_rm_r(SseOpcode::Cvtdq2ps, RegMem::reg(xmm1), w_xmm8, None),
         "440F5BC1",
         "cvtdq2ps %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Cvttps2dq, RegMem::reg(xmm9), w_xmm8),
+        Inst::xmm_rm_r(SseOpcode::Cvttps2dq, RegMem::reg(xmm9), w_xmm8, None),
         "F3450F5BC1",
         "cvttps2dq %xmm9, %xmm8",
     ));

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2232,7 +2232,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     }
                 };
                 ctx.emit(Inst::gen_move(dst, src, ty));
-                ctx.emit(Inst::xmm_rm_r(opcode, RegMem::from(dst), dst));
+                ctx.emit(Inst::xmm_rm_r(opcode, RegMem::from(dst), dst, None));
             }
         }
 
@@ -2307,18 +2307,34 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 ctx.emit(Inst::xmm_rmi_reg(SseOpcode::Psrld, RegMemImm::imm(16), tmp));
 
                 // Get the high 16 bits
-                ctx.emit(Inst::xmm_rm_r(SseOpcode::Psubd, RegMem::from(tmp), dst));
+                ctx.emit(Inst::xmm_rm_r(
+                    SseOpcode::Psubd,
+                    RegMem::from(tmp),
+                    dst,
+                    None,
+                ));
 
                 // Convert the low 16 bits
-                ctx.emit(Inst::xmm_rm_r(SseOpcode::Cvtdq2ps, RegMem::from(tmp), tmp));
+                ctx.emit(Inst::xmm_rm_r(
+                    SseOpcode::Cvtdq2ps,
+                    RegMem::from(tmp),
+                    tmp,
+                    None,
+                ));
 
                 // Shift the high bits by 1, convert, and double to get the correct value.
                 ctx.emit(Inst::xmm_rmi_reg(SseOpcode::Psrld, RegMemImm::imm(1), dst));
-                ctx.emit(Inst::xmm_rm_r(SseOpcode::Cvtdq2ps, RegMem::from(dst), dst));
+                ctx.emit(Inst::xmm_rm_r(
+                    SseOpcode::Cvtdq2ps,
+                    RegMem::from(dst),
+                    dst,
+                    None,
+                ));
                 ctx.emit(Inst::xmm_rm_r(
                     SseOpcode::Addps,
                     RegMem::reg(dst.to_reg()),
                     dst,
+                    None,
                 ));
 
                 // Add together the two converted values.
@@ -2326,6 +2342,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     SseOpcode::Addps,
                     RegMem::reg(tmp.to_reg()),
                     dst,
+                    None,
                 ));
             }
         }
@@ -2387,11 +2404,13 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         tmp,
                         cond.encode(),
                         false,
+                        None,
                     ));
                     ctx.emit(Inst::xmm_rm_r(
                         SseOpcode::Andps,
                         RegMem::reg(tmp.to_reg()),
                         dst,
+                        None,
                     ));
 
                     // Sets top bit of tmp if float is positive
@@ -2400,6 +2419,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         SseOpcode::Pxor,
                         RegMem::reg(dst.to_reg()),
                         tmp,
+                        None,
                     ));
 
                     // Convert the packed float to packed doubleword.
@@ -2407,6 +2427,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         SseOpcode::Cvttps2dq,
                         RegMem::reg(dst.to_reg()),
                         dst,
+                        None,
                     ));
 
                     // Set top bit only if < 0
@@ -2415,6 +2436,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         SseOpcode::Pand,
                         RegMem::reg(dst.to_reg()),
                         tmp,
+                        None,
                     ));
                     ctx.emit(Inst::xmm_rmi_reg(SseOpcode::Psrad, RegMemImm::imm(31), tmp));
 
@@ -2425,6 +2447,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         SseOpcode::Pxor,
                         RegMem::reg(tmp.to_reg()),
                         dst,
+                        None,
                     ));
                 } else if op == Opcode::FcvtToUintSat {
                     unimplemented!("f32x4.convert_i32x4_u");


### PR DESCRIPTION
The changes in https://github.com/bytecodealliance/wasmtime/pull/2278 added `SourceLoc`s to several x64 `Inst` variants; between when that PR was last run in CI and when it was merged, new instructions were added that require this new parameter. This change adds the parameter in order to fix CI.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
