### PR TITLE
Fix icmp_imm.i128

### DIFF
--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -774,12 +774,12 @@ fn narrow_icmp_imm(
     let ty = pos.func.dfg.ctrl_typevar(inst);
     let ty_half = ty.half_width().unwrap();
 
-    let imm_low = pos
-        .ins()
-        .iconst(ty_half, imm & ((1u128 << ty_half.bits()) - 1) as i64);
-    let imm_high = pos
-        .ins()
-        .iconst(ty_half, imm.wrapping_shr(ty_half.bits().into()));
+    let mask = ((1u128 << ty_half.bits()) - 1) as i64;
+    let imm_low = pos.ins().iconst(ty_half, imm & mask);
+    let imm_high = pos.ins().iconst(
+        ty_half,
+        imm.checked_shr(ty_half.bits().into()).unwrap_or(0) & mask,
+    );
     let (arg_low, arg_high) = pos.ins().isplit(arg);
 
     match cond {

--- a/cranelift/filetests/filetests/legalizer/icmp_imm_i128.clif
+++ b/cranelift/filetests/filetests/legalizer/icmp_imm_i128.clif
@@ -1,0 +1,23 @@
+test legalizer
+target x86_64
+
+function %icmp_imm_i128(i128) -> i8 {
+block0(v0: i128):
+    v1 = icmp_imm.i128 eq v0, 1
+    v2 = bint.i8 v1
+    return v2
+}
+
+; check: function %icmp_imm_i128(i64 [%rdi], i64 [%rsi]) -> i8 [%rax] fast {
+; nextln:                                 block0(v3: i64, v4: i64):
+; nextln:                                     v7 -> v3
+; nextln:                                     v8 -> v4
+; nextln: [-]                                 v0 = iconcat v3, v4
+; nextln: [RexOp1pu_id#b8]                    v5 = iconst.i64 1
+; nextln: [RexOp1pu_id#b8]                    v6 = iconst.i64 0
+; nextln: [RexOp1icscc#8039]                  v9 = icmp eq v7, v5
+; nextln: [RexOp1icscc#8039]                  v10 = icmp eq v8, v6
+; nextln: [RexOp1rr#21]                       v1 = band v9, v10
+; nextln: [RexOp2urm_noflags#4b6]             v2 = bint.i8 v1
+; nextln: [Op1ret#c3]                         return v2
+; nextln: }


### PR DESCRIPTION
The immediate splitting code contained a bug causing both low and high
to be equal for i128. This is the root cause for
bjorn3/rustc_codegen_cranelift#1097 and likely the only bug preventing
cg_clif from bootstrapping rustc.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
