### PR TITLE
Update to a CentOS 7 docker container for binary compatible builds.

### DIFF
--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -41,7 +41,6 @@ if (process.env.CENTOS !== undefined) {
 let path = process.env.PATH;
 path = `${path}:/rust/bin`;
 path = `/opt/rh/devtoolset-8/root/usr/bin:${path}`;
-path = `/opt/rh/rh-python36/root/usr/bin:${path}`;
 
 // Spawn a container daemonized in the background which we'll connect to via
 // `docker exec`. This'll have access to the current directory.
@@ -52,7 +51,7 @@ child_process.execFileSync('docker', [
   '-v', `${process.cwd()}:${process.cwd()}`,
   '-v', `${child_process.execSync('rustc --print sysroot').toString().trim()}:/rust:ro`,
   '--env', `PATH=${path}`,
-  'centos:6',
+  'centos:7',
 ], stdio);
 
 // Use ourselves to run future commands
@@ -63,7 +62,7 @@ const exec = s => {
   child_process.execSync(`docker exec centos ${s}`, stdio);
 };
 exec('yum install -y centos-release-scl cmake xz epel-release');
-exec('yum install -y rh-python36 patchelf unzip');
+exec('yum install -y python3 patchelf unzip');
 exec('yum install -y devtoolset-8-gcc devtoolset-8-binutils devtoolset-8-gcc-c++');
 exec('yum install -y git');
 


### PR DESCRIPTION
CentOS 6 just went EOL at the end of November 2020; as of today, the
repository seems to have disappeared, so our CI builds are failing. This
PR updates us to CentOS 7, which should be usable until June 30, 2024.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
