### PR TITLE
machinst ABI: Allow back-end to define stack alignment

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -152,6 +152,11 @@ impl ABIMachineSpec for AArch64MachineDeps {
         64
     }
 
+    /// Return required stack alignment in bytes.
+    fn stack_align(_call_conv: isa::CallConv) -> u32 {
+        16
+    }
+
     fn compute_arg_locs(
         call_conv: isa::CallConv,
         params: &[ir::AbiParam],

--- a/cranelift/codegen/src/isa/arm32/abi.rs
+++ b/cranelift/codegen/src/isa/arm32/abi.rs
@@ -45,6 +45,11 @@ impl ABIMachineSpec for Arm32MachineDeps {
         32
     }
 
+    /// Return required stack alignment in bytes.
+    fn stack_align(_call_conv: isa::CallConv) -> u32 {
+        8
+    }
+
     fn compute_arg_locs(
         _call_conv: isa::CallConv,
         params: &[ir::AbiParam],

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -90,6 +90,11 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         64
     }
 
+    /// Return required stack alignment in bytes.
+    fn stack_align(_call_conv: isa::CallConv) -> u32 {
+        16
+    }
+
     fn compute_arg_locs(
         call_conv: isa::CallConv,
         params: &[ir::AbiParam],

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -216,6 +216,9 @@ pub trait ABIMachineSpec {
         }
     }
 
+    /// Returns required stack alignment in bytes.
+    fn stack_align(call_conv: isa::CallConv) -> u32;
+
     /// Process a list of parameters or return values and allocate them to registers
     /// and stack slots.
     ///
@@ -936,7 +939,7 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
             );
             total_stacksize += self.flags.baldrdash_prologue_words() as u32 * bytes;
         }
-        let mask = 2 * bytes - 1;
+        let mask = M::stack_align(self.call_conv) - 1;
         let total_stacksize = (total_stacksize + mask) & !mask; // 16-align the stack.
 
         let mut fixed_frame_storage_size = 0;


### PR DESCRIPTION
The common gen_prologue code currently assumes that the stack
pointer has to be aligned to twice the word size.  While this
is true for many ABIs, it does not hold universally.

This patch adds a new constant STACK_ALIGN that back-ends can
provide to define the specific stack alignment required by the
ABI on that platform.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
