### PR TITLE
SimpleJIT hot code swapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
 name = "cranelift-simplejit"
 version = "0.68.0"
 dependencies = [
+ "anyhow",
  "cranelift",
  "cranelift-codegen",
  "cranelift-entity",

--- a/cranelift/codegen/src/ir/libcall.rs
+++ b/cranelift/codegen/src/ir/libcall.rs
@@ -63,6 +63,7 @@ pub enum LibCall {
 
     /// Elf __tls_get_addr
     ElfTlsGetAddr,
+    // When adding a new variant make sure to add it to `all_libcalls` too.
 }
 
 impl fmt::Display for LibCall {
@@ -135,6 +136,33 @@ impl LibCall {
             },
             _ => return None,
         })
+    }
+
+    /// Get a list of all known `LibCall`'s.
+    pub fn all_libcalls() -> &'static [LibCall] {
+        use LibCall::*;
+        &[
+            Probestack,
+            UdivI64,
+            SdivI64,
+            UremI64,
+            SremI64,
+            IshlI64,
+            UshrI64,
+            SshrI64,
+            CeilF32,
+            CeilF64,
+            FloorF32,
+            FloorF64,
+            TruncF32,
+            TruncF64,
+            NearestF32,
+            NearestF64,
+            Memcpy,
+            Memset,
+            Memmove,
+            ElfTlsGetAddr,
+        ]
     }
 }
 

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -490,3 +490,97 @@ pub trait Module {
     /// Define a data object, producing the data contents from the given `DataContext`.
     fn define_data(&mut self, data: DataId, data_ctx: &DataContext) -> ModuleResult<()>;
 }
+
+impl<M: Module> Module for &mut M {
+    fn isa(&self) -> &dyn isa::TargetIsa {
+        (**self).isa()
+    }
+
+    fn declarations(&self) -> &ModuleDeclarations {
+        (**self).declarations()
+    }
+
+    fn get_name(&self, name: &str) -> Option<FuncOrDataId> {
+        (**self).get_name(name)
+    }
+
+    fn target_config(&self) -> isa::TargetFrontendConfig {
+        (**self).target_config()
+    }
+
+    fn make_context(&self) -> Context {
+        (**self).make_context()
+    }
+
+    fn clear_context(&self, ctx: &mut Context) {
+        (**self).clear_context(ctx)
+    }
+
+    fn make_signature(&self) -> ir::Signature {
+        (**self).make_signature()
+    }
+
+    fn clear_signature(&self, sig: &mut ir::Signature) {
+        (**self).clear_signature(sig)
+    }
+
+    fn declare_function(
+        &mut self,
+        name: &str,
+        linkage: Linkage,
+        signature: &ir::Signature,
+    ) -> ModuleResult<FuncId> {
+        (**self).declare_function(name, linkage, signature)
+    }
+
+    fn declare_data(
+        &mut self,
+        name: &str,
+        linkage: Linkage,
+        writable: bool,
+        tls: bool,
+    ) -> ModuleResult<DataId> {
+        (**self).declare_data(name, linkage, writable, tls)
+    }
+
+    fn declare_func_in_func(&self, func: FuncId, in_func: &mut ir::Function) -> ir::FuncRef {
+        (**self).declare_func_in_func(func, in_func)
+    }
+
+    fn declare_data_in_func(&self, data: DataId, func: &mut ir::Function) -> ir::GlobalValue {
+        (**self).declare_data_in_func(data, func)
+    }
+
+    fn declare_func_in_data(&self, func: FuncId, ctx: &mut DataContext) -> ir::FuncRef {
+        (**self).declare_func_in_data(func, ctx)
+    }
+
+    fn declare_data_in_data(&self, data: DataId, ctx: &mut DataContext) -> ir::GlobalValue {
+        (**self).declare_data_in_data(data, ctx)
+    }
+
+    fn define_function<TS>(
+        &mut self,
+        func: FuncId,
+        ctx: &mut Context,
+        trap_sink: &mut TS,
+    ) -> ModuleResult<ModuleCompiledFunction>
+    where
+        TS: binemit::TrapSink,
+    {
+        (**self).define_function(func, ctx, trap_sink)
+    }
+
+    fn define_function_bytes(
+        &mut self,
+        func: FuncId,
+        bytes: &[u8],
+        relocs: &[RelocRecord],
+    ) -> ModuleResult<ModuleCompiledFunction> {
+        (**self).define_function_bytes(func, bytes, relocs)
+    }
+
+    fn define_data(&mut self, data: DataId, data_ctx: &DataContext) -> ModuleResult<()> {
+        (**self).define_data(data, data_ctx)
+    }
+}

--- a/cranelift/simplejit/Cargo.toml
+++ b/cranelift/simplejit/Cargo.toml
@@ -14,6 +14,7 @@ cranelift-module = { path = "../module", version = "0.68.0" }
 cranelift-native = { path = "../native", version = "0.68.0" }
 cranelift-codegen = { path = "../codegen", version = "0.68.0", default-features = false, features = ["std"] }
 cranelift-entity = { path = "../entity", version = "0.68.0" }
+anyhow = "1.0"
 region = "2.2.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"

--- a/cranelift/simplejit/examples/simplejit-minimal.rs
+++ b/cranelift/simplejit/examples/simplejit-minimal.rs
@@ -1,12 +1,22 @@
 use cranelift::prelude::*;
 use cranelift_codegen::binemit::NullTrapSink;
+use cranelift_codegen::settings::{self, Configurable};
 use cranelift_module::{default_libcall_names, Linkage, Module};
 use cranelift_simplejit::{SimpleJITBuilder, SimpleJITModule};
 use std::mem;
 
 fn main() {
+    let mut flag_builder = settings::builder();
+    flag_builder.set("use_colocated_libcalls", "false").unwrap();
+    // FIXME set back to true once the x64 backend supports it.
+    flag_builder.set("is_pic", "false").unwrap();
+    let isa_builder = cranelift_native::builder().unwrap_or_else(|msg| {
+        panic!("host machine is not supported: {}", msg);
+    });
+    let isa = isa_builder.finish(settings::Flags::new(flag_builder));
     let mut module: SimpleJITModule =
-        SimpleJITModule::new(SimpleJITBuilder::new(default_libcall_names()));
+        SimpleJITModule::new(SimpleJITBuilder::with_isa(isa, default_libcall_names()));
+
     let mut ctx = module.make_context();
     let mut func_ctx = FunctionBuilderContext::new();
 

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -435,6 +435,11 @@ impl<'simple_jit_backend> Module for SimpleJITModule {
                 .allocate(std::mem::size_of::<[u8; 16]>(), EXECUTABLE_DATA_ALIGNMENT)
                 .unwrap()
                 .cast::<[u8; 16]>();
+            self.record_function_for_perf(
+                plt_entry as *mut _,
+                std::mem::size_of::<[u8; 16]>(),
+                &format!("{}@plt", name),
+            );
             self.function_plt_entries[id] = Some(NonNull::new(plt_entry).unwrap());
             unsafe {
                 Self::write_plt_entry_bytes(plt_entry, got_entry);

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -188,14 +188,7 @@ impl SimpleJITModule {
         match *name {
             ir::ExternalName::User { .. } => {
                 let (name, linkage) = if ModuleDeclarations::is_function(name) {
-                    let func_id = FuncId::from_name(name);
-                    match &self.compiled_functions[func_id] {
-                        Some(compiled) => return compiled.ptr,
-                        None => {
-                            let decl = self.declarations.get_function_decl(func_id);
-                            (&decl.name, decl.linkage)
-                        }
-                    }
+                    return self.get_plt_address(name);
                 } else {
                     let data_id = DataId::from_name(name);
                     match &self.compiled_data_objects[data_id] {

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -568,11 +568,14 @@ impl<'simple_jit_backend> Module for SimpleJITModule {
         unsafe {
             std::ptr::write(self.function_got_entries[id].unwrap().as_ptr(), ptr);
         }
-        self.compiled_functions[id].as_ref().unwrap().perform_relocations(
-            |name| unreachable!("non GOT or PLT relocation in function {} to {}", id, name),
-            |name| self.get_got_address(name),
-            |name| self.get_plt_address(name),
-        );
+        self.compiled_functions[id]
+            .as_ref()
+            .unwrap()
+            .perform_relocations(
+                |name| unreachable!("non GOT or PLT relocation in function {} to {}", id, name),
+                |name| self.get_got_address(name),
+                |name| self.get_plt_address(name),
+            );
 
         Ok(ModuleCompiledFunction { size: code_size })
     }
@@ -618,11 +621,14 @@ impl<'simple_jit_backend> Module for SimpleJITModule {
         unsafe {
             std::ptr::write(self.function_got_entries[id].unwrap().as_ptr(), ptr);
         }
-        self.compiled_functions[id].as_ref().unwrap().perform_relocations(
-            |name| unreachable!("non GOT or PLT relocation in function {} to {}", id, name),
-            |name| self.get_got_address(name),
-            |name| self.get_plt_address(name),
-        );
+        self.compiled_functions[id]
+            .as_ref()
+            .unwrap()
+            .perform_relocations(
+                |name| unreachable!("non GOT or PLT relocation in function {} to {}", id, name),
+                |name| self.get_got_address(name),
+                |name| self.get_plt_address(name),
+            );
 
         Ok(ModuleCompiledFunction { size: total_size })
     }

--- a/cranelift/simplejit/src/backend.rs
+++ b/cranelift/simplejit/src/backend.rs
@@ -51,6 +51,7 @@ impl SimpleJITBuilder {
         // which might not reach all definitions; we can't handle that here, so
         // we require long-range relocation types.
         flag_builder.set("use_colocated_libcalls", "false").unwrap();
+        flag_builder.set("is_pic", "true").unwrap();
         let isa_builder = cranelift_native::builder().unwrap_or_else(|msg| {
             panic!("host machine is not supported: {}", msg);
         });

--- a/cranelift/simplejit/src/compiled_blob.rs
+++ b/cranelift/simplejit/src/compiled_blob.rs
@@ -21,27 +21,24 @@ impl CompiledBlob {
         } in &self.relocs
         {
             debug_assert!((offset as usize) < self.size);
-            let at = unsafe { self.ptr.offset(offset as isize) };
+            let at = unsafe { self.ptr.offset(isize::try_from(offset).unwrap()) };
             let base = get_definition(name);
-            // TODO: Handle overflow.
-            let what = unsafe { base.offset(addend as isize) };
+            let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
             match reloc {
                 Reloc::Abs4 => {
-                    // TODO: Handle overflow.
                     #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
-                        write_unaligned(at as *mut u32, what as u32)
+                        write_unaligned(at as *mut u32, u32::try_from(what as usize).unwrap())
                     };
                 }
                 Reloc::Abs8 => {
                     #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
-                        write_unaligned(at as *mut u64, what as u64)
+                        write_unaligned(at as *mut u64, u64::try_from(what as usize).unwrap())
                     };
                 }
                 Reloc::X86PCRel4 | Reloc::X86CallPCRel4 => {
-                    // TODO: Handle overflow.
-                    let pcrel = ((what as isize) - (at as isize)) as i32;
+                    let pcrel = i32::try_from((what as isize) - (at as isize)).unwrap();
                     #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
                         write_unaligned(at as *mut i32, pcrel)

--- a/cranelift/simplejit/src/compiled_blob.rs
+++ b/cranelift/simplejit/src/compiled_blob.rs
@@ -1,6 +1,7 @@
 use cranelift_codegen::binemit::Reloc;
 use cranelift_codegen::ir::ExternalName;
 use cranelift_module::RelocRecord;
+use std::convert::TryFrom;
 
 #[derive(Clone)]
 pub(crate) struct CompiledBlob {
@@ -10,7 +11,11 @@ pub(crate) struct CompiledBlob {
 }
 
 impl CompiledBlob {
-    pub(crate) fn perform_relocations(&self, get_definition: impl Fn(&ExternalName) -> *const u8) {
+    pub(crate) fn perform_relocations(
+        &self,
+        get_address: impl Fn(&ExternalName) -> *const u8,
+        get_got_entry: impl Fn(&ExternalName) -> *const u8,
+    ) {
         use std::ptr::write_unaligned;
 
         for &RelocRecord {
@@ -22,29 +27,42 @@ impl CompiledBlob {
         {
             debug_assert!((offset as usize) < self.size);
             let at = unsafe { self.ptr.offset(isize::try_from(offset).unwrap()) };
-            let base = get_definition(name);
-            let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
             match reloc {
                 Reloc::Abs4 => {
+                    let base = get_address(name);
+                    let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
                     #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
                         write_unaligned(at as *mut u32, u32::try_from(what as usize).unwrap())
                     };
                 }
                 Reloc::Abs8 => {
+                    let base = get_address(name);
+                    let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
                     #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
                         write_unaligned(at as *mut u64, u64::try_from(what as usize).unwrap())
                     };
                 }
                 Reloc::X86PCRel4 | Reloc::X86CallPCRel4 => {
+                    let base = get_address(name);
+                    let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
                     let pcrel = i32::try_from((what as isize) - (at as isize)).unwrap();
                     #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
                         write_unaligned(at as *mut i32, pcrel)
                     };
                 }
-                Reloc::X86GOTPCRel4 | Reloc::X86CallPLTRel4 => panic!("unexpected PIC relocation"),
+                Reloc::X86GOTPCRel4 => {
+                    let base = get_got_entry(name);
+                    let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
+                    let pcrel = i32::try_from((what as isize) - (at as isize)).unwrap();
+                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+                    unsafe {
+                        write_unaligned(at as *mut i32, pcrel)
+                    };
+                }
+                Reloc::X86CallPLTRel4 => todo!("PLT relocation"),
                 _ => unimplemented!(),
             }
         }

--- a/cranelift/simplejit/tests/basic.rs
+++ b/cranelift/simplejit/tests/basic.rs
@@ -1,6 +1,7 @@
 use cranelift_codegen::binemit::NullTrapSink;
 use cranelift_codegen::ir::*;
 use cranelift_codegen::isa::CallConv;
+use cranelift_codegen::settings::{self, Configurable};
 use cranelift_codegen::{ir::types::I16, Context};
 use cranelift_entity::EntityRef;
 use cranelift_frontend::*;
@@ -9,8 +10,17 @@ use cranelift_simplejit::*;
 
 #[test]
 fn error_on_incompatible_sig_in_declare_function() {
+    let mut flag_builder = settings::builder();
+    flag_builder.set("use_colocated_libcalls", "false").unwrap();
+    // FIXME set back to true once the x64 backend supports it.
+    flag_builder.set("is_pic", "false").unwrap();
+    let isa_builder = cranelift_native::builder().unwrap_or_else(|msg| {
+        panic!("host machine is not supported: {}", msg);
+    });
+    let isa = isa_builder.finish(settings::Flags::new(flag_builder));
     let mut module: SimpleJITModule =
-        SimpleJITModule::new(SimpleJITBuilder::new(default_libcall_names()));
+        SimpleJITModule::new(SimpleJITBuilder::with_isa(isa, default_libcall_names()));
+
     let mut sig = Signature {
         params: vec![AbiParam::new(types::I64)],
         returns: vec![],
@@ -58,8 +68,16 @@ fn define_simple_function(module: &mut SimpleJITModule) -> FuncId {
 #[test]
 #[should_panic(expected = "Result::unwrap()` on an `Err` value: DuplicateDefinition(\"abc\")")]
 fn panic_on_define_after_finalize() {
+    let mut flag_builder = settings::builder();
+    flag_builder.set("use_colocated_libcalls", "false").unwrap();
+    // FIXME set back to true once the x64 backend supports it.
+    flag_builder.set("is_pic", "false").unwrap();
+    let isa_builder = cranelift_native::builder().unwrap_or_else(|msg| {
+        panic!("host machine is not supported: {}", msg);
+    });
+    let isa = isa_builder.finish(settings::Flags::new(flag_builder));
     let mut module: SimpleJITModule =
-        SimpleJITModule::new(SimpleJITBuilder::new(default_libcall_names()));
+        SimpleJITModule::new(SimpleJITBuilder::with_isa(isa, default_libcall_names()));
 
     define_simple_function(&mut module);
     define_simple_function(&mut module);
@@ -140,8 +158,16 @@ fn switch_error() {
 
 #[test]
 fn libcall_function() {
+    let mut flag_builder = settings::builder();
+    flag_builder.set("use_colocated_libcalls", "false").unwrap();
+    // FIXME set back to true once the x64 backend supports it.
+    flag_builder.set("is_pic", "false").unwrap();
+    let isa_builder = cranelift_native::builder().unwrap_or_else(|msg| {
+        panic!("host machine is not supported: {}", msg);
+    });
+    let isa = isa_builder.finish(settings::Flags::new(flag_builder));
     let mut module: SimpleJITModule =
-        SimpleJITModule::new(SimpleJITBuilder::new(default_libcall_names()));
+        SimpleJITModule::new(SimpleJITBuilder::with_isa(isa, default_libcall_names()));
 
     let sig = Signature {
         params: vec![],


### PR DESCRIPTION
This makes it possible to change functions when using SimpleJIT without having to recompile everything or even restart the jitted code. When a changed function is currently on the stack, the old version will be returned to, but all new calls will be redirected to the new version. It is not yet possible to swap data objects.

This is a prerequisite of https://github.com/bjorn3/rustc_codegen_cranelift/issues/1087.

I have tested this PR by implementing lazy compilation in cg_clif as suggested by @flodiebold in https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/cranelift.20backend.20work/near/187645798 in February.

r? @pchickey (By the way, is it deliberate that you are marked as unavailable on zulip? I sent you a PM)
cc https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/hot.20code.20swapping.20for.20simplejit/near/216403611