### PR TITLE
2499: First pass on TableOps fuzzer generator wasm_encoder migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,15 +2356,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49891b7c581cf9e0090b25cd274e6498ad478f0a7819319ea96da2f253caaacb"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed89eaf99e08b84f96e477a16588a07dd3b51dc5f07291c3706782f62a10a5e1"
@@ -2380,7 +2371,7 @@ checksum = "cdd382e46cf44347f4d0c29122143cbab85cf248b9a8f680845c0239b6842a85"
 dependencies = [
  "arbitrary",
  "leb128",
- "wasm-encoder 0.2.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -2607,7 +2598,7 @@ dependencies = [
  "env_logger 0.8.1",
  "log",
  "rayon",
- "wasm-encoder 0.1.0",
+ "wasm-encoder",
  "wasm-smith",
  "wasmi",
  "wasmparser 0.70.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,6 +2356,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49891b7c581cf9e0090b25cd274e6498ad478f0a7819319ea96da2f253caaacb"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed89eaf99e08b84f96e477a16588a07dd3b51dc5f07291c3706782f62a10a5e1"
@@ -2371,7 +2380,7 @@ checksum = "cdd382e46cf44347f4d0c29122143cbab85cf248b9a8f680845c0239b6842a85"
 dependencies = [
  "arbitrary",
  "leb128",
- "wasm-encoder",
+ "wasm-encoder 0.2.0",
 ]
 
 [[package]]
@@ -2598,6 +2607,7 @@ dependencies = [
  "env_logger 0.8.1",
  "log",
  "rayon",
+ "wasm-encoder 0.1.0",
  "wasm-smith",
  "wasmi",
  "wasmparser 0.70.0",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -16,6 +16,7 @@ wasmparser = "0.70"
 wasmprinter = "0.2.17"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
+wasm-encoder = "0.1"
 wasm-smith = "0.2.0"
 wasmi = "0.7.0"
 

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -16,7 +16,7 @@ wasmparser = "0.70"
 wasmprinter = "0.2.17"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
-wasm-encoder = "0.1"
+wasm-encoder = "0.2"
 wasm-smith = "0.2.0"
 wasmi = "0.7.0"
 

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -80,7 +80,7 @@ impl TableOps {
         exports.export("run", Export::Function(0));
 
         let mut params: Vec<(u32, ValType)> = Vec::with_capacity(self.num_params() as usize);
-        for i in 0..self.num_params() {
+        for _i in 0..self.num_params() {
             params.push((0, ValType::ExternRef));
         }
         let mut func = Function::new(params);

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -35,7 +35,7 @@ impl TableOps {
         table_size
     }
 
-    /// Convert into a a wasm_encoded binary.
+    /// Serialize this module into a Wasm binary.
     ///
     /// The module requires a single import: `(import "" "gc" (func))`. This
     /// should be a function to trigger GC.

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -40,17 +40,6 @@ fn log_wasm(wasm: &[u8]) {
     }
 }
 
-fn log_wat(wat: &str) {
-    if !log::log_enabled!(log::Level::Debug) {
-        return;
-    }
-
-    let i = CNT.fetch_add(1, SeqCst);
-    let name = format!("testcase{}.wat", i);
-    log::debug!("wrote wat file to `{}`", name);
-    std::fs::write(&name, wat).expect("failed to write wat file");
-}
-
 /// Instantiate the Wasm buffer, and implicitly fail if we have an unexpected
 /// panic or segfault or anything else that can be detected "passively".
 ///
@@ -420,7 +409,7 @@ pub fn table_ops(config: crate::generators::Config, ops: crate::generators::tabl
 
         let wasm = ops.to_wasm_binary();
         log_wasm(&wasm);
-        let module = match Module::new(&engine, &wat) {
+        let module = match Module::new(&engine, &wasm) {
             Ok(m) => m,
             Err(_) => return,
         };

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -418,9 +418,8 @@ pub fn table_ops(config: crate::generators::Config, ops: crate::generators::tabl
         let engine = Engine::new(&config);
         let store = Store::new(&engine);
 
-        let wat = ops.to_wasm_binary();
-        let wat = wasmprinter::print_bytes(&wat).unwrap();
-        log_wat(&wat);
+        let wasm = ops.to_wasm_binary();
+        log_wasm(&wasm);
         let module = match Module::new(&engine, &wat) {
             Ok(m) => m,
             Err(_) => return,

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -404,7 +404,8 @@ pub fn table_ops(config: crate::generators::Config, ops: crate::generators::tabl
         let engine = Engine::new(&config);
         let store = Store::new(&engine);
 
-        let wat = ops.to_wat_string();
+        let wat = ops.to_wasm_binary();
+        let wat = wasmprinter::print_bytes(&wat).unwrap();
         log_wat(&wat);
         let module = match Module::new(&engine, &wat) {
             Ok(m) => m,


### PR DESCRIPTION
This PR migrates the TableOps fuzzer generator from the old string concatenation strategy to utilizing `wasm_encoder` to generate a wasm binary for us.

Tests updated accordingly.

Closes #2499 
