### PR TITLE
Make endianness explicit in Cranelift IR MemFlags

### DIFF
--- a/cranelift/codegen/src/ir/globalvalue.rs
+++ b/cranelift/codegen/src/ir/globalvalue.rs
@@ -1,7 +1,7 @@
 //! Global values.
 
 use crate::ir::immediates::{Imm64, Offset32};
-use crate::ir::{ExternalName, GlobalValue, Type};
+use crate::ir::{ExternalName, GlobalValue, MemFlags, Type};
 use crate::isa::TargetIsa;
 use crate::machinst::RelocDistance;
 use core::fmt;
@@ -30,7 +30,7 @@ pub enum GlobalValueData {
 
         /// Specifies whether the memory that this refers to is readonly, allowing for the
         /// elimination of redundant loads.
-        readonly: bool,
+        flags: MemFlags,
     },
 
     /// Value is an offset from another global value.
@@ -114,15 +114,8 @@ impl fmt::Display for GlobalValueData {
                 base,
                 offset,
                 global_type,
-                readonly,
-            } => write!(
-                f,
-                "load.{} notrap aligned {}{}{}",
-                global_type,
-                if readonly { "readonly " } else { "" },
-                base,
-                offset
-            ),
+                flags,
+            } => write!(f, "load.{}{} {}{}", global_type, flags, base, offset),
             Self::IAddImm {
                 global_type,
                 base,

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -50,7 +50,7 @@ pub use crate::ir::instructions::{
 pub use crate::ir::jumptable::JumpTableData;
 pub use crate::ir::layout::Layout;
 pub use crate::ir::libcall::{get_probestack_funcref, LibCall};
-pub use crate::ir::memflags::MemFlags;
+pub use crate::ir::memflags::{Endianness, MemFlags};
 pub use crate::ir::progpoint::{ExpandedProgramPoint, ProgramOrder, ProgramPoint};
 pub use crate::ir::sourceloc::SourceLoc;
 pub use crate::ir::stackslot::{StackLayoutInfo, StackSlotData, StackSlotKind, StackSlots};

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -3,7 +3,7 @@
 use crate::ir;
 use crate::ir::types;
 use crate::ir::types::*;
-use crate::ir::MemFlags;
+use crate::ir::{Endianness, MemFlags};
 use crate::isa;
 use crate::isa::aarch64::{inst::EmitState, inst::*};
 use crate::machinst::*;
@@ -313,11 +313,21 @@ impl ABIMachineSpec for AArch64MachineDeps {
     }
 
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Inst {
-        Inst::gen_load(into_reg, mem.into(), ty, MemFlags::trusted())
+        Inst::gen_load(
+            into_reg,
+            mem.into(),
+            ty,
+            MemFlags::trusted(Endianness::Little),
+        )
     }
 
     fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type) -> Inst {
-        Inst::gen_store(mem.into(), from_reg, ty, MemFlags::trusted())
+        Inst::gen_store(
+            mem.into(),
+            from_reg,
+            ty,
+            MemFlags::trusted(Endianness::Little),
+        )
     }
 
     fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Inst {
@@ -403,12 +413,12 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
     fn gen_load_base_offset(into_reg: Writable<Reg>, base: Reg, offset: i32, ty: Type) -> Inst {
         let mem = AMode::RegOffset(base, offset as i64, ty);
-        Inst::gen_load(into_reg, mem, ty, MemFlags::trusted())
+        Inst::gen_load(into_reg, mem, ty, MemFlags::trusted(Endianness::Little))
     }
 
     fn gen_store_base_offset(base: Reg, offset: i32, from_reg: Reg, ty: Type) -> Inst {
         let mem = AMode::RegOffset(base, offset as i64, ty);
-        Inst::gen_store(mem, from_reg, ty, MemFlags::trusted())
+        Inst::gen_store(mem, from_reg, ty, MemFlags::trusted(Endianness::Little))
     }
 
     fn gen_sp_reg_adjust(amount: i32) -> SmallVec<[Inst; 2]> {
@@ -465,7 +475,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 writable_stack_reg(),
                 SImm7Scaled::maybe_from_i64(-16, types::I64).unwrap(),
             ),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         });
         // mov fp (x29), sp. This uses the ADDI rd, rs, 0 form of `MOV` because
         // the usual encoding (`ORR`) does not work with SP.
@@ -502,7 +512,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 writable_stack_reg(),
                 SImm7Scaled::maybe_from_i64(16, types::I64).unwrap(),
             ),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         });
 
         insts
@@ -551,7 +561,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     stack_reg(),
                     SImm7Scaled::maybe_from_i64((i * 16) as i64, types::I64).unwrap(),
                 ),
-                flags: MemFlags::trusted(),
+                flags: MemFlags::trusted(Endianness::Little),
             });
         }
 
@@ -563,7 +573,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     stack_reg(),
                     SImm9::maybe_from_i64((vec_offset + (i * 16)) as i64).unwrap(),
                 ),
-                flags: MemFlags::trusted(),
+                flags: MemFlags::trusted(Endianness::Little),
             });
         }
 
@@ -602,7 +612,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     stack_reg(),
                     SImm7Scaled::maybe_from_i64((i * 16) as i64, types::I64).unwrap(),
                 ),
-                flags: MemFlags::trusted(),
+                flags: MemFlags::trusted(Endianness::Little),
             });
         }
 
@@ -613,7 +623,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     stack_reg(),
                     SImm9::maybe_from_i64(((i * 16) + int_save_bytes) as i64).unwrap(),
                 ),
-                flags: MemFlags::trusted(),
+                flags: MemFlags::trusted(Endianness::Little),
             });
         }
 
@@ -634,7 +644,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 writable_xreg(BALDRDASH_TLS_REG),
                 AMode::UnsignedOffset(fp_reg(), UImm12Scaled::maybe_from_i64(off, I64).unwrap()),
                 I64,
-                MemFlags::trusted(),
+                MemFlags::trusted(Endianness::Little),
             ));
         }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3,7 +3,7 @@
 use crate::binemit::{CodeOffset, Reloc, StackMap};
 use crate::ir::constant::ConstantData;
 use crate::ir::types::*;
-use crate::ir::{MemFlags, TrapCode};
+use crate::ir::{Endianness, MemFlags, TrapCode};
 use crate::isa::aarch64::inst::*;
 use crate::machinst::ty_bits;
 
@@ -1606,7 +1606,7 @@ impl MachInstEmit for Inst {
                 let inst = Inst::FpuLoad64 {
                     rd,
                     mem: AMode::Label(MemLabel::PCRel(8)),
-                    flags: MemFlags::trusted(),
+                    flags: MemFlags::trusted(Endianness::Little),
                 };
                 inst.emit(sink, emit_info, state);
                 let inst = Inst::Jump {
@@ -1619,7 +1619,7 @@ impl MachInstEmit for Inst {
                 let inst = Inst::FpuLoad128 {
                     rd,
                     mem: AMode::Label(MemLabel::PCRel(8)),
-                    flags: MemFlags::trusted(),
+                    flags: MemFlags::trusted(Endianness::Little),
                 };
                 inst.emit(sink, emit_info, state);
                 let inst = Inst::Jump {
@@ -2214,7 +2214,7 @@ impl MachInstEmit for Inst {
                         I32,
                         ExtendOp::UXTW,
                     ),
-                    flags: MemFlags::trusted(),
+                    flags: MemFlags::trusted(Endianness::Little),
                 };
                 inst.emit(sink, emit_info, state);
                 // Add base of jump table to jump-table-sourced block offset
@@ -2261,7 +2261,7 @@ impl MachInstEmit for Inst {
                 let inst = Inst::ULoad64 {
                     rd,
                     mem: AMode::Label(MemLabel::PCRel(8)),
-                    flags: MemFlags::trusted(),
+                    flags: MemFlags::trusted(Endianness::Little),
                 };
                 inst.emit(sink, emit_info, state);
                 let inst = Inst::Jump {

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1,4 +1,5 @@
 use crate::ir::types::*;
+use crate::ir::Endianness;
 use crate::isa::aarch64::inst::*;
 use crate::isa::test_utils;
 use crate::isa::CallConv;
@@ -1079,7 +1080,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad8 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41004038",
         "ldurb w1, [x2]",
@@ -1088,7 +1089,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad8 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::zero(I8)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41004039",
         "ldrb w1, [x2]",
@@ -1097,7 +1098,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad8 {
             rd: writable_xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(5)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41686538",
         "ldrb w1, [x2, x5]",
@@ -1106,7 +1107,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad8 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41008038",
         "ldursb x1, [x2]",
@@ -1115,7 +1116,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad8 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(63, I8).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41FC8039",
         "ldrsb x1, [x2, #63]",
@@ -1124,7 +1125,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad8 {
             rd: writable_xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(5)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "4168A538",
         "ldrsb x1, [x2, x5]",
@@ -1133,7 +1134,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad16 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(5).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41504078",
         "ldurh w1, [x2, #5]",
@@ -1142,7 +1143,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad16 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8, I16).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41104079",
         "ldrh w1, [x2, #8]",
@@ -1151,7 +1152,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad16 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(3), I16),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41786378",
         "ldrh w1, [x2, x3, LSL #1]",
@@ -1160,7 +1161,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad16 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41008078",
         "ldursh x1, [x2]",
@@ -1169,7 +1170,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad16 {
             rd: writable_xreg(28),
             mem: AMode::UnsignedOffset(xreg(20), UImm12Scaled::maybe_from_i64(24, I16).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "9C328079",
         "ldrsh x28, [x20, #24]",
@@ -1178,7 +1179,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad16 {
             rd: writable_xreg(28),
             mem: AMode::RegScaled(xreg(20), xreg(20), I16),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "9C7AB478",
         "ldrsh x28, [x20, x20, LSL #1]",
@@ -1187,7 +1188,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad32 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410040B8",
         "ldur w1, [x2]",
@@ -1196,7 +1197,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad32 {
             rd: writable_xreg(12),
             mem: AMode::UnsignedOffset(xreg(0), UImm12Scaled::maybe_from_i64(204, I32).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "0CCC40B9",
         "ldr w12, [x0, #204]",
@@ -1205,7 +1206,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad32 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(12), I32),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41786CB8",
         "ldr w1, [x2, x12, LSL #2]",
@@ -1214,7 +1215,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad32 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410080B8",
         "ldursw x1, [x2]",
@@ -1223,7 +1224,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad32 {
             rd: writable_xreg(12),
             mem: AMode::UnsignedOffset(xreg(1), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "2CFCBFB9",
         "ldrsw x12, [x1, #16380]",
@@ -1232,7 +1233,7 @@ fn test_aarch64_binemit() {
         Inst::SLoad32 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(5), xreg(1), I32),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "A178A1B8",
         "ldrsw x1, [x5, x1, LSL #2]",
@@ -1241,7 +1242,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410040F8",
         "ldur x1, [x2]",
@@ -1250,7 +1251,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(-256).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410050F8",
         "ldur x1, [x2, #-256]",
@@ -1259,7 +1260,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::maybe_from_i64(255).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41F04FF8",
         "ldur x1, [x2, #255]",
@@ -1268,7 +1269,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41FC7FF9",
         "ldr x1, [x2, #32760]",
@@ -1277,7 +1278,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(3)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "416863F8",
         "ldr x1, [x2, x3]",
@@ -1286,7 +1287,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(3), I64),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "417863F8",
         "ldr x1, [x2, x3, LSL #3]",
@@ -1295,7 +1296,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::SXTW),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41D863F8",
         "ldr x1, [x2, w3, SXTW #3]",
@@ -1304,7 +1305,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegExtended(xreg(2), xreg(3), ExtendOp::SXTW),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41C863F8",
         "ldr x1, [x2, w3, SXTW]",
@@ -1313,7 +1314,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::Label(MemLabel::PCRel(64)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "01020058",
         "ldr x1, pc+64",
@@ -1322,7 +1323,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410C41F8",
         "ldr x1, [x2, #16]!",
@@ -1331,7 +1332,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410441F8",
         "ldr x1, [x2], #16",
@@ -1340,7 +1341,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(32768, I8),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "100090D2B063308B010240F9",
         "movz x16, #32768 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1349,7 +1350,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(-32768, I8),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "F0FF8F92B063308B010240F9",
         "movn x16, #32767 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1358,7 +1359,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(1048576, I8), // 2^20
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "1002A0D2B063308B010240F9",
         "movz x16, #16, LSL #16 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1367,7 +1368,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::FPOffset(1048576 + 1, I8), // 2^20 + 1
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "300080521002A072B063308B010240F9",
         "movz w16, #1 ; movk w16, #16, LSL #16 ; add x16, fp, x16, UXTX ; ldr x1, [x16]",
@@ -1377,7 +1378,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegOffset(xreg(7), 8, I64),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "E18040F8",
         "ldur x1, [x7, #8]",
@@ -1387,7 +1388,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegOffset(xreg(7), 1024, I64),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "E10042F9",
         "ldr x1, [x7, #1024]",
@@ -1397,7 +1398,7 @@ fn test_aarch64_binemit() {
         Inst::ULoad64 {
             rd: writable_xreg(1),
             mem: AMode::RegOffset(xreg(7), 1048576, I64),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "1002A0D2F060308B010240F9",
         "movz x16, #16, LSL #16 ; add x16, x7, x16, UXTX ; ldr x1, [x16]",
@@ -1407,7 +1408,7 @@ fn test_aarch64_binemit() {
         Inst::Store8 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41000038",
         "sturb w1, [x2]",
@@ -1416,7 +1417,7 @@ fn test_aarch64_binemit() {
         Inst::Store8 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(4095, I8).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41FC3F39",
         "strb w1, [x2, #4095]",
@@ -1425,7 +1426,7 @@ fn test_aarch64_binemit() {
         Inst::Store16 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41000078",
         "sturh w1, [x2]",
@@ -1434,7 +1435,7 @@ fn test_aarch64_binemit() {
         Inst::Store16 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(8190, I16).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41FC3F79",
         "strh w1, [x2, #8190]",
@@ -1443,7 +1444,7 @@ fn test_aarch64_binemit() {
         Inst::Store32 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410000B8",
         "stur w1, [x2]",
@@ -1452,7 +1453,7 @@ fn test_aarch64_binemit() {
         Inst::Store32 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(16380, I32).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41FC3FB9",
         "str w1, [x2, #16380]",
@@ -1461,7 +1462,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::Unscaled(xreg(2), SImm9::zero()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410000F8",
         "stur x1, [x2]",
@@ -1470,7 +1471,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::UnsignedOffset(xreg(2), UImm12Scaled::maybe_from_i64(32760, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "41FC3FF9",
         "str x1, [x2, #32760]",
@@ -1479,7 +1480,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegReg(xreg(2), xreg(3)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "416823F8",
         "str x1, [x2, x3]",
@@ -1488,7 +1489,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegScaled(xreg(2), xreg(3), I64),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "417823F8",
         "str x1, [x2, x3, LSL #3]",
@@ -1497,7 +1498,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegScaledExtended(xreg(2), xreg(3), I64, ExtendOp::UXTW),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "415823F8",
         "str x1, [x2, w3, UXTW #3]",
@@ -1506,7 +1507,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::RegExtended(xreg(2), xreg(3), ExtendOp::UXTW),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "414823F8",
         "str x1, [x2, w3, UXTW]",
@@ -1515,7 +1516,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::PreIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410C01F8",
         "str x1, [x2, #16]!",
@@ -1524,7 +1525,7 @@ fn test_aarch64_binemit() {
         Inst::Store64 {
             rd: xreg(1),
             mem: AMode::PostIndexed(writable_xreg(2), SImm9::maybe_from_i64(16).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "410401F8",
         "str x1, [x2], #16",
@@ -1535,7 +1536,7 @@ fn test_aarch64_binemit() {
             rt: xreg(8),
             rt2: xreg(9),
             mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "482500A9",
         "stp x8, x9, [x10]",
@@ -1545,7 +1546,7 @@ fn test_aarch64_binemit() {
             rt: xreg(8),
             rt2: xreg(9),
             mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(504, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "48A51FA9",
         "stp x8, x9, [x10, #504]",
@@ -1555,7 +1556,7 @@ fn test_aarch64_binemit() {
             rt: xreg(8),
             rt2: xreg(9),
             mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-64, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "48253CA9",
         "stp x8, x9, [x10, #-64]",
@@ -1565,7 +1566,7 @@ fn test_aarch64_binemit() {
             rt: xreg(21),
             rt2: xreg(28),
             mem: PairAMode::SignedOffset(xreg(1), SImm7Scaled::maybe_from_i64(-512, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "357020A9",
         "stp x21, x28, [x1, #-512]",
@@ -1578,7 +1579,7 @@ fn test_aarch64_binemit() {
                 writable_xreg(10),
                 SImm7Scaled::maybe_from_i64(-64, I64).unwrap(),
             ),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "4825BCA9",
         "stp x8, x9, [x10, #-64]!",
@@ -1591,7 +1592,7 @@ fn test_aarch64_binemit() {
                 writable_xreg(20),
                 SImm7Scaled::maybe_from_i64(504, I64).unwrap(),
             ),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "8FC29FA8",
         "stp x15, x16, [x20], #504",
@@ -1602,7 +1603,7 @@ fn test_aarch64_binemit() {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
             mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "482540A9",
         "ldp x8, x9, [x10]",
@@ -1612,7 +1613,7 @@ fn test_aarch64_binemit() {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
             mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(504, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "48A55FA9",
         "ldp x8, x9, [x10, #504]",
@@ -1622,7 +1623,7 @@ fn test_aarch64_binemit() {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
             mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-64, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "48257CA9",
         "ldp x8, x9, [x10, #-64]",
@@ -1632,7 +1633,7 @@ fn test_aarch64_binemit() {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
             mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::maybe_from_i64(-512, I64).unwrap()),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "482560A9",
         "ldp x8, x9, [x10, #-512]",
@@ -1645,7 +1646,7 @@ fn test_aarch64_binemit() {
                 writable_xreg(10),
                 SImm7Scaled::maybe_from_i64(-64, I64).unwrap(),
             ),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "4825FCA9",
         "ldp x8, x9, [x10, #-64]!",
@@ -1658,7 +1659,7 @@ fn test_aarch64_binemit() {
                 writable_xreg(12),
                 SImm7Scaled::maybe_from_i64(504, I64).unwrap(),
             ),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "88E5DFA8",
         "ldp x8, x25, [x12], #504",
@@ -4986,7 +4987,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad32 {
             rd: writable_vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F32),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "107969BC",
         "ldr s16, [x8, x9, LSL #2]",
@@ -4996,7 +4997,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad64 {
             rd: writable_vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F64),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "107969FC",
         "ldr d16, [x8, x9, LSL #3]",
@@ -5006,7 +5007,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad128 {
             rd: writable_vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), I128),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "1079E93C",
         "ldr q16, [x8, x9, LSL #4]",
@@ -5016,7 +5017,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad32 {
             rd: writable_vreg(16),
             mem: AMode::Label(MemLabel::PCRel(8)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "5000001C",
         "ldr s16, pc+8",
@@ -5026,7 +5027,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad64 {
             rd: writable_vreg(16),
             mem: AMode::Label(MemLabel::PCRel(8)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "5000005C",
         "ldr d16, pc+8",
@@ -5036,7 +5037,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoad128 {
             rd: writable_vreg(16),
             mem: AMode::Label(MemLabel::PCRel(8)),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "5000009C",
         "ldr q16, pc+8",
@@ -5046,7 +5047,7 @@ fn test_aarch64_binemit() {
         Inst::FpuStore32 {
             rd: vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F32),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "107929BC",
         "str s16, [x8, x9, LSL #2]",
@@ -5056,7 +5057,7 @@ fn test_aarch64_binemit() {
         Inst::FpuStore64 {
             rd: vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), F64),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "107929FC",
         "str d16, [x8, x9, LSL #3]",
@@ -5066,7 +5067,7 @@ fn test_aarch64_binemit() {
         Inst::FpuStore128 {
             rd: vreg(16),
             mem: AMode::RegScaled(xreg(8), xreg(9), I128),
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         },
         "1079A93C",
         "str q16, [x8, x9, LSL #4]",

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -199,6 +199,9 @@ pub struct TargetFrontendConfig {
 
     /// The pointer width of the target.
     pub pointer_width: PointerWidth,
+
+    /// The endianness of the target.
+    pub endianness: ir::Endianness,
 }
 
 impl TargetFrontendConfig {
@@ -235,6 +238,14 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
         CallConv::triple_default(self.triple())
     }
 
+    /// Get the endianness of this ISA.
+    fn endianness(&self) -> ir::Endianness {
+        match self.triple().endianness().unwrap() {
+            target_lexicon::Endianness::Little => ir::Endianness::Little,
+            target_lexicon::Endianness::Big => ir::Endianness::Big,
+        }
+    }
+
     /// Get the pointer type of this ISA.
     fn pointer_type(&self) -> ir::Type {
         ir::Type::int(u16::from(self.pointer_bits())).unwrap()
@@ -260,6 +271,7 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
         TargetFrontendConfig {
             default_call_conv: self.default_call_conv(),
             pointer_width: self.pointer_width(),
+            endianness: self.endianness(),
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -634,7 +634,7 @@ impl From<StackAMode> for SyntheticAmode {
                 SyntheticAmode::Real(Amode::ImmReg {
                     simm32,
                     base: regs::rbp(),
-                    flags: MemFlags::trusted(),
+                    flags: MemFlags::trusted(ir::Endianness::Little),
                 })
             }
             StackAMode::NominalSPOffset(off, _ty) => {
@@ -651,7 +651,7 @@ impl From<StackAMode> for SyntheticAmode {
                 SyntheticAmode::Real(Amode::ImmReg {
                     simm32,
                     base: regs::rsp(),
-                    flags: MemFlags::trusted(),
+                    flags: MemFlags::trusted(ir::Endianness::Little),
                 })
             }
         }

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -3,7 +3,7 @@
 use super::regs::{self, show_ireg_sized};
 use super::EmitState;
 use crate::ir::condcodes::{FloatCC, IntCC};
-use crate::ir::MemFlags;
+use crate::ir::{Endianness, MemFlags};
 use crate::isa::x64::inst::Inst;
 use crate::machinst::*;
 use regalloc::{
@@ -44,7 +44,7 @@ impl Amode {
         Self::ImmReg {
             simm32,
             base,
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         }
     }
 
@@ -57,7 +57,7 @@ impl Amode {
             base,
             index,
             shift,
-            flags: MemFlags::trusted(),
+            flags: MemFlags::trusted(Endianness::Little),
         }
     }
 
@@ -109,7 +109,7 @@ impl Amode {
         match self {
             Amode::ImmReg { flags, .. } => *flags,
             Amode::ImmRegRegShift { flags, .. } => *flags,
-            Amode::RipRelative { .. } => MemFlags::trusted(),
+            Amode::RipRelative { .. } => MemFlags::trusted(Endianness::Little),
         }
     }
 

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -1695,9 +1695,12 @@ fn convert_ushr(
             let masks = pos.func.dfg.constants.insert(USHR_MASKS.as_ref().into());
             let mask_address = pos.ins().const_addr(isa.pointer_type(), masks);
             let mask_offset = pos.ins().ishl_imm(arg1, 4);
-            let mask =
-                pos.ins()
-                    .load_complex(arg0_type, MemFlags::new(), &[mask_address, mask_offset], 0);
+            let mask = pos.ins().load_complex(
+                arg0_type,
+                MemFlags::new(isa.endianness()),
+                &[mask_address, mask_offset],
+                0,
+            );
             pos.func.dfg.replace(inst).band(shifted, mask);
         } else if arg0_type.is_vector() {
             // x86 has encodings for these shifts.
@@ -1779,9 +1782,12 @@ fn convert_ishl(
             let masks = pos.func.dfg.constants.insert(SHL_MASKS.as_ref().into());
             let mask_address = pos.ins().const_addr(isa.pointer_type(), masks);
             let mask_offset = pos.ins().ishl_imm(arg1, 4);
-            let mask =
-                pos.ins()
-                    .load_complex(arg0_type, MemFlags::new(), &[mask_address, mask_offset], 0);
+            let mask = pos.ins().load_complex(
+                arg0_type,
+                MemFlags::new(isa.endianness()),
+                &[mask_address, mask_offset],
+                0,
+            );
             pos.func.dfg.replace(inst).band(shifted, mask);
         } else if arg0_type.is_vector() {
             // x86 has encodings for these shifts.

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -673,7 +673,7 @@ fn generate_gv<M: ABIMachineSpec>(
             base,
             offset,
             global_type: _,
-            readonly: _,
+            flags: _,
         } => {
             let base = generate_gv::<M>(f, abi, base, insts);
             let into_reg = Writable::from_reg(M::get_stacklimit_reg());

--- a/cranelift/filetests/filetests/isa/x86/i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/i128.clif
@@ -30,16 +30,16 @@ block0(v0: i128):
 function u0:2(i64, i128) fast {
 ; check: block0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v6: i64 [%rbp]):
 block0(v0: i64, v1: i128):
-    ; check: store v2, v0+8
-    ; check: store v3, v0+16
+    ; check: store little v2, v0+8
+    ; check: store little v3, v0+16
     store v1, v0+8
     return
 }
 
 function u0:3(i64) -> i128 fast {
 block0(v0: i64):
-    ; check: v2 = load.i64 v0+8
-    ; check: v3 = load.i64 v0+16
+    ; check: v2 = load.i64 little v0+8
+    ; check: v3 = load.i64 little v0+16
     v1 = load.i128 v0+8
     ; check: return v2, v3, v5
     return v1

--- a/cranelift/filetests/filetests/isa/x86/legalize-byte-ops-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-byte-ops-i8.clif
@@ -10,7 +10,7 @@ ss0 = explicit_slot 1 ; black box
 block0(v0: i8, v1: i8):
     v99 = stack_addr.i64 ss0
 
-    ; check: istore8 $(V), $(V)
+    ; check: istore8 little $(V), $(V)
 
     v2 = band v0, v1
     store v2, v99

--- a/cranelift/filetests/filetests/isa/x86/legalize-heaps.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-heaps.clif
@@ -70,7 +70,7 @@ block0(v0: i32, v1: i64, v3: i64):
     ; check:         v7 = iadd v21, v1
 
     v8 = heap_addr.i64 heap4, v0, 0
-    ; check:         v22 = load.i32 notrap aligned v3+88
+    ; check:         v22 = load.i32 little notrap aligned v3+88
     ; check:         v23 = iadd_imm v22, 0
     ; check:         v24 = icmp.i32 ugt v0, v23
     ; check:         brz v24, $(resume_4=$BB)
@@ -83,7 +83,7 @@ block0(v0: i32, v1: i64, v3: i64):
     ; check:         v8 = iadd v26, v25
 
     v9 = heap_addr.i64 heap5, v0, 0
-    ; check:         v27 = load.i32 notrap aligned v3+88
+    ; check:         v27 = load.i32 little notrap aligned v3+88
     ; check:         v28 = iadd_imm v27, 0
     ; check:         v29 = icmp.i32 ugt v0, v28
     ; check:         brz v29, $(resume_5=$BB)

--- a/cranelift/filetests/filetests/isa/x86/legalize-memory.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-memory.clif
@@ -24,7 +24,7 @@ function %load(i64 vmctx) -> i64 {
 
 block1(v1: i64):
     v2 = global_value.i64 gv2
-    ; check: $(p1=$V) = load.i64 notrap aligned v1-16
+    ; check: $(p1=$V) = load.i64 little notrap aligned v1-16
     ; check: v2 = iadd_imm $p1, 32
     return v2
     ; check: return v2
@@ -59,9 +59,9 @@ block0(v0: i32, v999: i64):
     ; nextln: $(hbase=$V) = iadd_imm v999, 64
     ; nextln: v1 = iadd $hbase, $xoff
     v2 = load.f32 v1+16
-    ; nextln: v2 = load.f32 v1+16
+    ; nextln: v2 = load.f32 little v1+16
     v3 = load.f32 v1+20
-    ; nextln: v3 = load.f32 v1+20
+    ; nextln: v3 = load.f32 little v1+20
     v4 = fadd v2, v3
     return v4
 }
@@ -79,7 +79,7 @@ block0(v0: i32, v999: i64):
     ; nextln:     trap heap_oob
     ; check: block1:
     ; nextln:     v1 = iconst.i64 0
-    ; nextln:     v2 = load.f32 v1+16
+    ; nextln:     v2 = load.f32 little v1+16
     ; nextln:     return v2
     ; nextln: }
     v1 = heap_addr.i64 heap0, v0, 0x1000_0001
@@ -110,6 +110,6 @@ block0(v0: i32, v999: i64):
     ; nextln: $(hbase=$V) = iadd_imm.i64 v999, 64
     ; nextln: v1 = iadd $hbase, $xoff
     v2 = load.f32 v1+0x7fff_ffff
-    ; nextln: v2 = load.f32 v1+0x7fff_ffff
+    ; nextln: v2 = load.f32 little v1+0x7fff_ffff
     return v2
 }

--- a/cranelift/filetests/filetests/isa/x86/legalize-tables.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-tables.clif
@@ -22,7 +22,7 @@ function %table_addrs(i32, i64, i64 vmctx) {
 
 block0(v0: i32, v1: i64, v3: i64):
     v4 = table_addr.i64 table0, v0, +0
-    ; check:         v8 = load.i32 notrap aligned v3+88
+    ; check:         v8 = load.i32 little notrap aligned v3+88
     ; check:         v9 = icmp uge v0, v8
     ; check:         brz v9, $(resume_1=$BB)
     ; nextln:        jump $(trap_1=$BB)
@@ -34,7 +34,7 @@ block0(v0: i32, v1: i64, v3: i64):
     ; check:         v4 = iadd v11, v10
 
     v5 = table_addr.i64 table1, v0, +0
-    ; check:         v12 = load.i32 notrap aligned v3+88
+    ; check:         v12 = load.i32 little notrap aligned v3+88
     ; check:         v13 = icmp.i32 uge v0, v12
     ; check:         brz v13, $(resume_2=$BB)
     ; nextln:        jump $(trap_2=$BB)

--- a/cranelift/filetests/filetests/isa/x86/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x86/pinned-reg.clif
@@ -71,4 +71,4 @@ block0(v42: i64):
 
 ; check: ,%r15]
 ; sameln: $(heap_base=$V) = get_pinned_reg.i64
-; nextln: load_complex.i64 $heap_base+
+; nextln: load_complex.i64 little $heap_base+

--- a/cranelift/filetests/filetests/isa/x86/prologue-epilogue.clif
+++ b/cranelift/filetests/filetests/isa/x86/prologue-epilogue.clif
@@ -109,32 +109,32 @@ block0(v0: i64, v1: i64):
 ; nextln:     x86_push v18
 ; nextln:     x86_push v19
 ; nextln:     x86_push v20
-; nextln:     v2 = load.i32 v0
-; nextln:     v3 = load.i32 v0+8
-; nextln:     v4 = load.i32 v0+16
-; nextln:     v5 = load.i32 v0+24
-; nextln:     v6 = load.i32 v0+32
-; nextln:     v7 = load.i32 v0+40
-; nextln:     v8 = load.i32 v0+48
-; nextln:     v9 = load.i32 v0+56
-; nextln:     v10 = load.i32 v0+64
-; nextln:     v11 = load.i32 v0+72
-; nextln:     v12 = load.i32 v0+80
-; nextln:     v13 = load.i32 v0+88
-; nextln:     v14 = load.i32 v0+96
-; nextln:     store v2, v1
-; nextln:     store v3, v1+8
-; nextln:     store v4, v1+16
-; nextln:     store v5, v1+24
-; nextln:     store v6, v1+32
-; nextln:     store v7, v1+40
-; nextln:     store v8, v1+48
-; nextln:     store v9, v1+56
-; nextln:     store v10, v1+64
-; nextln:     store v11, v1+72
-; nextln:     store v12, v1+80
-; nextln:     store v13, v1+88
-; nextln:     store v14, v1+96
+; nextln:     v2 = load.i32 little v0
+; nextln:     v3 = load.i32 little v0+8
+; nextln:     v4 = load.i32 little v0+16
+; nextln:     v5 = load.i32 little v0+24
+; nextln:     v6 = load.i32 little v0+32
+; nextln:     v7 = load.i32 little v0+40
+; nextln:     v8 = load.i32 little v0+48
+; nextln:     v9 = load.i32 little v0+56
+; nextln:     v10 = load.i32 little v0+64
+; nextln:     v11 = load.i32 little v0+72
+; nextln:     v12 = load.i32 little v0+80
+; nextln:     v13 = load.i32 little v0+88
+; nextln:     v14 = load.i32 little v0+96
+; nextln:     store little v2, v1
+; nextln:     store little v3, v1+8
+; nextln:     store little v4, v1+16
+; nextln:     store little v5, v1+24
+; nextln:     store little v6, v1+32
+; nextln:     store little v7, v1+40
+; nextln:     store little v8, v1+48
+; nextln:     store little v9, v1+56
+; nextln:     store little v10, v1+64
+; nextln:     store little v11, v1+72
+; nextln:     store little v12, v1+80
+; nextln:     store little v13, v1+88
+; nextln:     store little v14, v1+96
 ; nextln:     v26 = x86_pop.i64
 ; nextln:     v25 = x86_pop.i64
 ; nextln:     v24 = x86_pop.i64
@@ -295,13 +295,13 @@ block0(v0: i64):
 ; nextln:     ss0 = explicit_slot 20, offset -36
 ; nextln:     ss1 = incoming_arg 16, offset -16
 ; nextln:     gv0 = vmctx
-; nextln:     gv1 = load.i64 notrap aligned gv0
-; nextln:     gv2 = load.i64 notrap aligned gv1+4
+; nextln:     gv1 = load.i64 little notrap aligned gv0
+; nextln:     gv2 = load.i64 little notrap aligned gv1+4
 ; nextln:     stack_limit = gv2
 ; nextln: 
 ; nextln: block0(v0: i64 [%rdi], v5: i64 [%rbp]):
-; nextln:     v1 = load.i64 notrap aligned v0
-; nextln:     v2 = load.i64 notrap aligned v1+4
+; nextln:     v1 = load.i64 little notrap aligned v0
+; nextln:     v2 = load.i64 little notrap aligned v1+4
 ; nextln:     v3 = iadd_imm v2, 32
 ; nextln:     v4 = ifcmp_sp v3
 ; nextln:     trapif uge v4, stk_ovf

--- a/cranelift/filetests/filetests/isa/x86/simd-bitwise-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitwise-legalize.clif
@@ -13,7 +13,7 @@ block0:
     ; nextln: v6 = raw_bitcast.i8x16 v5
     ; nextln: v7 = const_addr.i64 const1
     ; nextln: v8 = ishl_imm v0, 4
-    ; nextln: v9 = load_complex.i8x16 v7+v8
+    ; nextln: v9 = load_complex.i8x16 little v7+v8
     ; nextln: v2 = band v6, v9
     return v2
 }
@@ -49,7 +49,7 @@ block0:
     ; nextln: v6 = raw_bitcast.i8x16 v5
     ; nextln: v7 = const_addr.i64 const1
     ; nextln: v8 = ishl_imm v0, 4
-    ; nextln: v9 = load_complex.i8x16 v7+v8
+    ; nextln: v9 = load_complex.i8x16 little v7+v8
     ; nextln: v2 = band v6, v9
     return v2
 }

--- a/cranelift/filetests/filetests/isa/x86/stack-load-store64.clif
+++ b/cranelift/filetests/filetests/isa/x86/stack-load-store64.clif
@@ -10,12 +10,12 @@ block0:
    v0 = stack_load.i64 ss0
 
 ; check: v1 = stack_addr.i64 ss0
-; check: v0 = load.i64 notrap aligned v1
+; check: v0 = load.i64 little notrap aligned v1
 
    stack_store.i64 v0, ss0
 
 ; check: v2 = stack_addr.i64 ss0
-; check: store notrap aligned v0, v2
+; check: store little notrap aligned v0, v2
 
    return
 }

--- a/cranelift/filetests/filetests/isa/x86/stack-load-store8.clif
+++ b/cranelift/filetests/filetests/isa/x86/stack-load-store8.clif
@@ -8,11 +8,11 @@ block0(v0: i8):
     stack_store v0, ss0
     ; check: v2 = stack_addr.i64 ss0
     ; nextln: v3 = uextend.i32 v0
-    ; nextln: istore8 notrap aligned v3, v2
+    ; nextln: istore8 little notrap aligned v3, v2
 
     v1 = stack_load.i8 ss0
     ; check: v4 = stack_addr.i64 ss0
-    ; nextln: v5 = uload8.i32 notrap aligned v4
+    ; nextln: v5 = uload8.i32 little notrap aligned v4
     ; nextln: v1 = ireduce.i8 v5
 
     return v1

--- a/cranelift/filetests/filetests/isa/x86/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x86/struct-arg.clif
@@ -17,7 +17,7 @@ block0(v0: i64):
 ; nextln:  [RexOp1copysp#8089]                 copy_special %rsp -> %rbp
 ; nextln:  [RexOp1spaddr_id#808d,%rax]         v2 = stack_addr.i64 ss0
 ; nextln:                                      v0 -> v2
-; nextln:  [RexOp2ld#4b6,%rax]                 v4 = uload8.i32 v2
+; nextln:  [RexOp2ld#4b6,%rax]                 v4 = uload8.i32 little v2
 ; nextln:  [null#00,%rax]                      v1 = ireduce.i8 v4
 ; nextln:  [RexOp1popq#58,%rbp]                v6 = x86_pop.i64
 ; nextln:  [Op1ret#c3]                         return v1, v6
@@ -38,7 +38,7 @@ block0(v0: i64, v1: i64):
 ; nextln: [RexOp1copysp#8089]                 copy_special %rsp -> %rbp
 ; nextln: [RexOp1spaddr_id#808d,%rax]         v3 = stack_addr.i64 ss0
 ; nextln:                                     v1 -> v3
-; nextln: [RexOp2ld#4b6,%rax]                 v5 = uload8.i32 v3
+; nextln: [RexOp2ld#4b6,%rax]                 v5 = uload8.i32 little v3
 ; nextln: [null#00,%rax]                      v2 = ireduce.i8 v5
 ; nextln: [RexOp1popq#58,%rbp]                v7 = x86_pop.i64
 ; nextln: [Op1ret#c3]                         return v2, v7

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -74,10 +74,10 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
 ; nextln: x86_push v7
 ; nextln: copy_special %rsp -> %rbp
 ; nextln: adjust_sp_down_imm 32
-; nextln: store notrap aligned v8, v6+16
-; nextln: store notrap aligned v9, v6
-; nextln: v11 = load.f64x2 notrap aligned v6+16
-; nextln: v12 = load.f64x2 notrap aligned v6
+; nextln: store little notrap aligned v8, v6+16
+; nextln: store little notrap aligned v9, v6
+; nextln: v11 = load.f64x2 little notrap aligned v6+16
+; nextln: v12 = load.f64x2 little notrap aligned v6
 ; nextln: adjust_sp_up_imm 32
 ; nextln: v10 = x86_pop.i64
 ; nextln: return v10, v11, v12
@@ -183,31 +183,31 @@ block0(v0: i64):
 ; nextln: adjust_sp_down_imm 112
 ; nextln: v0 = spill v11
 ; nextln: v12 = copy_to_ssa.i64 %rcx
-; nextln: v13 = load.i64 v12
+; nextln: v13 = load.i64 little v12
 ; nextln: v1 = spill v13
 ; nextln: v14 = fill_nop v0
-; nextln: v15 = load.i64 v14+8
+; nextln: v15 = load.i64 little v14+8
 ; nextln: v2 = spill v15
 ; nextln: v16 = fill_nop v0
-; nextln: v17 = load.i64 v16+16
+; nextln: v17 = load.i64 little v16+16
 ; nextln: v3 = spill v17
 ; nextln: v18 = fill_nop v0
-; nextln: v19 = load.i64 v18+24
+; nextln: v19 = load.i64 little v18+24
 ; nextln: v4 = spill v19
 ; nextln: v20 = fill_nop v0
-; nextln: v21 = load.i64 v20+32
+; nextln: v21 = load.i64 little v20+32
 ; nextln: v5 = spill v21
 ; nextln: v22 = fill_nop v0
-; nextln: v23 = load.i64 v22+40
+; nextln: v23 = load.i64 little v22+40
 ; nextln: v6 = spill v23
 ; nextln: v24 = fill_nop v0
-; nextln: v25 = load.i64 v24+48
+; nextln: v25 = load.i64 little v24+48
 ; nextln: v7 = spill v25
 ; nextln: v26 = fill_nop v0
-; nextln: v27 = load.i64 v26+56
+; nextln: v27 = load.i64 little v26+56
 ; nextln: v8 = spill v27
 ; nextln: v28 = fill_nop v0
-; nextln: v29 = load.i64 v28+64
+; nextln: v29 = load.i64 little v28+64
 ; nextln: v9 = spill v29
 ; nextln: v30 = fill v1
 ; nextln: v31 = fill v2
@@ -220,31 +220,31 @@ block0(v0: i64):
 ; nextln: v10 = call fn0(v30, v31, v32, v33)
 ; nextln: v34 = fill v1
 ; nextln: v35 = fill v0
-; nextln: store v34, v35+8
+; nextln: store little v34, v35+8
 ; nextln: v36 = fill v2
 ; nextln: v37 = fill_nop v0
-; nextln: store v36, v37+16
+; nextln: store little v36, v37+16
 ; nextln: v38 = fill v3
 ; nextln: v39 = fill_nop v0
-; nextln: store v38, v39+24
+; nextln: store little v38, v39+24
 ; nextln: v40 = fill v4
 ; nextln: v41 = fill_nop v0
-; nextln: store v40, v41+32
+; nextln: store little v40, v41+32
 ; nextln: v42 = fill v5
 ; nextln: v43 = fill_nop v0
-; nextln: store v42, v43+40
+; nextln: store little v42, v43+40
 ; nextln: v44 = fill v6
 ; nextln: v45 = fill_nop v0
-; nextln: store v44, v45+48
+; nextln: store little v44, v45+48
 ; nextln: v46 = fill v7
 ; nextln: v47 = fill_nop v0
-; nextln: store v46, v47+56
+; nextln: store little v46, v47+56
 ; nextln: v48 = fill v8
 ; nextln: v49 = fill_nop v0
-; nextln: store v48, v49+64
+; nextln: store little v48, v49+64
 ; nextln: v50 = fill v9
 ; nextln: v51 = fill_nop v0
-; nextln: store v50, v51+72
+; nextln: store little v50, v51+72
 ; nextln: adjust_sp_up_imm 112
 ; nextln: v61 = x86_pop.i64 
 ; nextln: v60 = x86_pop.i64 

--- a/cranelift/filetests/filetests/legalizer/pass_by_ref.clif
+++ b/cranelift/filetests/filetests/legalizer/pass_by_ref.clif
@@ -8,9 +8,9 @@ block0(v0: i128):
 }
 ; check:  function %legalize_entry(i64 ptr [%rcx]) -> i64 [%rax] windows_fastcall {
 ; nextln: block0(v3: i64):
-; nextln:     v4 = load.i64 v3
+; nextln:     v4 = load.i64 little v3
 ; nextln:     v1 -> v4
-; nextln:     v5 = load.i64 v3+8
+; nextln:     v5 = load.i64 little v3+8
 ; nextln:     v2 -> v5
 ; nextln:     v0 = iconcat v4, v5
 ; nextln:     return v2
@@ -26,6 +26,6 @@ block0:
 ; check:  sig0 = (i64 ptr [%rcx]) windows_fastcall
 ; check:  v0 = vconst.i32x4 const0
 ; nextln: v1 = stack_addr.i64 ss0
-; nextln: store v0, v1
+; nextln: store little v0, v1
 ; nextln: v2 = func_addr.i64 fn0
 ; nextln: call_indirect sig0, v2(v1)

--- a/cranelift/filetests/filetests/licm/load_readonly_notrap.clif
+++ b/cranelift/filetests/filetests/licm/load_readonly_notrap.clif
@@ -31,13 +31,13 @@ block3(v9: i32):
 
 ; sameln: function %hoist_load(i32, i64 vmctx) -> i32 fast {
 ; nextln:    gv0 = vmctx
-; nextln:    gv1 = load.i64 notrap aligned readonly gv0
+; nextln:    gv1 = load.i64 little notrap aligned readonly gv0
 ; nextln:    heap0 = static gv1, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000, index_type i32
 ; nextln: 
 ; nextln: block0(v0: i32, v1: i64):
 ; nextln:    v4 = iconst.i32 1
 ; nextln:    v5 = heap_addr.i64 heap0, v4, 1
-; nextln:    v6 = load.i32 notrap aligned readonly v5
+; nextln:    v6 = load.i32 little notrap aligned readonly v5
 ; nextln:    jump block1(v0, v1)
 ; nextln: 
 ; nextln: block1(v2: i32, v3: i64):

--- a/cranelift/filetests/filetests/licm/reject_load_notrap.clif
+++ b/cranelift/filetests/filetests/licm/reject_load_notrap.clif
@@ -32,7 +32,7 @@ block3(v9: i32):
 
 ; sameln: function %hoist_load(i32, i64 vmctx) -> i32 fast {
 ; nextln:    gv0 = vmctx
-; nextln:    gv1 = load.i64 notrap aligned readonly gv0
+; nextln:    gv1 = load.i64 little notrap aligned readonly gv0
 ; nextln:    heap0 = static gv1, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000, index_type i32
 ; nextln: 
 ; nextln: block0(v0: i32, v1: i64):
@@ -41,7 +41,7 @@ block3(v9: i32):
 ; nextln:    jump block1(v0, v1)
 ; nextln: 
 ; nextln: block1(v2: i32, v3: i64):
-; nextln:    v6 = load.i32 notrap aligned v5
+; nextln:    v6 = load.i32 little notrap aligned v5
 ; nextln:    v7 = iadd v2, v6
 ; nextln:    brz v2, block3(v2)
 ; nextln:    jump block2

--- a/cranelift/filetests/filetests/licm/reject_load_readonly.clif
+++ b/cranelift/filetests/filetests/licm/reject_load_readonly.clif
@@ -32,7 +32,7 @@ block3(v9: i32):
 
 ; sameln: function %hoist_load(i32, i64 vmctx) -> i32 fast {
 ; nextln:    gv0 = vmctx
-; nextln:    gv1 = load.i64 notrap aligned readonly gv0
+; nextln:    gv1 = load.i64 little notrap aligned readonly gv0
 ; nextln:    heap0 = static gv1, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000, index_type i32
 ; nextln: 
 ; nextln: block0(v0: i32, v1: i64):
@@ -41,7 +41,7 @@ block3(v9: i32):
 ; nextln:    jump block1(v0, v1)
 ; nextln: 
 ; nextln: block1(v2: i32, v3: i64):
-; nextln:    v6 = load.i32 aligned readonly v5
+; nextln:    v6 = load.i32 little aligned readonly v5
 ; nextln:    v7 = iadd v2, v6
 ; nextln:    brz v2, block3(v2)
 ; nextln:    jump block2

--- a/cranelift/filetests/filetests/parser/memory.clif
+++ b/cranelift/filetests/filetests/parser/memory.clif
@@ -12,10 +12,10 @@ block0(v0: i64):
 
 function %load_and_add_imm(i64 vmctx) -> i32 {
     gv2 = vmctx
-    gv3 = load.i32 notrap aligned gv2-72
+    gv3 = load.i32 little notrap aligned gv2-72
     gv4 = iadd_imm.i32 gv3, -32
     ; check: gv2 = vmctx
-    ; check: gv3 = load.i32 notrap aligned gv2-72
+    ; check: gv3 = load.i32 little notrap aligned gv2-72
     ; check: gv4 = iadd_imm.i32 gv3, -32
 block0(v0: i64):
     v1 = global_value.i32 gv4
@@ -27,8 +27,8 @@ block0(v0: i64):
 function %backref(i64 vmctx) -> i32 {
     gv0 = iadd_imm.i32 gv1, -32
     ; check: gv0 = iadd_imm.i32 gv1, -32
-    gv1 = load.i32 notrap aligned gv2
-    ; check: gv1 = load.i32 notrap aligned gv2
+    gv1 = load.i32 little notrap aligned gv2
+    ; check: gv1 = load.i32 little notrap aligned gv2
     gv2 = vmctx
     ; check: gv2 = vmctx
 block0(v0: i64):

--- a/cranelift/filetests/filetests/parser/tiny.clif
+++ b/cranelift/filetests/filetests/parser/tiny.clif
@@ -151,37 +151,37 @@ block0:
 ; Memory access instructions.
 function %memory(i32) {
 block0(v1: i32):
-    v2 = load.i64 v1
-    v3 = load.i64 aligned v1
-    v4 = load.i64 notrap v1
-    v5 = load.i64 notrap aligned v1
-    v6 = load.i64 aligned notrap v1
-    v7 = load.i64 v1-12
-    v8 = load.i64 notrap v1+0x1_0000
-    v9 = load_complex.i64 v1+v2
-    v10 = load_complex.i64 v1+v2+0x1
-    store v2, v1
-    store aligned v3, v1+12
-    store notrap aligned v3, v1-12
-    store_complex v3, v1+v2
-    store_complex v3, v1+v2+0x1
+    v2 = load.i64 little v1
+    v3 = load.i64 little aligned v1
+    v4 = load.i64 little notrap v1
+    v5 = load.i64 little notrap aligned v1
+    v6 = load.i64 big aligned notrap v1
+    v7 = load.i64 big v1-12
+    v8 = load.i64 big notrap v1+0x1_0000
+    v9 = load_complex.i64 little v1+v2
+    v10 = load_complex.i64 big v1+v2+0x1
+    store little v2, v1
+    store little aligned v3, v1+12
+    store big notrap aligned v3, v1-12
+    store_complex little v3, v1+v2
+    store_complex big v3, v1+v2+0x1
 }
 ; sameln: function %memory(i32) fast {
 ; nextln: block0(v1: i32):
-; nextln:     v2 = load.i64 v1
-; nextln:     v3 = load.i64 aligned v1
-; nextln:     v4 = load.i64 notrap v1
-; nextln:     v5 = load.i64 notrap aligned v1
-; nextln:     v6 = load.i64 notrap aligned v1
-; nextln:     v7 = load.i64 v1-12
-; nextln:     v8 = load.i64 notrap v1+0x0001_0000
-; nextln:     v9 = load_complex.i64 v1+v2
-; nextln:     v10 = load_complex.i64 v1+v2+1
-; nextln:     store v2, v1
-; nextln:     store aligned v3, v1+12
-; nextln:     store notrap aligned v3, v1-12
-; nextln:     store_complex v3, v1+v2
-; nextln:     store_complex v3, v1+v2+1
+; nextln:     v2 = load.i64 little v1
+; nextln:     v3 = load.i64 little aligned v1
+; nextln:     v4 = load.i64 little notrap v1
+; nextln:     v5 = load.i64 little notrap aligned v1
+; nextln:     v6 = load.i64 big notrap aligned v1
+; nextln:     v7 = load.i64 big v1-12
+; nextln:     v8 = load.i64 big notrap v1+0x0001_0000
+; nextln:     v9 = load_complex.i64 little v1+v2
+; nextln:     v10 = load_complex.i64 big v1+v2+1
+; nextln:     store little v2, v1
+; nextln:     store little aligned v3, v1+12
+; nextln:     store big notrap aligned v3, v1-12
+; nextln:     store_complex little v3, v1+v2
+; nextln:     store_complex big v3, v1+v2+1
 
 ; Register diversions.
 ; This test file has no ISA, so we can unly use register unit numbers.

--- a/cranelift/filetests/filetests/peepmatic/do_not_reorder_instructions_when_transplanting.clif
+++ b/cranelift/filetests/filetests/peepmatic/do_not_reorder_instructions_when_transplanting.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
     v3 = iadd_imm v1, -16
     v4 = iconst.i32 16
     v5 = iadd v3, v4
-    ; check:  v1 = load.i32 v0
+    ; check:  v1 = load.i32 little v0
     ; nextln: v5 -> v1
     ; nextln: v2 = iconst.i32 16
     ; nextln: v3 = iadd_imm v1, -16

--- a/cranelift/filetests/filetests/postopt/complex_memory_ops.clif
+++ b/cranelift/filetests/filetests/postopt/complex_memory_ops.clif
@@ -17,13 +17,13 @@ block0(v0: i64, v1: i64):
 ; sameln: function %dual_loads
 ; nextln: block0(v0: i64, v1: i64):
 ; nextln:    v3 = iadd v0, v1
-; nextln:    v4 = load_complex.i64 v0+v1
-; nextln:    v5 = uload8_complex.i64 v0+v1
-; nextln:    v6 = sload8_complex.i64 v0+v1
-; nextln:    v7 = uload16_complex.i64 v0+v1
-; nextln:    v8 = sload16_complex.i64 v0+v1
-; nextln:    v9 = uload32_complex v0+v1
-; nextln:    v10 = sload32_complex v0+v1
+; nextln:    v4 = load_complex.i64 little v0+v1
+; nextln:    v5 = uload8_complex.i64 little v0+v1
+; nextln:    v6 = sload8_complex.i64 little v0+v1
+; nextln:    v7 = uload16_complex.i64 little v0+v1
+; nextln:    v8 = sload16_complex.i64 little v0+v1
+; nextln:    v9 = uload32_complex little v0+v1
+; nextln:    v10 = sload32_complex little v0+v1
 ; nextln:    return v10
 ; nextln: }
 
@@ -43,13 +43,13 @@ block0(v0: i64, v1: i64):
 ; sameln: function %dual_loads2
 ; nextln: block0(v0: i64, v1: i64):
 ; nextln:    v3 = iadd v0, v1
-; nextln:    v4 = load_complex.i64 v0+v1+1
-; nextln:    v5 = uload8_complex.i64 v0+v1+1
-; nextln:    v6 = sload8_complex.i64 v0+v1+1
-; nextln:    v7 = uload16_complex.i64 v0+v1+1
-; nextln:    v8 = sload16_complex.i64 v0+v1+1
-; nextln:    v9 = uload32_complex v0+v1+1
-; nextln:    v10 = sload32_complex v0+v1+1
+; nextln:    v4 = load_complex.i64 little v0+v1+1
+; nextln:    v5 = uload8_complex.i64 little v0+v1+1
+; nextln:    v6 = sload8_complex.i64 little v0+v1+1
+; nextln:    v7 = uload16_complex.i64 little v0+v1+1
+; nextln:    v8 = sload16_complex.i64 little v0+v1+1
+; nextln:    v9 = uload32_complex little v0+v1+1
+; nextln:    v10 = sload32_complex little v0+v1+1
 ; nextln:    return v10
 ; nextln: }
 
@@ -66,10 +66,10 @@ block0(v0: i64, v1: i64, v2: i64):
 ; sameln: function %dual_stores
 ; nextln: block0(v0: i64, v1: i64, v2: i64):
 ; nextln:    v3 = iadd v0, v1
-; nextln:    store_complex v2, v0+v1
-; nextln:    istore8_complex v2, v0+v1
-; nextln:    istore16_complex v2, v0+v1
-; nextln:    istore32_complex v2, v0+v1
+; nextln:    store_complex little v2, v0+v1
+; nextln:    istore8_complex little v2, v0+v1
+; nextln:    istore16_complex little v2, v0+v1
+; nextln:    istore32_complex little v2, v0+v1
 ; nextln:    return
 ; nextln: }
 
@@ -86,9 +86,9 @@ block0(v0: i64, v1: i64, v2: i64):
 ; sameln: function %dual_stores2
 ; nextln: block0(v0: i64, v1: i64, v2: i64):
 ; nextln:    v3 = iadd v0, v1
-; nextln:    store_complex v2, v0+v1+1
-; nextln:    istore8_complex v2, v0+v1+1
-; nextln:    istore16_complex v2, v0+v1+1
-; nextln:    istore32_complex v2, v0+v1+1
+; nextln:    store_complex little v2, v0+v1+1
+; nextln:    istore8_complex little v2, v0+v1+1
+; nextln:    istore16_complex little v2, v0+v1+1
+; nextln:    istore32_complex little v2, v0+v1+1
 ; nextln:    return
 ; nextln: }

--- a/cranelift/filetests/filetests/postopt/fold_offset_into_address.clif
+++ b/cranelift/filetests/filetests/postopt/fold_offset_into_address.clif
@@ -13,7 +13,7 @@ block0(v0: i64):
 ; sameln: function u0:0(i64 vmctx) -> i64 fast {
 ; nextln: block0(v0: i64):
 ; nextln:                                     v1 = iadd_imm v0, 16
-; nextln: [RexOp1ldDisp8#808b]                v2 = load.i64 notrap aligned v0+16
+; nextln: [RexOp1ldDisp8#808b]                v2 = load.i64 little notrap aligned v0+16
 ; nextln: [Op1ret#c3]                         return v2
 ; nextln: }
 
@@ -27,6 +27,6 @@ block0(v3: i64, v0: i64):
 ; sameln: function u0:1(i64, i64 vmctx) fast {
 ; nextln: block0(v3: i64, v0: i64):
 ; nextln:                                     v1 = iadd_imm v0, 16
-; nextln: [RexOp1stDisp8#8089]                store notrap aligned v3, v0+16
+; nextln: [RexOp1stDisp8#8089]                store little notrap aligned v3, v0+16
 ; nextln: [Op1ret#c3]                         return
 ; nextln: }

--- a/cranelift/filetests/filetests/simple_gvn/readonly.clif
+++ b/cranelift/filetests/filetests/simple_gvn/readonly.clif
@@ -20,6 +20,6 @@ block0(v0: i32, v1: i64):
 ; check: v2 = heap_addr.i64 heap0, v0, 1
 ; check: v3 -> v2
 ; check: v4 = iconst.i32 0
-; check: store notrap aligned v4, v2
-; check: store notrap aligned v4, v2
+; check: store little notrap aligned v4, v2
+; check: store little notrap aligned v4, v2
 ; check: return

--- a/cranelift/filetests/filetests/simple_preopt/do_not_reorder_instructions_when_transplanting.clif
+++ b/cranelift/filetests/filetests/simple_preopt/do_not_reorder_instructions_when_transplanting.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
     v3 = iadd_imm v1, -16
     v4 = iconst.i32 16
     v5 = iadd v3, v4
-    ; check:  v1 = load.i32 v0
+    ; check:  v1 = load.i32 little v0
     ; nextln: v5 -> v1
     ; nextln: v2 = iconst.i32 16
     ; nextln: v3 = iadd_imm v1, -16

--- a/cranelift/filetests/filetests/verifier/memory.clif
+++ b/cranelift/filetests/filetests/verifier/memory.clif
@@ -1,15 +1,15 @@
 test verifier
 
 function %cycle() {
-    gv0 = load.i32 notrap aligned gv1 ; error: global value cycle: [gv0, gv1]
-    gv1 = load.i32 notrap aligned gv0-32
+    gv0 = load.i32 little notrap aligned gv1 ; error: global value cycle: [gv0, gv1]
+    gv1 = load.i32 little notrap aligned gv0-32
 
 block1:
     return
 }
 
 function %self_cycle() {
-    gv0 = load.i32 notrap aligned gv0 ; error: global value cycle: [gv0]
+    gv0 = load.i32 little notrap aligned gv0 ; error: global value cycle: [gv0]
 
 block1:
     return

--- a/cranelift/filetests/filetests/wasm/multi-val-b1.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-b1.clif
@@ -13,16 +13,16 @@ block0(v0: b1, v1: b1, v2: b1, v3: b1):
     return v0, v1, v2, v3
     ; check:  v5 = bint.i8 v0
     ; nextln: v9 = uextend.i32 v5
-    ; nextln: istore8 notrap aligned v9, v4
+    ; nextln: istore8 little notrap aligned v9, v4
     ; nextln: v6 = bint.i8 v1
     ; nextln: v10 = uextend.i32 v6
-    ; nextln: istore8 notrap aligned v10, v4+1
+    ; nextln: istore8 little notrap aligned v10, v4+1
     ; nextln: v7 = bint.i8 v2
     ; nextln: v11 = uextend.i32 v7
-    ; nextln: istore8 notrap aligned v11, v4+2
+    ; nextln: istore8 little notrap aligned v11, v4+2
     ; nextln: v8 = bint.i8 v3
     ; nextln: v12 = uextend.i32 v8
-    ; nextln: istore8 notrap aligned v12, v4+3
+    ; nextln: istore8 little notrap aligned v12, v4+3
 }
 
 function %call_4_b1s() {
@@ -43,22 +43,22 @@ block0:
     ; check: v8 = stack_addr.i64 ss0
     v4, v5, v6, v7 = call fn0(v0, v1, v2, v3)
     ; check:  v9 = call fn0(v0, v1, v2, v3, v8)
-    ; nextln: v22 = uload8.i32 notrap aligned v9
+    ; nextln: v22 = uload8.i32 little notrap aligned v9
     ; nextln: v10 = ireduce.i8 v22
     ; nextln: v11 = raw_bitcast.b8 v10
     ; nextln: v12 = breduce.b1 v11
     ; nextln: v4 -> v12
-    ; nextln: v23 = uload8.i32 notrap aligned v9+1
+    ; nextln: v23 = uload8.i32 little notrap aligned v9+1
     ; nextln: v13 = ireduce.i8 v23
     ; nextln: v14 = raw_bitcast.b8 v13
     ; nextln: v15 = breduce.b1 v14
     ; nextln: v5 -> v15
-    ; nextln: v24 = uload8.i32 notrap aligned v9+2
+    ; nextln: v24 = uload8.i32 little notrap aligned v9+2
     ; nextln: v16 = ireduce.i8 v24
     ; nextln: v17 = raw_bitcast.b8 v16
     ; nextln: v18 = breduce.b1 v17
     ; nextln: v6 -> v18
-    ; nextln: v25 = uload8.i32 notrap aligned v9+3
+    ; nextln: v25 = uload8.i32 little notrap aligned v9+3
     ; nextln: v19 = ireduce.i8 v25
     ; nextln: v20 = raw_bitcast.b8 v19
     ; nextln: v21 = breduce.b1 v20

--- a/cranelift/filetests/filetests/wasm/multi-val-call-indirect.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-call-indirect.clif
@@ -13,13 +13,13 @@ block0(v0: i64):
     v1, v2, v3, v4 = call_indirect sig0, v0()
     ; check:  v5 = stack_addr.i64 ss0
     ; nextln: v6 = call_indirect sig0, v0(v5)
-    ; nextln: v7 = load.i64 notrap aligned v6
+    ; nextln: v7 = load.i64 little notrap aligned v6
     ; nextln: v1 -> v7
-    ; nextln: v8 = load.i64 notrap aligned v6+8
+    ; nextln: v8 = load.i64 little notrap aligned v6+8
     ; nextln: v2 -> v8
-    ; nextln: v9 = load.i64 notrap aligned v6+16
+    ; nextln: v9 = load.i64 little notrap aligned v6+16
     ; nextln: v3 -> v9
-    ; nextln: v10 = load.i64 notrap aligned v6+24
+    ; nextln: v10 = load.i64 little notrap aligned v6+24
     ; nextln: v4 -> v10
 
     return

--- a/cranelift/filetests/filetests/wasm/multi-val-call-legalize-args.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-call-legalize-args.clif
@@ -12,13 +12,13 @@ block0(v0: i64, v1: i64, v2: i64):
     v4, v5, v6, v7 = call_indirect sig0, v0(v3)
     ; check: v8 = stack_addr.i64 ss0
     ; check: v9 = call_indirect sig0, v0(v1, v2, v8)
-    ; check: v10 = load.i64 notrap aligned v9
+    ; check: v10 = load.i64 little notrap aligned v9
     ; check: v4 -> v10
-    ; check: v11 = load.i64 notrap aligned v9+8
+    ; check: v11 = load.i64 little notrap aligned v9+8
     ; check: v5 -> v11
-    ; check: v12 = load.i64 notrap aligned v9+16
+    ; check: v12 = load.i64 little notrap aligned v9+16
     ; check: v6 -> v12
-    ; check: v13 = load.i64 notrap aligned v9+24
+    ; check: v13 = load.i64 little notrap aligned v9+24
     ; check: v7 -> v13
     return
 }

--- a/cranelift/filetests/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
@@ -21,30 +21,30 @@ block0:
     ; check:  v18 = stack_addr.i64 ss0
     ; nextln: v25 = func_addr.i64 fn0
     ; nextln: v19 = call_indirect sig0, v25(v18)
-    ; nextln: v20 = load.i32 notrap aligned v19
+    ; nextln: v20 = load.i32 little notrap aligned v19
     ; nextln: v0 -> v20
-    ; nextln: v21 = load.i32 notrap aligned v19+4
+    ; nextln: v21 = load.i32 little notrap aligned v19+4
     ; nextln: v1 -> v21
-    ; nextln: v22 = load.i32 notrap aligned v19+8
+    ; nextln: v22 = load.i32 little notrap aligned v19+8
     ; nextln: v2 -> v22
-    ; nextln: v23 = load.i32 notrap aligned v19+12
+    ; nextln: v23 = load.i32 little notrap aligned v19+12
     ; nextln: v3 -> v23
-    ; nextln: v24 = load.i32 notrap aligned v19+16
+    ; nextln: v24 = load.i32 little notrap aligned v19+16
     ; nextln: v4 -> v24
 
     v5, v6, v7, v8, v9 = call fn1()
     ; check:  v26 = stack_addr.i64 ss1
     ; nextln: v33 = func_addr.i64 fn1
     ; nextln: v27 = call_indirect sig1, v33(v26)
-    ; nextln: v28 = load.f32 notrap aligned v27
+    ; nextln: v28 = load.f32 little notrap aligned v27
     ; nextln: v5 -> v28
-    ; nextln: v29 = load.f32 notrap aligned v27+4
+    ; nextln: v29 = load.f32 little notrap aligned v27+4
     ; nextln: v6 -> v29
-    ; nextln: v30 = load.f32 notrap aligned v27+8
+    ; nextln: v30 = load.f32 little notrap aligned v27+8
     ; nextln: v7 -> v30
-    ; nextln: v31 = load.f32 notrap aligned v27+12
+    ; nextln: v31 = load.f32 little notrap aligned v27+12
     ; nextln: v8 -> v31
-    ; nextln: v32 = load.f32 notrap aligned v27+16
+    ; nextln: v32 = load.f32 little notrap aligned v27+16
     ; nextln: v9 -> v32
 
     v10 = iadd v0, v1

--- a/cranelift/filetests/filetests/wasm/multi-val-sret-slot-alignment.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-sret-slot-alignment.clif
@@ -16,11 +16,11 @@ block0:
     v3 = iconst.i64 3
     return v0, v1, v2, v3
     ; check:  v6 = uextend.i32 v0
-    ; nextln: istore8 notrap aligned v6, v4
-    ; nextln: store notrap aligned v1, v4+4
+    ; nextln: istore8 little notrap aligned v6, v4
+    ; nextln: store little notrap aligned v1, v4+4
     ; nextln: v7 = uextend.i32 v2
-    ; nextln: istore8 notrap aligned v7, v4+8
-    ; nextln: store notrap aligned v3, v4+16
+    ; nextln: istore8 little notrap aligned v7, v4+8
+    ; nextln: store little notrap aligned v3, v4+16
     ; nextln: return v4
 }
 
@@ -36,15 +36,15 @@ block0:
     ; check:  v4 = stack_addr.i64 ss0
     ; nextln: v10 = func_addr.i64 fn0
     ; nextln: v5 = call_indirect sig0, v10(v4)
-    ; nextln: v11 = uload8.i32 notrap aligned v5
+    ; nextln: v11 = uload8.i32 little notrap aligned v5
     ; nextln: v6 = ireduce.i8 v11
     ; nextln: v0 -> v6
-    ; nextln: v7 = load.i32 notrap aligned v5+4
+    ; nextln: v7 = load.i32 little notrap aligned v5+4
     ; nextln: v1 -> v7
-    ; nextln: v12 = uload8.i32 notrap aligned v5+8
+    ; nextln: v12 = uload8.i32 little notrap aligned v5+8
     ; nextln: v8 = ireduce.i8 v12
     ; nextln: v2 -> v8
-    ; nextln: v9 = load.i64 notrap aligned v5+16
+    ; nextln: v9 = load.i64 little notrap aligned v5+16
     ; nextln: v3 -> v9
 
     return

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -676,7 +676,7 @@ impl<'a> FunctionBuilder<'a> {
             return;
         }
 
-        let mut flags = MemFlags::new();
+        let mut flags = MemFlags::new(config.endianness);
         flags.set_aligned();
 
         // Load all of the memory first. This is necessary in case `dest` overlaps.
@@ -763,7 +763,7 @@ impl<'a> FunctionBuilder<'a> {
             let size = self.ins().iconst(config.pointer_type(), size as i64);
             self.call_memset(config, buffer, ch, size);
         } else {
-            let mut flags = MemFlags::new();
+            let mut flags = MemFlags::new(config.endianness);
             flags.set_aligned();
 
             let ch = u64::from(ch);
@@ -1078,8 +1078,8 @@ block0:
     v1 -> v4
     v3 = iconst.i32 0
     v0 -> v3
-    v2 = load.i64 aligned v0
-    store aligned v2, v1
+    v2 = load.i64 little aligned v0
+    store little aligned v2, v1
     return v1
 }
 "
@@ -1193,7 +1193,7 @@ block0:
     v2 = iconst.i32 0
     v0 -> v2
     v1 = iconst.i64 0x0001_0001_0101
-    store aligned v1, v0
+    store little aligned v1, v0
     return v0
 }
 "

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -160,7 +160,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 GlobalVariable::Const(val) => val,
                 GlobalVariable::Memory { gv, offset, ty } => {
                     let addr = builder.ins().global_value(environ.pointer_type(), gv);
-                    let flags = ir::MemFlags::trusted();
+                    let flags = ir::MemFlags::trusted(environ.endianness());
                     builder.ins().load(ty, flags, addr, offset)
                 }
                 GlobalVariable::Custom => environ.translate_custom_global_get(
@@ -175,7 +175,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 GlobalVariable::Const(_) => panic!("global #{} is a constant", *global_index),
                 GlobalVariable::Memory { gv, offset, ty } => {
                     let addr = builder.ins().global_value(environ.pointer_type(), gv);
-                    let flags = ir::MemFlags::trusted();
+                    let flags = ir::MemFlags::trusted(environ.endianness());
                     let mut val = state.pop1();
                     // Ensure SIMD values are cast to their default Cranelift type, I8x16.
                     if ty.is_vector() {
@@ -2056,7 +2056,8 @@ fn prepare_load<FE: FuncEnvironment + ?Sized>(
     // Note that we don't set `is_aligned` here, even if the load instruction's
     // alignment immediate says it's aligned, because WebAssembly's immediate
     // field is just a hint, while Cranelift's aligned flag needs a guarantee.
-    let flags = MemFlags::new();
+    // WebAssembly memory accesses are always little-endian.
+    let flags = MemFlags::new(ir::Endianness::Little);
 
     Ok((flags, base, offset.into()))
 }
@@ -2103,7 +2104,7 @@ fn translate_store<FE: FuncEnvironment + ?Sized>(
         builder,
     );
     // See the comments in `prepare_load` about the flags.
-    let flags = MemFlags::new();
+    let flags = MemFlags::new(ir::Endianness::Little);
     builder
         .ins()
         .Store(opcode, val_ty, flags, offset.into(), val, base);
@@ -2207,7 +2208,7 @@ fn translate_atomic_rmw<FE: FuncEnvironment + ?Sized>(
         finalise_atomic_mem_addr(linear_mem_addr, memarg, access_ty, builder, state, environ)?;
 
     // See the comments in `prepare_load` about the flags.
-    let flags = MemFlags::new();
+    let flags = MemFlags::new(ir::Endianness::Little);
     let mut res = builder
         .ins()
         .atomic_rmw(access_ty, flags, op, final_effective_address, arg2);
@@ -2260,7 +2261,7 @@ fn translate_atomic_cas<FE: FuncEnvironment + ?Sized>(
         finalise_atomic_mem_addr(linear_mem_addr, memarg, access_ty, builder, state, environ)?;
 
     // See the comments in `prepare_load` about the flags.
-    let flags = MemFlags::new();
+    let flags = MemFlags::new(ir::Endianness::Little);
     let mut res = builder
         .ins()
         .atomic_cas(flags, final_effective_address, expected, replacement);
@@ -2302,7 +2303,7 @@ fn translate_atomic_load<FE: FuncEnvironment + ?Sized>(
         finalise_atomic_mem_addr(linear_mem_addr, memarg, access_ty, builder, state, environ)?;
 
     // See the comments in `prepare_load` about the flags.
-    let flags = MemFlags::new();
+    let flags = MemFlags::new(ir::Endianness::Little);
     let mut res = builder
         .ins()
         .atomic_load(access_ty, flags, final_effective_address);
@@ -2348,7 +2349,7 @@ fn translate_atomic_store<FE: FuncEnvironment + ?Sized>(
         finalise_atomic_mem_addr(linear_mem_addr, memarg, access_ty, builder, state, environ)?;
 
     // See the comments in `prepare_load` about the flags.
-    let flags = MemFlags::new();
+    let flags = MemFlags::new(ir::Endianness::Little);
     builder
         .ins()
         .atomic_store(flags, data, final_effective_address);

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -232,6 +232,11 @@ pub trait TargetEnvironment {
     /// Get the information needed to produce Cranelift IR for the given target.
     fn target_config(&self) -> TargetFrontendConfig;
 
+    /// Get the target endianness.
+    fn endianness(&self) -> ir::Endianness {
+        self.target_config().endianness
+    }
+
     /// Get the Cranelift integer type to use for native pointers.
     ///
     /// This returns `I64` for 64-bit architectures and `I32` for 32-bit architectures.

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -305,6 +305,7 @@ mod tests {
             isa::TargetFrontendConfig {
                 default_call_conv: isa::CallConv::Fast,
                 pointer_width: PointerWidth::U64,
+                endianness: ir::Endianness::Little,
             },
             ReturnMode::NormalReturns,
             false,
@@ -344,6 +345,7 @@ mod tests {
             isa::TargetFrontendConfig {
                 default_call_conv: isa::CallConv::Fast,
                 pointer_width: PointerWidth::U64,
+                endianness: ir::Endianness::Little,
             },
             ReturnMode::NormalReturns,
             false,
@@ -388,6 +390,7 @@ mod tests {
             isa::TargetFrontendConfig {
                 default_call_conv: isa::CallConv::Fast,
                 pointer_width: PointerWidth::U64,
+                endianness: ir::Endianness::Little,
             },
             ReturnMode::NormalReturns,
             false,

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -89,7 +89,7 @@
 // assume no valid stack pointer will ever be `usize::max_value() - 32k`.
 
 use crate::func_environ::{get_func_name, FuncEnvironment};
-use cranelift_codegen::ir::{self, ExternalName};
+use cranelift_codegen::ir::{self, ExternalName, MemFlags};
 use cranelift_codegen::machinst::buffer::MachSrcLoc;
 use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::{binemit, isa, Context};
@@ -389,7 +389,7 @@ impl Compiler for Cranelift {
                 .unwrap()
                 .into(),
             global_type: isa.pointer_type(),
-            readonly: true,
+            flags: MemFlags::trusted_readonly(isa.endianness()),
         });
         let stack_limit = context.func.create_global_value(ir::GlobalValueData::Load {
             base: interrupts_ptr,
@@ -397,7 +397,7 @@ impl Compiler for Cranelift {
                 .unwrap()
                 .into(),
             global_type: isa.pointer_type(),
-            readonly: false,
+            flags: MemFlags::trusted(isa.endianness()),
         });
         context.func.stack_limit = Some(stack_limit);
         let mut func_translator = self.take_translator();

--- a/crates/jit/src/trampoline.rs
+++ b/crates/jit/src/trampoline.rs
@@ -84,7 +84,7 @@ pub(crate) fn build_trampoline(
         };
 
         // Load the argument values out of `values_vec`.
-        let mflags = ir::MemFlags::trusted();
+        let mflags = ir::MemFlags::trusted(isa.endianness());
         let callee_args = signature
             .params
             .iter()
@@ -116,7 +116,7 @@ pub(crate) fn build_trampoline(
         let results = builder.func.dfg.inst_results(call).to_vec();
 
         // Store the return values into `values_vec`.
-        let mflags = ir::MemFlags::trusted();
+        let mflags = ir::MemFlags::trusted(isa.endianness());
         for (i, r) in results.iter().enumerate() {
             builder
                 .ins()

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -126,7 +126,7 @@ fn make_trampoline(
         builder.seal_block(block0);
 
         let values_vec_ptr_val = builder.ins().stack_addr(pointer_type, ss, 0);
-        let mflags = MemFlags::trusted();
+        let mflags = MemFlags::trusted(isa.endianness());
         for i in 2..signature.params.len() {
             let val = builder.func.dfg.block_params(block0)[i];
             builder.ins().store(
@@ -152,7 +152,7 @@ fn make_trampoline(
             .ins()
             .call_indirect(new_sig, callee_value, &callee_args);
 
-        let mflags = MemFlags::trusted();
+        let mflags = MemFlags::trusted(isa.endianness());
         let mut results = Vec::new();
         for (i, r) in signature.returns.iter().enumerate() {
             let load = builder.ins().load(


### PR DESCRIPTION
WebAssembly memory operations are by definition little-endian even on
big-endian target platforms.  However, other memory accesses will require
native target endianness (e.g. to access parts of the VMContext that is
also accessed by VM native code).  This means on big-endian targets,
the code generator will have to handle both little- and big-endian
memory accesses.  However, there is currently no way to encode that
distinction into the Cranelift IR that describes memory accesses.

This patch provides such a way by adding an explicit endianness marker
to each instance of MemFlags.  Since each Cranelift IR instruction that
describes memory accesses already has an instance of MemFlags attached,
that will now automatically provide endianness information.

Beyond the core mechanics of adding the endianness marker to MemFlags,
this patch also updates all creators of MemFlags instances.  In order
to ensure each MemFlags has the correct endianness marker, it is now
mandatory to pass such a marker whenever constructing a MemFlags.

This in turn requires all places constructing a MemFlags (except for
the WebAssembly translator) to pass in the native target endianness.
This can be determined from the TargetIsa where that is readily
available; front-end code wil retrieve the target endianness from a new
member of the TargetFrontendConfig structure filled by the back end.

In addition, the GlobalValueData::Load structure was changed to hold
a full MemFlags instead of just a "readonly" flag, which not only
simplifies related code a bit but now allows passing through of
endianness information as well.

Finally, IR parsing and debug printing routines were updated to
handle the new endianness marker; this in turn required updating
Cranelift "filetests" test cases that contain memory instructions.

This patch addresses issue #2124.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
