### PR TITLE
Fix a panic in table-ops translation

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -494,6 +494,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
                 let reference_type = self.reference_type(WasmType::ExternRef);
 
+                builder.ensure_inserted_block();
                 let continue_block = builder.create_block();
                 let non_null_elem_block = builder.create_block();
                 let gc_block = builder.create_block();
@@ -643,6 +644,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 //    drop the old table element *after* we've replaced it with
                 //    the new `value`!
 
+                builder.ensure_inserted_block();
                 let current_block = builder.current_block().unwrap();
                 let inc_ref_count_block = builder.create_block();
                 builder.insert_block_after(inc_ref_count_block, current_block);

--- a/tests/misc_testsuite/reference-types/no-panic.wast
+++ b/tests/misc_testsuite/reference-types/no-panic.wast
@@ -1,0 +1,26 @@
+(module
+  (func $test (param i32) (result externref)
+        i32.const 0
+        if
+        else
+        end
+        local.get 0
+        table.get 0
+  )
+  (table 4 externref)
+  (export "test" (func $test))
+)
+
+(module
+  (func $test (param i32)
+        i32.const 0
+        if
+        else
+        end
+        local.get 0
+        ref.null extern
+        table.set 0
+  )
+  (table 4 externref)
+  (export "test" (func $test))
+)


### PR DESCRIPTION
This fixes an issue where `ensure_inserted_block()` wasn't called before
we do some block manipulation in the Wasmtime translation of some
table-related instructions. It looks like `ensure_inserted_block()` is
otherwise called on most instructions being added, so we just need to
call it explicitly it seems here.

Closes #2347
