### PR TITLE
Don't run old x86 backend-specific tests with new x64 backend.

### DIFF
--- a/cranelift/codegen/src/isa/x86/unwind.rs
+++ b/cranelift/codegen/src/isa/x86/unwind.rs
@@ -257,7 +257,6 @@ mod tests {
     use target_lexicon::triple;
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_small_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -314,7 +313,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_medium_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -371,7 +369,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_large_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -444,7 +441,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_multi_return_func() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")

--- a/cranelift/codegen/src/isa/x86/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x86/unwind/systemv.rs
@@ -142,7 +142,6 @@ mod tests {
     use target_lexicon::triple;
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_simple_func() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -185,7 +184,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_multi_return_func() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")

--- a/cranelift/codegen/src/isa/x86/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/x86/unwind/winx64.rs
@@ -69,7 +69,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_small_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -127,7 +126,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_medium_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -189,7 +187,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "x64", should_panic)] // TODO #2079
     fn test_large_alloc() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")


### PR DESCRIPTION
Some of the test failures tracked by #2079 are in unwind tests that are
specific to the old x86 backend: namely, these tests invoke the unwind
implementation that is paired with the old backend, rather than generic
over all backends. It thus doesn't make sense to try to run these tests
with the new backend. (The new backend's unwind code should have
analogous tests written/ported over eventually.)

It seems that we were actually building *both* x86 backends when the
`x64` feature was enabled, except that the old x86 backend would never
be instantiated by the usual ISA-lookup logic because a `x86-64` target
triple unconditionally resolves to the new one.

This PR resolves both of the issues by tweaking the feature-config
directives to exclude the `x86` backend when `x64` is enabled.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
