### PR TITLE
Remove the global variable associated with traps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,7 +2247,6 @@ dependencies = [
  "backtrace",
  "bincode",
  "cfg-if 1.0.0",
- "lazy_static",
  "libc",
  "log",
  "region",

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -46,7 +46,7 @@ pub mod trampoline;
 
 pub use crate::code_memory::CodeMemory;
 pub use crate::compiler::{Compilation, CompilationStrategy, Compiler};
-pub use crate::instantiate::{CompilationArtifacts, CompiledModule, SetupError};
+pub use crate::instantiate::{CompilationArtifacts, CompiledModule, ModuleCode, SetupError};
 pub use crate::link::link_module;
 
 /// Version number of this crate.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -43,7 +43,8 @@ pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
-    catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, SignalHandler, Trap,
+    catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, with_last_info,
+    SignalHandler, Trap, TrapInfo,
 };
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -23,7 +23,6 @@ libc = "0.2"
 cfg-if = "1.0"
 backtrace = "0.3.42"
 rustc-demangle = "0.1.16"
-lazy_static = "1.4"
 log = "0.4.8"
 wat = { version = "1.0.18", optional = true }
 smallvec = "1.4.0"

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -492,13 +492,13 @@ impl Table {
         // come from different modules.
 
         let dst_table_index = dst_table.wasmtime_table_index();
-        let dst_table = dst_table.instance.get_defined_table(dst_table_index);
+        let dst_table_index = dst_table.instance.get_defined_table(dst_table_index);
 
         let src_table_index = src_table.wasmtime_table_index();
-        let src_table = src_table.instance.get_defined_table(src_table_index);
+        let src_table_index = src_table.instance.get_defined_table(src_table_index);
 
-        runtime::Table::copy(dst_table, src_table, dst_index, src_index, len)
-            .map_err(Trap::from_runtime)?;
+        runtime::Table::copy(dst_table_index, src_table_index, dst_index, src_index, len)
+            .map_err(|e| Trap::from_runtime(&dst_table.instance.store, e))?;
         Ok(())
     }
 
@@ -523,7 +523,7 @@ impl Table {
         self.instance
             .handle
             .defined_table_fill(table_index, dst, val.into_table_element()?, len)
-            .map_err(Trap::from_runtime)?;
+            .map_err(|e| Trap::from_runtime(&self.instance.store, e))?;
 
         Ok(())
     }

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -43,7 +43,7 @@ fn instantiate(
             )
             .map_err(|e| -> Error {
                 match e {
-                    InstantiationError::Trap(trap) => Trap::from_runtime(trap).into(),
+                    InstantiationError::Trap(trap) => Trap::from_runtime(store, trap).into(),
                     other => other.into(),
                 }
             })?;
@@ -165,11 +165,9 @@ impl Instance {
             bail!("cross-`Engine` instantiation is not currently supported");
         }
 
-        store.register_module(&module);
-        let host_info = Box::new(module.register_frame_info());
-
+        store.register_module(module.compiled_module());
         let handle = with_imports(store, module.compiled_module(), imports, |imports| {
-            instantiate(store, module.compiled_module(), imports, host_info)
+            instantiate(store, module.compiled_module(), imports, Box::new(()))
         })?;
 
         Ok(Instance {

--- a/crates/wasmtime/src/unix.rs
+++ b/crates/wasmtime/src/unix.rs
@@ -26,6 +26,6 @@ impl StoreExt for Store {
     where
         H: 'static + Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool,
     {
-        *self.signal_handler_mut() = Some(Box::new(handler));
+        self.set_signal_handler(Some(Box::new(handler)));
     }
 }

--- a/crates/wasmtime/src/windows.rs
+++ b/crates/wasmtime/src/windows.rs
@@ -26,6 +26,6 @@ impl StoreExt for Store {
     where
         H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool,
     {
-        *self.signal_handler_mut() = Some(Box::new(handler));
+        self.set_signal_handler(Some(Box::new(handler)));
     }
 }


### PR DESCRIPTION
This commit removes the global variable associated with wasm traps which
stores frame information. The only purpose of this global is to help
symbolicate `Trap`s created since we support creating a `Trap` without a
`Store`. The global, however, is only used for wasm frames on the stack,
and when wasm frames are on the stack we know that our thread local for
"what was the last context" is set and configured.

The change here is to hijack this thread-local some more to effectively
store the `Store` inside of it. All frame information is then moved
directly into `Store` and no longer lives off on the side in a global.
Additionally support for registering/unregistering modules is now
simplified because once a module is registered with a store it can never
be unregistered.

This has one slight functional change where if there are two instances
of `Store` interleaving calls to wasm code on the stack we'll only be
able to symbolicate one of them instead of both. That's arguably also a
feature however because this is sort of a way to leak information across
stores right now.

Otherwise, though, this isn't intended to change any existing logic, but
instead keep everything working as-is.
