### PR TITLE
Update spec tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wat",
 ]
 
@@ -1167,7 +1167,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "typemap",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wat",
 ]
 
@@ -2406,9 +2406,9 @@ checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmparser"
-version = "0.69.1"
+version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd19c6066bcf391a9d6f81db9b809f31d31723da2652c8416cb81cd5aabed944"
+checksum = "fd2dd6dadf3a723971297bcc0ec103e0aa8118bf68e23f49cb575e21621894a8"
 
 [[package]]
 name = "wasmprinter"
@@ -2417,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba006f5c5bf41a2a5c3b45e861ea6eb067382acb022b6a35a00a0390f9547f6"
 dependencies = [
  "anyhow",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
 ]
 
 [[package]]
@@ -2438,7 +2438,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -2516,7 +2516,7 @@ dependencies = [
  "test-programs",
  "tracing-subscriber",
  "wasi-common",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-debug",
@@ -2552,7 +2552,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wasmtime-environ",
 ]
 
@@ -2571,7 +2571,7 @@ dependencies = [
  "more-asserts",
  "serde",
  "thiserror",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
 ]
 
 [[package]]
@@ -2600,7 +2600,7 @@ dependencies = [
  "rayon",
  "wasm-smith",
  "wasmi",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -2628,7 +2628,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -2645,7 +2645,7 @@ version = "0.21.0"
 dependencies = [
  "cranelift-codegen",
  "lightbeam",
- "wasmparser 0.69.1",
+ "wasmparser 0.69.2",
  "wasmtime-environ",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"
 humantime = "2.0.0"
-wasmparser = "0.69"
+wasmparser = "0.69.2"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/build.rs
+++ b/build.rs
@@ -210,7 +210,8 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             | ("simd", "simd_f32x4_pmin_pmax")
             | ("simd", "simd_f64x2_pmin_pmax")
             | ("simd", "simd_f32x4_rounding")
-            | ("simd", "simd_f64x2_rounding") => {
+            | ("simd", "simd_f64x2_rounding")
+            | ("simd", "simd_i32x4_dot_i16x8") => {
                 return !(cfg!(feature = "experimental_x64")
                     || env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "aarch64")
             }

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.69.1", default-features = false }
+wasmparser = { version = "0.69.2", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.68.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.68.0" }
 cranelift-frontend = { path = "../frontend", version = "0.68.0", default-features = false }

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.23.0"
-wasmparser = "0.69.0"
+wasmparser = "0.69.2"
 object = { version = "0.22.0", default-features = false, features = ["read", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.21.0" }
 target-lexicon = { version = "0.11.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.68.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.68.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.68.0", features = ["enable-serde"] }
-wasmparser = "0.69.0"
+wasmparser = "0.69.2"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -12,7 +12,7 @@ arbitrary = { version = "0.4.1", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.69.0"
+wasmparser = "0.69.2"
 wasmprinter = "0.2.16"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -28,7 +28,7 @@ rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.69.0"
+wasmparser = "0.69.2"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "1.0"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ more-asserts = "0.2.1"
 smallvec = "1.0.0"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.69.0"
+wasmparser = "0.69.2"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 lightbeam = { path = "..", version = "0.21.0" }
-wasmparser = "0.69"
+wasmparser = "0.69.2"
 cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.68.0" }
 wasmtime-environ = { path = "../../environ", version = "0.21.0" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -16,7 +16,7 @@ wasmtime-jit = { path = "../jit", version = "0.21.0" }
 wasmtime-cache = { path = "../cache", version = "0.21.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.21.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.69.0"
+wasmparser = "0.69.2"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -371,9 +371,6 @@ impl WastContext {
 
 fn is_matching_assert_invalid_error_message(expected: &str, actual: &str) -> bool {
     actual.contains(expected)
-        // Waiting on https://github.com/WebAssembly/bulk-memory-operations/pull/137
-        // to propagate to WebAssembly/testsuite.
-        || (expected.contains("unknown table") && actual.contains("unknown elem"))
         // `elem.wast` and `proposals/bulk-memory-operations/elem.wast` disagree
         // on the expected error message for the same error.
         || (expected.contains("out of bounds") && actual.contains("does not fit"))


### PR DESCRIPTION
This updates the Wasm spec tests to the commits at https://github.com/WebAssembly/testsuite/pull/37, which brings in some tests for new Wasm SIMD operations. Since the spec tesets have not been updated in a while, it brings in other changes, like those to `data.wast` which cause a failure:

```
---- wast::Cranelift::spec::data stdout ----
thread 'wast::Cranelift::spec::data' panicked at 'called `Result::unwrap()` on an `Err` value: failed directive on tests/spec_testsuite/data.wast:290:1

Caused by:
    assert_invalid: expected "unknown memory 1", got "WebAssembly failed to compile
    
    Caused by:
        0: WebAssembly translation error
        1: Invalid input WebAssembly code at offset 21: Data segment extends past end of the data section"', /home/abrown/Code/wasmtime/target/debug/build/wasmtime-cli-02b4b8fc65746038/out/wast_testsuite_tests.rs:470:14

failures:
    wast::Cranelift::spec::data

test result: FAILED. 264 passed; 1 failed; 48 ignored; 0 measured; 0 filtered out
```

Is this an error stringifying problem or a problem in Wasmtime itself?