### PR TITLE
Support big-endian hosts with GuestType

### DIFF
--- a/crates/wiggle/src/guest_type.rs
+++ b/crates/wiggle/src/guest_type.rs
@@ -88,7 +88,7 @@ macro_rules! primitives {
                 if ptr.mem().is_borrowed(region) {
                     return Err(GuestError::PtrBorrowed(region));
                 }
-                Ok(unsafe { *host_ptr.cast::<Self>() })
+                Ok(unsafe { <$i>::from_le_bytes(*host_ptr.cast::<[u8; mem::size_of::<Self>()]>()) })
             }
 
             #[inline]
@@ -108,7 +108,7 @@ macro_rules! primitives {
                     return Err(GuestError::PtrBorrowed(region));
                 }
                 unsafe {
-                    *host_ptr.cast::<Self>() = val;
+                    *host_ptr.cast::<[u8; mem::size_of::<Self>()]>() = <$i>::to_le_bytes(val);
                 }
                 Ok(())
             }


### PR DESCRIPTION
The GuestType trait is used to access data elements in guest memory.
According to the WebAssembly spec, those are always stored in
little-endian byte order, even on big-endian hosts.  Accessing such
elements on big-endian hosts therefore requires byte swapping.

Fixed by adding from_le_bytes / to_le_bytes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
