### PR TITLE
Support wasm `select` instruction with V128-typed operands.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wat",
 ]
 
@@ -1090,7 +1090,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "typemap",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wat",
 ]
 
@@ -2224,6 +2224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c97fc0456d6d09ca7b64bc33c34f4e8f29d5ccfa8e5595ef7a8957818339e6f6"
 
 [[package]]
+name = "wasmparser"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f091cf3849e5fe76a60255bff169277459f2201435bc583b6656880553f0ad0"
+
+[[package]]
 name = "wasmprinter"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,7 +2256,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -2328,7 +2334,7 @@ dependencies = [
  "test-programs",
  "tracing-subscriber",
  "wasi-common",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-debug",
@@ -2363,7 +2369,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wasmtime-environ",
 ]
 
@@ -2382,7 +2388,7 @@ dependencies = [
  "more-asserts",
  "serde",
  "thiserror",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
 ]
 
 [[package]]
@@ -2410,7 +2416,7 @@ dependencies = [
  "log",
  "rayon",
  "wasm-smith",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -2437,7 +2443,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -2454,7 +2460,7 @@ version = "0.21.0"
 dependencies = [
  "cranelift-codegen",
  "lightbeam",
- "wasmparser 0.66.0",
+ "wasmparser 0.67.0",
  "wasmtime-environ",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"
 humantime = "2.0.0"
-wasmparser = "0.66"
+wasmparser = "0.67"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -3880,6 +3880,17 @@ fn test_aarch64_binemit() {
     ));
 
     insns.push((
+        Inst::VecCSel {
+            rd: writable_vreg(5),
+            rn: vreg(10),
+            rm: vreg(19),
+            cond: Cond::Gt,
+        },
+        "6C000054651EB34E02000014451DAA4E",
+        "vcsel v5.16b, v10.16b, v19.16b, gt (if-then-else diamond)",
+    ));
+
+    insns.push((
         Inst::Extend {
             rd: writable_xreg(1),
             rn: xreg(2),

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1412,6 +1412,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 ctx.emit(Inst::FpuCSel32 { cond, rd, rn, rm });
             } else if is_float && bits == 64 {
                 ctx.emit(Inst::FpuCSel64 { cond, rd, rn, rm });
+            } else if is_float && bits == 128 {
+                ctx.emit(Inst::VecCSel { cond, rd, rn, rm });
             } else {
                 ctx.emit(Inst::CSel { cond, rd, rn, rm });
             }

--- a/cranelift/filetests/filetests/isa/aarch64/simd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd.clif
@@ -47,3 +47,17 @@ block0:
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
+
+function %f4(i32, i8x16, i8x16) -> i8x16 {
+block0(v0: i32, v1: i8x16, v2: i8x16):
+   v3 = select v0, v1, v2
+   return v3
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  subs wzr, w0, wzr
+; nextln:  vcsel v0.16b, v0.16b, v1.16b, ne (if-then-else diamond)
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.66.0", default-features = false }
+wasmparser = { version = "0.67.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.68.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.68.0" }
 cranelift-frontend = { path = "../frontend", version = "0.68.0", default-features = false }

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.23.0"
-wasmparser = "0.66.0"
+wasmparser = "0.67.0"
 object = { version = "0.22.0", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.21.0" }
 target-lexicon = { version = "0.11.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.68.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.68.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.68.0", features = ["enable-serde"] }
-wasmparser = "0.66.0"
+wasmparser = "0.67.0"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -12,7 +12,7 @@ arbitrary = { version = "0.4.1", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.66.0"
+wasmparser = "0.67.0"
 wasmprinter = "0.2.13"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -28,7 +28,7 @@ rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.66.0"
+wasmparser = "0.67.0"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "1.0"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ more-asserts = "0.2.1"
 smallvec = "1.0.0"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.66.0"
+wasmparser = "0.67.0"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 lightbeam = { path = "..", version = "0.21.0" }
-wasmparser = "0.66"
+wasmparser = "0.67"
 cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.68.0" }
 wasmtime-environ = { path = "../../environ", version = "0.21.0" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -16,7 +16,7 @@ wasmtime-jit = { path = "../jit", version = "0.21.0" }
 wasmtime-cache = { path = "../cache", version = "0.21.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.21.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.66.0"
+wasmparser = "0.67.0"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"


### PR DESCRIPTION
* this requires upgrading to wasmparser 0.67.0.

* There are no CLIF side changes because the CLIF `select` instruction is
  polymorphic enough.

* on aarch64, there is unfortunately no conditional-move (csel) instruction on
  vectors.  This patch adds a synthetic instruction `VecCSel` which *does*
  behave like that.  At emit time, this is emitted as an if-then-else diamond
  (4 insns).

* aarch64 implementation is otherwise straightforwards.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
