### PR TITLE
Disable some x64 SIMD tests that seem to be nondeterministic.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -175,49 +175,10 @@ fn write_testsuite_tests(
 
 /// For experimental_x64 backend features that are not supported yet, mark tests as panicking, so
 /// they stop "passing" once the features are properly implemented.
-fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str) -> bool {
-    if !cfg!(feature = "experimental_x64") || strategy != "Cranelift" {
-        return false;
-    }
-
-    match (testsuite, testname) {
-        ("simd", "simd_address") => return false,
-        ("simd", "simd_bitwise") => return false,
-        ("simd", "simd_bit_shift") => return false,
-        ("simd", "simd_boolean") => return false,
-        ("simd", "simd_const") => return false,
-        ("simd", "simd_i8x16_arith") => return false,
-        ("simd", "simd_i8x16_arith2") => return false,
-        ("simd", "simd_i8x16_cmp") => return false,
-        ("simd", "simd_i8x16_sat_arith") => return false,
-        ("simd", "simd_i16x8_arith") => return false,
-        ("simd", "simd_i16x8_arith2") => return false,
-        ("simd", "simd_i16x8_cmp") => return false,
-        ("simd", "simd_i16x8_sat_arith") => return false,
-        ("simd", "simd_i32x4_arith") => return false,
-        ("simd", "simd_i32x4_arith2") => return false,
-        ("simd", "simd_i32x4_cmp") => return false,
-        ("simd", "simd_i64x2_arith") => return false,
-        ("simd", "simd_f32x4") => return false,
-        ("simd", "simd_f32x4_arith") => return false,
-        ("simd", "simd_f32x4_cmp") => return false,
-        ("simd", "simd_f32x4_pmin_pmax") => return false,
-        ("simd", "simd_f64x2") => return false,
-        ("simd", "simd_f64x2_arith") => return false,
-        ("simd", "simd_f64x2_cmp") => return false,
-        ("simd", "simd_f64x2_pmin_pmax") => return false,
-        ("simd", "simd_lane") => return false,
-        ("simd", "simd_load") => return false,
-        ("simd", "simd_load_splat") => return false,
-        ("simd", "simd_splat") => return false,
-        ("simd", "simd_store") => return false,
-        ("simd", "simd_conversions") => return false,
-        ("simd", "simd_f32x4_rounding") => return false,
-        ("simd", "simd_f64x2_rounding") => return false,
-        ("simd", _) => return true,
-        _ => {}
-    }
-
+///
+/// TODO(#2470): removed all tests from this set as we are disabling x64 SIMD tests unconditionally
+/// instead until we resolve a nondeterminism bug. Restore when fixed.
+fn experimental_x64_should_panic(_testsuite: &str, _testname: &str, _strategy: &str) -> bool {
     false
 }
 
@@ -237,6 +198,11 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             // because Cranelift only supports reference types on x64.
             ("reference_types", _) => {
                 return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
+            }
+
+            // Ignore all x64 SIMD tests for now (#2470).
+            ("simd", _) if cfg!(feature = "experimental_x64") => {
+                return env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64";
             }
 
             // These are only implemented on aarch64 and x64.


### PR DESCRIPTION
We are seeing some repeated but nondeterministic failures of these
tests, as tracked in #2470. We will disable them for now while we
investigate, so as not to block CI for other work.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
