### PR TITLE
Implement the module linking alias section 

### DIFF
--- a/cranelift/wasm/src/environ/mod.rs
+++ b/cranelift/wasm/src/environ/mod.rs
@@ -6,6 +6,6 @@ mod spec;
 
 pub use crate::environ::dummy::DummyEnvironment;
 pub use crate::environ::spec::{
-    FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode, TargetEnvironment, WasmError,
-    WasmFuncType, WasmResult, WasmType,
+    Alias, FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode, TargetEnvironment,
+    WasmError, WasmFuncType, WasmResult, WasmType,
 };

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -9,7 +9,8 @@
 use crate::state::FuncTranslationState;
 use crate::translation_utils::{
     DataIndex, ElemIndex, EntityIndex, EntityType, Event, EventIndex, FuncIndex, Global,
-    GlobalIndex, Memory, MemoryIndex, ModuleIndex, Table, TableIndex, TypeIndex,
+    GlobalIndex, InstanceIndex, InstanceTypeIndex, Memory, MemoryIndex, ModuleIndex,
+    ModuleTypeIndex, SignatureIndex, Table, TableIndex, TypeIndex,
 };
 use core::convert::From;
 use core::convert::TryFrom;
@@ -200,6 +201,30 @@ pub enum ReturnMode {
     NormalReturns,
     /// Use a single fallthrough return at the end of the function.
     FallthroughReturn,
+}
+
+/// An entry in the alias section of a wasm module (from the module linking
+/// proposal)
+pub enum Alias {
+    /// A parent's module is being aliased into our own index space.
+    ///
+    /// Note that the index here is in the parent's index space, not our own.
+    ParentModule(ModuleIndex),
+
+    /// A parent's type is being aliased into our own index space
+    ///
+    /// Note that the index here is in the parent's index space, not our own.
+    ParentType(TypeIndex),
+
+    /// A previously created instance is having one of its exports aliased into
+    /// our index space.
+    Child {
+        /// The index we're aliasing.
+        instance: InstanceIndex,
+        /// The nth export that we're inserting into our own index space
+        /// locally.
+        export: usize,
+    },
 }
 
 /// Environment affecting the translation of a WebAssembly.
@@ -684,6 +709,27 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         Err(WasmError::Unsupported("module linking".to_string()))
     }
 
+    /// Translates a type index to its signature index, only called for type
+    /// indices which point to functions.
+    fn type_to_signature(&self, index: TypeIndex) -> WasmResult<SignatureIndex> {
+        drop(index);
+        Err(WasmError::Unsupported("module linking".to_string()))
+    }
+
+    /// Translates a type index to its module type index, only called for type
+    /// indices which point to modules.
+    fn type_to_module_type(&self, index: TypeIndex) -> WasmResult<ModuleTypeIndex> {
+        drop(index);
+        Err(WasmError::Unsupported("module linking".to_string()))
+    }
+
+    /// Translates a type index to its instance type index, only called for type
+    /// indices which point to instances.
+    fn type_to_instance_type(&self, index: TypeIndex) -> WasmResult<InstanceTypeIndex> {
+        drop(index);
+        Err(WasmError::Unsupported("module linking".to_string()))
+    }
+
     /// Provides the number of imports up front. By default this does nothing, but
     /// implementations can use this to preallocate memory if desired.
     fn reserve_imports(&mut self, _num: u32) -> WasmResult<()> {
@@ -845,6 +891,22 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         name: &'data str,
     ) -> WasmResult<()>;
 
+    /// Declares an instance export to the environment.
+    fn declare_instance_export(
+        &mut self,
+        index: InstanceIndex,
+        name: &'data str,
+    ) -> WasmResult<()> {
+        drop((index, name));
+        Err(WasmError::Unsupported("module linking".to_string()))
+    }
+
+    /// Declares an instance export to the environment.
+    fn declare_module_export(&mut self, index: ModuleIndex, name: &'data str) -> WasmResult<()> {
+        drop((index, name));
+        Err(WasmError::Unsupported("module linking".to_string()))
+    }
+
     /// Notifies the implementation that all exports have been declared.
     fn finish_exports(&mut self) -> WasmResult<()> {
         Ok(())
@@ -952,6 +1014,12 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         drop(amount);
     }
 
+    /// Declares that a module will come later with the type signature provided.
+    fn declare_module(&mut self, ty: TypeIndex) -> WasmResult<()> {
+        drop(ty);
+        Err(WasmError::Unsupported("module linking".to_string()))
+    }
+
     /// Called at the beginning of translating a module.
     ///
     /// The `index` argument is a monotonically increasing index which
@@ -981,5 +1049,15 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
     fn declare_instance(&mut self, module: ModuleIndex, args: Vec<EntityIndex>) -> WasmResult<()> {
         drop((module, args));
         Err(WasmError::Unsupported("wasm instance".to_string()))
+    }
+
+    /// Declares a new alias being added to this module.
+    ///
+    /// The alias comes from the `instance` specified (or the parent if `None`
+    /// is supplied) and the index is either in the module's own index spaces
+    /// for the parent or an index into the exports for nested instances.
+    fn declare_alias(&mut self, alias: Alias) -> WasmResult<()> {
+        drop(alias);
+        Err(WasmError::Unsupported("wasm alias".to_string()))
     }
 }

--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -57,7 +57,7 @@ mod state;
 mod translation_utils;
 
 pub use crate::environ::{
-    DummyEnvironment, FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode,
+    Alias, DummyEnvironment, FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode,
     TargetEnvironment, WasmError, WasmFuncType, WasmResult, WasmType,
 };
 pub use crate::func_translator::FuncTranslator;

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -2,10 +2,10 @@
 //! to deal with each part of it.
 use crate::environ::{ModuleEnvironment, WasmResult};
 use crate::sections_translator::{
-    parse_data_section, parse_element_section, parse_event_section, parse_export_section,
-    parse_function_section, parse_global_section, parse_import_section, parse_instance_section,
-    parse_memory_section, parse_name_section, parse_start_section, parse_table_section,
-    parse_type_section,
+    parse_alias_section, parse_data_section, parse_element_section, parse_event_section,
+    parse_export_section, parse_function_section, parse_global_section, parse_import_section,
+    parse_instance_section, parse_memory_section, parse_module_section, parse_name_section,
+    parse_start_section, parse_table_section, parse_type_section,
 };
 use crate::state::ModuleTranslationState;
 use cranelift_codegen::timing;
@@ -113,7 +113,7 @@ pub fn translate_module<'data>(
 
             Payload::ModuleSection(s) => {
                 validator.module_section(&s)?;
-                environ.reserve_modules(s.get_count());
+                parse_module_section(s, environ)?;
             }
             Payload::InstanceSection(s) => {
                 validator.instance_section(&s)?;
@@ -121,7 +121,7 @@ pub fn translate_module<'data>(
             }
             Payload::AliasSection(s) => {
                 validator.alias_section(&s)?;
-                unimplemented!("module linking not implemented yet")
+                parse_alias_section(s, environ)?;
             }
             Payload::ModuleCodeSectionStart {
                 count,

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -7,7 +7,7 @@
 //! The special case of the initialize expressions for table elements offsets or global variables
 //! is handled, according to the semantics of WebAssembly, to only specific expressions that are
 //! interpreted on the fly.
-use crate::environ::{ModuleEnvironment, WasmError, WasmResult};
+use crate::environ::{Alias, ModuleEnvironment, WasmError, WasmResult};
 use crate::state::ModuleTranslationState;
 use crate::translation_utils::{
     tabletype_to_type, type_to_type, DataIndex, ElemIndex, EntityIndex, EntityType, Event,
@@ -36,9 +36,15 @@ fn entity_type(
     environ: &mut dyn ModuleEnvironment<'_>,
 ) -> WasmResult<EntityType> {
     Ok(match ty {
-        ImportSectionEntryType::Function(sig) => EntityType::Function(TypeIndex::from_u32(sig)),
-        ImportSectionEntryType::Module(sig) => EntityType::Module(TypeIndex::from_u32(sig)),
-        ImportSectionEntryType::Instance(sig) => EntityType::Instance(TypeIndex::from_u32(sig)),
+        ImportSectionEntryType::Function(sig) => {
+            EntityType::Function(environ.type_to_signature(TypeIndex::from_u32(sig))?)
+        }
+        ImportSectionEntryType::Module(sig) => {
+            EntityType::Module(environ.type_to_module_type(TypeIndex::from_u32(sig))?)
+        }
+        ImportSectionEntryType::Instance(sig) => {
+            EntityType::Instance(environ.type_to_instance_type(TypeIndex::from_u32(sig))?)
+        }
         ImportSectionEntryType::Memory(ty) => EntityType::Memory(memory(ty)),
         ImportSectionEntryType::Event(evt) => EntityType::Event(event(evt)),
         ImportSectionEntryType::Global(ty) => {
@@ -156,24 +162,40 @@ pub fn parse_import_section<'data>(
 
     for entry in imports {
         let import = entry?;
-        match entity_type(import.ty, environ)? {
-            EntityType::Function(idx) => {
-                environ.declare_func_import(idx, import.module, import.field)?;
+        match import.ty {
+            ImportSectionEntryType::Function(sig) => {
+                environ.declare_func_import(
+                    TypeIndex::from_u32(sig),
+                    import.module,
+                    import.field,
+                )?;
             }
-            EntityType::Module(idx) => {
-                environ.declare_module_import(idx, import.module, import.field)?;
+            ImportSectionEntryType::Module(sig) => {
+                environ.declare_module_import(
+                    TypeIndex::from_u32(sig),
+                    import.module,
+                    import.field,
+                )?;
             }
-            EntityType::Instance(idx) => {
-                environ.declare_instance_import(idx, import.module, import.field)?;
+            ImportSectionEntryType::Instance(sig) => {
+                environ.declare_instance_import(
+                    TypeIndex::from_u32(sig),
+                    import.module,
+                    import.field,
+                )?;
             }
-            EntityType::Memory(ty) => {
-                environ.declare_memory_import(ty, import.module, import.field)?;
+            ImportSectionEntryType::Memory(ty) => {
+                environ.declare_memory_import(memory(ty), import.module, import.field)?;
             }
-            EntityType::Event(e) => environ.declare_event_import(e, import.module, import.field)?,
-            EntityType::Global(ty) => {
+            ImportSectionEntryType::Event(e) => {
+                environ.declare_event_import(event(e), import.module, import.field)?;
+            }
+            ImportSectionEntryType::Global(ty) => {
+                let ty = global(ty, environ, GlobalInit::Import)?;
                 environ.declare_global_import(ty, import.module, import.field)?;
             }
-            EntityType::Table(ty) => {
+            ImportSectionEntryType::Table(ty) => {
+                let ty = table(ty, environ)?;
                 environ.declare_table_import(ty, import.module, import.field)?;
             }
         }
@@ -316,9 +338,15 @@ pub fn parse_export_section<'data>(
             ExternalKind::Global => {
                 environ.declare_global_export(GlobalIndex::new(index), field)?
             }
-            ExternalKind::Type | ExternalKind::Module | ExternalKind::Instance => {
-                unimplemented!("module linking not implemented yet")
+            ExternalKind::Module => {
+                environ.declare_module_export(ModuleIndex::new(index), field)?
             }
+            ExternalKind::Instance => {
+                environ.declare_instance_export(InstanceIndex::new(index), field)?
+            }
+
+            // this never gets past validation
+            ExternalKind::Type => unreachable!(),
         }
     }
 
@@ -476,12 +504,25 @@ pub fn parse_name_section<'data>(
     Ok(())
 }
 
+/// Parses the Module section of the wasm module.
+pub fn parse_module_section<'data>(
+    section: wasmparser::ModuleSectionReader<'data>,
+    environ: &mut dyn ModuleEnvironment<'data>,
+) -> WasmResult<()> {
+    environ.reserve_modules(section.get_count());
+
+    for module_ty in section {
+        environ.declare_module(TypeIndex::from_u32(module_ty?))?;
+    }
+    Ok(())
+}
+
 /// Parses the Instance section of the wasm module.
 pub fn parse_instance_section<'data>(
     section: wasmparser::InstanceSectionReader<'data>,
     environ: &mut dyn ModuleEnvironment<'data>,
 ) -> WasmResult<()> {
-    environ.reserve_types(section.get_count())?;
+    environ.reserve_instances(section.get_count());
 
     for instance in section {
         let instance = instance?;
@@ -506,6 +547,32 @@ pub fn parse_instance_section<'data>(
             })
             .collect::<WasmResult<Vec<_>>>()?;
         environ.declare_instance(module, args)?;
+    }
+    Ok(())
+}
+
+/// Parses the Alias section of the wasm module.
+pub fn parse_alias_section<'data>(
+    section: wasmparser::AliasSectionReader<'data>,
+    environ: &mut dyn ModuleEnvironment<'data>,
+) -> WasmResult<()> {
+    for alias in section {
+        let alias = alias?;
+        let alias = match alias.instance {
+            wasmparser::AliasedInstance::Parent => {
+                match alias.kind {
+                    ExternalKind::Module => Alias::ParentModule(ModuleIndex::from_u32(alias.index)),
+                    ExternalKind::Type => Alias::ParentType(TypeIndex::from_u32(alias.index)),
+                    // shouldn't get past validation
+                    _ => unreachable!(),
+                }
+            }
+            wasmparser::AliasedInstance::Child(i) => Alias::Child {
+                instance: InstanceIndex::from_u32(i),
+                export: alias.index as usize,
+            },
+        };
+        environ.declare_alias(alias)?;
     }
     Ok(())
 }

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -97,6 +97,18 @@ entity_impl!(InstanceIndex);
 pub struct EventIndex(u32);
 entity_impl!(EventIndex);
 
+/// Specialized index for just module types.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct ModuleTypeIndex(u32);
+entity_impl!(ModuleTypeIndex);
+
+/// Specialized index for just instance types.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct InstanceTypeIndex(u32);
+entity_impl!(InstanceTypeIndex);
+
 /// An index of an entity.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
@@ -131,13 +143,13 @@ pub enum EntityType {
     Table(Table),
     /// A function type where the index points to the type section and records a
     /// function signature.
-    Function(TypeIndex),
+    Function(SignatureIndex),
     /// An instance where the index points to the type section and records a
     /// instance's exports.
-    Instance(TypeIndex),
+    Instance(InstanceTypeIndex),
     /// A module where the index points to the type section and records a
     /// module's imports and exports.
-    Module(TypeIndex),
+    Module(ModuleTypeIndex),
 }
 
 /// A WebAssembly global.

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1039,7 +1039,6 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         callee: ir::Value,
         call_args: &[ir::Value],
     ) -> WasmResult<ir::Inst> {
-        let sig_index = self.module.types[ty_index].unwrap_function();
         let pointer_type = self.pointer_type();
 
         let table_entry_addr = pos.ins().table_addr(pointer_type, table, callee, 0);
@@ -1071,7 +1070,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 let vmctx = self.vmctx(pos.func);
                 let base = pos.ins().global_value(pointer_type, vmctx);
                 let offset =
-                    i32::try_from(self.offsets.vmctx_vmshared_signature_id(sig_index)).unwrap();
+                    i32::try_from(self.offsets.vmctx_vmshared_signature_id(ty_index)).unwrap();
 
                 // Load the caller ID.
                 let mut mem_flags = ir::MemFlags::trusted();

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -99,7 +99,7 @@ use std::sync::Mutex;
 use wasmtime_environ::{
     CompileError, CompiledFunction, Compiler, FunctionAddressMap, FunctionBodyData,
     InstructionAddressMap, ModuleTranslation, Relocation, RelocationTarget, StackMapInformation,
-    TrapInformation, Tunables,
+    TrapInformation, Tunables, TypeTables,
 };
 
 mod func_environ;
@@ -348,13 +348,14 @@ impl Compiler for Cranelift {
         mut input: FunctionBodyData<'_>,
         isa: &dyn isa::TargetIsa,
         tunables: &Tunables,
+        types: &TypeTables,
     ) -> Result<CompiledFunction, CompileError> {
         let module = &translation.module;
         let func_index = module.func_index(func_index);
         let mut context = Context::new();
         context.func.name = get_func_name(func_index);
         let sig_index = module.functions[func_index];
-        context.func.signature = translation.native_signatures[sig_index].clone();
+        context.func.signature = types.native_signatures[sig_index].clone();
         if tunables.generate_native_debuginfo {
             context.func.collect_debug_info();
         }
@@ -362,7 +363,7 @@ impl Compiler for Cranelift {
         let mut func_env = FuncEnvironment::new(
             isa.frontend_config(),
             module,
-            &translation.native_signatures,
+            &types.native_signatures,
             tunables,
         );
 

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -1,7 +1,7 @@
 //! A `Compilation` contains the compiled function bodies for a WebAssembly
 //! module.
 
-use crate::{FunctionAddressMap, FunctionBodyData, ModuleTranslation, Tunables};
+use crate::{FunctionAddressMap, FunctionBodyData, ModuleTranslation, Tunables, TypeTables};
 use cranelift_codegen::{binemit, ir, isa, isa::unwind::UnwindInfo};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex, WasmError};
@@ -104,5 +104,6 @@ pub trait Compiler: Send + Sync {
         data: FunctionBodyData<'_>,
         isa: &dyn isa::TargetIsa,
         tunables: &Tunables,
+        types: &TypeTables,
     ) -> Result<CompiledFunction, CompileError>;
 }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -2,20 +2,14 @@
 
 use crate::tunables::Tunables;
 use crate::WASM_MAX_PAGES;
+use cranelift_codegen::ir;
 use cranelift_entity::{EntityRef, PrimaryMap};
-use cranelift_wasm::{
-    DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
-    ElemIndex, EntityIndex, EntityType, FuncIndex, Global, GlobalIndex, InstanceIndex, Memory,
-    MemoryIndex, ModuleIndex, SignatureIndex, Table, TableIndex, TypeIndex, WasmFuncType,
-};
+use cranelift_wasm::*;
 use indexmap::IndexMap;
 use more_asserts::assert_ge;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering::SeqCst},
-    Arc,
-};
+use std::sync::Arc;
 
 /// A WebAssembly table initializer.
 #[derive(Clone, Debug, Hash, Serialize, Deserialize)]
@@ -121,23 +115,16 @@ impl TablePlan {
     }
 }
 
-/// Different types that can appear in a module
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Different types that can appear in a module.
+///
+/// Note that each of these variants are intended to index further into a
+/// separate table.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
 pub enum ModuleType {
-    /// A function type, indexed further into the `signatures` table.
     Function(SignatureIndex),
-    /// A module type
-    Module {
-        /// The module's imports
-        imports: Vec<(String, Option<String>, EntityType)>,
-        /// The module's exports
-        exports: Vec<(String, EntityType)>,
-    },
-    /// An instance type
-    Instance {
-        /// the instance's exports
-        exports: Vec<(String, EntityType)>,
-    },
+    Module(ModuleTypeIndex),
+    Instance(InstanceTypeIndex),
 }
 
 impl ModuleType {
@@ -153,17 +140,19 @@ impl ModuleType {
 
 /// A translated WebAssembly module, excluding the function bodies and
 /// memory initializers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
-    /// A unique identifier (within this process) for this module.
-    #[serde(skip_serializing, skip_deserializing, default = "Module::next_id")]
-    pub id: usize,
+    /// The parent index of this module, used for the module linking proposal.
+    ///
+    /// This index is into the list of modules returned from compilation of a
+    /// single wasm file with nested modules.
+    pub parent: Option<usize>,
 
     /// The name of this wasm module, often found in the wasm file.
     pub name: Option<String>,
 
     /// All import records, in the order they are declared in the module.
-    pub imports: Vec<(String, Option<String>, EntityIndex)>,
+    pub initializers: Vec<Initializer>,
 
     /// Exported entities.
     pub exports: IndexMap<String, EntityIndex>,
@@ -184,22 +173,19 @@ pub struct Module {
     /// WebAssembly table initializers.
     pub func_names: HashMap<FuncIndex, String>,
 
-    /// Unprocessed signatures exactly as provided by `declare_signature()`.
-    pub signatures: PrimaryMap<SignatureIndex, WasmFuncType>,
-
     /// Types declared in the wasm module.
     pub types: PrimaryMap<TypeIndex, ModuleType>,
 
-    /// Number of imported functions in the module.
+    /// Number of imported or aliased functions in the module.
     pub num_imported_funcs: usize,
 
-    /// Number of imported tables in the module.
+    /// Number of imported or aliased tables in the module.
     pub num_imported_tables: usize,
 
-    /// Number of imported memories in the module.
+    /// Number of imported or aliased memories in the module.
     pub num_imported_memories: usize,
 
-    /// Number of imported globals in the module.
+    /// Number of imported or aliased globals in the module.
     pub num_imported_globals: usize,
 
     /// Types of functions, imported and local.
@@ -214,64 +200,63 @@ pub struct Module {
     /// WebAssembly global variables.
     pub globals: PrimaryMap<GlobalIndex, Global>,
 
-    /// WebAssembly instances.
-    pub instances: PrimaryMap<InstanceIndex, Instance>,
+    /// The type of each wasm instance this module defines.
+    pub instances: PrimaryMap<InstanceIndex, InstanceTypeIndex>,
 
-    /// WebAssembly modules.
-    pub modules: PrimaryMap<ModuleIndex, TypeIndex>,
+    /// The type of each nested wasm module this module contains.
+    pub modules: PrimaryMap<ModuleIndex, ModuleTypeIndex>,
 }
 
-/// Different forms an instance can take in a wasm module
+/// Initialization routines for creating an instance, encompassing imports,
+/// modules, instances, aliases, etc.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Instance {
-    /// This is an imported instance with the specified type
-    Import(TypeIndex),
-    /// This is a locally created instance which instantiates the specified
-    /// module with the given list of entities.
+pub enum Initializer {
+    /// An imported item is required to be provided.
+    Import {
+        /// Module name of this import
+        module: String,
+        /// Optional field name of this import
+        field: Option<String>,
+        /// Where this import will be placed, which also has type information
+        /// about the import.
+        index: EntityIndex,
+    },
+
+    /// A module from the parent's declared modules is inserted into our own
+    /// index space.
+    AliasParentModule(ModuleIndex),
+
+    /// A module from the parent's declared modules is inserted into our own
+    /// index space.
+    #[allow(missing_docs)]
+    AliasInstanceExport {
+        instance: InstanceIndex,
+        export: usize,
+    },
+
+    /// A module is being instantiated with previously configured intializers
+    /// as arguments.
     Instantiate {
         /// The module that this instance is instantiating.
         module: ModuleIndex,
         /// The arguments provided to instantiation.
         args: Vec<EntityIndex>,
     },
+
+    /// A module is defined into the module index space, and which module is
+    /// being defined is specified by the index payload.
+    DefineModule(usize),
 }
 
 impl Module {
     /// Allocates the module data structures.
     pub fn new() -> Self {
-        Self {
-            id: Self::next_id(),
-            name: None,
-            imports: Vec::new(),
-            exports: IndexMap::new(),
-            start_func: None,
-            table_elements: Vec::new(),
-            passive_elements: HashMap::new(),
-            passive_data: HashMap::new(),
-            func_names: HashMap::new(),
-            num_imported_funcs: 0,
-            num_imported_tables: 0,
-            num_imported_memories: 0,
-            num_imported_globals: 0,
-            signatures: PrimaryMap::new(),
-            functions: PrimaryMap::new(),
-            table_plans: PrimaryMap::new(),
-            memory_plans: PrimaryMap::new(),
-            globals: PrimaryMap::new(),
-            instances: PrimaryMap::new(),
-            modules: PrimaryMap::new(),
-            types: PrimaryMap::new(),
-        }
+        Module::default()
     }
 
     /// Get the given passive element, if it exists.
     pub fn get_passive_element(&self, index: ElemIndex) -> Option<&[FuncIndex]> {
         self.passive_elements.get(&index).map(|es| &**es)
-    }
-
-    fn next_id() -> usize {
-        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
-        NEXT_ID.fetch_add(1, SeqCst)
     }
 
     /// Convert a `DefinedFuncIndex` into a `FuncIndex`.
@@ -361,18 +346,37 @@ impl Module {
     pub fn is_imported_global(&self, index: GlobalIndex) -> bool {
         index.index() < self.num_imported_globals
     }
-
-    /// Convenience method for looking up the original Wasm signature of a
-    /// function.
-    pub fn wasm_func_type(&self, func_index: FuncIndex) -> &WasmFuncType {
-        &self.signatures[self.functions[func_index]]
-    }
 }
 
-impl Default for Module {
-    fn default() -> Module {
-        Module::new()
-    }
+/// All types which are recorded for the entirety of a translation.
+///
+/// Note that this is shared amongst all modules coming out of a translation
+/// in the case of nested modules and the module linking proposal.
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct TypeTables {
+    pub wasm_signatures: PrimaryMap<SignatureIndex, WasmFuncType>,
+    pub native_signatures: PrimaryMap<SignatureIndex, ir::Signature>,
+    pub module_signatures: PrimaryMap<ModuleTypeIndex, ModuleSignature>,
+    pub instance_signatures: PrimaryMap<InstanceTypeIndex, InstanceSignature>,
+}
+
+/// The type signature of known modules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleSignature {
+    /// All imports in this module, listed in order with their module/name and
+    /// what type they're importing.
+    pub imports: Vec<(String, Option<String>, EntityType)>,
+    /// Exports are what an instance type conveys, so we go through an
+    /// indirection over there.
+    pub exports: InstanceTypeIndex,
+}
+
+/// The type signature of known instances.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceSignature {
+    /// The name of what's being exported as well as its type signature.
+    pub exports: Vec<(String, EntityType)>,
 }
 
 mod passive_data_serde {

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -24,7 +24,7 @@ use crate::BuiltinFunctionIndex;
 use cranelift_codegen::ir;
 use cranelift_wasm::{
     DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GlobalIndex, MemoryIndex,
-    SignatureIndex, TableIndex,
+    TableIndex, TypeIndex,
 };
 use more_asserts::assert_lt;
 use std::convert::TryFrom;
@@ -78,7 +78,7 @@ impl VMOffsets {
     pub fn new(pointer_size: u8, module: &Module) -> Self {
         Self {
             pointer_size,
-            num_signature_ids: cast_to_u32(module.signatures.len()),
+            num_signature_ids: cast_to_u32(module.types.len()),
             num_imported_functions: cast_to_u32(module.num_imported_funcs),
             num_imported_tables: cast_to_u32(module.num_imported_tables),
             num_imported_memories: cast_to_u32(module.num_imported_memories),
@@ -430,7 +430,7 @@ impl VMOffsets {
     }
 
     /// Return the offset to `VMSharedSignatureId` index `index`.
-    pub fn vmctx_vmshared_signature_id(&self, index: SignatureIndex) -> u32 {
+    pub fn vmctx_vmshared_signature_id(&self, index: TypeIndex) -> u32 {
         assert_lt!(index.as_u32(), self.num_signature_ids);
         self.vmctx_signature_ids_begin()
             .checked_add(

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -14,7 +14,7 @@ use wasmtime_environ::isa::{TargetFrontendConfig, TargetIsa};
 use wasmtime_environ::wasm::{DefinedMemoryIndex, MemoryIndex};
 use wasmtime_environ::{
     CompiledFunctions, Compiler as EnvCompiler, DebugInfoData, Module, ModuleMemoryOffset,
-    ModuleTranslation, Tunables, VMOffsets,
+    ModuleTranslation, Tunables, TypeTables, VMOffsets,
 };
 
 /// Select which kind of compilation to use.
@@ -127,13 +127,20 @@ impl Compiler {
     pub fn compile<'data>(
         &self,
         translation: &mut ModuleTranslation,
+        types: &TypeTables,
     ) -> Result<Compilation, SetupError> {
         let functions = mem::take(&mut translation.function_body_inputs);
         let functions = functions.into_iter().collect::<Vec<_>>();
         let funcs = maybe_parallel!(functions.(into_iter | into_par_iter))
             .map(|(index, func)| {
-                self.compiler
-                    .compile_function(translation, index, func, &*self.isa, &self.tunables)
+                self.compiler.compile_function(
+                    translation,
+                    index,
+                    func,
+                    &*self.isa,
+                    &self.tunables,
+                    types,
+                )
             })
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
@@ -150,7 +157,8 @@ impl Compiler {
             vec![]
         };
 
-        let (obj, unwind_info) = build_object(&*self.isa, &translation, &funcs, dwarf_sections)?;
+        let (obj, unwind_info) =
+            build_object(&*self.isa, &translation, types, &funcs, dwarf_sections)?;
 
         Ok(Compilation {
             obj,

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -47,7 +47,7 @@ pub mod trampoline;
 pub use crate::code_memory::CodeMemory;
 pub use crate::compiler::{Compilation, CompilationStrategy, Compiler};
 pub use crate::instantiate::{
-    CompilationArtifacts, CompiledModule, ModuleCode, SetupError, SymbolizeContext,
+    CompilationArtifacts, CompiledModule, ModuleCode, SetupError, SymbolizeContext, TypeTables,
 };
 pub use crate::link::link_module;
 

--- a/crates/jit/src/object.rs
+++ b/crates/jit/src/object.rs
@@ -8,7 +8,7 @@ use wasmtime_debug::DwarfSection;
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::isa::{unwind::UnwindInfo, TargetIsa};
 use wasmtime_environ::wasm::{FuncIndex, SignatureIndex};
-use wasmtime_environ::{CompiledFunctions, ModuleTranslation};
+use wasmtime_environ::{CompiledFunctions, ModuleTranslation, TypeTables};
 use wasmtime_obj::{ObjectBuilder, ObjectBuilderTarget};
 
 pub use wasmtime_obj::utils;
@@ -24,6 +24,7 @@ pub enum ObjectUnwindInfo {
 pub(crate) fn build_object(
     isa: &dyn TargetIsa,
     translation: &ModuleTranslation,
+    types: &TypeTables,
     funcs: &CompiledFunctions,
     dwarf_sections: Vec<DwarfSection>,
 ) -> Result<(Object, Vec<ObjectUnwindInfo>), anyhow::Error> {
@@ -38,10 +39,16 @@ pub(crate) fn build_object(
             .map(|info| ObjectUnwindInfo::Func(translation.module.func_index(index), info.clone()))
     }));
 
-    let mut trampolines = PrimaryMap::with_capacity(translation.module.signatures.len());
+    let mut trampolines = PrimaryMap::with_capacity(types.native_signatures.len());
     let mut cx = FunctionBuilderContext::new();
     // Build trampolines for every signature.
-    for (i, native_sig) in translation.native_signatures.iter() {
+    //
+    // TODO: for the module linking proposal this builds too many native
+    // signatures. This builds trampolines for all signatures for all modules
+    // for each module. That's a lot of trampolines! We should instead figure
+    // out a way to share trampolines amongst all modules when compiling
+    // module-linking modules.
+    for (i, native_sig) in types.native_signatures.iter() {
         let func = build_trampoline(isa, &mut cx, native_sig, std::mem::size_of::<u128>())?;
         // Preserve trampoline function unwind info.
         if let Some(info) = &func.unwind_info {

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -115,6 +115,15 @@ impl Extern {
         };
         Store::same(my_store, store)
     }
+
+    pub(crate) fn desc(&self) -> &'static str {
+        match self {
+            Extern::Func(_) => "function",
+            Extern::Table(_) => "table",
+            Extern::Memory(_) => "memory",
+            Extern::Global(_) => "global",
+        }
+    }
 }
 
 impl From<Func> for Extern {

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -10,7 +10,7 @@ use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::Module;
 use wasmtime_runtime::{
     Imports, InstanceHandle, StackMapRegistry, VMExternRefActivationsTable, VMFunctionBody,
-    VMFunctionImport,
+    VMFunctionImport, VMSharedSignatureIndex,
 };
 
 pub(crate) fn create_handle(
@@ -19,11 +19,11 @@ pub(crate) fn create_handle(
     finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
     state: Box<dyn Any>,
     func_imports: &[VMFunctionImport],
+    shared_signature_id: Option<VMSharedSignatureIndex>,
 ) -> Result<StoreInstanceHandle> {
     let mut imports = Imports::default();
     imports.functions = func_imports;
     let module = Arc::new(module);
-    let module2 = module.clone();
 
     unsafe {
         let handle = InstanceHandle::new(
@@ -31,7 +31,7 @@ pub(crate) fn create_handle(
             &finished_functions,
             imports,
             store.memory_creator(),
-            &store.lookup_shared_signature(&module2),
+            &|_| shared_signature_id.unwrap(),
             state,
             store.interrupts(),
             store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -3,13 +3,17 @@ use crate::trampoline::StoreInstanceHandle;
 use crate::{GlobalType, Mutability, Store, Val};
 use anyhow::Result;
 use wasmtime_environ::entity::PrimaryMap;
-use wasmtime_environ::{wasm, Module};
+use wasmtime_environ::{
+    wasm::{self, SignatureIndex},
+    Module, ModuleType,
+};
 use wasmtime_runtime::VMFunctionImport;
 
 pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreInstanceHandle> {
     let mut module = Module::new();
     let mut func_imports = Vec::new();
     let mut externref_init = None;
+    let mut shared_signature_id = None;
 
     let global = wasm::Global {
         wasm_ty: gt.content().to_wasm_type(),
@@ -35,17 +39,19 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
             Val::FuncRef(Some(f)) => {
                 // Add a function import to the stub module, and then initialize
                 // our global with a `ref.func` to grab that imported function.
-                let signatures = store.signatures().borrow();
                 let shared_sig_index = f.sig_index();
-                let (wasm, _) = signatures
-                    .lookup_shared(shared_sig_index)
-                    .expect("signature not registered");
-                let local_sig_index = module.signatures.push(wasm.clone());
-                let func_index = module.functions.push(local_sig_index);
+                shared_signature_id = Some(shared_sig_index);
+                let sig_id = SignatureIndex::from_u32(u32::max_value() - 1);
+                module.types.push(ModuleType::Function(sig_id));
+                let func_index = module.functions.push(sig_id);
                 module.num_imported_funcs = 1;
                 module
-                    .imports
-                    .push(("".into(), None, wasm::EntityIndex::Function(func_index)));
+                    .initializers
+                    .push(wasmtime_environ::Initializer::Import {
+                        module: "".into(),
+                        field: None,
+                        index: wasm::EntityIndex::Function(func_index),
+                    });
 
                 let f = f.caller_checked_anyfunc();
                 let f = unsafe { f.as_ref() };
@@ -70,6 +76,7 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
         PrimaryMap::new(),
         Box::new(()),
         &func_imports,
+        shared_signature_id,
     )?;
 
     if let Some(x) = externref_init {

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -29,7 +29,7 @@ pub fn create_handle_with_memory(
         .exports
         .insert(String::new(), wasm::EntityIndex::Memory(memory_id));
 
-    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[])
+    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[], None)
 }
 
 struct LinearMemoryProxy {

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -27,5 +27,5 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Stor
         .exports
         .insert(String::new(), wasm::EntityIndex::Table(table_id));
 
-    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[])
+    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[], None)
 }

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -65,10 +65,10 @@ pub fn compile_to_obj(
     );
 
     let environ = ModuleEnvironment::new(compiler.isa().frontend_config(), &tunables, &features);
-    let mut translation = environ
+    let (mut translation, types) = environ
         .translate(wasm)
         .context("failed to translate module")?;
     assert_eq!(translation.len(), 1);
-    let compilation = compiler.compile(&mut translation[0])?;
+    let compilation = compiler.compile(&mut translation[0], &types)?;
     Ok(compilation.obj)
 }

--- a/tests/all/module_linking.rs
+++ b/tests/all/module_linking.rs
@@ -52,3 +52,126 @@ fn types() -> Result<()> {
     Module::new(&engine, "(module (type (instance)))")?;
     Ok(())
 }
+
+#[test]
+fn imports_exports() -> Result<()> {
+    let engine = engine();
+
+    // empty module type
+    let module = Module::new(&engine, "(module (module (export \"\")))")?;
+    let mut e = module.exports();
+    assert_eq!(e.len(), 1);
+    let export = e.next().unwrap();
+    assert_eq!(export.name(), "");
+    let module_ty = match export.ty() {
+        ExternType::Module(m) => m,
+        _ => panic!("unexpected type"),
+    };
+    assert_eq!(module_ty.imports().len(), 0);
+    assert_eq!(module_ty.exports().len(), 0);
+
+    // empty instance type
+    let module = Module::new(
+        &engine,
+        "
+            (module
+                (module)
+                (instance (export \"\") (instantiate 0)))
+        ",
+    )?;
+    let mut e = module.exports();
+    assert_eq!(e.len(), 1);
+    let export = e.next().unwrap();
+    assert_eq!(export.name(), "");
+    let instance_ty = match export.ty() {
+        ExternType::Instance(i) => i,
+        _ => panic!("unexpected type"),
+    };
+    assert_eq!(instance_ty.exports().len(), 0);
+
+    // full module type
+    let module = Module::new(
+        &engine,
+        "
+            (module
+                (import \"\" \"a\" (module
+                    (import \"a\" (func))
+                    (export \"\" (global i32))
+                ))
+            )
+        ",
+    )?;
+    let mut i = module.imports();
+    assert_eq!(i.len(), 1);
+    let import = i.next().unwrap();
+    assert_eq!(import.module(), "");
+    assert_eq!(import.name(), Some("a"));
+    let module_ty = match import.ty() {
+        ExternType::Module(m) => m,
+        _ => panic!("unexpected type"),
+    };
+    assert_eq!(module_ty.imports().len(), 1);
+    assert_eq!(module_ty.exports().len(), 1);
+    let import = module_ty.imports().next().unwrap();
+    assert_eq!(import.module(), "a");
+    assert_eq!(import.name(), None);
+    match import.ty() {
+        ExternType::Func(f) => {
+            assert_eq!(f.results().len(), 0);
+            assert_eq!(f.params().len(), 0);
+        }
+        _ => panic!("unexpected type"),
+    }
+    let export = module_ty.exports().next().unwrap();
+    assert_eq!(export.name(), "");
+    match export.ty() {
+        ExternType::Global(g) => {
+            assert_eq!(*g.content(), ValType::I32);
+            assert_eq!(g.mutability(), Mutability::Const);
+        }
+        _ => panic!("unexpected type"),
+    }
+
+    // full instance type
+    let module = Module::new(
+        &engine,
+        "
+            (module
+                (import \"\" \"b\" (instance
+                    (export \"m\" (memory 1))
+                    (export \"t\" (table 1 funcref))
+                ))
+            )
+        ",
+    )?;
+    let mut i = module.imports();
+    assert_eq!(i.len(), 1);
+    let import = i.next().unwrap();
+    assert_eq!(import.module(), "");
+    assert_eq!(import.name(), Some("b"));
+    let instance_ty = match import.ty() {
+        ExternType::Instance(m) => m,
+        _ => panic!("unexpected type"),
+    };
+    assert_eq!(instance_ty.exports().len(), 2);
+    let mem_export = instance_ty.exports().nth(0).unwrap();
+    assert_eq!(mem_export.name(), "m");
+    match mem_export.ty() {
+        ExternType::Memory(m) => {
+            assert_eq!(m.limits().min(), 1);
+            assert_eq!(m.limits().max(), None);
+        }
+        _ => panic!("unexpected type"),
+    }
+    let table_export = instance_ty.exports().nth(1).unwrap();
+    assert_eq!(table_export.name(), "t");
+    match table_export.ty() {
+        ExternType::Table(t) => {
+            assert_eq!(t.limits().min(), 1);
+            assert_eq!(t.limits().max(), None);
+            assert_eq!(*t.element(), ValType::FuncRef);
+        }
+        _ => panic!("unexpected type"),
+    }
+    Ok(())
+}

--- a/tests/misc_testsuite/module-linking/alias.wast
+++ b/tests/misc_testsuite/module-linking/alias.wast
@@ -1,0 +1,114 @@
+;; functions
+(module
+  (module $m
+    (func $foo (export "foo") (result i32)
+      i32.const 1)
+  )
+  (instance $a (instantiate $m))
+
+  (func (export "get") (result i32)
+    call $a.$foo)
+)
+(assert_return (invoke "get") (i32.const 1))
+
+;; globals
+(module
+  (module $m
+    (global $g (export "g") (mut i32) (i32.const 2))
+  )
+  (instance $a (instantiate $m))
+
+  (func (export "get") (result i32)
+    global.get $a.$g)
+)
+(assert_return (invoke "get") (i32.const 2))
+
+;; memories
+(module
+  (module $m
+    (memory $m (export "m") 1)
+    (data (i32.const 0) "\03\00\00\00")
+  )
+  (instance $a (instantiate $m))
+  (alias (instance $a) (memory $m))
+
+  (func (export "get") (result i32)
+    i32.const 0
+    i32.load)
+)
+(assert_return (invoke "get") (i32.const 3))
+
+;; tables
+(module
+  (module $m
+    (table $t (export "t") 1 funcref)
+    (func (result i32)
+      i32.const 4)
+    (elem (i32.const 0) 0)
+  )
+  (instance $a (instantiate $m))
+
+  (func (export "get") (result i32)
+    i32.const 0
+    call_indirect $a.$t (result i32))
+)
+(assert_return (invoke "get") (i32.const 4))
+
+;; TODO instances/modules -- needs import/export of modules/instances to work
+
+;; alias parent -- type
+(module
+  (type $t (func))
+  (module $m
+    (func $f (type $t))
+  )
+  (instance $a (instantiate $m))
+)
+
+;; alias parent -- module
+(module
+  (module $a)
+  (module $m
+    (instance (instantiate $a))
+  )
+  (instance (instantiate $m))
+)
+
+;; The alias, import, type, module, and instance sections can all be interleaved
+(module
+  (module $a)
+  (type $t (func))
+  (module $m
+    ;; alias
+    (alias $thunk parent (type $t))
+    ;; import
+    (import "" "" (func (type $thunk)))
+    ;; module (referencing parent type)
+    (module
+      (func (type $thunk))
+    )
+    ;; type
+    (type $thunk2 (func))
+    ;; module (referencing previous alias)
+    (module $m2
+      (func (export "") (type $thunk2))
+    )
+    ;; instance
+    (instance $i (instantiate $m2))
+    ;; alias that instance
+    (alias $my_f (instance $i) (func 0))
+    ;; module
+    (module $m3
+      (import "" (func)))
+    ;; use our aliased function to create the module
+    (instance $i2 (instantiate $m3 (func $my_f)))
+    ;; module
+    (module $m4
+      (import "" (func)))
+  )
+
+  ;; instantiate the above module
+  (module $smol (func $f (export "")))
+  (instance $smol (instantiate $smol))
+  (instance (instantiate $m (func $smol.$f)))
+)


### PR DESCRIPTION


This commit is intended to do almost everything necessary for processing
the alias section of module linking. Most of this is internal
refactoring, the highlights being:

* Type contents are now stored separately from a `wasmtime_env::Module`.
  Given that modules can freely alias types and have them used all over
  the place, it seemed best to have one canonical location to type
  storage which everywhere else points to (with indices). A new
  `TypeTables` structure is produced during compilation which is shared
  amongst all member modules in a wasm blob.

* Instantiation is heavily refactored to account for module linking. The
  main gotcha here is that imports are now listed as "initializers". We
  have a sort of pseudo-bytecode-interpreter which interprets the
  initialization of a module. This is more complicated than just
  matching imports at this point because in the module linking proposal
  the module, alias, import, and instance sections may all be
  interleaved. This means that imports aren't guaranteed to show up at
  the beginning of the address space for modules/instances.

Otherwise most of the changes here largely fell out from these two
design points. Aliases are recorded as initializers in this scheme.
Copying around type information and/or just knowing type information
during compilation is also pretty easy since everything is just a
pointer into a `TypeTables` and we don't have to actually copy any types
themselves. Lots of various refactorings were necessary to accomodate
these changes.

Tests are hoped to cover a breadth of functionality here, but not
necessarily a depth. There's still one more piece of the module linking
proposal missing which is exporting instances/modules, which will come
in a future PR.

It's also worth nothing that there's one large TODO which isn't
implemented in this change that I plan on opening an issue for.
With module linking when a set of modules comes back from compilation
each modules has all the trampolines for the entire set of modules. This
is quite a lot of duplicate trampolines across module-linking modules.
We'll want to refactor this at some point to instead have only one set
of trampolines per set of module linking modules and have them shared
from there. I figured it was best to separate out this change, however,
since it's purely related to resource usage, and doesn't impact
non-module-linking modules at all.

cc #2094

