### PR TITLE
Add FuncEnvironment hooks to generate prologue and epilogue code.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/unwind.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind.rs
@@ -104,7 +104,7 @@ impl UnwindInfoGenerator<Inst> for AArch64UnwindInfo {
 
         // TODO epilogues
 
-        let prologue_size = if context.prologue.is_empty() {
+        let prologue_size = if context.prologue.len() == 0 {
             0
         } else {
             context.insts_layout[context.prologue.end as usize - 1]

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -624,6 +624,26 @@ pub trait FuncEnvironment: TargetEnvironment {
     ) -> WasmResult<()> {
         Ok(())
     }
+
+    /// Optional callback for the `FunctionEnvironment` performing this translation to perform work
+    /// before the function body is translated.
+    fn before_translate_function(
+        &mut self,
+        _builder: &mut FunctionBuilder,
+        _state: &FuncTranslationState,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
+    /// Optional callback for the `FunctionEnvironment` performing this translation to perform work
+    /// after the function body is translated.
+    fn after_translate_function(
+        &mut self,
+        _builder: &mut FunctionBuilder,
+        _state: &FuncTranslationState,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
 }
 
 /// An object satisfying the `ModuleEnvironment` trait can be passed as argument to the

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -225,6 +225,7 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
     // The control stack is initialized with a single block representing the whole function.
     debug_assert_eq!(state.control_stack.len(), 1, "State not initialized");
 
+    environ.before_translate_function(builder, state)?;
     while !reader.eof() {
         let pos = reader.original_position();
         builder.set_srcloc(cur_srcloc(&reader));
@@ -234,6 +235,7 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
         translate_operator(validator, &op, builder, state, environ)?;
         environ.after_translate_operator(&op, builder, state)?;
     }
+    environ.after_translate_function(builder, state)?;
     let pos = reader.original_position();
     validator.finish(pos)?;
 
@@ -243,7 +245,6 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
     // If the exit block is unreachable, it may not have the correct arguments, so we would
     // generate a return instruction that doesn't match the signature.
     if state.reachable {
-        debug_assert!(builder.is_pristine());
         if !builder.is_unreachable() {
             match environ.return_mode() {
                 ReturnMode::NormalReturns => {


### PR DESCRIPTION
In some cases, it is useful to do some work at entry to or exit from a
Cranelift function translated from WebAssembly. This PR adds two
optional methods to the `FuncEnvironment` trait to do just this,
analogous to the pre/post-hooks on operators that already exist.

This PR also includes a drive-by compilation fix due to the latest
nightly wherein `.is_empty()` on a `Range` ambiguously refers to either
the `Range` impl or the `ExactSizeIterator` impl and can't resolve.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
