### PR TITLE
Update wasmparser for exception handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wat",
 ]
 
@@ -1150,7 +1150,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "typemap",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wat",
 ]
 
@@ -2321,24 +2321,18 @@ checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmparser"
-version = "0.66.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c97fc0456d6d09ca7b64bc33c34f4e8f29d5ccfa8e5595ef7a8957818339e6f6"
-
-[[package]]
-name = "wasmparser"
-version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f091cf3849e5fe76a60255bff169277459f2201435bc583b6656880553f0ad0"
+checksum = "29a00e14eed9c2ecbbdbdd4fb284f49d21b6808965de24769a6379a13ec47d4c"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b580bee9eb1f029fac6014620b31f82ea2afa22d0701b9bd7f879747e3f5242"
+checksum = "f39a73b5f09cfcb1b568b61968d39b19e4ddec9b49040cfc091adf3b0788bca6"
 dependencies = [
  "anyhow",
- "wasmparser 0.66.0",
+ "wasmparser 0.68.0",
 ]
 
 [[package]]
@@ -2357,7 +2351,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -2435,7 +2429,7 @@ dependencies = [
  "test-programs",
  "tracing-subscriber",
  "wasi-common",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-debug",
@@ -2471,7 +2465,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wasmtime-environ",
 ]
 
@@ -2490,7 +2484,7 @@ dependencies = [
  "more-asserts",
  "serde",
  "thiserror",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
 ]
 
 [[package]]
@@ -2518,7 +2512,7 @@ dependencies = [
  "log",
  "rayon",
  "wasm-smith",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -2545,7 +2539,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -2562,7 +2556,7 @@ version = "0.21.0"
 dependencies = [
  "cranelift-codegen",
  "lightbeam",
- "wasmparser 0.67.0",
+ "wasmparser 0.68.0",
  "wasmtime-environ",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"
 humantime = "2.0.0"
-wasmparser = "0.67"
+wasmparser = "0.68"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.67.0", default-features = false }
+wasmparser = { version = "0.68.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.68.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.68.0" }
 cranelift-frontend = { path = "../frontend", version = "0.68.0", default-features = false }

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -534,6 +534,17 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             state.popn(return_count);
             state.reachable = false;
         }
+        /********************************** Exception handing **********************************/
+        Operator::Try { .. }
+        | Operator::Catch
+        | Operator::BrOnExn { .. }
+        | Operator::Throw { .. }
+        | Operator::Rethrow => {
+            return Err(wasm_unsupported!(
+                "proposed exception handling operator {:?}",
+                op
+            ));
+        }
         /************************************ Calls ****************************************
          * The call instructions pop off their arguments from the stack and append their
          * return values to it. `call_indirect` needs environment support because there is an

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -2,9 +2,9 @@
 //! to deal with each part of it.
 use crate::environ::{ModuleEnvironment, WasmResult};
 use crate::sections_translator::{
-    parse_data_section, parse_element_section, parse_export_section, parse_function_section,
-    parse_global_section, parse_import_section, parse_memory_section, parse_name_section,
-    parse_start_section, parse_table_section, parse_type_section,
+    parse_data_section, parse_element_section, parse_event_section, parse_export_section,
+    parse_function_section, parse_global_section, parse_import_section, parse_memory_section,
+    parse_name_section, parse_start_section, parse_table_section, parse_type_section,
 };
 use crate::state::ModuleTranslationState;
 use cranelift_codegen::timing;
@@ -63,6 +63,11 @@ pub fn translate_module<'data>(
             Payload::MemorySection(memories) => {
                 validator.memory_section(&memories)?;
                 parse_memory_section(memories, environ)?;
+            }
+
+            Payload::EventSection(events) => {
+                validator.event_section(&events)?;
+                parse_event_section(events, environ)?;
             }
 
             Payload::GlobalSection(globals) => {

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -91,6 +91,12 @@ entity_impl!(ModuleIndex);
 pub struct InstanceIndex(u32);
 entity_impl!(InstanceIndex);
 
+/// Index type of an event inside the WebAssembly module.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct EventIndex(u32);
+entity_impl!(EventIndex);
+
 /// An index of an entity.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
@@ -119,6 +125,8 @@ pub enum EntityType {
     Global(Global),
     /// A linear memory with the specified limits
     Memory(Memory),
+    /// An event definition.
+    Event(Event),
     /// A table with the specified element type and limits
     Table(Table),
     /// A function type where the index points to the type section and records a
@@ -210,6 +218,14 @@ pub struct Memory {
     pub maximum: Option<u32>,
     /// Whether the memory may be shared between multiple threads.
     pub shared: bool,
+}
+
+/// WebAssembly event.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct Event {
+    /// The event signature type.
+    pub ty: TypeIndex,
 }
 
 /// Helper function translating wasmparser types to Cranelift types when possible.

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.23.0"
-wasmparser = "0.67.0"
+wasmparser = "0.68.0"
 object = { version = "0.22.0", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.21.0" }
 target-lexicon = { version = "0.11.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.68.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.68.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.68.0", features = ["enable-serde"] }
-wasmparser = "0.67.0"
+wasmparser = "0.68.0"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -12,8 +12,8 @@ arbitrary = { version = "0.4.1", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.67.0"
-wasmprinter = "0.2.13"
+wasmparser = "0.68.0"
+wasmprinter = "0.2.15"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 wasm-smith = "0.1.10"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -28,7 +28,7 @@ rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.67.0"
+wasmparser = "0.68.0"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "1.0"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ more-asserts = "0.2.1"
 smallvec = "1.0.0"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.67.0"
+wasmparser = "0.68.0"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 lightbeam = { path = "..", version = "0.21.0" }
-wasmparser = "0.67"
+wasmparser = "0.68"
 cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.68.0" }
 wasmtime-environ = { path = "../../environ", version = "0.21.0" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -16,7 +16,7 @@ wasmtime-jit = { path = "../jit", version = "0.21.0" }
 wasmtime-cache = { path = "../cache", version = "0.21.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.21.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.67.0"
+wasmparser = "0.68.0"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"

--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -133,6 +133,7 @@ impl ValType {
             wasm::WasmType::V128 => Self::V128,
             wasm::WasmType::FuncRef => Self::FuncRef,
             wasm::WasmType::ExternRef => Self::ExternRef,
+            wasm::WasmType::ExnRef => unimplemented!(),
         }
     }
 }
@@ -222,6 +223,7 @@ impl ExternType {
                 };
                 InstanceType::from_wasmtime(module, exports).into()
             }
+            EntityType::Event(_) => unimplemented!("wasm event support"),
         }
     }
 }


### PR DESCRIPTION
Updates wasmparser dependency and stubs EH wasmtime handling. This PR allows not to block on future wasmparser updates. Just to note: `exnref` support might go away in the future EH proposals, but for legacy tools support (e.g. wabt / llvm), I recommend to  still introduce it for prototyping.