### PR TITLE
Add extension marker to i32 arguments of builtin functions

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -69,7 +69,16 @@ macro_rules! declare_function_signatures {
             }
 
             fn i32(&self) -> AbiParam {
-                AbiParam::new(I32)
+                // Some platform ABIs require i32 values to be zero- or sign-
+                // extended to the full register width.  We need to indicate
+                // this here by using the appropriate .uext or .sext attribute.
+                // The attribute can be added unconditionally; platforms whose
+                // ABI does not require such extensions will simply ignore it.
+                // Note that currently all i32 arguments or return values used
+                // by builtin functions are unsigned, so we always use .uext.
+                // If that ever changes, we will have to add a second type
+                // marker here.
+                AbiParam::new(I32).uext()
             }
 
             $(


### PR DESCRIPTION
Some platform ABIs require i32 values to be zero- or sign-extended
to the full register width.  The extension is implemented by the
cranelift codegen backend, but this happens only if the appropriate
"uext" or "sext" attribute is present in the cranelift IR.

For calls to builtin functions, that IR is synthesized by the code
in func_environ.rs -- to ensure correct codegen for the target ABI,
this code needs to add those attributes as necessary.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
