### PR TITLE
[machinst x64]: implement dot product

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -498,6 +498,7 @@ pub enum SseOpcode {
     Pinsrb,
     Pinsrw,
     Pinsrd,
+    Pmaddwd,
     Pmaxsb,
     Pmaxsw,
     Pmaxsd,
@@ -598,6 +599,7 @@ impl SseOpcode {
             | SseOpcode::Mulps
             | SseOpcode::Mulss
             | SseOpcode::Orps
+            | SseOpcode::Pmaddwd
             | SseOpcode::Rcpss
             | SseOpcode::Rsqrtss
             | SseOpcode::Sqrtps
@@ -842,6 +844,7 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Pinsrb => "pinsrb",
             SseOpcode::Pinsrw => "pinsrw",
             SseOpcode::Pinsrd => "pinsrd",
+            SseOpcode::Pmaddwd => "pmaddwd",
             SseOpcode::Pmaxsb => "pmaxsb",
             SseOpcode::Pmaxsw => "pmaxsw",
             SseOpcode::Pmaxsd => "pmaxsd",

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1805,6 +1805,7 @@ pub(crate) fn emit(
                 SseOpcode::Pcmpgtw => (LegacyPrefixes::_66, 0x0F65, 2),
                 SseOpcode::Pcmpgtd => (LegacyPrefixes::_66, 0x0F66, 2),
                 SseOpcode::Pcmpgtq => (LegacyPrefixes::_66, 0x0F3837, 3),
+                SseOpcode::Pmaddwd => (LegacyPrefixes::_66, 0x0FF5, 2),
                 SseOpcode::Pmovsxbd => (LegacyPrefixes::_66, 0x0F3821, 3),
                 SseOpcode::Pmovsxbw => (LegacyPrefixes::_66, 0x0F3820, 3),
                 SseOpcode::Pmovsxbq => (LegacyPrefixes::_66, 0x0F3822, 3),

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3068,6 +3068,12 @@ fn test_x64_emit() {
     ));
 
     insns.push((
+        Inst::xmm_rm_r(SseOpcode::Pmaddwd, RegMem::reg(xmm8), w_xmm9),
+        "66450FF5C8",
+        "pmaddwd %xmm8, %xmm9",
+    ));
+
+    insns.push((
         Inst::xmm_rm_r(SseOpcode::Pmaxsb, RegMem::reg(xmm15), w_xmm6),
         "66410F383CF7",
         "pmaxsb  %xmm15, %xmm6",

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -4144,6 +4144,20 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         }
 
+        Opcode::WideningPairwiseDotProductS => {
+            let lhs = put_input_in_reg(ctx, inputs[0]);
+            let lhs_ty = ctx.input_ty(insn, 0);
+            let rhs = input_to_reg_mem(ctx, inputs[1]);
+            let dst = get_output_reg(ctx, outputs[0]);
+            let dst_ty = ty.unwrap();
+            assert!(
+                dst_ty == types::I32X4 && lhs_ty == types::I16X8,
+                "dot product only expands two I16x8 vectors into an I32x4 vector"
+            );
+            ctx.emit(Inst::gen_move(dst, lhs, lhs_ty));
+            ctx.emit(Inst::xmm_rm_r(SseOpcode::Pmaddwd, rhs, dst))
+        }
+
         Opcode::IaddImm
         | Opcode::ImulImm
         | Opcode::UdivImm


### PR DESCRIPTION
Implements dot product for the x64 backend. Probably should not be merged until we can ~~enable the spec tests, which requires https://github.com/WebAssembly/testsuite/pull/37 to merge~~ (merged in #2481) and https://github.com/bytecodealliance/wasmtime/issues/2432 to be resolved.