### PR TITLE
Fix module initialization with externref element segments

### DIFF
--- a/tests/misc_testsuite/reference-types/externref-segment.wast
+++ b/tests/misc_testsuite/reference-types/externref-segment.wast
@@ -1,0 +1,5 @@
+(module
+  (table 2 externref)
+  (elem (i32.const 0) externref (ref.null extern))
+  (elem (i32.const 1) externref (ref.null extern))
+)


### PR DESCRIPTION
This commit fixes an issue with reference-types-using-modules where they
panicked on instantiation if any element segments had an externref null
specified.
