### PR TITLE
Improve usability of constants

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -41,6 +41,23 @@ impl DataValue {
         }
     }
 
+    /// Try to cast a [DataValue] as an i64 integer; this performs necessary casting for integers
+    /// and booleans and returns an error for the remaining types.
+    pub fn to_integer(self) -> Result<i64, DataValueCastFailure> {
+        match self {
+            Self::I8(i) => Ok(i as i64),
+            Self::I16(i) => Ok(i as i64),
+            Self::I32(i) => Ok(i as i64),
+            Self::I64(i) => Ok(i),
+            Self::U8(i) => Ok(i as i64),
+            Self::U16(i) => Ok(i as i64),
+            Self::U32(i) => Ok(i as i64),
+            Self::U64(i) => Ok(i as i64),
+            Self::B(i) => Ok(i as i64),
+            _ => Err(DataValueCastFailure::TryInto(self.ty(), types::I64)),
+        }
+    }
+
     /// Return the Cranelift IR [Type] for this [DataValue].
     pub fn ty(&self) -> Type {
         match self {

--- a/cranelift/codegen/src/ir/constant.rs
+++ b/cranelift/codegen/src/ir/constant.rs
@@ -169,9 +169,10 @@ pub type ConstantOffset = u32;
 /// Inner type for storing data and offset together in the constant pool. The offset is optional
 /// because it must be set relative to the function code size (i.e. constants are emitted after the
 /// function body); because the function is not yet compiled when constants are inserted,
-/// [`set_offset`](crate::ir::ConstantPool::set_offset) must be called once a constant's offset
-/// from the beginning of the function is known (see
-/// `relaxation` in `relaxation.rs`).
+/// [`set_offset`](crate::ir::ConstantPool::set_offset) must be called once a constant's offset from
+/// the beginning of the function is known (see `relaxation` in `relaxation.rs`). TODO the offset
+/// part of this can be removed with the x86 backend
+/// (https://github.com/bytecodealliance/wasmtime/issues/1936).
 #[derive(Clone)]
 pub struct ConstantPoolEntry {
     data: ConstantData,
@@ -261,7 +262,9 @@ impl ConstantPool {
     }
 
     /// Assign an offset to a given constant, where the offset is the number of bytes from the
-    /// beginning of the function to the beginning of the constant data inside the pool.
+    /// beginning of the function to the beginning of the constant data inside the pool. TODO this
+    /// method should be removed with the x86 backend
+    /// (https://github.com/bytecodealliance/wasmtime/issues/1936).
     pub fn set_offset(&mut self, constant_handle: Constant, constant_offset: ConstantOffset) {
         assert!(
             self.handles_to_values.contains_key(&constant_handle),
@@ -274,7 +277,9 @@ impl ConstantPool {
     }
 
     /// Retrieve the offset of a given constant, where the offset is the number of bytes from the
-    /// beginning of the function to the beginning of the constant data inside the pool.
+    /// beginning of the function to the beginning of the constant data inside the pool. TODO this
+    /// method should be removed with the x86 backend
+    /// (https://github.com/bytecodealliance/wasmtime/issues/1936).
     pub fn get_offset(&self, constant_handle: Constant) -> ConstantOffset {
         self.handles_to_values
             .get(&constant_handle)

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -179,14 +179,9 @@ pub(crate) fn put_input_in_reg<C: LowerCtx<I = Inst>>(
         } else {
             c
         };
+        let masked = DataValue::U64(masked);
         let to_reg = ctx.alloc_tmp(Inst::rc_for_type(ty).unwrap(), ty);
-        for inst in Inst::gen_constant(to_reg, masked, ty, |reg_class, ty| {
-            ctx.alloc_tmp(reg_class, ty)
-        })
-        .into_iter()
-        {
-            ctx.emit(inst);
-        }
+        ctx.emit_constant(masked, to_reg);
         to_reg.to_reg()
     } else {
         ctx.put_input_in_reg(input.insn, input.input)

--- a/cranelift/codegen/src/isa/arm32/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/mod.rs
@@ -809,14 +809,14 @@ impl MachInst for Inst {
 
     fn gen_constant<F: FnMut(RegClass, Type) -> Writable<Reg>>(
         to_reg: Writable<Reg>,
-        value: u64,
-        ty: Type,
+        value: DataValue,
         _alloc_tmp: F,
     ) -> SmallVec<[Inst; 4]> {
-        match ty {
+        match value.ty() {
             B1 | I8 | B8 | I16 | B16 | I32 | B32 => {
-                let v: i64 = value as i64;
-
+                let v = value
+                    .to_integer()
+                    .expect("a value that can be converted to a scalar integer");
                 if v >= (1 << 32) || v < -(1 << 32) {
                     panic!("Cannot load constant value {}", value)
                 }

--- a/cranelift/codegen/src/isa/arm32/lower.rs
+++ b/cranelift/codegen/src/isa/arm32/lower.rs
@@ -71,11 +71,7 @@ pub(crate) fn input_to_reg<C: LowerCtx<I = Inst>>(
     let inputs = ctx.get_input_as_source_or_const(input.insn, input.input);
     let in_reg = if let Some(c) = inputs.constant {
         let to_reg = ctx.alloc_tmp(Inst::rc_for_type(ty).unwrap(), ty);
-        for inst in Inst::gen_constant(to_reg, c, ty, |reg_class, ty| ctx.alloc_tmp(reg_class, ty))
-            .into_iter()
-        {
-            ctx.emit(inst);
-        }
+        ctx.emit_constant(DataValue::U64(c), to_reg);
         to_reg.to_reg()
     } else {
         ctx.put_input_in_reg(input.insn, input.input)


### PR DESCRIPTION
This adds a higher-level method, `LowerCtx::emit_constant` for lowering a constant in one of two ways:
 - using a `DataValue` (instead of the previous `u64`), a value can be generated into a register using `MachInst::gen_constant`
 - alternately, if `MachInst::should_genenerate_constant_in_pool` is true, then a value is emitted into the constant pool/island and loaded from memory at runtime; this path uses `MachInst::gen_constant_in_pool`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
