### PR TITLE
Fix assertion with cross-store values in `Func::new`

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -295,12 +295,17 @@ impl Func {
 
             // Unlike our arguments we need to dynamically check that the return
             // values produced are correct. There could be a bug in `func` that
-            // produces the wrong number or wrong types of values, and we need
-            // to catch that here.
+            // produces the wrong number, wrong types, or wrong stores of
+            // values, and we need to catch that here.
             for (i, (ret, ty)) in returns.into_iter().zip(ty_clone.results()).enumerate() {
                 if ret.ty() != ty {
                     return Err(Trap::new(
                         "function attempted to return an incompatible value",
+                    ));
+                }
+                if !ret.comes_from_same_store(&store) {
+                    return Err(Trap::new(
+                        "cross-`Store` values are not currently supported",
                     ));
                 }
                 unsafe {


### PR DESCRIPTION
If a host-defined `Func::new` closure returns values from the wrong
store, this currently trips a debug assertion and causes other issues
elsewhere in release mode. This commit adds the same dynamic checks
found in `Func::wrap` in the `Func::new` case today.

