### PR TITLE
Remove an `Arc` holding module code from `InstanceHandle`

### DIFF
--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -246,7 +246,6 @@ impl CompiledModule {
     ) -> Result<InstanceHandle, InstantiationError> {
         InstanceHandle::new(
             self.module.clone(),
-            self.code.clone(),
             &self.finished_functions.0,
             imports,
             mem_creator,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -41,9 +41,6 @@ pub(crate) struct Instance {
     /// The `Module` this `Instance` was instantiated from.
     module: Arc<Module>,
 
-    /// The module's JIT code (if exists).
-    code: Arc<dyn Any>,
-
     /// Offsets in the `vmctx` region.
     offsets: VMOffsets,
 
@@ -814,7 +811,6 @@ impl InstanceHandle {
     /// instance.
     pub unsafe fn new(
         module: Arc<Module>,
-        code: Arc<dyn Any>,
         finished_functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
         imports: Imports,
         mem_creator: Option<&dyn RuntimeMemoryCreator>,
@@ -851,7 +847,6 @@ impl InstanceHandle {
         let handle = {
             let instance = Instance {
                 module,
-                code,
                 offsets,
                 memories,
                 tables,

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -98,7 +98,11 @@ fn instantiate(
 #[derive(Clone)]
 pub struct Instance {
     pub(crate) handle: StoreInstanceHandle,
-    store: Store,
+    // Note that this is required to keep the module's code memory alive while
+    // we have a handle to this `Instance`. We may eventually want to shrink
+    // this to only hold onto the bare minimum each instance needs to allow
+    // deallocating some `Module` resources early, but until then we just hold
+    // on to everything.
     module: Module,
 }
 
@@ -170,7 +174,6 @@ impl Instance {
 
         Ok(Instance {
             handle,
-            store: store.clone(),
             module: module.clone(),
         })
     }
@@ -180,7 +183,7 @@ impl Instance {
     /// This is the [`Store`] that generally serves as a sort of global cache
     /// for various instance-related things.
     pub fn store(&self) -> &Store {
-        &self.store
+        &self.handle.store
     }
 
     /// Returns the list of exported items from this [`Instance`].

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -28,7 +28,6 @@ pub(crate) fn create_handle(
     unsafe {
         let handle = InstanceHandle::new(
             module,
-            Arc::new(()),
             &finished_functions,
             imports,
             store.memory_creator(),


### PR DESCRIPTION
We've generally moved to a model where `InstanceHandle` doesn't hold
ownership of its internals, instead relying on the caller to manage
that. This removes an allocation on the `Func::wrap` path but otherwise
shouldn't have much impact.
