### PR TITLE
Instantiate nested modules for module linking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,7 @@ fn main() -> anyhow::Result<()> {
             test_directory_module(out, "tests/misc_testsuite/bulk-memory-operations", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/reference-types", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/multi-memory", strategy)?;
+            test_directory_module(out, "tests/misc_testsuite/module-linking", strategy)?;
             Ok(())
         })?;
 

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -8,8 +8,8 @@
 
 use crate::state::FuncTranslationState;
 use crate::translation_utils::{
-    DataIndex, ElemIndex, EntityType, Event, EventIndex, FuncIndex, Global, GlobalIndex, Memory,
-    MemoryIndex, Table, TableIndex, TypeIndex,
+    DataIndex, ElemIndex, EntityIndex, EntityType, Event, EventIndex, FuncIndex, Global,
+    GlobalIndex, Memory, MemoryIndex, ModuleIndex, Table, TableIndex, TypeIndex,
 };
 use core::convert::From;
 use core::convert::TryFrom;
@@ -22,6 +22,7 @@ use cranelift_frontend::FunctionBuilder;
 use serde::{Deserialize, Serialize};
 use std::boxed::Box;
 use std::string::ToString;
+use std::vec::Vec;
 use thiserror::Error;
 use wasmparser::ValidatorResources;
 use wasmparser::{BinaryReaderError, FuncValidator, FunctionBody, Operator, WasmFeatures};
@@ -948,5 +949,17 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
     /// Note that for nested modules this may be called multiple times.
     fn module_end(&mut self, index: usize) {
         drop(index);
+    }
+
+    /// Indicates that this module will have `amount` instances.
+    fn reserve_instances(&mut self, amount: u32) {
+        drop(amount);
+    }
+
+    /// Declares a new instance which this module will instantiate before it's
+    /// instantiated.
+    fn declare_instance(&mut self, module: ModuleIndex, args: Vec<EntityIndex>) -> WasmResult<()> {
+        drop((module, args));
+        Err(WasmError::Unsupported("wasm instance".to_string()))
     }
 }

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -3,8 +3,9 @@
 use crate::environ::{ModuleEnvironment, WasmResult};
 use crate::sections_translator::{
     parse_data_section, parse_element_section, parse_event_section, parse_export_section,
-    parse_function_section, parse_global_section, parse_import_section, parse_memory_section,
-    parse_name_section, parse_start_section, parse_table_section, parse_type_section,
+    parse_function_section, parse_global_section, parse_import_section, parse_instance_section,
+    parse_memory_section, parse_name_section, parse_start_section, parse_table_section,
+    parse_type_section,
 };
 use crate::state::ModuleTranslationState;
 use cranelift_codegen::timing;
@@ -116,7 +117,7 @@ pub fn translate_module<'data>(
             }
             Payload::InstanceSection(s) => {
                 validator.instance_section(&s)?;
-                unimplemented!("module linking not implemented yet")
+                parse_instance_section(s, environ)?;
             }
             Payload::AliasSection(s) => {
                 validator.alias_section(&s)?;

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -115,15 +115,6 @@ impl Extern {
         };
         Store::same(my_store, store)
     }
-
-    pub(crate) fn desc(&self) -> &'static str {
-        match self {
-            Extern::Func(_) => "function",
-            Extern::Table(_) => "table",
-            Extern::Memory(_) => "memory",
-            Extern::Global(_) => "global",
-        }
-    }
 }
 
 impl From<Func> for Extern {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -81,7 +81,7 @@ use wasmtime_jit::{CompilationArtifacts, CompiledModule};
 #[derive(Clone)]
 pub struct Module {
     engine: Engine,
-    compiled: Arc<[CompiledModule]>,
+    pub(crate) compiled: Arc<[CompiledModule]>,
     index: usize,
 }
 

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -13,6 +13,7 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
     let simd = wast.iter().any(|s| s == "simd");
 
     let multi_memory = wast.iter().any(|s| s == "multi-memory");
+    let module_linking = wast.iter().any(|s| s == "module-linking");
     let bulk_mem = multi_memory || wast.iter().any(|s| s == "bulk-memory-operations");
 
     // Some simd tests assume support for multiple tables, which are introduced
@@ -24,6 +25,7 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
         .wasm_bulk_memory(bulk_mem)
         .wasm_reference_types(reftypes)
         .wasm_multi_memory(multi_memory)
+        .wasm_module_linking(module_linking)
         .strategy(strategy)?
         .cranelift_debug_verifier(true);
 

--- a/tests/misc_testsuite/module-linking/instantiate.wast
+++ b/tests/misc_testsuite/module-linking/instantiate.wast
@@ -1,0 +1,162 @@
+(module
+  (module)
+  (instance $a (instantiate 0))
+)
+
+(module $a
+  (global (export "global") (mut i32) (i32.const 0))
+
+  (func (export "reset")
+    i32.const 0
+    global.set 0)
+
+  (func $set (export "inc")
+    i32.const 1
+    global.get 0
+    i32.add
+    global.set 0)
+
+  (func (export "get") (result i32)
+    global.get 0)
+
+  (func (export "load") (result i32)
+    i32.const 0
+    i32.load)
+
+  (memory (export "memory") 1)
+  (table (export "table") 1 funcref)
+  (elem (i32.const 0) $set)
+)
+
+;; Imported functions work
+(module
+  (import "a" "inc" (func $set))
+  (module
+    (import "" (func))
+    (start 0))
+  (instance $a (instantiate 0 (func $set)))
+)
+
+(assert_return (invoke $a "get") (i32.const 1))
+
+;; Imported globals work
+(module
+  (import "a" "global" (global $g (mut i32)))
+  (module
+    (import "" (global (mut i32)))
+    (func
+      i32.const 2
+      global.set 0)
+    (start 0))
+
+  (instance $a (instantiate 0 (global $g)))
+)
+(assert_return (invoke $a "get") (i32.const 2))
+
+;; Imported tables work
+(module
+  (import "a" "table" (table $t 1 funcref))
+  (module
+    (import "" (table 1 funcref))
+    (func
+      i32.const 0
+      call_indirect)
+    (start 0))
+
+  (instance $a (instantiate 0 (table $t)))
+)
+(assert_return (invoke $a "get") (i32.const 3))
+
+;; Imported memories work
+(module
+  (import "a" "memory" (memory $m 1))
+  (module
+    (import "" (memory 1))
+    (func
+      i32.const 0
+      i32.const 4
+      i32.store)
+    (start 0))
+
+  (instance $a (instantiate 0 (memory $m)))
+)
+(assert_return (invoke $a "load") (i32.const 4))
+
+;; all at once
+(module
+  (import "a" "inc" (func $f))
+  (import "a" "global" (global $g (mut i32)))
+  (import "a" "table" (table $t 1 funcref))
+  (import "a" "memory" (memory $m 1))
+
+  (module
+    (import "" (memory 1))
+    (import "" (global (mut i32)))
+    (import "" (table 1 funcref))
+    (import "" (func))
+    (func $start
+      call 0
+
+      i32.const 0
+      i32.const 4
+      i32.store
+
+      i32.const 0
+      call_indirect
+
+      global.get 0
+      global.set 0)
+    (start $start))
+
+  (instance $a
+    (instantiate 0
+      (memory $m)
+      (global $g)
+      (table $t)
+      (func $f)
+    )
+  )
+)
+
+;; instantiate lots
+(module
+  (import "a" "inc" (func $f))
+  (import "a" "global" (global $g (mut i32)))
+  (import "a" "table" (table $t 1 funcref))
+  (import "a" "memory" (memory $m 1))
+
+  (module $mm (import "" (memory 1)))
+  (module $mf (import "" (func)))
+  (module $mt (import "" (table 1 funcref)))
+  (module $mg (import "" (global (mut i32))))
+
+  (instance (instantiate $mm (memory $m)))
+  (instance (instantiate $mf (func $f)))
+  (instance (instantiate $mt (table $t)))
+  (instance (instantiate $mg (global $g)))
+)
+
+;; instantiate nested
+(assert_return (invoke $a "reset"))
+(assert_return (invoke $a "get") (i32.const 0))
+(module
+  (import "a" "inc" (func))
+  (module
+    (import "" (func))
+    (module
+      (import "" (func))
+      (module
+        (import "" (func))
+        (module
+          (import "" (func))
+          (start 0)
+        )
+        (instance (instantiate 0 (func 0)))
+      )
+      (instance (instantiate 0 (func 0)))
+    )
+    (instance (instantiate 0 (func 0)))
+  )
+  (instance (instantiate 0 (func 0)))
+)
+(assert_return (invoke $a "get") (i32.const 1))


### PR DESCRIPTION


This commit implements the interpretation necessary of the instance
section of the module linking proposal. Instantiating a module which
itself has nested instantiated instances will now instantiate the nested
instances properly. This isn't all that useful without the ability to
alias exports off the result, but we can at least observe the side
effects of instantiation through the `start` function.

cc #2094

