### PR TITLE
Fix iconst.i8 0 miscompilation with opt_level=speed_and_size

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift/codegen/meta/src/isa/x86/encodings.rs
@@ -549,10 +549,13 @@ fn define_moves(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions, r:
     }
     e.enc64(bconst.bind(B64), rec_pu_id_bool.opcodes(&MOV_IMM).rex());
 
+    // You may expect that i8 encodings would use 0x30 (XORB) to indicate that encodings should be
+    // on 8-bit operands (f.ex "xor %al, %al"). Cranelift currently does not know when it can
+    // safely drop the 0x66 prefix, so we explicitly select a wider but permissible opcode.
     let is_zero_int = InstructionPredicate::new_is_zero_int(&formats.unary_imm, "imm");
     e.enc_both_instp(
         iconst.bind(I8),
-        rec_u_id_z.opcodes(&XORB),
+        rec_u_id_z.opcodes(&XOR),
         is_zero_int.clone(),
     );
 

--- a/cranelift/codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift/codegen/meta/src/isa/x86/opcodes.rs
@@ -711,9 +711,6 @@ pub static XOR_IMM8_SIGN_EXTEND: [u8; 1] = [0x83];
 /// r/m{16,32,64} XOR register of the same size.
 pub static XOR: [u8; 1] = [0x31];
 
-/// r/m8 XOR r8.
-pub static XORB: [u8; 1] = [0x30];
-
 /// Bitwise logical XOR of packed double-precision floating-point values.
 pub static XORPD: [u8; 3] = [0x66, 0x0f, 0x57];
 

--- a/cranelift/filetests/filetests/isa/x86/optimized-zero-constants-32bit.clif
+++ b/cranelift/filetests/filetests/isa/x86/optimized-zero-constants-32bit.clif
@@ -44,9 +44,9 @@ block0:
 
 function %zero_byte() -> i8 fast {
 block0:
-  ; asm: xor %al, %al
-  [-,%rax]     v0 = iconst.i8 0     ; bin: 30 c0
-  ; asm: xor %dh, %dh
-  [-,%rdi]     v1 = iconst.i8 0     ; bin: 30 ff
+  ; asm: xor %eax, %eax
+  [-,%rax]     v0 = iconst.i8 0     ; bin: 31 c0
+  ; asm: xor %edi, %edi
+  [-,%rdi]     v1 = iconst.i8 0     ; bin: 31 ff
   return v0
 }

--- a/cranelift/filetests/filetests/isa/x86/optimized-zero-constants.clif
+++ b/cranelift/filetests/filetests/isa/x86/optimized-zero-constants.clif
@@ -62,11 +62,11 @@ block0:
 
 function %zero_byte() -> i8 fast {
 block0:
-  ; asm: xor %r8b, %r8b
-  [-,%r15]     v0 = iconst.i8 0     ; bin: 45 30 ff
-  ; asm: xor %al, %al
-  [-,%rax]     v1 = iconst.i8 0     ; bin: 30 c0
-  ; asm: xor %dh, %dh
-  [-,%rdi]     v2 = iconst.i8 0     ; bin: 30 ff
+  ; asm: xor %r8d, %r8d
+  [-,%r15]     v0 = iconst.i8 0     ; bin: 45 31 ff
+  ; asm: xor %eax, eax
+  [-,%rax]     v1 = iconst.i8 0     ; bin: 31 c0
+  ; asm: xor %edi, %edi
+  [-,%rdi]     v2 = iconst.i8 0     ; bin: 31 ff
   return v0
 }


### PR DESCRIPTION
This fixes the cg_clif miscompilation I wrote about at https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/miscompilation.20with.20opt_level.3Dspeed_and_size/near/219461997 when using `opt_level=speed_and_size`. See https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/miscompilation.20with.20opt_level.3Dspeed_and_size/near/219596956 for the root problem this fixes.