### PR TITLE
Specify unsealed / unfilled blocks

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -459,19 +459,23 @@ impl<'a> FunctionBuilder<'a> {
     /// for another function.
     pub fn finalize(&mut self) {
         // Check that all the `Block`s are filled and sealed.
-        debug_assert!(
-            self.func_ctx.blocks.iter().all(
-                |(block, block_data)| block_data.pristine || self.func_ctx.ssa.is_sealed(block)
-            ),
-            "all blocks should be sealed before dropping a FunctionBuilder"
-        );
-        debug_assert!(
-            self.func_ctx
-                .blocks
-                .values()
-                .all(|block_data| block_data.pristine || block_data.filled),
-            "all blocks should be filled before dropping a FunctionBuilder"
-        );
+        #[cfg(debug_assertions)]
+        {
+            for (block, block_data) in self.func_ctx.blocks.iter() {
+                if !(block_data.pristine || self.func_ctx.ssa.is_sealed(block)) {
+                    panic!(
+                        "FunctionBuilder finalized, but block {} is not sealed",
+                        block
+                    );
+                }
+                if !(block_data.pristine || block_data.filled) {
+                    panic!(
+                        "FunctionBuilder finalized, but block {} is not filled",
+                        block
+                    );
+                }
+            }
+        }
 
         // In debug mode, check that all blocks are valid basic blocks.
         #[cfg(debug_assertions)]

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -462,18 +462,16 @@ impl<'a> FunctionBuilder<'a> {
         #[cfg(debug_assertions)]
         {
             for (block, block_data) in self.func_ctx.blocks.iter() {
-                if !(block_data.pristine || self.func_ctx.ssa.is_sealed(block)) {
-                    panic!(
-                        "FunctionBuilder finalized, but block {} is not sealed",
-                        block
-                    );
-                }
-                if !(block_data.pristine || block_data.filled) {
-                    panic!(
-                        "FunctionBuilder finalized, but block {} is not filled",
-                        block
-                    );
-                }
+                assert!(
+                    block_data.pristine || self.func_ctx.ssa.is_sealed(block),
+                    "FunctionBuilder finalized, but block {} is not sealed",
+                    block,
+                );
+                assert!(
+                    block_data.pristine || block_data.filled,
+                    "FunctionBuilder finalized, but block {} is not filled",
+                    block,
+                );
             }
         }
 


### PR DESCRIPTION
Hello! I'm suggesting this quick change that's helped me with debugging. Required information below.

- This change has not been discussed in an issue, but it's a cosmetic change which I don't think warrants deep debate.
- This change adds an offending block identifier to error messages when a `FunctionBuilder` is finalized, but some blocks are not sealed or not filled. This should help with debugging. This also removes confusing / outdated references to dropping the `FunctionBuilder` in the messages.
- There are no new test cases, because the only change is in an error message. All existing test cases still pass.
- It doesn't look like I can assign a reviewer, let me know if there's anything I need to do on that front.