### PR TITLE
Fix incorrect minimum Rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
   <p>
     <a href="https://github.com/bytecodealliance/wasmtime/actions?query=workflow%3ACI"><img src="https://github.com/bytecodealliance/wasmtime/workflows/CI/badge.svg" alt="build status" /></a>
     <a href="https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen.svg" alt="zulip chat" /></a>
-    <img src="https://img.shields.io/badge/rustc-1.37+-green.svg" alt="min rustc" />
     <a href="https://docs.rs/wasmtime"><img src="https://docs.rs/wasmtime/badge.svg" alt="Documentation Status" /></a>
   </p>
 

--- a/cranelift/README.md
+++ b/cranelift/README.md
@@ -11,7 +11,6 @@ into executable machine code.
 [![Build Status](https://github.com/bytecodealliance/wasmtime/workflows/CI/badge.svg)](https://github.com/bytecodealliance/wasmtime/actions)
 [![Fuzzit Status](https://app.fuzzit.dev/badge?org_id=bytecodealliance)](https://app.fuzzit.dev/orgs/bytecodealliance/dashboard)
 [![Chat](https://img.shields.io/badge/chat-zulip-brightgreen.svg)](https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/general)
-![Minimum rustc 1.37](https://img.shields.io/badge/rustc-1.37+-green.svg)
 [![Documentation Status](https://docs.rs/cranelift/badge.svg)](https://docs.rs/cranelift)
 
 For more information, see [the documentation](docs/index.md).
@@ -85,10 +84,23 @@ Building Cranelift
 Cranelift uses a [conventional Cargo build
 process](https://doc.rust-lang.org/cargo/guide/working-on-an-existing-project.html).
 
+As a user of wasmtime and or Cranelift you can use stable rust 1.43 or newer.
+
+However if you want to develop Cranelift, you'll need a nightly version of
+Rust, as some tests use unstable features.
+
 Cranelift consists of a collection of crates, and uses a [Cargo
-Workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html),
-so for some cargo commands, such as `cargo test`, the `--all` is needed
-to tell cargo to visit all of the crates.
+Workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html).
+If you want to test the whole `wasmtime` repo, some cargo commands, such as
+`cargo test`, add `--all` to them, to tell cargo to visit all of the crates.
+
+Note, Lightbeam, one of the other crates that are part of `wasmtime`
+require a nightly version of Rust to test. So if you call `cargo test --all`
+you'll need to do so with a nightly version.
+Consider either setting it for this project `rustup override set nightly` or
+running the upcoming test commands with `cargo +nightly`, or only testing
+specific components such as Cranelift.
+
 
 `test-all.sh` at the top level is a script which runs all the cargo
 tests and also performs code format, lint, and documentation checks.

--- a/crates/lightbeam/README.md
+++ b/crates/lightbeam/README.md
@@ -6,7 +6,7 @@ Lightbeam is an optimising one-pass streaming compiler for WebAssembly, intended
 
 ## Quality of output
 
-Already - with a very small number of relatively simple optimisation rules - Lightbeam produces surprisingly high-quality output considering how restricted it is. It even produces better code than Cranelift, Firefox or both for some workloads. Here's a very simple example, this recursive fibonacci function in Rust:
+Already - with a very small number of relatively simple optimizations rules - Lightbeam produces surprisingly high-quality output considering how restricted it is. It even produces better code than Cranelift, Firefox or both for some workloads. Here's a very simple example, this recursive fibonacci function in Rust:
 
 ```rust
 fn fib(n: i32) -> i32 {
@@ -18,7 +18,7 @@ fn fib(n: i32) -> i32 {
 }
 ```
 
-When compiled with optimisations enabled, rustc will produce the following WebAssembly:
+When compiled with optimizations enabled, rustc will produce the following WebAssembly:
 
 ```rust
 (module
@@ -87,7 +87,7 @@ fib:
   ret
 ```
 
-Cranelift with optimisations enabled produces similar:
+Cranelift with optimizationss enabled produces similar:
 
 ```asm
 fib:
@@ -154,7 +154,7 @@ fib:
   ret
 ```
 
-Now obviously I'm not advocating for replacing Firefox's optimising compiler with Lightbeam since the latter can only really produce better code when receiving optimised WebAssembly (and so debug-mode or hand-written WebAssembly may produce much worse output). However, this shows that even with the restrictions of a streaming compiler it's absolutely possible to produce high-quality assembly output. For the assembly above, the Lightbeam output runs within 15% of native speed. This is paramount for one of Lightbeam's intended usecases for real-time systems that want good runtime performance but cannot tolerate compiler bombs.
+Now obviously I'm not advocating for replacing Firefox's optimizing compiler with Lightbeam since the latter can only really produce better code when receiving optimized WebAssembly (and so debug-mode or hand-written WebAssembly may produce much worse output). However, this shows that even with the restrictions of a streaming compiler it's absolutely possible to produce high-quality assembly output. For the assembly above, the Lightbeam output runs within 15% of native speed. This is paramount for one of Lightbeam's intended usecases for real-time systems that want good runtime performance but cannot tolerate compiler bombs.
 
 ## Specification compliance
 
@@ -163,6 +163,8 @@ Lightbeam passes 100% of the specification test suite, but that doesn't necessar
 ## Getting involved
 
 You can file issues in the [Wasmtime issue tracker][Wasmtime issue tracker]. If you want to get involved jump into the [Bytecode Alliance Zulip][bytecodealliance-zulip] and someone can direct you to the right place. I wish I could say "the most useful thing you can do is play with it and open issues where you find problems" but until it passes the spec suite that won't be very helpful.
+
+Lightbeam can be built with stable Rust, however building and running the tests for Lightbeam requires a nightly version of Rust.
 
 [bytecodealliance-zulip]: https://bytecodealliance.zulipchat.com/
 [Wasmtime issue tracker]: https://github.com/bytecodealliance/wasmtime/issues


### PR DESCRIPTION
This removes the Rust 1.37 badge which is no longer correct,
and in lack of an automated system will become outdated again.
The more reliable strategy is to not document this information.

This also documents that in order to build cranelift a nightly
version of the Rust is required.

Fixes issue #2377 

I don't know if this change is complete, I'm not familiar with the topology of this project and acted on a broad suggestion.
