### PR TITLE
LTO1/3: Explicitly disable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,6 @@ harness = false
 
 [profile.dev.package.backtrace]
 debug = false # FIXME(#1813)
+
+[profile.release]
+lto = "off"


### PR DESCRIPTION
This is an experiment to get measurements of CI run times, with and without LTO enabled. See discussion on [Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/206238-general/topic/enable.20lto.20for.20production.20builds.20of.20wasmtime.3F/near/217617612).

This PR will establish a baseline of the CI run times, without any LTO. It'll be closed once the experiments have been all done.