### PR TITLE
LTO(2/3): Enable thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,6 @@ harness = false
 
 [profile.dev.package.backtrace]
 debug = false # FIXME(#1813)
+
+[profile.release]
+lto = "thin"


### PR DESCRIPTION
This is an experiment to get measurements of CI run times, with and without LTO enabled. See discussion on [Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/206238-general/topic/enable.20lto.20for.20production.20builds.20of.20wasmtime.3F/near/217617612).

This PR will establish the time it takes for CI to compile and run with thin LTO.