### PR TITLE
Support building big-endian objects

### DIFF
--- a/crates/jit/src/object.rs
+++ b/crates/jit/src/object.rs
@@ -28,10 +28,6 @@ pub(crate) fn build_object(
     dwarf_sections: Vec<DwarfSection>,
 ) -> Result<(Object, Vec<ObjectUnwindInfo>), anyhow::Error> {
     const CODE_SECTION_ALIGNMENT: u64 = 0x1000;
-    assert_eq!(
-        isa.triple().architecture.endianness(),
-        Ok(target_lexicon::Endianness::Little)
-    );
 
     let mut unwind_info = Vec::new();
 

--- a/crates/obj/src/builder.rs
+++ b/crates/obj/src/builder.rs
@@ -122,10 +122,6 @@ fn process_unwind_info(info: &UnwindInfo, obj: &mut Object, code_section: Sectio
 
 /// Builds ELF image from the module `Compilation`.
 // const CODE_SECTION_ALIGNMENT: u64 = 0x1000;
-// assert_eq!(
-//     isa.triple().architecture.endianness(),
-//     Ok(target_lexicon::Endianness::Little)
-// );
 
 /// Iterates through all `LibCall` members and all runtime exported functions.
 #[macro_export]
@@ -223,7 +219,10 @@ impl ObjectBuilderTarget {
         Ok(Self {
             binary_format: BinaryFormat::Elf,
             architecture: to_object_architecture(arch)?,
-            endianness: Endianness::Little,
+            endianness: match arch.endianness().unwrap() {
+                target_lexicon::Endianness::Little => object::Endianness::Little,
+                target_lexicon::Endianness::Big => object::Endianness::Big,
+            },
         })
     }
 


### PR DESCRIPTION
The JIT build_object routine currently rejects building object files
for any big-endian platform.  However, most of the object builder
code works fine for either byte order, with the exception of a small
change in the ObjectBuilderTarget::new routine.

This patch adds that change and removes the assert in build_object.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
