### PR TITLE
Store `WasmFuncType` in `FuncType`

### DIFF
--- a/crates/c-api/src/types/func.rs
+++ b/crates/c-api/src/types/func.rs
@@ -54,17 +54,9 @@ pub extern "C" fn wasm_functype_new(
     params: &mut wasm_valtype_vec_t,
     results: &mut wasm_valtype_vec_t,
 ) -> Box<wasm_functype_t> {
-    let params = params
-        .take()
-        .into_iter()
-        .map(|vt| vt.unwrap().ty.clone())
-        .collect::<Vec<_>>();
-    let results = results
-        .take()
-        .into_iter()
-        .map(|vt| vt.unwrap().ty.clone())
-        .collect::<Vec<_>>();
-    let functype = FuncType::new(params.into_boxed_slice(), results.into_boxed_slice());
+    let params = params.take().into_iter().map(|vt| vt.unwrap().ty.clone());
+    let results = results.take().into_iter().map(|vt| vt.unwrap().ty.clone());
+    let functype = FuncType::new(params, results);
     Box::new(wasm_functype_t::new(functype))
 }
 
@@ -74,7 +66,6 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
     ft.params_cache.get_or_init(|| {
         ft.ty
             .params()
-            .iter()
             .map(|p| Some(Box::new(wasm_valtype_t { ty: p.clone() })))
             .collect::<Vec<_>>()
             .into()
@@ -87,7 +78,6 @@ pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_v
     ft.returns_cache.get_or_init(|| {
         ft.ty
             .results()
-            .iter()
             .map(|p| Some(Box::new(wasm_valtype_t { ty: p.clone() })))
             .collect::<Vec<_>>()
             .into()

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -25,7 +25,7 @@ pub fn dummy_imports<'module>(
 /// Construct a dummy function for the given function type
 pub fn dummy_func(store: &Store, ty: FuncType) -> Func {
     Func::new(store, ty.clone(), move |_, _, results| {
-        for (ret_ty, result) in ty.results().iter().zip(results) {
+        for (ret_ty, result) in ty.results().zip(results) {
             *result = dummy_value(ret_ty)?;
         }
         Ok(())
@@ -33,7 +33,7 @@ pub fn dummy_func(store: &Store, ty: FuncType) -> Func {
 }
 
 /// Construct a dummy value for the given value type.
-pub fn dummy_value(val_ty: &ValType) -> Result<Val, Trap> {
+pub fn dummy_value(val_ty: ValType) -> Result<Val, Trap> {
     Ok(match val_ty {
         ValType::I32 => Val::I32(0),
         ValType::I64 => Val::I64(0),
@@ -58,19 +58,19 @@ pub fn dummy_value(val_ty: &ValType) -> Result<Val, Trap> {
 }
 
 /// Construct a sequence of dummy values for the given types.
-pub fn dummy_values(val_tys: &[ValType]) -> Result<Vec<Val>, Trap> {
-    val_tys.iter().map(dummy_value).collect()
+pub fn dummy_values(val_tys: impl IntoIterator<Item = ValType>) -> Result<Vec<Val>, Trap> {
+    val_tys.into_iter().map(dummy_value).collect()
 }
 
 /// Construct a dummy global for the given global type.
 pub fn dummy_global(store: &Store, ty: GlobalType) -> Result<Global, Trap> {
-    let val = dummy_value(ty.content())?;
+    let val = dummy_value(ty.content().clone())?;
     Ok(Global::new(store, ty, val).unwrap())
 }
 
 /// Construct a dummy table for the given table type.
 pub fn dummy_table(store: &Store, ty: TableType) -> Result<Table, Trap> {
-    let init_val = dummy_value(&ty.element())?;
+    let init_val = dummy_value(ty.element().clone())?;
     Ok(Table::new(store, ty, init_val).unwrap())
 }
 

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -716,7 +716,7 @@ impl Linker {
         // Otherwise return a no-op function.
         Ok(Func::new(
             &self.store,
-            FuncType::new(Vec::new().into_boxed_slice(), Vec::new().into_boxed_slice()),
+            FuncType::new(None, None),
             move |_, _, _| Ok(()),
         ))
     }

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -214,7 +214,7 @@ pub fn create_handle_with_function(
 
     let pointer_type = isa.pointer_type();
     let sig = ft.get_wasmtime_signature(pointer_type);
-    let wft = ft.to_wasm_func_type();
+    let wft = ft.as_wasm_func_type();
 
     let mut fn_builder_ctx = FunctionBuilderContext::new();
     let mut module = Module::new();
@@ -241,7 +241,7 @@ pub fn create_handle_with_function(
         &sig,
         mem::size_of::<u128>(),
     )?;
-    store.signatures().borrow_mut().register(&wft, trampoline);
+    store.signatures().borrow_mut().register(wft, trampoline);
 
     // Next up we wrap everything up into an `InstanceHandle` by publishing our
     // code memory (makes it executable) and ensuring all our various bits of
@@ -265,7 +265,7 @@ pub unsafe fn create_handle_with_raw_function(
     store: &Store,
     state: Box<dyn Any>,
 ) -> Result<StoreInstanceHandle> {
-    let wft = ft.to_wasm_func_type();
+    let wft = ft.as_wasm_func_type();
 
     let mut module = Module::new();
     let mut finished_functions = PrimaryMap::new();
@@ -276,7 +276,7 @@ pub unsafe fn create_handle_with_raw_function(
         .exports
         .insert(String::new(), EntityIndex::Function(func_id));
     finished_functions.push(func);
-    store.signatures().borrow_mut().register(&wft, trampoline);
+    store.signatures().borrow_mut().register(wft, trampoline);
 
     create_handle(module, store, finished_functions, state, &[])
 }

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -112,7 +112,7 @@ impl Val {
         }
     }
 
-    pub(crate) unsafe fn read_value_from(store: &Store, p: *const u128, ty: &ValType) -> Val {
+    pub(crate) unsafe fn read_value_from(store: &Store, p: *const u128, ty: ValType) -> Val {
         match ty {
             ValType::I32 => Val::I32(ptr::read(p as *const i32)),
             ValType::I64 => Val::I64(ptr::read(p as *const i64)),

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -22,8 +22,8 @@ fn main() -> Result<()> {
     // Create external print functions.
     println!("Creating callback...");
     let callback_type = FuncType::new(
-        Box::new([ValType::I32, ValType::I64]),
-        Box::new([ValType::I64, ValType::I32]),
+        [ValType::I32, ValType::I64].iter().cloned(),
+        [ValType::I64, ValType::I32].iter().cloned(),
     );
     let callback_func = Func::new(&store, callback_type, |_, args, results| {
         println!("Calling back...");

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -8,18 +8,14 @@ use wasmtime::*;
 const N_THREADS: i32 = 10;
 const N_REPS: i32 = 3;
 
-fn print_message(_: Caller<'_>, args: &[Val], _: &mut [Val]) -> Result<(), Trap> {
-    println!("> Thread {} is running", args[0].unwrap_i32());
-    Ok(())
-}
-
 fn run(engine: &Engine, module: Module, id: i32) -> Result<()> {
     let store = Store::new(&engine);
 
     // Create external print functions.
     println!("Creating callback...");
-    let callback_type = FuncType::new(Box::new([ValType::I32]), Box::new([]));
-    let callback_func = Func::new(&store, callback_type, print_message);
+    let callback_func = Func::wrap(&store, |arg: i32| {
+        println!("> Thread {} is running", arg);
+    });
 
     let id_type = GlobalType::new(ValType::I32, Mutability::Const);
     let id_global = Global::new(&store, id_type, Val::I32(id))?;

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -78,26 +78,26 @@ fn signatures_match() {
     let store = Store::default();
 
     let f = Func::wrap(&store, || {});
-    assert_eq!(f.ty().params(), &[]);
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
     assert_eq!(f.param_arity(), 0);
-    assert_eq!(f.ty().results(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[]);
     assert_eq!(f.result_arity(), 0);
 
     let f = Func::wrap(&store, || -> i32 { loop {} });
-    assert_eq!(f.ty().params(), &[]);
-    assert_eq!(f.ty().results(), &[ValType::I32]);
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::I32]);
 
     let f = Func::wrap(&store, || -> i64 { loop {} });
-    assert_eq!(f.ty().params(), &[]);
-    assert_eq!(f.ty().results(), &[ValType::I64]);
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::I64]);
 
     let f = Func::wrap(&store, || -> f32 { loop {} });
-    assert_eq!(f.ty().params(), &[]);
-    assert_eq!(f.ty().results(), &[ValType::F32]);
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::F32]);
 
     let f = Func::wrap(&store, || -> f64 { loop {} });
-    assert_eq!(f.ty().params(), &[]);
-    assert_eq!(f.ty().results(), &[ValType::F64]);
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::F64]);
 
     let f = Func::wrap(
         &store,
@@ -106,7 +106,7 @@ fn signatures_match() {
         },
     );
     assert_eq!(
-        f.ty().params(),
+        f.ty().params().collect::<Vec<_>>(),
         &[
             ValType::F32,
             ValType::F64,
@@ -117,7 +117,7 @@ fn signatures_match() {
             ValType::FuncRef,
         ]
     );
-    assert_eq!(f.ty().results(), &[ValType::F64]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::F64]);
 }
 
 #[test]
@@ -283,13 +283,13 @@ fn get_from_wrapper() {
 #[test]
 fn get_from_signature() {
     let store = Store::default();
-    let ty = FuncType::new(Box::new([]), Box::new([]));
+    let ty = FuncType::new(None, None);
     let f = Func::new(&store, ty, |_, _, _| panic!());
     assert!(f.get0::<()>().is_ok());
     assert!(f.get0::<i32>().is_err());
     assert!(f.get1::<i32, ()>().is_err());
 
-    let ty = FuncType::new(Box::new([ValType::I32]), Box::new([ValType::F64]));
+    let ty = FuncType::new(Some(ValType::I32), Some(ValType::F64));
     let f = Func::new(&store, ty, |_, _, _| panic!());
     assert!(f.get0::<()>().is_err());
     assert!(f.get0::<i32>().is_err());
@@ -434,7 +434,7 @@ fn caller_memory() -> anyhow::Result<()> {
 #[test]
 fn func_write_nothing() -> anyhow::Result<()> {
     let store = Store::default();
-    let ty = FuncType::new(Box::new([]), Box::new([ValType::I32]));
+    let ty = FuncType::new(None, Some(ValType::I32));
     let f = Func::new(&store, ty, |_, _, _| Ok(()));
     let err = f.call(&[]).unwrap_err().downcast::<Trap>()?;
     assert!(err
@@ -515,8 +515,8 @@ fn externref_signature_no_reference_types() -> anyhow::Result<()> {
     Func::new(
         &store,
         FuncType::new(
-            Box::new([ValType::FuncRef, ValType::ExternRef]),
-            Box::new([ValType::FuncRef, ValType::ExternRef]),
+            [ValType::FuncRef, ValType::ExternRef].iter().cloned(),
+            [ValType::FuncRef, ValType::ExternRef].iter().cloned(),
         ),
         |_, _, _| Ok(()),
     );

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -22,21 +22,17 @@ fn test_import_calling_export() {
     let other = Rc::new(RefCell::new(None::<Func>));
     let other2 = Rc::downgrade(&other);
 
-    let callback_func = Func::new(
-        &store,
-        FuncType::new(Box::new([]), Box::new([])),
-        move |_, _, _| {
-            other2
-                .upgrade()
-                .unwrap()
-                .borrow()
-                .as_ref()
-                .expect("expected a function ref")
-                .call(&[])
-                .expect("expected function not to trap");
-            Ok(())
-        },
-    );
+    let callback_func = Func::new(&store, FuncType::new(None, None), move |_, _, _| {
+        other2
+            .upgrade()
+            .unwrap()
+            .borrow()
+            .as_ref()
+            .expect("expected a function ref")
+            .call(&[])
+            .expect("expected function not to trap");
+        Ok(())
+    });
 
     let imports = vec![callback_func.into()];
     let instance =
@@ -71,7 +67,7 @@ fn test_returns_incorrect_type() -> Result<()> {
 
     let callback_func = Func::new(
         &store,
-        FuncType::new(Box::new([]), Box::new([ValType::I32])),
+        FuncType::new(None, Some(ValType::I32)),
         |_, _, results| {
             // Evil! Returns I64 here instead of promised in the signature I32.
             results[0] = Val::I64(228);

--- a/tests/all/import_indexes.rs
+++ b/tests/all/import_indexes.rs
@@ -20,7 +20,7 @@ fn same_import_names_still_distinct() -> anyhow::Result<()> {
     let imports = [
         Func::new(
             &store,
-            FuncType::new(Box::new([]), Box::new([ValType::I32])),
+            FuncType::new(None, Some(ValType::I32)),
             |_, params, results| {
                 assert!(params.is_empty());
                 assert_eq!(results.len(), 1);
@@ -31,7 +31,7 @@ fn same_import_names_still_distinct() -> anyhow::Result<()> {
         .into(),
         Func::new(
             &store,
-            FuncType::new(Box::new([]), Box::new([ValType::F32])),
+            FuncType::new(None, Some(ValType::F32)),
             |_, params, results| {
                 assert!(params.is_empty());
                 assert_eq!(results.len(), 1);

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -13,7 +13,7 @@ fn test_trap_return() -> Result<()> {
     "#;
 
     let module = Module::new(store.engine(), wat)?;
-    let hello_type = FuncType::new(Box::new([]), Box::new([]));
+    let hello_type = FuncType::new(None, None);
     let hello_func = Func::new(&store, hello_type, |_, _, _| Err(Trap::new("test 123")));
 
     let instance = Instance::new(&store, &module, &[hello_func.into()])?;
@@ -86,7 +86,7 @@ fn test_trap_trace_cb() -> Result<()> {
         )
     "#;
 
-    let fn_type = FuncType::new(Box::new([]), Box::new([]));
+    let fn_type = FuncType::new(None, None);
     let fn_func = Func::new(&store, fn_type, |_, _, _| Err(Trap::new("cb throw")));
 
     let module = Module::new(store.engine(), wat)?;
@@ -237,7 +237,7 @@ fn trap_start_function_import() -> Result<()> {
     )?;
 
     let module = Module::new(store.engine(), &binary)?;
-    let sig = FuncType::new(Box::new([]), Box::new([]));
+    let sig = FuncType::new(None, None);
     let func = Func::new(&store, sig, |_, _, _| Err(Trap::new("user trap")));
     let err = Instance::new(&store, &module, &[func.into()])
         .err()
@@ -267,7 +267,7 @@ fn rust_panic_import() -> Result<()> {
     )?;
 
     let module = Module::new(store.engine(), &binary)?;
-    let sig = FuncType::new(Box::new([]), Box::new([]));
+    let sig = FuncType::new(None, None);
     let func = Func::new(&store, sig, |_, _, _| panic!("this is a panic"));
     let instance = Instance::new(
         &store,
@@ -311,7 +311,7 @@ fn rust_panic_start_function() -> Result<()> {
     )?;
 
     let module = Module::new(store.engine(), &binary)?;
-    let sig = FuncType::new(Box::new([]), Box::new([]));
+    let sig = FuncType::new(None, None);
     let func = Func::new(&store, sig, |_, _, _| panic!("this is a panic"));
     let err = panic::catch_unwind(AssertUnwindSafe(|| {
         drop(Instance::new(&store, &module, &[func.into()]));


### PR DESCRIPTION
This commit updates `wasmtime::FuncType` to exactly store an internal
`WasmFuncType` from the cranelift crates. This allows us to remove a
translation layer when we are given a `FuncType` and want to get an
internal cranelift type out as a result.

The other major change from this commit was changing the constructor and
accessors of `FuncType` to be iterator-based instead of exposing
implementation details.
