### PR TITLE
Move native signatures out of `Module`

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -362,12 +362,18 @@ impl Compiler for Cranelift {
         let func_index = module.func_index(func_index);
         let mut context = Context::new();
         context.func.name = get_func_name(func_index);
-        context.func.signature = module.native_func_signature(func_index).clone();
+        let sig_index = module.functions[func_index];
+        context.func.signature = translation.native_signatures[sig_index].clone();
         if tunables.debug_info {
             context.func.collect_debug_info();
         }
 
-        let mut func_env = FuncEnvironment::new(isa.frontend_config(), module, tunables);
+        let mut func_env = FuncEnvironment::new(
+            isa.frontend_config(),
+            module,
+            &translation.native_signatures,
+            tunables,
+        );
 
         // We use these as constant offsets below in
         // `stack_limit_from_arguments`, so assert their values here. This

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -2,7 +2,6 @@
 
 use crate::tunables::Tunables;
 use crate::WASM_MAX_PAGES;
-use cranelift_codegen::ir;
 use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_wasm::{
     DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
@@ -169,7 +168,7 @@ pub struct Module {
     pub func_names: HashMap<FuncIndex, String>,
 
     /// Unprocessed signatures exactly as provided by `declare_signature()`.
-    pub signatures: PrimaryMap<SignatureIndex, (WasmFuncType, ir::Signature)>,
+    pub signatures: PrimaryMap<SignatureIndex, WasmFuncType>,
 
     /// Number of imported functions in the module.
     pub num_imported_funcs: usize,
@@ -319,16 +318,10 @@ impl Module {
         index.index() < self.num_imported_globals
     }
 
-    /// Convenience method for looking up the native signature of a compiled
-    /// Wasm function.
-    pub fn native_func_signature(&self, func_index: FuncIndex) -> &ir::Signature {
-        &self.signatures[self.functions[func_index]].1
-    }
-
     /// Convenience method for looking up the original Wasm signature of a
     /// function.
     pub fn wasm_func_type(&self, func_index: FuncIndex) -> &WasmFuncType {
-        &self.signatures[self.functions[func_index]].0
+        &self.signatures[self.functions[func_index]]
     }
 }
 

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -158,8 +158,7 @@ impl Compiler {
             vec![]
         };
 
-        let (obj, unwind_info) =
-            build_object(&*self.isa, &translation.module, &funcs, dwarf_sections)?;
+        let (obj, unwind_info) = build_object(&*self.isa, &translation, &funcs, dwarf_sections)?;
 
         Ok(Compilation {
             obj,

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -541,7 +541,7 @@ impl Func {
         // Signatures should always be registered in the store's registry of
         // shared signatures, so we should be able to unwrap safely here.
         let signatures = self.instance.store.signatures().borrow();
-        let (wft, _, _) = signatures
+        let (wft, _) = signatures
             .lookup_shared(self.sig_index())
             .expect("signature should be registered");
 
@@ -554,7 +554,7 @@ impl Func {
     /// Returns the number of parameters that this function takes.
     pub fn param_arity(&self) -> usize {
         let signatures = self.instance.store.signatures().borrow();
-        let (sig, _, _) = signatures
+        let (sig, _) = signatures
             .lookup_shared(self.sig_index())
             .expect("signature should be registered");
         sig.params.len()
@@ -563,7 +563,7 @@ impl Func {
     /// Returns the number of results this function produces.
     pub fn result_arity(&self) -> usize {
         let signatures = self.instance.store.signatures().borrow();
-        let (sig, _, _) = signatures
+        let (sig, _) = signatures
             .lookup_shared(self.sig_index())
             .expect("signature should be registered");
         sig.returns.len()
@@ -657,7 +657,7 @@ impl Func {
             .borrow()
             .lookup_shared(unsafe { export.anyfunc.as_ref().type_index })
             .expect("failed to retrieve trampoline from module")
-            .2;
+            .1;
 
         Func {
             instance,

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -293,7 +293,7 @@ fn with_imports<R>(
                 let ty = store
                     .signatures()
                     .borrow()
-                    .lookup(&m.signatures[m.functions[i]].0)
+                    .lookup(&m.signatures[m.functions[i]])
                     .ok_or_else(|| anyhow!("function types incompatible"))?;
                 if !func.matches_expected(ty) {
                     bail!("function types incompatible");

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -915,10 +915,9 @@ impl Store {
         module: &'a wasmtime_environ::Module,
     ) -> impl Fn(wasm::SignatureIndex) -> VMSharedSignatureIndex + 'a {
         move |index| {
-            let (wasm, _native) = &module.signatures[index];
             self.signatures()
                 .borrow()
-                .lookup(wasm)
+                .lookup(&module.signatures[index])
                 .expect("signature not previously registered")
         }
     }
@@ -993,8 +992,8 @@ impl Store {
         let trampolines = module.compiled_module().trampolines();
         let module = module.compiled_module().module();
         let mut signatures = self.signatures().borrow_mut();
-        for (index, (wasm, native)) in module.signatures.iter() {
-            signatures.register(wasm, native, trampolines[index]);
+        for (index, wasm) in module.signatures.iter() {
+            signatures.register(wasm, trampolines[index]);
         }
     }
 

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -223,7 +223,7 @@ pub fn create_handle_with_function(
 
     // First up we manufacture a trampoline which has the ABI specified by `ft`
     // and calls into `stub_fn`...
-    let sig_id = module.signatures.push((wft.clone(), sig.clone()));
+    let sig_id = module.signatures.push(wft.clone());
     let func_id = module.functions.push(sig_id);
     module
         .exports
@@ -241,10 +241,7 @@ pub fn create_handle_with_function(
         &sig,
         mem::size_of::<u128>(),
     )?;
-    store
-        .signatures()
-        .borrow_mut()
-        .register(&wft, &sig, trampoline);
+    store.signatures().borrow_mut().register(&wft, trampoline);
 
     // Next up we wrap everything up into an `InstanceHandle` by publishing our
     // code memory (makes it executable) and ensuring all our various bits of
@@ -268,23 +265,18 @@ pub unsafe fn create_handle_with_raw_function(
     store: &Store,
     state: Box<dyn Any>,
 ) -> Result<StoreInstanceHandle> {
-    let pointer_type = store.engine().compiler().isa().pointer_type();
-    let sig = ft.get_wasmtime_signature(pointer_type);
     let wft = ft.to_wasm_func_type();
 
     let mut module = Module::new();
     let mut finished_functions = PrimaryMap::new();
 
-    let sig_id = module.signatures.push((wft.clone(), sig.clone()));
+    let sig_id = module.signatures.push(wft.clone());
     let func_id = module.functions.push(sig_id);
     module
         .exports
         .insert(String::new(), EntityIndex::Function(func_id));
     finished_functions.push(func);
-    store
-        .signatures()
-        .borrow_mut()
-        .register(&wft, &sig, trampoline);
+    store.signatures().borrow_mut().register(&wft, trampoline);
 
     create_handle(module, store, finished_functions, state, &[])
 }

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -37,10 +37,10 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
                 // our global with a `ref.func` to grab that imported function.
                 let signatures = store.signatures().borrow();
                 let shared_sig_index = f.sig_index();
-                let (wasm, native, _) = signatures
+                let (wasm, _) = signatures
                     .lookup_shared(shared_sig_index)
                     .expect("signature not registered");
-                let local_sig_index = module.signatures.push((wasm.clone(), native.clone()));
+                let local_sig_index = module.signatures.push(wasm.clone());
                 let func_index = module.functions.push(local_sig_index);
                 module.num_imported_funcs = 1;
                 module


### PR DESCRIPTION
After compilation there's actually no need to hold onto the native
signature for a wasm function type, so this commit moves out the
`ir::Signature` value from a `Module` into a separate field that's
deallocated when compilation is finished. This simplifies the
`SignatureRegistry` because it only needs to track wasm functino types
and it also means less work is done for `Func::wrap`.
