### PR TITLE
Command: config; fix message typo

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -39,7 +39,7 @@ impl ConfigNewCommand {
         let path = wasmtime_cache::create_new_config(self.path.as_ref())?;
 
         println!(
-            "Successfully created a new configuation file at '{}'.",
+            "Successfully created a new configuration file at '{}'.",
             path.display()
         );
 


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Trivial typo fix in ConfigNewCommand::execute,  ~configuation~ -> configuration