### PR TITLE
Fix and enable GC on new x64 backend.

### DIFF
--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -24,7 +24,6 @@ impl Drop for GcOnDrop {
 }
 
 #[test]
-#[cfg_attr(feature = "experimental_x64", ignore)] // TODO #2079 investigate.
 fn smoke_test_gc() -> anyhow::Result<()> {
     let (store, module) = ref_types_module(
         r#"
@@ -121,7 +120,6 @@ fn wasm_dropping_refs() -> anyhow::Result<()> {
 }
 
 #[test]
-#[cfg_attr(feature = "experimental_x64", ignore)] // TODO #2079 investigate.
 fn many_live_refs() -> anyhow::Result<()> {
     let mut wat = r#"
         (module
@@ -375,7 +373,6 @@ fn gc_during_gc_when_passing_refs_into_wasm() -> anyhow::Result<()> {
 }
 
 #[test]
-#[cfg_attr(feature = "experimental_x64", ignore)] // TODO #2079 investigate.
 fn gc_during_gc_from_many_table_gets() -> anyhow::Result<()> {
     let (store, module) = ref_types_module(
         r#"


### PR DESCRIPTION
One critical bit of plumbing was missing: the `StackMapSink` passed to
`compile_and_emit` was not actually receiving stackmaps. This seemingly
very basic issue was not caught because the other major user of reftype
support, SpiderMonkey, extracts stackmaps with a lower-level API. The
SM integration was built this way to avoid an awkward API quirk when
passing stackmaps through a `CodeSink` that proxies them to a
`StackMapSink`: the `CodeSink` wants `Value`s for each reference slot,
while the actual `StackMapSink` does not require these. This PR tweaks
the plumbing in a slightly different way to make `wasmtime` GC tests,
and presumably other consumers of stack-map info from the top-level
Cranelift interface, happy.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
