### PR TITLE
Fix a use-after-free of trampoline code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,7 +2247,6 @@ dependencies = [
  "backtrace",
  "bincode",
  "cfg-if 1.0.0",
- "lazy_static",
  "libc",
  "log",
  "region",

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -46,7 +46,7 @@ pub mod trampoline;
 
 pub use crate::code_memory::CodeMemory;
 pub use crate::compiler::{Compilation, CompilationStrategy, Compiler};
-pub use crate::instantiate::{CompilationArtifacts, CompiledModule, SetupError};
+pub use crate::instantiate::{CompilationArtifacts, CompiledModule, ModuleCode, SetupError};
 pub use crate::link::link_module;
 
 /// Version number of this crate.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -43,7 +43,8 @@ pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
-    catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, SignalHandler, Trap,
+    catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, with_last_info,
+    SignalHandler, Trap, TrapInfo,
 };
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -23,7 +23,6 @@ libc = "0.2"
 cfg-if = "1.0"
 backtrace = "0.3.42"
 rustc-demangle = "0.1.16"
-lazy_static = "1.4"
 log = "0.4.8"
 wat = { version = "1.0.18", optional = true }
 smallvec = "1.4.0"

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -492,13 +492,13 @@ impl Table {
         // come from different modules.
 
         let dst_table_index = dst_table.wasmtime_table_index();
-        let dst_table = dst_table.instance.get_defined_table(dst_table_index);
+        let dst_table_index = dst_table.instance.get_defined_table(dst_table_index);
 
         let src_table_index = src_table.wasmtime_table_index();
-        let src_table = src_table.instance.get_defined_table(src_table_index);
+        let src_table_index = src_table.instance.get_defined_table(src_table_index);
 
-        runtime::Table::copy(dst_table, src_table, dst_index, src_index, len)
-            .map_err(Trap::from_runtime)?;
+        runtime::Table::copy(dst_table_index, src_table_index, dst_index, src_index, len)
+            .map_err(|e| Trap::from_runtime(&dst_table.instance.store, e))?;
         Ok(())
     }
 
@@ -523,7 +523,7 @@ impl Table {
         self.instance
             .handle
             .defined_table_fill(table_index, dst, val.into_table_element()?, len)
-            .map_err(Trap::from_runtime)?;
+            .map_err(|e| Trap::from_runtime(&self.instance.store, e))?;
 
         Ok(())
     }

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -16,6 +16,11 @@ fn instantiate(
     imports: Imports<'_>,
     host: Box<dyn Any>,
 ) -> Result<StoreInstanceHandle, Error> {
+    // Register the module just before instantiation to ensure we have a
+    // trampoline registered for every signature and to preserve the module's
+    // compiled JIT code within the `Store`.
+    store.register_module(compiled_module);
+
     let config = store.engine().config();
     let instance = unsafe {
         let instance = compiled_module.instantiate(
@@ -98,11 +103,6 @@ fn instantiate(
 #[derive(Clone)]
 pub struct Instance {
     pub(crate) handle: StoreInstanceHandle,
-    // Note that this is required to keep the module's code memory alive while
-    // we have a handle to this `Instance`. We may eventually want to shrink
-    // this to only hold onto the bare minimum each instance needs to allow
-    // deallocating some `Module` resources early, but until then we just hold
-    // on to everything.
     module: Module,
 }
 
@@ -165,7 +165,6 @@ impl Instance {
             bail!("cross-`Engine` instantiation is not currently supported");
         }
 
-        store.register_module(module.compiled_module());
         let handle = with_imports(store, module.compiled_module(), imports, |imports| {
             instantiate(store, module.compiled_module(), imports, Box::new(()))
         })?;

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -43,7 +43,7 @@ fn instantiate(
             )
             .map_err(|e| -> Error {
                 match e {
-                    InstantiationError::Trap(trap) => Trap::from_runtime(trap).into(),
+                    InstantiationError::Trap(trap) => Trap::from_runtime(store, trap).into(),
                     other => other.into(),
                 }
             })?;
@@ -165,11 +165,9 @@ impl Instance {
             bail!("cross-`Engine` instantiation is not currently supported");
         }
 
-        store.register_module(&module);
-        let host_info = Box::new(module.register_frame_info());
-
+        store.register_module(module.compiled_module());
         let handle = with_imports(store, module.compiled_module(), imports, |imports| {
-            instantiate(store, module.compiled_module(), imports, host_info)
+            instantiate(store, module.compiled_module(), imports, Box::new(()))
         })?;
 
         Ok(Instance {

--- a/crates/wasmtime/src/unix.rs
+++ b/crates/wasmtime/src/unix.rs
@@ -26,6 +26,6 @@ impl StoreExt for Store {
     where
         H: 'static + Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool,
     {
-        *self.signal_handler_mut() = Some(Box::new(handler));
+        self.set_signal_handler(Some(Box::new(handler)));
     }
 }

--- a/crates/wasmtime/src/windows.rs
+++ b/crates/wasmtime/src/windows.rs
@@ -26,6 +26,6 @@ impl StoreExt for Store {
     where
         H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool,
     {
-        *self.signal_handler_mut() = Some(Box::new(handler));
+        self.set_signal_handler(Some(Box::new(handler)));
     }
 }


### PR DESCRIPTION


This commit fixes an issue with wasmtime where it was possible for a
trampoline from one module to get used for another module after it was
freed. This issue arises because we register a module's native
trampolines *before* it's fully instantiated, which is a fallible
process. Some fallibility is predictable, such as import type
mismatches, but other fallibility is less predictable, such as failure
to allocate a linear memory.

The problem happened when a module was registered with a `Store`,
retaining information about its trampolines, but then instantiation
failed and the module's code was never persisted within the `Store`.
Unlike as documented in #2374 the `Module` inside an `Instance` is not
the primary way to hold on to a module's code, but rather the
`Arc<ModuleCode>` is persisted within the global frame information off
on the side. This persistence only made its way into the store through
the `Box<Any>` field of `InstanceHandle`, but that's never made if
instantiation fails during import matching.

The fix here is to build on the refactoring of #2407 to not store module
code in frame information but rather explicitly in the `Store`.
Registration is now deferred until just-before an instance handle is
created, and during module registration we insert the `Arc<ModuleCode>`
into a set stored within the `Store`.

