### PR TITLE
Allow offloading compilation in cranelift-object

### DIFF
--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -44,7 +44,7 @@ mod traps;
 pub use crate::data_context::{DataContext, DataDescription, Init};
 pub use crate::module::{
     DataId, FuncId, FuncOrDataId, Linkage, Module, ModuleCompiledFunction, ModuleDeclarations,
-    ModuleError, ModuleResult,
+    ModuleError, ModuleResult, RelocRecord,
 };
 pub use crate::traps::TrapSite;
 

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -335,6 +335,19 @@ pub struct ModuleCompiledFunction {
     pub size: binemit::CodeOffset,
 }
 
+/// A record of a relocation to perform.
+#[derive(Clone)]
+pub struct RelocRecord {
+    /// Where in the generated code this relocation is to be applied.
+    pub offset: binemit::CodeOffset,
+    /// The kind of relocation this represents.
+    pub reloc: binemit::Reloc,
+    /// What symbol we're relocating against.
+    pub name: ir::ExternalName,
+    /// The offset to add to the relocation.
+    pub addend: binemit::Addend,
+}
+
 /// A `Module` is a utility for collecting functions and data objects, and linking them together.
 pub trait Module {
     /// Return the `TargetIsa` to compile for.
@@ -470,6 +483,7 @@ pub trait Module {
         &mut self,
         func: FuncId,
         bytes: &[u8],
+        relocs: &[RelocRecord],
     ) -> ModuleResult<ModuleCompiledFunction>;
 
     /// Define a data object, producing the data contents from the given `DataContext`.


### PR DESCRIPTION
This commit is a slight refactoring of the `Module` trait and backend in
`cranelift-object`. The goal is to enable parallelization of compilation
when using `cranelift-object`. Currently this is difficult because
`ObjectModule::define_function` requires `&mut self`. This instead
soups up the `define_function_bytes` interface to handle relocations so
compilation can happen externally before defining it in a `Module`. This
also means that `define_function` is now a convenience wrapper around
`define_function_bytes`.
