### PR TITLE
Remove empty .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,0 @@
-# This file tells tools we use rustfmt. We use the default settings.


### PR DESCRIPTION
AFAIK this isn't really necessary nowadays given the prevalence of
rustfmt, and for whatever reason the Rust plugin for vim uses this file
in lieu of all other options, meaning it doesn't pass `--edition 2018`
by default which has been causing issues as I've been working on `async`
stuff. In any case I don't think we need the file regardless, so this
commit deletes it.
