### PR TITLE
Refactor module instantiation in the runtime.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
     name: Doc - build the API documentation
     runs-on: ubuntu-latest
     env:
-      RUSTDOCFLAGS: -Dbroken_intra_doc_links
+      RUSTDOCFLAGS: -Dbroken_intra_doc_links --cfg nightlydoc
       OPENVINO_SKIP_LINKING: 1
     steps:
     - uses: actions/checkout@v2
@@ -120,6 +120,8 @@ jobs:
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features wat
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features lightbeam
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features jitdump
+    - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features cache
+    - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features async
 
     # Check some feature combinations of the `wasmtime-c-api` crate
     - run: cargo check --manifest-path crates/c-api/Cargo.toml --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,6 +3035,7 @@ dependencies = [
  "indexmap",
  "libc",
  "log",
+ "paste",
  "region",
  "rustc-demangle",
  "serde",
@@ -3038,6 +3045,7 @@ dependencies = [
  "wasmparser",
  "wasmtime-cache",
  "wasmtime-environ",
+ "wasmtime-fiber",
  "wasmtime-jit",
  "wasmtime-profiling",
  "wasmtime-runtime",
@@ -3184,6 +3192,16 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmparser",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "0.22.0"
+dependencies = [
+ "backtrace",
+ "cc",
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -101,6 +101,8 @@ pub fn translate_module<'data>(
 
             Payload::DataCountSection { count, range } => {
                 validator.data_count_section(count, &range)?;
+
+                // NOTE: the count here is the total segment count, not the passive segment count
                 environ.reserve_passive_data(count)?;
             }
 

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -56,8 +56,8 @@ pub extern "C" fn wasmtime_config_interruptable_set(c: &mut wasm_config_t, enabl
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_max_wasm_stack_set(c: &mut wasm_config_t, size: usize) {
-    c.config.max_wasm_stack(size);
+pub extern "C" fn wasmtime_config_max_wasm_stack_set(c: &mut wasm_config_t, size: usize) -> bool {
+    c.config.max_wasm_stack(size).is_ok()
 }
 
 #[no_mangle]

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -43,7 +43,7 @@ impl<'config> ModuleCacheEntry<'config> {
     }
 
     /// Gets cached data if state matches, otherwise calls the `compute`.
-    pub fn get_data<T, U, E>(&self, state: T, compute: fn(T) -> Result<U, E>) -> Result<U, E>
+    pub fn get_data<T, U, E>(&self, state: T, compute: impl Fn(T) -> Result<U, E>) -> Result<U, E>
     where
         T: Hash,
         U: Serialize + for<'a> Deserialize<'a>,

--- a/crates/cache/src/tests.rs
+++ b/crates/cache/src/tests.rs
@@ -65,28 +65,68 @@ fn test_write_read_cache() {
     let entry1 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler1, &cache_config));
     let entry2 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler2, &cache_config));
 
-    entry1.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry1.get_data::<_, i32, i32>(2, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry1.get_data::<_, i32, i32>(3, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry1.get_data::<_, i32, i32>(4, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
+    entry1
+        .get_data(4, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(4, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry2.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
-    entry2.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry2
+        .get_data(1, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(4, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry2
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 }

--- a/crates/environ/src/data_structures.rs
+++ b/crates/environ/src/data_structures.rs
@@ -20,7 +20,7 @@ pub mod isa {
 }
 
 pub mod entity {
-    pub use cranelift_entity::{packed_option, BoxedSlice, EntityRef, PrimaryMap};
+    pub use cranelift_entity::{packed_option, BoxedSlice, EntityRef, EntitySet, PrimaryMap};
 }
 
 pub mod wasm {

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -42,8 +42,16 @@ impl MemoryStyle {
         // A heap with a maximum that doesn't exceed the static memory bound specified by the
         // tunables make it static.
         //
-        // If the module doesn't declare an explicit maximum treat it as 4GiB.
-        let maximum = memory.maximum.unwrap_or(WASM_MAX_PAGES);
+        // If the module doesn't declare an explicit maximum treat it as 4GiB when not
+        // requested to use the static memory bound itself as the maximum.
+        let maximum = memory
+            .maximum
+            .unwrap_or(if tunables.static_memory_bound_is_maximum {
+                tunables.static_memory_bound
+            } else {
+                WASM_MAX_PAGES
+            });
+
         if maximum <= tunables.static_memory_bound {
             assert_ge!(tunables.static_memory_bound, memory.minimum);
             return (

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -27,6 +27,9 @@ pub struct Tunables {
     /// Whether or not fuel is enabled for generated code, meaning that fuel
     /// will be consumed every time a wasm instruction is executed.
     pub consume_fuel: bool,
+
+    /// Whether or not to treat the static memory bound as the maximum for unbounded heaps.
+    pub static_memory_bound_is_maximum: bool,
 }
 
 impl Default for Tunables {
@@ -62,6 +65,7 @@ impl Default for Tunables {
             parse_wasm_debuginfo: true,
             interruptable: false,
             consume_fuel: false,
+            static_memory_bound_is_maximum: false,
         }
     }
 }

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "wasmtime-fiber"
+version = "0.22.0"
+authors = ["The Wasmtime Project Developers"]
+description = "Fiber support for Wasmtime"
+license = "Apache-2.0 WITH LLVM-exception"
+repository = "https://github.com/bytecodealliance/wasmtime"
+edition = "2018"
+
+# We link to some native code with symbols that don't change often, so let Cargo
+# know that we can't show up multiple times in a crate graph. If this is an
+# issue in the future we should tweak the build script to set `#define`
+# directives or similar to embed a version number of this crate in symbols.
+links = "wasmtime-fiber-shims"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.80"
+
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3.9"
+features = [
+  "fibersapi",
+  "winbase",
+]
+
+[build-dependencies]
+cc = "1.0"
+
+[dev-dependencies]
+backtrace = "0.3"

--- a/crates/fiber/build.rs
+++ b/crates/fiber/build.rs
@@ -1,20 +1,18 @@
 use std::env;
+use std::fs;
 
 fn main() {
     let mut build = cc::Build::new();
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    if family == "windows" {
-        build.file("src/arch/windows.c");
-    } else if arch == "x86_64" {
-        build.file("src/arch/x86_64.S");
-    } else if arch == "x86" {
-        build.file("src/arch/x86.S");
-    } else if arch == "arm" {
-        build.file("src/arch/arm.S");
-    } else if arch == "aarch64" {
-        build.file("src/arch/aarch64.S");
+
+    let family_file = format!("src/arch/{}.c", family);
+    let arch_file = format!("src/arch/{}.S", arch);
+    if fs::metadata(&family_file).is_ok() {
+        build.file(&family_file);
+    } else if fs::metadata(&arch_file).is_ok() {
+        build.file(&arch_file);
     } else {
         panic!(
             "wasmtime doesn't support fibers on platform: {}",

--- a/crates/fiber/build.rs
+++ b/crates/fiber/build.rs
@@ -9,6 +9,8 @@ fn main() {
         build.file("src/arch/windows.c");
     } else if arch == "x86_64" {
         build.file("src/arch/x86_64.S");
+    } else if arch == "x86" {
+        build.file("src/arch/x86.S");
     } else if arch == "aarch64" {
         build.file("src/arch/aarch64.S");
     } else {

--- a/crates/fiber/build.rs
+++ b/crates/fiber/build.rs
@@ -11,6 +11,8 @@ fn main() {
         build.file("src/arch/x86_64.S");
     } else if arch == "x86" {
         build.file("src/arch/x86.S");
+    } else if arch == "arm" {
+        build.file("src/arch/arm.S");
     } else if arch == "aarch64" {
         build.file("src/arch/aarch64.S");
     } else {

--- a/crates/fiber/build.rs
+++ b/crates/fiber/build.rs
@@ -1,0 +1,23 @@
+use std::env;
+
+fn main() {
+    let mut build = cc::Build::new();
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if family == "windows" {
+        build.file("src/arch/windows.c");
+    } else if arch == "x86_64" {
+        build.file("src/arch/x86_64.S");
+    } else if arch == "aarch64" {
+        build.file("src/arch/aarch64.S");
+    } else {
+        panic!(
+            "wasmtime doesn't support fibers on platform: {}",
+            env::var("TARGET").unwrap()
+        );
+    }
+    build.define(&format!("CFG_TARGET_OS_{}", os), None);
+    build.define(&format!("CFG_TARGET_ARCH_{}", arch), None);
+    build.compile("wasmtime-fiber");
+}

--- a/crates/fiber/src/arch/aarch64.S
+++ b/crates/fiber/src/arch/aarch64.S
@@ -1,0 +1,111 @@
+// A WORD OF CAUTION
+//
+// This entire file basically needs to be kept in sync with itself. It's not
+// really possible to modify just one bit of this file without understanding
+// all the other bits. Documentation tries to reference various bits here and
+// there but try to make sure to read over everything before tweaking things!
+//
+// Also at this time this file is heavily based off the x86_64 file, so you'll
+// probably want to read that one as well.
+
+#define GLOBL(fnname) .globl fnname
+#define TYPE(fnname) .type fnname,@function
+#define FUNCTION(fnname) fnname
+#define SIZE(fnname) .size fnname,.-fnname
+
+// fn(top_of_stack(%x0): *mut u8)
+GLOBL(wasmtime_fiber_switch)
+.p2align 2
+TYPE(wasmtime_fiber_switch)
+FUNCTION(wasmtime_fiber_switch):
+    // Save all callee-saved registers on the stack since we're assuming
+    // they're clobbered as a result of the stack switch.
+    str lr, [sp, -16]!
+    stp x20, x19, [sp, -16]!
+    stp x22, x21, [sp, -16]!
+    stp x24, x23, [sp, -16]!
+    stp x26, x25, [sp, -16]!
+    stp x28, x27, [sp, -16]!
+
+    // Load our previously saved stack pointer to resume to, and save off our
+    // current stack pointer on where to come back to eventually.
+    ldr x8, [x0, -0x10]
+    mov x9, sp
+    str x9, [x0, -0x10]
+
+    // Switch to the new stack and restore all our callee-saved registers after
+    // the switch and return to our new stack.
+    mov sp, x8
+    ldp x28, x27, [sp], 16
+    ldp x26, x25, [sp], 16
+    ldp x24, x23, [sp], 16
+    ldp x22, x21, [sp], 16
+    ldp x20, x19, [sp], 16
+    ldr lr, [sp], 16
+    ret
+SIZE(wasmtime_fiber_switch)
+
+// fn(
+//    top_of_stack(%x0): *mut u8,
+//    entry_point(%x1): extern fn(*mut u8, *mut u8),
+//    entry_arg0(%x2): *mut u8,
+// )
+GLOBL(wasmtime_fiber_init)
+.p2align 2
+TYPE(wasmtime_fiber_init)
+FUNCTION(wasmtime_fiber_init):
+    adr x8, wasmtime_fiber_start
+    stp x0, x8, [x0, -0x28] // x0 => x19, x8 => lr
+    stp x2, x1, [x0, -0x38] // x1 => x20, x2 => x21
+
+    // `wasmtime_fiber_switch` has an 0x60 byte stack, and we add 0x10 more for
+    // the original reserved 16 bytes.
+    add x8, x0, -0x70
+    str x8, [x0, -0x10]
+    ret
+SIZE(wasmtime_fiber_init)
+
+.p2align 2
+TYPE(wasmtime_fiber_start)
+FUNCTION(wasmtime_fiber_start):
+.cfi_startproc simple
+
+    // See the x86_64 file for more commentary on what these CFI directives are
+    // doing. Like over there note that the relative offsets to registers here
+    // match the frame layout in `wasmtime_fiber_switch`.
+    .cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */ \
+	4,	      /* the byte length of this expression */ \
+	0x6f,         /* DW_OP_reg31(%sp) */ \
+	0x06,         /* DW_OP_deref */ \
+	0x23, 0x60    /* DW_OP_plus_uconst 0x60 */
+
+    .cfi_rel_offset lr, -0x10
+    .cfi_rel_offset x19, -0x18
+    .cfi_rel_offset x20, -0x20
+    .cfi_rel_offset x21, -0x28
+    .cfi_rel_offset x22, -0x30
+    .cfi_rel_offset x23, -0x38
+    .cfi_rel_offset x24, -0x40
+    .cfi_rel_offset x25, -0x48
+    .cfi_rel_offset x26, -0x50
+    .cfi_rel_offset x27, -0x58
+    .cfi_rel_offset x29, -0x60
+
+    // Load our two arguments from the stack, where x1 is our start procedure
+    // and x0 is its first argument. This also blows away the stack space used
+    // by those two arguments.
+    mov x0, x21
+    mov x1, x19
+
+    // ... and then we call the function! Note that this is a function call so
+    // our frame stays on the stack to backtrace through.
+    blr x20
+    // .. technically we shouldn't get here, and I would like to write in an
+    // instruction which just aborts, but I don't know such an instruction in
+    // aarch64 lan, and I would like to write in an instruction which just
+    // aborts, but I don't know such an instruction in aarch64 land
+    .cfi_endproc
+SIZE(wasmtime_fiber_start)
+
+.section .note.GNU-stack,"",%progbits
+

--- a/crates/fiber/src/arch/aarch64.S
+++ b/crates/fiber/src/arch/aarch64.S
@@ -110,8 +110,7 @@ FUNCTION(wasmtime_fiber_start):
     blr x20
     // .. technically we shouldn't get here, and I would like to write in an
     // instruction which just aborts, but I don't know such an instruction in
-    // aarch64 lan, and I would like to write in an instruction which just
-    // aborts, but I don't know such an instruction in aarch64 land
+    // aarch64 land.
     .cfi_endproc
 SIZE(wasmtime_fiber_start)
 

--- a/crates/fiber/src/arch/aarch64.S
+++ b/crates/fiber/src/arch/aarch64.S
@@ -26,6 +26,10 @@ FUNCTION(wasmtime_fiber_switch):
     stp x24, x23, [sp, -16]!
     stp x26, x25, [sp, -16]!
     stp x28, x27, [sp, -16]!
+    stp d9, d8, [sp, -16]!
+    stp d11, d10, [sp, -16]!
+    stp d13, d12, [sp, -16]!
+    stp d15, d14, [sp, -16]!
 
     // Load our previously saved stack pointer to resume to, and save off our
     // current stack pointer on where to come back to eventually.
@@ -36,6 +40,10 @@ FUNCTION(wasmtime_fiber_switch):
     // Switch to the new stack and restore all our callee-saved registers after
     // the switch and return to our new stack.
     mov sp, x8
+    ldp d15, d14, [sp], 16
+    ldp d13, d12, [sp], 16
+    ldp d11, d10, [sp], 16
+    ldp d9, d8, [sp], 16
     ldp x28, x27, [sp], 16
     ldp x26, x25, [sp], 16
     ldp x24, x23, [sp], 16
@@ -58,9 +66,9 @@ FUNCTION(wasmtime_fiber_init):
     stp x0, x8, [x0, -0x28] // x0 => x19, x8 => lr
     stp x2, x1, [x0, -0x38] // x1 => x20, x2 => x21
 
-    // `wasmtime_fiber_switch` has an 0x60 byte stack, and we add 0x10 more for
+    // `wasmtime_fiber_switch` has an 0xa0 byte stack, and we add 0x10 more for
     // the original reserved 16 bytes.
-    add x8, x0, -0x70
+    add x8, x0, -0xb0
     str x8, [x0, -0x10]
     ret
 SIZE(wasmtime_fiber_init)
@@ -73,11 +81,11 @@ FUNCTION(wasmtime_fiber_start):
     // See the x86_64 file for more commentary on what these CFI directives are
     // doing. Like over there note that the relative offsets to registers here
     // match the frame layout in `wasmtime_fiber_switch`.
-    .cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */ \
-	4,	      /* the byte length of this expression */ \
-	0x6f,         /* DW_OP_reg31(%sp) */ \
-	0x06,         /* DW_OP_deref */ \
-	0x23, 0x60    /* DW_OP_plus_uconst 0x60 */
+    .cfi_escape 0x0f,    /* DW_CFA_def_cfa_expression */ \
+        5,               /* the byte length of this expression */ \
+        0x6f,            /* DW_OP_reg31(%sp) */ \
+        0x06,            /* DW_OP_deref */ \
+        0x23, 0xa0, 0x1  /* DW_OP_plus_uconst 0xa0 */
 
     .cfi_rel_offset lr, -0x10
     .cfi_rel_offset x19, -0x18

--- a/crates/fiber/src/arch/aarch64.S
+++ b/crates/fiber/src/arch/aarch64.S
@@ -20,7 +20,7 @@ TYPE(wasmtime_fiber_switch)
 FUNCTION(wasmtime_fiber_switch):
     // Save all callee-saved registers on the stack since we're assuming
     // they're clobbered as a result of the stack switch.
-    str lr, [sp, -16]!
+    stp lr, fp, [sp, -16]!
     stp x20, x19, [sp, -16]!
     stp x22, x21, [sp, -16]!
     stp x24, x23, [sp, -16]!
@@ -49,7 +49,7 @@ FUNCTION(wasmtime_fiber_switch):
     ldp x24, x23, [sp], 16
     ldp x22, x21, [sp], 16
     ldp x20, x19, [sp], 16
-    ldr lr, [sp], 16
+    ldp lr, fp, [sp], 16
     ret
 SIZE(wasmtime_fiber_switch)
 

--- a/crates/fiber/src/arch/arm.S
+++ b/crates/fiber/src/arch/arm.S
@@ -1,0 +1,79 @@
+// A WORD OF CAUTION
+//
+// This entire file basically needs to be kept in sync with itself. It's not
+// really possible to modify just one bit of this file without understanding
+// all the other bits. Documentation tries to reference various bits here and
+// there but try to make sure to read over everything before tweaking things!
+//
+// Also at this time this file is heavily based off the x86_64 file, so you'll
+// probably want to read that one as well.
+
+#define SIZE(fnname) .size fnname,.-fnname
+
+// fn(top_of_stack(%r0): *mut u8)
+.globl wasmtime_fiber_switch
+wasmtime_fiber_switch:
+    // Save callee-saved registers
+    push {r4-r11,lr}
+
+    // Swap stacks, recording our current stack pointer
+    ldr r4, [r0, #-0x08]
+    str sp, [r0, #-0x08]
+    mov sp, r4
+
+    // Restore and return
+    pop {r4-r11,lr}
+    bx lr
+SIZE(wasmtime_fiber_switch)
+
+// fn(
+//    top_of_stack(%r0): *mut u8,
+//    entry_point(%r1): extern fn(*mut u8, *mut u8),
+//    entry_arg0(%r2): *mut u8,
+// )
+.globl wasmtime_fiber_init
+wasmtime_fiber_init:
+    adr r3, wasmtime_fiber_start
+    str r3, [r0, #-0x0c] // => lr
+    str r0, [r0, #-0x10] // => r11
+    str r1, [r0, #-0x14] // => r10
+    str r2, [r0, #-0x18] // => r9
+
+    add r3, r0, #-0x2c
+    str r3, [r0, #-0x08]
+    bx lr
+SIZE(wasmtime_fiber_init)
+
+wasmtime_fiber_start:
+.cfi_startproc simple
+    // See the x86_64 file for more commentary on what these CFI directives are
+    // doing. Like over there note that the relative offsets to registers here
+    // match the frame layout in `wasmtime_fiber_switch`.
+    //
+    // TODO: this is only lightly tested. This gets backtraces in gdb but not
+    // at runtime. Perhaps the libgcc at runtime was too old? Doesn't support
+    // something here? Unclear. Will need investigation if someone ends up
+    // needing this and it still doesn't work.
+    .cfi_escape 0x0f,    /* DW_CFA_def_cfa_expression */ \
+        5,               /* the byte length of this expression */ \
+        0x7d, 0x00,      /* DW_OP_breg14(%sp) + 0 */ \
+        0x06,            /* DW_OP_deref */ \
+        0x23, 0x24	 /* DW_OP_plus_uconst 0x24 */
+
+    .cfi_rel_offset lr, -0x04
+    .cfi_rel_offset r11, -0x08
+    .cfi_rel_offset r10, -0x0c
+    .cfi_rel_offset r9, -0x10
+    .cfi_rel_offset r8, -0x14
+    .cfi_rel_offset r7, -0x18
+    .cfi_rel_offset r6, -0x1c
+    .cfi_rel_offset r5, -0x20
+    .cfi_rel_offset r4, -0x24
+
+    mov r1, r11
+    mov r0, r9
+    blx r10
+    .cfi_endproc
+SIZE(wasmtime_fiber_start)
+
+.section .note.GNU-stack,"",%progbits

--- a/crates/fiber/src/arch/windows.c
+++ b/crates/fiber/src/arch/windows.c
@@ -1,0 +1,5 @@
+#include <windows.h>
+
+LPVOID wasmtime_fiber_get_current() {
+   return GetCurrentFiber();
+}

--- a/crates/fiber/src/arch/x86.S
+++ b/crates/fiber/src/arch/x86.S
@@ -1,0 +1,109 @@
+// A WORD OF CAUTION
+//
+// This entire file basically needs to be kept in sync with itself. It's not
+// really possible to modify just one bit of this file without understanding
+// all the other bits. Documentation tries to reference various bits here and
+// there but try to make sure to read over everything before tweaking things!
+//
+// This file is modeled after x86_64.S and comments are not copied over. For
+// reference be sure to review the other file. Note that the pointer size is
+// different so the reserved space at the top of the stack is 8 bytes, not 16
+// bytes. Still two pointers though.
+
+.text
+
+#define SIZE(fnname) .size fnname,.-fnname
+
+// fn(top_of_stack: *mut u8)
+.globl wasmtime_fiber_switch
+.type wasmtime_fiber_switch,@function
+wasmtime_fiber_switch:
+    // Load our stack-to-use
+    mov 0x4(%esp), %eax
+    mov -0x8(%eax), %ecx
+
+    // Save callee-saved registers
+    push %ebp
+    push %ebx
+    push %esi
+    push %edi
+
+    // Save our current stack and jump to the stack-to-use
+    mov %esp, -0x8(%eax)
+    mov %ecx, %esp
+
+    // Restore callee-saved registers
+    pop %edi
+    pop %esi
+    pop %ebx
+    pop %ebp
+    ret
+SIZE(wasmtime_fiber_switch)
+
+// fn(
+//    top_of_stack: *mut u8,
+//    entry_point: extern fn(*mut u8, *mut u8),
+//    entry_arg0: *mut u8,
+// )
+.globl wasmtime_fiber_init
+.type wasmtime_fiber_init,@function
+wasmtime_fiber_init:
+    mov 4(%esp), %eax
+
+    // move top_of_stack to the 2nd argument
+    mov %eax, -0x0c(%eax)
+
+    // move entry_arg0 to the 1st argument
+    mov 12(%esp), %ecx
+    mov %ecx, -0x10(%eax)
+
+    // Move our start function to the return address which the `ret` in
+    // `wasmtime_fiber_start` will return to.
+    lea wasmtime_fiber_start, %ecx
+    mov %ecx, -0x14(%eax)
+
+    // And move `entry_point` to get loaded into `%ebp` through the context
+    // switch. This'll get jumped to in `wasmtime_fiber_start`.
+    mov 8(%esp), %ecx
+    mov %ecx, -0x18(%eax)
+
+    // Our stack from top-to-bottom looks like:
+    //
+    //	  * 8 bytes of reserved space per unix.rs (two-pointers space)
+    //	  * 8 bytes of arguments (two arguments wasmtime_fiber_start forwards)
+    //	  * 4 bytes of return address
+    //	  * 16 bytes of saved registers
+    //
+    // Note that after the return address the stack is conveniently 16-byte
+    // aligned as required, so we just leave the arguments on the stack in
+    // `wasmtime_fiber_start` and immediately do the call.
+    lea -0x24(%eax), %ecx
+    mov %ecx, -0x08(%eax)
+    ret
+SIZE(wasmtime_fiber_init)
+
+.type wasmtime_fiber_start,@function
+wasmtime_fiber_start:
+.cfi_startproc simple
+    .cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */ \
+        5,            /* the byte length of this expression */ \
+        0x74, 0x08,   /* DW_OP_breg4 (%esp) + 8 */ \
+        0x06,         /* DW_OP_deref */ \
+        0x23, 0x14    /* DW_OP_plus_uconst 0x14 */
+
+    .cfi_rel_offset eip, -4
+    .cfi_rel_offset ebp, -8
+    .cfi_rel_offset ebx, -12
+    .cfi_rel_offset esi, -16
+    .cfi_rel_offset edi, -20
+
+    // Our arguments and stack alignment are all prepped by
+    // `wasmtime_fiber_init`.
+    call *%ebp
+    ud2
+    .cfi_endproc
+SIZE(wasmtime_fiber_start)
+
+// Mark that we don't need executable stack.
+.section .note.GNU-stack,"",%progbits
+

--- a/crates/fiber/src/arch/x86_64.S
+++ b/crates/fiber/src/arch/x86_64.S
@@ -67,22 +67,25 @@ GLOBL(wasmtime_fiber_init)
 .align 16
 TYPE(wasmtime_fiber_init)
 FUNCTION(wasmtime_fiber_init):
-    // The first 16 bytes of the stack are reserved (see unix.rs) so we store
-    // the initial data used in `wasmtime_fiber_start` just below
-    // that.
-    movq %rdi, -0x18(%rdi)
-    movq %rsi, -0x20(%rdi)
-    movq %rdx, -0x28(%rdi)
-
-    // After these arguments is the return address of where to switch to,
-    // which for the first run is `wasmtime_fiber_start`.
+    // Here we're going to set up a stack frame as expected by
+    // `wasmtime_fiber_switch`. The values we store here will get restored into
+    // registers by that function and the `wasmtime_fiber_start` function will
+    // take over and understands which values are in which registers.
+    //
+    // The first 16 bytes of stack aree reserveed for metadata, so we start
+    // sttoring values beneatht that.
     lea FUNCTION(wasmtime_fiber_start)(%rip), %rax
-    movq %rax, -0x30(%rdi)
+    movq %rax, -0x18(%rdi)
+    movq %rdi, -0x20(%rdi)    // loaded into rbp during switch
+    movq %rsi, -0x28(%rdi)    // loaded into rbx during switch
+    movq %rdx, -0x30(%rdi)    // loaded into r12 during switch
 
     // And then we specify the stack pointer resumption should begin at. Our
-    // `wasmtime_fiber_switch` function saves 6 registers so we need to ensure
-    // that there's space for that as well. 0x30 + 6 * 8 == 0x60 here.
-    lea -0x60(%rdi), %rax
+    // `wasmtime_fiber_switch` function consumes 6 registers plus a return
+    // pointer, and the top 16 bytes aree resereved, so that's:
+    //
+    //	(6 + 1) * 16 + 16 = 0x48
+    lea -0x48(%rdi), %rax
     movq %rax, -0x10(%rdi)
     ret
 SIZE(wasmtime_fiber_init)
@@ -117,14 +120,13 @@ FUNCTION(wasmtime_fiber_start):
     // The expression we're encoding here is that the CFA, the stack pointer of
     // whatever called into `wasmtime_fiber_start`, is:
     //
-    //        *($rsp + 0x18) + 0x38
+    //        *$rsp + 0x38
     //
     // $rsp is the stack pointer of `wasmtime_fiber_start` at the time the next
     // instruction after the `.cfi_escape` is executed. Our $rsp at the start
-    // of this function is 3 words below stack start (0xAff0 in
-    // the diagram in unix.rs). The $rsp to resume at is at 0xAff0, so we
-    // add an offset to $rsp to get to that memory location and then we
-    // dereference it.
+    // of this function is 16 bytes below the top of the stack (0xAff0 in
+    // the diagram in unix.rs). The $rsp to resume at is stored at that
+    // location, so we dereference the stack pointer to load it.
     //
     // After dereferencing, though, we have the $rsp value for
     // `wasmtime_fiber_switch` itself. That's a weird function which sort of
@@ -134,8 +136,8 @@ FUNCTION(wasmtime_fiber_start):
     // the return address of the caller's `call` instruction. Hence we offset
     // another 0x38 bytes.
     .cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */ \
-        5,            /* the byte length of this expression */ \
-        0x77, 0x18,   /* DW_OP_breg7 (%rsp) + 0x18 */ \
+        4,            /* the byte length of this expression */ \
+        0x57,         /* DW_OP_reg7 (%rsp) */ \
         0x06,         /* DW_OP_deref */ \
         0x23, 0x38    /* DW_OP_plus_uconst 0x38 */
 
@@ -152,21 +154,17 @@ FUNCTION(wasmtime_fiber_start):
     .cfi_rel_offset r14, -48
     .cfi_rel_offset r15, -56
 
-    // Update the CFA expression after each adjustment of $rsp as we load
-    // registers to call the entrypoint. The major change is that the $rsp
-    // offset is decreasing by 8, and for the last adjustment a 0 offset means
-    // we can use DW_OP_reg7.
-    popq %rdi
-    .cfi_escape 0x0f, 5, 0x77, 0x10, 0x06, 0x23, 0x38
-    popq %rax
-    .cfi_escape 0x0f, 5, 0x77, 0x08, 0x06, 0x23, 0x38
-    popq %rsi
-    .cfi_escape 0x0f, 4, 0x57,       0x06, 0x23, 0x38
 
-    // And finally head off into the fiber. Note the `callq` keeps this frame
-    // on the stack so all our CFI directives can be read. Additionally this
-    // is not expected to ever return, but for safety we put a `ud2` at the end.
-    callq *%rax
+    // The body of this function is pretty similar. All our parameters are
+    // already loaded into registers by the switch function. The
+    // `wasmtime_fiber_init` routine arranged the various values to be
+    // materialized into the registers used here. Our job is to then move the
+    // values into the ABI-defined registers and call the entry-point. Note that
+    // `callq` is used here to leave this frame on the stack so we can use the
+    // dwarf info here for unwinding. The trailing `ud2` is just for safety.
+    mov %r12,%rdi
+    mov %rbp,%rsi
+    callq *%rbx
     ud2
     .cfi_endproc
 SIZE(wasmtime_fiber_start)

--- a/crates/fiber/src/arch/x86_64.S
+++ b/crates/fiber/src/arch/x86_64.S
@@ -134,10 +134,10 @@ FUNCTION(wasmtime_fiber_start):
     // the return address of the caller's `call` instruction. Hence we offset
     // another 0x38 bytes.
     .cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */ \
-	5,            /* the byte length of this expression */ \
-	0x77, 0x18,   /* DW_OP_breg7 (%rsp) + 0x18 */ \
-	0x06,         /* DW_OP_deref */ \
-	0x23, 0x38    /* DW_OP_plus_uconst 0x38 */
+        5,            /* the byte length of this expression */ \
+        0x77, 0x18,   /* DW_OP_breg7 (%rsp) + 0x18 */ \
+        0x06,         /* DW_OP_deref */ \
+        0x23, 0x38    /* DW_OP_plus_uconst 0x38 */
 
     // And now after we've indicated where our CFA is for our parent function,
     // we can define that where all of the saved registers are located. This

--- a/crates/fiber/src/arch/x86_64.S
+++ b/crates/fiber/src/arch/x86_64.S
@@ -1,0 +1,177 @@
+// A WORD OF CAUTION
+//
+// This entire file basically needs to be kept in sync with itself. It's not
+// really possible to modify just one bit of this file without understanding
+// all the other bits. Documentation tries to reference various bits here and
+// there but try to make sure to read over everything before tweaking things!
+
+.text
+
+#if CFG_TARGET_OS_macos
+
+#define GLOBL(fnname) .globl _##fnname
+#define TYPE(fnname)
+#define FUNCTION(fnname) _##fnname
+#define SIZE(fnname)
+
+#else
+
+#define GLOBL(fnname) .globl fnname
+#define TYPE(fnname) .type fnname,@function
+#define FUNCTION(fnname) fnname
+#define SIZE(fnname) .size fnname,.-fnname
+
+#endif
+
+// fn(top_of_stack(%rdi): *mut u8)
+GLOBL(wasmtime_fiber_switch)
+.align 16
+TYPE(wasmtime_fiber_switch)
+FUNCTION(wasmtime_fiber_switch):
+    // We're switching to arbitrary code somewhere else, so pessimistically
+    // assume that all callee-save register are clobbered. This means we need
+    // to save/restore all of them.
+    //
+    // Note that this order for saving is important since we use CFI directives
+    // below to point to where all the saved registers are.
+    pushq %rbp
+    pushq %rbx
+    pushq %r12
+    pushq %r13
+    pushq %r14
+    pushq %r15
+
+    // Load pointer that we're going to resume at and store where we're going
+    // to get resumed from. This is in accordance with the diagram at the top
+    // of unix.rs.
+    movq -0x10(%rdi), %rax
+    mov %rsp, -0x10(%rdi)
+
+    // Swap stacks and restore all our callee-saved registers
+    mov %rax, %rsp
+    popq %r15
+    popq %r14
+    popq %r13
+    popq %r12
+    popq %rbx
+    popq %rbp
+    ret
+SIZE(wasmtime_fiber_switch)
+
+// fn(
+//    top_of_stack(%rdi): *mut u8,
+//    entry_point(%rsi): extern fn(*mut u8, *mut u8),
+//    entry_arg0(%rdx): *mut u8,
+// )
+GLOBL(wasmtime_fiber_init)
+.align 16
+TYPE(wasmtime_fiber_init)
+FUNCTION(wasmtime_fiber_init):
+    // The first 16 bytes of the stack are reserved (see unix.rs) so we store
+    // the initial data used in `wasmtime_fiber_start` just below
+    // that.
+    movq %rdi, -0x18(%rdi)
+    movq %rsi, -0x20(%rdi)
+    movq %rdx, -0x28(%rdi)
+
+    // After these arguments is the return address of where to switch to,
+    // which for the first run is `wasmtime_fiber_start`.
+    lea FUNCTION(wasmtime_fiber_start)(%rip), %rax
+    movq %rax, -0x30(%rdi)
+
+    // And then we specify the stack pointer resumption should begin at. Our
+    // `wasmtime_fiber_switch` function saves 6 registers so we need to ensure
+    // that there's space for that as well. 0x30 + 6 * 8 == 0x60 here.
+    lea -0x60(%rdi), %rax
+    movq %rax, -0x10(%rdi)
+    ret
+SIZE(wasmtime_fiber_init)
+
+// This is a pretty special function that has no real signature. Its use is to
+// be the "base" function of all fibers. This entrypoint is used in
+// `wasmtime_fiber_init` to bootstrap the execution of a new fiber.
+//
+// We also use this function as a persistent frame on the stack to emit dwarf
+// information to unwind into the caller. This allows us to unwind from the
+// fiber's stack back to the main stack that the fiber was called from. We use
+// special dwarf directives here to do so since this is a pretty nonstandard
+// function.
+//
+// If you're curious a decent introduction to CFI things and unwinding is at
+// https://www.imperialviolet.org/2017/01/18/cfi.html
+.align 16
+TYPE(wasmtime_fiber_start)
+FUNCTION(wasmtime_fiber_start):
+// Use the `simple` directive on the startproc here which indicates that some
+// default settings for the platform are omitted, since this function is so
+// nonstandard
+.cfi_startproc simple
+    // This is where things get special, we're specifying a custom dwarf
+    // expression for how to calculate the CFA. The goal here is that we need
+    // to load the parent's stack pointer just before the call it made into
+    // `wasmtime_fiber_switch`. Note that the CFA value changes over time as
+    // well because a fiber may be resumed multiple times from different points
+    // on the original stack. This means that our custom CFA directive involves
+    // `DW_OP_deref`, which loads data from memory.
+    //
+    // The expression we're encoding here is that the CFA, the stack pointer of
+    // whatever called into `wasmtime_fiber_start`, is:
+    //
+    //        *($rsp + 0x18) + 0x38
+    //
+    // $rsp is the stack pointer of `wasmtime_fiber_start` at the time the next
+    // instruction after the `.cfi_escape` is executed. Our $rsp at the start
+    // of this function is 3 words below stack start (0xAff0 in
+    // the diagram in unix.rs). The $rsp to resume at is at 0xAff0, so we
+    // add an offset to $rsp to get to that memory location and then we
+    // dereference it.
+    //
+    // After dereferencing, though, we have the $rsp value for
+    // `wasmtime_fiber_switch` itself. That's a weird function which sort of
+    // and sort of doesn't exist on the stack.  We want to point to the caller
+    // of `wasmtime_fiber_switch`, so to do that we need to skip the stack space
+    // reserved by `wasmtime_fiber_switch`, which is the 6 saved registers plus
+    // the return address of the caller's `call` instruction. Hence we offset
+    // another 0x38 bytes.
+    .cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */ \
+	5,            /* the byte length of this expression */ \
+	0x77, 0x18,   /* DW_OP_breg7 (%rsp) + 0x18 */ \
+	0x06,         /* DW_OP_deref */ \
+	0x23, 0x38    /* DW_OP_plus_uconst 0x38 */
+
+    // And now after we've indicated where our CFA is for our parent function,
+    // we can define that where all of the saved registers are located. This
+    // uses standard `.cfi` directives which indicate that these registers are
+    // all stored relative to the CFA. Note that this order is kept in sync
+    // with the above register spills in `wasmtime_fiber_switch`.
+    .cfi_rel_offset rip, -8
+    .cfi_rel_offset rbp, -16
+    .cfi_rel_offset rbx, -24
+    .cfi_rel_offset r12, -32
+    .cfi_rel_offset r13, -40
+    .cfi_rel_offset r14, -48
+    .cfi_rel_offset r15, -56
+
+    // Update the CFA expression after each adjustment of $rsp as we load
+    // registers to call the entrypoint. The major change is that the $rsp
+    // offset is decreasing by 8, and for the last adjustment a 0 offset means
+    // we can use DW_OP_reg7.
+    popq %rdi
+    .cfi_escape 0x0f, 5, 0x77, 0x10, 0x06, 0x23, 0x38
+    popq %rax
+    .cfi_escape 0x0f, 5, 0x77, 0x08, 0x06, 0x23, 0x38
+    popq %rsi
+    .cfi_escape 0x0f, 4, 0x57,       0x06, 0x23, 0x38
+
+    // And finally head off into the fiber. Note the `callq` keeps this frame
+    // on the stack so all our CFI directives can be read. Additionally this
+    // is not expected to ever return, but for safety we put a `ud2` at the end.
+    callq *%rax
+    ud2
+    .cfi_endproc
+SIZE(wasmtime_fiber_start)
+
+// Mark that we don't need executable stack.
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -1,0 +1,249 @@
+use std::any::Any;
+use std::cell::Cell;
+use std::io;
+use std::marker::PhantomData;
+use std::panic::{self, AssertUnwindSafe};
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+use windows as imp;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+use unix as imp;
+
+pub struct Fiber<'a, Resume, Yield, Return> {
+    inner: imp::Fiber,
+    done: Cell<bool>,
+    _phantom: PhantomData<&'a (Resume, Yield, Return)>,
+}
+
+pub struct Suspend<Resume, Yield, Return> {
+    inner: imp::Suspend,
+    _phantom: PhantomData<(Resume, Yield, Return)>,
+}
+
+enum RunResult<Resume, Yield, Return> {
+    Executing,
+    Resuming(Resume),
+    Yield(Yield),
+    Returned(Return),
+    Panicked(Box<dyn Any + Send>),
+}
+
+impl<'a, Resume, Yield, Return> Fiber<'a, Resume, Yield, Return> {
+    /// Creates a new fiber which will execute `func` on a new native stack of
+    /// size `stack_size`.
+    ///
+    /// This function returns a `Fiber` which, when resumed, will execute `func`
+    /// to completion. When desired the `func` can suspend itself via
+    /// `Fiber::suspend`.
+    pub fn new(
+        stack_size: usize,
+        func: impl FnOnce(Resume, &Suspend<Resume, Yield, Return>) -> Return + 'a,
+    ) -> io::Result<Fiber<'a, Resume, Yield, Return>> {
+        Ok(Fiber {
+            inner: imp::Fiber::new(stack_size, func)?,
+            done: Cell::new(false),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Resumes execution of this fiber.
+    ///
+    /// This function will transfer execution to the fiber and resume from where
+    /// it last left off.
+    ///
+    /// Returns `true` if the fiber finished or `false` if the fiber was
+    /// suspended in the middle of execution.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the current thread is already executing a fiber or if this
+    /// fiber has already finished.
+    ///
+    /// Note that if the fiber itself panics during execution then the panic
+    /// will be propagated to this caller.
+    pub fn resume(&self, val: Resume) -> Result<Return, Yield> {
+        assert!(!self.done.replace(true), "cannot resume a finished fiber");
+        let result = Cell::new(RunResult::Resuming(val));
+        self.inner.resume(&result);
+        match result.into_inner() {
+            RunResult::Resuming(_) | RunResult::Executing => unreachable!(),
+            RunResult::Yield(y) => {
+                self.done.set(false);
+                Err(y)
+            }
+            RunResult::Returned(r) => Ok(r),
+            RunResult::Panicked(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    /// Returns whether this fiber has finished executing.
+    pub fn done(&self) -> bool {
+        self.done.get()
+    }
+}
+
+impl<Resume, Yield, Return> Suspend<Resume, Yield, Return> {
+    /// Suspend execution of a currently running fiber.
+    ///
+    /// This function will switch control back to the original caller of
+    /// `Fiber::resume`. This function will then return once the `Fiber::resume`
+    /// function is called again.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the current thread is not executing a fiber from this library.
+    pub fn suspend(&self, value: Yield) -> Resume {
+        self.inner
+            .switch::<Resume, Yield, Return>(RunResult::Yield(value))
+    }
+
+    fn execute(
+        inner: imp::Suspend,
+        initial: Resume,
+        func: impl FnOnce(Resume, &Suspend<Resume, Yield, Return>) -> Return,
+    ) {
+        let suspend = Suspend {
+            inner,
+            _phantom: PhantomData,
+        };
+        let result = panic::catch_unwind(AssertUnwindSafe(|| (func)(initial, &suspend)));
+        suspend.inner.switch::<Resume, Yield, Return>(match result {
+            Ok(result) => RunResult::Returned(result),
+            Err(panic) => RunResult::Panicked(panic),
+        });
+    }
+}
+
+impl<A, B, C> Drop for Fiber<'_, A, B, C> {
+    fn drop(&mut self) {
+        debug_assert!(self.done.get(), "fiber dropped without finishing");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Fiber;
+    use std::cell::Cell;
+    use std::panic::{self, AssertUnwindSafe};
+    use std::rc::Rc;
+
+    #[test]
+    fn small_stacks() {
+        Fiber::<(), (), ()>::new(0, |_, _| {})
+            .unwrap()
+            .resume(())
+            .unwrap();
+        Fiber::<(), (), ()>::new(1, |_, _| {})
+            .unwrap()
+            .resume(())
+            .unwrap();
+    }
+
+    #[test]
+    fn smoke() {
+        let hit = Rc::new(Cell::new(false));
+        let hit2 = hit.clone();
+        let fiber = Fiber::<(), (), ()>::new(1024 * 1024, move |_, _| {
+            hit2.set(true);
+        })
+        .unwrap();
+        assert!(!hit.get());
+        fiber.resume(()).unwrap();
+        assert!(hit.get());
+    }
+
+    #[test]
+    fn suspend_and_resume() {
+        let hit = Rc::new(Cell::new(false));
+        let hit2 = hit.clone();
+        let fiber = Fiber::<(), (), ()>::new(1024 * 1024, move |_, s| {
+            s.suspend(());
+            hit2.set(true);
+            s.suspend(());
+        })
+        .unwrap();
+        assert!(!hit.get());
+        assert!(fiber.resume(()).is_err());
+        assert!(!hit.get());
+        assert!(fiber.resume(()).is_err());
+        assert!(hit.get());
+        assert!(fiber.resume(()).is_ok());
+        assert!(hit.get());
+    }
+
+    #[test]
+    fn backtrace_traces_to_host() {
+        #[inline(never)] // try to get this to show up in backtraces
+        fn look_for_me() {
+            run_test();
+        }
+        fn assert_contains_host() {
+            let trace = backtrace::Backtrace::new();
+            println!("{:?}", trace);
+            assert!(
+                trace
+                .frames()
+                .iter()
+                .flat_map(|f| f.symbols())
+                .filter_map(|s| Some(s.name()?.to_string()))
+                .any(|s| s.contains("look_for_me"))
+                // TODO: apparently windows unwind routines don't unwind through fibers, so this will always fail. Is there a way we can fix that?
+                || cfg!(windows)
+            );
+        }
+
+        fn run_test() {
+            let fiber = Fiber::<(), (), ()>::new(1024 * 1024, move |(), s| {
+                assert_contains_host();
+                s.suspend(());
+                assert_contains_host();
+                s.suspend(());
+                assert_contains_host();
+            })
+            .unwrap();
+            assert!(fiber.resume(()).is_err());
+            assert!(fiber.resume(()).is_err());
+            assert!(fiber.resume(()).is_ok());
+        }
+
+        look_for_me();
+    }
+
+    #[test]
+    fn panics_propagated() {
+        let a = Rc::new(Cell::new(false));
+        let b = SetOnDrop(a.clone());
+        let fiber = Fiber::<(), (), ()>::new(1024 * 1024, move |(), _s| {
+            drop(&b);
+            panic!();
+        })
+        .unwrap();
+        assert!(panic::catch_unwind(AssertUnwindSafe(|| fiber.resume(()))).is_err());
+        assert!(a.get());
+
+        struct SetOnDrop(Rc<Cell<bool>>);
+
+        impl Drop for SetOnDrop {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+    }
+
+    #[test]
+    fn suspend_and_resume_values() {
+        let fiber = Fiber::new(1024 * 1024, move |first, s| {
+            assert_eq!(first, 2.0);
+            assert_eq!(s.suspend(4), 3.0);
+            "hello".to_string()
+        })
+        .unwrap();
+        assert_eq!(fiber.resume(2.0), Err(4));
+        assert_eq!(fiber.resume(3.0), Ok("hello".to_string()));
+    }
+}

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -1,0 +1,174 @@
+//! The unix fiber implementation has some platform-specific details
+//! (naturally) but there's a few details of the stack layout which are common
+//! amongst all platforms using this file. Remember that none of this applies to
+//! Windows, which is entirely separate.
+//!
+//! The stack is expected to look pretty standard with a guard page at the end.
+//! Currently allocation happens in this file but this is probably going to be
+//! refactored to happen somewhere else. Otherwise though the stack layout is
+//! expected to look like so:
+//!
+//!
+//! ```text
+//! 0xB000 +-----------------------+   <- top of stack
+//!        | &Cell<RunResult>      |   <- where to store results
+//! 0xAff8 +-----------------------+
+//!        | *const u8             |   <- last sp to resume from
+//! 0xAff0 +-----------------------+   <- 16-byte aligned
+//!        |                       |
+//!        ~        ...            ~   <- actual native stack space to use
+//!        |                       |
+//! 0x1000 +-----------------------+
+//!        |  guard page           |
+//! 0x0000 +-----------------------+
+//! ```
+//!
+//! Here `0xAff8` is filled in temporarily while `resume` is running. The fiber
+//! started with 0xB000 as a parameter so it knows how to find this.
+//! Additionally `resumes` stores state at 0xAff0 to restart execution, and
+//! `suspend`, which has 0xB000 so it can find this, will read that and write
+//! its own resumption information into this slot as well.
+
+use crate::RunResult;
+use std::cell::Cell;
+use std::io;
+use std::ptr;
+
+pub struct Fiber {
+    // Description of the mmap region we own. This should be abstracted
+    // eventually so we aren't personally mmap-ing this region.
+    mmap: *mut libc::c_void,
+    mmap_len: usize,
+}
+
+pub struct Suspend {
+    top_of_stack: *mut u8,
+}
+
+extern "C" {
+    fn wasmtime_fiber_init(
+        top_of_stack: *mut u8,
+        entry: extern "C" fn(*mut u8, *mut u8),
+        entry_arg0: *mut u8,
+    );
+    fn wasmtime_fiber_switch(top_of_stack: *mut u8);
+}
+
+extern "C" fn fiber_start<F, A, B, C>(arg0: *mut u8, top_of_stack: *mut u8)
+where
+    F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+{
+    unsafe {
+        let inner = Suspend { top_of_stack };
+        let initial = inner.take_resume::<A, B, C>();
+        super::Suspend::<A, B, C>::execute(inner, initial, Box::from_raw(arg0.cast::<F>()))
+    }
+}
+
+impl Fiber {
+    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Fiber>
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
+        let fiber = Fiber::alloc_with_stack(stack_size)?;
+        unsafe {
+            // Initialize the top of the stack to be resumed from
+            let top_of_stack = fiber.top_of_stack();
+            let data = Box::into_raw(Box::new(func)).cast();
+            wasmtime_fiber_init(top_of_stack, fiber_start::<F, A, B, C>, data);
+            Ok(fiber)
+        }
+    }
+
+    fn alloc_with_stack(stack_size: usize) -> io::Result<Fiber> {
+        unsafe {
+            // Round up our stack size request to the nearest multiple of the
+            // page size.
+            let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+            let stack_size = if stack_size == 0 {
+                page_size
+            } else {
+                (stack_size + (page_size - 1)) & (!(page_size - 1))
+            };
+
+            // Add in one page for a guard page and then ask for some memory.
+            let mmap_len = stack_size + page_size;
+            let mmap = libc::mmap(
+                ptr::null_mut(),
+                mmap_len,
+                libc::PROT_NONE,
+                libc::MAP_ANON | libc::MAP_PRIVATE,
+                -1,
+                0,
+            );
+            if mmap == libc::MAP_FAILED {
+                return Err(io::Error::last_os_error());
+            }
+            let ret = Fiber { mmap, mmap_len };
+            let res = libc::mprotect(
+                mmap.cast::<u8>().add(page_size).cast(),
+                stack_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+            );
+            if res != 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(ret)
+            }
+        }
+    }
+
+    pub(crate) fn resume<A, B, C>(&self, result: &Cell<RunResult<A, B, C>>) {
+        unsafe {
+            // Store where our result is going at the very tip-top of the
+            // stack, otherwise known as our reserved slot for this information.
+            //
+            // In the diagram above this is updating address 0xAff8
+            let top_of_stack = self.top_of_stack();
+            let addr = top_of_stack.cast::<usize>().offset(-1);
+            addr.write(result as *const _ as usize);
+
+            wasmtime_fiber_switch(top_of_stack);
+
+            // null this out to help catch use-after-free
+            addr.write(0);
+        }
+    }
+
+    unsafe fn top_of_stack(&self) -> *mut u8 {
+        self.mmap.cast::<u8>().add(self.mmap_len)
+    }
+}
+
+impl Drop for Fiber {
+    fn drop(&mut self) {
+        unsafe {
+            let ret = libc::munmap(self.mmap, self.mmap_len);
+            debug_assert!(ret == 0);
+        }
+    }
+}
+
+impl Suspend {
+    pub(crate) fn switch<A, B, C>(&self, result: RunResult<A, B, C>) -> A {
+        unsafe {
+            // Calculate 0xAff8 and then write to it
+            (*self.result_location::<A, B, C>()).set(result);
+            wasmtime_fiber_switch(self.top_of_stack);
+            self.take_resume::<A, B, C>()
+        }
+    }
+
+    unsafe fn take_resume<A, B, C>(&self) -> A {
+        match (*self.result_location::<A, B, C>()).replace(RunResult::Executing) {
+            RunResult::Resuming(val) => val,
+            _ => panic!("not in resuming state"),
+        }
+    }
+
+    unsafe fn result_location<A, B, C>(&self) -> *const Cell<RunResult<A, B, C>> {
+        let ret = self.top_of_stack.cast::<*const u8>().offset(-1).read();
+        assert!(!ret.is_null());
+        return ret.cast();
+    }
+}

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -35,10 +35,10 @@ use std::io;
 use std::ptr;
 
 pub struct Fiber {
-    // Description of the mmap region we own. This should be abstracted
-    // eventually so we aren't personally mmap-ing this region.
-    mmap: *mut libc::c_void,
-    mmap_len: usize,
+    // The top of the stack; for stacks allocated by the fiber implementation itself,
+    // the base address of the allocation will be `top_of_stack.sub(alloc_len.unwrap())`
+    top_of_stack: *mut u8,
+    alloc_len: Option<usize>,
 }
 
 pub struct Suspend {
@@ -66,21 +66,40 @@ where
 }
 
 impl Fiber {
-    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Fiber>
+    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Self>
     where
         F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
     {
-        let fiber = Fiber::alloc_with_stack(stack_size)?;
+        let fiber = Self::alloc_with_stack(stack_size)?;
+        fiber.init(func);
+        Ok(fiber)
+    }
+
+    pub fn new_with_stack<F, A, B, C>(top_of_stack: *mut u8, func: F) -> Self
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
+        let fiber = Self {
+            top_of_stack,
+            alloc_len: None,
+        };
+
+        fiber.init(func);
+
+        fiber
+    }
+
+    fn init<F, A, B, C>(&self, func: F)
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
         unsafe {
-            // Initialize the top of the stack to be resumed from
-            let top_of_stack = fiber.top_of_stack();
             let data = Box::into_raw(Box::new(func)).cast();
-            wasmtime_fiber_init(top_of_stack, fiber_start::<F, A, B, C>, data);
-            Ok(fiber)
+            wasmtime_fiber_init(self.top_of_stack, fiber_start::<F, A, B, C>, data);
         }
     }
 
-    fn alloc_with_stack(stack_size: usize) -> io::Result<Fiber> {
+    fn alloc_with_stack(stack_size: usize) -> io::Result<Self> {
         unsafe {
             // Round up our stack size request to the nearest multiple of the
             // page size.
@@ -104,7 +123,10 @@ impl Fiber {
             if mmap == libc::MAP_FAILED {
                 return Err(io::Error::last_os_error());
             }
-            let ret = Fiber { mmap, mmap_len };
+            let ret = Self {
+                top_of_stack: mmap.cast::<u8>().add(mmap_len),
+                alloc_len: Some(mmap_len),
+            };
             let res = libc::mprotect(
                 mmap.cast::<u8>().add(page_size).cast(),
                 stack_size,
@@ -124,27 +146,24 @@ impl Fiber {
             // stack, otherwise known as our reserved slot for this information.
             //
             // In the diagram above this is updating address 0xAff8
-            let top_of_stack = self.top_of_stack();
-            let addr = top_of_stack.cast::<usize>().offset(-1);
+            let addr = self.top_of_stack.cast::<usize>().offset(-1);
             addr.write(result as *const _ as usize);
 
-            wasmtime_fiber_switch(top_of_stack);
+            wasmtime_fiber_switch(self.top_of_stack);
 
             // null this out to help catch use-after-free
             addr.write(0);
         }
-    }
-
-    unsafe fn top_of_stack(&self) -> *mut u8 {
-        self.mmap.cast::<u8>().add(self.mmap_len)
     }
 }
 
 impl Drop for Fiber {
     fn drop(&mut self) {
         unsafe {
-            let ret = libc::munmap(self.mmap, self.mmap_len);
-            debug_assert!(ret == 0);
+            if let Some(alloc_len) = self.alloc_len {
+                let ret = libc::munmap(self.top_of_stack.sub(alloc_len) as _, alloc_len);
+                debug_assert!(ret == 0);
+            }
         }
     }
 }

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -40,7 +40,7 @@ where
 }
 
 impl Fiber {
-    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Fiber>
+    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Self>
     where
         F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
     {
@@ -61,9 +61,17 @@ impl Fiber {
                 drop(Box::from_raw(state.initial_closure.get().cast::<F>()));
                 Err(io::Error::last_os_error())
             } else {
-                Ok(Fiber { fiber, state })
+                Ok(Self { fiber, state })
             }
         }
+    }
+
+    pub fn new_with_stack<F, A, B, C>(_top_of_stack: *mut u8, _func: F) -> Self
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
+        // Windows fibers have no support for custom stacks
+        unimplemented!()
     }
 
     pub(crate) fn resume<A, B, C>(&self, result: &Cell<RunResult<A, B, C>>) {

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -1,0 +1,126 @@
+use crate::RunResult;
+use std::cell::Cell;
+use std::io;
+use std::ptr;
+use winapi::shared::minwindef::*;
+use winapi::um::fibersapi::*;
+use winapi::um::winbase::*;
+
+pub struct Fiber {
+    fiber: LPVOID,
+    state: Box<StartState>,
+}
+
+pub struct Suspend {
+    state: *const StartState,
+}
+
+struct StartState {
+    parent: Cell<LPVOID>,
+    initial_closure: Cell<*mut u8>,
+    result_location: Cell<*const u8>,
+}
+
+extern "C" {
+    fn wasmtime_fiber_get_current() -> LPVOID;
+}
+
+unsafe extern "system" fn fiber_start<F, A, B, C>(data: LPVOID)
+where
+    F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+{
+    let state = data.cast::<StartState>();
+    let func = Box::from_raw((*state).initial_closure.get().cast::<F>());
+    (*state).initial_closure.set(ptr::null_mut());
+    let suspend = Suspend { state };
+    let initial = suspend.take_resume::<A, B, C>();
+    super::Suspend::<A, B, C>::execute(suspend, initial, *func);
+}
+
+impl Fiber {
+    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Fiber>
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
+        unsafe {
+            let state = Box::new(StartState {
+                initial_closure: Cell::new(Box::into_raw(Box::new(func)).cast()),
+                parent: Cell::new(ptr::null_mut()),
+                result_location: Cell::new(ptr::null()),
+            });
+            let fiber = CreateFiber(
+                stack_size,
+                Some(fiber_start::<F, A, B, C>),
+                &*state as *const StartState as *mut _,
+            );
+            if fiber.is_null() {
+                drop(Box::from_raw(state.initial_closure.get().cast::<F>()));
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(Fiber { fiber, state })
+            }
+        }
+    }
+
+    pub(crate) fn resume<A, B, C>(&self, result: &Cell<RunResult<A, B, C>>) {
+        unsafe {
+            let is_fiber = IsThreadAFiber() != 0;
+            let parent_fiber = if is_fiber {
+                wasmtime_fiber_get_current()
+            } else {
+                ConvertThreadToFiber(ptr::null_mut())
+            };
+            assert!(
+                !parent_fiber.is_null(),
+                "failed to make current thread a fiber"
+            );
+            self.state
+                .result_location
+                .set(result as *const _ as *const _);
+            self.state.parent.set(parent_fiber);
+            SwitchToFiber(self.fiber);
+            self.state.parent.set(ptr::null_mut());
+            self.state.result_location.set(ptr::null());
+            if !is_fiber {
+                let res = ConvertFiberToThread();
+                assert!(res != 0, "failed to convert main thread back");
+            }
+        }
+    }
+}
+
+impl Drop for Fiber {
+    fn drop(&mut self) {
+        unsafe {
+            DeleteFiber(self.fiber);
+        }
+    }
+}
+
+impl Suspend {
+    pub(crate) fn switch<A, B, C>(&self, result: RunResult<A, B, C>) -> A {
+        unsafe {
+            (*self.result_location::<A, B, C>()).set(result);
+            debug_assert!(IsThreadAFiber() != 0);
+            let parent = (*self.state).parent.get();
+            debug_assert!(!parent.is_null());
+            SwitchToFiber(parent);
+            self.take_resume::<A, B, C>()
+        }
+    }
+    unsafe fn take_resume<A, B, C>(&self) -> A {
+        match (*self.result_location::<A, B, C>()).replace(RunResult::Executing) {
+            RunResult::Resuming(val) => val,
+            _ => panic!("not in resuming state"),
+        }
+    }
+
+    unsafe fn result_location<A, B, C>(&self) -> *const Cell<RunResult<A, B, C>> {
+        let ret = (*self.state)
+            .result_location
+            .get()
+            .cast::<Cell<RunResult<A, B, C>>>();
+        assert!(!ret.is_null());
+        return ret;
+    }
+}

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -21,6 +21,8 @@ struct StartState {
     result_location: Cell<*const u8>,
 }
 
+const FIBER_FLAG_FLOAT_SWITCH: DWORD = 1;
+
 extern "C" {
     fn wasmtime_fiber_get_current() -> LPVOID;
 }
@@ -48,8 +50,10 @@ impl Fiber {
                 parent: Cell::new(ptr::null_mut()),
                 result_location: Cell::new(ptr::null()),
             });
-            let fiber = CreateFiber(
+            let fiber = CreateFiberEx(
+                0,
                 stack_size,
+                FIBER_FLAG_FLOAT_SWITCH,
                 Some(fiber_start::<F, A, B, C>),
                 &*state as *const StartState as *mut _,
             );

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -33,3 +33,9 @@ cc = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+default = ["async"]
+
+# Enables support for "async" fiber stacks in the instance allocator
+async = []

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -4,12 +4,11 @@
 
 use crate::export::Export;
 use crate::externref::{StackMapRegistry, VMExternRefActivationsTable};
-use crate::imports::Imports;
-use crate::memory::{DefaultMemoryCreator, RuntimeLinearMemory, RuntimeMemoryCreator};
+use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 use crate::table::{Table, TableElement};
 use crate::traphandlers::Trap;
 use crate::vmcontext::{
-    VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport,
+    VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionImport,
     VMGlobalDefinition, VMGlobalImport, VMInterrupts, VMMemoryDefinition, VMMemoryImport,
     VMSharedSignatureIndex, VMTableDefinition, VMTableImport,
 };
@@ -17,23 +16,24 @@ use crate::{ExportFunction, ExportGlobal, ExportMemory, ExportTable};
 use indexmap::IndexMap;
 use memoffset::offset_of;
 use more_asserts::assert_lt;
-use std::alloc::{self, Layout};
+use std::alloc::Layout;
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{mem, ptr, slice};
-use thiserror::Error;
-use wasmtime_environ::entity::{packed_option::ReservedValue, BoxedSlice, EntityRef, PrimaryMap};
+use wasmtime_environ::entity::{packed_option::ReservedValue, BoxedSlice, EntityRef, EntitySet};
 use wasmtime_environ::wasm::{
-    DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
-    ElemIndex, EntityIndex, FuncIndex, GlobalIndex, GlobalInit, MemoryIndex, SignatureIndex,
-    TableElementType, TableIndex, WasmType,
+    DataIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, ElemIndex, EntityIndex,
+    FuncIndex, GlobalIndex, MemoryIndex, TableElementType, TableIndex,
 };
-use wasmtime_environ::{ir, DataInitializer, Module, ModuleType, TableElements, VMOffsets};
+use wasmtime_environ::{ir, Module, VMOffsets};
+
+mod allocator;
+
+pub use allocator::*;
 
 /// Runtime representation of an instance value, which erases all `Instance`
 /// information since instances are just a collection of values.
@@ -56,14 +56,13 @@ pub(crate) struct Instance {
     /// WebAssembly table data.
     tables: BoxedSlice<DefinedTableIndex, Table>,
 
-    /// Passive elements in this instantiation. As `elem.drop`s happen, these
-    /// entries get removed. A missing entry is considered equivalent to an
-    /// empty slice.
-    passive_elements: RefCell<HashMap<ElemIndex, Box<[*mut VMCallerCheckedAnyfunc]>>>,
+    /// Stores the dropped passive element segments in this instantiation by index.
+    /// If the index is present in the set, the segment has been dropped.
+    dropped_elements: RefCell<EntitySet<ElemIndex>>,
 
-    /// Passive data segments from our module. As `data.drop`s happen, entries
-    /// get removed. A missing entry is considered equivalent to an empty slice.
-    passive_data: RefCell<HashMap<DataIndex, Arc<[u8]>>>,
+    /// Stores the dropped passive data segments in this instantiation by index.
+    /// If the index is present in the set, the segment has been dropped.
+    dropped_data: RefCell<EntitySet<DataIndex>>,
 
     /// Hosts can store arbitrary per-instance information here.
     host_state: Box<dyn Any>,
@@ -551,11 +550,21 @@ impl Instance {
         // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-table-init
 
         let table = self.get_table(table_index);
-        let passive_elements = self.passive_elements.borrow();
-        let elem = passive_elements
-            .get(&elem_index)
-            .map(|e| &**e)
-            .unwrap_or_else(|| &[]);
+        let elem_index = self.module.passive_elements_map.get(&elem_index);
+        let elem = match elem_index {
+            Some(index) => {
+                if self
+                    .dropped_elements
+                    .borrow()
+                    .contains(ElemIndex::new(*index))
+                {
+                    &[]
+                } else {
+                    self.module.passive_elements[*index].as_ref()
+                }
+            }
+            None => &[],
+        };
 
         if src
             .checked_add(len)
@@ -567,8 +576,14 @@ impl Instance {
 
         // TODO(#983): investigate replacing this get/set loop with a `memcpy`.
         for (dst, src) in (dst..dst + len).zip(src..src + len) {
+            let elem = self
+                .get_caller_checked_anyfunc(elem[src as usize])
+                .map_or(ptr::null_mut(), |f: &VMCallerCheckedAnyfunc| {
+                    f as *const VMCallerCheckedAnyfunc as *mut _
+                });
+
             table
-                .set(dst, TableElement::FuncRef(elem[src as usize]))
+                .set(dst, TableElement::FuncRef(elem))
                 .expect("should never panic because we already did the bounds check above");
         }
 
@@ -579,10 +594,14 @@ impl Instance {
     pub(crate) fn elem_drop(&self, elem_index: ElemIndex) {
         // https://webassembly.github.io/reference-types/core/exec/instructions.html#exec-elem-drop
 
-        let mut passive_elements = self.passive_elements.borrow_mut();
-        passive_elements.remove(&elem_index);
-        // Note that we don't check that we actually removed an element because
-        // dropping a non-passive element is a no-op (not a trap).
+        if let Some(index) = self.module.passive_elements_map.get(&elem_index) {
+            self.dropped_elements
+                .borrow_mut()
+                .insert(ElemIndex::new(*index));
+        }
+
+        // Note that we don't check that we actually removed a segment because
+        // dropping a non-passive segment is a no-op (not a trap).
     }
 
     /// Do a `memory.copy`
@@ -701,10 +720,17 @@ impl Instance {
         // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-memory-init
 
         let memory = self.get_memory(memory_index);
-        let passive_data = self.passive_data.borrow();
-        let data = passive_data
-            .get(&data_index)
-            .map_or(&[][..], |data| &**data);
+        let data_index = self.module.passive_data_map.get(&data_index);
+        let data = match data_index {
+            Some(index) => {
+                if self.dropped_data.borrow().contains(DataIndex::new(*index)) {
+                    &[]
+                } else {
+                    self.module.passive_data[*index].as_ref()
+                }
+            }
+            None => &[],
+        };
 
         if src
             .checked_add(len)
@@ -729,8 +755,14 @@ impl Instance {
 
     /// Drop the given data segment, truncating its length to zero.
     pub(crate) fn data_drop(&self, data_index: DataIndex) {
-        let mut passive_data = self.passive_data.borrow_mut();
-        passive_data.remove(&data_index);
+        if let Some(index) = self.module.passive_data_map.get(&data_index) {
+            self.dropped_data
+                .borrow_mut()
+                .insert(DataIndex::new(*index));
+        }
+
+        // Note that we don't check that we actually removed a segment because
+        // dropping a non-passive segment is a no-op (not a trap).
     }
 
     /// Get a table by index regardless of whether it is locally-defined or an
@@ -780,197 +812,8 @@ pub struct InstanceHandle {
 }
 
 impl InstanceHandle {
-    /// Create a new `InstanceHandle` pointing at a new `Instance`.
-    ///
-    /// # Unsafety
-    ///
-    /// This method is not necessarily inherently unsafe to call, but in general
-    /// the APIs of an `Instance` are quite unsafe and have not been really
-    /// audited for safety that much. As a result the unsafety here on this
-    /// method is a low-overhead way of saying "this is an extremely unsafe type
-    /// to work with".
-    ///
-    /// Extreme care must be taken when working with `InstanceHandle` and it's
-    /// recommended to have relatively intimate knowledge of how it works
-    /// internally if you'd like to do so. If possible it's recommended to use
-    /// the `wasmtime` crate API rather than this type since that is vetted for
-    /// safety.
-    ///
-    /// It is your responsibility to ensure that the given raw
-    /// `externref_activations_table` and `stack_map_registry` outlive this
-    /// instance.
-    pub unsafe fn new(
-        module: Arc<Module>,
-        finished_functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
-        imports: Imports,
-        mem_creator: Option<&dyn RuntimeMemoryCreator>,
-        lookup_shared_signature: &dyn Fn(SignatureIndex) -> VMSharedSignatureIndex,
-        host_state: Box<dyn Any>,
-        interrupts: *const VMInterrupts,
-        externref_activations_table: *mut VMExternRefActivationsTable,
-        stack_map_registry: *mut StackMapRegistry,
-    ) -> Result<Self, InstantiationError> {
-        debug_assert!(!externref_activations_table.is_null());
-        debug_assert!(!stack_map_registry.is_null());
-
-        let tables = create_tables(&module);
-        let memories = create_memories(&module, mem_creator.unwrap_or(&DefaultMemoryCreator {}))?;
-
-        let vmctx_tables = tables
-            .values()
-            .map(Table::vmtable)
-            .collect::<PrimaryMap<DefinedTableIndex, _>>()
-            .into_boxed_slice();
-
-        let vmctx_memories = memories
-            .values()
-            .map(|a| a.vmmemory())
-            .collect::<PrimaryMap<DefinedMemoryIndex, _>>()
-            .into_boxed_slice();
-
-        let vmctx_globals = create_globals(&module);
-
-        let offsets = VMOffsets::new(mem::size_of::<*const u8>() as u8, &module);
-
-        let passive_data = RefCell::new(module.passive_data.clone());
-
-        let handle = {
-            let instance = Instance {
-                module,
-                offsets,
-                memories,
-                tables,
-                passive_elements: Default::default(),
-                passive_data,
-                host_state,
-                vmctx: VMContext {},
-            };
-            let layout = instance.alloc_layout();
-            let instance_ptr = alloc::alloc(layout) as *mut Instance;
-            if instance_ptr.is_null() {
-                alloc::handle_alloc_error(layout);
-            }
-            ptr::write(instance_ptr, instance);
-            InstanceHandle {
-                instance: instance_ptr,
-            }
-        };
-        let instance = handle.instance();
-
-        let mut ptr = instance.signature_ids_ptr();
-        for sig in handle.module().types.values() {
-            *ptr = match sig {
-                ModuleType::Function(sig) => lookup_shared_signature(*sig),
-                _ => VMSharedSignatureIndex::new(u32::max_value()),
-            };
-            ptr = ptr.add(1);
-        }
-
-        debug_assert_eq!(imports.functions.len(), handle.module().num_imported_funcs);
-        ptr::copy(
-            imports.functions.as_ptr(),
-            instance.imported_functions_ptr() as *mut VMFunctionImport,
-            imports.functions.len(),
-        );
-        debug_assert_eq!(imports.tables.len(), handle.module().num_imported_tables);
-        ptr::copy(
-            imports.tables.as_ptr(),
-            instance.imported_tables_ptr() as *mut VMTableImport,
-            imports.tables.len(),
-        );
-        debug_assert_eq!(
-            imports.memories.len(),
-            handle.module().num_imported_memories
-        );
-        ptr::copy(
-            imports.memories.as_ptr(),
-            instance.imported_memories_ptr() as *mut VMMemoryImport,
-            imports.memories.len(),
-        );
-        debug_assert_eq!(imports.globals.len(), handle.module().num_imported_globals);
-        ptr::copy(
-            imports.globals.as_ptr(),
-            instance.imported_globals_ptr() as *mut VMGlobalImport,
-            imports.globals.len(),
-        );
-        ptr::copy(
-            vmctx_tables.values().as_slice().as_ptr(),
-            instance.tables_ptr() as *mut VMTableDefinition,
-            vmctx_tables.len(),
-        );
-        ptr::copy(
-            vmctx_memories.values().as_slice().as_ptr(),
-            instance.memories_ptr() as *mut VMMemoryDefinition,
-            vmctx_memories.len(),
-        );
-        ptr::copy(
-            vmctx_globals.values().as_slice().as_ptr(),
-            instance.globals_ptr() as *mut VMGlobalDefinition,
-            vmctx_globals.len(),
-        );
-        ptr::write(
-            instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
-            VMBuiltinFunctionsArray::initialized(),
-        );
-        *instance.interrupts() = interrupts;
-        *instance.externref_activations_table() = externref_activations_table;
-        *instance.stack_map_registry() = stack_map_registry;
-
-        for (index, sig) in instance.module.functions.iter() {
-            let type_index = lookup_shared_signature(*sig);
-
-            let (func_ptr, vmctx) =
-                if let Some(def_index) = instance.module.defined_func_index(index) {
-                    (
-                        NonNull::new(finished_functions[def_index] as *mut _).unwrap(),
-                        instance.vmctx_ptr(),
-                    )
-                } else {
-                    let import = instance.imported_function(index);
-                    (import.body, import.vmctx)
-                };
-
-            ptr::write(
-                instance.anyfunc_ptr(index),
-                VMCallerCheckedAnyfunc {
-                    func_ptr,
-                    type_index,
-                    vmctx,
-                },
-            );
-        }
-
-        // Perform infallible initialization in this constructor, while fallible
-        // initialization is deferred to the `initialize` method.
-        initialize_passive_elements(instance);
-        initialize_globals(instance);
-
-        Ok(handle)
-    }
-
-    /// Finishes the instantiation process started by `Instance::new`.
-    ///
-    /// Only safe to call immediately after instantiation.
-    pub unsafe fn initialize(
-        &self,
-        is_bulk_memory: bool,
-        data_initializers: &[DataInitializer<'_>],
-    ) -> Result<(), InstantiationError> {
-        // Check initializer bounds before initializing anything. Only do this
-        // when bulk memory is disabled, since the bulk memory proposal changes
-        // instantiation such that the intermediate results of failed
-        // initializations are visible.
-        if !is_bulk_memory {
-            check_table_init_bounds(self.instance())?;
-            check_memory_init_bounds(self.instance(), data_initializers)?;
-        }
-
-        // Apply fallible initializers. Note that this can "leak" state even if
-        // it fails.
-        initialize_tables(self.instance())?;
-        initialize_memories(self.instance(), data_initializers)?;
-
-        Ok(())
+    pub(crate) unsafe fn new(instance: *mut Instance) -> Self {
+        Self { instance }
     }
 
     /// Create a new `InstanceHandle` pointing at the instance
@@ -1126,305 +969,4 @@ impl InstanceHandle {
             instance: self.instance,
         }
     }
-
-    /// Deallocates memory associated with this instance.
-    ///
-    /// Note that this is unsafe because there might be other handles to this
-    /// `InstanceHandle` elsewhere, and there's nothing preventing usage of
-    /// this handle after this function is called.
-    pub unsafe fn dealloc(&self) {
-        let instance = self.instance();
-        let layout = instance.alloc_layout();
-        ptr::drop_in_place(self.instance);
-        alloc::dealloc(self.instance.cast(), layout);
-    }
-}
-
-fn check_table_init_bounds(instance: &Instance) -> Result<(), InstantiationError> {
-    for init in &instance.module().table_elements {
-        let start = get_table_init_start(init, instance);
-        let table = instance.get_table(init.table_index);
-
-        let size = usize::try_from(table.size()).unwrap();
-        if size < start + init.elements.len() {
-            return Err(InstantiationError::Link(LinkError(
-                "table out of bounds: elements segment does not fit".to_owned(),
-            )));
-        }
-    }
-
-    Ok(())
-}
-
-/// Compute the offset for a memory data initializer.
-fn get_memory_init_start(init: &DataInitializer<'_>, instance: &Instance) -> usize {
-    let mut start = init.location.offset;
-
-    if let Some(base) = init.location.base {
-        let val = unsafe {
-            if let Some(def_index) = instance.module.defined_global_index(base) {
-                *instance.global(def_index).as_u32()
-            } else {
-                *(*instance.imported_global(base).from).as_u32()
-            }
-        };
-        start += usize::try_from(val).unwrap();
-    }
-
-    start
-}
-
-/// Return a byte-slice view of a memory's data.
-unsafe fn get_memory_slice<'instance>(
-    init: &DataInitializer<'_>,
-    instance: &'instance Instance,
-) -> &'instance mut [u8] {
-    let memory = if let Some(defined_memory_index) = instance
-        .module
-        .defined_memory_index(init.location.memory_index)
-    {
-        instance.memory(defined_memory_index)
-    } else {
-        let import = instance.imported_memory(init.location.memory_index);
-        let foreign_instance = (&mut *(import).vmctx).instance();
-        let foreign_memory = &mut *(import).from;
-        let foreign_index = foreign_instance.memory_index(foreign_memory);
-        foreign_instance.memory(foreign_index)
-    };
-    slice::from_raw_parts_mut(memory.base, memory.current_length)
-}
-
-fn check_memory_init_bounds(
-    instance: &Instance,
-    data_initializers: &[DataInitializer<'_>],
-) -> Result<(), InstantiationError> {
-    for init in data_initializers {
-        let start = get_memory_init_start(init, instance);
-        unsafe {
-            let mem_slice = get_memory_slice(init, instance);
-            if mem_slice.get_mut(start..start + init.data.len()).is_none() {
-                return Err(InstantiationError::Link(LinkError(
-                    "memory out of bounds: data segment does not fit".into(),
-                )));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Allocate memory for just the tables of the current module.
-fn create_tables(module: &Module) -> BoxedSlice<DefinedTableIndex, Table> {
-    let num_imports = module.num_imported_tables;
-    let mut tables: PrimaryMap<DefinedTableIndex, _> =
-        PrimaryMap::with_capacity(module.table_plans.len() - num_imports);
-    for table in &module.table_plans.values().as_slice()[num_imports..] {
-        tables.push(Table::new(table));
-    }
-    tables.into_boxed_slice()
-}
-
-/// Compute the offset for a table element initializer.
-fn get_table_init_start(init: &TableElements, instance: &Instance) -> usize {
-    let mut start = init.offset;
-
-    if let Some(base) = init.base {
-        let val = unsafe {
-            if let Some(def_index) = instance.module.defined_global_index(base) {
-                *instance.global(def_index).as_u32()
-            } else {
-                *(*instance.imported_global(base).from).as_u32()
-            }
-        };
-        start += usize::try_from(val).unwrap();
-    }
-
-    start
-}
-
-/// Initialize the table memory from the provided initializers.
-fn initialize_tables(instance: &Instance) -> Result<(), InstantiationError> {
-    for init in &instance.module().table_elements {
-        let start = get_table_init_start(init, instance);
-        let table = instance.get_table(init.table_index);
-
-        if start
-            .checked_add(init.elements.len())
-            .map_or(true, |end| end > table.size() as usize)
-        {
-            return Err(InstantiationError::Trap(Trap::wasm(
-                ir::TrapCode::TableOutOfBounds,
-            )));
-        }
-
-        for (i, func_idx) in init.elements.iter().enumerate() {
-            let item = match table.element_type() {
-                TableElementType::Func => instance
-                    .get_caller_checked_anyfunc(*func_idx)
-                    .map_or(ptr::null_mut(), |f: &VMCallerCheckedAnyfunc| {
-                        f as *const VMCallerCheckedAnyfunc as *mut VMCallerCheckedAnyfunc
-                    })
-                    .into(),
-                TableElementType::Val(_) => {
-                    assert!(*func_idx == FuncIndex::reserved_value());
-                    TableElement::ExternRef(None)
-                }
-            };
-            table.set(u32::try_from(start + i).unwrap(), item).unwrap();
-        }
-    }
-
-    Ok(())
-}
-
-/// Initialize the `Instance::passive_elements` map by resolving the
-/// `Module::passive_elements`'s `FuncIndex`s into `VMCallerCheckedAnyfunc`s for
-/// this instance.
-fn initialize_passive_elements(instance: &Instance) {
-    let mut passive_elements = instance.passive_elements.borrow_mut();
-    debug_assert!(
-        passive_elements.is_empty(),
-        "should only be called once, at initialization time"
-    );
-
-    passive_elements.extend(
-        instance
-            .module
-            .passive_elements
-            .iter()
-            .filter(|(_, segments)| !segments.is_empty())
-            .map(|(idx, segments)| {
-                (
-                    *idx,
-                    segments
-                        .iter()
-                        .map(|s| {
-                            instance.get_caller_checked_anyfunc(*s).map_or(
-                                ptr::null_mut(),
-                                |f: &VMCallerCheckedAnyfunc| {
-                                    f as *const VMCallerCheckedAnyfunc as *mut _
-                                },
-                            )
-                        })
-                        .collect(),
-                )
-            }),
-    );
-}
-
-/// Allocate memory for just the memories of the current module.
-fn create_memories(
-    module: &Module,
-    mem_creator: &dyn RuntimeMemoryCreator,
-) -> Result<BoxedSlice<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>, InstantiationError> {
-    let num_imports = module.num_imported_memories;
-    let mut memories: PrimaryMap<DefinedMemoryIndex, _> =
-        PrimaryMap::with_capacity(module.memory_plans.len() - num_imports);
-    for plan in &module.memory_plans.values().as_slice()[num_imports..] {
-        memories.push(
-            mem_creator
-                .new_memory(plan)
-                .map_err(InstantiationError::Resource)?,
-        );
-    }
-    Ok(memories.into_boxed_slice())
-}
-
-/// Initialize the table memory from the provided initializers.
-fn initialize_memories(
-    instance: &Instance,
-    data_initializers: &[DataInitializer<'_>],
-) -> Result<(), InstantiationError> {
-    for init in data_initializers {
-        let memory = instance.get_memory(init.location.memory_index);
-
-        let start = get_memory_init_start(init, instance);
-        if start
-            .checked_add(init.data.len())
-            .map_or(true, |end| end > memory.current_length)
-        {
-            return Err(InstantiationError::Trap(Trap::wasm(
-                ir::TrapCode::HeapOutOfBounds,
-            )));
-        }
-
-        unsafe {
-            let mem_slice = get_memory_slice(init, instance);
-            let end = start + init.data.len();
-            let to_init = &mut mem_slice[start..end];
-            to_init.copy_from_slice(init.data);
-        }
-    }
-
-    Ok(())
-}
-
-/// Allocate memory for just the globals of the current module,
-/// with initializers applied.
-fn create_globals(module: &Module) -> BoxedSlice<DefinedGlobalIndex, VMGlobalDefinition> {
-    let num_imports = module.num_imported_globals;
-    let mut vmctx_globals = PrimaryMap::with_capacity(module.globals.len() - num_imports);
-
-    for _ in &module.globals.values().as_slice()[num_imports..] {
-        vmctx_globals.push(VMGlobalDefinition::new());
-    }
-
-    vmctx_globals.into_boxed_slice()
-}
-
-fn initialize_globals(instance: &Instance) {
-    let module = instance.module();
-    let num_imports = module.num_imported_globals;
-    for (index, global) in module.globals.iter().skip(num_imports) {
-        let def_index = module.defined_global_index(index).unwrap();
-        unsafe {
-            let to = instance.global_ptr(def_index);
-            match global.initializer {
-                GlobalInit::I32Const(x) => *(*to).as_i32_mut() = x,
-                GlobalInit::I64Const(x) => *(*to).as_i64_mut() = x,
-                GlobalInit::F32Const(x) => *(*to).as_f32_bits_mut() = x,
-                GlobalInit::F64Const(x) => *(*to).as_f64_bits_mut() = x,
-                GlobalInit::V128Const(x) => *(*to).as_u128_bits_mut() = x.0,
-                GlobalInit::GetGlobal(x) => {
-                    let from = if let Some(def_x) = module.defined_global_index(x) {
-                        instance.global(def_x)
-                    } else {
-                        *instance.imported_global(x).from
-                    };
-                    *to = from;
-                }
-                GlobalInit::RefFunc(f) => {
-                    *(*to).as_anyfunc_mut() = instance.get_caller_checked_anyfunc(f).unwrap()
-                        as *const VMCallerCheckedAnyfunc;
-                }
-                GlobalInit::RefNullConst => match global.wasm_ty {
-                    WasmType::FuncRef => *(*to).as_anyfunc_mut() = ptr::null(),
-                    WasmType::ExternRef => *(*to).as_externref_mut() = None,
-                    ty => panic!("unsupported reference type for global: {:?}", ty),
-                },
-                GlobalInit::Import => panic!("locally-defined global initialized as import"),
-            }
-        }
-    }
-}
-
-/// An link error while instantiating a module.
-#[derive(Error, Debug)]
-#[error("Link error: {0}")]
-pub struct LinkError(pub String);
-
-/// An error while instantiating a module.
-#[derive(Error, Debug)]
-pub enum InstantiationError {
-    /// Insufficient resources available for execution.
-    #[error("Insufficient resources: {0}")]
-    Resource(String),
-
-    /// A wasm link error occured.
-    #[error("Failed to link module")]
-    Link(#[from] LinkError),
-
-    /// A trap ocurred during instantiation, after linking.
-    #[error("Trap occurred during instantiation")]
-    Trap(Trap),
 }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -4,7 +4,7 @@
 
 use crate::export::Export;
 use crate::externref::{StackMapRegistry, VMExternRefActivationsTable};
-use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
+use crate::memory::{Memory, RuntimeMemoryCreator};
 use crate::table::{Table, TableElement};
 use crate::traphandlers::Trap;
 use crate::vmcontext::{
@@ -51,7 +51,7 @@ pub(crate) struct Instance {
     offsets: VMOffsets,
 
     /// WebAssembly linear memory data.
-    memories: PrimaryMap<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>,
+    memories: PrimaryMap<DefinedMemoryIndex, Memory>,
 
     /// WebAssembly table data.
     tables: PrimaryMap<DefinedTableIndex, Table>,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -24,7 +24,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{mem, ptr, slice};
-use wasmtime_environ::entity::{packed_option::ReservedValue, BoxedSlice, EntityRef, EntitySet};
+use wasmtime_environ::entity::{packed_option::ReservedValue, EntityRef, EntitySet, PrimaryMap};
 use wasmtime_environ::wasm::{
     DataIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, ElemIndex, EntityIndex,
     FuncIndex, GlobalIndex, MemoryIndex, TableElementType, TableIndex,
@@ -51,10 +51,10 @@ pub(crate) struct Instance {
     offsets: VMOffsets,
 
     /// WebAssembly linear memory data.
-    memories: BoxedSlice<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>,
+    memories: PrimaryMap<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>,
 
     /// WebAssembly table data.
-    tables: BoxedSlice<DefinedTableIndex, Table>,
+    tables: PrimaryMap<DefinedTableIndex, Table>,
 
     /// Stores the dropped passive element segments in this instantiation by index.
     /// If the index is present in the set, the segment has been dropped.

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -24,7 +24,9 @@ use wasmtime_environ::wasm::{
     DefinedFuncIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GlobalInit, SignatureIndex,
     TableElementType, WasmType,
 };
-use wasmtime_environ::{ir, Module, ModuleType, OwnedDataInitializer, TableElements, VMOffsets};
+use wasmtime_environ::{
+    ir, Module, ModuleTranslation, ModuleType, OwnedDataInitializer, TableElements, VMOffsets,
+};
 
 /// Represents a request for a new runtime instance.
 pub struct InstanceAllocationRequest<'a> {
@@ -80,6 +82,21 @@ pub enum InstantiationError {
 ///
 /// This trait is unsafe as it requires knowledge of Wasmtime's runtime internals to implement correctly.
 pub unsafe trait InstanceAllocator: Send + Sync {
+    /// Validates a module translation.
+    ///
+    /// This is used to ensure a module being compiled is supported by the instance allocator.
+    fn validate_module(&self, translation: &ModuleTranslation) -> Result<(), String> {
+        drop(translation);
+        Ok(())
+    }
+
+    /// Adjusts the tunables prior to creation of any JIT compiler.
+    ///
+    /// This method allows the instance allocator control over tunables passed to a `wasmtime_jit::Compiler`.
+    fn adjust_tunables(&self, tunables: &mut wasmtime_environ::Tunables) {
+        drop(tunables);
+    }
+
     /// Allocates an instance for the given allocation request.
     ///
     /// # Safety

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -1,0 +1,536 @@
+use crate::externref::{StackMapRegistry, VMExternRefActivationsTable};
+use crate::imports::Imports;
+use crate::instance::{Instance, InstanceHandle, RuntimeMemoryCreator};
+use crate::memory::{DefaultMemoryCreator, RuntimeLinearMemory};
+use crate::table::{Table, TableElement};
+use crate::traphandlers::Trap;
+use crate::vmcontext::{
+    VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport,
+    VMGlobalDefinition, VMGlobalImport, VMInterrupts, VMMemoryDefinition, VMMemoryImport,
+    VMSharedSignatureIndex, VMTableDefinition, VMTableImport,
+};
+use std::alloc;
+use std::any::Any;
+use std::cell::RefCell;
+use std::convert::TryFrom;
+use std::ptr::{self, NonNull};
+use std::slice;
+use std::sync::Arc;
+use thiserror::Error;
+use wasmtime_environ::entity::{
+    packed_option::ReservedValue, BoxedSlice, EntityRef, EntitySet, PrimaryMap,
+};
+use wasmtime_environ::wasm::{
+    DefinedFuncIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GlobalInit, SignatureIndex,
+    TableElementType, WasmType,
+};
+use wasmtime_environ::{ir, Module, ModuleType, OwnedDataInitializer, TableElements, VMOffsets};
+
+/// Represents a request for a new runtime instance.
+pub struct InstanceAllocationRequest<'a> {
+    /// The module being instantiated.
+    pub module: Arc<Module>,
+
+    /// The finished (JIT) functions for the module.
+    pub finished_functions: &'a PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+
+    /// The imports to use for the instantiation.
+    pub imports: Imports<'a>,
+
+    /// A callback for looking up shared signature indexes.
+    pub lookup_shared_signature: &'a dyn Fn(SignatureIndex) -> VMSharedSignatureIndex,
+
+    /// The host state to associate with the instance.
+    pub host_state: Box<dyn Any>,
+
+    /// The pointer to the VM interrupts structure to use for the instance.
+    pub interrupts: *const VMInterrupts,
+
+    /// The pointer to the reference activations table to use for the instance.
+    pub externref_activations_table: *mut VMExternRefActivationsTable,
+
+    /// The pointer to the stack map registry to use for the instance.
+    pub stack_map_registry: *mut StackMapRegistry,
+}
+
+/// An link error while instantiating a module.
+#[derive(Error, Debug)]
+#[error("Link error: {0}")]
+pub struct LinkError(pub String);
+
+/// An error while instantiating a module.
+#[derive(Error, Debug)]
+pub enum InstantiationError {
+    /// Insufficient resources available for execution.
+    #[error("Insufficient resources: {0}")]
+    Resource(String),
+
+    /// A wasm link error occured.
+    #[error("Failed to link module")]
+    Link(#[from] LinkError),
+
+    /// A trap ocurred during instantiation, after linking.
+    #[error("Trap occurred during instantiation")]
+    Trap(Trap),
+}
+
+/// Represents a runtime instance allocator.
+///
+/// # Safety
+///
+/// This trait is unsafe as it requires knowledge of Wasmtime's runtime internals to implement correctly.
+pub unsafe trait InstanceAllocator: Send + Sync {
+    /// Allocates an instance for the given allocation request.
+    ///
+    /// # Safety
+    ///
+    /// This method is not inherently unsafe, but care must be made to ensure
+    /// pointers passed in the allocation request outlive the returned instance.
+    unsafe fn allocate(
+        &self,
+        req: InstanceAllocationRequest,
+    ) -> Result<InstanceHandle, InstantiationError>;
+
+    /// Finishes the instantiation process started by an instance allocator.
+    ///
+    /// # Safety
+    ///
+    /// This method is only safe to call immediately after an instance has been allocated.
+    unsafe fn initialize(
+        &self,
+        handle: &InstanceHandle,
+        is_bulk_memory: bool,
+        data_initializers: &Arc<[OwnedDataInitializer]>,
+    ) -> Result<(), InstantiationError>;
+
+    /// Deallocates a previously allocated instance.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because there are no guarantees that the given handle
+    /// is the only owner of the underlying instance to deallocate.
+    ///
+    /// Use extreme care when deallocating an instance so that there are no dangling instance pointers.
+    unsafe fn deallocate(&self, handle: &InstanceHandle);
+}
+
+unsafe fn initialize_vmcontext(
+    instance: &Instance,
+    functions: &[VMFunctionImport],
+    tables: &[VMTableImport],
+    memories: &[VMMemoryImport],
+    globals: &[VMGlobalImport],
+    finished_functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    lookup_shared_signature: &dyn Fn(SignatureIndex) -> VMSharedSignatureIndex,
+    interrupts: *const VMInterrupts,
+    externref_activations_table: *mut VMExternRefActivationsTable,
+    stack_map_registry: *mut StackMapRegistry,
+    get_mem_def: impl Fn(DefinedMemoryIndex) -> VMMemoryDefinition,
+    get_table_def: impl Fn(DefinedTableIndex) -> VMTableDefinition,
+) {
+    let module = &instance.module;
+
+    *instance.interrupts() = interrupts;
+    *instance.externref_activations_table() = externref_activations_table;
+    *instance.stack_map_registry() = stack_map_registry;
+
+    // Initialize shared signatures
+    let mut ptr = instance.signature_ids_ptr();
+    for sig in module.types.values() {
+        *ptr = match sig {
+            ModuleType::Function(sig) => lookup_shared_signature(*sig),
+            _ => VMSharedSignatureIndex::new(u32::max_value()),
+        };
+        ptr = ptr.add(1);
+    }
+
+    // Initialize the built-in functions
+    ptr::write(
+        instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
+        VMBuiltinFunctionsArray::initialized(),
+    );
+
+    // Initialize the imports
+    debug_assert_eq!(functions.len(), module.num_imported_funcs);
+    ptr::copy(
+        functions.as_ptr(),
+        instance.imported_functions_ptr() as *mut VMFunctionImport,
+        functions.len(),
+    );
+    debug_assert_eq!(tables.len(), module.num_imported_tables);
+    ptr::copy(
+        tables.as_ptr(),
+        instance.imported_tables_ptr() as *mut VMTableImport,
+        tables.len(),
+    );
+    debug_assert_eq!(memories.len(), module.num_imported_memories);
+    ptr::copy(
+        memories.as_ptr(),
+        instance.imported_memories_ptr() as *mut VMMemoryImport,
+        memories.len(),
+    );
+    debug_assert_eq!(globals.len(), module.num_imported_globals);
+    ptr::copy(
+        globals.as_ptr(),
+        instance.imported_globals_ptr() as *mut VMGlobalImport,
+        globals.len(),
+    );
+
+    // Initialize the defined functions
+    for (index, sig) in instance.module.functions.iter() {
+        let type_index = lookup_shared_signature(*sig);
+
+        let (func_ptr, vmctx) = if let Some(def_index) = instance.module.defined_func_index(index) {
+            (
+                NonNull::new(finished_functions[def_index] as *mut _).unwrap(),
+                instance.vmctx_ptr(),
+            )
+        } else {
+            let import = instance.imported_function(index);
+            (import.body, import.vmctx)
+        };
+
+        ptr::write(
+            instance.anyfunc_ptr(index),
+            VMCallerCheckedAnyfunc {
+                func_ptr,
+                type_index,
+                vmctx,
+            },
+        );
+    }
+
+    // Initialize the defined tables
+    let mut ptr = instance.tables_ptr();
+    for i in 0..module.table_plans.len() - module.num_imported_tables {
+        ptr::write(ptr, get_table_def(DefinedTableIndex::new(i)));
+        ptr = ptr.add(1);
+    }
+
+    // Initialize the defined memories
+    let mut ptr = instance.memories_ptr();
+    for i in 0..module.memory_plans.len() - module.num_imported_memories {
+        ptr::write(ptr, get_mem_def(DefinedMemoryIndex::new(i)));
+        ptr = ptr.add(1);
+    }
+
+    // Initialize the defined globals
+    initialize_vmcontext_globals(instance);
+}
+
+unsafe fn initialize_vmcontext_globals(instance: &Instance) {
+    let module = &instance.module;
+    let num_imports = module.num_imported_globals;
+    for (index, global) in module.globals.iter().skip(num_imports) {
+        let def_index = module.defined_global_index(index).unwrap();
+        let to = instance.global_ptr(def_index);
+
+        // Initialize the global before writing to it
+        ptr::write(to, VMGlobalDefinition::new());
+
+        match global.initializer {
+            GlobalInit::I32Const(x) => *(*to).as_i32_mut() = x,
+            GlobalInit::I64Const(x) => *(*to).as_i64_mut() = x,
+            GlobalInit::F32Const(x) => *(*to).as_f32_bits_mut() = x,
+            GlobalInit::F64Const(x) => *(*to).as_f64_bits_mut() = x,
+            GlobalInit::V128Const(x) => *(*to).as_u128_bits_mut() = x.0,
+            GlobalInit::GetGlobal(x) => {
+                let from = if let Some(def_x) = module.defined_global_index(x) {
+                    instance.global(def_x)
+                } else {
+                    *instance.imported_global(x).from
+                };
+                *to = from;
+            }
+            GlobalInit::RefFunc(f) => {
+                *(*to).as_anyfunc_mut() = instance.get_caller_checked_anyfunc(f).unwrap()
+                    as *const VMCallerCheckedAnyfunc;
+            }
+            GlobalInit::RefNullConst => match global.wasm_ty {
+                WasmType::FuncRef => *(*to).as_anyfunc_mut() = ptr::null(),
+                WasmType::ExternRef => *(*to).as_externref_mut() = None,
+                ty => panic!("unsupported reference type for global: {:?}", ty),
+            },
+            GlobalInit::Import => panic!("locally-defined global initialized as import"),
+        }
+    }
+}
+
+/// Represents the on-demand instance allocator.
+#[derive(Clone)]
+pub struct OnDemandInstanceAllocator {
+    mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
+}
+
+impl OnDemandInstanceAllocator {
+    /// Creates a new on-demand instance allocator.
+    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>) -> Self {
+        Self { mem_creator }
+    }
+
+    fn create_tables(module: &Module) -> BoxedSlice<DefinedTableIndex, Table> {
+        let num_imports = module.num_imported_tables;
+        let mut tables: PrimaryMap<DefinedTableIndex, _> =
+            PrimaryMap::with_capacity(module.table_plans.len() - num_imports);
+        for table in &module.table_plans.values().as_slice()[num_imports..] {
+            tables.push(Table::new(table));
+        }
+        tables.into_boxed_slice()
+    }
+
+    fn create_memories(
+        &self,
+        module: &Module,
+    ) -> Result<BoxedSlice<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>, InstantiationError>
+    {
+        let creator = self
+            .mem_creator
+            .as_deref()
+            .unwrap_or_else(|| &DefaultMemoryCreator);
+        let num_imports = module.num_imported_memories;
+        let mut memories: PrimaryMap<DefinedMemoryIndex, _> =
+            PrimaryMap::with_capacity(module.memory_plans.len() - num_imports);
+        for plan in &module.memory_plans.values().as_slice()[num_imports..] {
+            memories.push(
+                creator
+                    .new_memory(plan)
+                    .map_err(InstantiationError::Resource)?,
+            );
+        }
+        Ok(memories.into_boxed_slice())
+    }
+
+    fn check_table_init_bounds(instance: &Instance) -> Result<(), InstantiationError> {
+        for init in &instance.module.table_elements {
+            let start = Self::get_table_init_start(init, instance);
+            let table = instance.get_table(init.table_index);
+
+            let size = usize::try_from(table.size()).unwrap();
+            if size < start + init.elements.len() {
+                return Err(InstantiationError::Link(LinkError(
+                    "table out of bounds: elements segment does not fit".to_owned(),
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_memory_init_start(init: &OwnedDataInitializer, instance: &Instance) -> usize {
+        let mut start = init.location.offset;
+
+        if let Some(base) = init.location.base {
+            let val = unsafe {
+                if let Some(def_index) = instance.module.defined_global_index(base) {
+                    *instance.global(def_index).as_u32()
+                } else {
+                    *(*instance.imported_global(base).from).as_u32()
+                }
+            };
+            start += usize::try_from(val).unwrap();
+        }
+
+        start
+    }
+
+    unsafe fn get_memory_slice<'instance>(
+        init: &OwnedDataInitializer,
+        instance: &'instance Instance,
+    ) -> &'instance mut [u8] {
+        let memory = if let Some(defined_memory_index) = instance
+            .module
+            .defined_memory_index(init.location.memory_index)
+        {
+            instance.memory(defined_memory_index)
+        } else {
+            let import = instance.imported_memory(init.location.memory_index);
+            let foreign_instance = (&mut *(import).vmctx).instance();
+            let foreign_memory = &mut *(import).from;
+            let foreign_index = foreign_instance.memory_index(foreign_memory);
+            foreign_instance.memory(foreign_index)
+        };
+        slice::from_raw_parts_mut(memory.base, memory.current_length)
+    }
+
+    fn check_memory_init_bounds(
+        instance: &Instance,
+        data_initializers: &[OwnedDataInitializer],
+    ) -> Result<(), InstantiationError> {
+        for init in data_initializers {
+            let start = Self::get_memory_init_start(init, instance);
+            unsafe {
+                let mem_slice = Self::get_memory_slice(init, instance);
+                if mem_slice.get_mut(start..start + init.data.len()).is_none() {
+                    return Err(InstantiationError::Link(LinkError(
+                        "memory out of bounds: data segment does not fit".into(),
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_table_init_start(init: &TableElements, instance: &Instance) -> usize {
+        let mut start = init.offset;
+
+        if let Some(base) = init.base {
+            let val = unsafe {
+                if let Some(def_index) = instance.module.defined_global_index(base) {
+                    *instance.global(def_index).as_u32()
+                } else {
+                    *(*instance.imported_global(base).from).as_u32()
+                }
+            };
+            start += usize::try_from(val).unwrap();
+        }
+
+        start
+    }
+
+    fn initialize_tables(instance: &Instance) -> Result<(), InstantiationError> {
+        for init in &instance.module.table_elements {
+            let start = Self::get_table_init_start(init, instance);
+            let table = instance.get_table(init.table_index);
+
+            if start
+                .checked_add(init.elements.len())
+                .map_or(true, |end| end > table.size() as usize)
+            {
+                return Err(InstantiationError::Trap(Trap::wasm(
+                    ir::TrapCode::TableOutOfBounds,
+                )));
+            }
+
+            for (i, func_idx) in init.elements.iter().enumerate() {
+                let item = match table.element_type() {
+                    TableElementType::Func => instance
+                        .get_caller_checked_anyfunc(*func_idx)
+                        .map_or(ptr::null_mut(), |f: &VMCallerCheckedAnyfunc| {
+                            f as *const VMCallerCheckedAnyfunc as *mut VMCallerCheckedAnyfunc
+                        })
+                        .into(),
+                    TableElementType::Val(_) => {
+                        assert!(*func_idx == FuncIndex::reserved_value());
+                        TableElement::ExternRef(None)
+                    }
+                };
+                table.set(u32::try_from(start + i).unwrap(), item).unwrap();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Initialize the table memory from the provided initializers.
+    fn initialize_memories(
+        instance: &Instance,
+        data_initializers: &[OwnedDataInitializer],
+    ) -> Result<(), InstantiationError> {
+        for init in data_initializers {
+            let memory = instance.get_memory(init.location.memory_index);
+
+            let start = Self::get_memory_init_start(init, instance);
+            if start
+                .checked_add(init.data.len())
+                .map_or(true, |end| end > memory.current_length)
+            {
+                return Err(InstantiationError::Trap(Trap::wasm(
+                    ir::TrapCode::HeapOutOfBounds,
+                )));
+            }
+
+            unsafe {
+                let mem_slice = Self::get_memory_slice(init, instance);
+                let end = start + init.data.len();
+                let to_init = &mut mem_slice[start..end];
+                to_init.copy_from_slice(&init.data);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
+    unsafe fn allocate(
+        &self,
+        req: InstanceAllocationRequest,
+    ) -> Result<InstanceHandle, InstantiationError> {
+        debug_assert!(!req.externref_activations_table.is_null());
+        debug_assert!(!req.stack_map_registry.is_null());
+
+        let memories = self.create_memories(&req.module)?;
+        let tables = Self::create_tables(&req.module);
+
+        let handle = {
+            let instance = Instance {
+                module: req.module.clone(),
+                offsets: VMOffsets::new(std::mem::size_of::<*const u8>() as u8, &req.module),
+                memories,
+                tables,
+                dropped_elements: RefCell::new(EntitySet::with_capacity(
+                    req.module.passive_elements.len(),
+                )),
+                dropped_data: RefCell::new(EntitySet::with_capacity(req.module.passive_data.len())),
+                host_state: req.host_state,
+                vmctx: VMContext {},
+            };
+            let layout = instance.alloc_layout();
+            let instance_ptr = alloc::alloc(layout) as *mut Instance;
+            if instance_ptr.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
+            ptr::write(instance_ptr, instance);
+            InstanceHandle::new(instance_ptr)
+        };
+
+        let instance = handle.instance();
+        initialize_vmcontext(
+            instance,
+            req.imports.functions,
+            req.imports.tables,
+            req.imports.memories,
+            req.imports.globals,
+            req.finished_functions,
+            req.lookup_shared_signature,
+            req.interrupts,
+            req.externref_activations_table,
+            req.stack_map_registry,
+            &|index| instance.memories[index].vmmemory(),
+            &|index| instance.tables[index].vmtable(),
+        );
+
+        Ok(handle)
+    }
+
+    unsafe fn initialize(
+        &self,
+        handle: &InstanceHandle,
+        is_bulk_memory: bool,
+        data_initializers: &Arc<[OwnedDataInitializer]>,
+    ) -> Result<(), InstantiationError> {
+        // Check initializer bounds before initializing anything. Only do this
+        // when bulk memory is disabled, since the bulk memory proposal changes
+        // instantiation such that the intermediate results of failed
+        // initializations are visible.
+        if !is_bulk_memory {
+            Self::check_table_init_bounds(handle.instance())?;
+            Self::check_memory_init_bounds(handle.instance(), data_initializers.as_ref())?;
+        }
+
+        // Apply fallible initializers. Note that this can "leak" state even if
+        // it fails.
+        Self::initialize_tables(handle.instance())?;
+        Self::initialize_memories(handle.instance(), data_initializers.as_ref())?;
+
+        Ok(())
+    }
+
+    unsafe fn deallocate(&self, handle: &InstanceHandle) {
+        let instance = handle.instance();
+        let layout = instance.alloc_layout();
+        ptr::drop_in_place(instance as *const Instance as *mut Instance);
+        alloc::dealloc(instance as *const Instance as *mut _, layout);
+    }
+}

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -290,7 +290,7 @@ impl OnDemandInstanceAllocator {
         let mut tables: PrimaryMap<DefinedTableIndex, _> =
             PrimaryMap::with_capacity(module.table_plans.len() - num_imports);
         for table in &module.table_plans.values().as_slice()[num_imports..] {
-            tables.push(Table::new(table));
+            tables.push(Table::new_dynamic(table));
         }
         tables.into_boxed_slice()
     }

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -73,6 +73,17 @@ pub enum InstantiationError {
     #[error("Trap occurred during instantiation")]
     Trap(Trap),
 }
+/// An error while creating a fiber stack.
+#[cfg(feature = "async")]
+#[derive(Error, Debug)]
+pub enum FiberStackError {
+    /// An error for when the allocator doesn't support custom fiber stacks.
+    #[error("Custom fiber stacks are not supported by the allocator")]
+    NotSupported,
+    /// A limit on how many fibers are supported has been reached.
+    #[error("Limit of {0} concurrent fibers has been reached")]
+    Limit(u32),
+}
 
 /// Represents a runtime instance allocator.
 ///
@@ -127,6 +138,24 @@ pub unsafe trait InstanceAllocator: Send + Sync {
     ///
     /// Use extreme care when deallocating an instance so that there are no dangling instance pointers.
     unsafe fn deallocate(&self, handle: &InstanceHandle);
+
+    /// Allocates a fiber stack for calling async functions on.
+    ///
+    /// Returns the top of the fiber stack if successfully allocated.
+    #[cfg(feature = "async")]
+    fn allocate_fiber_stack(&self) -> Result<*mut u8, FiberStackError>;
+
+    /// Deallocates a fiber stack that was previously allocated.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because there are no guarantees that the given stack
+    /// is no longer in use.
+    ///
+    /// Additionally, passing a stack pointer that was not returned from `allocate_fiber_stack`
+    /// will lead to undefined behavior.
+    #[cfg(feature = "async")]
+    unsafe fn deallocate_fiber_stack(&self, stack: *mut u8);
 }
 
 unsafe fn initialize_vmcontext(
@@ -543,5 +572,17 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
         let layout = instance.alloc_layout();
         ptr::drop_in_place(instance as *const Instance as *mut Instance);
         alloc::dealloc(instance as *const Instance as *mut _, layout);
+    }
+
+    #[cfg(feature = "async")]
+    fn allocate_fiber_stack(&self) -> Result<*mut u8, FiberStackError> {
+        // The on-demand allocator does not support allocating fiber stacks
+        Err(FiberStackError::NotSupported)
+    }
+
+    #[cfg(feature = "async")]
+    unsafe fn deallocate_fiber_stack(&self, _stack: *mut u8) {
+        // This should never be called as `allocate_fiber_stack` never returns success
+        unreachable!()
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -42,7 +42,7 @@ pub use crate::instance::{
     OnDemandInstanceAllocator, RuntimeInstance,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
-pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
+pub use crate::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -37,7 +37,10 @@ pub mod libcalls;
 pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
-pub use crate::instance::{InstanceHandle, InstantiationError, LinkError, RuntimeInstance};
+pub use crate::instance::{
+    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstantiationError, LinkError,
+    OnDemandInstanceAllocator, RuntimeInstance,
+};
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -55,6 +55,9 @@ pub use crate::vmcontext::{
     VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMTrampoline,
 };
 
+#[cfg(feature = "async")]
+pub use crate::instance::FiberStackError;
+
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -52,10 +52,6 @@ pub struct MmapMemory {
     // Size in bytes of extra guard pages after the end to optimize loads and stores with
     // constant offsets.
     offset_guard_size: usize,
-
-    // Records whether we're using a bounds-checking strategy which requires
-    // handlers to catch trapping accesses.
-    pub(crate) needs_signal_handlers: bool,
 }
 
 #[derive(Debug)]
@@ -74,15 +70,6 @@ impl MmapMemory {
         assert!(plan.memory.maximum.is_none() || plan.memory.maximum.unwrap() <= WASM_MAX_PAGES);
 
         let offset_guard_bytes = plan.offset_guard_size as usize;
-
-        // If we have an offset guard, or if we're doing the static memory
-        // allocation strategy, we need signal handlers to catch out of bounds
-        // acceses.
-        let needs_signal_handlers = offset_guard_bytes > 0
-            || match plan.style {
-                MemoryStyle::Dynamic => false,
-                MemoryStyle::Static { .. } => true,
-            };
 
         let minimum_pages = match plan.style {
             MemoryStyle::Dynamic => plan.memory.minimum,
@@ -105,7 +92,6 @@ impl MmapMemory {
             mmap: mmap.into(),
             maximum: plan.memory.maximum,
             offset_guard_size: offset_guard_bytes,
-            needs_signal_handlers,
         })
     }
 }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -750,7 +750,7 @@ impl VMContext {
     }
 }
 
-///
+/// Trampoline function pointer type.
 pub type VMTrampoline = unsafe extern "C" fn(
     *mut VMContext,        // callee vmctx
     *mut VMContext,        // caller vmctx

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -9,12 +9,16 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition = "2018"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "nightlydoc"]
+
 [dependencies]
 wasmtime-runtime = { path = "../runtime", version = "0.22.0" }
 wasmtime-environ = { path = "../environ", version = "0.22.0" }
 wasmtime-jit = { path = "../jit", version = "0.22.0" }
 wasmtime-cache = { path = "../cache", version = "0.22.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.22.0" }
+wasmtime-fiber = { path = "../fiber", version = "0.22.0", optional = true }
 target-lexicon = { version = "0.11.0", default-features = false }
 wasmparser = "0.73"
 anyhow = "1.0.19"
@@ -30,6 +34,7 @@ smallvec = "1.6.1"
 serde = { version = "1.0.94", features = ["derive"] }
 bincode = "1.2.1"
 indexmap = "1.6"
+paste = "1.0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"
@@ -42,7 +47,7 @@ wasmtime-wasi = { path = "../wasi" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ['cache', 'wat', 'jitdump', 'parallel-compilation']
+default = ['async', 'cache', 'wat', 'jitdump', 'parallel-compilation']
 
 # Enables experimental support for the lightbeam codegen backend, an alternative
 # to cranelift. Requires Nightly Rust currently, and this is not enabled by
@@ -63,3 +68,7 @@ cache = ["wasmtime-cache"]
 
 # Enables support for new x64 backend.
 experimental_x64 = ["wasmtime-jit/experimental_x64"]
+
+# Enables support for "async stores" as well as defining host functions as
+# `async fn` and calling functions asynchronously.
+async = ["wasmtime-fiber"]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -71,4 +71,4 @@ experimental_x64 = ["wasmtime-jit/experimental_x64"]
 
 # Enables support for "async stores" as well as defining host functions as
 # `async fn` and calling functions asynchronously.
-async = ["wasmtime-fiber"]
+async = ["wasmtime-fiber", "wasmtime-runtime/async"]

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -764,7 +764,9 @@ impl Config {
 
     pub(crate) fn build_compiler(&self) -> Compiler {
         let isa = self.target_isa();
-        Compiler::new(isa, self.strategy, self.tunables.clone(), self.features)
+        let mut tunables = self.tunables.clone();
+        self.instance_allocator().adjust_tunables(&mut tunables);
+        Compiler::new(isa, self.strategy, tunables, self.features)
     }
 
     pub(crate) fn instance_allocator(&self) -> &dyn InstanceAllocator {

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -470,6 +470,7 @@ impl Config {
     ///
     /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     #[cfg(feature = "cache")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "cache")))]
     pub fn cache_config_load(&mut self, path: impl AsRef<Path>) -> Result<&mut Self> {
         self.cache_config = CacheConfig::from_file(Some(path.as_ref()))?;
         Ok(self)
@@ -497,6 +498,7 @@ impl Config {
     ///
     /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     #[cfg(feature = "cache")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "cache")))]
     pub fn cache_config_load_default(&mut self) -> Result<&mut Self> {
         self.cache_config = CacheConfig::from_file(None)?;
         Ok(self)

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -5,10 +5,13 @@ use anyhow::{bail, ensure, Context as _, Result};
 use smallvec::{smallvec, SmallVec};
 use std::cmp::max;
 use std::fmt;
+use std::future::Future;
 use std::mem;
 use std::panic::{self, AssertUnwindSafe};
+use std::pin::Pin;
 use std::ptr::{self, NonNull};
 use std::rc::Weak;
+use std::task::{Context, Poll};
 use wasmtime_environ::wasm::EntityIndex;
 use wasmtime_runtime::{
     raise_user_trap, InstanceHandle, VMContext, VMFunctionBody, VMSharedSignatureIndex,
@@ -33,6 +36,61 @@ use wasmtime_runtime::{
 /// Functions are internally reference counted so you can `clone` a `Func`. The
 /// cloning process only performs a shallow clone, so two cloned `Func`
 /// instances are equivalent in their functionality.
+///
+/// # `Func` and `async`
+///
+/// Functions from the perspective of WebAssembly are always synchronous. You
+/// might have an `async` function in Rust, however, which you'd like to make
+/// available from WebAssembly. Wasmtime supports asynchronously calling
+/// WebAssembly through native stack switching. You can get some more
+/// information about [asynchronous stores](Store::new_async), but from the
+/// perspective of `Func` it's important to know that whether or not your
+/// [`Store`] is asynchronous will dictate whether you call functions through
+/// [`Func::call`] or [`Func::call_async`] (or the wrappers such as
+/// [`Func::get0`] vs [`Func::get0_async`]).
+///
+/// Note that asynchronous function APIs here are a bit trickier than their
+/// synchronous bretheren. For example [`Func::new_async`] and
+/// [`Func::wrapN_async`](Func::wrap1_async) take explicit state parameters to
+/// allow you to close over the state in the returned future. It's recommended
+/// that you pass state via these parameters instead of through the closure's
+/// environment, which may give Rust lifetime errors. Additionally unlike
+/// synchronous functions which can all get wrapped through [`Func::wrap`]
+/// asynchronous functions need to explicitly wrap based on the number of
+/// parameters that they have (e.g. no wasm parameters gives you
+/// [`Func::wrap0_async`], one wasm parameter you'd use [`Func::wrap1_async`],
+/// etc). Be sure to consult the documentation for [`Func::wrap`] for how the
+/// wasm type signature is inferred from the Rust type signature.
+///
+/// # To `Func::call` or to `Func::getN`
+///
+/// There are four ways to call a `Func`. Half are asynchronus and half are
+/// synchronous, corresponding to the type of store you're using. Within each
+/// half you've got two choices:
+///
+/// * Dynamically typed - if you don't statically know the signature of the
+///   function that you're calling you'll be using [`Func::call`] or
+///   [`Func::call_async`]. These functions take a variable-length slice of
+///   "boxed" arguments in their [`Val`] representation. Additionally the
+///   results are returned as an owned slice of [`Val`]. These methods are the
+///   most heavily optimized due to the dynamic type checks that must occur, in
+///   addition to some dynamic allocations for where to put all the arguments.
+///   While this allows you to call all possible wasm function signatures, if
+///   you're looking for a speedier alternative you can also use...
+///
+/// * Statically typed - if you statically know the type signature of the wasm
+///   function you're calling then you can use the [`Func::getN`](Func::get1)
+///   family of functions where `N` is the number of wasm arguments the function
+///   takes. Asynchronous users can use [`Func::getN_async`](Func::get1_async).
+///   These functions will perform type validation up-front and then return a
+///   specialized closure which can be used to invoke the wasm function. This
+///   route involves no dynamic allocation and does not type-checks during
+///   runtime, so it's recommended to use this where possible for maximal speed.
+///
+/// Unfortunately a limitation of the code generation backend right now means
+/// that the statically typed `getN` methods only work with wasm functions that
+/// return 0 or 1 value. If 2 or more values are returned you'll need to use the
+/// dynamic `call` API. We hope to fix this in the future, though!
 ///
 /// # Examples
 ///
@@ -148,15 +206,104 @@ pub struct Func {
     export: wasmtime_runtime::ExportFunction,
 }
 
-macro_rules! getters {
-    ($(
-        $(#[$doc:meta])*
-        ($name:ident $(,$args:ident)*)
-    )*) => ($(
-        $(#[$doc])*
+macro_rules! for_each_function_signature {
+    ($mac:ident) => {
+        $mac!(0);
+        $mac!(1 A1);
+        $mac!(2 A1 A2);
+        $mac!(3 A1 A2 A3);
+        $mac!(4 A1 A2 A3 A4);
+        $mac!(5 A1 A2 A3 A4 A5);
+        $mac!(6 A1 A2 A3 A4 A5 A6);
+        $mac!(7 A1 A2 A3 A4 A5 A6 A7);
+        $mac!(8 A1 A2 A3 A4 A5 A6 A7 A8);
+        $mac!(9 A1 A2 A3 A4 A5 A6 A7 A8 A9);
+        $mac!(10 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10);
+        $mac!(11 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11);
+        $mac!(12 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12);
+        $mac!(13 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13);
+        $mac!(14 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14);
+        $mac!(15 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15);
+        $mac!(16 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15 A16);
+    };
+}
+
+macro_rules! generate_get_methods {
+    ($num:tt $($args:ident)*) => (paste::paste! {
+        /// Extracts a natively-callable object from this `Func`, if the
+        /// signature matches.
+        ///
+        /// See the [`Func`] structure for more documentation. Returns an error
+        /// if the type parameters and return parameter provided don't match the
+        /// actual function's type signature.
+        ///
+        /// # Panics
+        ///
+        /// Panics if this is called on a function in an asynchronous store.
         #[allow(non_snake_case)]
-        pub fn $name<$($args,)* R>(&self)
-            -> anyhow::Result<impl Fn($($args,)*) -> Result<R, Trap>>
+        pub fn [<get $num>]<$($args,)* R>(&self)
+            -> Result<impl Fn($($args,)*) -> Result<R, Trap>>
+        where
+            $($args: WasmTy,)*
+            R: WasmTy,
+        {
+            assert!(!self.store().is_async(), concat!("must use `get", $num, "_async` on synchronous stores"));
+            self.[<_get $num>]::<$($args,)* R>()
+        }
+
+        /// Extracts a natively-callable object from this `Func`, if the
+        /// signature matches.
+        ///
+        /// See the [`Func`] structure for more documentation. Returns an error
+        /// if the type parameters and return parameter provided don't match the
+        /// actual function's type signature.
+        ///
+        /// # Panics
+        ///
+        /// Panics if this is called on a function in a synchronous store.
+        #[allow(non_snake_case, warnings)]
+        #[cfg(feature = "async")]
+        #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+        pub fn [<get $num _async>]<$($args,)* R>(&self)
+            -> Result<impl Fn($($args,)*) -> WasmCall<R>>
+        where
+            $($args: WasmTy + 'static,)*
+            R: WasmTy + 'static,
+        {
+            assert!(self.store().is_async(), concat!("must use `get", $num, "` on synchronous stores"));
+
+            // TODO: ideally we wouldn't box up the future here but could
+            // instead name the future returned by `on_fiber`.  Unfortunately
+            // that would require a bunch of inter-future borrows which are safe
+            // but gnarly to implement by hand.
+            //
+            // Otherwise the implementation here is pretty similar to
+            // `call_async` where we're just calling the `on_fiber` method to
+            // run the blocking work. Most of the goop here is juggling
+            // lifetimes and making sure everything lives long enough and
+            // closures have the right signatures.
+            //
+            // This is... less readable than ideal.
+            let func = self.[<_get $num>]::<$($args,)* R>()?;
+            let store = self.store().clone();
+            Ok(move |$($args),*| {
+                let func = func.clone();
+                let store = store.clone();
+                WasmCall {
+                    inner: Pin::from(Box::new(async move {
+                        match store.on_fiber(|| func($($args,)*)).await {
+                            Ok(result) => result,
+                            Err(trap) => Err(trap),
+                        }
+                    }))
+                }
+            })
+        }
+
+        // Internal helper to share between `getN` and `getN_async`
+        #[allow(non_snake_case)]
+        fn [<_get $num>]<$($args,)* R>(&self)
+            -> Result<impl Fn($($args,)*) -> Result<R, Trap> + Clone>
         where
             $($args: WasmTy,)*
             R: WasmTy,
@@ -228,7 +375,40 @@ macro_rules! getters {
                 }
             })
         }
-    )*)
+    })
+}
+
+macro_rules! generate_wrap_async_func {
+    ($num:tt $($args:ident)*) => (paste::paste!{
+        /// Same as [`Func::wrap`], except the closure asynchronously produces
+        /// its result. For more information see the [`Func`] documentation.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if called with a non-asynchronous store.
+        #[allow(non_snake_case)]
+        #[cfg(feature = "async")]
+        #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+        pub fn [<wrap $num _async>]<T, $($args,)* R>(
+            store: &Store,
+            state: T,
+            func: impl for<'a> Fn(Caller<'a>, &'a T, $($args),*) -> Box<dyn Future<Output = R> + 'a> + 'static,
+        ) -> Func
+        where
+            T: 'static,
+            $($args: WasmTy,)*
+            R: WasmRet,
+        {
+            Func::wrap(store, move |caller: Caller<'_>, $($args: $args),*| {
+                let store = Store::upgrade(&caller.store).unwrap();
+                let mut future = Pin::from(func(caller, &state, $($args),*));
+                match store.block_on(future.as_mut()) {
+                    Ok(ret) => ret.into_result(),
+                    Err(e) => Err(e),
+                }
+            })
+        }
+    })
 }
 
 impl Func {
@@ -322,6 +502,100 @@ impl Func {
             trampoline,
             export,
         }
+    }
+
+    /// Creates a new host-defined WebAssembly function which, when called,
+    /// will run the asynchronous computation defined by `func` to completion
+    /// and then return the result to WebAssembly.
+    ///
+    /// This function is the asynchronous analogue of [`Func::new`] and much of
+    /// that documentation applies to this as well. There are a few key
+    /// differences (besides being asynchronous) that are worth pointing out:
+    ///
+    /// * The state parameter `T` is passed to the provided function `F` on
+    ///   each invocation. This is done so you can use the state in `T` in the
+    ///   computation of the output future (the future can close over this
+    ///   value). Unfortunately due to limitations of async-in-Rust right now
+    ///   you **cannot** close over the captured variables in `F` itself in the
+    ///   returned future. This means that you likely won't close over much
+    ///   state in `F` and will instead use `T`.
+    ///
+    /// * The closure here returns a *boxed* future, not something that simply
+    ///   implements a future. This is also unfortunately due to limitations in
+    ///   Rust right now.
+    ///
+    /// Overall we're not super happy with this API signature and would love to
+    /// change it to make it more ergonomic. Despite this, however, you should
+    /// be able to still hook into asynchronous computations and plug them into
+    /// wasm. Improvements are always welcome with PRs!
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `store` is not an [asynchronous
+    /// store](Store::new_async).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use wasmtime::*;
+    /// # fn main() -> anyhow::Result<()> {
+    /// // Simulate some application-specific state as well as asynchronous
+    /// // functions to query that state.
+    /// struct MyDatabase {
+    ///     // ...
+    /// }
+    ///
+    /// impl MyDatabase {
+    ///     async fn get_row_count(&self) -> u32 {
+    ///         // ...
+    /// #       100
+    ///     }
+    /// }
+    ///
+    /// let my_database = MyDatabase {
+    ///     // ...
+    /// };
+    ///
+    /// // Using `new_async` we can hook up into calling our async
+    /// // `get_row_count` function.
+    /// let store = Store::new_async(&Engine::default());
+    /// let get_row_count_type = wasmtime::FuncType::new(
+    ///     None,
+    ///     Some(wasmtime::ValType::I32),
+    /// );
+    /// let double = Func::new_async(&store, get_row_count_type, my_database, |_, database, params, results| {
+    ///     Box::new(async move {
+    ///         let count = database.get_row_count().await;
+    ///         results[0] = Val::I32(count as i32);
+    ///         Ok(())
+    ///     })
+    /// });
+    /// // ...
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "async")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+    pub fn new_async<T, F>(store: &Store, ty: FuncType, state: T, func: F) -> Func
+    where
+        T: 'static,
+        F: for<'a> Fn(
+                Caller<'a>,
+                &'a T,
+                &'a [Val],
+                &'a mut [Val],
+            ) -> Box<dyn Future<Output = Result<(), Trap>> + 'a>
+            + 'static,
+    {
+        assert!(store.is_async());
+        Func::new(store, ty, move |caller, params, results| {
+            let store = Store::upgrade(&caller.store).unwrap();
+            let mut future = Pin::from(func(caller, &state, params, results));
+            match store.block_on(future.as_mut()) {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(trap)) | Err(trap) => Err(trap),
+            }
+        })
     }
 
     pub(crate) unsafe fn from_caller_checked_anyfunc(
@@ -535,6 +809,8 @@ impl Func {
         func.into_func(store)
     }
 
+    for_each_function_signature!(generate_wrap_async_func);
+
     pub(crate) fn sig_index(&self) -> VMSharedSignatureIndex {
         unsafe { self.export.anyfunc.as_ref().type_index }
     }
@@ -579,9 +855,52 @@ impl Func {
     /// trap will occur. If a trap occurs while executing this function, then a
     /// trap will also be returned.
     ///
-    /// This function should not panic unless the underlying function itself
+    /// # Panics
+    ///
+    /// This function will panic if called on a function belonging to an async
+    /// store. Asynchronous stores must always use `call_async`.
     /// initiates a panic.
     pub fn call(&self, params: &[Val]) -> Result<Box<[Val]>> {
+        assert!(
+            !self.store().is_async(),
+            "must use `call_async` on asynchronous stores",
+        );
+        self._call(params)
+    }
+
+    /// Invokes this function with the `params` given, returning the results
+    /// asynchronously.
+    ///
+    /// This function is the same as [`Func::call`] except that it is
+    /// asynchronous. This is only compatible with [asynchronous
+    /// stores](Store::new_async).
+    ///
+    /// It's important to note that the execution of WebAssembly will happen
+    /// synchronously in the `poll` method of the future returned from this
+    /// function. Wasmtime does not manage its own thread pool or similar to
+    /// execute WebAssembly in. Future `poll` methods are generally expected to
+    /// resolve quickly, so it's recommended that you run or poll this future
+    /// in a "blocking context".
+    ///
+    /// For more information see the documentation on [asynchronous
+    /// stores](Store::new_async).
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is called on a function in a synchronous store. This
+    /// only works with functions defined within an asynchronous store.
+    #[cfg(feature = "async")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+    pub async fn call_async(&self, params: &[Val]) -> Result<Box<[Val]>> {
+        assert!(
+            self.store().is_async(),
+            "must use `call` on synchronous stores",
+        );
+        let result = self.store().on_fiber(|| self._call(params)).await??;
+        Ok(result)
+    }
+
+    fn _call(&self, params: &[Val]) -> Result<Box<[Val]>> {
         // We need to perform a dynamic check that the arguments given to us
         // match the signature of this function and are appropriate to pass to
         // this function. This involves checking to make sure we have the right
@@ -669,127 +988,7 @@ impl Func {
         }
     }
 
-    getters! {
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get0)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// This function serves as an optimized version of the [`Func::call`]
-        /// method if the type signature of a function is statically known to
-        /// the program. This method is faster than `call` on a few metrics:
-        ///
-        /// * Runtime type-checking only happens once, when this method is
-        ///   called.
-        /// * The result values, if any, aren't boxed into a vector.
-        /// * Arguments and return values don't go through boxing and unboxing.
-        /// * No trampolines are used to transfer control flow to/from JIT code,
-        ///   instead this function jumps directly into JIT code.
-        ///
-        /// For more information about which Rust types match up to which wasm
-        /// types, see the documentation on [`Func::wrap`].
-        ///
-        /// # Return
-        ///
-        /// This function will return `None` if the type signature asserted
-        /// statically does not match the runtime type signature. `Some`,
-        /// however, will be returned if the underlying function takes one
-        /// parameter of type `A` and returns the parameter `R`. Currently `R`
-        /// can either be `()` (no return values) or one wasm type. At this time
-        /// a multi-value return isn't supported.
-        ///
-        /// The returned closure will always return a `Result<R, Trap>` and an
-        /// `Err` is returned if a trap happens while the wasm is executing.
-        (get1, A1)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get2, A1, A2)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get3, A1, A2, A3)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get4, A1, A2, A3, A4)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get5, A1, A2, A3, A4, A5)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get6, A1, A2, A3, A4, A5, A6)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get7, A1, A2, A3, A4, A5, A6, A7)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get8, A1, A2, A3, A4, A5, A6, A7, A8)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get9, A1, A2, A3, A4, A5, A6, A7, A8, A9)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get10, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get11, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get12, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get13, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get14, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func::get1`] method for more documentation.
-        (get15, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)
-    }
+    for_each_function_signature!(generate_get_methods);
 
     /// Get a reference to this function's store.
     pub fn store(&self) -> &Store {
@@ -900,6 +1099,11 @@ pub unsafe trait WasmRet {
     #[doc(hidden)]
     type Abi: Copy;
 
+    // The "ok" version of this, meaning that which is returned if there is no
+    // error.
+    #[doc(hidden)]
+    type Ok: WasmTy;
+
     // Same as `WasmTy::compatible_with_store`.
     #[doc(hidden)]
     fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool;
@@ -932,6 +1136,10 @@ pub unsafe trait WasmRet {
     // Same as `WasmTy::store_to_args`.
     #[doc(hidden)]
     unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128);
+
+    // Converts this result into an explicit `Result` to match on.
+    #[doc(hidden)]
+    fn into_result(self) -> Result<Self::Ok, Trap>;
 }
 
 unsafe impl WasmTy for () {
@@ -1335,6 +1543,7 @@ where
     T: WasmTy,
 {
     type Abi = <T as WasmTy>::Abi;
+    type Ok = T;
 
     #[inline]
     fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool {
@@ -1369,6 +1578,11 @@ where
     unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
         <Self as WasmTy>::store_to_args(abi, ptr)
     }
+
+    #[inline]
+    fn into_result(self) -> Result<T, Trap> {
+        Ok(self)
+    }
 }
 
 unsafe impl<T> WasmRet for Result<T, Trap>
@@ -1376,6 +1590,7 @@ where
     T: WasmTy,
 {
     type Abi = <T as WasmTy>::Abi;
+    type Ok = T;
 
     #[inline]
     fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool {
@@ -1419,6 +1634,11 @@ where
     unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
         <T as WasmTy>::store_to_args(abi, ptr);
     }
+
+    #[inline]
+    fn into_result(self) -> Result<T, Trap> {
+        self
+    }
 }
 
 /// Internal trait implemented for all arguments that can be passed to
@@ -1429,6 +1649,14 @@ where
 pub trait IntoFunc<Params, Results> {
     #[doc(hidden)]
     fn into_func(self, store: &Store) -> Func;
+}
+
+/// TODO
+#[cfg(feature = "async")]
+#[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+pub trait IntoFuncAsync<T, Params, Results> {
+    #[doc(hidden)]
+    fn into_func(self, store: &Store, state: T) -> Func;
 }
 
 /// A structure representing the *caller's* context when creating a function
@@ -1552,9 +1780,7 @@ unsafe fn raise_cross_store_trap() -> ! {
 }
 
 macro_rules! impl_into_func {
-    ($(
-        ($($args:ident)*)
-    )*) => ($(
+    ($num:tt $($args:ident)*) => {
         // Implement for functions without a leading `&Caller` parameter,
         // delegating to the implementation below which does have the leading
         // `Caller` parameter.
@@ -1699,27 +1925,23 @@ macro_rules! impl_into_func {
                 }
             }
         }
-    )*)
+    }
 }
 
-impl_into_func! {
-    ()
-    (A1)
-    (A1 A2)
-    (A1 A2 A3)
-    (A1 A2 A3 A4)
-    (A1 A2 A3 A4 A5)
-    (A1 A2 A3 A4 A5 A6)
-    (A1 A2 A3 A4 A5 A6 A7)
-    (A1 A2 A3 A4 A5 A6 A7 A8)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15)
-    (A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15 A16)
+for_each_function_signature!(impl_into_func);
+
+/// Returned future from the [`Func::get1_async`] family of methods, used to
+/// represent an asynchronous call into WebAssembly.
+pub struct WasmCall<R> {
+    inner: Pin<Box<dyn Future<Output = Result<R, Trap>>>>,
+}
+
+impl<R> Future for WasmCall<R> {
+    type Output = Result<R, Trap>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
 }
 
 #[test]

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -399,8 +399,9 @@ macro_rules! generate_wrap_async_func {
             $($args: WasmTy,)*
             R: WasmRet,
         {
+            assert!(store.is_async());
             Func::wrap(store, move |caller: Caller<'_>, $($args: $args),*| {
-                let store = Store::upgrade(&caller.store).unwrap();
+                let store = caller.store();
                 let mut future = Pin::from(func(caller, &state, $($args),*));
                 match store.block_on(future.as_mut()) {
                     Ok(ret) => ret.into_result(),
@@ -589,7 +590,7 @@ impl Func {
     {
         assert!(store.is_async());
         Func::new(store, ty, move |caller, params, results| {
-            let store = Store::upgrade(&caller.store).unwrap();
+            let store = caller.store();
             let mut future = Pin::from(func(caller, &state, params, results));
             match store.block_on(future.as_mut()) {
                 Ok(Ok(())) => Ok(()),

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1651,14 +1651,6 @@ pub trait IntoFunc<Params, Results> {
     fn into_func(self, store: &Store) -> Func;
 }
 
-/// TODO
-#[cfg(feature = "async")]
-#[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
-pub trait IntoFuncAsync<T, Params, Results> {
-    #[doc(hidden)]
-    fn into_func(self, store: &Store, state: T) -> Func;
-}
-
 /// A structure representing the *caller's* context when creating a function
 /// via [`Func::wrap`].
 ///

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -520,7 +520,7 @@ impl<'a> Instantiator<'a> {
             // initializers may have run which placed elements into other instance's
             // tables. This means that from this point on, regardless of whether
             // initialization is successful, we need to keep the instance alive.
-            let instance = self.store.add_instance(instance);
+            let instance = self.store.add_instance(instance, false);
             allocator
                 .initialize(
                     &instance.handle,

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -90,14 +90,67 @@ impl Instance {
     /// see why it failed, or bubble it upwards. If you'd like to specifically
     /// check for trap errors, you can use `error.downcast::<Trap>()`.
     ///
+    /// # Panics
+    ///
+    /// This function will panic if called within an asynchronous store
+    /// (created with [`Store::new_async`]).
+    ///
     /// [inst]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
     /// [issue]: https://github.com/bytecodealliance/wasmtime/issues/727
     /// [`ExternType`]: crate::ExternType
     pub fn new(store: &Store, module: &Module, imports: &[Extern]) -> Result<Instance, Error> {
+        assert!(
+            !store.is_async(),
+            "cannot instantiate synchronously within an asynchronous store"
+        );
         let mut i = Instantiator::new(store, module, imports)?;
         loop {
             if let Some((instance, items)) = i.step()? {
                 Instantiator::start_raw(&instance)?;
+                if let Some(items) = items {
+                    break Ok(Instance::from_wasmtime(&items, store));
+                }
+            }
+        }
+    }
+
+    /// Same as [`Instance::new`], except for usage in [asynchronous stores].
+    ///
+    /// For more details about this function see the documentation on
+    /// [`Instance::new`]. The only difference between these two methods is that
+    /// this one will asynchronously invoke the wasm start function in case it
+    /// calls any imported function which is an asynchronous host function (e.g.
+    /// created with [`Func::new_async`](crate::Func::new_async).
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if called within a non-asynchronous store
+    /// (created with [`Store::new`]). This is only compatible with asynchronous
+    /// stores created with [`Store::new_async`].
+    ///
+    /// [asynchronous stores]: Store::new_async
+    #[cfg(feature = "async")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+    pub async fn new_async(
+        store: &Store,
+        module: &Module,
+        imports: &[Extern],
+    ) -> Result<Instance, Error> {
+        assert!(
+            store.is_async(),
+            "cannot instantiate asynchronously within a synchronous store"
+        );
+
+        assert!(
+            !store.is_async(),
+            "cannot instantiate synchronously within an asynchronous store"
+        );
+        let mut i = Instantiator::new(store, module, imports)?;
+        loop {
+            if let Some((instance, items)) = i.step()? {
+                store
+                    .on_fiber(|| Instantiator::start_raw(&instance))
+                    .await??;
                 if let Some(items) = items {
                     break Ok(Instance::from_wasmtime(&items, store));
                 }
@@ -123,6 +176,33 @@ impl Instance {
 
     pub(crate) fn wasmtime_export(&self) -> &RuntimeInstance {
         &self.items
+    }
+
+    fn start(&self) -> Result<(), Error> {
+        let start_func = match self.handle.module().start_func {
+            Some(func) => func,
+            None => return Ok(()),
+        };
+
+        let f = match self
+            .handle
+            .lookup_by_declaration(&EntityIndex::Function(start_func))
+        {
+            wasmtime_runtime::Export::Function(f) => f,
+            _ => unreachable!(), // valid modules shouldn't hit this
+        };
+        let vmctx_ptr = self.handle.vmctx_ptr();
+        unsafe {
+            super::func::invoke_wasm_and_catch_traps(vmctx_ptr, self.store(), || {
+                mem::transmute::<
+                    *const VMFunctionBody,
+                    unsafe extern "C" fn(*mut VMContext, *mut VMContext),
+                >(f.anyfunc.as_ref().func_ptr.as_ptr())(
+                    f.anyfunc.as_ref().vmctx, vmctx_ptr
+                )
+            })?;
+        }
+        Ok(())
     }
 
     /// Returns the associated [`Store`] that this `Instance` is compiled into.

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -140,6 +140,38 @@
 //! create a "wasi instance" and then add all of its items into a [`Linker`],
 //! which can then be used to instantiate a [`Module`] that uses WASI.
 //!
+//! ## Crate Features
+//!
+//! The `wasmtime` crate comes with a number of compile-time features that can
+//! be used to customize what features it supports. Some of these features are
+//! just internal details, but some affect the public API of the `wasmtime`
+//! crate. Be sure to check the API you're using to see if any crate features
+//! are enabled.
+//!
+//! * `cache` - Enabled by default, this feature adds support for wasmtime to
+//!   perform internal caching of modules in a global location. This must still
+//!   be enabled explicitly through [`Config::cache_config_load`] or
+//!   [`Config::cache_config_load_default`].
+//!
+//! * `wat` - Enabled by default, this feature adds support for accepting the
+//!   text format of WebAssembly in [`Module::new`]. The text format will be
+//!   automatically recognized and translated to binary when compiling a
+//!   module.
+//!
+//! * `parallel-compilation` - Enabled by default, this feature enables support
+//!   for compiling functions of a module in parallel with `rayon`.
+//!
+//! * `async` - Enabled by default, this feature enables APIs and runtime
+//!   support for defining asynchronous host functions and calling WebAssembly
+//!   asynchronously.
+//!
+//! * `jitdump` - Enabled by default, this feature compiles in support for the
+//!   jitdump runtime profilng format. The profiler can be selected with
+//!   [`Config::profiler`].
+//!
+//! * `vtune` - Not enabled by default, this feature compiles in support for
+//!   supporting VTune profiling of JIT code.
+//!
 //! ## Examples
 //!
 //! In addition to the examples below be sure to check out the [online embedding
@@ -233,6 +265,8 @@
 #![deny(missing_docs, broken_intra_doc_links)]
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
+#![cfg_attr(nightlydoc, feature(doc_cfg))]
+#![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
 
 mod config;
 mod engine;

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -18,8 +18,8 @@ use std::task::{Context, Poll};
 use wasmtime_environ::wasm;
 use wasmtime_jit::{CompiledModule, ModuleCode, TypeTables};
 use wasmtime_runtime::{
-    InstanceHandle, RuntimeMemoryCreator, SignalHandler, StackMapRegistry, TrapInfo, VMContext,
-    VMExternRef, VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex,
+    InstanceHandle, SignalHandler, StackMapRegistry, TrapInfo, VMContext, VMExternRef,
+    VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex,
 };
 
 /// A `Store` is a collection of WebAssembly instances and host-defined items.
@@ -252,15 +252,6 @@ impl Store {
     /// Returns the [`Engine`] that this store is associated with.
     pub fn engine(&self) -> &Engine {
         &self.inner.engine
-    }
-
-    /// Returns an optional reference to a ['RuntimeMemoryCreator']
-    pub(crate) fn memory_creator(&self) -> Option<&dyn RuntimeMemoryCreator> {
-        self.engine()
-            .config()
-            .memory_creator
-            .as_ref()
-            .map(|x| x as _)
     }
 
     pub(crate) fn signatures(&self) -> &RefCell<SignatureRegistry> {
@@ -964,9 +955,10 @@ impl fmt::Debug for Store {
 
 impl Drop for StoreInner {
     fn drop(&mut self) {
-        for instance in self.instances.get_mut().iter() {
+        let allocator = self.engine.config().instance_allocator();
+        for instance in self.instances.borrow().iter() {
             unsafe {
-                instance.dealloc();
+                allocator.deallocate(instance);
             }
         }
     }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -830,6 +830,7 @@ impl Store {
     /// This only works on async futures and stores, and assumes that we're
     /// executing on a fiber. This will yield execution back to the caller once
     /// and when we come back we'll continue with `fuel_to_inject` more fuel.
+    #[cfg(feature = "async")]
     fn out_of_gas_yield(&self, fuel_to_inject: u64) {
         // Small future that yields once and then returns ()
         #[derive(Default)]

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -93,7 +93,10 @@ pub(crate) struct StoreInner {
 #[derive(Copy, Clone)]
 enum OutOfGas {
     Trap,
-    InjectFuel(u64),
+    InjectFuel {
+        injection_count: u32,
+        fuel_to_inject: u64,
+    },
 }
 
 struct HostInfoKey(VMExternRef);
@@ -158,21 +161,51 @@ impl Store {
     /// resolves to `Pending` we switch away from the temporary stack back to
     /// the main stack and propagate the `Pending` status.
     ///
-    /// Note that the intention with supporting asynchronous WebAssembly in
-    /// Wasmtime is to primarily provide the *ability* to suspend wasm
-    /// computation while the host is waiting for a result. You'll likely need
-    /// to continue to massage the exact future returned to suit your
-    /// application's needs. For example the `Future::poll` method is not
-    /// expected to take a large amount of time, but executing WebAssembly can
-    /// take arbitrarily long. This means that you may want to run futures on a
-    /// dedicated thread pool in some scenarios, or perhaps have some form of
-    /// "fuel" in other scenarios (Wasmtime hopes to support fuel natively in
-    /// the future).
-    ///
     /// In general it's encouraged that the integration with `async` and
     /// wasmtime is designed early on in your embedding of Wasmtime to ensure
     /// that it's planned that WebAssembly executes in the right context of your
     /// application.
+    ///
+    /// # Execution in `poll`
+    ///
+    /// The [`Future::poll`](std::future::Future::poll) method is the main
+    /// driving force behind Rust's futures. That method's own documentation
+    /// states "an implementation of `poll` should strive to return quickly, and
+    /// should not block". This, however, can be at odds with executing
+    /// WebAssembly code as part of the `poll` method itself. If your
+    /// WebAssembly is untrusted then this could allow the `poll` method to take
+    /// arbitrarily long in the worst case, likely blocking all other
+    /// asynchronous tasks.
+    ///
+    /// To remedy this situation you have a two possible ways to solve this:
+    ///
+    /// * First you can spawn futures into a thread pool. Care must be taken for
+    ///   this because Wasmtime futures are not `Send` or `Sync`. If you ensure
+    ///   that the entire state of a `Store` is wrapped up in a single future,
+    ///   though, you can send the whole future at once to a separate thread. By
+    ///   doing this in a thread pool you are relaxing the requirement that
+    ///   `Future::poll` must be fast because your future is executing on a
+    ///   separate thread. This strategy, however, would likely still require
+    ///   some form of cancellation via [`Store::interrupt_handle`] to ensure
+    ///   wasm doesn't take *too* long to execute.
+    ///
+    /// * Alternatively you can enable the
+    ///   [`Config::consume_fuel`](crate::Config::consume_fuel) method as well
+    ///   as [`Store::out_of_fuel_async_yield`] When doing so this will
+    ///   configure Wasmtime futures to yield periodically while they're
+    ///   executing WebAssembly code. After consuming the specified amount of
+    ///   fuel wasm futures will return `Poll::Pending` from their `poll`
+    ///   method, and will get automatically re-polled later. This enables the
+    ///   `Future::poll` method to take roughly a fixed amount of time since
+    ///   fuel is guaranteed to get consumed while wasm is executing. Note that
+    ///   to prevent infinite execution of wasm you'll still need to use
+    ///   [`Store::interrupt_handle`].
+    ///
+    /// In either case special care needs to be taken when integrating
+    /// asynchronous wasm into your application. You should carefully plan where
+    /// WebAssembly will execute and what compute resources will be allotted to
+    /// it. If Wasmtime doesn't support exactly what you'd like just yet, please
+    /// feel free to open an issue!
     #[cfg(feature = "async")]
     #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
     pub fn new_async(engine: &Engine) -> Store {
@@ -617,15 +650,20 @@ impl Store {
     /// automatically re-injected after fuel runs out. This is how much fuel
     /// will be consumed between yields of an async future.
     ///
+    /// The `injection_count` parameter indicates how many times this fuel will
+    /// be injected. Multiplying the two parameters is the total amount of fuel
+    /// this store is allowed before wasm traps.
+    ///
     /// # Panics
     ///
     /// This method will panic if it is not called on an [async
     /// store](Store::new_async).
-    pub fn out_of_fuel_async_yield(&self, fuel_to_inject: u64) {
+    pub fn out_of_fuel_async_yield(&self, injection_count: u32, fuel_to_inject: u64) {
         assert!(self.is_async());
-        self.inner
-            .out_of_gas_behavior
-            .set(OutOfGas::InjectFuel(fuel_to_inject));
+        self.inner.out_of_gas_behavior.set(OutOfGas::InjectFuel {
+            injection_count,
+            fuel_to_inject,
+        });
     }
 
     pub(crate) fn is_async(&self) -> bool {
@@ -809,7 +847,7 @@ impl Store {
     }
 
     /// Immediately raise a trap on an out-of-gas condition.
-    fn out_of_gas_trap(&self) {
+    fn out_of_gas_trap(&self) -> ! {
         #[derive(Debug)]
         struct OutOfGasError;
 
@@ -892,9 +930,21 @@ unsafe impl TrapInfo for Store {
         match self.inner.out_of_gas_behavior.get() {
             OutOfGas::Trap => self.out_of_gas_trap(),
             #[cfg(feature = "async")]
-            OutOfGas::InjectFuel(fuel) => self.out_of_gas_yield(fuel),
+            OutOfGas::InjectFuel {
+                injection_count,
+                fuel_to_inject,
+            } => {
+                if injection_count == 0 {
+                    self.out_of_gas_trap();
+                }
+                self.inner.out_of_gas_behavior.set(OutOfGas::InjectFuel {
+                    injection_count: injection_count - 1,
+                    fuel_to_inject,
+                });
+                self.out_of_gas_yield(fuel_to_inject);
+            }
             #[cfg(not(feature = "async"))]
-            OutOfGas::InjectFuel(_) => unreachable!(),
+            OutOfGas::InjectFuel { .. } => unreachable!(),
         }
     }
 }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -18,9 +18,18 @@ use std::task::{Context, Poll};
 use wasmtime_environ::wasm;
 use wasmtime_jit::{CompiledModule, ModuleCode, TypeTables};
 use wasmtime_runtime::{
-    InstanceHandle, SignalHandler, StackMapRegistry, TrapInfo, VMContext, VMExternRef,
-    VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex,
+    InstanceAllocator, InstanceHandle, SignalHandler, StackMapRegistry, TrapInfo, VMContext,
+    VMExternRef, VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex,
 };
+
+/// Used to associate instances with the store.
+///
+/// This is needed to track if the instance was allocated expliclty with the default
+/// instance allocator.
+struct StoreInstance {
+    handle: InstanceHandle,
+    use_default_allocator: bool,
+}
 
 /// A `Store` is a collection of WebAssembly instances and host-defined items.
 ///
@@ -63,7 +72,7 @@ pub(crate) struct StoreInner {
     engine: Engine,
     interrupts: Arc<VMInterrupts>,
     signatures: RefCell<SignatureRegistry>,
-    instances: RefCell<Vec<InstanceHandle>>,
+    instances: RefCell<Vec<StoreInstance>>,
     signal_handler: RefCell<Option<Box<SignalHandler<'static>>>>,
     externref_activations_table: VMExternRefActivationsTable,
     stack_map_registry: StackMapRegistry,
@@ -374,8 +383,15 @@ impl Store {
         Ok(())
     }
 
-    pub(crate) unsafe fn add_instance(&self, handle: InstanceHandle) -> StoreInstanceHandle {
-        self.inner.instances.borrow_mut().push(handle.clone());
+    pub(crate) unsafe fn add_instance(
+        &self,
+        handle: InstanceHandle,
+        use_default_allocator: bool,
+    ) -> StoreInstanceHandle {
+        self.inner.instances.borrow_mut().push(StoreInstance {
+            handle: handle.clone(),
+            use_default_allocator,
+        });
         StoreInstanceHandle {
             store: self.clone(),
             handle,
@@ -388,7 +404,7 @@ impl Store {
             .instances
             .borrow()
             .iter()
-            .any(|i| i.vmctx_ptr() == handle.vmctx_ptr()));
+            .any(|i| i.handle.vmctx_ptr() == handle.vmctx_ptr()));
         StoreInstanceHandle {
             store: self.clone(),
             handle,
@@ -958,7 +974,14 @@ impl Drop for StoreInner {
         let allocator = self.engine.config().instance_allocator();
         for instance in self.instances.borrow().iter() {
             unsafe {
-                allocator.deallocate(instance);
+                if instance.use_default_allocator {
+                    self.engine
+                        .config()
+                        .default_instance_allocator
+                        .deallocate(&instance.handle);
+                } else {
+                    allocator.deallocate(&instance.handle);
+                }
             }
         }
     }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -78,17 +78,22 @@ pub(crate) struct StoreInner {
     instance_count: Cell<usize>,
     memory_count: Cell<usize>,
     table_count: Cell<usize>,
-<<<<<<< HEAD
 
     /// An adjustment to add to the fuel consumed value in `interrupts` above
     /// to get the true amount of fuel consumed.
     fuel_adj: Cell<i64>,
-=======
+
     #[cfg(feature = "async")]
     current_suspend: Cell<*const wasmtime_fiber::Suspend<Result<(), Trap>, (), Result<(), Trap>>>,
     #[cfg(feature = "async")]
     current_poll_cx: Cell<*mut Context<'static>>,
->>>>>>> Implement support for `async` functions in Wasmtime
+    out_of_gas_behavior: Cell<OutOfGas>,
+}
+
+#[derive(Copy, Clone)]
+enum OutOfGas {
+    Trap,
+    InjectFuel(u64),
 }
 
 struct HostInfoKey(VMExternRef);
@@ -202,6 +207,7 @@ impl Store {
                 current_suspend: Cell::new(ptr::null()),
                 #[cfg(feature = "async")]
                 current_poll_cx: Cell::new(ptr::null_mut()),
+                out_of_gas_behavior: Cell::new(OutOfGas::Trap),
             }),
         }
     }
@@ -571,6 +577,57 @@ impl Store {
         }
     }
 
+    /// Configures a [`Store`] to generate a [`Trap`] whenever it runs out of
+    /// fuel.
+    ///
+    /// When a [`Store`] is configured to consume fuel with
+    /// [`Config::consume_fuel`](crate::Config::consume_fuel) this method will
+    /// configure what happens when fuel runs out. Specifically a WebAssembly
+    /// trap will be raised and the current execution of WebAssembly will be
+    /// aborted.
+    ///
+    /// This is the default behavior for running out of fuel.
+    pub fn out_of_fuel_trap(&self) {
+        self.inner.out_of_gas_behavior.set(OutOfGas::Trap);
+    }
+
+    /// Configures a [`Store`] to yield execution of async WebAssembly code
+    /// periodically.
+    ///
+    /// When a [`Store`] is configured to consume fuel with
+    /// [`Config::consume_fuel`](crate::Config::consume_fuel) this method will
+    /// configure what happens when fuel runs out. Specifically executing
+    /// WebAssembly will be suspended and control will be yielded back to the
+    /// caller. This is only suitable with use of [async
+    /// stores](Store::new_async) because only then are futures used and yields
+    /// are possible.
+    ///
+    /// The purpose of this behavior is to ensure that futures which represent
+    /// execution of WebAssembly do not execute too long inside their
+    /// `Future::poll` method. This allows for some form of cooperative
+    /// multitasking where WebAssembly will voluntarily yield control
+    /// periodically (based on fuel consumption) back to the running thread.
+    ///
+    /// Note that futures returned by this crate will automatically flag
+    /// themselves to get re-polled if a yield happens. This means that
+    /// WebAssembly will continue to execute, just after giving the host an
+    /// opportunity to do something else.
+    ///
+    /// The `fuel_to_inject` parameter indicates how much fuel should be
+    /// automatically re-injected after fuel runs out. This is how much fuel
+    /// will be consumed between yields of an async future.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if it is not called on an [async
+    /// store](Store::new_async).
+    pub fn out_of_fuel_async_yield(&self, fuel_to_inject: u64) {
+        assert!(self.is_async());
+        self.inner
+            .out_of_gas_behavior
+            .set(OutOfGas::InjectFuel(fuel_to_inject));
+    }
+
     pub(crate) fn is_async(&self) -> bool {
         self.inner.is_async
     }
@@ -750,6 +807,64 @@ impl Store {
             }
         }
     }
+
+    /// Immediately raise a trap on an out-of-gas condition.
+    fn out_of_gas_trap(&self) {
+        #[derive(Debug)]
+        struct OutOfGasError;
+
+        impl fmt::Display for OutOfGasError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("all fuel consumed by WebAssembly")
+            }
+        }
+
+        impl std::error::Error for OutOfGasError {}
+        unsafe {
+            wasmtime_runtime::raise_lib_trap(wasmtime_runtime::Trap::User(Box::new(OutOfGasError)))
+        }
+    }
+
+    /// Yields execution to the caller on out-of-gas
+    ///
+    /// This only works on async futures and stores, and assumes that we're
+    /// executing on a fiber. This will yield execution back to the caller once
+    /// and when we come back we'll continue with `fuel_to_inject` more fuel.
+    fn out_of_gas_yield(&self, fuel_to_inject: u64) {
+        // Small future that yields once and then returns ()
+        #[derive(Default)]
+        struct Yield {
+            yielded: bool,
+        }
+
+        impl Future for Yield {
+            type Output = ();
+
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.yielded {
+                    Poll::Ready(())
+                } else {
+                    // Flag ourselves as yielded to return next time, and also
+                    // flag the waker that we're already ready to get
+                    // re-enqueued for another poll.
+                    self.yielded = true;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        let mut future = Yield::default();
+        match self.block_on(unsafe { Pin::new_unchecked(&mut future) }) {
+            // If this finished successfully then we were resumed normally via a
+            // `poll`, so inject some more fuel and keep going.
+            Ok(()) => self.add_fuel(fuel_to_inject),
+            // If the future was dropped while we were yielded, then we need to
+            // clean up this fiber. Do so by raising a trap which will abort all
+            // wasm and get caught on the other side to clean things up.
+            Err(trap) => unsafe { wasmtime_runtime::raise_user_trap(trap.into()) },
+        }
+    }
 }
 
 unsafe impl TrapInfo for Store {
@@ -773,19 +888,12 @@ unsafe impl TrapInfo for Store {
     }
 
     fn out_of_gas(&self) {
-        #[derive(Debug)]
-        struct OutOfGas;
-
-        impl fmt::Display for OutOfGas {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_str("all fuel consumed by WebAssembly")
-            }
-        }
-
-        impl std::error::Error for OutOfGas {}
-
-        unsafe {
-            wasmtime_runtime::raise_lib_trap(wasmtime_runtime::Trap::User(Box::new(OutOfGas)))
+        match self.inner.out_of_gas_behavior.get() {
+            OutOfGas::Trap => self.out_of_gas_trap(),
+            #[cfg(feature = "async")]
+            OutOfGas::InjectFuel(fuel) => self.out_of_gas_yield(fuel),
+            #[cfg(not(feature = "async"))]
+            OutOfGas::InjectFuel(_) => unreachable!(),
         }
     }
 }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -749,12 +749,14 @@ impl Store {
     /// that the various comments are illuminating as to what's going on here.
     #[cfg(feature = "async")]
     pub(crate) async fn on_fiber<R>(&self, func: impl FnOnce() -> R) -> Result<R, Trap> {
-        debug_assert!(self.is_async());
+        let config = self.inner.engine.config();
 
-        // TODO: allocation of a fiber should be much more abstract where we
-        // shouldn't be allocating huge stacks on every async wasm function call.
+        debug_assert!(self.is_async());
+        debug_assert!(config.async_stack_size > 0);
+
+        type SuspendType = wasmtime_fiber::Suspend<Result<(), Trap>, (), Result<(), Trap>>;
         let mut slot = None;
-        let fiber = wasmtime_fiber::Fiber::new(10 * 1024 * 1024, |keep_going, suspend| {
+        let func = |keep_going, suspend: &SuspendType| {
             // First check and see if we were interrupted/dropped, and only
             // continue if we haven't been.
             keep_going?;
@@ -772,18 +774,46 @@ impl Store {
 
             slot = Some(func());
             Ok(())
-        })
-        .map_err(|e| Trap::from(anyhow::Error::from(e)))?;
+        };
+
+        let (fiber, stack) = match config.instance_allocator().allocate_fiber_stack() {
+            Ok(stack) => {
+                // Use the returned stack and take care to deallocate it when finished
+                (
+                    unsafe {
+                        wasmtime_fiber::Fiber::new_with_stack(stack, func)
+                            .map_err(|e| Trap::from(anyhow::Error::from(e)))?
+                    },
+                    stack,
+                )
+            }
+            Err(wasmtime_runtime::FiberStackError::NotSupported) => {
+                // The allocator doesn't support custom fiber stacks for the current platform
+                // Request that the fiber itself allocates the stack
+                (
+                    wasmtime_fiber::Fiber::new(config.async_stack_size, func)
+                        .map_err(|e| Trap::from(anyhow::Error::from(e)))?,
+                    std::ptr::null_mut(),
+                )
+            }
+            Err(e) => return Err(Trap::from(anyhow::Error::from(e))),
+        };
 
         // Once we have the fiber representing our synchronous computation, we
         // wrap that in a custom future implementation which does the
         // translation from the future protocol to our fiber API.
-        FiberFuture { fiber, store: self }.await?;
+        FiberFuture {
+            fiber,
+            store: self,
+            stack,
+        }
+        .await?;
         return Ok(slot.unwrap());
 
         struct FiberFuture<'a> {
             fiber: wasmtime_fiber::Fiber<'a, Result<(), Trap>, (), Result<(), Trap>>,
             store: &'a Store,
+            stack: *mut u8,
         }
 
         impl Future for FiberFuture<'_> {
@@ -840,15 +870,23 @@ impl Store {
         // completion.
         impl Drop for FiberFuture<'_> {
             fn drop(&mut self) {
-                if self.fiber.done() {
-                    return;
+                if !self.fiber.done() {
+                    let result = self.fiber.resume(Err(Trap::new("future dropped")));
+                    // This resumption with an error should always complete the
+                    // fiber. While it's technically possible for host code to catch
+                    // the trap and re-resume, we'd ideally like to signal that to
+                    // callers that they shouldn't be doing that.
+                    debug_assert!(result.is_ok());
                 }
-                let result = self.fiber.resume(Err(Trap::new("future dropped")));
-                // This resumption with an error should always complete the
-                // fiber. While it's technically possible for host code to catch
-                // the trap and re-resume, we'd ideally like to signal that to
-                // callers that they shouldn't be doing that.
-                debug_assert!(result.is_ok());
+                if !self.stack.is_null() {
+                    unsafe {
+                        self.store
+                            .engine()
+                            .config()
+                            .instance_allocator()
+                            .deallocate_fiber_stack(self.stack)
+                    };
+                }
             }
         }
     }

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -44,6 +44,6 @@ pub(crate) fn create_handle(
                 stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
             })?;
 
-        Ok(store.add_instance(handle))
+        Ok(store.add_instance(handle, true))
     }
 }

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -9,15 +9,15 @@ use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::Module;
 use wasmtime_runtime::{
-    Imports, InstanceHandle, StackMapRegistry, VMExternRefActivationsTable, VMFunctionBody,
-    VMFunctionImport, VMSharedSignatureIndex,
+    Imports, InstanceAllocationRequest, InstanceAllocator, StackMapRegistry,
+    VMExternRefActivationsTable, VMFunctionBody, VMFunctionImport, VMSharedSignatureIndex,
 };
 
 pub(crate) fn create_handle(
     module: Module,
     store: &Store,
     finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
-    state: Box<dyn Any>,
+    host_state: Box<dyn Any>,
     func_imports: &[VMFunctionImport],
     shared_signature_id: Option<VMSharedSignatureIndex>,
 ) -> Result<StoreInstanceHandle> {
@@ -26,17 +26,24 @@ pub(crate) fn create_handle(
     let module = Arc::new(module);
 
     unsafe {
-        let handle = InstanceHandle::new(
-            module,
-            &finished_functions,
-            imports,
-            store.memory_creator(),
-            &|_| shared_signature_id.unwrap(),
-            state,
-            store.interrupts(),
-            store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
-            store.stack_map_registry() as *const StackMapRegistry as *mut _,
-        )?;
+        // Use the default allocator when creating handles associated with host objects
+        let handle = store
+            .engine()
+            .config()
+            .default_instance_allocator
+            .allocate(InstanceAllocationRequest {
+                module: module.clone(),
+                finished_functions: &finished_functions,
+                imports,
+                lookup_shared_signature: &|_| shared_signature_id.unwrap(),
+                host_state,
+                interrupts: store.interrupts(),
+                externref_activations_table: store.externref_activations_table()
+                    as *const VMExternRefActivationsTable
+                    as *mut _,
+                stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
+            })?;
+
         Ok(store.add_instance(handle))
     }
 }

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -54,9 +54,7 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
 }
 
 #[derive(Clone)]
-pub(crate) struct MemoryCreatorProxy {
-    pub(crate) mem_creator: Arc<dyn MemoryCreator>,
-}
+pub(crate) struct MemoryCreatorProxy(pub Arc<dyn MemoryCreator>);
 
 impl RuntimeMemoryCreator for MemoryCreatorProxy {
     fn new_memory(&self, plan: &MemoryPlan) -> Result<Box<dyn RuntimeLinearMemory>, String> {
@@ -65,7 +63,7 @@ impl RuntimeMemoryCreator for MemoryCreatorProxy {
             MemoryStyle::Static { bound } => Some(bound as u64 * WASM_PAGE_SIZE as u64),
             MemoryStyle::Dynamic => None,
         };
-        self.mem_creator
+        self.0
             .new_memory(ty, reserved_size_in_bytes, plan.offset_guard_size)
             .map(|mem| Box::new(LinearMemoryProxy { mem }) as Box<dyn RuntimeLinearMemory>)
     }

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -52,6 +52,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wasi-common",
     // wasmtime
     "lightbeam",
+    "wasmtime-fiber",
     "wasmtime-environ",
     "wasmtime-runtime",
     "wasmtime-debug",

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -1,0 +1,303 @@
+use std::cell::Cell;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use wasmtime::*;
+
+fn async_store() -> Store {
+    let engine = Engine::default();
+    Store::new_async(&engine)
+}
+
+#[test]
+fn smoke() {
+    let store = async_store();
+    let func = Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        move |_caller, _state, _params, _results| Box::new(async { Ok(()) }),
+    );
+    run(func.call_async(&[])).unwrap();
+    run(func.call_async(&[])).unwrap();
+    let future1 = func.call_async(&[]);
+    let future2 = func.call_async(&[]);
+    run(future2).unwrap();
+    run(future1).unwrap();
+}
+
+#[test]
+fn smoke_with_suspension() {
+    let store = async_store();
+    let func = Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        move |_caller, _state, _params, _results| {
+            Box::new(async {
+                PendingOnce::default().await;
+                Ok(())
+            })
+        },
+    );
+    run(func.call_async(&[])).unwrap();
+    run(func.call_async(&[])).unwrap();
+    let future1 = func.call_async(&[]);
+    let future2 = func.call_async(&[]);
+    run(future2).unwrap();
+    run(future1).unwrap();
+}
+
+#[test]
+fn smoke_get_with_suspension() {
+    let store = async_store();
+    let func = Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        move |_caller, _state, _params, _results| {
+            Box::new(async {
+                PendingOnce::default().await;
+                Ok(())
+            })
+        },
+    );
+    let func = func.get0_async::<()>().unwrap();
+    run(func()).unwrap();
+    run(func()).unwrap();
+    let future1 = func();
+    let future2 = func();
+    run(future2).unwrap();
+    run(future1).unwrap();
+}
+
+#[test]
+fn recursive_call() {
+    let store = async_store();
+    let async_wasm_func = Rc::new(Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        |_caller, _state, _params, _results| {
+            Box::new(async {
+                PendingOnce::default().await;
+                Ok(())
+            })
+        },
+    ));
+    let weak = Rc::downgrade(&async_wasm_func);
+
+    // Create an imported function which recursively invokes another wasm
+    // function asynchronously, although this one is just our own host function
+    // which suffices for this test.
+    let func2 = Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        move |_caller, _state, _params, _results| {
+            let async_wasm_func = weak.upgrade().unwrap();
+            Box::new(async move {
+                async_wasm_func.call_async(&[]).await?;
+                Ok(())
+            })
+        },
+    );
+
+    // Create an instance which calls an async import twice.
+    let module = Module::new(
+        store.engine(),
+        "
+            (module
+                (import \"\" \"\" (func))
+                (func (export \"\")
+                    ;; call imported function which recursively does an async
+                    ;; call
+                    call 0
+                    ;; do it again, and our various pointers all better align
+                    call 0))
+        ",
+    )
+    .unwrap();
+
+    run(async {
+        let instance = Instance::new_async(&store, &module, &[func2.into()]).await?;
+        let func = instance.get_func("").unwrap();
+        func.call_async(&[]).await
+    })
+    .unwrap();
+}
+
+#[test]
+fn suspend_while_suspending() {
+    let store = async_store();
+
+    // Create a synchronous function which calls our asynchronous function and
+    // runs it locally. This shouldn't generally happen but we know everything
+    // is synchronous in this test so it's fine for us to do this.
+    //
+    // The purpose of this test is intended to stress various cases in how
+    // we manage pointers in ways that are not necessarily common but are still
+    // possible in safe code.
+    let async_thunk = Rc::new(Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        |_caller, _state, _params, _results| Box::new(async { Ok(()) }),
+    ));
+    let weak = Rc::downgrade(&async_thunk);
+    let sync_call_async_thunk = Func::new(
+        &store,
+        FuncType::new(None, None),
+        move |_caller, _params, _results| {
+            let async_thunk = weak.upgrade().unwrap();
+            run(async_thunk.call_async(&[]))?;
+            Ok(())
+        },
+    );
+
+    // A small async function that simply awaits once to pump the loops and
+    // then finishes.
+    let async_import = Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        move |_caller, _state, _params, _results| {
+            Box::new(async move {
+                PendingOnce::default().await;
+                Ok(())
+            })
+        },
+    );
+
+    let module = Module::new(
+        store.engine(),
+        "
+            (module
+                (import \"\" \"\" (func $sync_call_async_thunk))
+                (import \"\" \"\" (func $async_import))
+                (func (export \"\")
+                    ;; Set some store-local state and pointers
+                    call $sync_call_async_thunk
+                    ;; .. and hopefully it's all still configured correctly
+                    call $async_import))
+        ",
+    )
+    .unwrap();
+    run(async {
+        let instance = Instance::new_async(
+            &store,
+            &module,
+            &[sync_call_async_thunk.into(), async_import.into()],
+        )
+        .await?;
+        let func = instance.get_func("").unwrap();
+        func.call_async(&[]).await
+    })
+    .unwrap();
+}
+
+#[test]
+fn cancel_during_run() {
+    let store = async_store();
+    let state = Rc::new(Cell::new(0));
+    let state2 = state.clone();
+
+    let async_thunk = Func::new_async(
+        &store,
+        FuncType::new(None, None),
+        (),
+        move |_caller, _state, _params, _results| {
+            assert_eq!(state2.get(), 0);
+            state2.set(1);
+            let dtor = SetOnDrop(state2.clone());
+            Box::new(async move {
+                drop(&dtor);
+                PendingOnce::default().await;
+                Ok(())
+            })
+        },
+    );
+    // Shouldn't have called anything yet...
+    assert_eq!(state.get(), 0);
+
+    // Create our future, but as per async conventions this still doesn't
+    // actually do anything. No wasm or host function has been called yet.
+    let mut future = Pin::from(Box::new(async_thunk.call_async(&[])));
+    assert_eq!(state.get(), 0);
+
+    // Push the future forward one tick, which actually runs the host code in
+    // our async func. Our future is designed to be pending once, however.
+    let poll = future
+        .as_mut()
+        .poll(&mut Context::from_waker(&dummy_waker()));
+    assert!(poll.is_pending());
+    assert_eq!(state.get(), 1);
+
+    // Now that our future is running (on a separate, now-suspended fiber), drop
+    // the future and that should deallocate all the Rust bits as well.
+    drop(future);
+    assert_eq!(state.get(), 2);
+
+    struct SetOnDrop(Rc<Cell<u32>>);
+
+    impl Drop for SetOnDrop {
+        fn drop(&mut self) {
+            assert_eq!(self.0.get(), 1);
+            self.0.set(2);
+        }
+    }
+}
+
+#[derive(Default)]
+struct PendingOnce {
+    already_polled: bool,
+}
+
+impl Future for PendingOnce {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.already_polled {
+            Poll::Ready(())
+        } else {
+            self.already_polled = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+fn run<F: Future>(future: F) -> F::Output {
+    let mut f = Pin::from(Box::new(future));
+    let waker = dummy_waker();
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match f.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => break val,
+            Poll::Pending => {}
+        }
+    }
+}
+
+fn dummy_waker() -> Waker {
+    return unsafe { Waker::from_raw(clone(5 as *const _)) };
+
+    unsafe fn clone(ptr: *const ()) -> RawWaker {
+        assert_eq!(ptr as usize, 5);
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+        RawWaker::new(ptr, &VTABLE)
+    }
+
+    unsafe fn wake(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn wake_by_ref(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn drop(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -1,3 +1,4 @@
+mod async_functions;
 mod cli_tests;
 mod custom_signal_handler;
 mod debug;


### PR DESCRIPTION
This PR refactors module instantiation in the runtime to allow for
different instance allocation strategy implementations.
    
It adds an `InstanceAllocator` trait with the current implementation put behind
the `OnDemandInstanceAllocator` struct.
    
The Wasmtime API has been updated to allow a `Config` to have an instance
allocation strategy set which will determine how instances get allocated.
    
This change is in preparation for an alternative *pooling* instance allocator
that can reserve all needed host process address space in advance.
    
This PR also makes changes to the `wasmtime_environ` crate to represent
compiled modules in a way that reduces copying at instantiation time.

See bytecodealliance/rfcs#5 about these proposed changes.

This PR depends on #2434.