### PR TITLE
[machinst x64]: implement packed shifts

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -182,6 +182,7 @@ fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str
     match (testsuite, testname) {
         ("simd", "simd_address") => return false,
         ("simd", "simd_bitwise") => return false,
+        ("simd", "simd_bit_shift") => return false,
         ("simd", "simd_boolean") => return false,
         ("simd", "simd_const") => return false,
         ("simd", "simd_i8x16_arith") => return false,
@@ -205,7 +206,9 @@ fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str
         ("simd", "simd_f64x2_cmp") => return false,
         ("simd", "simd_f64x2_pmin_pmax") => return false,
         ("simd", "simd_lane") => return false,
+        ("simd", "simd_load") => return false,
         ("simd", "simd_load_splat") => return false,
+        ("simd", "simd_splat") => return false,
         ("simd", "simd_store") => return false,
         ("simd", _) => return true,
         _ => {}

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -482,6 +482,8 @@ pub enum SseOpcode {
     Psubusb,
     Psubusw,
     Ptest,
+    Punpckhbw,
+    Punpcklbw,
     Pxor,
     Rcpss,
     Roundss,
@@ -616,6 +618,8 @@ impl SseOpcode {
             | SseOpcode::Psubsw
             | SseOpcode::Psubusb
             | SseOpcode::Psubusw
+            | SseOpcode::Punpckhbw
+            | SseOpcode::Punpcklbw
             | SseOpcode::Pxor
             | SseOpcode::Sqrtpd
             | SseOpcode::Sqrtsd
@@ -783,6 +787,8 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Psubusb => "psubusb",
             SseOpcode::Psubusw => "psubusw",
             SseOpcode::Ptest => "ptest",
+            SseOpcode::Punpckhbw => "punpckhbw",
+            SseOpcode::Punpcklbw => "punpcklbw",
             SseOpcode::Pxor => "pxor",
             SseOpcode::Rcpss => "rcpss",
             SseOpcode::Roundss => "roundss",

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -533,7 +533,7 @@ pub(crate) fn emit(
                     }
 
                     RegMemImm::Mem { addr } => {
-                        let amode = addr.finalize(state);
+                        let amode = addr.finalize(state, sink);
                         emit_std_reg_mem(
                             sink,
                             state,
@@ -592,7 +592,7 @@ pub(crate) fn emit(
 
                     RegMemImm::Mem { addr } => {
                         // Here we revert to the "normal" G-E ordering.
-                        let amode = addr.finalize(state);
+                        let amode = addr.finalize(state, sink);
                         emit_std_reg_mem(
                             sink,
                             state,
@@ -649,7 +649,7 @@ pub(crate) fn emit(
                     rex_flags,
                 ),
                 RegMem::Mem { addr: src } => {
-                    let amode = src.finalize(state);
+                    let amode = src.finalize(state, sink);
                     emit_std_reg_mem(
                         sink,
                         state,
@@ -715,7 +715,7 @@ pub(crate) fn emit(
                     emit_std_enc_enc(sink, prefix, opcode, 1, subopcode, src, rex_flags)
                 }
                 RegMem::Mem { addr: src } => {
-                    let amode = src.finalize(state);
+                    let amode = src.finalize(state, sink);
                     emit_std_enc_mem(sink, state, prefix, opcode, 1, subopcode, &amode, rex_flags);
                 }
             }
@@ -736,7 +736,7 @@ pub(crate) fn emit(
                     emit_std_enc_enc(sink, prefix, 0xF7, 1, subopcode, src, rex_flags)
                 }
                 RegMem::Mem { addr: src } => {
-                    let amode = src.finalize(state);
+                    let amode = src.finalize(state, sink);
                     emit_std_enc_mem(sink, state, prefix, 0xF7, 1, subopcode, &amode, rex_flags);
                 }
             }
@@ -981,7 +981,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr: src } => {
-                    let src = &src.finalize(state);
+                    let src = &src.finalize(state, sink);
 
                     emit_std_reg_mem(
                         sink,
@@ -998,7 +998,7 @@ pub(crate) fn emit(
         }
 
         Inst::Mov64MR { src, dst } => {
-            let src = &src.finalize(state);
+            let src = &src.finalize(state, sink);
 
             emit_std_reg_mem(
                 sink,
@@ -1013,7 +1013,7 @@ pub(crate) fn emit(
         }
 
         Inst::LoadEffectiveAddress { addr, dst } => {
-            let amode = addr.finalize(state);
+            let amode = addr.finalize(state, sink);
 
             emit_std_reg_mem(
                 sink,
@@ -1075,7 +1075,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr: src } => {
-                    let src = &src.finalize(state);
+                    let src = &src.finalize(state, sink);
 
                     emit_std_reg_mem(
                         sink,
@@ -1092,7 +1092,7 @@ pub(crate) fn emit(
         }
 
         Inst::MovRM { size, src, dst } => {
-            let dst = &dst.finalize(state);
+            let dst = &dst.finalize(state, sink);
 
             match size {
                 1 => {
@@ -1248,7 +1248,7 @@ pub(crate) fn emit(
                         emit_std_reg_reg(sink, prefix, opcode_bytes, 2, dst.to_reg(), *reg, rex);
                     }
                     RegMemImm::Mem { addr } => {
-                        let addr = &addr.finalize(state);
+                        let addr = &addr.finalize(state, sink);
                         emit_std_reg_mem(
                             sink,
                             state,
@@ -1307,7 +1307,7 @@ pub(crate) fn emit(
                 }
 
                 RegMemImm::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     // Whereas here we revert to the "normal" G-E ordering.
                     let opcode = if *size == 1 { 0x3A } else { 0x3B };
                     emit_std_reg_mem(sink, state, prefix, opcode, 1, *reg_g, addr, rex);
@@ -1367,7 +1367,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, 2, reg_g.to_reg(), *reg_e, rex_flags);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_reg_mem(
                         sink,
                         state,
@@ -1418,7 +1418,7 @@ pub(crate) fn emit(
                 }
 
                 RegMemImm::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_enc_mem(
                         sink,
                         state,
@@ -1484,7 +1484,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_enc_mem(
                         sink,
                         state,
@@ -1582,7 +1582,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_enc_mem(
                         sink,
                         state,
@@ -1728,7 +1728,7 @@ pub(crate) fn emit(
                     );
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_reg_mem(
                         sink,
                         state,
@@ -1841,7 +1841,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, length, reg_g.to_reg(), *reg_e, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_reg_mem(
                         sink,
                         state,
@@ -1986,7 +1986,7 @@ pub(crate) fn emit(
                     }
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     assert!(
                         !regs_swapped,
                         "No existing way to encode a mem argument in the ModRM r/m field."
@@ -2020,7 +2020,7 @@ pub(crate) fn emit(
                 SseOpcode::Movupd => (LegacyPrefixes::_66, 0x0F11),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
-            let dst = &dst.finalize(state);
+            let dst = &dst.finalize(state, sink);
             emit_std_reg_mem(
                 sink,
                 state,
@@ -2087,7 +2087,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, 2, reg_g.to_reg(), *reg_e, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_reg_mem(sink, state, prefix, opcode, 2, reg_g.to_reg(), addr, rex);
                 }
             }
@@ -2107,7 +2107,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, len, *dst, *reg, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state);
+                    let addr = &addr.finalize(state, sink);
                     emit_std_reg_mem(sink, state, prefix, opcode, len, *dst, addr, rex);
                 }
             }
@@ -2621,7 +2621,7 @@ pub(crate) fn emit(
                 types::I64 => (LegacyPrefixes::_F0, RexFlags::set_w(), 0x0FB1),
                 _ => unreachable!(),
             };
-            let amode = dst.finalize(state);
+            let amode = dst.finalize(state, sink);
             emit_std_reg_mem(sink, state, prefix, opcodes, 2, *src, &amode, rex);
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1826,6 +1826,8 @@ pub(crate) fn emit(
                 SseOpcode::Psubsw => (LegacyPrefixes::_66, 0x0FE9, 2),
                 SseOpcode::Psubusb => (LegacyPrefixes::_66, 0x0FD8, 2),
                 SseOpcode::Psubusw => (LegacyPrefixes::_66, 0x0FD9, 2),
+                SseOpcode::Punpckhbw => (LegacyPrefixes::_66, 0x0F68, 2),
+                SseOpcode::Punpcklbw => (LegacyPrefixes::_66, 0x0F60, 2),
                 SseOpcode::Pxor => (LegacyPrefixes::_66, 0x0FEF, 2),
                 SseOpcode::Subps => (LegacyPrefixes::None, 0x0F5C, 2),
                 SseOpcode::Subpd => (LegacyPrefixes::_66, 0x0F5C, 2),

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3157,6 +3157,18 @@ fn test_x64_emit() {
         "packsswb %xmm11, %xmm2",
     ));
 
+    insns.push((
+        Inst::xmm_rm_r(SseOpcode::Punpckhbw, RegMem::reg(xmm3), w_xmm2),
+        "660F68D3",
+        "punpckhbw %xmm3, %xmm2",
+    ));
+
+    insns.push((
+        Inst::xmm_rm_r(SseOpcode::Punpcklbw, RegMem::reg(xmm1), w_xmm8),
+        "66440F60C1",
+        "punpcklbw %xmm1, %xmm8",
+    ));
+
     // ========================================================
     // XMM_RM_R: Integer Conversion
     insns.push((

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -15,3 +15,78 @@ block0:
 ; nextln: pandn   %xmm2, %xmm0
 ; nextln: por     %xmm1, %xmm0
 ; not:    movdqa
+
+
+
+; 8x16 shifts: these lower to complex sequences of instructions
+
+function %ishl_i8x16(i32) -> i8x16 {
+block0(v0: i32):
+    v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
+    v2 = ishl v1, v0
+    return v2
+}
+; check:  movd    %edi, %xmm1
+; nextln: psllw   %xmm1, %xmm0
+; nextln: lea     const(VCodeConstant(0)), %r12
+; nextln: shlq    $$4, %rdi
+; nextln: movdqu  0(%r12,%rdi,1), %xmm1
+; nextln: pand    %xmm1, %xmm0
+
+function %ushr_i8x16_imm() -> i8x16 {
+block0:
+    v0 = iconst.i32 1
+    v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
+    v2 = ushr v1, v0
+    return v2
+}
+; check:  load_const VCodeConstant(1), %xmm0
+; nextln: psrlw   $$1, %xmm0
+; nextln: movdqu  const(VCodeConstant(0)), %xmm1
+; nextln: pand    %xmm1, %xmm0
+
+function %sshr_i8x16(i32) -> i8x16 {
+block0(v0: i32):
+    v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
+    v2 = sshr v1, v0
+    return v2
+}
+; check:  addl    $$8, %edi
+; nextln: movd    %edi, %xmm2
+; nextln: movdqa  %xmm0, %xmm1
+; nextln: punpcklbw %xmm1, %xmm1
+; nextln: psraw   %xmm2, %xmm1
+; nextln: punpckhbw %xmm0, %xmm0
+; nextln: psraw   %xmm2, %xmm0
+
+function %sshr_i8x16_imm(i8x16, i32) -> i8x16 {
+block0(v0: i8x16, v1: i32):
+    v2 = sshr_imm v0, 3
+    return v2
+}
+; check:  movdqa  %xmm0, %xmm1
+; nextln: movdqa  %xmm1, %xmm0
+; nextln: punpcklbw %xmm0, %xmm0
+; nextln: psraw   $$11, %xmm0
+; nextln: punpckhbw %xmm1, %xmm1
+; nextln: psraw   $$11, %xmm1
+; nextln: packsswb %xmm1, %xmm0
+
+
+
+; i16x4 arithmetic shifts: x86 does not have a instruction for this
+
+function %sshr_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = sshr v0, v1
+    return v2
+}
+; check:  pextrd.w $$0, %xmm0, %r12
+; nextln: pextrd.w $$1, %xmm0, %r13
+; nextln: movq    %rdi, %rcx
+; nextln: sarq    %cl, %r12
+; nextln: movq    %rdi, %rcx
+; nextln: sarq    %cl, %r13
+; nextln: pinsrd.w $$0, %r12, %xmm1
+; nextln: pinsrd.w $$1, %r13, %xmm1
+; nextln: movdqa  %xmm1, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-run.clif
@@ -10,3 +10,111 @@ block0(v0: i8x16, v1: i8x16, v2: i8x16):
 }
 ; Remember that bitselect accepts: 1) the selector vector, 2) the "if true" vector, and 3) the "if false" vector.
 ; run: %bitselect_i8x16([0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 255], [127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 42], [42 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127]) == [42 0 0 0 0 0 0 0 0 0 0 0 0 0 0 42]
+
+
+
+; shift left
+
+function %ishl_i8x16(i8x16, i32) -> i8x16 {
+block0(v0: i8x16, v1: i32):
+    v2 = ishl v0, v1
+    return v2
+}
+; run: %ishl_i8x16([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 4) == [0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0]
+
+function %ishl_i16x8(i16x8, i32) -> i16x8 {
+block0(v0: i16x8, v1: i32):
+    v2 = ishl v0, v1
+    return v2
+}
+; run: %ishl_i16x8([1 2 4 8 16 32 64 128], 17) == [0 0 0 0 0 0 0 0]
+
+function %ishl_i32x4(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = ishl v0, v1
+    return v2
+}
+; run: %ishl_i32x4([1 2 4 8], 1) == [2 4 8 16]
+
+function %ishl_imm_i64x2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v2 = ishl_imm v0, 1
+    return v2
+}
+; run: %ishl_imm_i64x2([1 0]) == [2 0]
+
+
+
+; shift right (logical)
+
+function %ushr_i8x16(i8x16, i32) -> i8x16 {
+block0(v0: i8x16, v1: i32):
+    v2 = ushr v0, v1
+    return v2
+}
+; run: %ushr_i8x16([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 1) == [0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7]
+
+function %ushr_i32x4(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = ushr v0, v1
+    return v2
+}
+; run: %ushr_i32x4([1 2 4 8], 33) == [0 0 0 0]
+
+function %ushr_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = ushr v0, v1
+    return v2
+}
+; run: %ushr_i64x2([1 2], 1) == [0 1]
+
+
+
+; shift right (arithmetic)
+
+function %sshr_i8x16(i8x16, i32) -> i8x16 {
+block0(v0: i8x16, v1: i32):
+    v2 = sshr v0, v1
+    return v2
+}
+; run: %sshr_i8x16([0 0xff 2 0xfd 4 0xfb 6 0xf9 8 0xf7 10 0xf5 12 0xf3 14 0xf1], 1) == [0 0xff 1 0xfe 2 0xfd 3 0xfc 4 0xfb 5 0xfa 6 0xf9 7 0xf8]
+
+function %sshr_i16x8(i16x8, i32) -> i16x8 {
+block0(v0: i16x8, v1: i32):
+    v2 = sshr v0, v1
+    return v2
+}
+; note: because of the shifted-in sign-bit, lane 0 remains -1 == 0xffff, whereas lane 4 has been shifted to -8 == 0xfff8
+; run: %ushr_i16x8([-1 2 4 8 -16 32 64 128], 1) == [-1 1 2 4 -8 16 32 64]
+
+function %sshr_i32x4(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = sshr v0, v1
+    return v2
+}
+; note: shifting in the sign-bit repeatedly in lane 3 fills the result with 1s (-1 == 0xffff_ffff)
+; run: %ushr_i32x4([1 2 4 -8], 33) == [0 0 0 0xffff_ffff]
+
+function %sshr_i64x2(i64x2, i32) -> i64x2 {
+block0(v0:i64x2, v1:i32):
+    v2 = sshr v0, v1
+    return v2
+}
+; run: %sshr_i64x2([1 -1], 0) == [1 -1]
+; run: %sshr_i64x2([1 -1], 1) == [0 -1] ; note the -1 shift result
+; run: %sshr_i64x2([2 -2], 1) == [1 -1]
+; run: %sshr_i64x2([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], 63) == [0xFFFFFFFF_FFFFFFFF 0]
+
+function %sshr_imm_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = sshr_imm v0, 1
+    return v1
+}
+; run: %sshr_imm_i32x4([1 2 4 -8]) == [0 1 2 -4]
+
+function %sshr_imm_i16x8(i16x8) -> i16x8 {
+block0(v0: i16x8):
+    v1 = sshr_imm v0, 1
+    return v1
+}
+; run: %sshr_imm_i16x8([1 2 4 -8 0 0 0 0]) == [0 1 2 -4 0 0 0 0]


### PR DESCRIPTION
This change first modifies `SyntheticAmode` to allow it to refer to constants: this is helpful because `SyntheticAmode` and `Amode` are used throughout the x64 backend to refer to memory locations so constants can now fit into that scheme. (In a future PR I will modify `vconst` to simply lower to a `Inst::XmmUnaryRmR`, which accepts a `SyntheticAmode`, instead of using the special `Inst::XmmLoadConst` variant).

With that in place, I added all of the lowerings for the vector versions of `ishl`, `sshr`, and `ushr`. There are several interesting parts to this:
 - vector shifts can accept an immediate shift amount, so this must be handled in each case; if the shift amount is dynamic, then it must be moved to an XMM register
 - the x86 ISA does not provide  `i8x16` shifts, so these are lowered either using a mask table (`ishl` and `ushr`) or using packing/unpacking (`sshr`)
 - the equivalent of `sshr.i64x2` is also missing in the x86 ISA so a "extract, scalar shift, insert" scheme is used (as it was in the old backend)

The issues above are documented in detail in the code.