### PR TITLE
MachInst backends: handle SourceLocs out-of-band, not in Insts.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -3,7 +3,6 @@
 use crate::ir;
 use crate::ir::types;
 use crate::ir::types::*;
-use crate::ir::SourceLoc;
 use crate::isa;
 use crate::isa::aarch64::{inst::EmitState, inst::*};
 use crate::machinst::*;
@@ -380,7 +379,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             extendop: ExtendOp::UXTX,
         });
         insts.push(Inst::TrapIf {
-            trap_info: (ir::SourceLoc::default(), ir::TrapCode::StackOverflow),
+            trap_code: ir::TrapCode::StackOverflow,
             // Here `Lo` == "less than" when interpreting the two
             // operands as unsigned integers.
             kind: CondBrKind::Cond(Cond::Lo),
@@ -554,7 +553,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     stack_reg(),
                     SImm9::maybe_from_i64((vec_offset + (i * 16)) as i64).unwrap(),
                 ),
-                srcloc: None,
             });
         }
 
@@ -603,7 +601,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     stack_reg(),
                     SImm9::maybe_from_i64(((i * 16) + int_save_bytes) as i64).unwrap(),
                 ),
-                srcloc: None,
             });
         }
 
@@ -634,7 +631,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         dest: &CallDest,
         uses: Vec<Reg>,
         defs: Vec<Writable<Reg>>,
-        loc: SourceLoc,
         opcode: ir::Opcode,
         tmp: Writable<Reg>,
         callee_conv: isa::CallConv,
@@ -649,7 +645,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
                         dest: name.clone(),
                         uses,
                         defs,
-                        loc,
                         opcode,
                         caller_callconv: caller_conv,
                         callee_callconv: callee_conv,
@@ -663,7 +658,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
                         rd: tmp,
                         name: Box::new(name.clone()),
                         offset: 0,
-                        srcloc: loc,
                     },
                 ));
                 insts.push((
@@ -673,7 +667,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
                             rn: tmp.to_reg(),
                             uses,
                             defs,
-                            loc,
                             opcode,
                             caller_callconv: caller_conv,
                             callee_callconv: callee_conv,
@@ -688,7 +681,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
                         rn: *reg,
                         uses,
                         defs,
-                        loc,
                         opcode,
                         caller_callconv: caller_conv,
                         callee_callconv: callee_conv,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1079,7 +1079,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad8 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "41004038",
         "ldurb w1, [x2]",
@@ -1088,7 +1087,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad8 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::zero(I8)),
-            srcloc: None,
         },
         "41004039",
         "ldrb w1, [x2]",
@@ -1097,7 +1095,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad8 {
             rd: writable_xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(5)),
-            srcloc: None,
         },
         "41686538",
         "ldrb w1, [x2, x5]",
@@ -1106,7 +1103,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad8 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "41008038",
         "ldursb x1, [x2]",
@@ -1115,7 +1111,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad8 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(63, I8).unwrap()),
-            srcloc: None,
         },
         "41FC8039",
         "ldrsb x1, [x2, #63]",
@@ -1124,7 +1119,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad8 {
             rd: writable_xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(5)),
-            srcloc: None,
         },
         "4168A538",
         "ldrsb x1, [x2, x5]",
@@ -1133,7 +1127,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad16 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(5).unwrap()),
-            srcloc: None,
         },
         "41504078",
         "ldurh w1, [x2, #5]",
@@ -1142,7 +1135,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad16 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8, I16).unwrap()),
-            srcloc: None,
         },
         "41104079",
         "ldrh w1, [x2, #8]",
@@ -1151,7 +1143,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad16 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(3), I16),
-            srcloc: None,
         },
         "41786378",
         "ldrh w1, [x2, x3, LSL #1]",
@@ -1160,7 +1151,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad16 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "41008078",
         "ldursh x1, [x2]",
@@ -1169,7 +1159,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad16 {
             rd: writable_xreg(28),
             mem: AMode::UnsignedOffset(xreg(20), UImm12Scaled::maybe_from_i64(24, I16).unwrap()),
-            srcloc: None,
         },
         "9C328079",
         "ldrsh x28, [x20, #24]",
@@ -1178,7 +1167,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad16 {
             rd: writable_xreg(28),
             mem: AMode::RegScaled(xreg(20), xreg(20), I16),
-            srcloc: None,
         },
         "9C7AB478",
         "ldrsh x28, [x20, x20, LSL #1]",
@@ -1187,7 +1175,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad32 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "410040B8",
         "ldur w1, [x2]",
@@ -1196,7 +1183,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad32 {
             rd: writable_xreg(12),
             mem: AMode::UnsignedOffset(xreg(0), UImm12Scaled::maybe_from_i64(204, I32).unwrap()),
-            srcloc: None,
         },
         "0CCC40B9",
         "ldr w12, [x0, #204]",
@@ -1205,7 +1191,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad32 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(12), I32),
-            srcloc: None,
         },
         "41786CB8",
         "ldr w1, [x2, x12, LSL #2]",
@@ -1214,7 +1199,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad32 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "410080B8",
         "ldursw x1, [x2]",
@@ -1223,7 +1207,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad32 {
             rd: writable_xreg(12),
             mem: AMode::UnsignedOffset(xreg(1), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
-            srcloc: None,
         },
         "2CFCBFB9",
         "ldrsw x12, [x1, #16380]",
@@ -1232,7 +1215,6 @@ fn test_aarch64_binemit() {
         Inst::SLoad32 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(5), xreg(1), I32),
-            srcloc: None,
         },
         "A178A1B8",
         "ldrsw x1, [x5, x1, LSL #2]",
@@ -1241,7 +1223,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "410040F8",
         "ldur x1, [x2]",
@@ -1250,7 +1231,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(-256).unwrap()),
-            srcloc: None,
         },
         "410050F8",
         "ldur x1, [x2, #-256]",
@@ -1259,7 +1239,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(255).unwrap()),
-            srcloc: None,
         },
         "41F04FF8",
         "ldur x1, [x2, #255]",
@@ -1268,7 +1247,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
-            srcloc: None,
         },
         "41FC7FF9",
         "ldr x1, [x2, #32760]",
@@ -1277,7 +1255,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(3)),
-            srcloc: None,
         },
         "416863F8",
         "ldr x1, [x2, x3]",
@@ -1286,7 +1263,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(3), I64),
-            srcloc: None,
         },
         "417863F8",
         "ldr x1, [x2, x3, LSL #3]",
@@ -1295,7 +1271,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::SXTW),
-            srcloc: None,
         },
         "41D863F8",
         "ldr x1, [x2, w3, SXTW #3]",
@@ -1304,7 +1279,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegExtended(xreg(2), xreg(3), ExtendOp::SXTW),
-            srcloc: None,
         },
         "41C863F8",
         "ldr x1, [x2, w3, SXTW]",
@@ -1313,7 +1287,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Label(MemLabel::PCRel(64)),
-            srcloc: None,
         },
         "01020058",
         "ldr x1, pc+64",
@@ -1322,7 +1295,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            srcloc: None,
         },
         "410C41F8",
         "ldr x1, [x2, #16]!",
@@ -1331,7 +1303,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            srcloc: None,
         },
         "410441F8",
         "ldr x1, [x2], #16",
@@ -1340,7 +1311,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(32768, I8),
-            srcloc: None,
         },
         "100090D2B063308B010240F9",
         "movz x16, #32768 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1349,7 +1319,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(-32768, I8),
-            srcloc: None,
         },
         "F0FF8F92B063308B010240F9",
         "movn x16, #32767 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1358,7 +1327,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(1048576, I8), // 2^20
-            srcloc: None,
         },
         "1002A0D2B063308B010240F9",
         "movz x16, #16, LSL #16 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1367,7 +1335,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(1048576 + 1, I8), // 2^20 + 1
-            srcloc: None,
         },
         "300080521002A072B063308B010240F9",
         "movz w16, #1 ; movk w16, #16, LSL #16 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1377,7 +1344,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegOffset(xreg(7), 8, I64),
-            srcloc: None,
         },
         "E18040F8",
         "ldur x1, [x7, #8]",
@@ -1387,7 +1353,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegOffset(xreg(7), 1024, I64),
-            srcloc: None,
         },
         "E10042F9",
         "ldr x1, [x7, #1024]",
@@ -1397,7 +1362,6 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegOffset(xreg(7), 1048576, I64),
-            srcloc: None,
         },
         "1002A0D2F060308B010240F9",
         "movz x16, #16, LSL #16 ; add x16, x7, x16, UXTX ; ldr x1, [x16]",
@@ -1407,7 +1371,6 @@ fn test_aarch64_binemit() {
         Inst::Store8 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "41000038",
         "sturb w1, [x2]",
@@ -1416,7 +1379,6 @@ fn test_aarch64_binemit() {
         Inst::Store8 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(4095, I8).unwrap()),
-            srcloc: None,
         },
         "41FC3F39",
         "strb w1, [x2, #4095]",
@@ -1425,7 +1387,6 @@ fn test_aarch64_binemit() {
         Inst::Store16 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "41000078",
         "sturh w1, [x2]",
@@ -1434,7 +1395,6 @@ fn test_aarch64_binemit() {
         Inst::Store16 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8190, I16).unwrap()),
-            srcloc: None,
         },
         "41FC3F79",
         "strh w1, [x2, #8190]",
@@ -1443,7 +1403,6 @@ fn test_aarch64_binemit() {
         Inst::Store32 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "410000B8",
         "stur w1, [x2]",
@@ -1452,7 +1411,6 @@ fn test_aarch64_binemit() {
         Inst::Store32 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
-            srcloc: None,
         },
         "41FC3FB9",
         "str w1, [x2, #16380]",
@@ -1461,7 +1419,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            srcloc: None,
         },
         "410000F8",
         "stur x1, [x2]",
@@ -1470,7 +1427,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
-            srcloc: None,
         },
         "41FC3FF9",
         "str x1, [x2, #32760]",
@@ -1479,7 +1435,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(3)),
-            srcloc: None,
         },
         "416823F8",
         "str x1, [x2, x3]",
@@ -1488,7 +1443,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(3), I64),
-            srcloc: None,
         },
         "417823F8",
         "str x1, [x2, x3, LSL #3]",
@@ -1497,7 +1451,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::UXTW),
-            srcloc: None,
         },
         "415823F8",
         "str x1, [x2, w3, UXTW #3]",
@@ -1506,7 +1459,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegExtended(xreg(2), xreg(3), ExtendOp::UXTW),
-            srcloc: None,
         },
         "414823F8",
         "str x1, [x2, w3, UXTW]",
@@ -1515,7 +1467,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            srcloc: None,
         },
         "410C01F8",
         "str x1, [x2, #16]!",
@@ -1524,7 +1475,6 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            srcloc: None,
         },
         "410401F8",
         "str x1, [x2], #16",
@@ -3911,7 +3861,7 @@ fn test_aarch64_binemit() {
         Inst::VecLoadReplicate {
             rd: writable_vreg(31),
             rn: xreg(0),
-            srcloc: None,
+
             size: VectorSize::Size64x2,
         },
         "1FCC404D",
@@ -3922,7 +3872,7 @@ fn test_aarch64_binemit() {
         Inst::VecLoadReplicate {
             rd: writable_vreg(0),
             rn: xreg(25),
-            srcloc: None,
+
             size: VectorSize::Size8x8,
         },
         "20C3400D",
@@ -4050,7 +4000,7 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::NotZero(xreg(8)),
         },
         "480000B40000A0D4",
@@ -4058,7 +4008,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Zero(xreg(8)),
         },
         "480000B50000A0D4",
@@ -4066,7 +4016,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Ne),
         },
         "400000540000A0D4",
@@ -4074,7 +4024,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Eq),
         },
         "410000540000A0D4",
@@ -4082,7 +4032,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Lo),
         },
         "420000540000A0D4",
@@ -4090,7 +4040,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Hs),
         },
         "430000540000A0D4",
@@ -4098,7 +4048,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Pl),
         },
         "440000540000A0D4",
@@ -4106,7 +4056,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Mi),
         },
         "450000540000A0D4",
@@ -4114,7 +4064,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Vc),
         },
         "460000540000A0D4",
@@ -4122,7 +4072,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Vs),
         },
         "470000540000A0D4",
@@ -4130,7 +4080,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Ls),
         },
         "480000540000A0D4",
@@ -4138,7 +4088,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Hi),
         },
         "490000540000A0D4",
@@ -4146,7 +4096,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Lt),
         },
         "4A0000540000A0D4",
@@ -4154,7 +4104,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Ge),
         },
         "4B0000540000A0D4",
@@ -4162,7 +4112,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Le),
         },
         "4C0000540000A0D4",
@@ -4170,7 +4120,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Gt),
         },
         "4D0000540000A0D4",
@@ -4178,7 +4128,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Nv),
         },
         "4E0000540000A0D4",
@@ -4186,7 +4136,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
             kind: CondBrKind::Cond(Cond::Al),
         },
         "4F0000540000A0D4",
@@ -4209,7 +4159,6 @@ fn test_aarch64_binemit() {
                 dest: ExternalName::testcase("test0"),
                 uses: Vec::new(),
                 defs: Vec::new(),
-                loc: SourceLoc::default(),
                 opcode: Opcode::Call,
                 caller_callconv: CallConv::SystemV,
                 callee_callconv: CallConv::SystemV,
@@ -4225,7 +4174,6 @@ fn test_aarch64_binemit() {
                 rn: xreg(10),
                 uses: Vec::new(),
                 defs: Vec::new(),
-                loc: SourceLoc::default(),
                 opcode: Opcode::CallIndirect,
                 caller_callconv: CallConv::SystemV,
                 callee_callconv: CallConv::SystemV,
@@ -4797,7 +4745,6 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad32 {
             rd: writable_vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F32),
-            srcloc: None,
         },
         "107969BC",
         "ldr s16, [x8, x9, LSL #2]",
@@ -4807,7 +4754,6 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad64 {
             rd: writable_vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F64),
-            srcloc: None,
         },
         "107969FC",
         "ldr d16, [x8, x9, LSL #3]",
@@ -4817,7 +4763,6 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad128 {
             rd: writable_vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), I128),
-            srcloc: None,
         },
         "1079E93C",
         "ldr q16, [x8, x9, LSL #4]",
@@ -4827,7 +4772,6 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad32 {
             rd: writable_vreg(16),
             mem: AMode::Label(MemLabel::PCRel(8)),
-            srcloc: None,
         },
         "5000001C",
         "ldr s16, pc+8",
@@ -4837,7 +4781,6 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad64 {
             rd: writable_vreg(16),
             mem: AMode::Label(MemLabel::PCRel(8)),
-            srcloc: None,
         },
         "5000005C",
         "ldr d16, pc+8",
@@ -4847,7 +4790,6 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad128 {
             rd: writable_vreg(16),
             mem: AMode::Label(MemLabel::PCRel(8)),
-            srcloc: None,
         },
         "5000009C",
         "ldr q16, pc+8",
@@ -4857,7 +4799,6 @@ fn test_aarch64_binemit() {
         Inst::FpuStore32 {
             rd: vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F32),
-            srcloc: None,
         },
         "107929BC",
         "str s16, [x8, x9, LSL #2]",
@@ -4867,7 +4808,6 @@ fn test_aarch64_binemit() {
         Inst::FpuStore64 {
             rd: vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F64),
-            srcloc: None,
         },
         "107929FC",
         "str d16, [x8, x9, LSL #3]",
@@ -4877,7 +4817,6 @@ fn test_aarch64_binemit() {
         Inst::FpuStore128 {
             rd: vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), I128),
-            srcloc: None,
         },
         "1079A93C",
         "str q16, [x8, x9, LSL #4]",
@@ -5000,7 +4939,6 @@ fn test_aarch64_binemit() {
         Inst::AtomicRMW {
             ty: I16,
             op: inst_common::AtomicRmwOp::Xor,
-            srcloc: None,
         },
         "BF3B03D53B7F5F487C031ACA3C7F1848B8FFFFB5BF3B03D5",
         "atomically { 16_bits_at_[x25]) Xor= x26 ; x27 = old_value_at_[x25]; x24,x28 = trash }",
@@ -5010,7 +4948,6 @@ fn test_aarch64_binemit() {
         Inst::AtomicRMW {
             ty: I32,
             op: inst_common::AtomicRmwOp::Xchg,
-            srcloc: None,
         },
         "BF3B03D53B7F5F88FC031AAA3C7F1888B8FFFFB5BF3B03D5",
         "atomically { 32_bits_at_[x25]) Xchg= x26 ; x27 = old_value_at_[x25]; x24,x28 = trash }",
@@ -5019,7 +4956,6 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::AtomicCAS {
             ty: I8,
-            srcloc: None,
         },
         "BF3B03D53B7F5F08581F40927F0318EB610000543C7F180878FFFFB5BF3B03D5",
         "atomically { compare-and-swap(8_bits_at_[x25], x26 -> x28), x27 = old_value_at_[x25]; x24 = trash }"
@@ -5028,7 +4964,6 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::AtomicCAS {
             ty: I64,
-            srcloc: None,
         },
         "BF3B03D53B7F5FC8F8031AAA7F0318EB610000543C7F18C878FFFFB5BF3B03D5",
         "atomically { compare-and-swap(64_bits_at_[x25], x26 -> x28), x27 = old_value_at_[x25]; x24 = trash }"
@@ -5039,7 +4974,6 @@ fn test_aarch64_binemit() {
             ty: I8,
             r_data: writable_xreg(7),
             r_addr: xreg(28),
-            srcloc: None,
         },
         "BF3B03D587034039",
         "atomically { x7 = zero_extend_8_bits_at[x28] }",
@@ -5050,7 +4984,6 @@ fn test_aarch64_binemit() {
             ty: I64,
             r_data: writable_xreg(28),
             r_addr: xreg(7),
-            srcloc: None,
         },
         "BF3B03D5FC0040F9",
         "atomically { x28 = zero_extend_64_bits_at[x7] }",
@@ -5061,7 +4994,6 @@ fn test_aarch64_binemit() {
             ty: I16,
             r_data: xreg(17),
             r_addr: xreg(8),
-            srcloc: None,
         },
         "11010079BF3B03D5",
         "atomically { 16_bits_at[x8] = x17 }",
@@ -5072,7 +5004,6 @@ fn test_aarch64_binemit() {
             ty: I32,
             r_data: xreg(18),
             r_addr: xreg(7),
-            srcloc: None,
         },
         "F20000B9BF3B03D5",
         "atomically { 32_bits_at[x7] = x18 }",

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -484,9 +484,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 //   msub rd, rd, rm, rn  ; rd = rn - rd * rm
 
                 // Check for divide by 0.
-                let trap_info = (ctx.srcloc(insn), TrapCode::IntegerDivisionByZero);
+                let trap_code = TrapCode::IntegerDivisionByZero;
                 ctx.emit(Inst::TrapIf {
-                    trap_info,
+                    trap_code,
                     kind: CondBrKind::Zero(rm),
                 });
 
@@ -507,9 +507,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     //   udf ; signed overflow
 
                     // Check for divide by 0.
-                    let trap_info = (ctx.srcloc(insn), TrapCode::IntegerDivisionByZero);
+                    let trap_code = TrapCode::IntegerDivisionByZero;
                     ctx.emit(Inst::TrapIf {
-                        trap_info,
+                        trap_code,
                         kind: CondBrKind::Zero(rm),
                     });
 
@@ -535,9 +535,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         nzcv: NZCV::new(false, false, false, false),
                         cond: Cond::Eq,
                     });
-                    let trap_info = (ctx.srcloc(insn), TrapCode::IntegerOverflow);
+                    let trap_code = TrapCode::IntegerOverflow;
                     ctx.emit(Inst::TrapIf {
-                        trap_info,
+                        trap_code,
                         kind: CondBrKind::Cond(Cond::Vs),
                     });
                 } else {
@@ -545,9 +545,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     //   udf ; divide by zero
 
                     // Check for divide by 0.
-                    let trap_info = (ctx.srcloc(insn), TrapCode::IntegerDivisionByZero);
+                    let trap_code = TrapCode::IntegerDivisionByZero;
                     ctx.emit(Inst::TrapIf {
-                        trap_info,
+                        trap_code,
                         kind: CondBrKind::Zero(rm),
                     });
                 }
@@ -1161,27 +1161,20 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let mem = lower_address(ctx, elem_ty, &inputs[..], off);
             let rd = get_output_reg(ctx, outputs[0]);
 
-            let memflags = ctx.memflags(insn).expect("memory flags");
-            let srcloc = if !memflags.notrap() {
-                Some(ctx.srcloc(insn))
-            } else {
-                None
-            };
-
             ctx.emit(match (ty_bits(elem_ty), sign_extend, is_float) {
-                (1, _, _) => Inst::ULoad8 { rd, mem, srcloc },
-                (8, false, _) => Inst::ULoad8 { rd, mem, srcloc },
-                (8, true, _) => Inst::SLoad8 { rd, mem, srcloc },
-                (16, false, _) => Inst::ULoad16 { rd, mem, srcloc },
-                (16, true, _) => Inst::SLoad16 { rd, mem, srcloc },
-                (32, false, false) => Inst::ULoad32 { rd, mem, srcloc },
-                (32, true, false) => Inst::SLoad32 { rd, mem, srcloc },
-                (32, _, true) => Inst::FpuLoad32 { rd, mem, srcloc },
-                (64, _, false) => Inst::ULoad64 { rd, mem, srcloc },
+                (1, _, _) => Inst::ULoad8 { rd, mem },
+                (8, false, _) => Inst::ULoad8 { rd, mem },
+                (8, true, _) => Inst::SLoad8 { rd, mem },
+                (16, false, _) => Inst::ULoad16 { rd, mem },
+                (16, true, _) => Inst::SLoad16 { rd, mem },
+                (32, false, false) => Inst::ULoad32 { rd, mem },
+                (32, true, false) => Inst::SLoad32 { rd, mem },
+                (32, _, true) => Inst::FpuLoad32 { rd, mem },
+                (64, _, false) => Inst::ULoad64 { rd, mem },
                 // Note that we treat some of the vector loads as scalar floating-point loads,
                 // which is correct in a little endian environment.
-                (64, _, true) => Inst::FpuLoad64 { rd, mem, srcloc },
-                (128, _, _) => Inst::FpuLoad128 { rd, mem, srcloc },
+                (64, _, true) => Inst::FpuLoad64 { rd, mem },
+                (128, _, _) => Inst::FpuLoad128 { rd, mem },
                 _ => panic!("Unsupported size in load"),
             });
 
@@ -1209,14 +1202,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let off = ctx.data(insn).load_store_offset().unwrap();
             let ty = ty.unwrap();
             let mem = lower_address(ctx, ty.lane_type(), &inputs[..], off);
-            let memflags = ctx.memflags(insn).expect("memory flags");
             let rd = get_output_reg(ctx, outputs[0]);
             let size = VectorSize::from_ty(ty);
-            let srcloc = if memflags.notrap() {
-                None
-            } else {
-                Some(ctx.srcloc(insn))
-            };
             let tmp = ctx.alloc_tmp(RegClass::I64, I64);
 
             ctx.emit(Inst::LoadAddr { rd: tmp, mem });
@@ -1224,7 +1211,6 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 rd,
                 rn: tmp.to_reg(),
                 size,
-                srcloc,
             });
         }
 
@@ -1249,21 +1235,14 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let mem = lower_address(ctx, elem_ty, &inputs[1..], off);
             let rd = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
 
-            let memflags = ctx.memflags(insn).expect("memory flags");
-            let srcloc = if !memflags.notrap() {
-                Some(ctx.srcloc(insn))
-            } else {
-                None
-            };
-
             ctx.emit(match (ty_bits(elem_ty), is_float) {
-                (1, _) | (8, _) => Inst::Store8 { rd, mem, srcloc },
-                (16, _) => Inst::Store16 { rd, mem, srcloc },
-                (32, false) => Inst::Store32 { rd, mem, srcloc },
-                (32, true) => Inst::FpuStore32 { rd, mem, srcloc },
-                (64, false) => Inst::Store64 { rd, mem, srcloc },
-                (64, true) => Inst::FpuStore64 { rd, mem, srcloc },
-                (128, _) => Inst::FpuStore128 { rd, mem, srcloc },
+                (1, _) | (8, _) => Inst::Store8 { rd, mem },
+                (16, _) => Inst::Store16 { rd, mem },
+                (32, false) => Inst::Store32 { rd, mem },
+                (32, true) => Inst::FpuStore32 { rd, mem },
+                (64, false) => Inst::Store64 { rd, mem },
+                (64, true) => Inst::FpuStore64 { rd, mem },
+                (128, _) => Inst::FpuStore128 { rd, mem },
                 _ => panic!("Unsupported size in store"),
             });
         }
@@ -1291,12 +1270,6 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let mut r_arg2 = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty_access = ty.unwrap();
             assert!(is_valid_atomic_transaction_ty(ty_access));
-            let memflags = ctx.memflags(insn).expect("memory flags");
-            let srcloc = if !memflags.notrap() {
-                Some(ctx.srcloc(insn))
-            } else {
-                None
-            };
             // Make sure that both args are in virtual regs, since in effect
             // we have to do a parallel copy to get them safely to the AtomicRMW input
             // regs, and that's not guaranteed safe if either is in a real reg.
@@ -1307,11 +1280,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             ctx.emit(Inst::gen_move(Writable::from_reg(xreg(26)), r_arg2, I64));
             // Now the AtomicRMW insn itself
             let op = inst_common::AtomicRmwOp::from(ctx.data(insn).atomic_rmw_op().unwrap());
-            ctx.emit(Inst::AtomicRMW {
-                ty: ty_access,
-                op,
-                srcloc,
-            });
+            ctx.emit(Inst::AtomicRMW { ty: ty_access, op });
             // And finally, copy the preordained AtomicRMW output reg to its destination.
             ctx.emit(Inst::gen_move(r_dst, xreg(27), I64));
             // Also, x24 and x28 are trashed.  `fn aarch64_get_regs` must mention that.
@@ -1327,12 +1296,6 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let mut r_replacement = put_input_in_reg(ctx, inputs[2], NarrowValueMode::None);
             let ty_access = ty.unwrap();
             assert!(is_valid_atomic_transaction_ty(ty_access));
-            let memflags = ctx.memflags(insn).expect("memory flags");
-            let srcloc = if !memflags.notrap() {
-                Some(ctx.srcloc(insn))
-            } else {
-                None
-            };
             // Make sure that all three args are in virtual regs.  See corresponding comment
             // for `Opcode::AtomicRmw` above.
             r_addr = ctx.ensure_in_vreg(r_addr, I64);
@@ -1351,10 +1314,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 I64,
             ));
             // Now the AtomicCAS itself, implemented in the normal way, with an LL-SC loop
-            ctx.emit(Inst::AtomicCAS {
-                ty: ty_access,
-                srcloc,
-            });
+            ctx.emit(Inst::AtomicCAS { ty: ty_access });
             // And finally, copy the preordained AtomicCAS output reg to its destination.
             ctx.emit(Inst::gen_move(r_dst, xreg(27), I64));
             // Also, x24 and x28 are trashed.  `fn aarch64_get_regs` must mention that.
@@ -1365,17 +1325,10 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let r_addr = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let ty_access = ty.unwrap();
             assert!(is_valid_atomic_transaction_ty(ty_access));
-            let memflags = ctx.memflags(insn).expect("memory flags");
-            let srcloc = if !memflags.notrap() {
-                Some(ctx.srcloc(insn))
-            } else {
-                None
-            };
             ctx.emit(Inst::AtomicLoad {
                 ty: ty_access,
                 r_data,
                 r_addr,
-                srcloc,
             });
         }
 
@@ -1384,17 +1337,10 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let r_addr = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty_access = ctx.input_ty(insn, 0);
             assert!(is_valid_atomic_transaction_ty(ty_access));
-            let memflags = ctx.memflags(insn).expect("memory flags");
-            let srcloc = if !memflags.notrap() {
-                Some(ctx.srcloc(insn))
-            } else {
-                None
-            };
             ctx.emit(Inst::AtomicStore {
                 ty: ty_access,
                 r_data,
                 r_addr,
-                srcloc,
             });
         }
 
@@ -1811,12 +1757,12 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Trap | Opcode::ResumableTrap => {
-            let trap_info = (ctx.srcloc(insn), ctx.data(insn).trap_code().unwrap());
-            ctx.emit_safepoint(Inst::Udf { trap_info });
+            let trap_code = ctx.data(insn).trap_code().unwrap();
+            ctx.emit_safepoint(Inst::Udf { trap_code });
         }
 
         Opcode::Trapif | Opcode::Trapff => {
-            let trap_info = (ctx.srcloc(insn), ctx.data(insn).trap_code().unwrap());
+            let trap_code = ctx.data(insn).trap_code().unwrap();
 
             let cond = if maybe_input_insn(ctx, inputs[0], Opcode::IaddIfcout).is_some() {
                 let condcode = ctx.data(insn).cond_code().unwrap();
@@ -1847,7 +1793,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             };
 
             ctx.emit_safepoint(Inst::TrapIf {
-                trap_info,
+                trap_code,
                 kind: CondBrKind::Cond(cond),
             });
         }
@@ -1864,11 +1810,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let rd = get_output_reg(ctx, outputs[0]);
             let (extname, _) = ctx.call_target(insn).unwrap();
             let extname = extname.clone();
-            let loc = ctx.srcloc(insn);
             ctx.emit(Inst::LoadExtName {
                 rd,
                 name: Box::new(extname),
-                srcloc: loc,
                 offset: 0,
             });
         }
@@ -1881,17 +1825,14 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let rd = get_output_reg(ctx, outputs[0]);
             let (extname, _, offset) = ctx.symbol_value(insn).unwrap();
             let extname = extname.clone();
-            let loc = ctx.srcloc(insn);
             ctx.emit(Inst::LoadExtName {
                 rd,
                 name: Box::new(extname),
-                srcloc: loc,
                 offset,
             });
         }
 
         Opcode::Call | Opcode::CallIndirect => {
-            let loc = ctx.srcloc(insn);
             let caller_conv = ctx.abi().call_conv();
             let (mut abi, inputs) = match op {
                 Opcode::Call => {
@@ -1901,7 +1842,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert!(inputs.len() == sig.params.len());
                     assert!(outputs.len() == sig.returns.len());
                     (
-                        AArch64ABICaller::from_func(sig, &extname, dist, loc, caller_conv)?,
+                        AArch64ABICaller::from_func(sig, &extname, dist, caller_conv)?,
                         &inputs[..],
                     )
                 }
@@ -1911,7 +1852,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert!(inputs.len() - 1 == sig.params.len());
                     assert!(outputs.len() == sig.returns.len());
                     (
-                        AArch64ABICaller::from_ptr(sig, ptr, loc, op, caller_conv)?,
+                        AArch64ABICaller::from_ptr(sig, ptr, op, caller_conv)?,
                         &inputs[1..],
                     )
                 }
@@ -2687,9 +2628,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             } else {
                 ctx.emit(Inst::FpuCmp64 { rn, rm: rn });
             }
-            let trap_info = (ctx.srcloc(insn), TrapCode::BadConversionToInteger);
+            let trap_code = TrapCode::BadConversionToInteger;
             ctx.emit(Inst::TrapIf {
-                trap_info,
+                trap_code,
                 kind: CondBrKind::Cond(lower_fp_condcode(FloatCC::Unordered)),
             });
 
@@ -2739,9 +2680,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     rn,
                     rm: tmp.to_reg(),
                 });
-                let trap_info = (ctx.srcloc(insn), TrapCode::IntegerOverflow);
+                let trap_code = TrapCode::IntegerOverflow;
                 ctx.emit(Inst::TrapIf {
-                    trap_info,
+                    trap_code,
                     kind: CondBrKind::Cond(lower_fp_condcode(low_cond).invert()),
                 });
 
@@ -2751,9 +2692,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     rn,
                     rm: tmp.to_reg(),
                 });
-                let trap_info = (ctx.srcloc(insn), TrapCode::IntegerOverflow);
+                let trap_code = TrapCode::IntegerOverflow;
                 ctx.emit(Inst::TrapIf {
-                    trap_info,
+                    trap_code,
                     kind: CondBrKind::Cond(lower_fp_condcode(FloatCC::LessThan).invert()),
                 });
             } else {
@@ -2792,9 +2733,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     rn,
                     rm: tmp.to_reg(),
                 });
-                let trap_info = (ctx.srcloc(insn), TrapCode::IntegerOverflow);
+                let trap_code = TrapCode::IntegerOverflow;
                 ctx.emit(Inst::TrapIf {
-                    trap_info,
+                    trap_code,
                     kind: CondBrKind::Cond(lower_fp_condcode(low_cond).invert()),
                 });
 
@@ -2804,9 +2745,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     rn,
                     rm: tmp.to_reg(),
                 });
-                let trap_info = (ctx.srcloc(insn), TrapCode::IntegerOverflow);
+                let trap_code = TrapCode::IntegerOverflow;
                 ctx.emit(Inst::TrapIf {
-                    trap_info,
+                    trap_code,
                     kind: CondBrKind::Cond(lower_fp_condcode(FloatCC::LessThan).invert()),
                 });
             };

--- a/cranelift/codegen/src/isa/arm32/abi.rs
+++ b/cranelift/codegen/src/isa/arm32/abi.rs
@@ -2,7 +2,6 @@
 
 use crate::ir;
 use crate::ir::types::*;
-use crate::ir::SourceLoc;
 use crate::isa;
 use crate::isa::arm32::inst::*;
 use crate::machinst::*;
@@ -217,7 +216,7 @@ impl ABIMachineSpec for Arm32MachineDeps {
             rm: limit_reg,
         });
         insts.push(Inst::TrapIf {
-            trap_info: (ir::SourceLoc::default(), ir::TrapCode::StackOverflow),
+            trap_info: ir::TrapCode::StackOverflow,
             // Here `Lo` == "less than" when interpreting the two
             // operands as unsigned integers.
             cond: Cond::Lo,
@@ -366,7 +365,6 @@ impl ABIMachineSpec for Arm32MachineDeps {
         dest: &CallDest,
         uses: Vec<Reg>,
         defs: Vec<Writable<Reg>>,
-        loc: SourceLoc,
         opcode: ir::Opcode,
         tmp: Writable<Reg>,
         _callee_conv: isa::CallConv,
@@ -381,7 +379,6 @@ impl ABIMachineSpec for Arm32MachineDeps {
                         dest: name.clone(),
                         uses,
                         defs,
-                        loc,
                         opcode,
                     }),
                 },
@@ -393,7 +390,6 @@ impl ABIMachineSpec for Arm32MachineDeps {
                         rt: tmp,
                         name: Box::new(name.clone()),
                         offset: 0,
-                        srcloc: loc,
                     },
                 ));
                 insts.push((
@@ -403,7 +399,6 @@ impl ABIMachineSpec for Arm32MachineDeps {
                             rm: tmp.to_reg(),
                             uses,
                             defs,
-                            loc,
                             opcode,
                         }),
                     },
@@ -416,7 +411,6 @@ impl ABIMachineSpec for Arm32MachineDeps {
                         rm: *reg,
                         uses,
                         defs,
-                        loc,
                         opcode,
                     }),
                 },

--- a/cranelift/codegen/src/isa/arm32/inst/emit.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/emit.rs
@@ -1,6 +1,7 @@
 //! 32-bit ARM ISA: binary code emission.
 
 use crate::binemit::{Reloc, StackMap};
+use crate::ir::SourceLoc;
 use crate::isa::arm32::inst::*;
 
 use core::convert::TryFrom;
@@ -229,6 +230,8 @@ pub struct EmitState {
     pub(crate) nominal_sp_to_fp: i64,
     /// Safepoint stack map for upcoming instruction, as provided to `pre_safepoint()`.
     stack_map: Option<StackMap>,
+    /// Source location of next machine code instruction to be emitted.
+    cur_srcloc: SourceLoc,
 }
 
 impl MachInstEmitState<Inst> for EmitState {
@@ -237,11 +240,16 @@ impl MachInstEmitState<Inst> for EmitState {
             virtual_sp_offset: 0,
             nominal_sp_to_fp: abi.frame_size() as i64,
             stack_map: None,
+            cur_srcloc: SourceLoc::default(),
         }
     }
 
     fn pre_safepoint(&mut self, stack_map: StackMap) {
         self.stack_map = Some(stack_map);
+    }
+
+    fn pre_sourceloc(&mut self, srcloc: SourceLoc) {
+        self.cur_srcloc = srcloc;
     }
 }
 
@@ -252,6 +260,10 @@ impl EmitState {
 
     fn clear_post_insn(&mut self) {
         self.stack_map = None;
+    }
+
+    fn cur_srcloc(&self) -> SourceLoc {
+        self.cur_srcloc
     }
 }
 
@@ -456,17 +468,13 @@ impl MachInstEmit for Inst {
                 let inst = enc_32_regs(inst, None, None, None, Some(rn));
                 emit_32(inst, sink);
             }
-            &Inst::Store {
-                rt,
-                ref mem,
-                srcloc,
-                bits,
-            } => {
+            &Inst::Store { rt, ref mem, bits } => {
                 let (mem_insts, mem) = mem_finalize(mem, state);
                 for inst in mem_insts.into_iter() {
                     inst.emit(sink, emit_info, state);
                 }
-                if let Some(srcloc) = srcloc {
+                let srcloc = state.cur_srcloc();
+                if srcloc != SourceLoc::default() {
                     // Register the offset at which the store instruction starts.
                     sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
                 }
@@ -496,7 +504,6 @@ impl MachInstEmit for Inst {
             &Inst::Load {
                 rt,
                 ref mem,
-                srcloc,
                 bits,
                 sign_extend,
             } => {
@@ -504,7 +511,8 @@ impl MachInstEmit for Inst {
                 for inst in mem_insts.into_iter() {
                     inst.emit(sink, emit_info, state);
                 }
-                if let Some(srcloc) = srcloc {
+                let srcloc = state.cur_srcloc();
+                if srcloc != SourceLoc::default() {
                     // Register the offset at which the load instruction starts.
                     sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
                 }
@@ -696,23 +704,24 @@ impl MachInstEmit for Inst {
                 }
             },
             &Inst::Call { ref info } => {
-                sink.add_reloc(info.loc, Reloc::Arm32Call, &info.dest, 0);
+                let srcloc = state.cur_srcloc();
+                sink.add_reloc(srcloc, Reloc::Arm32Call, &info.dest, 0);
                 emit_32(0b11110_0_0000000000_11_0_1_0_00000000000, sink);
                 if info.opcode.is_call() {
-                    sink.add_call_site(info.loc, info.opcode);
+                    sink.add_call_site(srcloc, info.opcode);
                 }
             }
             &Inst::CallInd { ref info } => {
+                let srcloc = state.cur_srcloc();
                 sink.put2(0b01000111_1_0000_000 | (machreg_to_gpr(info.rm) << 3));
                 if info.opcode.is_call() {
-                    sink.add_call_site(info.loc, info.opcode);
+                    sink.add_call_site(srcloc, info.opcode);
                 }
             }
             &Inst::LoadExtName {
                 rt,
                 ref name,
                 offset,
-                srcloc,
             } => {
                 //  maybe nop2          (0|2) bytes (pc is now 4-aligned)
                 //  ldr rt, [pc, #4]    4 bytes
@@ -729,7 +738,6 @@ impl MachInstEmit for Inst {
                 let inst = Inst::Load {
                     rt,
                     mem,
-                    srcloc: Some(srcloc),
                     bits: 32,
                     sign_extend: false,
                 };
@@ -740,6 +748,7 @@ impl MachInstEmit for Inst {
                 };
                 inst.emit(sink, emit_info, state);
 
+                let srcloc = state.cur_srcloc();
                 sink.add_reloc(srcloc, Reloc::Abs4, name, offset.into());
                 sink.put4(0);
             }
@@ -784,7 +793,8 @@ impl MachInstEmit for Inst {
                 sink.put2(inst);
             }
             &Inst::Udf { trap_info } => {
-                let (srcloc, code) = trap_info;
+                let srcloc = state.cur_srcloc();
+                let code = trap_info;
                 sink.add_trap(srcloc, code);
                 sink.put2(0b11011110_00000000);
             }

--- a/cranelift/codegen/src/isa/arm32/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/emit_tests.rs
@@ -1244,7 +1244,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(0),
             mem: AMode::reg_plus_reg(rreg(1), rreg(2), 0),
-            srcloc: None,
             bits: 32,
         },
         "41F80200",
@@ -1254,7 +1253,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(8),
             mem: AMode::reg_plus_reg(rreg(9), rreg(10), 3),
-            srcloc: None,
             bits: 32,
         },
         "49F83A80",
@@ -1264,7 +1262,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(0),
             mem: AMode::RegOffset(rreg(1), 4095),
-            srcloc: None,
             bits: 32,
         },
         "C1F8FF0F",
@@ -1274,7 +1271,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(8),
             mem: AMode::RegOffset(rreg(9), 0),
-            srcloc: None,
             bits: 32,
         },
         "C9F80080",
@@ -1284,7 +1280,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(7),
             mem: AMode::RegOffset(rreg(11), 65535),
-            srcloc: None,
             bits: 32,
         },
         "4FF6FF7C4BF80C70",
@@ -1294,7 +1289,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(10),
             mem: AMode::RegOffset(rreg(4), 16777215),
-            srcloc: None,
             bits: 32,
         },
         "4FF6FF7CC0F2FF0C44F80CA0",
@@ -1304,7 +1298,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(0),
             mem: AMode::reg_plus_reg(rreg(1), rreg(2), 0),
-            srcloc: None,
             bits: 16,
         },
         "21F80200",
@@ -1314,7 +1307,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(8),
             mem: AMode::reg_plus_reg(rreg(9), rreg(10), 2),
-            srcloc: None,
             bits: 16,
         },
         "29F82A80",
@@ -1324,7 +1316,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(0),
             mem: AMode::RegOffset(rreg(1), 3210),
-            srcloc: None,
             bits: 16,
         },
         "A1F88A0C",
@@ -1334,7 +1325,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(8),
             mem: AMode::RegOffset(rreg(9), 1),
-            srcloc: None,
             bits: 16,
         },
         "A9F80180",
@@ -1344,7 +1334,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(7),
             mem: AMode::RegOffset(rreg(11), 65535),
-            srcloc: None,
             bits: 16,
         },
         "4FF6FF7C2BF80C70",
@@ -1354,7 +1343,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(10),
             mem: AMode::RegOffset(rreg(4), 16777215),
-            srcloc: None,
             bits: 16,
         },
         "4FF6FF7CC0F2FF0C24F80CA0",
@@ -1364,7 +1352,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(0),
             mem: AMode::reg_plus_reg(rreg(1), rreg(2), 0),
-            srcloc: None,
             bits: 8,
         },
         "01F80200",
@@ -1374,7 +1361,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(8),
             mem: AMode::reg_plus_reg(rreg(9), rreg(10), 1),
-            srcloc: None,
             bits: 8,
         },
         "09F81A80",
@@ -1384,7 +1370,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(0),
             mem: AMode::RegOffset(rreg(1), 4),
-            srcloc: None,
             bits: 8,
         },
         "81F80400",
@@ -1394,7 +1379,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(8),
             mem: AMode::RegOffset(rreg(9), 777),
-            srcloc: None,
             bits: 8,
         },
         "89F80983",
@@ -1404,7 +1388,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(7),
             mem: AMode::RegOffset(rreg(11), 65535),
-            srcloc: None,
             bits: 8,
         },
         "4FF6FF7C0BF80C70",
@@ -1414,7 +1397,6 @@ fn test_arm32_emit() {
         Inst::Store {
             rt: rreg(10),
             mem: AMode::RegOffset(rreg(4), 16777215),
-            srcloc: None,
             bits: 8,
         },
         "4FF6FF7CC0F2FF0C04F80CA0",
@@ -1424,7 +1406,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::reg_plus_reg(rreg(1), rreg(2), 0),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1435,7 +1416,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::reg_plus_reg(rreg(9), rreg(10), 1),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1446,7 +1426,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::RegOffset(rreg(1), 55),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1457,7 +1436,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::RegOffset(rreg(9), 1234),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1468,7 +1446,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(7),
             mem: AMode::RegOffset(rreg(11), 9876),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1479,7 +1456,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(10),
             mem: AMode::RegOffset(rreg(4), 252645135),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1490,7 +1466,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::PCRel(-56),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1501,7 +1476,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::PCRel(1024),
-            srcloc: None,
             bits: 32,
             sign_extend: false,
         },
@@ -1512,7 +1486,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::reg_plus_reg(rreg(1), rreg(2), 0),
-            srcloc: None,
             bits: 16,
             sign_extend: true,
         },
@@ -1523,7 +1496,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::reg_plus_reg(rreg(9), rreg(10), 2),
-            srcloc: None,
             bits: 16,
             sign_extend: false,
         },
@@ -1534,7 +1506,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::RegOffset(rreg(1), 55),
-            srcloc: None,
             bits: 16,
             sign_extend: false,
         },
@@ -1545,7 +1516,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::RegOffset(rreg(9), 1234),
-            srcloc: None,
             bits: 16,
             sign_extend: true,
         },
@@ -1556,7 +1526,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(7),
             mem: AMode::RegOffset(rreg(11), 9876),
-            srcloc: None,
             bits: 16,
             sign_extend: true,
         },
@@ -1567,7 +1536,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(10),
             mem: AMode::RegOffset(rreg(4), 252645135),
-            srcloc: None,
             bits: 16,
             sign_extend: false,
         },
@@ -1578,7 +1546,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::PCRel(56),
-            srcloc: None,
             bits: 16,
             sign_extend: false,
         },
@@ -1589,7 +1556,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::PCRel(-1000),
-            srcloc: None,
             bits: 16,
             sign_extend: true,
         },
@@ -1600,7 +1566,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::reg_plus_reg(rreg(1), rreg(2), 0),
-            srcloc: None,
             bits: 8,
             sign_extend: true,
         },
@@ -1611,7 +1576,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::reg_plus_reg(rreg(9), rreg(10), 3),
-            srcloc: None,
             bits: 8,
             sign_extend: false,
         },
@@ -1622,7 +1586,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::RegOffset(rreg(1), 55),
-            srcloc: None,
             bits: 8,
             sign_extend: false,
         },
@@ -1633,7 +1596,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::RegOffset(rreg(9), 1234),
-            srcloc: None,
             bits: 8,
             sign_extend: true,
         },
@@ -1644,7 +1606,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(7),
             mem: AMode::RegOffset(rreg(11), 9876),
-            srcloc: None,
             bits: 8,
             sign_extend: true,
         },
@@ -1655,7 +1616,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(10),
             mem: AMode::RegOffset(rreg(4), 252645135),
-            srcloc: None,
             bits: 8,
             sign_extend: false,
         },
@@ -1666,7 +1626,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(0),
             mem: AMode::PCRel(72),
-            srcloc: None,
             bits: 8,
             sign_extend: false,
         },
@@ -1677,7 +1636,6 @@ fn test_arm32_emit() {
         Inst::Load {
             rt: writable_rreg(8),
             mem: AMode::PCRel(-1234),
-            srcloc: None,
             bits: 8,
             sign_extend: true,
         },
@@ -1961,7 +1919,7 @@ fn test_arm32_emit() {
     insns.push((
         Inst::TrapIf {
             cond: Cond::Eq,
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_info: TrapCode::Interrupt,
         },
         "40F0018000DE",
         "bne 2 ; udf #0",
@@ -1969,14 +1927,14 @@ fn test_arm32_emit() {
     insns.push((
         Inst::TrapIf {
             cond: Cond::Hs,
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_info: TrapCode::Interrupt,
         },
         "C0F0018000DE",
         "blo 2 ; udf #0",
     ));
     insns.push((
         Inst::Udf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_info: TrapCode::Interrupt,
         },
         "00DE",
         "udf #0",

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -98,82 +98,82 @@ fn test_x64_emit() {
     //
     // Addr_IR, offset zero
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rax), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rax), w_rdi),
         "488B38",
         "movq    0(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rbx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rbx), w_rdi),
         "488B3B",
         "movq    0(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rcx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rcx), w_rdi),
         "488B39",
         "movq    0(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rdx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rdx), w_rdi),
         "488B3A",
         "movq    0(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rbp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rbp), w_rdi),
         "488B7D00",
         "movq    0(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rsp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rsp), w_rdi),
         "488B3C24",
         "movq    0(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rsi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rsi), w_rdi),
         "488B3E",
         "movq    0(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, rdi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, rdi), w_rdi),
         "488B3F",
         "movq    0(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r8), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r8), w_rdi),
         "498B38",
         "movq    0(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r9), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r9), w_rdi),
         "498B39",
         "movq    0(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r10), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r10), w_rdi),
         "498B3A",
         "movq    0(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r11), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r11), w_rdi),
         "498B3B",
         "movq    0(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r12), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r12), w_rdi),
         "498B3C24",
         "movq    0(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r13), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r13), w_rdi),
         "498B7D00",
         "movq    0(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r14), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r14), w_rdi),
         "498B3E",
         "movq    0(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0, r15), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0, r15), w_rdi),
         "498B3F",
         "movq    0(%r15), %rdi",
     ));
@@ -181,82 +181,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset max simm8
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rax), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rax), w_rdi),
         "488B787F",
         "movq    127(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rbx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rbx), w_rdi),
         "488B7B7F",
         "movq    127(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rcx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rcx), w_rdi),
         "488B797F",
         "movq    127(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rdx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rdx), w_rdi),
         "488B7A7F",
         "movq    127(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rbp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rbp), w_rdi),
         "488B7D7F",
         "movq    127(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rsp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rsp), w_rdi),
         "488B7C247F",
         "movq    127(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rsi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rsi), w_rdi),
         "488B7E7F",
         "movq    127(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, rdi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, rdi), w_rdi),
         "488B7F7F",
         "movq    127(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r8), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r8), w_rdi),
         "498B787F",
         "movq    127(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r9), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r9), w_rdi),
         "498B797F",
         "movq    127(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r10), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r10), w_rdi),
         "498B7A7F",
         "movq    127(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r11), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r11), w_rdi),
         "498B7B7F",
         "movq    127(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r12), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r12), w_rdi),
         "498B7C247F",
         "movq    127(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r13), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r13), w_rdi),
         "498B7D7F",
         "movq    127(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r14), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r14), w_rdi),
         "498B7E7F",
         "movq    127(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(127, r15), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(127, r15), w_rdi),
         "498B7F7F",
         "movq    127(%r15), %rdi",
     ));
@@ -264,82 +264,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset min simm8
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rax), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rax), w_rdi),
         "488B7880",
         "movq    -128(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rbx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rbx), w_rdi),
         "488B7B80",
         "movq    -128(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rcx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rcx), w_rdi),
         "488B7980",
         "movq    -128(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rdx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rdx), w_rdi),
         "488B7A80",
         "movq    -128(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rbp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rbp), w_rdi),
         "488B7D80",
         "movq    -128(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rsp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rsp), w_rdi),
         "488B7C2480",
         "movq    -128(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rsi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rsi), w_rdi),
         "488B7E80",
         "movq    -128(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rdi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, rdi), w_rdi),
         "488B7F80",
         "movq    -128(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r8), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r8), w_rdi),
         "498B7880",
         "movq    -128(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r9), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r9), w_rdi),
         "498B7980",
         "movq    -128(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r10), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r10), w_rdi),
         "498B7A80",
         "movq    -128(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r11), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r11), w_rdi),
         "498B7B80",
         "movq    -128(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r12), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r12), w_rdi),
         "498B7C2480",
         "movq    -128(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r13), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r13), w_rdi),
         "498B7D80",
         "movq    -128(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r14), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r14), w_rdi),
         "498B7E80",
         "movq    -128(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r15), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-128i32 as u32, r15), w_rdi),
         "498B7F80",
         "movq    -128(%r15), %rdi",
     ));
@@ -347,82 +347,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset smallest positive simm32
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rax), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rax), w_rdi),
         "488BB880000000",
         "movq    128(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rbx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rbx), w_rdi),
         "488BBB80000000",
         "movq    128(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rcx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rcx), w_rdi),
         "488BB980000000",
         "movq    128(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rdx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rdx), w_rdi),
         "488BBA80000000",
         "movq    128(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rbp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rbp), w_rdi),
         "488BBD80000000",
         "movq    128(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rsp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rsp), w_rdi),
         "488BBC2480000000",
         "movq    128(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rsi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rsi), w_rdi),
         "488BBE80000000",
         "movq    128(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, rdi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, rdi), w_rdi),
         "488BBF80000000",
         "movq    128(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r8), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r8), w_rdi),
         "498BB880000000",
         "movq    128(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r9), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r9), w_rdi),
         "498BB980000000",
         "movq    128(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r10), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r10), w_rdi),
         "498BBA80000000",
         "movq    128(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r11), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r11), w_rdi),
         "498BBB80000000",
         "movq    128(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r12), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r12), w_rdi),
         "498BBC2480000000",
         "movq    128(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r13), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r13), w_rdi),
         "498BBD80000000",
         "movq    128(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r14), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r14), w_rdi),
         "498BBE80000000",
         "movq    128(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(128, r15), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(128, r15), w_rdi),
         "498BBF80000000",
         "movq    128(%r15), %rdi",
     ));
@@ -430,82 +430,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset smallest negative simm32
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rax), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rax), w_rdi),
         "488BB87FFFFFFF",
         "movq    -129(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rbx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rbx), w_rdi),
         "488BBB7FFFFFFF",
         "movq    -129(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rcx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rcx), w_rdi),
         "488BB97FFFFFFF",
         "movq    -129(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rdx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rdx), w_rdi),
         "488BBA7FFFFFFF",
         "movq    -129(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rbp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rbp), w_rdi),
         "488BBD7FFFFFFF",
         "movq    -129(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rsp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rsp), w_rdi),
         "488BBC247FFFFFFF",
         "movq    -129(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rsi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rsi), w_rdi),
         "488BBE7FFFFFFF",
         "movq    -129(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rdi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, rdi), w_rdi),
         "488BBF7FFFFFFF",
         "movq    -129(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r8), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r8), w_rdi),
         "498BB87FFFFFFF",
         "movq    -129(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r9), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r9), w_rdi),
         "498BB97FFFFFFF",
         "movq    -129(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r10), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r10), w_rdi),
         "498BBA7FFFFFFF",
         "movq    -129(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r11), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r11), w_rdi),
         "498BBB7FFFFFFF",
         "movq    -129(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r12), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r12), w_rdi),
         "498BBC247FFFFFFF",
         "movq    -129(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r13), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r13), w_rdi),
         "498BBD7FFFFFFF",
         "movq    -129(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r14), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r14), w_rdi),
         "498BBE7FFFFFFF",
         "movq    -129(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r15), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-129i32 as u32, r15), w_rdi),
         "498BBF7FFFFFFF",
         "movq    -129(%r15), %rdi",
     ));
@@ -513,82 +513,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset large positive simm32
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rax), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rax), w_rdi),
         "488BB877207317",
         "movq    393420919(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rbx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rbx), w_rdi),
         "488BBB77207317",
         "movq    393420919(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rcx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rcx), w_rdi),
         "488BB977207317",
         "movq    393420919(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rdx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rdx), w_rdi),
         "488BBA77207317",
         "movq    393420919(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rbp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rbp), w_rdi),
         "488BBD77207317",
         "movq    393420919(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rsp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rsp), w_rdi),
         "488BBC2477207317",
         "movq    393420919(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rsi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rsi), w_rdi),
         "488BBE77207317",
         "movq    393420919(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rdi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, rdi), w_rdi),
         "488BBF77207317",
         "movq    393420919(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r8), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r8), w_rdi),
         "498BB877207317",
         "movq    393420919(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r9), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r9), w_rdi),
         "498BB977207317",
         "movq    393420919(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r10), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r10), w_rdi),
         "498BBA77207317",
         "movq    393420919(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r11), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r11), w_rdi),
         "498BBB77207317",
         "movq    393420919(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r12), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r12), w_rdi),
         "498BBC2477207317",
         "movq    393420919(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r13), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r13), w_rdi),
         "498BBD77207317",
         "movq    393420919(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r14), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r14), w_rdi),
         "498BBE77207317",
         "movq    393420919(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r15), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(0x17732077, r15), w_rdi),
         "498BBF77207317",
         "movq    393420919(%r15), %rdi",
     ));
@@ -596,82 +596,82 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IR, offset large negative simm32
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rax), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rax), w_rdi),
         "488BB8D9A6BECE",
         "movq    -826366247(%rax), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rbx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rbx), w_rdi),
         "488BBBD9A6BECE",
         "movq    -826366247(%rbx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rcx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rcx), w_rdi),
         "488BB9D9A6BECE",
         "movq    -826366247(%rcx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rdx), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rdx), w_rdi),
         "488BBAD9A6BECE",
         "movq    -826366247(%rdx), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rbp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rbp), w_rdi),
         "488BBDD9A6BECE",
         "movq    -826366247(%rbp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rsp), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rsp), w_rdi),
         "488BBC24D9A6BECE",
         "movq    -826366247(%rsp), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rsi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rsi), w_rdi),
         "488BBED9A6BECE",
         "movq    -826366247(%rsi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rdi), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, rdi), w_rdi),
         "488BBFD9A6BECE",
         "movq    -826366247(%rdi), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r8), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r8), w_rdi),
         "498BB8D9A6BECE",
         "movq    -826366247(%r8), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r9), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r9), w_rdi),
         "498BB9D9A6BECE",
         "movq    -826366247(%r9), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r10), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r10), w_rdi),
         "498BBAD9A6BECE",
         "movq    -826366247(%r10), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r11), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r11), w_rdi),
         "498BBBD9A6BECE",
         "movq    -826366247(%r11), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r12), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r12), w_rdi),
         "498BBC24D9A6BECE",
         "movq    -826366247(%r12), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r13), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r13), w_rdi),
         "498BBDD9A6BECE",
         "movq    -826366247(%r13), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r14), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r14), w_rdi),
         "498BBED9A6BECE",
         "movq    -826366247(%r14), %rdi",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r15), w_rdi, None),
+        Inst::mov64_m_r(Amode::imm_reg(-0x31415927i32 as u32, r15), w_rdi),
         "498BBFD9A6BECE",
         "movq    -826366247(%r15), %rdi",
     ));
@@ -683,42 +683,42 @@ fn test_x64_emit() {
     //
     // Addr_IRRS, offset max simm8
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rax, rax, 0), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rax, rax, 0), w_r11),
         "4C8B5C007F",
         "movq    127(%rax,%rax,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rdi, rax, 1), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rdi, rax, 1), w_r11),
         "4C8B5C477F",
         "movq    127(%rdi,%rax,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r8, rax, 2), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r8, rax, 2), w_r11),
         "4D8B5C807F",
         "movq    127(%r8,%rax,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r15, rax, 3), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r15, rax, 3), w_r11),
         "4D8B5CC77F",
         "movq    127(%r15,%rax,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rax, rdi, 3), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rax, rdi, 3), w_r11),
         "4C8B5CF87F",
         "movq    127(%rax,%rdi,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rdi, rdi, 2), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, rdi, rdi, 2), w_r11),
         "4C8B5CBF7F",
         "movq    127(%rdi,%rdi,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r8, rdi, 1), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r8, rdi, 1), w_r11),
         "4D8B5C787F",
         "movq    127(%r8,%rdi,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r15, rdi, 0), w_r11, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(127, r15, rdi, 0), w_r11),
         "4D8B5C3F7F",
         "movq    127(%r15,%rdi,1), %r11",
     ));
@@ -726,74 +726,42 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IRRS, offset min simm8
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, rax, r8, 2),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rax, r8, 2), w_r11),
         "4E8B5C8080",
         "movq    -128(%rax,%r8,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, rdi, r8, 3),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rdi, r8, 3), w_r11),
         "4E8B5CC780",
         "movq    -128(%rdi,%r8,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, r8, r8, 0),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r8, r8, 0), w_r11),
         "4F8B5C0080",
         "movq    -128(%r8,%r8,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, r15, r8, 1),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r15, r8, 1), w_r11),
         "4F8B5C4780",
         "movq    -128(%r15,%r8,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, rax, r15, 1),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rax, r15, 1), w_r11),
         "4E8B5C7880",
         "movq    -128(%rax,%r15,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, rdi, r15, 0),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, rdi, r15, 0), w_r11),
         "4E8B5C3F80",
         "movq    -128(%rdi,%r15,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, r8, r15, 3),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r8, r15, 3), w_r11),
         "4F8B5CF880",
         "movq    -128(%r8,%r15,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32 as u32, r15, r15, 2),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(-128i32 as u32, r15, r15, 2), w_r11),
         "4F8B5CBF80",
         "movq    -128(%r15,%r15,4), %r11",
     ));
@@ -801,74 +769,42 @@ fn test_x64_emit() {
     // ========================================================
     // Addr_IRRS, offset large positive simm32
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, rax, rax, 0),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rax, rax, 0), w_r11),
         "4C8B9C00BE25664F",
         "movq    1332094398(%rax,%rax,1), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, rdi, rax, 1),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rdi, rax, 1), w_r11),
         "4C8B9C47BE25664F",
         "movq    1332094398(%rdi,%rax,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, r8, rax, 2),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r8, rax, 2), w_r11),
         "4D8B9C80BE25664F",
         "movq    1332094398(%r8,%rax,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, r15, rax, 3),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r15, rax, 3), w_r11),
         "4D8B9CC7BE25664F",
         "movq    1332094398(%r15,%rax,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, rax, rdi, 3),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rax, rdi, 3), w_r11),
         "4C8B9CF8BE25664F",
         "movq    1332094398(%rax,%rdi,8), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, rdi, rdi, 2),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, rdi, rdi, 2), w_r11),
         "4C8B9CBFBE25664F",
         "movq    1332094398(%rdi,%rdi,4), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, r8, rdi, 1),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r8, rdi, 1), w_r11),
         "4D8B9C78BE25664F",
         "movq    1332094398(%r8,%rdi,2), %r11",
     ));
     insns.push((
-        Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, r15, rdi, 0),
-            w_r11,
-            None,
-        ),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(0x4f6625be, r15, rdi, 0), w_r11),
         "4D8B9C3FBE25664F",
         "movq    1332094398(%r15,%rdi,1), %r11",
     ));
@@ -879,7 +815,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rax, r8, 2),
             w_r11,
-            None,
         ),
         "4E8B9C8070E9B2D9",
         "movq    -642586256(%rax,%r8,4), %r11",
@@ -888,7 +823,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rdi, r8, 3),
             w_r11,
-            None,
         ),
         "4E8B9CC770E9B2D9",
         "movq    -642586256(%rdi,%r8,8), %r11",
@@ -897,7 +831,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r8, r8, 0),
             w_r11,
-            None,
         ),
         "4F8B9C0070E9B2D9",
         "movq    -642586256(%r8,%r8,1), %r11",
@@ -906,7 +839,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r15, r8, 1),
             w_r11,
-            None,
         ),
         "4F8B9C4770E9B2D9",
         "movq    -642586256(%r15,%r8,2), %r11",
@@ -915,7 +847,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rax, r15, 1),
             w_r11,
-            None,
         ),
         "4E8B9C7870E9B2D9",
         "movq    -642586256(%rax,%r15,2), %r11",
@@ -924,7 +855,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, rdi, r15, 0),
             w_r11,
-            None,
         ),
         "4E8B9C3F70E9B2D9",
         "movq    -642586256(%rdi,%r15,1), %r11",
@@ -933,7 +863,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r8, r15, 3),
             w_r11,
-            None,
         ),
         "4F8B9CF870E9B2D9",
         "movq    -642586256(%r8,%r15,8), %r11",
@@ -942,7 +871,6 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(-0x264d1690i32 as u32, r15, r15, 2),
             w_r11,
-            None,
         ),
         "4F8B9CBF70E9B2D9",
         "movq    -642586256(%r15,%r15,4), %r11",
@@ -1292,42 +1220,22 @@ fn test_x64_emit() {
     // ========================================================
     // Div
     insns.push((
-        Inst::div(
-            4,
-            true, /*signed*/
-            RegMem::reg(regs::rsi()),
-            SourceLoc::default(),
-        ),
+        Inst::div(4, true /*signed*/, RegMem::reg(regs::rsi())),
         "F7FE",
         "idiv    %esi",
     ));
     insns.push((
-        Inst::div(
-            8,
-            true, /*signed*/
-            RegMem::reg(regs::r15()),
-            SourceLoc::default(),
-        ),
+        Inst::div(8, true /*signed*/, RegMem::reg(regs::r15())),
         "49F7FF",
         "idiv    %r15",
     ));
     insns.push((
-        Inst::div(
-            4,
-            false, /*signed*/
-            RegMem::reg(regs::r14()),
-            SourceLoc::default(),
-        ),
+        Inst::div(4, false /*signed*/, RegMem::reg(regs::r14())),
         "41F7F6",
         "div     %r14d",
     ));
     insns.push((
-        Inst::div(
-            8,
-            false, /*signed*/
-            RegMem::reg(regs::rdi()),
-            SourceLoc::default(),
-        ),
+        Inst::div(8, false /*signed*/, RegMem::reg(regs::rdi())),
         "48F7F7",
         "div     %rdi",
     ));
@@ -1455,17 +1363,17 @@ fn test_x64_emit() {
     // ========================================================
     // MovZX_RM_R
     insns.push((
-        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(rdi), w_rdi, None),
+        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(rdi), w_rdi),
         "400FB6FF",
         "movzbl  %dil, %edi",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(rax), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(rax), w_rsi),
         "0FB6F0",
         "movzbl  %al, %esi",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(r15), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::BL, RegMem::reg(r15), w_rsi),
         "410FB6F7",
         "movzbl  %r15b, %esi",
     ));
@@ -1474,7 +1382,6 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "0FB671F9",
         "movzbl  -7(%rcx), %esi",
@@ -1484,7 +1391,6 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "410FB658F9",
         "movzbl  -7(%r8), %ebx",
@@ -1494,7 +1400,6 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "450FB64AF9",
         "movzbl  -7(%r10), %r9d",
@@ -1504,18 +1409,17 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "410FB653F9",
         "movzbl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::BQ, RegMem::reg(rax), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::BQ, RegMem::reg(rax), w_rsi),
         "480FB6F0",
         "movzbq  %al, %rsi",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::BQ, RegMem::reg(r10), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::BQ, RegMem::reg(r10), w_rsi),
         "490FB6F2",
         "movzbq  %r10b, %rsi",
     ));
@@ -1524,7 +1428,6 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "480FB671F9",
         "movzbq  -7(%rcx), %rsi",
@@ -1534,7 +1437,6 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "490FB658F9",
         "movzbq  -7(%r8), %rbx",
@@ -1544,7 +1446,6 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "4D0FB64AF9",
         "movzbq  -7(%r10), %r9",
@@ -1554,18 +1455,17 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "490FB653F9",
         "movzbq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::WL, RegMem::reg(rcx), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::WL, RegMem::reg(rcx), w_rsi),
         "0FB7F1",
         "movzwl  %cx, %esi",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::WL, RegMem::reg(r10), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::WL, RegMem::reg(r10), w_rsi),
         "410FB7F2",
         "movzwl  %r10w, %esi",
     ));
@@ -1574,7 +1474,6 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "0FB771F9",
         "movzwl  -7(%rcx), %esi",
@@ -1584,7 +1483,6 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "410FB758F9",
         "movzwl  -7(%r8), %ebx",
@@ -1594,7 +1492,6 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "450FB74AF9",
         "movzwl  -7(%r10), %r9d",
@@ -1604,18 +1501,17 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "410FB753F9",
         "movzwl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::WQ, RegMem::reg(rcx), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::WQ, RegMem::reg(rcx), w_rsi),
         "480FB7F1",
         "movzwq  %cx, %rsi",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::WQ, RegMem::reg(r11), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::WQ, RegMem::reg(r11), w_rsi),
         "490FB7F3",
         "movzwq  %r11w, %rsi",
     ));
@@ -1624,7 +1520,6 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "480FB771F9",
         "movzwq  -7(%rcx), %rsi",
@@ -1634,7 +1529,6 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "490FB758F9",
         "movzwq  -7(%r8), %rbx",
@@ -1644,7 +1538,6 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "4D0FB74AF9",
         "movzwq  -7(%r10), %r9",
@@ -1654,13 +1547,12 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "490FB753F9",
         "movzwq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movzx_rm_r(ExtMode::LQ, RegMem::reg(rcx), w_rsi, None),
+        Inst::movzx_rm_r(ExtMode::LQ, RegMem::reg(rcx), w_rsi),
         "8BF1",
         "movl    %ecx, %esi",
     ));
@@ -1669,7 +1561,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "8B71F9",
         "movl    -7(%rcx), %esi",
@@ -1679,7 +1570,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "418B58F9",
         "movl    -7(%r8), %ebx",
@@ -1689,7 +1579,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "458B4AF9",
         "movl    -7(%r10), %r9d",
@@ -1699,7 +1588,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "418B53F9",
         "movl    -7(%r11), %edx",
@@ -1708,42 +1596,42 @@ fn test_x64_emit() {
     // ========================================================
     // Mov64_M_R
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, rbx, 0), w_rcx, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, rbx, 0), w_rcx),
         "488B8C18B3000000",
         "movq    179(%rax,%rbx,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, rbx, 0), w_r8, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, rbx, 0), w_r8),
         "4C8B8418B3000000",
         "movq    179(%rax,%rbx,1), %r8",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, r9, 0), w_rcx, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, r9, 0), w_rcx),
         "4A8B8C08B3000000",
         "movq    179(%rax,%r9,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, r9, 0), w_r8, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, rax, r9, 0), w_r8),
         "4E8B8408B3000000",
         "movq    179(%rax,%r9,1), %r8",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, rbx, 0), w_rcx, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, rbx, 0), w_rcx),
         "498B8C1AB3000000",
         "movq    179(%r10,%rbx,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, rbx, 0), w_r8, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, rbx, 0), w_r8),
         "4D8B841AB3000000",
         "movq    179(%r10,%rbx,1), %r8",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, r9, 0), w_rcx, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, r9, 0), w_rcx),
         "4B8B8C0AB3000000",
         "movq    179(%r10,%r9,1), %rcx",
     ));
     insns.push((
-        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, r9, 0), w_r8, None),
+        Inst::mov64_m_r(Amode::imm_reg_reg_shift(179, r10, r9, 0), w_r8),
         "4F8B840AB3000000",
         "movq    179(%r10,%r9,1), %r8",
     ));
@@ -1774,17 +1662,17 @@ fn test_x64_emit() {
     // ========================================================
     // MovSX_RM_R
     insns.push((
-        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(rdi), w_rdi, None),
+        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(rdi), w_rdi),
         "400FBEFF",
         "movsbl  %dil, %edi",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(rcx), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(rcx), w_rsi),
         "0FBEF1",
         "movsbl  %cl, %esi",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(r14), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(r14), w_rsi),
         "410FBEF6",
         "movsbl  %r14b, %esi",
     ));
@@ -1793,7 +1681,6 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "0FBE71F9",
         "movsbl  -7(%rcx), %esi",
@@ -1803,7 +1690,6 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "410FBE58F9",
         "movsbl  -7(%r8), %ebx",
@@ -1813,7 +1699,6 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "450FBE4AF9",
         "movsbl  -7(%r10), %r9d",
@@ -1823,18 +1708,17 @@ fn test_x64_emit() {
             ExtMode::BL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "410FBE53F9",
         "movsbl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::BQ, RegMem::reg(rcx), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::BQ, RegMem::reg(rcx), w_rsi),
         "480FBEF1",
         "movsbq  %cl, %rsi",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::BQ, RegMem::reg(r15), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::BQ, RegMem::reg(r15), w_rsi),
         "490FBEF7",
         "movsbq  %r15b, %rsi",
     ));
@@ -1843,7 +1727,6 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "480FBE71F9",
         "movsbq  -7(%rcx), %rsi",
@@ -1853,7 +1736,6 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "490FBE58F9",
         "movsbq  -7(%r8), %rbx",
@@ -1863,7 +1745,6 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "4D0FBE4AF9",
         "movsbq  -7(%r10), %r9",
@@ -1873,18 +1754,17 @@ fn test_x64_emit() {
             ExtMode::BQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "490FBE53F9",
         "movsbq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::WL, RegMem::reg(rcx), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::WL, RegMem::reg(rcx), w_rsi),
         "0FBFF1",
         "movswl  %cx, %esi",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::WL, RegMem::reg(r14), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::WL, RegMem::reg(r14), w_rsi),
         "410FBFF6",
         "movswl  %r14w, %esi",
     ));
@@ -1893,7 +1773,6 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "0FBF71F9",
         "movswl  -7(%rcx), %esi",
@@ -1903,7 +1782,6 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "410FBF58F9",
         "movswl  -7(%r8), %ebx",
@@ -1913,7 +1791,6 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "450FBF4AF9",
         "movswl  -7(%r10), %r9d",
@@ -1923,18 +1800,17 @@ fn test_x64_emit() {
             ExtMode::WL,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "410FBF53F9",
         "movswl  -7(%r11), %edx",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::WQ, RegMem::reg(rcx), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::WQ, RegMem::reg(rcx), w_rsi),
         "480FBFF1",
         "movswq  %cx, %rsi",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::WQ, RegMem::reg(r13), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::WQ, RegMem::reg(r13), w_rsi),
         "490FBFF5",
         "movswq  %r13w, %rsi",
     ));
@@ -1943,7 +1819,6 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "480FBF71F9",
         "movswq  -7(%rcx), %rsi",
@@ -1953,7 +1828,6 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "490FBF58F9",
         "movswq  -7(%r8), %rbx",
@@ -1963,7 +1837,6 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "4D0FBF4AF9",
         "movswq  -7(%r10), %r9",
@@ -1973,18 +1846,17 @@ fn test_x64_emit() {
             ExtMode::WQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "490FBF53F9",
         "movswq  -7(%r11), %rdx",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::LQ, RegMem::reg(rcx), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::LQ, RegMem::reg(rcx), w_rsi),
         "4863F1",
         "movslq  %ecx, %rsi",
     ));
     insns.push((
-        Inst::movsx_rm_r(ExtMode::LQ, RegMem::reg(r15), w_rsi, None),
+        Inst::movsx_rm_r(ExtMode::LQ, RegMem::reg(r15), w_rsi),
         "4963F7",
         "movslq  %r15d, %rsi",
     ));
@@ -1993,7 +1865,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, rcx)),
             w_rsi,
-            None,
         ),
         "486371F9",
         "movslq  -7(%rcx), %rsi",
@@ -2003,7 +1874,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r8)),
             w_rbx,
-            None,
         ),
         "496358F9",
         "movslq  -7(%r8), %rbx",
@@ -2013,7 +1883,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r10)),
             w_r9,
-            None,
         ),
         "4D634AF9",
         "movslq  -7(%r10), %r9",
@@ -2023,7 +1892,6 @@ fn test_x64_emit() {
             ExtMode::LQ,
             RegMem::mem(Amode::imm_reg(-7i32 as u32, r11)),
             w_rdx,
-            None,
         ),
         "496353F9",
         "movslq  -7(%r11), %rdx",
@@ -2032,325 +1900,325 @@ fn test_x64_emit() {
     // ========================================================
     // Mov_R_M.  Byte stores are tricky.  Check everything carefully.
     insns.push((
-        Inst::mov_r_m(8, rax, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(8, rax, Amode::imm_reg(99, rdi)),
         "48894763",
         "movq    %rax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rbx, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(8, rbx, Amode::imm_reg(99, r8)),
         "49895863",
         "movq    %rbx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rcx, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(8, rcx, Amode::imm_reg(99, rsi)),
         "48894E63",
         "movq    %rcx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rdx, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(8, rdx, Amode::imm_reg(99, r9)),
         "49895163",
         "movq    %rdx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rsi, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(8, rsi, Amode::imm_reg(99, rax)),
         "48897063",
         "movq    %rsi, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rdi, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(8, rdi, Amode::imm_reg(99, r15)),
         "49897F63",
         "movq    %rdi, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rsp, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(8, rsp, Amode::imm_reg(99, rcx)),
         "48896163",
         "movq    %rsp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rbp, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(8, rbp, Amode::imm_reg(99, r14)),
         "49896E63",
         "movq    %rbp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r8, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(8, r8, Amode::imm_reg(99, rdi)),
         "4C894763",
         "movq    %r8, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r9, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(8, r9, Amode::imm_reg(99, r8)),
         "4D894863",
         "movq    %r9, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r10, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(8, r10, Amode::imm_reg(99, rsi)),
         "4C895663",
         "movq    %r10, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r11, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(8, r11, Amode::imm_reg(99, r9)),
         "4D895963",
         "movq    %r11, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r12, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(8, r12, Amode::imm_reg(99, rax)),
         "4C896063",
         "movq    %r12, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r13, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(8, r13, Amode::imm_reg(99, r15)),
         "4D896F63",
         "movq    %r13, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r14, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(8, r14, Amode::imm_reg(99, rcx)),
         "4C897163",
         "movq    %r14, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r15, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(8, r15, Amode::imm_reg(99, r14)),
         "4D897E63",
         "movq    %r15, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(4, rax, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(4, rax, Amode::imm_reg(99, rdi)),
         "894763",
         "movl    %eax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rbx, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(4, rbx, Amode::imm_reg(99, r8)),
         "41895863",
         "movl    %ebx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rcx, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(4, rcx, Amode::imm_reg(99, rsi)),
         "894E63",
         "movl    %ecx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rdx, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(4, rdx, Amode::imm_reg(99, r9)),
         "41895163",
         "movl    %edx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rsi, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(4, rsi, Amode::imm_reg(99, rax)),
         "897063",
         "movl    %esi, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rdi, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(4, rdi, Amode::imm_reg(99, r15)),
         "41897F63",
         "movl    %edi, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rsp, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(4, rsp, Amode::imm_reg(99, rcx)),
         "896163",
         "movl    %esp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rbp, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(4, rbp, Amode::imm_reg(99, r14)),
         "41896E63",
         "movl    %ebp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r8, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(4, r8, Amode::imm_reg(99, rdi)),
         "44894763",
         "movl    %r8d, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r9, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(4, r9, Amode::imm_reg(99, r8)),
         "45894863",
         "movl    %r9d, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r10, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(4, r10, Amode::imm_reg(99, rsi)),
         "44895663",
         "movl    %r10d, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r11, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(4, r11, Amode::imm_reg(99, r9)),
         "45895963",
         "movl    %r11d, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r12, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(4, r12, Amode::imm_reg(99, rax)),
         "44896063",
         "movl    %r12d, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r13, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(4, r13, Amode::imm_reg(99, r15)),
         "45896F63",
         "movl    %r13d, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r14, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(4, r14, Amode::imm_reg(99, rcx)),
         "44897163",
         "movl    %r14d, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r15, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(4, r15, Amode::imm_reg(99, r14)),
         "45897E63",
         "movl    %r15d, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(2, rax, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(2, rax, Amode::imm_reg(99, rdi)),
         "66894763",
         "movw    %ax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rbx, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(2, rbx, Amode::imm_reg(99, r8)),
         "6641895863",
         "movw    %bx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rcx, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(2, rcx, Amode::imm_reg(99, rsi)),
         "66894E63",
         "movw    %cx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rdx, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(2, rdx, Amode::imm_reg(99, r9)),
         "6641895163",
         "movw    %dx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rsi, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(2, rsi, Amode::imm_reg(99, rax)),
         "66897063",
         "movw    %si, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rdi, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(2, rdi, Amode::imm_reg(99, r15)),
         "6641897F63",
         "movw    %di, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rsp, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(2, rsp, Amode::imm_reg(99, rcx)),
         "66896163",
         "movw    %sp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rbp, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(2, rbp, Amode::imm_reg(99, r14)),
         "6641896E63",
         "movw    %bp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r8, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(2, r8, Amode::imm_reg(99, rdi)),
         "6644894763",
         "movw    %r8w, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r9, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(2, r9, Amode::imm_reg(99, r8)),
         "6645894863",
         "movw    %r9w, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r10, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(2, r10, Amode::imm_reg(99, rsi)),
         "6644895663",
         "movw    %r10w, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r11, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(2, r11, Amode::imm_reg(99, r9)),
         "6645895963",
         "movw    %r11w, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r12, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(2, r12, Amode::imm_reg(99, rax)),
         "6644896063",
         "movw    %r12w, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r13, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(2, r13, Amode::imm_reg(99, r15)),
         "6645896F63",
         "movw    %r13w, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r14, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(2, r14, Amode::imm_reg(99, rcx)),
         "6644897163",
         "movw    %r14w, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r15, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(2, r15, Amode::imm_reg(99, r14)),
         "6645897E63",
         "movw    %r15w, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(1, rax, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(1, rax, Amode::imm_reg(99, rdi)),
         "884763",
         "movb    %al, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rbx, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(1, rbx, Amode::imm_reg(99, r8)),
         "41885863",
         "movb    %bl, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rcx, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(1, rcx, Amode::imm_reg(99, rsi)),
         "884E63",
         "movb    %cl, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rdx, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(1, rdx, Amode::imm_reg(99, r9)),
         "41885163",
         "movb    %dl, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rsi, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(1, rsi, Amode::imm_reg(99, rax)),
         "40887063",
         "movb    %sil, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rdi, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(1, rdi, Amode::imm_reg(99, r15)),
         "41887F63",
         "movb    %dil, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rsp, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(1, rsp, Amode::imm_reg(99, rcx)),
         "40886163",
         "movb    %spl, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rbp, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(1, rbp, Amode::imm_reg(99, r14)),
         "41886E63",
         "movb    %bpl, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r8, Amode::imm_reg(99, rdi), None),
+        Inst::mov_r_m(1, r8, Amode::imm_reg(99, rdi)),
         "44884763",
         "movb    %r8b, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r9, Amode::imm_reg(99, r8), None),
+        Inst::mov_r_m(1, r9, Amode::imm_reg(99, r8)),
         "45884863",
         "movb    %r9b, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r10, Amode::imm_reg(99, rsi), None),
+        Inst::mov_r_m(1, r10, Amode::imm_reg(99, rsi)),
         "44885663",
         "movb    %r10b, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r11, Amode::imm_reg(99, r9), None),
+        Inst::mov_r_m(1, r11, Amode::imm_reg(99, r9)),
         "45885963",
         "movb    %r11b, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r12, Amode::imm_reg(99, rax), None),
+        Inst::mov_r_m(1, r12, Amode::imm_reg(99, rax)),
         "44886063",
         "movb    %r12b, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r13, Amode::imm_reg(99, r15), None),
+        Inst::mov_r_m(1, r13, Amode::imm_reg(99, r15)),
         "45886F63",
         "movb    %r13b, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r14, Amode::imm_reg(99, rcx), None),
+        Inst::mov_r_m(1, r14, Amode::imm_reg(99, rcx)),
         "44887163",
         "movb    %r14b, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r15, Amode::imm_reg(99, r14), None),
+        Inst::mov_r_m(1, r15, Amode::imm_reg(99, r14)),
         "45887E63",
         "movb    %r15b, 99(%r14)",
     ));
@@ -2885,7 +2753,6 @@ fn test_x64_emit() {
             },
             Vec::new(),
             Vec::new(),
-            SourceLoc::default(),
             Opcode::Call,
         ),
         "E800000000",
@@ -2895,13 +2762,7 @@ fn test_x64_emit() {
     // ========================================================
     // CallUnknown
     fn call_unknown(rm: RegMem) -> Inst {
-        Inst::call_unknown(
-            rm,
-            Vec::new(),
-            Vec::new(),
-            SourceLoc::default(),
-            Opcode::CallIndirect,
-        )
+        Inst::call_unknown(rm, Vec::new(), Vec::new(), Opcode::CallIndirect)
     }
 
     insns.push((call_unknown(RegMem::reg(rbp)), "FFD5", "call    *%rbp"));
@@ -2983,12 +2844,12 @@ fn test_x64_emit() {
     // XMM_RM_R: float binary ops
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm1), w_xmm0, None),
+        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm1), w_xmm0),
         "F30F58C1",
         "addss   %xmm1, %xmm0",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm11), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Addss, RegMem::reg(xmm11), w_xmm13),
         "F3450F58EB",
         "addss   %xmm11, %xmm13",
     ));
@@ -2997,24 +2858,23 @@ fn test_x64_emit() {
             SseOpcode::Addss,
             RegMem::mem(Amode::imm_reg_reg_shift(123, r10, rdx, 2)),
             w_xmm0,
-            None,
         ),
         "F3410F5844927B",
         "addss   123(%r10,%rdx,4), %xmm0",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Addsd, RegMem::reg(xmm15), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Addsd, RegMem::reg(xmm15), w_xmm4),
         "F2410F58E7",
         "addsd   %xmm15, %xmm4",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm0), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm0), w_xmm1),
         "F30F5CC8",
         "subss   %xmm0, %xmm1",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm12), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Subss, RegMem::reg(xmm12), w_xmm1),
         "F3410F5CCC",
         "subss   %xmm12, %xmm1",
     ));
@@ -3023,58 +2883,57 @@ fn test_x64_emit() {
             SseOpcode::Subss,
             RegMem::mem(Amode::imm_reg_reg_shift(321, r10, rax, 3)),
             w_xmm10,
-            None,
         ),
         "F3450F5C94C241010000",
         "subss   321(%r10,%rax,8), %xmm10",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Subsd, RegMem::reg(xmm5), w_xmm14, None),
+        Inst::xmm_rm_r(SseOpcode::Subsd, RegMem::reg(xmm5), w_xmm14),
         "F2440F5CF5",
         "subsd   %xmm5, %xmm14",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Mulss, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Mulss, RegMem::reg(xmm5), w_xmm4),
         "F30F59E5",
         "mulss   %xmm5, %xmm4",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Mulsd, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Mulsd, RegMem::reg(xmm5), w_xmm4),
         "F20F59E5",
         "mulsd   %xmm5, %xmm4",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Divss, RegMem::reg(xmm8), w_xmm7, None),
+        Inst::xmm_rm_r(SseOpcode::Divss, RegMem::reg(xmm8), w_xmm7),
         "F3410F5EF8",
         "divss   %xmm8, %xmm7",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Divsd, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Divsd, RegMem::reg(xmm5), w_xmm4),
         "F20F5EE5",
         "divsd   %xmm5, %xmm4",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Andps, RegMem::reg(xmm3), w_xmm12, None),
+        Inst::xmm_rm_r(SseOpcode::Andps, RegMem::reg(xmm3), w_xmm12),
         "440F54E3",
         "andps   %xmm3, %xmm12",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Andnps, RegMem::reg(xmm4), w_xmm11, None),
+        Inst::xmm_rm_r(SseOpcode::Andnps, RegMem::reg(xmm4), w_xmm11),
         "440F55DC",
         "andnps  %xmm4, %xmm11",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm1), w_xmm15, None),
+        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm1), w_xmm15),
         "440F56F9",
         "orps    %xmm1, %xmm15",
     ));
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm5), w_xmm4, None),
+        Inst::xmm_rm_r(SseOpcode::Orps, RegMem::reg(xmm5), w_xmm4),
         "0F56E5",
         "orps    %xmm5, %xmm4",
     ));
@@ -3083,217 +2942,217 @@ fn test_x64_emit() {
     // XMM_RM_R: Integer Packed
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddb, RegMem::reg(xmm9), w_xmm5, None),
+        Inst::xmm_rm_r(SseOpcode::Paddb, RegMem::reg(xmm9), w_xmm5),
         "66410FFCE9",
         "paddb   %xmm9, %xmm5",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddw, RegMem::reg(xmm7), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Paddw, RegMem::reg(xmm7), w_xmm6),
         "660FFDF7",
         "paddw   %xmm7, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddd, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Paddd, RegMem::reg(xmm12), w_xmm13),
         "66450FFEEC",
         "paddd   %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddq, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Paddq, RegMem::reg(xmm1), w_xmm8),
         "66440FD4C1",
         "paddq   %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddsb, RegMem::reg(xmm9), w_xmm5, None),
+        Inst::xmm_rm_r(SseOpcode::Paddsb, RegMem::reg(xmm9), w_xmm5),
         "66410FECE9",
         "paddsb  %xmm9, %xmm5",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddsw, RegMem::reg(xmm7), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Paddsw, RegMem::reg(xmm7), w_xmm6),
         "660FEDF7",
         "paddsw  %xmm7, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddusb, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Paddusb, RegMem::reg(xmm12), w_xmm13),
         "66450FDCEC",
         "paddusb %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Paddusw, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Paddusw, RegMem::reg(xmm1), w_xmm8),
         "66440FDDC1",
         "paddusw %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubsb, RegMem::reg(xmm9), w_xmm5, None),
+        Inst::xmm_rm_r(SseOpcode::Psubsb, RegMem::reg(xmm9), w_xmm5),
         "66410FE8E9",
         "psubsb  %xmm9, %xmm5",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubsw, RegMem::reg(xmm7), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Psubsw, RegMem::reg(xmm7), w_xmm6),
         "660FE9F7",
         "psubsw  %xmm7, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubusb, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Psubusb, RegMem::reg(xmm12), w_xmm13),
         "66450FD8EC",
         "psubusb %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubusw, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Psubusw, RegMem::reg(xmm1), w_xmm8),
         "66440FD9C1",
         "psubusw %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pavgb, RegMem::reg(xmm12), w_xmm13, None),
+        Inst::xmm_rm_r(SseOpcode::Pavgb, RegMem::reg(xmm12), w_xmm13),
         "66450FE0EC",
         "pavgb   %xmm12, %xmm13",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pavgw, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Pavgw, RegMem::reg(xmm1), w_xmm8),
         "66440FE3C1",
         "pavgw   %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubb, RegMem::reg(xmm5), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Psubb, RegMem::reg(xmm5), w_xmm9),
         "66440FF8CD",
         "psubb   %xmm5, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubw, RegMem::reg(xmm6), w_xmm7, None),
+        Inst::xmm_rm_r(SseOpcode::Psubw, RegMem::reg(xmm6), w_xmm7),
         "660FF9FE",
         "psubw   %xmm6, %xmm7",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubd, RegMem::reg(xmm13), w_xmm12, None),
+        Inst::xmm_rm_r(SseOpcode::Psubd, RegMem::reg(xmm13), w_xmm12),
         "66450FFAE5",
         "psubd   %xmm13, %xmm12",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Psubq, RegMem::reg(xmm8), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Psubq, RegMem::reg(xmm8), w_xmm1),
         "66410FFBC8",
         "psubq   %xmm8, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmulld, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmulld, RegMem::reg(xmm15), w_xmm6),
         "66410F3840F7",
         "pmulld  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmullw, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmullw, RegMem::reg(xmm14), w_xmm1),
         "66410FD5CE",
         "pmullw  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmuludq, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pmuludq, RegMem::reg(xmm8), w_xmm9),
         "66450FF4C8",
         "pmuludq %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxsb, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxsb, RegMem::reg(xmm15), w_xmm6),
         "66410F383CF7",
         "pmaxsb  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxsw, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxsw, RegMem::reg(xmm15), w_xmm6),
         "66410FEEF7",
         "pmaxsw  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxsd, RegMem::reg(xmm15), w_xmm6, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxsd, RegMem::reg(xmm15), w_xmm6),
         "66410F383DF7",
         "pmaxsd  %xmm15, %xmm6",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxub, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxub, RegMem::reg(xmm14), w_xmm1),
         "66410FDECE",
         "pmaxub  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxuw, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxuw, RegMem::reg(xmm14), w_xmm1),
         "66410F383ECE",
         "pmaxuw  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pmaxud, RegMem::reg(xmm14), w_xmm1, None),
+        Inst::xmm_rm_r(SseOpcode::Pmaxud, RegMem::reg(xmm14), w_xmm1),
         "66410F383FCE",
         "pmaxud  %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminsb, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pminsb, RegMem::reg(xmm8), w_xmm9),
         "66450F3838C8",
         "pminsb  %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminsw, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pminsw, RegMem::reg(xmm8), w_xmm9),
         "66450FEAC8",
         "pminsw  %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminsd, RegMem::reg(xmm8), w_xmm9, None),
+        Inst::xmm_rm_r(SseOpcode::Pminsd, RegMem::reg(xmm8), w_xmm9),
         "66450F3839C8",
         "pminsd  %xmm8, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminub, RegMem::reg(xmm3), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pminub, RegMem::reg(xmm3), w_xmm2),
         "660FDAD3",
         "pminub  %xmm3, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminuw, RegMem::reg(xmm3), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pminuw, RegMem::reg(xmm3), w_xmm2),
         "660F383AD3",
         "pminuw  %xmm3, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pminud, RegMem::reg(xmm3), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pminud, RegMem::reg(xmm3), w_xmm2),
         "660F383BD3",
         "pminud  %xmm3, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::reg(xmm11), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::reg(xmm11), w_xmm2),
         "66410FEFD3",
         "pxor    %xmm11, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Pshufb, RegMem::reg(xmm11), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Pshufb, RegMem::reg(xmm11), w_xmm2),
         "66410F3800D3",
         "pshufb  %xmm11, %xmm2",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Packsswb, RegMem::reg(xmm11), w_xmm2, None),
+        Inst::xmm_rm_r(SseOpcode::Packsswb, RegMem::reg(xmm11), w_xmm2),
         "66410F63D3",
         "packsswb %xmm11, %xmm2",
     ));
@@ -3301,25 +3160,25 @@ fn test_x64_emit() {
     // ========================================================
     // XMM_RM_R: Integer Conversion
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Cvtdq2ps, RegMem::reg(xmm1), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Cvtdq2ps, RegMem::reg(xmm1), w_xmm8),
         "440F5BC1",
         "cvtdq2ps %xmm1, %xmm8",
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Cvttps2dq, RegMem::reg(xmm9), w_xmm8, None),
+        Inst::xmm_rm_r(SseOpcode::Cvttps2dq, RegMem::reg(xmm9), w_xmm8),
         "F3450F5BC1",
         "cvttps2dq %xmm9, %xmm8",
     ));
 
     // XMM_Mov_R_M: float stores
     insns.push((
-        Inst::xmm_mov_r_m(SseOpcode::Movss, xmm15, Amode::imm_reg(128, r12), None),
+        Inst::xmm_mov_r_m(SseOpcode::Movss, xmm15, Amode::imm_reg(128, r12)),
         "F3450F11BC2480000000",
         "movss   %xmm15, 128(%r12)",
     ));
     insns.push((
-        Inst::xmm_mov_r_m(SseOpcode::Movsd, xmm1, Amode::imm_reg(0, rsi), None),
+        Inst::xmm_mov_r_m(SseOpcode::Movsd, xmm1, Amode::imm_reg(0, rsi)),
         "F20F110E",
         "movsd   %xmm1, 0(%rsi)",
     ));
@@ -3526,12 +3385,12 @@ fn test_x64_emit() {
     // ========================================================
     // XmmRmRImm
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Cmppd, RegMem::reg(xmm5), w_xmm1, 2, false, None),
+        Inst::xmm_rm_r_imm(SseOpcode::Cmppd, RegMem::reg(xmm5), w_xmm1, 2, false),
         "660FC2CD02",
         "cmppd   $2, %xmm5, %xmm1",
     ));
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Cmpps, RegMem::reg(xmm15), w_xmm7, 0, false, None),
+        Inst::xmm_rm_r_imm(SseOpcode::Cmpps, RegMem::reg(xmm15), w_xmm7, 0, false),
         "410FC2FF00",
         "cmpps   $0, %xmm15, %xmm7",
     ));
@@ -3549,7 +3408,6 @@ fn test_x64_emit() {
             ty: types::I8,
             src: rbx,
             dst: am1,
-            srcloc: None,
         },
         "F0410FB09C9241010000",
         "lock cmpxchgb %bl, 321(%r10,%rdx,4)",
@@ -3560,7 +3418,6 @@ fn test_x64_emit() {
             ty: types::I8,
             src: rdx,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F00FB094F1C7CFFFFF",
         "lock cmpxchgb %dl, -12345(%rcx,%rsi,8)",
@@ -3570,7 +3427,6 @@ fn test_x64_emit() {
             ty: types::I8,
             src: rsi,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F0400FB0B4F1C7CFFFFF",
         "lock cmpxchgb %sil, -12345(%rcx,%rsi,8)",
@@ -3580,7 +3436,6 @@ fn test_x64_emit() {
             ty: types::I8,
             src: r10,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F0440FB094F1C7CFFFFF",
         "lock cmpxchgb %r10b, -12345(%rcx,%rsi,8)",
@@ -3590,7 +3445,6 @@ fn test_x64_emit() {
             ty: types::I8,
             src: r15,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F0440FB0BCF1C7CFFFFF",
         "lock cmpxchgb %r15b, -12345(%rcx,%rsi,8)",
@@ -3601,7 +3455,6 @@ fn test_x64_emit() {
             ty: types::I16,
             src: rsi,
             dst: am2.clone(),
-            srcloc: None,
         },
         "66F00FB1B4F1C7CFFFFF",
         "lock cmpxchgw %si, -12345(%rcx,%rsi,8)",
@@ -3611,7 +3464,6 @@ fn test_x64_emit() {
             ty: types::I16,
             src: r10,
             dst: am2.clone(),
-            srcloc: None,
         },
         "66F0440FB194F1C7CFFFFF",
         "lock cmpxchgw %r10w, -12345(%rcx,%rsi,8)",
@@ -3622,7 +3474,6 @@ fn test_x64_emit() {
             ty: types::I32,
             src: rsi,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F00FB1B4F1C7CFFFFF",
         "lock cmpxchgl %esi, -12345(%rcx,%rsi,8)",
@@ -3632,7 +3483,6 @@ fn test_x64_emit() {
             ty: types::I32,
             src: r10,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F0440FB194F1C7CFFFFF",
         "lock cmpxchgl %r10d, -12345(%rcx,%rsi,8)",
@@ -3643,7 +3493,6 @@ fn test_x64_emit() {
             ty: types::I64,
             src: rsi,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F0480FB1B4F1C7CFFFFF",
         "lock cmpxchgq %rsi, -12345(%rcx,%rsi,8)",
@@ -3653,7 +3502,6 @@ fn test_x64_emit() {
             ty: types::I64,
             src: r10,
             dst: am2.clone(),
-            srcloc: None,
         },
         "F04C0FB194F1C7CFFFFF",
         "lock cmpxchgq %r10, -12345(%rcx,%rsi,8)",
@@ -3661,22 +3509,22 @@ fn test_x64_emit() {
 
     // AtomicRmwSeq
     insns.push((
-        Inst::AtomicRmwSeq { ty: types::I8, op: inst_common::AtomicRmwOp::Or, srcloc: None },
+        Inst::AtomicRmwSeq { ty: types::I8, op: inst_common::AtomicRmwOp::Or, },
         "490FB6014989C34D09D3F0450FB0190F85EFFFFFFF",
         "atomically { 8_bits_at_[%r9]) Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
-        Inst::AtomicRmwSeq { ty: types::I16, op: inst_common::AtomicRmwOp::And, srcloc: None },
+        Inst::AtomicRmwSeq { ty: types::I16, op: inst_common::AtomicRmwOp::And, },
         "490FB7014989C34D21D366F0450FB1190F85EEFFFFFF",
         "atomically { 16_bits_at_[%r9]) And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
-        Inst::AtomicRmwSeq { ty: types::I32, op: inst_common::AtomicRmwOp::Xchg, srcloc: None },
+        Inst::AtomicRmwSeq { ty: types::I32, op: inst_common::AtomicRmwOp::Xchg, },
         "418B014989C34D89D3F0450FB1190F85EFFFFFFF",
         "atomically { 32_bits_at_[%r9]) Xchg= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
-        Inst::AtomicRmwSeq { ty: types::I64, op: inst_common::AtomicRmwOp::Add, srcloc: None },
+        Inst::AtomicRmwSeq { ty: types::I64, op: inst_common::AtomicRmwOp::Add, },
         "498B014989C34D01D3F04D0FB1190F85EFFFFFFF",
         "atomically { 64_bits_at_[%r9]) Add= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
@@ -3709,8 +3557,8 @@ fn test_x64_emit() {
 
     insns.push((Inst::Hlt, "CC", "hlt"));
 
-    let trap_info = (SourceLoc::default(), TrapCode::UnreachableCodeReached);
-    insns.push((Inst::Ud2 { trap_info }, "0F0B", "ud2 unreachable"));
+    let trap_code = TrapCode::UnreachableCodeReached;
+    insns.push((Inst::Ud2 { trap_code }, "0F0B", "ud2 unreachable"));
 
     // ========================================================
     // Actually run the tests!

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -111,7 +111,7 @@
 use super::abi::*;
 use crate::binemit::StackMap;
 use crate::ir::types::*;
-use crate::ir::{ArgumentExtension, SourceLoc, StackSlot};
+use crate::ir::{ArgumentExtension, StackSlot};
 use crate::machinst::*;
 use crate::settings;
 use crate::CodegenResult;
@@ -350,7 +350,6 @@ pub trait ABIMachineSpec {
         dest: &CallDest,
         uses: Vec<Reg>,
         defs: Vec<Writable<Reg>>,
-        loc: SourceLoc,
         opcode: ir::Opcode,
         tmp: Writable<Reg>,
         callee_conv: isa::CallConv,
@@ -1102,8 +1101,6 @@ pub struct ABICallerImpl<M: ABIMachineSpec> {
     defs: Vec<Writable<Reg>>,
     /// Call destination.
     dest: CallDest,
-    /// Location of callsite.
-    loc: ir::SourceLoc,
     /// Actual call opcode; used to distinguish various types of calls.
     opcode: ir::Opcode,
     /// Caller's calling convention.
@@ -1127,7 +1124,6 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
         sig: &ir::Signature,
         extname: &ir::ExternalName,
         dist: RelocDistance,
-        loc: ir::SourceLoc,
         caller_conv: isa::CallConv,
     ) -> CodegenResult<ABICallerImpl<M>> {
         let sig = ABISig::from_func_sig::<M>(sig)?;
@@ -1137,7 +1133,6 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
             uses,
             defs,
             dest: CallDest::ExtName(extname.clone(), dist),
-            loc,
             opcode: ir::Opcode::Call,
             caller_conv,
             _mach: PhantomData,
@@ -1149,7 +1144,6 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
     pub fn from_ptr(
         sig: &ir::Signature,
         ptr: Reg,
-        loc: ir::SourceLoc,
         opcode: ir::Opcode,
         caller_conv: isa::CallConv,
     ) -> CodegenResult<ABICallerImpl<M>> {
@@ -1160,7 +1154,6 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
             uses,
             defs,
             dest: CallDest::Reg(ptr),
-            loc,
             opcode,
             caller_conv,
             _mach: PhantomData,
@@ -1311,7 +1304,6 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
             &self.dest,
             uses,
             defs,
-            self.loc,
             self.opcode,
             tmp,
             self.sig.call_conv,

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1535,7 +1535,7 @@ mod test {
 
         buf.bind_label(label(1));
         let inst = Inst::Udf {
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
         };
         inst.emit(&mut buf, &info, &mut state);
 
@@ -1551,7 +1551,7 @@ mod test {
         let mut state = Default::default();
         let inst = Inst::TrapIf {
             kind: CondBrKind::NotZero(xreg(0)),
-            trap_info: (SourceLoc::default(), TrapCode::Interrupt),
+            trap_code: TrapCode::Interrupt,
         };
         inst.emit(&mut buf2, &info, &mut state);
         let inst = Inst::Nop4;

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -98,7 +98,7 @@
 
 use crate::binemit::{CodeInfo, CodeOffset, StackMap};
 use crate::ir::condcodes::IntCC;
-use crate::ir::{Function, Type};
+use crate::ir::{Function, SourceLoc, Type};
 use crate::isa::unwind::input as unwind_input;
 use crate::result::CodegenResult;
 use crate::settings::Flags;
@@ -302,6 +302,9 @@ pub trait MachInstEmitState<I: MachInst>: Default + Clone + Debug {
     /// Update the emission state before emitting an instruction that is a
     /// safepoint.
     fn pre_safepoint(&mut self, _stack_map: StackMap) {}
+    /// Update the emission state to indicate instructions are associated with a
+    /// particular SourceLoc.
+    fn pre_sourceloc(&mut self, _srcloc: SourceLoc) {}
 }
 
 /// The result of a `MachBackend::compile_function()` call. Contains machine

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -509,6 +509,7 @@ impl<I: VCodeInst> VCode<I> {
                     buffer.start_srcloc(srcloc);
                     cur_srcloc = Some(srcloc);
                 }
+                state.pre_sourceloc(cur_srcloc.unwrap_or(SourceLoc::default()));
 
                 if safepoint_idx < self.safepoint_insns.len()
                     && self.safepoint_insns[safepoint_idx] == iix


### PR DESCRIPTION
In existing MachInst backends, many instructions -- any that can trap or
result in a relocation -- carry `SourceLoc` values in order to propagate
the location-in-original-source to use to describe resulting traps or
relocation errors.

This is quite tedious, and also error-prone: it is likely that the
necessary plumbing will be missed in some cases, and in any case, it's
unnecessarily verbose.

This PR factors out the `SourceLoc` handling so that it is tracked
during emission as part of the `EmitState`, and plumbed through
automatically by the machine-independent framework. Instruction emission
code that directly emits trap or relocation records can query the
current location as necessary. Then we only need to ensure that memory
references and trap instructions, at their (one) emission point rather
than their (many) lowering/generation points, are wired up correctly.

This does have the side-effect that some loads and stores that do not
correspond directly to user code's heap accesses will have unnecessary
but harmless trap metadata. For example, the load that fetches a code
offset from a jump table will have a 'heap out of bounds' trap record
attached to it; but because it is bounds-checked, and will never
actually trap if the lowering is correct, this should be harmless.  The
simplicity improvement here seemed more worthwhile to me than plumbing
through a "corresponds to user-level load/store" bit, because the latter
is a bit complex when we allow for op merging.

Closes #2290: though it does not implement a full "metadata" scheme as
described in that issue, this seems simpler overall.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
