### PR TITLE
aarch64: Fix aarch64_map_regs for FpuRRI

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2311,11 +2311,15 @@ fn aarch64_map_regs<RUM: RegUsageMapper>(inst: &mut Inst, mapper: &RUM) {
             map_use(mapper, rm);
         }
         &mut Inst::FpuRRI {
+            fpu_op,
             ref mut rd,
             ref mut rn,
             ..
         } => {
-            map_def(mapper, rd);
+            match fpu_op {
+                FPUOpRI::UShr32(..) | FPUOpRI::UShr64(..) => map_def(mapper, rd),
+                FPUOpRI::Sli32(..) | FPUOpRI::Sli64(..) => map_mod(mapper, rd),
+            }
             map_use(mapper, rn);
         }
         &mut Inst::FpuRRRR {


### PR DESCRIPTION
This was wrong since I added it in 02c3f238f.

Copyright (c) 2020, Arm Limited.