### PR TITLE
x64 new-backend CI: use `Cargo.lock` in build.

### DIFF
--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -6,6 +6,7 @@
 CARGO_VERSION=${CARGO_VERSION:-"+nightly"}
 
 cargo $CARGO_VERSION \
+            --locked \
             -Zfeatures=all -Zpackage-features \
             test \
             --features test-programs/test_programs \


### PR DESCRIPTION
We do a `cargo fetch --locked` for most of our CI builds, but
`run-experimental-x64-ci.sh` was not doing this. As a result, some CI
runs seem to fail depending on which versions of crates they download. A
common failure mode is that two different versions of the `syn` crate
get into the build somehow, resulting in errors in wiggle/witx.

This change simply adds the `--locked` flag to the `cargo test` run for
the new x64 backend.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
