### PR TITLE
Fix off-by-one error looking up frame info for a function

### DIFF
--- a/crates/wasmtime/src/frame_info.rs
+++ b/crates/wasmtime/src/frame_info.rs
@@ -156,8 +156,13 @@ pub fn register(module: &CompiledModule) -> Option<GlobalFrameInfoRegistration> 
         let (start, end) = unsafe {
             let ptr = (*allocated).as_ptr();
             let len = (*allocated).len();
-            (ptr as usize, ptr as usize + len)
+            // First and last byte of the function text.
+            (ptr as usize, ptr as usize + len - 1)
         };
+        // Skip empty functions.
+        if end < start {
+            continue;
+        }
         min = cmp::min(min, start);
         max = cmp::max(max, end);
         let func = FunctionInfo {
@@ -270,4 +275,39 @@ impl FrameInfo {
     pub fn func_offset(&self) -> usize {
         (self.instr.bits() - self.func_start.bits()) as usize
     }
+}
+
+#[test]
+fn test_frame_info() -> Result<(), anyhow::Error> {
+    use crate::*;
+    let store = Store::default();
+    let module = Module::new(
+        store.engine(),
+        r#"
+            (module
+                (func (export "add") (param $x i32) (param $y i32) (result i32) (i32.add (local.get $x) (local.get $y)))
+                (func (export "sub") (param $x i32) (param $y i32) (result i32) (i32.sub (local.get $x) (local.get $y)))
+                (func (export "mul") (param $x i32) (param $y i32) (result i32) (i32.mul (local.get $x) (local.get $y)))
+                (func (export "div_s") (param $x i32) (param $y i32) (result i32) (i32.div_s (local.get $x) (local.get $y)))
+                (func (export "div_u") (param $x i32) (param $y i32) (result i32) (i32.div_u (local.get $x) (local.get $y)))
+                (func (export "rem_s") (param $x i32) (param $y i32) (result i32) (i32.rem_s (local.get $x) (local.get $y)))
+                (func (export "rem_u") (param $x i32) (param $y i32) (result i32) (i32.rem_u (local.get $x) (local.get $y)))
+            )
+         "#,
+    )?;
+    // Create an instance to ensure the frame information is registered.
+    let _ = Instance::new(&store, &module, &[])?;
+    let info = FRAME_INFO.read().unwrap();
+    for (i, alloc) in module.compiled_module().finished_functions() {
+        let (start, end) = unsafe {
+            let ptr = (**alloc).as_ptr();
+            let len = (**alloc).len();
+            (ptr as usize, ptr as usize + len)
+        };
+        for pc in start..end {
+            let frame = info.lookup_frame_info(pc).unwrap();
+            assert!(frame.func_index() == i.as_u32());
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
The ModuleFrameInfo and FunctionInfo data structures maintain
a list of ranges via a BTreeMap.  The key to that map is one
past the end of the module/function in question.  This causes
a problem in the case of immediately adjacent ranges.  For
example, if we have two functions occupying adjacent ranges:
  A:   0-100
  B: 100-200
function A is stored with a key of 100 and B with a key of 200.

Now, when looking up the function associated with address 100,
we'd expect to find B.  However the current code:

       let (end, func) = info.functions.range(pc..).next()?;
       if pc < func.start || *end < pc {

will look up the value 100 in the map and return function A,
which will then fail the pc < func.start check in the next
line, so the result will be failure.

Instead, it seems we need to look up the range starting at pc + 1.
In addition, the *end < pc check also look incorrect: in the case
of *end == pc, the PC value is actually outside of the function
that was found, and we should therefore return failure.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
