### PR TITLE
Remove size-of-struct asserts that break with some Rust versions.

### DIFF
--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -876,7 +876,7 @@ impl VCodeConstantData {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::mem::{size_of, size_of_val};
+    use std::mem::size_of;
 
     #[test]
     fn size_of_constant_structs() {
@@ -888,11 +888,8 @@ mod test {
             size_of::<PrimaryMap<VCodeConstant, VCodeConstantData>>(),
             24
         );
-        assert_eq!(size_of::<HashMap<Constant, VCodeConstant>>(), 48);
-        assert_eq!(size_of::<HashMap<*const [u8], VCodeConstant>>(), 48);
-        assert_eq!(size_of::<VCodeConstants>(), 120);
-        assert_eq!(size_of_val(&VCodeConstants::with_capacity(0)), 120);
-        // TODO This structure could use some significant memory-size optimization. The use of
-        // HashMap to deduplicate both pool and well-known constants is clearly an issue.
+        // TODO The VCodeConstants structure's memory size could be further optimized.
+        // With certain versions of Rust, each `HashMap` in `VCodeConstants` occupied at
+        // least 48 bytes, making an empty `VCodeConstants` cost 120 bytes.
     }
 }


### PR DESCRIPTION
The asserts on the sizes of the VCode constant-table data structures
introduced in PR #2328 are dependent on the size of data structures such
as `HashMap` in the standard library, which can change. In particular,
on Rust 1.46 (which is not current, but could be e.g. pinned by a
project using Cranelift), it appears that these asserts fail. We
shouldn't depend on stdlib internals; IMHO the asserts on our own struct
sizes are enough to catch accidental size blowups.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
