### PR TITLE
Get lightbeam compiling on stable Rust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,9 +55,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    # Note that we use nightly Rust here to get intra-doc links which are a
+    # nightly-only feature right now.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-11-02
+        toolchain: nightly
     - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
     - run: cargo doc --package cranelift-codegen-meta --document-private-items
     - uses: actions/upload-artifact@v1
@@ -91,8 +93,6 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-      with:
-        toolchain: nightly-2020-11-02
 
     # Check some feature combinations of the `wasmtime` crate
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --no-default-features
@@ -140,9 +140,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    # Note that building with fuzzers requires nightly since it uses unstable
+    # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-11-02
+        toolchain: nightly
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
@@ -199,7 +201,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2020-11-02
+            rust: nightly
           - build: macos
             os: macos-latest
             rust: stable
@@ -268,12 +270,10 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-    # Build and test lightbeam if we're using the nightly toolchain. Note that
+    # Build and test lightbeam. Note that
     # Lightbeam tests fail right now, but we don't want to block on that.
     - run: cargo build --package lightbeam
-      if: matrix.build == 'nightly'
     - run: cargo test --package lightbeam
-      if: matrix.build == 'nightly'
       continue-on-error: true
       env:
         RUST_BACKTRACE: 1
@@ -290,7 +290,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-11-02
+        toolchain: nightly
     - uses: ./.github/actions/define-llvm-env
 
     # Install wasm32 targets in order to build various tests throughout the
@@ -301,7 +301,7 @@ jobs:
     # Run the x64 CI script.
     - run: ./ci/run-experimental-x64-ci.sh
       env:
-        CARGO_VERSION: "+nightly-2020-11-02"
+        CARGO_VERSION: "+nightly"
         RUST_BACKTRACE: 1
 
   # Verify that cranelift's code generation is deterministic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,20 +183,22 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "capstone"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031ba51c39151a1d6336ec859646153187204b0147c7b3f6fe2de636f1b8dbb3"
+checksum = "f60e7f097987a09a9b678c6214b5a5eb326f9fc1e3eac88cce5d086c2b3b8dc9"
 dependencies = [
  "capstone-sys",
+ "libc",
 ]
 
 [[package]]
 name = "capstone-sys"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae25eddcb80e24f98c35952c37a91ff7f8d0f60dbbdafb9763e8d5cc566b8d7"
+checksum = "aebe07897b48983847943662bfc3198aabfa51636c81313c1955d04d857ed739"
 dependencies = [
  "cc",
+ "libc",
 ]
 
 [[package]]
@@ -710,14 +712,14 @@ dependencies = [
 
 [[package]]
 name = "dynasm"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a814e1edeb85dd2a3c6fc0d6bf76d02ca5695d438c70ecee3d90774f3259c5"
+checksum = "62a59fbab09460c1569eeea9b5e4cf62f13f5198b1c2ba0e5196dd7fdd17cd42"
 dependencies = [
  "bitflags",
  "byteorder",
  "lazy_static",
- "owning_ref",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -725,11 +727,12 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a393aaeb4441a48bcf47b5b6155971f82cc1eb77e22855403ccc0415ac8328d"
+checksum = "85bec3edae2841d37b1c3dc7f3fd403c9061f26e9ffeeee97a3ea909b1bb2ef1"
 dependencies = [
  "byteorder",
+ "dynasm",
  "memmap",
 ]
 
@@ -1070,6 +1073,7 @@ name = "lightbeam"
 version = "0.21.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "capstone",
  "cranelift-codegen",
  "derive_more",
@@ -1082,7 +1086,6 @@ dependencies = [
  "more-asserts",
  "quickcheck",
  "smallvec",
- "staticvec",
  "thiserror",
  "typemap",
  "wasmparser 0.65.0",
@@ -1245,15 +1248,6 @@ checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1852,12 +1846,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "staticvec"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f4be0fd89694157f3814ca88715ad8ba6010c453b1e89ca264aee04d70b9"
 
 [[package]]
 name = "strsim"

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -32,7 +32,7 @@ cranelift = { path = "umbrella", version = "0.68.0" }
 filecheck = "0.5.0"
 log = "0.4.8"
 term = "0.6.1"
-capstone = { version = "0.6.0", optional = true }
+capstone = { version = "0.7.0", optional = true }
 wat = { version = "1.0.18", optional = true }
 target-lexicon = { version = "0.11", features = ["std"] }
 peepmatic-souper = { path = "./peepmatic/crates/souper", version = "0.68.0", optional = true }

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -11,17 +11,17 @@ keywords = ["webassembly", "wasm", "compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-capstone = "0.6.0"
+arrayvec = "0.5"
+capstone = "0.7.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.68.0" }
 derive_more = "0.99"
-dynasm = "0.5.2"
-dynasmrt = "0.5.2"
+dynasm = "1.0.0"
+dynasmrt = "1.0.0"
 iter-enum = "0.2"
 itertools = "0.9.0"
 memoffset = "0.6.0"
 more-asserts = "0.2.1"
 smallvec = "1.0.0"
-staticvec = "0.10"
 thiserror = "1.0.9"
 typemap = "0.3"
 wasmparser = "0.65.0"

--- a/crates/lightbeam/src/disassemble.rs
+++ b/crates/lightbeam/src/disassemble.rs
@@ -2,6 +2,7 @@ use capstone::prelude::*;
 use dynasmrt::AssemblyOffset;
 use std::error::Error;
 use std::fmt::{Display, Write};
+use std::io;
 
 pub fn disassemble<D: Display>(
     mem: &[u8],
@@ -10,10 +11,11 @@ pub fn disassemble<D: Display>(
     let cs = Capstone::new()
         .x86()
         .mode(arch::x86::ArchMode::Mode64)
-        .build()?;
+        .build()
+        .map_err(map_caperr)?;
 
     println!("{} bytes:", mem.len());
-    let insns = cs.disasm_all(&mem, 0x0)?;
+    let insns = cs.disasm_all(&mem, 0x0).map_err(map_caperr)?;
     for i in insns.iter() {
         let mut line = String::new();
 
@@ -48,4 +50,8 @@ pub fn disassemble<D: Display>(
     }
 
     Ok(())
+}
+
+fn map_caperr(err: capstone::Error) -> Box<dyn Error> {
+    Box::new(io::Error::new(io::ErrorKind::Other, err.to_string()))
 }

--- a/crates/lightbeam/src/lib.rs
+++ b/crates/lightbeam/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(test, feature(test))]
-#![feature(proc_macro_hygiene)]
 
 #[cfg(test)]
 extern crate test;


### PR DESCRIPTION
This will hopefully remove a small thorn in our side with periodic
nightly breakage due to nightly features changing. This commit moves
lightbeam to stable Rust, swapping out `staticvec` for `arrayvec` and
otherwise updating some dependencies (namely `dynasm`) to compile with
stable.

This then also updates CI appropriately to not use a pinned nightly and
instead us a floating `nightly` channel so we can head off any breakage
coming up ASAP.

