### PR TITLE
Cranelift AArch64: Further vector constant improvements

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -2073,6 +2073,24 @@ fn test_aarch64_binemit() {
         "dup v18.2d, v10.d[0]",
     ));
     insns.push((
+        Inst::VecDupFPImm {
+            rd: writable_vreg(31),
+            imm: ASIMDFPModImm::maybe_from_u64(1_f32.to_bits() as u64, ScalarSize::Size32).unwrap(),
+            size: VectorSize::Size32x2,
+        },
+        "1FF6030F",
+        "fmov v31.2s, #1",
+    ));
+    insns.push((
+        Inst::VecDupFPImm {
+            rd: writable_vreg(0),
+            imm: ASIMDFPModImm::maybe_from_u64(2_f64.to_bits(), ScalarSize::Size64).unwrap(),
+            size: VectorSize::Size64x2,
+        },
+        "00F4006F",
+        "fmov v0.2d, #2",
+    ));
+    insns.push((
         Inst::VecDupImm {
             rd: writable_vreg(31),
             imm: ASIMDMovModImm::maybe_from_u64(255, ScalarSize::Size8).unwrap(),
@@ -2084,13 +2102,93 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::VecDupImm {
+            rd: writable_vreg(30),
+            imm: ASIMDMovModImm::maybe_from_u64(0, ScalarSize::Size16).unwrap(),
+            invert: false,
+            size: VectorSize::Size16x8,
+        },
+        "1E84004F",
+        "movi v30.8h, #0",
+    ));
+    insns.push((
+        Inst::VecDupImm {
             rd: writable_vreg(0),
-            imm: ASIMDMovModImm::zero(),
+            imm: ASIMDMovModImm::zero(ScalarSize::Size16),
             invert: true,
             size: VectorSize::Size16x4,
         },
         "0084002F",
         "mvni v0.4h, #0",
+    ));
+    insns.push((
+        Inst::VecDupImm {
+            rd: writable_vreg(0),
+            imm: ASIMDMovModImm::maybe_from_u64(256, ScalarSize::Size16).unwrap(),
+            invert: false,
+            size: VectorSize::Size16x8,
+        },
+        "20A4004F",
+        "movi v0.8h, #1, LSL #8",
+    ));
+    insns.push((
+        Inst::VecDupImm {
+            rd: writable_vreg(8),
+            imm: ASIMDMovModImm::maybe_from_u64(2228223, ScalarSize::Size32).unwrap(),
+            invert: false,
+            size: VectorSize::Size32x4,
+        },
+        "28D4014F",
+        "movi v8.4s, #33, MSL #16",
+    ));
+    insns.push((
+        Inst::VecDupImm {
+            rd: writable_vreg(16),
+            imm: ASIMDMovModImm::maybe_from_u64(35071, ScalarSize::Size32).unwrap(),
+            invert: true,
+            size: VectorSize::Size32x2,
+        },
+        "10C5042F",
+        "mvni v16.2s, #136, MSL #8",
+    ));
+    insns.push((
+        Inst::VecDupImm {
+            rd: writable_vreg(1),
+            imm: ASIMDMovModImm::maybe_from_u64(0, ScalarSize::Size32).unwrap(),
+            invert: false,
+            size: VectorSize::Size32x2,
+        },
+        "0104000F",
+        "movi v1.2s, #0",
+    ));
+    insns.push((
+        Inst::VecDupImm {
+            rd: writable_vreg(24),
+            imm: ASIMDMovModImm::maybe_from_u64(1107296256, ScalarSize::Size32).unwrap(),
+            invert: false,
+            size: VectorSize::Size32x4,
+        },
+        "5864024F",
+        "movi v24.4s, #66, LSL #24",
+    ));
+    insns.push((
+        Inst::VecDupImm {
+            rd: writable_vreg(8),
+            imm: ASIMDMovModImm::zero(ScalarSize::Size64),
+            invert: false,
+            size: VectorSize::Size64x2,
+        },
+        "08E4006F",
+        "movi v8.2d, #0",
+    ));
+    insns.push((
+        Inst::VecDupImm {
+            rd: writable_vreg(7),
+            imm: ASIMDMovModImm::maybe_from_u64(18374687574904995840, ScalarSize::Size64).unwrap(),
+            invert: false,
+            size: VectorSize::Size64x2,
+        },
+        "87E6046F",
+        "movi v7.2d, #18374687574904995840",
     ));
     insns.push((
         Inst::VecExtend {
@@ -4374,6 +4472,16 @@ fn test_aarch64_binemit() {
         },
         "7705085E",
         "mov d23, v11.d[0]",
+    ));
+
+    insns.push((
+        Inst::FpuExtend {
+            rd: writable_vreg(31),
+            rn: vreg(0),
+            size: ScalarSize::Size32,
+        },
+        "1F40201E",
+        "fmov s31, s0",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -853,7 +853,7 @@ pub(crate) fn lower_constant_f128<C: LowerCtx<I = Inst>>(
         // is potentially expensive.
         ctx.emit(Inst::VecDupImm {
             rd,
-            imm: ASIMDMovModImm::zero(),
+            imm: ASIMDMovModImm::zero(ScalarSize::Size8),
             invert: false,
             size: VectorSize::Size8x16,
         });

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -2075,8 +2075,6 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // derivation of these sequences.  Alternative sequences are discussed in
             // https://github.com/bytecodealliance/wasmtime/issues/2296, although they are not
             // used here.
-            // Also .. FIXME: when https://github.com/bytecodealliance/wasmtime/pull/2310 is
-            // merged, use `lower_splat_constant` instead to generate the constants.
             let tmp_r0 = ctx.alloc_tmp(RegClass::I64, I64);
             let tmp_v0 = ctx.alloc_tmp(RegClass::V128, I8X16);
             let tmp_v1 = ctx.alloc_tmp(RegClass::V128, I8X16);
@@ -2100,12 +2098,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         size: VectorSize::Size8x16,
                         imm: 7,
                     });
-                    lower_constant_u64(ctx, tmp_r0, 0x8040201008040201u64);
-                    ctx.emit(Inst::VecDup {
-                        rd: tmp_v0,
-                        rn: tmp_r0.to_reg(),
-                        size: VectorSize::Size64x2,
-                    });
+                    lower_splat_const(ctx, tmp_v0, 0x8040201008040201u64, VectorSize::Size64x2);
                     ctx.emit(Inst::VecRRR {
                         alu_op: VecALUOp::And,
                         rd: tmp_v1,

--- a/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
@@ -715,7 +715,7 @@ block0(v0: f32):
 ; nextln: movz x0, #20352, LSL #16
 ; nextln: fmov d1, x0
 ; nextln: fmin s2, s0, s1
-; nextln: movi v1.8b, #0
+; nextln: movi v1.2s, #0
 ; nextln: fmax s2, s2, s1
 ; nextln: fcmp s0, s0
 ; nextln: fcsel s0, s1, s2, ne
@@ -738,7 +738,7 @@ block0(v0: f32):
 ; nextln: movz x0, #52992, LSL #16
 ; nextln: fmov d2, x0
 ; nextln: fmax s1, s1, s2
-; nextln: movi v2.8b, #0
+; nextln: movi v2.2s, #0
 ; nextln: fcmp s0, s0
 ; nextln: fcsel s0, s2, s1, ne
 ; nextln: fcvtzs w0, s0
@@ -757,7 +757,7 @@ block0(v0: f32):
 ; nextln: movz x0, #24448, LSL #16
 ; nextln: fmov d1, x0
 ; nextln: fmin s2, s0, s1
-; nextln: movi v1.8b, #0
+; nextln: movi v1.2s, #0
 ; nextln: fmax s2, s2, s1
 ; nextln: fcmp s0, s0
 ; nextln: fcsel s0, s1, s2, ne
@@ -780,7 +780,7 @@ block0(v0: f32):
 ; nextln: movz x0, #57088, LSL #16
 ; nextln: fmov d2, x0
 ; nextln: fmax s1, s1, s2
-; nextln: movi v2.8b, #0
+; nextln: movi v2.2s, #0
 ; nextln: fcmp s0, s0
 ; nextln: fcsel s0, s2, s1, ne
 ; nextln: fcvtzs x0, s0
@@ -798,7 +798,7 @@ block0(v0: f64):
 ; nextln:  mov fp, sp
 ; nextln: ldr d1, pc+8 ; b 12 ; data.f64 4294967295
 ; nextln: fmin d2, d0, d1
-; nextln: movi v1.8b, #0
+; nextln: movi v1.2s, #0
 ; nextln: fmax d2, d2, d1
 ; nextln: fcmp d0, d0
 ; nextln: fcsel d0, d1, d2, ne
@@ -820,7 +820,7 @@ block0(v0: f64):
 ; nextln: movz x0, #49632, LSL #48
 ; nextln: fmov d2, x0
 ; nextln: fmax d1, d1, d2
-; nextln: movi v2.8b, #0
+; nextln: movi v2.2s, #0
 ; nextln: fcmp d0, d0
 ; nextln: fcsel d0, d2, d1, ne
 ; nextln: fcvtzs w0, d0
@@ -839,7 +839,7 @@ block0(v0: f64):
 ; nextln: movz x0, #17392, LSL #48
 ; nextln: fmov d1, x0
 ; nextln: fmin d2, d0, d1
-; nextln: movi v1.8b, #0
+; nextln: movi v1.2s, #0
 ; nextln: fmax d2, d2, d1
 ; nextln: fcmp d0, d0
 ; nextln: fcsel d0, d1, d2, ne
@@ -862,7 +862,7 @@ block0(v0: f64):
 ; nextln: movz x0, #50144, LSL #48
 ; nextln: fmov d2, x0
 ; nextln: fmax d1, d1, d2
-; nextln: movi v2.8b, #0
+; nextln: movi v2.2s, #0
 ; nextln: fcmp d0, d0
 ; nextln: fcsel d0, d2, d1, ne
 ; nextln: fcvtzs x0, d0

--- a/cranelift/filetests/filetests/isa/aarch64/simd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd.clif
@@ -127,3 +127,46 @@ block0(v0: i64, v1: i64):
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
+
+function %f9() -> i32x2 {
+block0:
+  v0 = iconst.i32 4278190335
+  v1 = splat.i32x2 v0
+  return v1
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  movi v0.2d, #18374687579166474495
+; nextln:  fmov d0, d0
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret
+
+function %f10() -> i32x4 {
+block0:
+  v0 = iconst.i32 4293918720
+  v1 = splat.i32x4 v0
+  return v1
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  mvni v0.4s, #15, MSL #16
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret
+
+function %f11() -> f32x4 {
+block0:
+  v0 = f32const 0x1.5
+  v1 = splat.f32x4 v0
+  return v1
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln:  mov fp, sp
+; nextln:  fmov v0.4s, #1.3125
+; nextln:  mov sp, fp
+; nextln:  ldp fp, lr, [sp], #16
+; nextln:  ret


### PR DESCRIPTION
Introduce support for `MOVI`/`MVNI` with 16-, 32-, and 64-bit elements, and the vector variant of `FMOV`.