### PR TITLE
Replace binaryen -ttf based fuzzing with wasm-smith

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
-    - run: cargo fuzz build --dev --features binaryen
+    - run: cargo fuzz build --dev
 
   rebuild_peephole_optimizers:
     name: Rebuild Peephole Optimizers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,27 +125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
-name = "binaryen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51ad23b3c7ab468d9daa948201921879ef0052e561c250fd0b326e6f000f2dd"
-dependencies = [
- "binaryen-sys",
-]
-
-[[package]]
-name = "binaryen-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5829a7c89f7827e58866704e4dfdf48a635d73c6e5449c1a8a0ba5a319d28a"
-dependencies = [
- "cc",
- "cmake",
- "heck",
- "regex",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff896bbe4adf62d6a909708c34db3ad94ce2103daa9673f64fe15e60ba70dad"
+checksum = "f372c777fcc75bbad237aa0b14e380cfddb3680f42c0584f1f0681542f8559b7"
 dependencies = [
  "arbitrary",
  "leb128",
@@ -2544,10 +2523,10 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "binaryen",
  "env_logger",
  "log",
  "rayon",
+ "wasm-smith",
  "wasmparser 0.63.0",
  "wasmprinter",
  "wasmtime",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -9,7 +9,6 @@ version = "0.19.0"
 [dependencies]
 anyhow = "1.0.22"
 arbitrary = { version = "0.4.1", features = ["derive"] }
-binaryen = { version = "0.10.0", optional = true }
 env_logger = "0.7.1"
 log = "0.4.8"
 rayon = "1.2.1"
@@ -17,6 +16,7 @@ wasmparser = "0.63.0"
 wasmprinter = "0.2.10"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
+wasm-smith = "0.1.9"
 
 [dev-dependencies]
 wat = "1.0.23"

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -8,54 +8,11 @@
 //! wrapper over an external tool, such that the wrapper implements the
 //! `Arbitrary` trait for the wrapped external tool.
 
-#[cfg(feature = "binaryen")]
 pub mod api;
 
 pub mod table_ops;
 
 use arbitrary::{Arbitrary, Unstructured};
-
-/// A Wasm test case generator that is powered by Binaryen's `wasm-opt -ttf`.
-#[derive(Clone)]
-#[cfg(feature = "binaryen")]
-pub struct WasmOptTtf {
-    /// The raw, encoded Wasm bytes.
-    pub wasm: Vec<u8>,
-}
-
-#[cfg(feature = "binaryen")]
-impl std::fmt::Debug for WasmOptTtf {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "WasmOptTtf {{ wasm: wat::parse_str(r###\"\n{}\n\"###).unwrap() }}",
-            wasmprinter::print_bytes(&self.wasm).expect("valid wasm should always disassemble")
-        )
-    }
-}
-
-#[cfg(feature = "binaryen")]
-impl Arbitrary for WasmOptTtf {
-    fn arbitrary(input: &mut arbitrary::Unstructured) -> arbitrary::Result<Self> {
-        crate::init_fuzzing();
-        let seed: Vec<u8> = Arbitrary::arbitrary(input)?;
-        let module = binaryen::tools::translate_to_fuzz_mvp(&seed);
-        let wasm = module.write();
-        Ok(WasmOptTtf { wasm })
-    }
-
-    fn arbitrary_take_rest(input: arbitrary::Unstructured) -> arbitrary::Result<Self> {
-        crate::init_fuzzing();
-        let seed: Vec<u8> = Arbitrary::arbitrary_take_rest(input)?;
-        let module = binaryen::tools::translate_to_fuzz_mvp(&seed);
-        let wasm = module.write();
-        Ok(WasmOptTtf { wasm })
-    }
-
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <Vec<u8> as Arbitrary>::size_hint(depth)
-    }
-}
 
 /// A description of configuration options that we should do differential
 /// testing between.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -32,25 +32,16 @@ test = false
 doc = false
 
 [[bin]]
-name = "instantiate_translated"
-path = "fuzz_targets/instantiate_translated.rs"
-test = false
-doc = false
-required-features = ["binaryen"]
-
-[[bin]]
 name = "api_calls"
 path = "fuzz_targets/api_calls.rs"
 test = false
 doc = false
-required-features = ["binaryen"]
 
 [[bin]]
 name = "differential"
 path = "fuzz_targets/differential.rs"
 test = false
 doc = false
-required-features = ["binaryen"]
 
 [[bin]]
 name = "spectests"
@@ -99,12 +90,15 @@ test = false
 doc = false
 required-features = ["peepmatic-fuzzing"]
 
-[features]
-binaryen = ["wasmtime-fuzzing/binaryen"]
-
 [[bin]]
 name = "instantiate-wasm-smith"
 path = "fuzz_targets/instantiate-wasm-smith.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "instantiate-swarm"
+path = "fuzz_targets/instantiate-swarm.rs"
 test = false
 doc = false
 

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -6,8 +6,9 @@ use wasmtime_fuzzing::{generators, oracles};
 fuzz_target!(|data: (
     generators::DifferentialConfig,
     generators::DifferentialConfig,
-    generators::WasmOptTtf
+    wasm_smith::Module,
 )| {
-    let (lhs, rhs, wasm) = data;
+    let (lhs, rhs, mut wasm) = data;
+    wasm.ensure_termination(1000);
     oracles::differential_execution(&wasm, &[lhs, rhs]);
 });

--- a/fuzz/fuzz_targets/instantiate-swarm.rs
+++ b/fuzz/fuzz_targets/instantiate-swarm.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::time::Duration;
+use wasm_smith::{ConfiguredModule, SwarmConfig};
+use wasmtime::Strategy;
+use wasmtime_fuzzing::oracles;
+
+fuzz_target!(|module: ConfiguredModule<SwarmConfig>| {
+    let mut cfg = wasmtime_fuzzing::fuzz_default_config(Strategy::Auto).unwrap();
+    cfg.wasm_multi_memory(true);
+    oracles::instantiate_with_config(&module.to_bytes(), cfg, Some(Duration::from_secs(20)));
+});

--- a/fuzz/fuzz_targets/instantiate_translated.rs
+++ b/fuzz/fuzz_targets/instantiate_translated.rs
@@ -1,9 +1,0 @@
-#![no_main]
-
-use libfuzzer_sys::fuzz_target;
-use wasmtime::Strategy;
-use wasmtime_fuzzing::{generators, oracles};
-
-fuzz_target!(|data: generators::WasmOptTtf| {
-    oracles::instantiate(&data.wasm, Strategy::Auto);
-});


### PR DESCRIPTION
This commit removes the binaryen support for fuzzing from wasmtime,
instead switching over to `wasm-smith`. In general it's great to have
what fuzzing we can, but our binaryen support suffers from a few issues:

* The Rust crate, binaryen-sys, seems largely unmaintained at this
  point. While we could likely take ownership and/or send PRs to update
  the crate it seems like the maintenance is largely on us at this point.

* Currently the binaryen-sys crate doesn't support fuzzing anything
  beyond MVP wasm, but we're interested at least in features like bulk
  memory and reference types. Additionally we'll also be interested in
  features like module-linking. New features would require either
  implementation work in binaryen or the binaryen-sys crate to support.

* We have 4-5 fuzz-bugs right now related to timeouts simply in
  generating a module for wasmtime to fuzz. One investigation along
  these lines in the past revealed a bug in binaryen itself, and in any
  case these bugs would otherwise need to get investigated, reported,
  and possibly fixed ourselves in upstream binaryen.

Overall I'm not sure at this point if maintaining binaryen fuzzing is
worth it with the advent of `wasm-smith` which has similar goals for
wasm module generation, but is much more readily maintainable on our
end.

Additonally in this commit I've added a fuzzer for wasm-smith's
`SwarmConfig`-based fuzzer which should expand the coverage of tested
modules.

Closes #2163
