### PR TITLE
feat(cranelift-codegen) Re-export `gimli` when `unwind` feature is enabled

### DIFF
--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -66,6 +66,8 @@ pub use crate::write::write_function;
 
 pub use cranelift_bforest as bforest;
 pub use cranelift_entity as entity;
+#[cfg(feature = "unwind")]
+pub use gimli;
 
 pub mod binemit;
 pub mod cfg_printer;


### PR DESCRIPTION
Hello!

When one wants to manipulate the unwind information, the exact version
of `gimli` must be used both by the user and `cranelift-codegen`. It
makes the update procedure less obvious.

This patch proposes to re-export `gimli` when the `unwind` feature is
turned on.

Thoughts?