### PR TITLE
Draft: I128 support (partial) on x64.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -4,6 +4,8 @@ use crate::ir;
 use crate::ir::types;
 use crate::ir::types::*;
 use crate::ir::MemFlags;
+use crate::ir::Opcode;
+use crate::ir::{ExternalName, LibCall};
 use crate::isa;
 use crate::isa::aarch64::{inst::EmitState, inst::*};
 use crate::machinst::*;
@@ -76,41 +78,41 @@ fn try_fill_baldrdash_reg(call_conv: isa::CallConv, param: &ir::AbiParam) -> Opt
         match &param.purpose {
             &ir::ArgumentPurpose::VMContext => {
                 // This is SpiderMonkey's `WasmTlsReg`.
-                Some(ABIArg::Reg(
-                    ValueRegs::one(xreg(BALDRDASH_TLS_REG).to_real_reg()),
-                    ir::types::I64,
-                    param.extension,
-                    param.purpose,
-                ))
+                Some(ABIArg::Reg {
+                    regs: ValueRegs::one(xreg(BALDRDASH_TLS_REG).to_real_reg()),
+                    ty: ir::types::I64,
+                    extension: param.extension,
+                    purpose: param.purpose,
+                })
             }
             &ir::ArgumentPurpose::SignatureId => {
                 // This is SpiderMonkey's `WasmTableCallSigReg`.
-                Some(ABIArg::Reg(
-                    ValueRegs::one(xreg(BALDRDASH_SIG_REG).to_real_reg()),
-                    ir::types::I64,
-                    param.extension,
-                    param.purpose,
-                ))
+                Some(ABIArg::Reg {
+                    regs: ValueRegs::one(xreg(BALDRDASH_SIG_REG).to_real_reg()),
+                    ty: ir::types::I64,
+                    extension: param.extension,
+                    purpose: param.purpose,
+                })
             }
             &ir::ArgumentPurpose::CalleeTLS => {
                 // This is SpiderMonkey's callee TLS slot in the extended frame of Wasm's ABI-2020.
                 assert!(call_conv == isa::CallConv::Baldrdash2020);
-                Some(ABIArg::Stack(
-                    BALDRDASH_CALLEE_TLS_OFFSET,
-                    ir::types::I64,
-                    ir::ArgumentExtension::None,
-                    param.purpose,
-                ))
+                Some(ABIArg::Stack {
+                    offset: BALDRDASH_CALLEE_TLS_OFFSET,
+                    ty: ir::types::I64,
+                    extension: ir::ArgumentExtension::None,
+                    purpose: param.purpose,
+                })
             }
             &ir::ArgumentPurpose::CallerTLS => {
                 // This is SpiderMonkey's caller TLS slot in the extended frame of Wasm's ABI-2020.
                 assert!(call_conv == isa::CallConv::Baldrdash2020);
-                Some(ABIArg::Stack(
-                    BALDRDASH_CALLER_TLS_OFFSET,
-                    ir::types::I64,
-                    ir::ArgumentExtension::None,
-                    param.purpose,
-                ))
+                Some(ABIArg::Stack {
+                    offset: BALDRDASH_CALLER_TLS_OFFSET,
+                    ty: ir::types::I64,
+                    extension: ir::ArgumentExtension::None,
+                    purpose: param.purpose,
+                })
             }
             _ => None,
         }
@@ -208,7 +210,9 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 | &ir::ArgumentPurpose::StackLimit
                 | &ir::ArgumentPurpose::SignatureId
                 | &ir::ArgumentPurpose::CallerTLS
-                | &ir::ArgumentPurpose::CalleeTLS => {}
+                | &ir::ArgumentPurpose::CalleeTLS
+                | &ir::ArgumentPurpose::StructReturn
+                | &ir::ArgumentPurpose::StructArgument(_) => {}
                 _ => panic!(
                     "Unsupported argument purpose {:?} in signature: {:?}",
                     param.purpose, params
@@ -233,18 +237,27 @@ impl ABIMachineSpec for AArch64MachineDeps {
             if let Some(param) = try_fill_baldrdash_reg(call_conv, param) {
                 assert!(rc == RegClass::I64);
                 ret.push(param);
+            } else if let ir::ArgumentPurpose::StructArgument(size) = param.purpose {
+                let offset = next_stack as i64;
+                let size = size as u64;
+                next_stack += size;
+                ret.push(ABIArg::StructArg {
+                    offset,
+                    size,
+                    purpose: param.purpose,
+                });
             } else if *next_reg < max_per_class_reg_vals && remaining_reg_vals > 0 {
                 let reg = match rc {
                     RegClass::I64 => xreg(*next_reg),
                     RegClass::V128 => vreg(*next_reg),
                     _ => unreachable!(),
                 };
-                ret.push(ABIArg::Reg(
-                    ValueRegs::one(reg.to_real_reg()),
-                    param.value_type,
-                    param.extension,
-                    param.purpose,
-                ));
+                ret.push(ABIArg::Reg {
+                    regs: ValueRegs::one(reg.to_real_reg()),
+                    ty: param.value_type,
+                    extension: param.extension,
+                    purpose: param.purpose,
+                });
                 *next_reg += 1;
                 remaining_reg_vals -= 1;
             } else {
@@ -255,12 +268,12 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 // Align.
                 debug_assert!(size.is_power_of_two());
                 next_stack = (next_stack + size - 1) & !(size - 1);
-                ret.push(ABIArg::Stack(
-                    next_stack as i64,
-                    param.value_type,
-                    param.extension,
-                    param.purpose,
-                ));
+                ret.push(ABIArg::Stack {
+                    offset: next_stack as i64,
+                    ty: param.value_type,
+                    extension: param.extension,
+                    purpose: param.purpose,
+                });
                 next_stack += size;
             }
         }
@@ -272,19 +285,19 @@ impl ABIMachineSpec for AArch64MachineDeps {
         let extra_arg = if add_ret_area_ptr {
             debug_assert!(args_or_rets == ArgsOrRets::Args);
             if next_xreg < max_per_class_reg_vals && remaining_reg_vals > 0 {
-                ret.push(ABIArg::Reg(
-                    ValueRegs::one(xreg(next_xreg).to_real_reg()),
-                    I64,
-                    ir::ArgumentExtension::None,
-                    ir::ArgumentPurpose::Normal,
-                ));
+                ret.push(ABIArg::Reg {
+                    regs: ValueRegs::one(xreg(next_xreg).to_real_reg()),
+                    ty: I64,
+                    extension: ir::ArgumentExtension::None,
+                    purpose: ir::ArgumentPurpose::Normal,
+                });
             } else {
-                ret.push(ABIArg::Stack(
-                    next_stack as i64,
-                    I64,
-                    ir::ArgumentExtension::None,
-                    ir::ArgumentPurpose::Normal,
-                ));
+                ret.push(ABIArg::Stack {
+                    offset: next_stack as i64,
+                    ty: I64,
+                    extension: ir::ArgumentExtension::None,
+                    purpose: ir::ArgumentPurpose::Normal,
+                });
                 next_stack += 8;
             }
             Some(ret.len() - 1)
@@ -705,6 +718,29 @@ impl ABIMachineSpec for AArch64MachineDeps {
             )),
         }
 
+        insts
+    }
+
+    fn gen_memcpy(
+        call_conv: isa::CallConv,
+        dst: Reg,
+        src: Reg,
+        size: usize,
+    ) -> SmallVec<[Self::I; 8]> {
+        let mut insts = SmallVec::new();
+        insts.push(Inst::gen_move(writable_xreg(0), dst, I64));
+        insts.push(Inst::gen_move(writable_xreg(1), src, I64));
+        insts.extend(Inst::load_constant(writable_xreg(2), size as u64).into_iter());
+        insts.push(Inst::Call {
+            info: Box::new(CallInfo {
+                dest: ExternalName::LibCall(LibCall::Memcpy),
+                uses: vec![xreg(0), xreg(1), xreg(2)],
+                defs: Self::get_regs_clobbered_by_call(call_conv),
+                opcode: Opcode::Call,
+                caller_callconv: call_conv,
+                callee_callconv: call_conv,
+            }),
+        });
         insts
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -3,7 +3,9 @@
 // Some variants are never constructed, but we still want them as options in the future.
 #![allow(dead_code)]
 
-use crate::ir::types::{F32X2, F32X4, F64X2, I16X4, I16X8, I32X2, I32X4, I64X2, I8X16, I8X8};
+use crate::ir::types::{
+    B16X8, B32X4, B64X2, B8X16, F32X2, F32X4, F64X2, I16X4, I16X8, I32X2, I32X4, I64X2, I8X16, I8X8,
+};
 use crate::ir::Type;
 use crate::isa::aarch64::inst::*;
 use crate::machinst::{ty_bits, MachLabel};

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -22,7 +22,7 @@ use super::lower_inst;
 
 use crate::data_value::DataValue;
 use log::{debug, trace};
-use regalloc::{Reg, RegClass, Writable};
+use regalloc::{Reg, Writable};
 use smallvec::SmallVec;
 
 //============================================================================
@@ -179,23 +179,28 @@ pub(crate) fn put_input_in_reg<C: LowerCtx<I = Inst>>(
         } else {
             c
         };
-        let to_reg = ctx.alloc_tmp(Inst::rc_for_type(ty).unwrap(), ty);
-        for inst in Inst::gen_constant(to_reg, masked, ty, |reg_class, ty| {
-            ctx.alloc_tmp(reg_class, ty)
-        })
+        let to_reg = ctx.alloc_tmp(ty).only_reg().unwrap();
+        for inst in Inst::gen_constant(
+            ValueRegs::one(to_reg),
+            masked as u128,
+            ty,
+            |_reg_class, ty| ctx.alloc_tmp(ty).only_reg().unwrap(),
+        )
         .into_iter()
         {
             ctx.emit(inst);
         }
         to_reg.to_reg()
     } else {
-        ctx.put_input_in_reg(input.insn, input.input)
+        ctx.put_input_in_regs(input.insn, input.input)
+            .only_reg()
+            .unwrap()
     };
 
     match (narrow_mode, from_bits) {
         (NarrowValueMode::None, _) => in_reg,
         (NarrowValueMode::ZeroExtend32, n) if n < 32 => {
-            let tmp = ctx.alloc_tmp(RegClass::I64, I32);
+            let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
             ctx.emit(Inst::Extend {
                 rd: tmp,
                 rn: in_reg,
@@ -206,7 +211,7 @@ pub(crate) fn put_input_in_reg<C: LowerCtx<I = Inst>>(
             tmp.to_reg()
         }
         (NarrowValueMode::SignExtend32, n) if n < 32 => {
-            let tmp = ctx.alloc_tmp(RegClass::I64, I32);
+            let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
             ctx.emit(Inst::Extend {
                 rd: tmp,
                 rn: in_reg,
@@ -223,7 +228,7 @@ pub(crate) fn put_input_in_reg<C: LowerCtx<I = Inst>>(
                 // Constants are zero-extended to full 64-bit width on load already.
                 in_reg
             } else {
-                let tmp = ctx.alloc_tmp(RegClass::I64, I32);
+                let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
                 ctx.emit(Inst::Extend {
                     rd: tmp,
                     rn: in_reg,
@@ -235,7 +240,7 @@ pub(crate) fn put_input_in_reg<C: LowerCtx<I = Inst>>(
             }
         }
         (NarrowValueMode::SignExtend64, n) if n < 64 => {
-            let tmp = ctx.alloc_tmp(RegClass::I64, I32);
+            let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
             ctx.emit(Inst::Extend {
                 rd: tmp,
                 rn: in_reg,
@@ -696,7 +701,7 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
     /* addends64.len() == 0 */
     {
         if addends32.len() > 0 {
-            let tmp = ctx.alloc_tmp(RegClass::I64, I64);
+            let tmp = ctx.alloc_tmp(I64).only_reg().unwrap();
             let (reg1, extendop) = addends32.pop().unwrap();
             let signed = match extendop {
                 ExtendOp::SXTW => true,
@@ -718,7 +723,7 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
         } else
         /* addends32.len() == 0 */
         {
-            let off_reg = ctx.alloc_tmp(RegClass::I64, I64);
+            let off_reg = ctx.alloc_tmp(I64).only_reg().unwrap();
             lower_constant_u64(ctx, off_reg, offset as u64);
             offset = 0;
             AMode::reg(off_reg.to_reg())
@@ -734,7 +739,7 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
     }
 
     // Allocate the temp and shoehorn it into the AMode.
-    let addr = ctx.alloc_tmp(RegClass::I64, I64);
+    let addr = ctx.alloc_tmp(I64).only_reg().unwrap();
     let (reg, memarg) = match memarg {
         AMode::RegExtended(r1, r2, extendop) => {
             (r1, AMode::RegExtended(addr.to_reg(), r2, extendop))
@@ -782,7 +787,7 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
         // If the register is the stack reg, we must move it to another reg
         // before adding it.
         let reg = if reg == stack_reg() {
-            let tmp = ctx.alloc_tmp(RegClass::I64, I64);
+            let tmp = ctx.alloc_tmp(I64).only_reg().unwrap();
             ctx.emit(Inst::gen_move(tmp, stack_reg(), I64));
             tmp.to_reg()
         } else {
@@ -824,7 +829,7 @@ pub(crate) fn lower_constant_f32<C: LowerCtx<I = Inst>>(
     rd: Writable<Reg>,
     value: f32,
 ) {
-    let alloc_tmp = |class, ty| ctx.alloc_tmp(class, ty);
+    let alloc_tmp = |_class, ty| ctx.alloc_tmp(ty).only_reg().unwrap();
 
     for inst in Inst::load_fp_constant32(rd, value.to_bits(), alloc_tmp) {
         ctx.emit(inst);
@@ -836,7 +841,7 @@ pub(crate) fn lower_constant_f64<C: LowerCtx<I = Inst>>(
     rd: Writable<Reg>,
     value: f64,
 ) {
-    let alloc_tmp = |class, ty| ctx.alloc_tmp(class, ty);
+    let alloc_tmp = |_class, ty| ctx.alloc_tmp(ty).only_reg().unwrap();
 
     for inst in Inst::load_fp_constant64(rd, value.to_bits(), alloc_tmp) {
         ctx.emit(inst);
@@ -858,7 +863,7 @@ pub(crate) fn lower_constant_f128<C: LowerCtx<I = Inst>>(
             size: VectorSize::Size8x16,
         });
     } else {
-        let alloc_tmp = |class, ty| ctx.alloc_tmp(class, ty);
+        let alloc_tmp = |_class, ty| ctx.alloc_tmp(ty).only_reg().unwrap();
         for inst in Inst::load_fp_constant128(rd, value, alloc_tmp) {
             ctx.emit(inst);
         }
@@ -885,7 +890,7 @@ pub(crate) fn lower_splat_const<C: LowerCtx<I = Inst>>(
         ),
         None => (value, size),
     };
-    let alloc_tmp = |class, ty| ctx.alloc_tmp(class, ty);
+    let alloc_tmp = |_class, ty| ctx.alloc_tmp(ty).only_reg().unwrap();
 
     for inst in Inst::load_replicated_vector_pattern(rd, value, size, alloc_tmp) {
         ctx.emit(inst);
@@ -1217,7 +1222,7 @@ pub(crate) fn lower_load<C: LowerCtx<I = Inst>, F: FnMut(&mut C, Writable<Reg>, 
 
     let off = ctx.data(ir_inst).load_store_offset().unwrap();
     let mem = lower_address(ctx, elem_ty, &inputs[..], off);
-    let rd = get_output_reg(ctx, output);
+    let rd = get_output_reg(ctx, output).only_reg().unwrap();
 
     f(ctx, rd, elem_ty, mem);
 }

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -1234,7 +1234,7 @@ impl LowerBackend for AArch64Backend {
     type MInst = Inst;
 
     fn lower<C: LowerCtx<I = Inst>>(&self, ctx: &mut C, ir_inst: IRInst) -> CodegenResult<()> {
-        lower_inst::lower_insn_to_regs(ctx, ir_inst)
+        lower_inst::lower_insn_to_regs(ctx, ir_inst, &self.flags)
     }
 
     fn lower_branch_group<C: LowerCtx<I = Inst>>(

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -12,7 +12,7 @@ use crate::{CodegenError, CodegenResult};
 use crate::isa::aarch64::abi::*;
 use crate::isa::aarch64::inst::*;
 
-use regalloc::{RegClass, Writable};
+use regalloc::Writable;
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -46,21 +46,21 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 ty if ty.is_bool() => value,
                 ty => unreachable!("Unknown type for const: {}", ty),
             };
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             lower_constant_u64(ctx, rd, value);
         }
         Opcode::F32const => {
             let value = f32::from_bits(ctx.get_constant(insn).unwrap() as u32);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             lower_constant_f32(ctx, rd, value);
         }
         Opcode::F64const => {
             let value = f64::from_bits(ctx.get_constant(insn).unwrap());
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             lower_constant_f64(ctx, rd, value);
         }
         Opcode::Iadd => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             if !ty.is_vector() {
                 let mul_insn =
@@ -116,7 +116,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         }
         Opcode::Isub => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let ty = ty.unwrap();
             if !ty.is_vector() {
@@ -148,7 +148,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // (SQADD / UQADD / SQSUB / UQSUB), which require scalar FP registers.
             let is_signed = op == Opcode::SaddSat || op == Opcode::SsubSat;
             let ty = ty.unwrap();
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             if !ty.is_vector() {
                 let narrow_mode = if is_signed {
                     NarrowValueMode::SignExtend64
@@ -162,8 +162,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     Opcode::SsubSat => FPUOp2::Sqsub64,
                     _ => unreachable!(),
                 };
-                let va = ctx.alloc_tmp(RegClass::V128, I128);
-                let vb = ctx.alloc_tmp(RegClass::V128, I128);
+                let va = ctx.alloc_tmp(I8X16).only_reg().unwrap();
+                let vb = ctx.alloc_tmp(I8X16).only_reg().unwrap();
                 let ra = put_input_in_reg(ctx, inputs[0], narrow_mode);
                 let rb = put_input_in_reg(ctx, inputs[1], narrow_mode);
                 ctx.emit(Inst::MovToFpu {
@@ -211,7 +211,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Ineg => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             if !ty.is_vector() {
                 let rn = zero_reg();
@@ -230,7 +230,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Imul => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty = ty.unwrap();
@@ -245,8 +245,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 });
             } else {
                 if ty == I64X2 {
-                    let tmp1 = ctx.alloc_tmp(RegClass::V128, I64X2);
-                    let tmp2 = ctx.alloc_tmp(RegClass::V128, I64X2);
+                    let tmp1 = ctx.alloc_tmp(I64X2).only_reg().unwrap();
+                    let tmp2 = ctx.alloc_tmp(I64X2).only_reg().unwrap();
 
                     // This I64X2 multiplication is performed with several 32-bit
                     // operations.
@@ -362,7 +362,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Umulhi | Opcode::Smulhi => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let is_signed = op == Opcode::Smulhi;
             let input_ty = ctx.input_ty(insn, 0);
             assert!(ctx.input_ty(insn, 1) == input_ty);
@@ -443,7 +443,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 ALUOp::UDiv64
             };
 
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], narrow_mode);
             let rm = put_input_in_reg(ctx, inputs[1], narrow_mode);
             // The div instruction does not trap on divide by zero or signed overflow
@@ -550,7 +550,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             assert!(from_bits <= to_bits);
             if from_bits < to_bits {
                 let signed = op == Opcode::Sextend;
-                let rd = get_output_reg(ctx, outputs[0]);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 if let Some(extract_insn) = maybe_input_insn(ctx, inputs[0], Opcode::Extractlane) {
                     let idx =
@@ -596,7 +596,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Bnot => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             if !ty.is_vector() {
                 let rm = put_input_in_rs_immlogic(ctx, inputs[0], NarrowValueMode::None);
@@ -620,7 +620,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::BandNot
         | Opcode::BorNot
         | Opcode::BxorNot => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             if !ty.is_vector() {
                 let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
@@ -646,7 +646,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
                 let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
                 let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-                let rd = get_output_reg(ctx, outputs[0]);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 ctx.emit(Inst::VecRRR {
                     alu_op,
@@ -660,7 +660,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Ishl | Opcode::Ushr | Opcode::Sshr => {
             let ty = ty.unwrap();
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             if !ty.is_vector() {
                 let size = OperandSize::from_bits(ty_bits(ty));
                 let narrow_mode = match (op, size) {
@@ -692,7 +692,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
                 let rm = if is_right_shift {
                     // Right shifts are implemented with a negative left shift.
-                    let tmp = ctx.alloc_tmp(RegClass::I64, I32);
+                    let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
                     let rm = put_input_in_rse_imm12(ctx, inputs[1], NarrowValueMode::None);
                     let rn = zero_reg();
                     ctx.emit(alu_inst_imm12(ALUOp::Sub32, tmp, rn, rm));
@@ -746,7 +746,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let ty = ty.unwrap();
             let ty_bits_size = ty_bits(ty) as u8;
 
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(
                 ctx,
                 inputs[0],
@@ -780,7 +780,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                             // ignored (because of the implicit masking done by the instruction),
                             // so this is equivalent to negating the input.
                             let alu_op = choose_32_64(ty, ALUOp::Sub32, ALUOp::Sub64);
-                            let tmp = ctx.alloc_tmp(RegClass::I64, ty);
+                            let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
                             ctx.emit(Inst::AluRRR {
                                 alu_op,
                                 rd: tmp,
@@ -803,7 +803,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                             // Really ty_bits_size - rn, but the upper bits of the result are
                             // ignored (because of the implicit masking done by the instruction),
                             // so this is equivalent to negating the input.
-                            let tmp = ctx.alloc_tmp(RegClass::I64, I32);
+                            let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
                             ctx.emit(Inst::AluRRR {
                                 alu_op: ALUOp::Sub32,
                                 rd: tmp,
@@ -816,7 +816,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         };
 
                         // Explicitly mask the rotation count.
-                        let tmp_masked_rm = ctx.alloc_tmp(RegClass::I64, I32);
+                        let tmp_masked_rm = ctx.alloc_tmp(I32).only_reg().unwrap();
                         ctx.emit(Inst::AluRRImmLogic {
                             alu_op: ALUOp::And32,
                             rd: tmp_masked_rm,
@@ -825,8 +825,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         });
                         let tmp_masked_rm = tmp_masked_rm.to_reg();
 
-                        let tmp1 = ctx.alloc_tmp(RegClass::I64, I32);
-                        let tmp2 = ctx.alloc_tmp(RegClass::I64, I32);
+                        let tmp1 = ctx.alloc_tmp(I32).only_reg().unwrap();
+                        let tmp2 = ctx.alloc_tmp(I32).only_reg().unwrap();
                         ctx.emit(Inst::AluRRImm12 {
                             alu_op: ALUOp::Sub32,
                             rd: tmp1,
@@ -865,7 +865,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         }
                         immshift.imm &= ty_bits_size - 1;
 
-                        let tmp1 = ctx.alloc_tmp(RegClass::I64, I32);
+                        let tmp1 = ctx.alloc_tmp(I32).only_reg().unwrap();
                         ctx.emit(Inst::AluRRImmShift {
                             alu_op: ALUOp::Lsr32,
                             rd: tmp1,
@@ -895,7 +895,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Bitrev | Opcode::Clz | Opcode::Cls | Opcode::Ctz => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let needs_zext = match op {
                 Opcode::Bitrev | Opcode::Ctz => false,
                 Opcode::Clz | Opcode::Cls => true,
@@ -965,12 +965,12 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             //   x += x << 32
             //   x >> 56
             let ty = ty.unwrap();
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             // FIXME(#1537): zero-extend 8/16/32-bit operands only to 32 bits,
             // and fix the sequence below to work properly for this.
             let narrow_mode = NarrowValueMode::ZeroExtend64;
             let rn = put_input_in_reg(ctx, inputs[0], narrow_mode);
-            let tmp = ctx.alloc_tmp(RegClass::I64, I64);
+            let tmp = ctx.alloc_tmp(I64).only_reg().unwrap();
 
             // If this is a 32-bit Popcnt, use Lsr32 to clear the top 32 bits of the register, then
             // the rest of the code is identical to the 64-bit version.
@@ -1231,7 +1231,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 } => (stack_slot, offset),
                 _ => unreachable!(),
             };
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let offset: i32 = offset.into();
             let inst = ctx
                 .abi()
@@ -1240,7 +1240,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::AtomicRmw => {
-            let r_dst = get_output_reg(ctx, outputs[0]);
+            let r_dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let mut r_addr = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let mut r_arg2 = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty_access = ty.unwrap();
@@ -1265,7 +1265,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // This is very similar to, but not identical to, the AtomicRmw case.  Note
             // that the AtomicCAS sequence does its own masking, so we don't need to worry
             // about zero-extending narrow (I8/I16/I32) values here.
-            let r_dst = get_output_reg(ctx, outputs[0]);
+            let r_dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let mut r_addr = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let mut r_expected = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let mut r_replacement = put_input_in_reg(ctx, inputs[2], NarrowValueMode::None);
@@ -1296,7 +1296,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::AtomicLoad => {
-            let r_data = get_output_reg(ctx, outputs[0]);
+            let r_data = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let r_addr = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let ty_access = ty.unwrap();
             assert!(is_valid_atomic_transaction_ty(ty_access));
@@ -1377,7 +1377,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             };
 
             // csel.cond rd, rn, rm
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[2], NarrowValueMode::None);
             let ty = ctx.output_ty(insn, 0);
@@ -1404,7 +1404,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             lower_icmp_or_ifcmp_to_flags(ctx, ifcmp_insn, is_signed);
 
             // csel.COND rd, rn, rm
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[2], NarrowValueMode::None);
             let ty = ctx.output_ty(insn, 0);
@@ -1423,8 +1423,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let ty = ty.unwrap();
             if !ty.is_vector() {
                 debug_assert_ne!(Opcode::Vselect, op);
-                let tmp = ctx.alloc_tmp(RegClass::I64, I64);
-                let rd = get_output_reg(ctx, outputs[0]);
+                let tmp = ctx.alloc_tmp(I64).only_reg().unwrap();
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let rcond = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
                 let rn = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
                 let rm = put_input_in_reg(ctx, inputs[2], NarrowValueMode::None);
@@ -1453,7 +1453,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let rcond = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
                 let rn = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
                 let rm = put_input_in_reg(ctx, inputs[2], NarrowValueMode::None);
-                let rd = get_output_reg(ctx, outputs[0]);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(rd, rcond, ty));
 
                 ctx.emit(Inst::VecRRR {
@@ -1474,7 +1474,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // single-def ifcmp.
             let ifcmp_insn = maybe_input_insn(ctx, inputs[0], Opcode::Ifcmp).unwrap();
             lower_icmp_or_ifcmp_to_flags(ctx, ifcmp_insn, is_signed);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             materialize_bool_result(ctx, insn, rd, cond);
         }
 
@@ -1483,7 +1483,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let cond = lower_fp_condcode(condcode);
             let ffcmp_insn = maybe_input_insn(ctx, inputs[0], Opcode::Ffcmp).unwrap();
             lower_fcmp_or_ffcmp_to_flags(ctx, ffcmp_insn);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             materialize_bool_result(ctx, insn, rd, cond);
         }
 
@@ -1491,7 +1491,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // Null references are represented by the constant value 0; invalid references are
             // represented by the constant value -1. See `define_reftypes()` in
             // `meta/src/isa/x86/encodings.rs` to confirm.
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let ty = ctx.input_ty(insn, 0);
             let (alu_op, const_value) = match op {
@@ -1511,7 +1511,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Copy => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let ty = ctx.input_ty(insn, 0);
             ctx.emit(Inst::gen_move(rd, rn, ty));
@@ -1521,7 +1521,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // Smaller integers/booleans are stored with high-order bits
             // undefined, so we can simply do a copy.
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ctx.input_ty(insn, 0);
             ctx.emit(Inst::gen_move(rd, rn, ty));
         }
@@ -1548,7 +1548,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // Nothing.
             } else {
                 let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-                let rd = get_output_reg(ctx, outputs[0]);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let to_bits = if to_bits == 64 {
                     64
                 } else {
@@ -1570,7 +1570,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // Booleans are stored as all-zeroes (0) or all-ones (-1). We AND
             // out the LSB to give a 0 / 1-valued integer result.
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let output_bits = ty_bits(ctx.output_ty(insn, 0));
 
             let (imm_ty, alu_op) = if output_bits > 32 {
@@ -1587,7 +1587,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Bitcast => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ity = ctx.input_ty(insn, 0);
             let oty = ctx.output_ty(insn, 0);
             let ity_bits = ty_bits(ity);
@@ -1639,7 +1639,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // (above the bits for the value's type) are undefined, so we
                 // need not extend the return values.
                 let reg = put_input_in_reg(ctx, *input, NarrowValueMode::None);
-                let retval_reg = ctx.retval(i);
+                let retval_reg = ctx.retval(i).only_reg().unwrap();
                 let ty = ctx.input_ty(insn, i);
                 ctx.emit(Inst::gen_move(retval_reg, reg, ty));
             }
@@ -1658,7 +1658,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let condcode = ctx.data(insn).cond_code().unwrap();
             let cond = lower_condcode(condcode);
             let is_signed = condcode_is_signed(condcode);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ctx.input_ty(insn, 0);
             let bits = ty_bits(ty);
             let narrow_mode = match (bits <= 32, is_signed) {
@@ -1686,7 +1686,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let ty = ctx.input_ty(insn, 0);
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             if !ty.is_vector() {
                 match ty_bits(ty) {
@@ -1763,7 +1763,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::FuncAddr => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let (extname, _) = ctx.call_target(insn).unwrap();
             let extname = extname.clone();
             ctx.emit(Inst::LoadExtName {
@@ -1778,7 +1778,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::SymbolValue => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let (extname, _, offset) = ctx.symbol_value(insn).unwrap();
             let extname = extname.clone();
             ctx.emit(Inst::LoadExtName {
@@ -1819,18 +1819,18 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             assert!(inputs.len() == abi.num_args());
             for (i, input) in inputs.iter().enumerate() {
                 let arg_reg = put_input_in_reg(ctx, *input, NarrowValueMode::None);
-                abi.emit_copy_reg_to_arg(ctx, i, arg_reg);
+                abi.emit_copy_regs_to_arg(ctx, i, ValueRegs::one(arg_reg));
             }
             abi.emit_call(ctx);
             for (i, output) in outputs.iter().enumerate() {
-                let retval_reg = get_output_reg(ctx, *output);
-                abi.emit_copy_retval_to_reg(ctx, i, retval_reg);
+                let retval_reg = get_output_reg(ctx, *output).only_reg().unwrap();
+                abi.emit_copy_retval_to_regs(ctx, i, ValueRegs::one(retval_reg));
             }
             abi.emit_stack_post_adjust(ctx);
         }
 
         Opcode::GetPinnedReg => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             ctx.emit(Inst::gen_move(rd, xreg(PINNED_REG), I64));
         }
 
@@ -1869,13 +1869,13 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Vconst => {
             let value = const_param_to_u128(ctx, insn).expect("Invalid immediate bytes");
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             lower_constant_f128(ctx, rd, value);
         }
 
         Opcode::RawBitcast => {
             let rm = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ctx.input_ty(insn, 0);
             ctx.emit(Inst::gen_move(rd, rm, ty));
         }
@@ -1883,7 +1883,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Extractlane => {
             if let InstructionData::BinaryImm8 { imm, .. } = ctx.data(insn) {
                 let idx = *imm;
-                let rd = get_output_reg(ctx, outputs[0]);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
                 let size = VectorSize::from_ty(ctx.input_ty(insn, 0));
                 let ty = ty.unwrap();
@@ -1908,7 +1908,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 unreachable!();
             };
             let input_ty = ctx.input_ty(insn, 1);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rm = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rn = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty = ty.unwrap();
@@ -1930,7 +1930,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Splat => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let size = VectorSize::from_ty(ty.unwrap());
 
             if let Some((_, insn)) = maybe_input_insn_multi(
@@ -1974,7 +1974,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     &load_inputs[..],
                     load_outputs[0],
                     |ctx, _rd, _elem_ty, mem| {
-                        let tmp = ctx.alloc_tmp(RegClass::I64, I64);
+                        let tmp = ctx.alloc_tmp(I64).only_reg().unwrap();
                         let (addr, addr_inst) = Inst::gen_load_addr(tmp, mem);
                         if let Some(addr_inst) = addr_inst {
                             ctx.emit(addr_inst);
@@ -1997,7 +1997,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::ScalarToVector => {
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let input_ty = ctx.input_ty(insn, 0);
             if (input_ty == I32 && ty.unwrap() == I32X4)
                 || (input_ty == I64 && ty.unwrap() == I64X2)
@@ -2016,9 +2016,10 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::VanyTrue | Opcode::VallTrue => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rm = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let tmp = ctx.alloc_tmp(RegClass::V128, ty.unwrap());
+            let src_ty = ctx.input_ty(insn, 0);
+            let tmp = ctx.alloc_tmp(src_ty).only_reg().unwrap();
 
             // This operation is implemented by using umaxp or uminv to
             // create a scalar value, which is then compared against zero.
@@ -2065,7 +2066,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::VhighBits => {
-            let dst_r = get_output_reg(ctx, outputs[0]);
+            let dst_r = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let src_v = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let ty = ctx.input_ty(insn, 0);
             // All three sequences use one integer temporary and two vector temporaries.  The
@@ -2075,9 +2076,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // derivation of these sequences.  Alternative sequences are discussed in
             // https://github.com/bytecodealliance/wasmtime/issues/2296, although they are not
             // used here.
-            let tmp_r0 = ctx.alloc_tmp(RegClass::I64, I64);
-            let tmp_v0 = ctx.alloc_tmp(RegClass::V128, I8X16);
-            let tmp_v1 = ctx.alloc_tmp(RegClass::V128, I8X16);
+            let tmp_r0 = ctx.alloc_tmp(I64).only_reg().unwrap();
+            let tmp_v0 = ctx.alloc_tmp(I8X16).only_reg().unwrap();
+            let tmp_v1 = ctx.alloc_tmp(I8X16).only_reg().unwrap();
             match ty {
                 I8X16 => {
                     // sshr  tmp_v1.16b, src_v.16b, #7
@@ -2250,7 +2251,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Shuffle => {
             let mask = const_param_to_u128(ctx, insn).expect("Invalid immediate mask bytes");
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rn2 = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             // 2 register table vector lookups require consecutive table registers;
@@ -2278,7 +2279,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Swizzle => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
 
@@ -2305,7 +2306,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 Opcode::Imax => VecALUOp::Smax,
                 _ => unreachable!(),
             };
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty = ty.unwrap();
@@ -2319,12 +2320,12 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::WideningPairwiseDotProductS => {
-            let r_y = get_output_reg(ctx, outputs[0]);
+            let r_y = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let r_a = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let r_b = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty = ty.unwrap();
             if ty == I32X4 {
-                let tmp = ctx.alloc_tmp(RegClass::V128, I8X16);
+                let tmp = ctx.alloc_tmp(I8X16).only_reg().unwrap();
                 // The args have type I16X8.
                 // "y = i32x4.dot_i16x8_s(a, b)"
                 // => smull  tmp, a, b
@@ -2364,7 +2365,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let bits = ty_bits(ty);
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             if !ty.is_vector() {
                 let fpu_op = match (op, bits) {
                     (Opcode::Fadd, 32) => FPUOp2::Add32,
@@ -2408,7 +2409,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             if ty == F32X4 || ty == F64X2 {
                 // pmin(a,b) => bitsel(b, a, cmpgt(a, b))
                 // pmax(a,b) => bitsel(b, a, cmpgt(b, a))
-                let r_dst = get_output_reg(ctx, outputs[0]);
+                let r_dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let r_a = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
                 let r_b = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
                 // Since we're going to write the output register `r_dst` anyway, we might as
@@ -2444,7 +2445,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let ty = ty.unwrap();
             let bits = ty_bits(ty);
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             if !ty.is_vector() {
                 let fpu_op = match (op, bits) {
                     (Opcode::Sqrt, 32) => FPUOp1::Sqrt32,
@@ -2493,7 +2494,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     _ => panic!("Unknown op/bits combination (scalar)"),
                 };
                 let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-                let rd = get_output_reg(ctx, outputs[0]);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::FpuRound { op, rd, rn });
             } else {
                 let (op, size) = match (op, ty) {
@@ -2508,7 +2509,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     _ => panic!("Unknown op/ty combination (vector){:?}", ty),
                 };
                 let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-                let rd = get_output_reg(ctx, outputs[0]);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::VecMisc { op, rd, rn, size });
             }
         }
@@ -2523,7 +2524,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ra = put_input_in_reg(ctx, inputs[2], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             ctx.emit(Inst::FpuRRRR {
                 fpu_op,
                 rn,
@@ -2549,8 +2550,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             assert!(bits == 32 || bits == 64);
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
-            let tmp = ctx.alloc_tmp(RegClass::V128, F64);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+            let tmp = ctx.alloc_tmp(F64).only_reg().unwrap();
 
             // Copy LHS to rd.
             ctx.emit(Inst::gen_move(rd, rn, ty));
@@ -2589,7 +2590,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             };
 
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             // First, check the output: it's important to carry the NaN conversion before the
             // in-bounds conversion, per wasm semantics.
@@ -2606,7 +2607,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 kind: CondBrKind::Cond(lower_fp_condcode(FloatCC::Unordered)),
             });
 
-            let tmp = ctx.alloc_tmp(RegClass::V128, I128);
+            let tmp = ctx.alloc_tmp(I8X16).only_reg().unwrap();
 
             // Check that the input is in range, with "truncate towards zero" semantics. This means
             // we allow values that are slightly out of range:
@@ -2731,7 +2732,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::FcvtFromUint | Opcode::FcvtFromSint => {
             let ty = ty.unwrap();
             let signed = op == Opcode::FcvtFromSint;
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             if ty.is_vector() {
                 let op = if signed {
@@ -2777,7 +2778,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let ty = ty.unwrap();
             let out_signed = op == Opcode::FcvtToSintSat;
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             if ty.is_vector() {
                 let op = if out_signed {
@@ -2824,8 +2825,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     _ => unreachable!(),
                 };
 
-                let rtmp1 = ctx.alloc_tmp(RegClass::V128, in_ty);
-                let rtmp2 = ctx.alloc_tmp(RegClass::V128, in_ty);
+                let rtmp1 = ctx.alloc_tmp(in_ty).only_reg().unwrap();
+                let rtmp2 = ctx.alloc_tmp(in_ty).only_reg().unwrap();
 
                 if in_bits == 32 {
                     lower_constant_f32(ctx, rtmp1, max as f32);
@@ -2915,7 +2916,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
             // Now handle the iadd as above, except use an AddS opcode that sets
             // flags.
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_rse_imm12(ctx, inputs[1], NarrowValueMode::None);
             let ty = ty.unwrap();
@@ -2996,7 +2997,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::DummySargT => unreachable!(),
 
         Opcode::Iabs => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let ty = ty.unwrap();
             ctx.emit(Inst::VecMisc {
@@ -3007,7 +3008,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             });
         }
         Opcode::AvgRound => {
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty = ty.unwrap();
@@ -3026,7 +3027,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             } else {
                 VecMiscNarrowOp::Sqxtun
             };
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let rn2 = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
             let ty = ty.unwrap();
@@ -3049,7 +3050,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::SwidenLow | Opcode::SwidenHigh | Opcode::UwidenLow | Opcode::UwidenHigh => {
             let lane_type = ty.unwrap().lane_type();
-            let rd = get_output_reg(ctx, outputs[0]);
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
             let (t, high_half) = match (lane_type, op) {
                 (I16, Opcode::SwidenLow) => (VecExtendOp::Sxtl8, false),
@@ -3308,8 +3309,8 @@ pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
                     NarrowValueMode::ZeroExtend32,
                 );
 
-                let rtmp1 = ctx.alloc_tmp(RegClass::I64, I32);
-                let rtmp2 = ctx.alloc_tmp(RegClass::I64, I32);
+                let rtmp1 = ctx.alloc_tmp(I32).only_reg().unwrap();
+                let rtmp2 = ctx.alloc_tmp(I32).only_reg().unwrap();
 
                 // Bounds-check, leaving condition codes for JTSequence's
                 // branch to default target below.

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -7,6 +7,7 @@ use crate::ir::Inst as IRInst;
 use crate::ir::{InstructionData, Opcode, TrapCode};
 use crate::machinst::lower::*;
 use crate::machinst::*;
+use crate::settings::Flags;
 use crate::{CodegenError, CodegenResult};
 
 use crate::isa::aarch64::abi::*;
@@ -24,6 +25,7 @@ use super::lower::*;
 pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
     ctx: &mut C,
     insn: IRInst,
+    flags: &Flags,
 ) -> CodegenResult<()> {
     let op = ctx.data(insn).opcode();
     let inputs = insn_inputs(ctx, insn);
@@ -1798,7 +1800,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert!(inputs.len() == sig.params.len());
                     assert!(outputs.len() == sig.returns.len());
                     (
-                        AArch64ABICaller::from_func(sig, &extname, dist, caller_conv)?,
+                        AArch64ABICaller::from_func(sig, &extname, dist, caller_conv, flags)?,
                         &inputs[..],
                     )
                 }
@@ -1808,7 +1810,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert!(inputs.len() - 1 == sig.params.len());
                     assert!(outputs.len() == sig.returns.len());
                     (
-                        AArch64ABICaller::from_ptr(sig, ptr, op, caller_conv)?,
+                        AArch64ABICaller::from_ptr(sig, ptr, op, caller_conv, flags)?,
                         &inputs[1..],
                     )
                 }
@@ -1817,8 +1819,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
             abi.emit_stack_pre_adjust(ctx);
             assert!(inputs.len() == abi.num_args());
-            for (i, input) in inputs.iter().enumerate() {
-                let arg_reg = put_input_in_reg(ctx, *input, NarrowValueMode::None);
+            for i in abi.get_copy_to_arg_order() {
+                let input = inputs[i];
+                let arg_reg = put_input_in_reg(ctx, input, NarrowValueMode::None);
                 abi.emit_copy_regs_to_arg(ctx, i, ValueRegs::one(arg_reg));
             }
             abi.emit_call(ctx);

--- a/cranelift/codegen/src/isa/arm32/abi.rs
+++ b/cranelift/codegen/src/isa/arm32/abi.rs
@@ -82,7 +82,7 @@ impl ABIMachineSpec for Arm32MachineDeps {
                 let reg = rreg(next_rreg);
 
                 ret.push(ABIArg::Reg(
-                    reg.to_real_reg(),
+                    ValueRegs::one(reg.to_real_reg()),
                     param.value_type,
                     param.extension,
                     param.purpose,
@@ -102,7 +102,7 @@ impl ABIMachineSpec for Arm32MachineDeps {
             debug_assert!(args_or_rets == ArgsOrRets::Args);
             if next_rreg < max_reg_val {
                 ret.push(ABIArg::Reg(
-                    rreg(next_rreg).to_real_reg(),
+                    ValueRegs::one(rreg(next_rreg).to_real_reg()),
                     I32,
                     ir::ArgumentExtension::None,
                     ir::ArgumentPurpose::Normal,

--- a/cranelift/codegen/src/isa/arm32/abi.rs
+++ b/cranelift/codegen/src/isa/arm32/abi.rs
@@ -81,12 +81,12 @@ impl ABIMachineSpec for Arm32MachineDeps {
             if next_rreg < max_reg_val {
                 let reg = rreg(next_rreg);
 
-                ret.push(ABIArg::Reg(
-                    ValueRegs::one(reg.to_real_reg()),
-                    param.value_type,
-                    param.extension,
-                    param.purpose,
-                ));
+                ret.push(ABIArg::Reg {
+                    regs: ValueRegs::one(reg.to_real_reg()),
+                    ty: param.value_type,
+                    extension: param.extension,
+                    purpose: param.purpose,
+                });
                 next_rreg += 1;
             } else {
                 // Arguments are stored on stack in reversed order.
@@ -101,12 +101,12 @@ impl ABIMachineSpec for Arm32MachineDeps {
         let extra_arg = if add_ret_area_ptr {
             debug_assert!(args_or_rets == ArgsOrRets::Args);
             if next_rreg < max_reg_val {
-                ret.push(ABIArg::Reg(
-                    ValueRegs::one(rreg(next_rreg).to_real_reg()),
-                    I32,
-                    ir::ArgumentExtension::None,
-                    ir::ArgumentPurpose::Normal,
-                ));
+                ret.push(ABIArg::Reg {
+                    regs: ValueRegs::one(rreg(next_rreg).to_real_reg()),
+                    ty: I32,
+                    extension: ir::ArgumentExtension::None,
+                    purpose: ir::ArgumentPurpose::Normal,
+                });
             } else {
                 stack_args.push((
                     I32,
@@ -124,12 +124,12 @@ impl ABIMachineSpec for Arm32MachineDeps {
         let max_stack = next_stack;
         for (ty, ext, purpose) in stack_args.into_iter().rev() {
             next_stack -= 4;
-            ret.push(ABIArg::Stack(
-                (max_stack - next_stack) as i64,
+            ret.push(ABIArg::Stack {
+                offset: (max_stack - next_stack) as i64,
                 ty,
-                ext,
+                extension: ext,
                 purpose,
-            ));
+            });
         }
         assert_eq!(next_stack, 0);
 
@@ -424,6 +424,15 @@ impl ABIMachineSpec for Arm32MachineDeps {
         }
 
         insts
+    }
+
+    fn gen_memcpy(
+        _call_conv: isa::CallConv,
+        _dst: Reg,
+        _src: Reg,
+        _size: usize,
+    ) -> SmallVec<[Self::I; 8]> {
+        panic!("StructArgs not implemented for ARM32 yet");
     }
 
     fn get_number_of_spillslots_for_value(rc: RegClass, _ty: Type) -> u32 {

--- a/cranelift/codegen/src/isa/arm32/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/mod.rs
@@ -808,11 +808,16 @@ impl MachInst for Inst {
     }
 
     fn gen_constant<F: FnMut(RegClass, Type) -> Writable<Reg>>(
-        to_reg: Writable<Reg>,
-        value: u64,
+        to_regs: ValueRegs<Writable<Reg>>,
+        value: u128,
         ty: Type,
         _alloc_tmp: F,
     ) -> SmallVec<[Inst; 4]> {
+        let to_reg = to_regs
+            .only_reg()
+            .expect("multi-reg values not supported yet");
+        let value = value as u64;
+
         match ty {
             B1 | I8 | B8 | I16 | B16 | I32 | B32 => {
                 let v: i64 = value as i64;
@@ -839,10 +844,10 @@ impl MachInst for Inst {
         None
     }
 
-    fn rc_for_type(ty: Type) -> CodegenResult<RegClass> {
+    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {
         match ty {
-            I8 | I16 | I32 | B1 | B8 | B16 | B32 => Ok(RegClass::I32),
-            IFLAGS => Ok(RegClass::I32),
+            I8 | I16 | I32 | B1 | B8 | B16 | B32 => Ok((&[RegClass::I32], &[I32])),
+            IFLAGS => Ok((&[RegClass::I32], &[I32])),
             _ => Err(CodegenError::Unsupported(format!(
                 "Unexpected SSA-value type: {}",
                 ty

--- a/cranelift/codegen/src/isa/arm32/lower.rs
+++ b/cranelift/codegen/src/isa/arm32/lower.rs
@@ -224,7 +224,7 @@ impl LowerBackend for Arm32Backend {
     type MInst = Inst;
 
     fn lower<C: LowerCtx<I = Inst>>(&self, ctx: &mut C, ir_inst: IRInst) -> CodegenResult<()> {
-        lower_inst::lower_insn_to_regs(ctx, ir_inst)
+        lower_inst::lower_insn_to_regs(ctx, ir_inst, &self.flags)
     }
 
     fn lower_branch_group<C: LowerCtx<I = Inst>>(

--- a/cranelift/codegen/src/isa/arm32/lower.rs
+++ b/cranelift/codegen/src/isa/arm32/lower.rs
@@ -13,7 +13,7 @@ use crate::isa::arm32::Arm32Backend;
 
 use super::lower_inst;
 
-use regalloc::{Reg, RegClass, Writable};
+use regalloc::{Reg, Writable};
 
 //============================================================================
 // Lowering: convert instruction outputs to result types.
@@ -55,7 +55,7 @@ pub(crate) enum NarrowValueMode {
 
 /// Lower an instruction output to a reg.
 pub(crate) fn output_to_reg<C: LowerCtx<I = Inst>>(ctx: &mut C, out: InsnOutput) -> Writable<Reg> {
-    ctx.get_output(out.insn, out.output)
+    ctx.get_output(out.insn, out.output).only_reg().unwrap()
 }
 
 /// Lower an instruction input to a reg.
@@ -70,21 +70,25 @@ pub(crate) fn input_to_reg<C: LowerCtx<I = Inst>>(
     let from_bits = ty.bits() as u8;
     let inputs = ctx.get_input_as_source_or_const(input.insn, input.input);
     let in_reg = if let Some(c) = inputs.constant {
-        let to_reg = ctx.alloc_tmp(Inst::rc_for_type(ty).unwrap(), ty);
-        for inst in Inst::gen_constant(to_reg, c, ty, |reg_class, ty| ctx.alloc_tmp(reg_class, ty))
-            .into_iter()
+        let to_reg = ctx.alloc_tmp(ty).only_reg().unwrap();
+        for inst in Inst::gen_constant(ValueRegs::one(to_reg), c as u128, ty, |_, ty| {
+            ctx.alloc_tmp(ty).only_reg().unwrap()
+        })
+        .into_iter()
         {
             ctx.emit(inst);
         }
         to_reg.to_reg()
     } else {
-        ctx.put_input_in_reg(input.insn, input.input)
+        ctx.put_input_in_regs(input.insn, input.input)
+            .only_reg()
+            .unwrap()
     };
 
     match (narrow_mode, from_bits) {
         (NarrowValueMode::None, _) => in_reg,
         (NarrowValueMode::ZeroExtend, 1) => {
-            let tmp = ctx.alloc_tmp(RegClass::I32, I32);
+            let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
             ctx.emit(Inst::AluRRImm8 {
                 alu_op: ALUOp::And,
                 rd: tmp,
@@ -94,7 +98,7 @@ pub(crate) fn input_to_reg<C: LowerCtx<I = Inst>>(
             tmp.to_reg()
         }
         (NarrowValueMode::ZeroExtend, n) if n < 32 => {
-            let tmp = ctx.alloc_tmp(RegClass::I32, I32);
+            let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
             ctx.emit(Inst::Extend {
                 rd: tmp,
                 rm: in_reg,
@@ -104,7 +108,7 @@ pub(crate) fn input_to_reg<C: LowerCtx<I = Inst>>(
             tmp.to_reg()
         }
         (NarrowValueMode::SignExtend, n) if n < 32 => {
-            let tmp = ctx.alloc_tmp(RegClass::I32, I32);
+            let tmp = ctx.alloc_tmp(I32).only_reg().unwrap();
             ctx.emit(Inst::Extend {
                 rd: tmp,
                 rm: in_reg,

--- a/cranelift/codegen/src/isa/arm32/lower_inst.rs
+++ b/cranelift/codegen/src/isa/arm32/lower_inst.rs
@@ -5,6 +5,7 @@ use crate::ir::Inst as IRInst;
 use crate::ir::Opcode;
 use crate::machinst::lower::*;
 use crate::machinst::*;
+use crate::settings::Flags;
 use crate::CodegenResult;
 
 use crate::isa::arm32::abi::*;
@@ -18,6 +19,7 @@ use super::lower::*;
 pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
     ctx: &mut C,
     insn: IRInst,
+    flags: &Flags,
 ) -> CodegenResult<()> {
     let op = ctx.data(insn).opcode();
     let inputs: SmallVec<[InsnInput; 4]> = (0..ctx.num_inputs(insn))
@@ -502,7 +504,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert_eq!(inputs.len(), sig.params.len());
                     assert_eq!(outputs.len(), sig.returns.len());
                     (
-                        Arm32ABICaller::from_func(sig, &extname, dist, caller_conv)?,
+                        Arm32ABICaller::from_func(sig, &extname, dist, caller_conv, flags)?,
                         &inputs[..],
                     )
                 }
@@ -512,7 +514,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert_eq!(inputs.len() - 1, sig.params.len());
                     assert_eq!(outputs.len(), sig.returns.len());
                     (
-                        Arm32ABICaller::from_ptr(sig, ptr, op, caller_conv)?,
+                        Arm32ABICaller::from_ptr(sig, ptr, op, caller_conv, flags)?,
                         &inputs[1..],
                     )
                 }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -32,7 +32,7 @@ fn try_fill_baldrdash_reg(call_conv: CallConv, param: &ir::AbiParam) -> Option<A
             &ir::ArgumentPurpose::VMContext => {
                 // This is SpiderMonkey's `WasmTlsReg`.
                 Some(ABIArg::Reg(
-                    regs::r14().to_real_reg(),
+                    ValueRegs::one(regs::r14().to_real_reg()),
                     types::I64,
                     param.extension,
                     param.purpose,
@@ -41,7 +41,7 @@ fn try_fill_baldrdash_reg(call_conv: CallConv, param: &ir::AbiParam) -> Option<A
             &ir::ArgumentPurpose::SignatureId => {
                 // This is SpiderMonkey's `WasmTableCallSigReg`.
                 Some(ABIArg::Reg(
-                    regs::r10().to_real_reg(),
+                    ValueRegs::one(regs::r10().to_real_reg()),
                     types::I64,
                     param.extension,
                     param.purpose,
@@ -168,7 +168,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 ret.push(param);
             } else if let Some(reg) = candidate {
                 ret.push(ABIArg::Reg(
-                    reg.to_real_reg(),
+                    ValueRegs::one(reg.to_real_reg()),
                     param.value_type,
                     param.extension,
                     param.purpose,
@@ -200,7 +200,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             debug_assert!(args_or_rets == ArgsOrRets::Args);
             if let Some(reg) = get_intreg_for_arg_systemv(&call_conv, next_gpr) {
                 ret.push(ABIArg::Reg(
-                    reg.to_real_reg(),
+                    ValueRegs::one(reg.to_real_reg()),
                     types::I64,
                     ir::ArgumentExtension::None,
                     ir::ArgumentPurpose::Normal,

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -15,7 +15,7 @@ use std::string::String;
 
 /// A possible addressing mode (amode) that can be used in instructions.
 /// These denote a 64-bit value only.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Amode {
     /// Immediate sign-extended and a Register.
     ImmReg {
@@ -346,23 +346,35 @@ impl PrettyPrintSized for RegMem {
 #[derive(Copy, Clone, PartialEq)]
 pub enum AluRmiROpcode {
     Add,
+    Adc,
     Sub,
+    Sbb,
     And,
     Or,
     Xor,
     /// The signless, non-extending (N x N -> N, for N in {32,64}) variant.
     Mul,
+    /// 8-bit form of And. Handled separately as we don't have full 8-bit op
+    /// support (we just use wider instructions). Used only with some sequences
+    /// with SETcc.
+    And8,
+    /// 8-bit form of Or.
+    Or8,
 }
 
 impl fmt::Debug for AluRmiROpcode {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let name = match self {
             AluRmiROpcode::Add => "add",
+            AluRmiROpcode::Adc => "adc",
             AluRmiROpcode::Sub => "sub",
+            AluRmiROpcode::Sbb => "sbb",
             AluRmiROpcode::And => "and",
             AluRmiROpcode::Or => "or",
             AluRmiROpcode::Xor => "xor",
             AluRmiROpcode::Mul => "imul",
+            AluRmiROpcode::And8 => "and",
+            AluRmiROpcode::Or8 => "or",
         };
         write!(fmt, "{}", name)
     }
@@ -371,6 +383,16 @@ impl fmt::Debug for AluRmiROpcode {
 impl fmt::Display for AluRmiROpcode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
+    }
+}
+
+impl AluRmiROpcode {
+    /// Is this a special-cased 8-bit ALU op?
+    pub fn is_8bit(self) -> bool {
+        match self {
+            AluRmiROpcode::And8 | AluRmiROpcode::Or8 => true,
+            _ => false,
+        }
     }
 }
 
@@ -1002,7 +1024,7 @@ impl fmt::Display for ExtMode {
 }
 
 /// These indicate the form of a scalar shift/rotate: left, signed right, unsigned right.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub enum ShiftKind {
     ShiftLeft,
     /// Inserts zeros in the most significant bits.

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1,5 +1,6 @@
 use crate::binemit::{Addend, Reloc};
 use crate::ir::immediates::{Ieee32, Ieee64};
+use crate::ir::LibCall;
 use crate::ir::TrapCode;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
@@ -2922,6 +2923,27 @@ pub(crate) fn emit(
 
         Inst::EpiloguePlaceholder => {
             // Generate no code.
+        }
+
+        Inst::ElfTlsGetAddr { ref symbol } => {
+            sink.put1(0x66);
+            sink.put1(0b01001000);
+            sink.put1(0x8d);
+            sink.put1(0x3d);
+            emit_reloc(sink, state, Reloc::ElfX86_64TlsGd, symbol, -4);
+            sink.put4(0);
+            sink.put1(0x66);
+            sink.put1(0x66);
+            sink.put1(0b01001000);
+            sink.put1(0xe8);
+            emit_reloc(
+                sink,
+                state,
+                Reloc::X86CallPLTRel4,
+                &ExternalName::LibCall(LibCall::ElfTlsGetAddr),
+                -4,
+            );
+            sink.put4(0);
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1243,6 +1243,16 @@ fn test_x64_emit() {
         "66F7D7",
         "notw    %di",
     ));
+    insns.push((
+        Inst::not(1, Writable::from_reg(regs::rdi())),
+        "40F6D7",
+        "notb    %dil",
+    ));
+    insns.push((
+        Inst::not(1, Writable::from_reg(regs::rax())),
+        "F6D0",
+        "notb    %al",
+    ));
 
     // ========================================================
     // Neg
@@ -1266,6 +1276,16 @@ fn test_x64_emit() {
         "66F7DF",
         "negw    %di",
     ));
+    insns.push((
+        Inst::neg(1, Writable::from_reg(regs::rdi())),
+        "40F6DF",
+        "negb    %dil",
+    ));
+    insns.push((
+        Inst::neg(1, Writable::from_reg(regs::rax())),
+        "F6D8",
+        "negb    %al",
+    ));
 
     // ========================================================
     // Div
@@ -1288,6 +1308,16 @@ fn test_x64_emit() {
         Inst::div(8, false /*signed*/, RegMem::reg(regs::rdi())),
         "48F7F7",
         "div     %rdi",
+    ));
+    insns.push((
+        Inst::div(1, false, RegMem::reg(regs::rax())),
+        "F6F0",
+        "div     %al",
+    ));
+    insns.push((
+        Inst::div(1, false, RegMem::reg(regs::rsi())),
+        "40F6F6",
+        "div     %sil",
     ));
 
     // ========================================================
@@ -2402,8 +2432,13 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::shift_r(1, ShiftKind::RotateRight, None, w_rsi),
-        "D2CE",
+        "40D2CE",
         "rorb    %cl, %sil",
+    ));
+    insns.push((
+        Inst::shift_r(1, ShiftKind::RotateRight, None, w_rax),
+        "D2C8",
+        "rorb    %cl, %al",
     ));
     insns.push((
         Inst::shift_r(1, ShiftKind::RotateRight, Some(5), w_r15),

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1026,6 +1026,56 @@ fn test_x64_emit() {
         "orq     %r15, %rdx",
     ));
     insns.push((
+        Inst::alu_rmi_r(false, AluRmiROpcode::And8, RegMemImm::reg(r15), w_rdx),
+        "4420FA",
+        "andb    %r15b, %dl",
+    ));
+    insns.push((
+        Inst::alu_rmi_r(false, AluRmiROpcode::And8, RegMemImm::reg(rax), w_rsi),
+        "4020C6",
+        "andb    %al, %sil",
+    ));
+    insns.push((
+        Inst::alu_rmi_r(false, AluRmiROpcode::And8, RegMemImm::reg(rax), w_rbx),
+        "20C3",
+        "andb    %al, %bl",
+    ));
+    insns.push((
+        Inst::alu_rmi_r(
+            false,
+            AluRmiROpcode::And8,
+            RegMemImm::mem(Amode::imm_reg(0, rax)),
+            w_rbx,
+        ),
+        "2218",
+        "andb    0(%rax), %bl",
+    ));
+    insns.push((
+        Inst::alu_rmi_r(false, AluRmiROpcode::Or8, RegMemImm::reg(r15), w_rdx),
+        "4408FA",
+        "orb     %r15b, %dl",
+    ));
+    insns.push((
+        Inst::alu_rmi_r(false, AluRmiROpcode::Or8, RegMemImm::reg(rax), w_rsi),
+        "4008C6",
+        "orb     %al, %sil",
+    ));
+    insns.push((
+        Inst::alu_rmi_r(false, AluRmiROpcode::Or8, RegMemImm::reg(rax), w_rbx),
+        "08C3",
+        "orb     %al, %bl",
+    ));
+    insns.push((
+        Inst::alu_rmi_r(
+            false,
+            AluRmiROpcode::Or8,
+            RegMemImm::mem(Amode::imm_reg(0, rax)),
+            w_rbx,
+        ),
+        "0A18",
+        "orb     0(%rax), %bl",
+    ));
+    insns.push((
         Inst::alu_rmi_r(true, AluRmiROpcode::Xor, RegMemImm::reg(r15), w_rdx),
         "4C31FA",
         "xorq    %r15, %rdx",

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -473,9 +473,7 @@ pub enum Inst {
 
     /// A call to the `ElfTlsGetAddr` libcall. Returns address
     /// of TLS symbol in rax.
-    ElfTlsGetAddr {
-        symbol: ExternalName,
-    },
+    ElfTlsGetAddr { symbol: ExternalName },
 }
 
 pub(crate) fn low32_will_sign_extend_to_64(x: u64) -> bool {
@@ -534,7 +532,7 @@ impl Inst {
             | Inst::XmmCmpRmR { .. }
             | Inst::XmmLoadConst { .. }
             | Inst::XmmMinMaxSeq { .. }
-            | Inst::XmmUninitializedValue { .. } 
+            | Inst::XmmUninitializedValue { .. }
             | Inst::ElfTlsGetAddr { .. } => None,
 
             // These use dynamic SSE opcodes.
@@ -2429,12 +2427,11 @@ fn x64_map_regs<RUM: RegUsageMapper>(inst: &mut Inst, mapper: &RUM) {
         | Inst::Ud2 { .. }
         | Inst::Hlt
         | Inst::AtomicRmwSeq { .. }
-        | Inst::ElfTlsGetAddr { .. } 
+        | Inst::ElfTlsGetAddr { .. }
         | Inst::Fence { .. } => {
             // Instruction doesn't explicitly mention any regs, so it can't have any virtual
             // regs that we'd need to remap.  Hence no action required.
         }
-
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1217,8 +1217,26 @@ impl PrettyPrint for Inst {
             (if is_64 { "q" } else { "l" }).to_string()
         }
 
+        fn suffix_lqb(is_64: bool, is_8: bool) -> String {
+            match (is_64, is_8) {
+                (_, true) => "b".to_string(),
+                (true, false) => "q".to_string(),
+                (false, false) => "l".to_string(),
+            }
+        }
+
         fn size_lq(is_64: bool) -> u8 {
             if is_64 {
+                8
+            } else {
+                4
+            }
+        }
+
+        fn size_lqb(is_64: bool, is_8: bool) -> u8 {
+            if is_8 {
+                1
+            } else if is_64 {
                 8
             } else {
                 4
@@ -1245,9 +1263,9 @@ impl PrettyPrint for Inst {
                 dst,
             } => format!(
                 "{} {}, {}",
-                ljustify2(op.to_string(), suffix_lq(*is_64)),
-                src.show_rru_sized(mb_rru, size_lq(*is_64)),
-                show_ireg_sized(dst.to_reg(), mb_rru, size_lq(*is_64)),
+                ljustify2(op.to_string(), suffix_lqb(*is_64, op.is_8bit())),
+                src.show_rru_sized(mb_rru, size_lqb(*is_64, op.is_8bit())),
+                show_ireg_sized(dst.to_reg(), mb_rru, size_lqb(*is_64, op.is_8bit())),
             ),
 
             Inst::UnaryRmR { src, dst, op, size } => format!(
@@ -2028,6 +2046,17 @@ impl Amode {
             }
         }
     }
+
+    /// Offset the amode by a fixed offset.
+    pub(crate) fn offset(self, offset: u32) -> Self {
+        let mut ret = self;
+        match &mut ret {
+            &mut Amode::ImmReg { ref mut simm32, .. } => *simm32 += offset,
+            &mut Amode::ImmRegRegShift { ref mut simm32, .. } => *simm32 += offset,
+            _ => panic!("Cannot offset amode: {:?}", self),
+        }
+        ret
+    }
 }
 
 impl RegMemImm {
@@ -2512,74 +2541,87 @@ impl MachInst for Inst {
         mut alloc_tmp: F,
     ) -> SmallVec<[Self; 4]> {
         let mut ret = SmallVec::new();
-        let to_reg = to_regs
-            .only_reg()
-            .expect("multi-reg values not supported on x64");
-        if ty == types::F32 {
-            if value == 0 {
-                ret.push(Inst::xmm_rm_r(
-                    SseOpcode::Xorps,
-                    RegMem::reg(to_reg.to_reg()),
-                    to_reg,
-                ));
-            } else {
-                let tmp = alloc_tmp(RegClass::I64, types::I32);
-                ret.push(Inst::imm(OperandSize::Size32, value as u64, tmp));
-
-                ret.push(Inst::gpr_to_xmm(
-                    SseOpcode::Movd,
-                    RegMem::reg(tmp.to_reg()),
-                    OperandSize::Size32,
-                    to_reg,
-                ));
-            }
-        } else if ty == types::F64 {
-            if value == 0 {
-                ret.push(Inst::xmm_rm_r(
-                    SseOpcode::Xorpd,
-                    RegMem::reg(to_reg.to_reg()),
-                    to_reg,
-                ));
-            } else {
-                let tmp = alloc_tmp(RegClass::I64, types::I64);
-                ret.push(Inst::imm(OperandSize::Size64, value as u64, tmp));
-
-                ret.push(Inst::gpr_to_xmm(
-                    SseOpcode::Movq,
-                    RegMem::reg(tmp.to_reg()),
-                    OperandSize::Size64,
-                    to_reg,
-                ));
-            }
+        if ty == types::I128 {
+            ret.push(Inst::imm(
+                OperandSize::Size64,
+                value as u64,
+                to_regs.regs()[0],
+            ));
+            ret.push(Inst::imm(
+                OperandSize::Size64,
+                (value >> 64) as u64,
+                to_regs.regs()[1],
+            ));
         } else {
-            // Must be an integer type.
-            debug_assert!(
-                ty == types::B1
-                    || ty == types::I8
-                    || ty == types::B8
-                    || ty == types::I16
-                    || ty == types::B16
-                    || ty == types::I32
-                    || ty == types::B32
-                    || ty == types::I64
-                    || ty == types::B64
-                    || ty == types::R32
-                    || ty == types::R64
-            );
-            if value == 0 {
-                ret.push(Inst::alu_rmi_r(
-                    ty == types::I64,
-                    AluRmiROpcode::Xor,
-                    RegMemImm::reg(to_reg.to_reg()),
-                    to_reg,
-                ));
+            let to_reg = to_regs
+                .only_reg()
+                .expect("multi-reg values not supported on x64");
+            if ty == types::F32 {
+                if value == 0 {
+                    ret.push(Inst::xmm_rm_r(
+                        SseOpcode::Xorps,
+                        RegMem::reg(to_reg.to_reg()),
+                        to_reg,
+                    ));
+                } else {
+                    let tmp = alloc_tmp(RegClass::I64, types::I32);
+                    ret.push(Inst::imm(OperandSize::Size32, value as u64, tmp));
+
+                    ret.push(Inst::gpr_to_xmm(
+                        SseOpcode::Movd,
+                        RegMem::reg(tmp.to_reg()),
+                        OperandSize::Size32,
+                        to_reg,
+                    ));
+                }
+            } else if ty == types::F64 {
+                if value == 0 {
+                    ret.push(Inst::xmm_rm_r(
+                        SseOpcode::Xorpd,
+                        RegMem::reg(to_reg.to_reg()),
+                        to_reg,
+                    ));
+                } else {
+                    let tmp = alloc_tmp(RegClass::I64, types::I64);
+                    ret.push(Inst::imm(OperandSize::Size64, value as u64, tmp));
+
+                    ret.push(Inst::gpr_to_xmm(
+                        SseOpcode::Movq,
+                        RegMem::reg(tmp.to_reg()),
+                        OperandSize::Size64,
+                        to_reg,
+                    ));
+                }
             } else {
-                let value = value as u64;
-                ret.push(Inst::imm(
-                    OperandSize::from_bytes(ty.bytes()),
-                    value.into(),
-                    to_reg,
-                ));
+                // Must be an integer type.
+                debug_assert!(
+                    ty == types::B1
+                        || ty == types::I8
+                        || ty == types::B8
+                        || ty == types::I16
+                        || ty == types::B16
+                        || ty == types::I32
+                        || ty == types::B32
+                        || ty == types::I64
+                        || ty == types::B64
+                        || ty == types::R32
+                        || ty == types::R64
+                );
+                if value == 0 {
+                    ret.push(Inst::alu_rmi_r(
+                        ty == types::I64,
+                        AluRmiROpcode::Xor,
+                        RegMemImm::reg(to_reg.to_reg()),
+                        to_reg,
+                    ));
+                } else {
+                    let value = value as u64;
+                    ret.push(Inst::imm(
+                        OperandSize::from_bytes(ty.bytes()),
+                        value.into(),
+                        to_reg,
+                    ));
+                }
             }
         }
         ret

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -88,7 +88,7 @@ fn matches_input_any<C: LowerCtx<I = Inst>>(
 
 /// Emits instruction(s) to generate the given 64-bit constant value into a newly-allocated
 /// temporary register, returning that register.
-fn generate_constant<C: LowerCtx<I = Inst>>(ctx: &mut C, ty: Type, c: u64) -> Reg {
+fn generate_constant<C: LowerCtx<I = Inst>>(ctx: &mut C, ty: Type, c: u64) -> ValueRegs<Reg> {
     let from_bits = ty_bits(ty);
     let masked = if from_bits < 64 {
         c & ((1u64 << from_bits) - 1)
@@ -96,15 +96,15 @@ fn generate_constant<C: LowerCtx<I = Inst>>(ctx: &mut C, ty: Type, c: u64) -> Re
         c
     };
 
-    let cst_copy = ctx.alloc_tmp(Inst::rc_for_type(ty).unwrap(), ty);
-    for inst in Inst::gen_constant(cst_copy, masked, ty, |reg_class, ty| {
-        ctx.alloc_tmp(reg_class, ty)
+    let cst_copy = ctx.alloc_tmp(ty);
+    for inst in Inst::gen_constant(cst_copy, masked as u128, ty, |_reg_class, ty| {
+        ctx.alloc_tmp(ty).only_reg().unwrap()
     })
     .into_iter()
     {
         ctx.emit(inst);
     }
-    cst_copy.to_reg()
+    non_writable_value_regs(cst_copy)
 }
 
 /// Put the given input into a register, and mark it as used (side-effect).
@@ -115,8 +115,12 @@ fn put_input_in_reg<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> Reg 
     if let Some(c) = input.constant {
         // Generate constants fresh at each use to minimize long-range register pressure.
         generate_constant(ctx, ty, c)
+            .only_reg()
+            .expect("multi-reg values not supported yet")
     } else {
-        ctx.put_input_in_reg(spec.insn, spec.input)
+        ctx.put_input_in_regs(spec.insn, spec.input)
+            .only_reg()
+            .expect("multi-reg values not supported yet")
     }
 }
 
@@ -172,7 +176,7 @@ fn input_to_reg_mem<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> RegM
     if let Some(c) = inputs.constant {
         // Generate constants fresh at each use to minimize long-range register pressure.
         let ty = ctx.input_ty(spec.insn, spec.input);
-        return RegMem::reg(generate_constant(ctx, ty, c));
+        return RegMem::reg(generate_constant(ctx, ty, c).only_reg().unwrap());
     }
 
     if let Some((src_insn, 0)) = inputs.inst {
@@ -183,7 +187,11 @@ fn input_to_reg_mem<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> RegM
         }
     }
 
-    RegMem::reg(ctx.put_input_in_reg(spec.insn, spec.input))
+    RegMem::reg(
+        ctx.put_input_in_regs(spec.insn, spec.input)
+            .only_reg()
+            .unwrap(),
+    )
 }
 
 /// An extension specification for `extend_input_to_reg`.
@@ -221,7 +229,7 @@ fn extend_input_to_reg<C: LowerCtx<I = Inst>>(
     };
 
     let src = input_to_reg_mem(ctx, spec);
-    let dst = ctx.alloc_tmp(RegClass::I64, requested_ty);
+    let dst = ctx.alloc_tmp(requested_ty).only_reg().unwrap();
     match ext_spec {
         ExtSpec::ZeroExtendTo32 | ExtSpec::ZeroExtendTo64 => {
             ctx.emit(Inst::movzx_rm_r(ext_mode, src, dst))
@@ -246,12 +254,6 @@ fn non_reg_input_to_sext_imm(input: NonRegInput, input_ty: Type) -> Option<u32> 
             None
         }
     })
-}
-
-fn input_to_sext_imm<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> Option<u32> {
-    let input = ctx.get_input_as_source_or_const(spec.insn, spec.input);
-    let input_ty = ctx.input_ty(spec.insn, spec.input);
-    non_reg_input_to_sext_imm(input, input_ty)
 }
 
 fn input_to_imm<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> Option<u64> {
@@ -530,19 +532,19 @@ fn emit_vm_call<C: LowerCtx<I = Inst>>(
 
     for (i, input) in inputs.iter().enumerate() {
         let arg_reg = put_input_in_reg(ctx, *input);
-        abi.emit_copy_reg_to_arg(ctx, i, arg_reg);
+        abi.emit_copy_regs_to_arg(ctx, i, ValueRegs::one(arg_reg));
     }
     if call_conv.extends_baldrdash() {
         let vm_context_vreg = ctx
             .get_vm_context()
             .expect("should have a VMContext to pass to libcall funcs");
-        abi.emit_copy_reg_to_arg(ctx, inputs.len(), vm_context_vreg);
+        abi.emit_copy_regs_to_arg(ctx, inputs.len(), ValueRegs::one(vm_context_vreg));
     }
 
     abi.emit_call(ctx);
     for (i, output) in outputs.iter().enumerate() {
-        let retval_reg = get_output_reg(ctx, *output);
-        abi.emit_copy_retval_to_reg(ctx, i, retval_reg);
+        let retval_reg = get_output_reg(ctx, *output).only_reg().unwrap();
+        abi.emit_copy_retval_to_regs(ctx, i, ValueRegs::one(retval_reg));
     }
     abi.emit_stack_post_adjust(ctx);
 
@@ -696,8 +698,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 .get_constant(insn)
                 .expect("constant value for iconst et al");
             let dst = get_output_reg(ctx, outputs[0]);
-            for inst in Inst::gen_constant(dst, value, ty.unwrap(), |reg_class, ty| {
-                ctx.alloc_tmp(reg_class, ty)
+            for inst in Inst::gen_constant(dst, value as u128, ty.unwrap(), |_reg_class, ty| {
+                ctx.alloc_tmp(ty).only_reg().unwrap()
             }) {
                 ctx.emit(inst);
             }
@@ -793,10 +795,10 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                             // Get inputs rhs=A and lhs=B and the dst register
                             let lhs = put_input_in_reg(ctx, inputs[0]);
                             let rhs = put_input_in_reg(ctx, inputs[1]);
-                            let dst = get_output_reg(ctx, outputs[0]);
+                            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                             // A' = A
-                            let rhs_1 = ctx.alloc_tmp(RegClass::V128, types::I64X2);
+                            let rhs_1 = ctx.alloc_tmp(types::I64X2).only_reg().unwrap();
                             ctx.emit(Inst::gen_move(rhs_1, rhs, ty));
 
                             // A' = A' >> 32
@@ -813,7 +815,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                             ));
 
                             // B' = B
-                            let lhs_1 = ctx.alloc_tmp(RegClass::V128, types::I64X2);
+                            let lhs_1 = ctx.alloc_tmp(types::I64X2).only_reg().unwrap();
                             ctx.emit(Inst::gen_move(lhs_1, lhs, ty));
 
                             // B' = B' >> 32
@@ -882,7 +884,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 };
                 let lhs = put_input_in_reg(ctx, inputs[0]);
                 let rhs = input_to_reg_mem(ctx, inputs[1]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 // Move the `lhs` to the same register as `dst`.
                 ctx.emit(Inst::gen_move(dst, lhs, ty));
@@ -926,7 +928,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     _ => unreachable!(),
                 };
 
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::mov_r_r(true, lhs, dst));
                 ctx.emit(Inst::alu_rmi_r(is_64, alu_op, rhs, dst));
             }
@@ -937,7 +939,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             debug_assert!(ty.is_vector() && ty.bytes() == 16);
             let lhs = input_to_reg_mem(ctx, inputs[0]);
             let rhs = put_input_in_reg(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let sse_op = match ty {
                 types::F32X4 => SseOpcode::Andnps,
                 types::F64X2 => SseOpcode::Andnpd,
@@ -951,7 +953,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Iabs => {
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             if ty.is_vector() {
                 let opcode = match ty {
@@ -969,7 +971,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Imax | Opcode::Umax | Opcode::Imin | Opcode::Umin => {
             let lhs = put_input_in_reg(ctx, inputs[0]);
             let rhs = input_to_reg_mem(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             if ty.is_vector() {
                 let sse_op = match op {
@@ -1012,11 +1014,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let ty = ty.unwrap();
             let size = ty.bytes() as u8;
             let src = put_input_in_reg(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             ctx.emit(Inst::gen_move(dst, src, ty));
 
             if ty.is_vector() {
-                let tmp = ctx.alloc_tmp(RegClass::V128, ty);
+                let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
                 ctx.emit(Inst::equals(ty, RegMem::from(tmp), tmp));
                 ctx.emit(Inst::xor(ty, RegMem::from(tmp), dst));
             } else if ty.is_bool() {
@@ -1031,14 +1033,14 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let condition = put_input_in_reg(ctx, inputs[0]);
             let if_true = put_input_in_reg(ctx, inputs[1]);
             let if_false = input_to_reg_mem(ctx, inputs[2]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             if ty.is_vector() {
-                let tmp1 = ctx.alloc_tmp(RegClass::V128, ty);
+                let tmp1 = ctx.alloc_tmp(ty).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(tmp1, if_true, ty));
                 ctx.emit(Inst::and(ty, RegMem::reg(condition.clone()), tmp1));
 
-                let tmp2 = ctx.alloc_tmp(RegClass::V128, ty);
+                let tmp2 = ctx.alloc_tmp(ty).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(tmp2, condition, ty));
                 ctx.emit(Inst::and_not(ty, if_false, tmp2));
 
@@ -1090,7 +1092,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         (None, Some(put_input_in_reg(ctx, inputs[1])))
                     };
 
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 let shift_kind = match op {
                     Opcode::Ishl => ShiftKind::ShiftLeft,
@@ -1114,13 +1116,13 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // incorrect bits to 0s (see below for handling signs in `sshr.i8x16`).
                 let src = put_input_in_reg(ctx, inputs[0]);
                 let shift_by = input_to_reg_mem_imm(ctx, inputs[1]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 // If necessary, move the shift index into the lowest bits of a vector register.
                 let shift_by_moved = match &shift_by {
                     RegMemImm::Imm { .. } => shift_by.clone(),
                     RegMemImm::Reg { reg } => {
-                        let tmp_shift_by = ctx.alloc_tmp(RegClass::V128, dst_ty);
+                        let tmp_shift_by = ctx.alloc_tmp(dst_ty).only_reg().unwrap();
                         ctx.emit(Inst::gpr_to_xmm(
                             SseOpcode::Movd,
                             RegMem::reg(*reg),
@@ -1193,8 +1195,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         // Otherwise, we must emit the entire mask table and dynamically (i.e. at run time) find the correct
                         // mask offset in the table. We do this use LEA to find the base address of the mask table and then
                         // complex addressing to offset to the right mask: `base_address + shift_by * 4`
-                        let base_mask_address = ctx.alloc_tmp(RegClass::I64, types::I64);
-                        let mask_offset = ctx.alloc_tmp(RegClass::I64, types::I64);
+                        let base_mask_address = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                        let mask_offset = ctx.alloc_tmp(types::I64).only_reg().unwrap();
                         let mask_constant = ctx.use_constant(VCodeConstantData::WellKnown(mask));
                         ctx.emit(Inst::lea(
                             SyntheticAmode::ConstantOffset(mask_constant),
@@ -1214,7 +1216,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 };
 
                 // Load the mask into a temporary register, `mask_value`.
-                let mask_value = ctx.alloc_tmp(RegClass::V128, dst_ty);
+                let mask_value = ctx.alloc_tmp(dst_ty).only_reg().unwrap();
                 ctx.emit(Inst::load(dst_ty, mask_address, mask_value, ExtKind::None));
 
                 // Remove the bits that would have disappeared in a true 8x16 shift. TODO in the future,
@@ -1238,7 +1240,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let src = put_input_in_reg(ctx, inputs[0]);
                 let shift_by = input_to_reg_mem_imm(ctx, inputs[1]);
                 let shift_by_ty = ctx.input_ty(insn, 1);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 // In order for PACKSSWB later to only use the high byte of each 16x8 lane, we shift right an extra 8
                 // bits, relying on PSRAW to fill in the upper bits appropriately.
@@ -1248,7 +1250,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     // Otherwise we add instructions to add the extra shift amount and move the value into an XMM
                     // register.
                     RegMemImm::Reg { reg } => {
-                        let bigger_shift_by_gpr = ctx.alloc_tmp(RegClass::I64, shift_by_ty);
+                        let bigger_shift_by_gpr = ctx.alloc_tmp(shift_by_ty).only_reg().unwrap();
                         ctx.emit(Inst::mov_r_r(true, reg, bigger_shift_by_gpr));
 
                         let is_64 = shift_by_ty == types::I64;
@@ -1260,7 +1262,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                             bigger_shift_by_gpr,
                         ));
 
-                        let bigger_shift_by_xmm = ctx.alloc_tmp(RegClass::V128, dst_ty);
+                        let bigger_shift_by_xmm = ctx.alloc_tmp(dst_ty).only_reg().unwrap();
                         ctx.emit(Inst::gpr_to_xmm(
                             SseOpcode::Movd,
                             RegMem::from(bigger_shift_by_gpr),
@@ -1282,7 +1284,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 ));
 
                 // Unpack and shift the upper lanes of `src` into a temporary register, `upper_lanes`.
-                let upper_lanes = ctx.alloc_tmp(RegClass::V128, dst_ty);
+                let upper_lanes = ctx.alloc_tmp(dst_ty).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(upper_lanes, src, dst_ty));
                 ctx.emit(Inst::xmm_rm_r(
                     SseOpcode::Punpckhbw,
@@ -1308,13 +1310,13 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // alternate lowering here). To remedy this, we extract each 64-bit lane to a GPR, shift each using a
                 // scalar instruction, and insert the shifted values back in the `dst` XMM register.
                 let src = put_input_in_reg(ctx, inputs[0]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(dst, src, dst_ty));
 
                 // Extract the upper and lower lanes into temporary GPRs.
-                let lower_lane = ctx.alloc_tmp(RegClass::I64, types::I64);
+                let lower_lane = ctx.alloc_tmp(types::I64).only_reg().unwrap();
                 emit_extract_lane(ctx, src, lower_lane, 0, types::I64);
-                let upper_lane = ctx.alloc_tmp(RegClass::I64, types::I64);
+                let upper_lane = ctx.alloc_tmp(types::I64).only_reg().unwrap();
                 emit_extract_lane(ctx, src, upper_lane, 1, types::I64);
 
                 // Shift each value.
@@ -1343,7 +1345,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // - shift using a dynamic value given in the lower bits of another XMM register.
                 let src = put_input_in_reg(ctx, inputs[0]);
                 let shift_by = input_to_reg_mem_imm(ctx, inputs[1]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let sse_op = match dst_ty {
                     types::I16X8 => match op {
                         Opcode::Ishl => SseOpcode::Psllw,
@@ -1369,7 +1371,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let shift_by = match shift_by {
                     RegMemImm::Imm { .. } => shift_by,
                     RegMemImm::Reg { reg } => {
-                        let tmp_shift_by = ctx.alloc_tmp(RegClass::V128, dst_ty);
+                        let tmp_shift_by = ctx.alloc_tmp(dst_ty).only_reg().unwrap();
                         ctx.emit(Inst::gpr_to_xmm(
                             SseOpcode::Movd,
                             RegMem::reg(reg),
@@ -1389,7 +1391,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Ineg => {
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
 
             if ty.is_vector() {
@@ -1397,7 +1399,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // of the input from the register.
 
                 let src = input_to_reg_mem(ctx, inputs[0]);
-                let tmp = ctx.alloc_tmp(RegClass::V128, types::I32X4);
+                let tmp = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
 
                 let subtract_opcode = match ty {
                     types::I8X16 => SseOpcode::Psubb,
@@ -1449,9 +1451,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             } else {
                 input_to_reg_mem(ctx, inputs[0])
             };
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
-            let tmp = ctx.alloc_tmp(RegClass::I64, ty);
+            let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
             ctx.emit(Inst::imm(
                 OperandSize::from_bytes(ty.bytes()),
                 u64::max_value(),
@@ -1498,9 +1500,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             debug_assert!(ty == types::I32 || ty == types::I64);
 
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
-            let tmp = ctx.alloc_tmp(RegClass::I64, ty);
+            let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
             ctx.emit(Inst::imm(OperandSize::Size32, ty.bits() as u64, tmp));
 
             ctx.emit(Inst::unary_rm_r(
@@ -1535,14 +1537,14 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // it won't for i32.popcnt), and we don't want a larger than necessary load.
                 RegMem::reg(put_input_in_reg(ctx, inputs[0]))
             };
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             if ty == types::I64 {
                 let is_64 = true;
 
-                let tmp1 = ctx.alloc_tmp(RegClass::I64, types::I64);
-                let tmp2 = ctx.alloc_tmp(RegClass::I64, types::I64);
-                let cst = ctx.alloc_tmp(RegClass::I64, types::I64);
+                let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                let cst = ctx.alloc_tmp(types::I64).only_reg().unwrap();
 
                 // mov src, tmp1
                 ctx.emit(Inst::mov64_rm_r(src.clone(), tmp1));
@@ -1672,8 +1674,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 assert_eq!(ty, types::I32);
                 let is_64 = false;
 
-                let tmp1 = ctx.alloc_tmp(RegClass::I64, types::I64);
-                let tmp2 = ctx.alloc_tmp(RegClass::I64, types::I64);
+                let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
 
                 // mov src, tmp1
                 ctx.emit(Inst::mov64_rm_r(src.clone(), tmp1));
@@ -1798,7 +1800,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // represented by the constant value -1. See `define_reftypes()` in
             // `meta/src/isa/x86/encodings.rs` to confirm.
             let src = put_input_in_reg(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ctx.input_ty(insn, 0);
             let imm = match op {
                 Opcode::IsNull => {
@@ -1856,14 +1858,14 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     ],
                 ) {
                     let src = put_input_in_reg(ctx, inputs[0]);
-                    let dst = get_output_reg(ctx, outputs[0]);
+                    let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                     ctx.emit(Inst::gen_move(dst, src, types::I64));
                     return Ok(());
                 }
             }
 
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             let ext_mode = ExtMode::new(src_ty.bits(), dst_ty.bits());
             assert_eq!(
@@ -1887,7 +1889,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Icmp => {
             let condcode = ctx.data(insn).cond_code().unwrap();
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ctx.input_ty(insn, 0);
             if !ty.is_vector() {
                 emit_cmp(ctx, insn);
@@ -1970,7 +1972,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     IntCC::NotEqual => {
                         ctx.emit(Inst::xmm_rm_r(eq(ty), input, dst));
                         // Emit all 1s into the `tmp` register.
-                        let tmp = ctx.alloc_tmp(RegClass::V128, ty);
+                        let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
                         ctx.emit(Inst::xmm_rm_r(eq(ty), RegMem::from(tmp), tmp));
                         // Invert the result of the `PCMPEQ*`.
                         ctx.emit(Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::from(tmp), dst));
@@ -1986,7 +1988,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         ctx.emit(Inst::xmm_rm_r(maxu(ty), input.clone(), dst));
                         ctx.emit(Inst::xmm_rm_r(eq(ty), input, dst));
                         // Emit all 1s into the `tmp` register.
-                        let tmp = ctx.alloc_tmp(RegClass::V128, ty);
+                        let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
                         ctx.emit(Inst::xmm_rm_r(eq(ty), RegMem::from(tmp), tmp));
                         // Invert the result of the `PCMPEQ*`.
                         ctx.emit(Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::from(tmp), dst));
@@ -2019,14 +2021,14 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // set, then both the ZF and CF flag bits must also be set we can get away with using
                 // one setcc for most condition codes.
 
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 match emit_fcmp(ctx, insn, cond_code, FcmpSpec::Normal) {
                     FcmpCondResult::Condition(cc) => {
                         ctx.emit(Inst::setcc(cc, dst));
                     }
                     FcmpCondResult::AndConditions(cc1, cc2) => {
-                        let tmp = ctx.alloc_tmp(RegClass::I64, types::I32);
+                        let tmp = ctx.alloc_tmp(types::I32).only_reg().unwrap();
                         ctx.emit(Inst::setcc(cc1, tmp));
                         ctx.emit(Inst::setcc(cc2, dst));
                         ctx.emit(Inst::alu_rmi_r(
@@ -2037,7 +2039,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         ));
                     }
                     FcmpCondResult::OrConditions(cc1, cc2) => {
-                        let tmp = ctx.alloc_tmp(RegClass::I64, types::I32);
+                        let tmp = ctx.alloc_tmp(types::I32).only_reg().unwrap();
                         ctx.emit(Inst::setcc(cc1, tmp));
                         ctx.emit(Inst::setcc(cc2, dst));
                         ctx.emit(Inst::alu_rmi_r(
@@ -2087,7 +2089,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // Move the `lhs` to the same register as `dst`; this may not emit an actual move
                 // but ensures that the registers are the same to match x86's read-write operand
                 // encoding.
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(dst, lhs, input_ty));
 
                 // Emit the comparison.
@@ -2100,7 +2102,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let src_reg = put_input_in_reg(ctx, inputs[i]);
                 let retval_reg = ctx.retval(i);
                 let ty = ctx.input_ty(insn, i);
-                ctx.emit(Inst::gen_move(retval_reg, src_reg, ty));
+                ctx.emit(Inst::gen_move(retval_reg.only_reg().unwrap(), src_reg, ty));
             }
             // N.B.: the Ret itself is generated by the ABI.
         }
@@ -2137,12 +2139,12 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             assert_eq!(inputs.len(), abi.num_args());
             for (i, input) in inputs.iter().enumerate() {
                 let arg_reg = put_input_in_reg(ctx, *input);
-                abi.emit_copy_reg_to_arg(ctx, i, arg_reg);
+                abi.emit_copy_regs_to_arg(ctx, i, ValueRegs::one(arg_reg));
             }
             abi.emit_call(ctx);
             for (i, output) in outputs.iter().enumerate() {
-                let retval_reg = get_output_reg(ctx, *output);
-                abi.emit_copy_retval_to_reg(ctx, i, retval_reg);
+                let retval_reg = get_output_reg(ctx, *output).only_reg().unwrap();
+                abi.emit_copy_retval_to_regs(ctx, i, ValueRegs::one(retval_reg));
             }
             abi.emit_stack_post_adjust(ctx);
         }
@@ -2189,8 +2191,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     FcmpCondResult::AndConditions(cc1, cc2) => {
                         // A bit unfortunate, but materialize the flags in their own register, and
                         // check against this.
-                        let tmp = ctx.alloc_tmp(RegClass::I64, types::I32);
-                        let tmp2 = ctx.alloc_tmp(RegClass::I64, types::I32);
+                        let tmp = ctx.alloc_tmp(types::I32).only_reg().unwrap();
+                        let tmp2 = ctx.alloc_tmp(types::I32).only_reg().unwrap();
                         ctx.emit(Inst::setcc(cc1, tmp));
                         ctx.emit(Inst::setcc(cc2, tmp2));
                         ctx.emit(Inst::alu_rmi_r(
@@ -2217,8 +2219,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // TODO use cmpeqpd for all 1s.
             let value = ctx.get_constant(insn).unwrap();
             let dst = get_output_reg(ctx, outputs[0]);
-            for inst in Inst::gen_constant(dst, value, types::F64, |reg_class, ty| {
-                ctx.alloc_tmp(reg_class, ty)
+            for inst in Inst::gen_constant(dst, value as u128, types::F64, |_reg_class, ty| {
+                ctx.alloc_tmp(ty).only_reg().unwrap()
             }) {
                 ctx.emit(inst);
             }
@@ -2228,8 +2230,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // TODO use cmpeqps for all 1s.
             let value = ctx.get_constant(insn).unwrap();
             let dst = get_output_reg(ctx, outputs[0]);
-            for inst in Inst::gen_constant(dst, value, types::F32, |reg_class, ty| {
-                ctx.alloc_tmp(reg_class, ty)
+            for inst in Inst::gen_constant(dst, value as u128, types::F32, |_reg_class, ty| {
+                ctx.alloc_tmp(ty).only_reg().unwrap()
             }) {
                 ctx.emit(inst);
             }
@@ -2238,7 +2240,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::WideningPairwiseDotProductS => {
             let lhs = put_input_in_reg(ctx, inputs[0]);
             let rhs = input_to_reg_mem(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
 
             ctx.emit(Inst::gen_move(dst, lhs, ty));
@@ -2256,7 +2258,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Fadd | Opcode::Fsub | Opcode::Fmul | Opcode::Fdiv => {
             let lhs = put_input_in_reg(ctx, inputs[0]);
             let rhs = input_to_reg_mem(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
 
             // Move the `lhs` to the same register as `dst`; this may not emit an actual move
@@ -2307,7 +2309,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Fmin | Opcode::Fmax => {
             let lhs = put_input_in_reg(ctx, inputs[0]);
             let rhs = put_input_in_reg(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let is_min = op == Opcode::Fmin;
             let output_ty = ty.unwrap();
             ctx.emit(Inst::gen_move(dst, rhs, output_ty));
@@ -2386,7 +2388,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         };
 
                     // Copy lhs into tmp
-                    let tmp_xmm1 = ctx.alloc_tmp(RegClass::V128, output_ty);
+                    let tmp_xmm1 = ctx.alloc_tmp(output_ty).only_reg().unwrap();
                     ctx.emit(Inst::xmm_mov(mov_op, RegMem::reg(lhs), tmp_xmm1));
 
                     // Perform min in reverse direction
@@ -2463,7 +2465,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     };
 
                     // Copy lhs into tmp.
-                    let tmp_xmm1 = ctx.alloc_tmp(RegClass::V128, types::F32);
+                    let tmp_xmm1 = ctx.alloc_tmp(types::F32).only_reg().unwrap();
                     ctx.emit(Inst::xmm_mov(mov_op, RegMem::reg(lhs), tmp_xmm1));
 
                     // Perform max in reverse direction.
@@ -2514,7 +2516,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::FminPseudo | Opcode::FmaxPseudo => {
             let lhs = input_to_reg_mem(ctx, inputs[0]);
             let rhs = put_input_in_reg(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             ctx.emit(Inst::gen_move(dst, rhs, ty));
             let sse_opcode = match (ty, op) {
@@ -2529,7 +2531,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Sqrt => {
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
 
             let sse_op = match ty {
@@ -2548,13 +2550,13 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Fpromote => {
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             ctx.emit(Inst::xmm_unary_rm_r(SseOpcode::Cvtss2sd, src, dst));
         }
 
         Opcode::Fdemote => {
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             ctx.emit(Inst::xmm_unary_rm_r(SseOpcode::Cvtsd2ss, src, dst));
         }
 
@@ -2579,12 +2581,12 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert_eq!(output_ty, types::F64);
                     SseOpcode::Cvtsi2sd
                 };
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::gpr_to_xmm(opcode, src, src_size, dst));
             } else {
                 let ty = ty.unwrap();
                 let src = put_input_in_reg(ctx, inputs[0]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let opcode = match ctx.input_ty(insn, 0) {
                     types::I32X4 => SseOpcode::Cvtdq2ps,
                     _ => {
@@ -2597,7 +2599,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::FcvtFromUint => {
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
 
             let input_ty = ctx.input_ty(insn, 0);
@@ -2624,11 +2626,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     types::I64 => {
                         let src = put_input_in_reg(ctx, inputs[0]);
 
-                        let src_copy = ctx.alloc_tmp(RegClass::I64, types::I64);
+                        let src_copy = ctx.alloc_tmp(types::I64).only_reg().unwrap();
                         ctx.emit(Inst::gen_move(src_copy, src, types::I64));
 
-                        let tmp_gpr1 = ctx.alloc_tmp(RegClass::I64, types::I64);
-                        let tmp_gpr2 = ctx.alloc_tmp(RegClass::I64, types::I64);
+                        let tmp_gpr1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                        let tmp_gpr2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
                         ctx.emit(Inst::cvt_u64_to_float_seq(
                             ty == types::F64,
                             src_copy,
@@ -2662,10 +2664,10 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
                 assert_eq!(ctx.input_ty(insn, 0), types::I32X4);
                 let src = put_input_in_reg(ctx, inputs[0]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 // Create a temporary register
-                let tmp = ctx.alloc_tmp(RegClass::V128, types::I32X4);
+                let tmp = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
                 ctx.emit(Inst::xmm_unary_rm_r(
                     SseOpcode::Movapd,
                     RegMem::reg(src),
@@ -2703,7 +2705,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::FcvtToUint | Opcode::FcvtToUintSat | Opcode::FcvtToSint | Opcode::FcvtToSintSat => {
             let src = put_input_in_reg(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             let input_ty = ctx.input_ty(insn, 0);
             if !input_ty.is_vector() {
@@ -2725,11 +2727,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let to_signed = op == Opcode::FcvtToSint || op == Opcode::FcvtToSintSat;
                 let is_sat = op == Opcode::FcvtToUintSat || op == Opcode::FcvtToSintSat;
 
-                let src_copy = ctx.alloc_tmp(RegClass::V128, input_ty);
+                let src_copy = ctx.alloc_tmp(input_ty).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(src_copy, src, input_ty));
 
-                let tmp_xmm = ctx.alloc_tmp(RegClass::V128, input_ty);
-                let tmp_gpr = ctx.alloc_tmp(RegClass::I64, output_ty);
+                let tmp_xmm = ctx.alloc_tmp(input_ty).only_reg().unwrap();
+                let tmp_gpr = ctx.alloc_tmp(output_ty).only_reg().unwrap();
 
                 if to_signed {
                     ctx.emit(Inst::cvt_float_to_sint_seq(
@@ -2744,7 +2746,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 if op == Opcode::FcvtToSintSat {
                     // Sets destination to zero if float is NaN
                     assert_eq!(types::F32X4, ctx.input_ty(insn, 0));
-                    let tmp = ctx.alloc_tmp(RegClass::V128, types::I32X4);
+                    let tmp = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
                     ctx.emit(Inst::xmm_unary_rm_r(
                         SseOpcode::Movapd,
                         RegMem::reg(src),
@@ -2849,8 +2851,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
                     // Create temporaries
                     assert_eq!(types::F32X4, ctx.input_ty(insn, 0));
-                    let tmp1 = ctx.alloc_tmp(RegClass::V128, types::I32X4);
-                    let tmp2 = ctx.alloc_tmp(RegClass::V128, types::I32X4);
+                    let tmp1 = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
+                    let tmp2 = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
 
                     // Converting to unsigned int so if float src is negative or NaN
                     // will first set to zero.
@@ -2923,7 +2925,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let input_ty = ctx.input_ty(insn, 0);
             let output_ty = ctx.output_ty(insn, 0);
             let src = put_input_in_reg(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             if output_ty.is_vector() {
                 match op {
                     Opcode::SwidenLow => match (input_ty, output_ty) {
@@ -3005,7 +3007,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let output_ty = ctx.output_ty(insn, 0);
             let src1 = put_input_in_reg(ctx, inputs[0]);
             let src2 = put_input_in_reg(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             if output_ty.is_vector() {
                 match op {
                     Opcode::Snarrow => match (input_ty, output_ty) {
@@ -3042,7 +3044,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             match (input_ty, output_ty) {
                 (types::F32, types::I32) => {
                     let src = put_input_in_reg(ctx, inputs[0]);
-                    let dst = get_output_reg(ctx, outputs[0]);
+                    let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                     ctx.emit(Inst::xmm_to_gpr(
                         SseOpcode::Movd,
                         src,
@@ -3052,7 +3054,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 }
                 (types::I32, types::F32) => {
                     let src = input_to_reg_mem(ctx, inputs[0]);
-                    let dst = get_output_reg(ctx, outputs[0]);
+                    let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                     ctx.emit(Inst::gpr_to_xmm(
                         SseOpcode::Movd,
                         src,
@@ -3062,7 +3064,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 }
                 (types::F64, types::I64) => {
                     let src = put_input_in_reg(ctx, inputs[0]);
-                    let dst = get_output_reg(ctx, outputs[0]);
+                    let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                     ctx.emit(Inst::xmm_to_gpr(
                         SseOpcode::Movq,
                         src,
@@ -3072,7 +3074,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 }
                 (types::I64, types::F64) => {
                     let src = input_to_reg_mem(ctx, inputs[0]);
-                    let dst = get_output_reg(ctx, outputs[0]);
+                    let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                     ctx.emit(Inst::gpr_to_xmm(
                         SseOpcode::Movq,
                         src,
@@ -3086,7 +3088,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Fabs | Opcode::Fneg => {
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             // In both cases, generate a constant and apply a single binary instruction:
             // - to compute the absolute value, set all bits to 1 but the MSB to 0, and bit-AND the
@@ -3095,7 +3097,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // src with it.
             let output_ty = ty.unwrap();
             if !output_ty.is_vector() {
-                let (val, opcode) = match output_ty {
+                let (val, opcode): (u64, _) = match output_ty {
                     types::F32 => match op {
                         Opcode::Fabs => (0x7fffffff, SseOpcode::Andps),
                         Opcode::Fneg => (0x80000000, SseOpcode::Xorps),
@@ -3109,9 +3111,12 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     _ => panic!("unexpected type {:?} for Fabs", output_ty),
                 };
 
-                for inst in Inst::gen_constant(dst, val, output_ty, |reg_class, ty| {
-                    ctx.alloc_tmp(reg_class, ty)
-                }) {
+                for inst in Inst::gen_constant(
+                    ValueRegs::one(dst),
+                    val as u128,
+                    output_ty,
+                    |_reg_class, ty| ctx.alloc_tmp(ty).only_reg().unwrap(),
+                ) {
                     ctx.emit(inst);
                 }
 
@@ -3128,7 +3133,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
                     // Generate an all 1s constant in an XMM register. This uses CMPPS but could
                     // have used CMPPD with the same effect.
-                    let tmp = ctx.alloc_tmp(RegClass::V128, output_ty);
+                    let tmp = ctx.alloc_tmp(output_ty).only_reg().unwrap();
                     let cond = FcmpImm::from(FloatCC::Equal);
                     let cmpps = Inst::xmm_rm_r_imm(
                         SseOpcode::Cmpps,
@@ -3164,7 +3169,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Fcopysign => {
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let lhs = put_input_in_reg(ctx, inputs[0]);
             let rhs = put_input_in_reg(ctx, inputs[1]);
 
@@ -3180,8 +3185,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // andp{s,d}  tmp_xmm1, tmp_xmm2
             // orp{s,d}   tmp_xmm2, dst
 
-            let tmp_xmm1 = ctx.alloc_tmp(RegClass::V128, types::F32);
-            let tmp_xmm2 = ctx.alloc_tmp(RegClass::V128, types::F32);
+            let tmp_xmm1 = ctx.alloc_tmp(types::F32).only_reg().unwrap();
+            let tmp_xmm2 = ctx.alloc_tmp(types::F32).only_reg().unwrap();
 
             let (sign_bit_cst, mov_op, and_not_op, and_op, or_op) = match ty {
                 types::F32 => (
@@ -3203,9 +3208,12 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 }
             };
 
-            for inst in Inst::gen_constant(tmp_xmm1, sign_bit_cst, ty, |reg_class, ty| {
-                ctx.alloc_tmp(reg_class, ty)
-            }) {
+            for inst in Inst::gen_constant(
+                ValueRegs::one(tmp_xmm1),
+                sign_bit_cst,
+                ty,
+                |_reg_class, ty| ctx.alloc_tmp(ty).only_reg().unwrap(),
+            ) {
                 ctx.emit(inst);
             }
             ctx.emit(Inst::xmm_mov(mov_op, RegMem::reg(tmp_xmm1.to_reg()), dst));
@@ -3253,7 +3261,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     _ => panic!("Unknown op/ty combination (vector){:?}", ty),
                 };
                 let src = put_input_in_reg(ctx, inputs[0]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(dst, src, ty));
                 ctx.emit(Inst::xmm_rm_r_imm(
                     op,
@@ -3378,7 +3386,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 _ => unreachable!(),
             };
 
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let is_xmm = elem_ty.is_float() || elem_ty.is_vector();
 
             match (sign_extend, is_xmm) {
@@ -3500,7 +3508,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // use the single instruction `lock xadd`.  However, those improvements have been
             // left for another day.
             // TODO: filed as https://github.com/bytecodealliance/wasmtime/issues/2153
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let mut addr = put_input_in_reg(ctx, inputs[0]);
             let mut arg2 = put_input_in_reg(ctx, inputs[1]);
             let ty_access = ty.unwrap();
@@ -3537,7 +3545,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::AtomicCas => {
             // This is very similar to, but not identical to, the `AtomicRmw` case.  As with
             // `AtomicRmw`, there's no need to zero-extend narrow values here.
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let addr = lower_to_amode(ctx, inputs[0], 0);
             let expected = put_input_in_reg(ctx, inputs[1]);
             let replacement = put_input_in_reg(ctx, inputs[2]);
@@ -3565,7 +3573,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // This is a normal load.  The x86-TSO memory model provides sufficient sequencing
             // to satisfy the CLIF synchronisation requirements for `AtomicLoad` without the
             // need for any fence instructions.
-            let data = get_output_reg(ctx, outputs[0]);
+            let data = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let addr = lower_to_amode(ctx, inputs[0], 0);
             let ty_access = ty.unwrap();
             assert!(is_valid_atomic_transaction_ty(ty_access));
@@ -3603,7 +3611,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::FuncAddr => {
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let (extname, _) = ctx.call_target(insn).unwrap();
             let extname = extname.clone();
             ctx.emit(Inst::LoadExtName {
@@ -3614,7 +3622,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::SymbolValue => {
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let (extname, _, offset) = ctx.symbol_value(insn).unwrap();
             let extname = extname.clone();
             ctx.emit(Inst::LoadExtName {
@@ -3633,7 +3641,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 } => (stack_slot, offset),
                 _ => unreachable!(),
             };
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let offset: i32 = offset.into();
             let inst = ctx
                 .abi()
@@ -3655,7 +3663,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
                 let ty = ctx.output_ty(insn, 0);
                 let rhs = put_input_in_reg(ctx, rhs_input);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let lhs = if is_int_or_ref_ty(ty) && ty.bytes() < 4 {
                     // Special case: since the higher bits are undefined per CLIF semantics, we
                     // can just apply a 32-bit cmove here. Force inputs into registers, to
@@ -3724,7 +3732,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 };
 
                 let rhs = put_input_in_reg(ctx, inputs[2]);
-                let dst = get_output_reg(ctx, outputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 let cc = if let Some(icmp) = matches_input(ctx, flag_input, Opcode::Icmp) {
                     emit_cmp(ctx, icmp);
@@ -3753,7 +3761,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Selectif | Opcode::SelectifSpectreGuard => {
             let lhs = input_to_reg_mem(ctx, inputs[1]);
             let rhs = put_input_in_reg(ctx, inputs[2]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ctx.output_ty(insn, 0);
 
             // Verification ensures that the input is always a single-def ifcmp.
@@ -3771,7 +3779,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let size = ty.bytes() as u8;
                 if size == 1 {
                     // Sign-extend operands to 32, then do a cmove of size 4.
-                    let lhs_se = ctx.alloc_tmp(RegClass::I64, types::I32);
+                    let lhs_se = ctx.alloc_tmp(types::I32).only_reg().unwrap();
                     ctx.emit(Inst::movsx_rm_r(ExtMode::BL, lhs, lhs_se));
                     ctx.emit(Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(rhs), dst));
                     ctx.emit(Inst::cmove(4, cc, RegMem::reg(lhs_se.to_reg()), dst));
@@ -3800,7 +3808,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let size = input_ty.bytes() as u8;
 
             let dividend = put_input_in_reg(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             ctx.emit(Inst::gen_move(
                 Writable::from_reg(regs::rax()),
@@ -3818,11 +3826,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // destination register.
                 let divisor = put_input_in_reg(ctx, inputs[1]);
 
-                let divisor_copy = ctx.alloc_tmp(RegClass::I64, types::I64);
+                let divisor_copy = ctx.alloc_tmp(types::I64).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(divisor_copy, divisor, types::I64));
 
                 let tmp = if op == Opcode::Sdiv && size == 8 {
-                    Some(ctx.alloc_tmp(RegClass::I64, types::I64))
+                    Some(ctx.alloc_tmp(types::I64).only_reg().unwrap())
                 } else {
                     None
                 };
@@ -3876,7 +3884,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
             let lhs = put_input_in_reg(ctx, inputs[0]);
             let rhs = input_to_reg_mem(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             // Move lhs in %rax.
             ctx.emit(Inst::gen_move(
@@ -3894,7 +3902,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::GetPinnedReg => {
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             ctx.emit(Inst::gen_move(dst, regs::pinned_reg(), types::I64));
         }
 
@@ -3920,7 +3928,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 unreachable!("vconst should always have unary_const format")
             };
             // TODO use Inst::gen_constant() instead.
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             ctx.emit(Inst::xmm_load_const(used_constant, dst, ty));
         }
@@ -3931,14 +3939,14 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // instruction should emit no machine code but a move is necessary to give the register
             // allocator a definition for the output virtual register.
             let src = put_input_in_reg(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
             ctx.emit(Inst::gen_move(dst, src, ty));
         }
 
         Opcode::Shuffle => {
             let ty = ty.unwrap();
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let lhs_ty = ctx.input_ty(insn, 0);
             let lhs = put_input_in_reg(ctx, inputs[0]);
             let rhs = put_input_in_reg(ctx, inputs[1]);
@@ -3964,7 +3972,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     .map(zero_unknown_lane_index)
                     .collect();
                 let constant = ctx.use_constant(VCodeConstantData::Generated(constructed_mask));
-                let tmp = ctx.alloc_tmp(RegClass::V128, types::I8X16);
+                let tmp = ctx.alloc_tmp(types::I8X16).only_reg().unwrap();
                 ctx.emit(Inst::xmm_load_const(constant, tmp, ty));
                 // After loading the constructed mask in a temporary register, we use this to
                 // shuffle the `dst` register (remember that, in this case, it is the same as
@@ -3976,11 +3984,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // we build the `constructed_mask` for each case statically.
 
                 // PSHUFB the `lhs` argument into `tmp0`, placing zeroes for unused lanes.
-                let tmp0 = ctx.alloc_tmp(RegClass::V128, lhs_ty);
+                let tmp0 = ctx.alloc_tmp(lhs_ty).only_reg().unwrap();
                 ctx.emit(Inst::gen_move(tmp0, lhs, lhs_ty));
                 let constructed_mask = mask.iter().cloned().map(zero_unknown_lane_index).collect();
                 let constant = ctx.use_constant(VCodeConstantData::Generated(constructed_mask));
-                let tmp1 = ctx.alloc_tmp(RegClass::V128, types::I8X16);
+                let tmp1 = ctx.alloc_tmp(types::I8X16).only_reg().unwrap();
                 ctx.emit(Inst::xmm_load_const(constant, tmp1, ty));
                 ctx.emit(Inst::xmm_rm_r(SseOpcode::Pshufb, RegMem::from(tmp1), tmp0));
 
@@ -3991,7 +3999,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     .map(zero_unknown_lane_index)
                     .collect();
                 let constant = ctx.use_constant(VCodeConstantData::Generated(constructed_mask));
-                let tmp2 = ctx.alloc_tmp(RegClass::V128, types::I8X16);
+                let tmp2 = ctx.alloc_tmp(types::I8X16).only_reg().unwrap();
                 ctx.emit(Inst::xmm_load_const(constant, tmp2, ty));
                 ctx.emit(Inst::xmm_rm_r(SseOpcode::Pshufb, RegMem::from(tmp2), dst));
 
@@ -4010,7 +4018,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // semantics match the Wasm SIMD semantics for this instruction.
             // The instruction format maps to variables like: %dst = swizzle %src, %mask
             let ty = ty.unwrap();
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let src = put_input_in_reg(ctx, inputs[0]);
             let swizzle_mask = put_input_in_reg(ctx, inputs[1]);
 
@@ -4018,7 +4026,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             ctx.emit(Inst::gen_move(dst, src, ty));
 
             // Create a mask for zeroing out-of-bounds lanes of the swizzle mask.
-            let zero_mask = ctx.alloc_tmp(RegClass::V128, types::I8X16);
+            let zero_mask = ctx.alloc_tmp(types::I8X16).only_reg().unwrap();
             static ZERO_MASK_VALUE: [u8; 16] = [
                 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
                 0x70, 0x70,
@@ -4045,7 +4053,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Insertlane => {
             // The instruction format maps to variables like: %dst = insertlane %in_vec, %src, %lane
             let ty = ty.unwrap();
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let in_vec = put_input_in_reg(ctx, inputs[0]);
             let src_ty = ctx.input_ty(insn, 1);
             debug_assert!(!src_ty.is_vector());
@@ -4064,7 +4072,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Extractlane => {
             // The instruction format maps to variables like: %dst = extractlane %src, %lane
             let ty = ty.unwrap();
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let src_ty = ctx.input_ty(insn, 0);
             assert_eq!(src_ty.bits(), 128);
             let src = put_input_in_reg(ctx, inputs[0]);
@@ -4085,7 +4093,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             assert!(src_ty.bits() < 128);
 
             let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
             // We know that splat will overwrite all of the lanes of `dst` but it takes several
             // instructions to do so. Because of the multiple instructions, there is no good way to
@@ -4098,7 +4106,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 8 => {
                     emit_insert_lane(ctx, src, dst, 0, ty.lane_type());
                     // Initialize a register with all 0s.
-                    let tmp = ctx.alloc_tmp(RegClass::V128, ty);
+                    let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
                     ctx.emit(Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::from(tmp), tmp));
                     // Shuffle the lowest byte lane to all other lanes.
                     ctx.emit(Inst::xmm_rm_r(SseOpcode::Pshufb, RegMem::from(tmp), dst))
@@ -4135,7 +4143,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::VanyTrue => {
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let src_ty = ctx.input_ty(insn, 0);
             assert_eq!(src_ty.bits(), 128);
             let src = put_input_in_reg(ctx, inputs[0]);
@@ -4146,8 +4154,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::VallTrue => {
-            let ty = ty.unwrap();
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let src_ty = ctx.input_ty(insn, 0);
             assert_eq!(src_ty.bits(), 128);
             let src = input_to_reg_mem(ctx, inputs[0]);
@@ -4161,7 +4168,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             };
 
             // Initialize a register with all 0s.
-            let tmp = ctx.alloc_tmp(RegClass::V128, ty);
+            let tmp = ctx.alloc_tmp(src_ty).only_reg().unwrap();
             ctx.emit(Inst::xmm_rm_r(SseOpcode::Pxor, RegMem::from(tmp), tmp));
             // Compare to see what lanes are filled with all 1s.
             ctx.emit(Inst::xmm_rm_r(eq(src_ty), src, tmp));
@@ -4179,7 +4186,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let src = put_input_in_reg(ctx, inputs[0]);
             let src_ty = ctx.input_ty(insn, 0);
             debug_assert!(src_ty.is_vector() && src_ty.bits() == 128);
-            let dst = get_output_reg(ctx, outputs[0]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             debug_assert!(dst.to_reg().get_class() == RegClass::I64);
 
             // The Intel specification allows using both 32-bit and 64-bit GPRs as destination for
@@ -4207,7 +4214,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     //     PACKSSWB([x1, x2, ...], [x1, x2, ...]) = [x1', x2', ..., x1', x2', ...]
                     // - use PMOVMSKB to gather the high bits; now we have duplicates, though
                     // - shift away the bottom 8 high bits to remove the duplicates.
-                    let tmp = ctx.alloc_tmp(RegClass::V128, src_ty);
+                    let tmp = ctx.alloc_tmp(src_ty).only_reg().unwrap();
                     ctx.emit(Inst::gen_move(tmp, src, src_ty));
                     ctx.emit(Inst::xmm_rm_r(SseOpcode::Packsswb, RegMem::reg(src), tmp));
                     ctx.emit(Inst::xmm_to_gpr(
@@ -4495,12 +4502,12 @@ impl LowerBackend for X64Backend {
                     // worse.)
 
                     // This temporary is used as a signed integer of 64-bits (to hold addresses).
-                    let tmp1 = ctx.alloc_tmp(RegClass::I64, types::I64);
+                    let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
                     // This temporary is used as a signed integer of 32-bits (for the wasm-table
                     // index) and then 64-bits (address addend). The small lie about the I64 type
                     // is benign, since the temporary is dead after this instruction (and its
                     // Cranelift type is thus unused).
-                    let tmp2 = ctx.alloc_tmp(RegClass::I64, types::I64);
+                    let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
 
                     let targets_for_term: Vec<MachLabel> = targets.to_vec();
                     let default_target = targets[0];

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -18,7 +18,7 @@ use alloc::vec::Vec;
 use cranelift_codegen_shared::condcodes::CondCode;
 use log::trace;
 use regalloc::{Reg, RegClass, Writable};
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use std::convert::TryFrom;
 use target_lexicon::Triple;
 
@@ -107,21 +107,24 @@ fn generate_constant<C: LowerCtx<I = Inst>>(ctx: &mut C, ty: Type, c: u64) -> Va
     non_writable_value_regs(cst_copy)
 }
 
-/// Put the given input into a register, and mark it as used (side-effect).
-fn put_input_in_reg<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> Reg {
+/// Put the given input into possibly multiple registers, and mark it as used (side-effect).
+fn put_input_in_regs<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> ValueRegs<Reg> {
     let ty = ctx.input_ty(spec.insn, spec.input);
     let input = ctx.get_input_as_source_or_const(spec.insn, spec.input);
 
     if let Some(c) = input.constant {
         // Generate constants fresh at each use to minimize long-range register pressure.
         generate_constant(ctx, ty, c)
-            .only_reg()
-            .expect("multi-reg values not supported yet")
     } else {
         ctx.put_input_in_regs(spec.insn, spec.input)
-            .only_reg()
-            .expect("multi-reg values not supported yet")
     }
+}
+
+/// Put the given input into a register, and mark it as used (side-effect).
+fn put_input_in_reg<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> Reg {
+    put_input_in_regs(ctx, spec)
+        .only_reg()
+        .expect("Multi-register value not expected")
 }
 
 /// Determines whether a load operation (indicated by `src_insn`) can be merged
@@ -373,18 +376,113 @@ fn emit_extract_lane<C: LowerCtx<I = Inst>>(
 ///
 /// Note: make sure that there are no instructions modifying the flags between a call to this
 /// function and the use of the flags!
-fn emit_cmp<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) {
+///
+/// Takes the condition code that will be tested, and returns
+/// the condition code that should be used. This allows us to
+/// synthesize comparisons out of multiple instructions for
+/// special cases (e.g., 128-bit integers).
+fn emit_cmp<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst, cc: IntCC) -> IntCC {
     let ty = ctx.input_ty(insn, 0);
 
     let inputs = [InsnInput { insn, input: 0 }, InsnInput { insn, input: 1 }];
 
-    // TODO Try to commute the operands (and invert the condition) if one is an immediate.
-    let lhs = put_input_in_reg(ctx, inputs[0]);
-    let rhs = input_to_reg_mem_imm(ctx, inputs[1]);
+    if ty == types::I128 {
+        // We need to compare both halves and combine the results appropriately.
+        let cmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+        let cmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+        let lhs = put_input_in_regs(ctx, inputs[0]);
+        let lhs_lo = lhs.regs()[0];
+        let lhs_hi = lhs.regs()[1];
+        let rhs = put_input_in_regs(ctx, inputs[1]);
+        let rhs_lo = RegMemImm::reg(rhs.regs()[0]);
+        let rhs_hi = RegMemImm::reg(rhs.regs()[1]);
+        match cc {
+            IntCC::Equal => {
+                ctx.emit(Inst::cmp_rmi_r(8, rhs_hi, lhs_hi));
+                ctx.emit(Inst::setcc(CC::Z, cmp1));
+                ctx.emit(Inst::cmp_rmi_r(8, rhs_lo, lhs_lo));
+                ctx.emit(Inst::setcc(CC::Z, cmp2));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::And,
+                    RegMemImm::reg(cmp1.to_reg()),
+                    cmp2,
+                ));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::And,
+                    RegMemImm::imm(1),
+                    cmp2,
+                ));
+                IntCC::NotEqual
+            }
+            IntCC::NotEqual => {
+                ctx.emit(Inst::cmp_rmi_r(8, rhs_hi, lhs_hi));
+                ctx.emit(Inst::setcc(CC::NZ, cmp1));
+                ctx.emit(Inst::cmp_rmi_r(8, rhs_lo, lhs_lo));
+                ctx.emit(Inst::setcc(CC::NZ, cmp2));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::Or,
+                    RegMemImm::reg(cmp1.to_reg()),
+                    cmp2,
+                ));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::And,
+                    RegMemImm::imm(1),
+                    cmp2,
+                ));
+                IntCC::NotEqual
+            }
+            IntCC::SignedLessThan
+            | IntCC::SignedLessThanOrEqual
+            | IntCC::SignedGreaterThan
+            | IntCC::SignedGreaterThanOrEqual
+            | IntCC::UnsignedLessThan
+            | IntCC::UnsignedLessThanOrEqual
+            | IntCC::UnsignedGreaterThan
+            | IntCC::UnsignedGreaterThanOrEqual => {
+                // Result = (lhs_hi <> rhs_hi) ||
+                //          (lhs_hi == rhs_hi && lhs_lo <> rhs_lo)
+                let cmp3 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                ctx.emit(Inst::cmp_rmi_r(8, rhs_hi, lhs_hi));
+                ctx.emit(Inst::setcc(CC::from_intcc(cc.without_equal()), cmp1));
+                ctx.emit(Inst::setcc(CC::Z, cmp2));
+                ctx.emit(Inst::cmp_rmi_r(8, rhs_lo, lhs_lo));
+                ctx.emit(Inst::setcc(CC::from_intcc(cc.unsigned()), cmp3));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::And,
+                    RegMemImm::reg(cmp2.to_reg()),
+                    cmp3,
+                ));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::Or,
+                    RegMemImm::reg(cmp1.to_reg()),
+                    cmp3,
+                ));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::And,
+                    RegMemImm::imm(1),
+                    cmp3,
+                ));
+                IntCC::NotEqual
+            }
+            _ => panic!("Unhandled IntCC in I128 comparison: {:?}", cc),
+        }
+    } else {
+        // TODO Try to commute the operands (and invert the condition) if one is an immediate.
+        let lhs = put_input_in_reg(ctx, inputs[0]);
+        let rhs = input_to_reg_mem_imm(ctx, inputs[1]);
 
-    // Cranelift's icmp semantics want to compare lhs - rhs, while Intel gives
-    // us dst - src at the machine instruction level, so invert operands.
-    ctx.emit(Inst::cmp_rmi_r(ty.bytes() as u8, rhs, lhs));
+        // Cranelift's icmp semantics want to compare lhs - rhs, while Intel gives
+        // us dst - src at the machine instruction level, so invert operands.
+        ctx.emit(Inst::cmp_rmi_r(ty.bytes() as u8, rhs, lhs));
+        cc
+    }
 }
 
 /// A specification for a fcmp emission.
@@ -478,6 +576,458 @@ fn emit_fcmp<C: LowerCtx<I = Inst>>(
     };
 
     cond_result
+}
+
+fn emit_bitrev<C: LowerCtx<I = Inst>>(ctx: &mut C, src: Reg, dst: Writable<Reg>, ty: Type) {
+    let bits = ty.bits();
+    let const_mask = if bits == 64 {
+        0xffff_ffff_ffff_ffff
+    } else {
+        (1u64 << bits) - 1
+    };
+    let tmp0 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+
+    ctx.emit(Inst::gen_move(tmp0, src, types::I64));
+
+    // Swap 1-bit units.
+    // tmp1 = src
+    ctx.emit(Inst::gen_move(tmp1, tmp0.to_reg(), types::I64));
+    // tmp2 = 0b0101..
+    ctx.emit(Inst::imm(
+        OperandSize::Size64,
+        0x5555_5555_5555_5555 & const_mask,
+        tmp2,
+    ));
+    // tmp1 = src >> 1
+    ctx.emit(Inst::shift_r(
+        8,
+        ShiftKind::ShiftRightLogical,
+        Some(1),
+        tmp1,
+    ));
+    // tmp1 = (src >> 1) & 0b0101..
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::reg(tmp2.to_reg()),
+        tmp1,
+    ));
+    // tmp2 = src & 0b0101..
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::reg(tmp0.to_reg()),
+        tmp2,
+    ));
+    // tmp2 = (src & 0b0101..) << 1
+    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, Some(1), tmp2));
+    // tmp0 = (src >> 1) & 0b0101.. | (src & 0b0101..) << 1
+    ctx.emit(Inst::gen_move(tmp0, tmp2.to_reg(), types::I64));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Or,
+        RegMemImm::reg(tmp1.to_reg()),
+        tmp0,
+    ));
+
+    // Swap 2-bit units.
+    ctx.emit(Inst::gen_move(tmp1, tmp0.to_reg(), types::I64));
+    ctx.emit(Inst::imm(
+        OperandSize::Size64,
+        0x3333_3333_3333_3333 & const_mask,
+        tmp2,
+    ));
+    ctx.emit(Inst::shift_r(
+        8,
+        ShiftKind::ShiftRightLogical,
+        Some(2),
+        tmp1,
+    ));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::reg(tmp2.to_reg()),
+        tmp1,
+    ));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::reg(tmp0.to_reg()),
+        tmp2,
+    ));
+    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, Some(2), tmp2));
+    ctx.emit(Inst::gen_move(tmp0, tmp2.to_reg(), types::I64));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Or,
+        RegMemImm::reg(tmp1.to_reg()),
+        tmp0,
+    ));
+
+    // Swap 4-bit units.
+    ctx.emit(Inst::gen_move(tmp1, tmp0.to_reg(), types::I64));
+    ctx.emit(Inst::imm(
+        OperandSize::Size64,
+        0x0f0f_0f0f_0f0f_0f0f & const_mask,
+        tmp2,
+    ));
+    ctx.emit(Inst::shift_r(
+        8,
+        ShiftKind::ShiftRightLogical,
+        Some(4),
+        tmp1,
+    ));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::reg(tmp2.to_reg()),
+        tmp1,
+    ));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::reg(tmp0.to_reg()),
+        tmp2,
+    ));
+    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, Some(4), tmp2));
+    ctx.emit(Inst::gen_move(tmp0, tmp2.to_reg(), types::I64));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Or,
+        RegMemImm::reg(tmp1.to_reg()),
+        tmp0,
+    ));
+
+    if bits > 8 {
+        // Swap 8-bit units.
+        ctx.emit(Inst::gen_move(tmp1, tmp0.to_reg(), types::I64));
+        ctx.emit(Inst::imm(
+            OperandSize::Size64,
+            0x00ff_00ff_00ff_00ff & const_mask,
+            tmp2,
+        ));
+        ctx.emit(Inst::shift_r(
+            8,
+            ShiftKind::ShiftRightLogical,
+            Some(8),
+            tmp1,
+        ));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::And,
+            RegMemImm::reg(tmp2.to_reg()),
+            tmp1,
+        ));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::And,
+            RegMemImm::reg(tmp0.to_reg()),
+            tmp2,
+        ));
+        ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, Some(8), tmp2));
+        ctx.emit(Inst::gen_move(tmp0, tmp2.to_reg(), types::I64));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::Or,
+            RegMemImm::reg(tmp1.to_reg()),
+            tmp0,
+        ));
+    }
+
+    if bits > 16 {
+        // Swap 16-bit units.
+        ctx.emit(Inst::gen_move(tmp1, tmp0.to_reg(), types::I64));
+        ctx.emit(Inst::imm(
+            OperandSize::Size64,
+            0x0000_ffff_0000_ffff & const_mask,
+            tmp2,
+        ));
+        ctx.emit(Inst::shift_r(
+            8,
+            ShiftKind::ShiftRightLogical,
+            Some(16),
+            tmp1,
+        ));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::And,
+            RegMemImm::reg(tmp2.to_reg()),
+            tmp1,
+        ));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::And,
+            RegMemImm::reg(tmp0.to_reg()),
+            tmp2,
+        ));
+        ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, Some(16), tmp2));
+        ctx.emit(Inst::gen_move(tmp0, tmp2.to_reg(), types::I64));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::Or,
+            RegMemImm::reg(tmp1.to_reg()),
+            tmp0,
+        ));
+    }
+
+    if bits > 32 {
+        // Swap 32-bit units.
+        ctx.emit(Inst::gen_move(tmp1, tmp0.to_reg(), types::I64));
+        ctx.emit(Inst::imm(
+            OperandSize::Size64,
+            0x0000_0000_ffff_ffff & const_mask,
+            tmp2,
+        ));
+        ctx.emit(Inst::shift_r(
+            8,
+            ShiftKind::ShiftRightLogical,
+            Some(32),
+            tmp1,
+        ));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::And,
+            RegMemImm::reg(tmp2.to_reg()),
+            tmp1,
+        ));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::And,
+            RegMemImm::reg(tmp0.to_reg()),
+            tmp2,
+        ));
+        ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, Some(32), tmp2));
+        ctx.emit(Inst::gen_move(tmp0, tmp2.to_reg(), types::I64));
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::Or,
+            RegMemImm::reg(tmp1.to_reg()),
+            tmp0,
+        ));
+    }
+
+    ctx.emit(Inst::gen_move(dst, tmp0.to_reg(), types::I64));
+}
+
+fn emit_shl_i128<C: LowerCtx<I = Inst>>(
+    ctx: &mut C,
+    src: ValueRegs<Reg>,
+    dst: ValueRegs<Writable<Reg>>,
+    amt_src: Reg,
+) {
+    let src_lo = src.regs()[0];
+    let src_hi = src.regs()[1];
+    let dst_lo = dst.regs()[0];
+    let dst_hi = dst.regs()[1];
+
+    // mov tmp1, src_lo
+    // shl tmp1, amt_src
+    // mov tmp2, src_hi
+    // shl tmp2, amt_src
+    // mov amt, 64
+    // sub amt, amt_src
+    // mov tmp3, src_lo
+    // shr tmp3, amt
+    // or tmp3, tmp2
+    // xor dst_lo, dst_lo
+    // mov amt, amt_src
+    // and amt, 64
+    // cmovz dst_hi, tmp3
+    // cmovz dst_lo, tmp1
+    // cmovnz dst_hi, tmp1
+
+    let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let tmp3 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let amt = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+
+    ctx.emit(Inst::gen_move(tmp1, src_lo, types::I64));
+    ctx.emit(Inst::gen_move(
+        Writable::from_reg(regs::rcx()),
+        amt_src,
+        types::I64,
+    ));
+    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, None, tmp1));
+
+    ctx.emit(Inst::gen_move(tmp2, src_hi, types::I64));
+    ctx.emit(Inst::gen_move(
+        Writable::from_reg(regs::rcx()),
+        amt_src,
+        types::I64,
+    ));
+    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, None, tmp2));
+
+    ctx.emit(Inst::imm(OperandSize::Size64, 64, amt));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Sub,
+        RegMemImm::reg(amt_src),
+        amt,
+    ));
+
+    ctx.emit(Inst::gen_move(tmp3, src_lo, types::I64));
+    ctx.emit(Inst::gen_move(
+        Writable::from_reg(regs::rcx()),
+        amt.to_reg(),
+        types::I64,
+    ));
+    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftRightLogical, None, tmp3));
+
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Or,
+        RegMemImm::reg(tmp2.to_reg()),
+        tmp3,
+    ));
+
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Xor,
+        RegMemImm::reg(dst_lo.to_reg()),
+        dst_lo,
+    ));
+    // This isn't semantically necessary, but it keeps the
+    // register allocator happy, because it cannot otherwise
+    // infer that cmovz + cmovnz always defines dst_hi.
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Xor,
+        RegMemImm::reg(dst_hi.to_reg()),
+        dst_hi,
+    ));
+
+    ctx.emit(Inst::gen_move(amt, amt_src, types::I64));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::imm(64),
+        amt,
+    ));
+    ctx.emit(Inst::cmove(8, CC::Z, RegMem::reg(tmp3.to_reg()), dst_hi));
+    ctx.emit(Inst::cmove(8, CC::Z, RegMem::reg(tmp1.to_reg()), dst_lo));
+    ctx.emit(Inst::cmove(8, CC::NZ, RegMem::reg(tmp1.to_reg()), dst_hi));
+}
+
+fn emit_shr_i128<C: LowerCtx<I = Inst>>(
+    ctx: &mut C,
+    src: ValueRegs<Reg>,
+    dst: ValueRegs<Writable<Reg>>,
+    amt_src: Reg,
+    is_signed: bool,
+) {
+    let src_lo = src.regs()[0];
+    let src_hi = src.regs()[1];
+    let dst_lo = dst.regs()[0];
+    let dst_hi = dst.regs()[1];
+
+    // mov tmp1, src_hi
+    // {u,s}shr tmp1, amt_src
+    // mov tmp2, src_lo
+    // {u,s}shr tmp2, amt_src
+    // mov amt, 64
+    // sub amt, amt_src
+    // mov tmp3, src_hi
+    // shl tmp3, amt
+    // or tmp3, tmp2
+    // if is_signed:
+    //   mov dst_hi, src_hi
+    //   sshr dst_hi, 63  // get the sign bit
+    // else:
+    //   xor dst_hi, dst_hi
+    // mov amt, amt_src
+    // and amt, 64
+    // cmovz dst_hi, tmp1
+    // cmovz dst_lo, tmp3
+    // cmovnz dst_lo, tmp1
+
+    let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let tmp3 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+    let amt = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+
+    let shift_kind = if is_signed {
+        ShiftKind::ShiftRightArithmetic
+    } else {
+        ShiftKind::ShiftRightLogical
+    };
+
+    ctx.emit(Inst::gen_move(tmp1, src_hi, types::I64));
+    ctx.emit(Inst::gen_move(
+        Writable::from_reg(regs::rcx()),
+        amt_src,
+        types::I64,
+    ));
+    ctx.emit(Inst::shift_r(8, shift_kind, None, tmp1));
+
+    ctx.emit(Inst::gen_move(tmp2, src_lo, types::I64));
+    ctx.emit(Inst::gen_move(
+        Writable::from_reg(regs::rcx()),
+        amt_src,
+        types::I64,
+    ));
+    ctx.emit(Inst::shift_r(8, shift_kind, None, tmp2));
+
+    ctx.emit(Inst::imm(OperandSize::Size64, 64, amt));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Sub,
+        RegMemImm::reg(amt_src),
+        amt,
+    ));
+
+    ctx.emit(Inst::gen_move(tmp3, src_hi, types::I64));
+    ctx.emit(Inst::gen_move(
+        Writable::from_reg(regs::rcx()),
+        amt.to_reg(),
+        types::I64,
+    ));
+    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftLeft, None, tmp3));
+
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Or,
+        RegMemImm::reg(tmp2.to_reg()),
+        tmp3,
+    ));
+
+    if is_signed {
+        ctx.emit(Inst::gen_move(dst_hi, src_hi, types::I64));
+        ctx.emit(Inst::shift_r(
+            8,
+            ShiftKind::ShiftRightArithmetic,
+            Some(63),
+            dst_hi,
+        ));
+    } else {
+        ctx.emit(Inst::alu_rmi_r(
+            true,
+            AluRmiROpcode::Xor,
+            RegMemImm::reg(dst_hi.to_reg()),
+            dst_hi,
+        ));
+    }
+    // This isn't semantically necessary, but it keeps the
+    // register allocator happy, because it cannot otherwise
+    // infer that cmovz + cmovnz always defines dst_lo.
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::Xor,
+        RegMemImm::reg(dst_lo.to_reg()),
+        dst_lo,
+    ));
+
+    ctx.emit(Inst::gen_move(amt, amt_src, types::I64));
+    ctx.emit(Inst::alu_rmi_r(
+        true,
+        AluRmiROpcode::And,
+        RegMemImm::imm(64),
+        amt,
+    ));
+    ctx.emit(Inst::cmove(8, CC::Z, RegMem::reg(tmp1.to_reg()), dst_hi));
+    ctx.emit(Inst::cmove(8, CC::Z, RegMem::reg(tmp3.to_reg()), dst_lo));
+    ctx.emit(Inst::cmove(8, CC::NZ, RegMem::reg(tmp1.to_reg()), dst_lo));
 }
 
 fn make_libcall_sig<C: LowerCtx<I = Inst>>(
@@ -665,6 +1215,101 @@ fn lower_to_amode<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput, offset: i
 
     let input = put_input_in_reg(ctx, spec);
     Amode::imm_reg(offset as u32, input).with_flags(flags)
+}
+
+fn emit_moves<C: LowerCtx<I = Inst>>(
+    ctx: &mut C,
+    dst: ValueRegs<Writable<Reg>>,
+    src: ValueRegs<Reg>,
+    ty: Type,
+) {
+    let (_, tys) = Inst::rc_for_type(ty).unwrap();
+    for ((dst, src), ty) in dst.regs().iter().zip(src.regs().iter()).zip(tys.iter()) {
+        ctx.emit(Inst::gen_move(*dst, *src, *ty));
+    }
+}
+
+fn emit_cmoves<C: LowerCtx<I = Inst>>(
+    ctx: &mut C,
+    size: u8,
+    cc: CC,
+    src: ValueRegs<Reg>,
+    dst: ValueRegs<Writable<Reg>>,
+) {
+    let size = size / src.len() as u8;
+    let size = u8::max(size, 4); // at least 32 bits
+    for (dst, src) in dst.regs().iter().zip(src.regs().iter()) {
+        ctx.emit(Inst::cmove(size, cc, RegMem::reg(*src), *dst));
+    }
+}
+
+fn emit_clz<C: LowerCtx<I = Inst>>(
+    ctx: &mut C,
+    orig_ty: Type,
+    ty: Type,
+    src: Reg,
+    dst: Writable<Reg>,
+) {
+    let src = RegMem::reg(src);
+    let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
+    ctx.emit(Inst::imm(
+        OperandSize::from_bytes(ty.bytes()),
+        u64::max_value(),
+        dst,
+    ));
+
+    ctx.emit(Inst::unary_rm_r(
+        ty.bytes() as u8,
+        UnaryRmROpcode::Bsr,
+        src,
+        tmp,
+    ));
+
+    ctx.emit(Inst::cmove(
+        ty.bytes() as u8,
+        CC::Z,
+        RegMem::reg(dst.to_reg()),
+        tmp,
+    ));
+
+    ctx.emit(Inst::imm(
+        OperandSize::from_bytes(ty.bytes()),
+        orig_ty.bits() as u64 - 1,
+        dst,
+    ));
+
+    ctx.emit(Inst::alu_rmi_r(
+        ty == types::I64,
+        AluRmiROpcode::Sub,
+        RegMemImm::reg(tmp.to_reg()),
+        dst,
+    ));
+}
+
+fn emit_ctz<C: LowerCtx<I = Inst>>(
+    ctx: &mut C,
+    orig_ty: Type,
+    ty: Type,
+    src: Reg,
+    dst: Writable<Reg>,
+) {
+    let src = RegMem::reg(src);
+    let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
+    ctx.emit(Inst::imm(OperandSize::Size32, orig_ty.bits() as u64, tmp));
+
+    ctx.emit(Inst::unary_rm_r(
+        ty.bytes() as u8,
+        UnaryRmROpcode::Bsf,
+        src,
+        dst,
+    ));
+
+    ctx.emit(Inst::cmove(
+        ty.bytes() as u8,
+        CC::Z,
+        RegMem::reg(tmp.to_reg()),
+        dst,
+    ));
 }
 
 //=============================================================================
@@ -889,6 +1534,102 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // Move the `lhs` to the same register as `dst`.
                 ctx.emit(Inst::gen_move(dst, lhs, ty));
                 ctx.emit(Inst::xmm_rm_r(sse_op, rhs, dst));
+            } else if ty == types::I128 || ty == types::B128 {
+                let alu_ops = match op {
+                    Opcode::Iadd => (AluRmiROpcode::Add, AluRmiROpcode::Adc),
+                    Opcode::Isub => (AluRmiROpcode::Sub, AluRmiROpcode::Sbb),
+                    // multiply handled specially below
+                    Opcode::Imul => (AluRmiROpcode::Mul, AluRmiROpcode::Mul),
+                    Opcode::Band => (AluRmiROpcode::And, AluRmiROpcode::And),
+                    Opcode::Bor => (AluRmiROpcode::Or, AluRmiROpcode::Or),
+                    Opcode::Bxor => (AluRmiROpcode::Xor, AluRmiROpcode::Xor),
+                    _ => panic!("Unsupported opcode with 128-bit integers: {:?}", op),
+                };
+                let lhs = put_input_in_regs(ctx, inputs[0]);
+                let rhs = put_input_in_regs(ctx, inputs[1]);
+                let dst = get_output_reg(ctx, outputs[0]);
+                assert_eq!(lhs.len(), 2);
+                assert_eq!(rhs.len(), 2);
+                assert_eq!(dst.len(), 2);
+
+                if op != Opcode::Imul {
+                    // add, sub, and, or, xor: just do ops on lower then upper half. Carry-flag
+                    // propagation is implicit (add/adc, sub/sbb).
+                    ctx.emit(Inst::gen_move(dst.regs()[0], lhs.regs()[0], types::I64));
+                    ctx.emit(Inst::gen_move(dst.regs()[1], lhs.regs()[1], types::I64));
+                    ctx.emit(Inst::alu_rmi_r(
+                        /* is_64 = */ true,
+                        alu_ops.0,
+                        RegMemImm::reg(rhs.regs()[0]),
+                        dst.regs()[0],
+                    ));
+                    ctx.emit(Inst::alu_rmi_r(
+                        /* is_64 = */ true,
+                        alu_ops.1,
+                        RegMemImm::reg(rhs.regs()[1]),
+                        dst.regs()[1],
+                    ));
+                } else {
+                    // mul:
+                    //   dst_lo = lhs_lo * rhs_lo
+                    //   dst_hi = umulhi(lhs_lo, rhs_lo) + lhs_lo * rhs_hi + lhs_hi * rhs_lo
+                    //
+                    // so we emit:
+                    //   mov dst_lo, lhs_lo
+                    //   mul dst_lo, rhs_lo
+                    //   mov dst_hi, lhs_lo
+                    //   mul dst_hi, rhs_hi
+                    //   mov tmp, lhs_hi
+                    //   mul tmp, rhs_lo
+                    //   add dst_hi, tmp
+                    //   mov rax, lhs_lo
+                    //   umulhi rhs_lo  // implicit rax arg/dst
+                    //   add dst_hi, rax
+                    let tmp = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                    ctx.emit(Inst::gen_move(dst.regs()[0], lhs.regs()[0], types::I64));
+                    ctx.emit(Inst::alu_rmi_r(
+                        /* is_64 = */ true,
+                        AluRmiROpcode::Mul,
+                        RegMemImm::reg(rhs.regs()[0]),
+                        dst.regs()[0],
+                    ));
+                    ctx.emit(Inst::gen_move(dst.regs()[1], lhs.regs()[0], types::I64));
+                    ctx.emit(Inst::alu_rmi_r(
+                        /* is_64 = */ true,
+                        AluRmiROpcode::Mul,
+                        RegMemImm::reg(rhs.regs()[1]),
+                        dst.regs()[1],
+                    ));
+                    ctx.emit(Inst::gen_move(tmp, lhs.regs()[1], types::I64));
+                    ctx.emit(Inst::alu_rmi_r(
+                        /* is_64 = */ true,
+                        AluRmiROpcode::Mul,
+                        RegMemImm::reg(rhs.regs()[0]),
+                        tmp,
+                    ));
+                    ctx.emit(Inst::alu_rmi_r(
+                        /* is_64 = */ true,
+                        AluRmiROpcode::Add,
+                        RegMemImm::reg(tmp.to_reg()),
+                        dst.regs()[1],
+                    ));
+                    ctx.emit(Inst::gen_move(
+                        Writable::from_reg(regs::rax()),
+                        lhs.regs()[0],
+                        types::I64,
+                    ));
+                    ctx.emit(Inst::mul_hi(
+                        /* size = */ 8,
+                        /* signed = */ false,
+                        RegMem::reg(rhs.regs()[0]),
+                    ));
+                    ctx.emit(Inst::alu_rmi_r(
+                        /* is_64 = */ true,
+                        AluRmiROpcode::Add,
+                        RegMemImm::reg(regs::rdx()),
+                        dst.regs()[1],
+                    ));
+                }
             } else {
                 let is_64 = ty == types::I64;
                 let alu_op = match op {
@@ -1013,17 +1754,27 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Bnot => {
             let ty = ty.unwrap();
             let size = ty.bytes() as u8;
-            let src = put_input_in_reg(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            ctx.emit(Inst::gen_move(dst, src, ty));
 
             if ty.is_vector() {
+                let src = put_input_in_reg(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                ctx.emit(Inst::gen_move(dst, src, ty));
                 let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
                 ctx.emit(Inst::equals(ty, RegMem::from(tmp), tmp));
                 ctx.emit(Inst::xor(ty, RegMem::from(tmp), dst));
+            } else if ty == types::I128 || ty == types::B128 {
+                let src = put_input_in_regs(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]);
+                ctx.emit(Inst::gen_move(dst.regs()[0], src.regs()[0], types::I64));
+                ctx.emit(Inst::not(8, dst.regs()[0]));
+                ctx.emit(Inst::gen_move(dst.regs()[1], src.regs()[1], types::I64));
+                ctx.emit(Inst::not(8, dst.regs()[1]));
             } else if ty.is_bool() {
                 unimplemented!("bool bnot")
             } else {
+                let src = put_input_in_reg(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                ctx.emit(Inst::gen_move(dst, src, ty));
                 ctx.emit(Inst::not(size, dst));
             }
         }
@@ -1055,7 +1806,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let dst_ty = ctx.output_ty(insn, 0);
             debug_assert_eq!(ctx.input_ty(insn, 0), dst_ty);
 
-            if !dst_ty.is_vector() {
+            if !dst_ty.is_vector() && dst_ty.bits() <= 64 {
                 // Scalar shifts on x86 have various encodings:
                 // - shift by one bit, e.g. `SAL r/m8, 1` (not used here)
                 // - shift by an immediate amount, e.g. `SAL r/m8, imm8`
@@ -1109,6 +1860,89 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     ctx.emit(Inst::mov_r_r(true, rhs.unwrap(), w_rcx));
                 }
                 ctx.emit(Inst::shift_r(size, shift_kind, count, dst));
+            } else if dst_ty == types::I128 {
+                let amt_src = put_input_in_reg(ctx, inputs[1]);
+                let src = put_input_in_regs(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]);
+
+                match op {
+                    Opcode::Ishl => {
+                        emit_shl_i128(ctx, src, dst, amt_src);
+                    }
+                    Opcode::Ushr => {
+                        emit_shr_i128(ctx, src, dst, amt_src, /* is_signed = */ false);
+                    }
+                    Opcode::Sshr => {
+                        emit_shr_i128(ctx, src, dst, amt_src, /* is_signed = */ true);
+                    }
+                    Opcode::Rotl => {
+                        // (mov tmp, src)
+                        // (shl.i128 tmp, amt)
+                        // (mov dst, src)
+                        // (ushr.i128 dst, 128-amt)
+                        // (or dst, tmp)
+                        let tmp = ctx.alloc_tmp(types::I128);
+                        emit_shl_i128(ctx, src, tmp, amt_src);
+                        let inv_amt = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                        ctx.emit(Inst::imm(OperandSize::Size64, 128, inv_amt));
+                        ctx.emit(Inst::alu_rmi_r(
+                            true,
+                            AluRmiROpcode::Sub,
+                            RegMemImm::reg(amt_src),
+                            inv_amt,
+                        ));
+                        emit_shr_i128(
+                            ctx,
+                            src,
+                            dst,
+                            inv_amt.to_reg(),
+                            /* is_signed = */ false,
+                        );
+                        ctx.emit(Inst::alu_rmi_r(
+                            true,
+                            AluRmiROpcode::Or,
+                            RegMemImm::reg(tmp.regs()[0].to_reg()),
+                            dst.regs()[0],
+                        ));
+                        ctx.emit(Inst::alu_rmi_r(
+                            true,
+                            AluRmiROpcode::Or,
+                            RegMemImm::reg(tmp.regs()[1].to_reg()),
+                            dst.regs()[1],
+                        ));
+                    }
+                    Opcode::Rotr => {
+                        // (mov tmp, src)
+                        // (ushr.i128 tmp, amt)
+                        // (mov dst, src)
+                        // (shl.i128 dst, 128-amt)
+                        // (or dst, tmp)
+                        let tmp = ctx.alloc_tmp(types::I128);
+                        emit_shr_i128(ctx, src, tmp, amt_src, /* is_signed = */ false);
+                        let inv_amt = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                        ctx.emit(Inst::imm(OperandSize::Size64, 128, inv_amt));
+                        ctx.emit(Inst::alu_rmi_r(
+                            true,
+                            AluRmiROpcode::Sub,
+                            RegMemImm::reg(amt_src),
+                            inv_amt,
+                        ));
+                        emit_shl_i128(ctx, src, dst, inv_amt.to_reg());
+                        ctx.emit(Inst::alu_rmi_r(
+                            true,
+                            AluRmiROpcode::Or,
+                            RegMemImm::reg(tmp.regs()[0].to_reg()),
+                            dst.regs()[0],
+                        ));
+                        ctx.emit(Inst::alu_rmi_r(
+                            true,
+                            AluRmiROpcode::Or,
+                            RegMemImm::reg(tmp.regs()[1].to_reg()),
+                            dst.regs()[1],
+                        ));
+                    }
+                    _ => unreachable!(),
+                }
             } else if dst_ty == types::I8X16 && (op == Opcode::Ishl || op == Opcode::Ushr) {
                 // Since the x86 instruction set does not have any 8x16 shift instructions (even in higher feature sets
                 // like AVX), we lower the `ishl.i8x16` and `ushr.i8x16` to a sequence of instructions. The basic idea,
@@ -1440,52 +2274,50 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // mov $(size_bits - 1), %dst
             // sub %tmp, %dst
 
-            let (ext_spec, ty) = match ctx.input_ty(insn, 0) {
-                types::I8 | types::I16 => (Some(ExtSpec::ZeroExtendTo32), types::I32),
-                a if a == types::I32 || a == types::I64 => (None, a),
-                _ => unreachable!(),
-            };
-
-            let src = if let Some(ext_spec) = ext_spec {
-                RegMem::reg(extend_input_to_reg(ctx, inputs[0], ext_spec))
+            let orig_ty = ty.unwrap();
+            if orig_ty == types::I128 {
+                // clz upper, tmp1
+                // clz lower, dst
+                // add dst, 64
+                // cmp tmp1, 64
+                // cmovnz tmp1, dst
+                let dsts = get_output_reg(ctx, outputs[0]);
+                let dst = dsts.regs()[0];
+                let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                let srcs = put_input_in_regs(ctx, inputs[0]);
+                let src_lo = srcs.regs()[0];
+                let src_hi = srcs.regs()[1];
+                emit_clz(ctx, types::I64, types::I64, src_hi, tmp1);
+                emit_clz(ctx, types::I64, types::I64, src_lo, dst);
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::Add,
+                    RegMemImm::imm(64),
+                    dst,
+                ));
+                ctx.emit(Inst::cmp_rmi_r(8, RegMemImm::imm(64), tmp1.to_reg()));
+                ctx.emit(Inst::cmove(8, CC::NZ, RegMem::reg(tmp1.to_reg()), dst));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::Xor,
+                    RegMemImm::reg(dsts.regs()[1].to_reg()),
+                    dsts.regs()[1],
+                ));
             } else {
-                input_to_reg_mem(ctx, inputs[0])
-            };
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                let (ext_spec, ty) = match orig_ty {
+                    types::I8 | types::I16 => (Some(ExtSpec::ZeroExtendTo32), types::I32),
+                    a if a == types::I32 || a == types::I64 => (None, a),
+                    _ => unreachable!(),
+                };
+                let src = if let Some(ext_spec) = ext_spec {
+                    extend_input_to_reg(ctx, inputs[0], ext_spec)
+                } else {
+                    put_input_in_reg(ctx, inputs[0])
+                };
 
-            let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
-            ctx.emit(Inst::imm(
-                OperandSize::from_bytes(ty.bytes()),
-                u64::max_value(),
-                dst,
-            ));
-
-            ctx.emit(Inst::unary_rm_r(
-                ty.bytes() as u8,
-                UnaryRmROpcode::Bsr,
-                src,
-                tmp,
-            ));
-
-            ctx.emit(Inst::cmove(
-                ty.bytes() as u8,
-                CC::Z,
-                RegMem::reg(dst.to_reg()),
-                tmp,
-            ));
-
-            ctx.emit(Inst::imm(
-                OperandSize::from_bytes(ty.bytes()),
-                ty.bits() as u64 - 1,
-                dst,
-            ));
-
-            ctx.emit(Inst::alu_rmi_r(
-                ty == types::I64,
-                AluRmiROpcode::Sub,
-                RegMemImm::reg(tmp.to_reg()),
-                dst,
-            ));
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                emit_clz(ctx, orig_ty, ty, src, dst);
+            }
         }
 
         Opcode::Ctz => {
@@ -1495,29 +2327,47 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             // bsf %src, %dst
             // mov $(size_bits), %tmp
             // cmovz %tmp, %dst
-            let ty = ctx.input_ty(insn, 0);
-            let ty = if ty.bits() < 32 { types::I32 } else { ty };
-            debug_assert!(ty == types::I32 || ty == types::I64);
+            let orig_ty = ctx.input_ty(insn, 0);
+            if orig_ty == types::I128 {
+                // ctz src_lo, dst
+                // ctz src_hi, tmp1
+                // add tmp1, 64
+                // cmp dst, 64
+                // cmovz tmp1, dst
+                let dsts = get_output_reg(ctx, outputs[0]);
+                let dst = dsts.regs()[0];
+                let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                let srcs = put_input_in_regs(ctx, inputs[0]);
+                let src_lo = srcs.regs()[0];
+                let src_hi = srcs.regs()[1];
+                emit_ctz(ctx, types::I64, types::I64, src_lo, dst);
+                emit_ctz(ctx, types::I64, types::I64, src_hi, tmp1);
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::Add,
+                    RegMemImm::imm(64),
+                    tmp1,
+                ));
+                ctx.emit(Inst::cmp_rmi_r(8, RegMemImm::imm(64), dst.to_reg()));
+                ctx.emit(Inst::cmove(8, CC::Z, RegMem::reg(tmp1.to_reg()), dst));
+                ctx.emit(Inst::alu_rmi_r(
+                    true,
+                    AluRmiROpcode::Xor,
+                    RegMemImm::reg(dsts.regs()[1].to_reg()),
+                    dsts.regs()[1],
+                ));
+            } else {
+                let ty = if orig_ty.bits() < 32 {
+                    types::I32
+                } else {
+                    orig_ty
+                };
+                debug_assert!(ty == types::I32 || ty == types::I64);
 
-            let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-
-            let tmp = ctx.alloc_tmp(ty).only_reg().unwrap();
-            ctx.emit(Inst::imm(OperandSize::Size32, ty.bits() as u64, tmp));
-
-            ctx.emit(Inst::unary_rm_r(
-                ty.bytes() as u8,
-                UnaryRmROpcode::Bsf,
-                src,
-                dst,
-            ));
-
-            ctx.emit(Inst::cmove(
-                ty.bytes() as u8,
-                CC::Z,
-                RegMem::reg(tmp.to_reg()),
-                dst,
-            ));
+                let src = put_input_in_reg(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                emit_ctz(ctx, orig_ty, ty, src, dst);
+            }
         }
 
         Opcode::Popcnt => {
@@ -1526,272 +2376,329 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let (ext_spec, ty) = match ctx.input_ty(insn, 0) {
                 types::I8 | types::I16 => (Some(ExtSpec::ZeroExtendTo32), types::I32),
                 a if a == types::I32 || a == types::I64 => (None, a),
+                types::I128 => (None, types::I128),
                 _ => unreachable!(),
             };
 
-            let src = if let Some(ext_spec) = ext_spec {
-                RegMem::reg(extend_input_to_reg(ctx, inputs[0], ext_spec))
+            let (srcs, ty): (SmallVec<[RegMem; 2]>, Type) = if let Some(ext_spec) = ext_spec {
+                (
+                    smallvec![RegMem::reg(extend_input_to_reg(ctx, inputs[0], ext_spec))],
+                    ty,
+                )
+            } else if ty == types::I128 {
+                let regs = put_input_in_regs(ctx, inputs[0]);
+                (
+                    smallvec![RegMem::reg(regs.regs()[0]), RegMem::reg(regs.regs()[1])],
+                    types::I64,
+                )
             } else {
                 // N.B.: explicitly put input in a reg here because the width of the instruction
                 // into which this RM op goes may not match the width of the input type (in fact,
                 // it won't for i32.popcnt), and we don't want a larger than necessary load.
-                RegMem::reg(put_input_in_reg(ctx, inputs[0]))
+                (smallvec![RegMem::reg(put_input_in_reg(ctx, inputs[0]))], ty)
             };
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
-            if ty == types::I64 {
-                let is_64 = true;
+            let mut dsts: SmallVec<[Reg; 2]> = smallvec![];
+            for src in srcs {
+                let dst = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                dsts.push(dst.to_reg());
+                if ty == types::I64 {
+                    let is_64 = true;
 
-                let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-                let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-                let cst = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                    let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                    let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                    let cst = ctx.alloc_tmp(types::I64).only_reg().unwrap();
 
-                // mov src, tmp1
-                ctx.emit(Inst::mov64_rm_r(src.clone(), tmp1));
+                    // mov src, tmp1
+                    ctx.emit(Inst::mov64_rm_r(src.clone(), tmp1));
 
-                // shr $1, tmp1
-                ctx.emit(Inst::shift_r(
-                    8,
-                    ShiftKind::ShiftRightLogical,
-                    Some(1),
-                    tmp1,
-                ));
+                    // shr $1, tmp1
+                    ctx.emit(Inst::shift_r(
+                        8,
+                        ShiftKind::ShiftRightLogical,
+                        Some(1),
+                        tmp1,
+                    ));
 
-                // mov 0x7777_7777_7777_7777, cst
-                ctx.emit(Inst::imm(OperandSize::Size64, 0x7777777777777777, cst));
+                    // mov 0x7777_7777_7777_7777, cst
+                    ctx.emit(Inst::imm(OperandSize::Size64, 0x7777777777777777, cst));
 
-                // andq cst, tmp1
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::reg(cst.to_reg()),
-                    tmp1,
-                ));
+                    // andq cst, tmp1
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::reg(cst.to_reg()),
+                        tmp1,
+                    ));
 
-                // mov src, tmp2
-                ctx.emit(Inst::mov64_rm_r(src, tmp2));
+                    // mov src, tmp2
+                    ctx.emit(Inst::mov64_rm_r(src, tmp2));
 
-                // sub tmp1, tmp2
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Sub,
-                    RegMemImm::reg(tmp1.to_reg()),
-                    tmp2,
-                ));
+                    // sub tmp1, tmp2
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Sub,
+                        RegMemImm::reg(tmp1.to_reg()),
+                        tmp2,
+                    ));
 
-                // shr $1, tmp1
-                ctx.emit(Inst::shift_r(
-                    8,
-                    ShiftKind::ShiftRightLogical,
-                    Some(1),
-                    tmp1,
-                ));
+                    // shr $1, tmp1
+                    ctx.emit(Inst::shift_r(
+                        8,
+                        ShiftKind::ShiftRightLogical,
+                        Some(1),
+                        tmp1,
+                    ));
 
-                // and cst, tmp1
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::reg(cst.to_reg()),
-                    tmp1,
-                ));
+                    // and cst, tmp1
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::reg(cst.to_reg()),
+                        tmp1,
+                    ));
 
-                // sub tmp1, tmp2
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Sub,
-                    RegMemImm::reg(tmp1.to_reg()),
-                    tmp2,
-                ));
+                    // sub tmp1, tmp2
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Sub,
+                        RegMemImm::reg(tmp1.to_reg()),
+                        tmp2,
+                    ));
 
-                // shr $1, tmp1
-                ctx.emit(Inst::shift_r(
-                    8,
-                    ShiftKind::ShiftRightLogical,
-                    Some(1),
-                    tmp1,
-                ));
+                    // shr $1, tmp1
+                    ctx.emit(Inst::shift_r(
+                        8,
+                        ShiftKind::ShiftRightLogical,
+                        Some(1),
+                        tmp1,
+                    ));
 
-                // and cst, tmp1
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::reg(cst.to_reg()),
-                    tmp1,
-                ));
+                    // and cst, tmp1
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::reg(cst.to_reg()),
+                        tmp1,
+                    ));
 
-                // sub tmp1, tmp2
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Sub,
-                    RegMemImm::reg(tmp1.to_reg()),
-                    tmp2,
-                ));
+                    // sub tmp1, tmp2
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Sub,
+                        RegMemImm::reg(tmp1.to_reg()),
+                        tmp2,
+                    ));
 
-                // mov tmp2, dst
-                ctx.emit(Inst::mov64_rm_r(RegMem::reg(tmp2.to_reg()), dst));
+                    // mov tmp2, dst
+                    ctx.emit(Inst::mov64_rm_r(RegMem::reg(tmp2.to_reg()), dst));
 
-                // shr $4, dst
-                ctx.emit(Inst::shift_r(8, ShiftKind::ShiftRightLogical, Some(4), dst));
+                    // shr $4, dst
+                    ctx.emit(Inst::shift_r(8, ShiftKind::ShiftRightLogical, Some(4), dst));
 
-                // add tmp2, dst
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Add,
-                    RegMemImm::reg(tmp2.to_reg()),
-                    dst,
-                ));
+                    // add tmp2, dst
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Add,
+                        RegMemImm::reg(tmp2.to_reg()),
+                        dst,
+                    ));
 
-                // mov $0x0F0F_0F0F_0F0F_0F0F, cst
-                ctx.emit(Inst::imm(OperandSize::Size64, 0x0F0F0F0F0F0F0F0F, cst));
+                    // mov $0x0F0F_0F0F_0F0F_0F0F, cst
+                    ctx.emit(Inst::imm(OperandSize::Size64, 0x0F0F0F0F0F0F0F0F, cst));
 
-                // and cst, dst
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::reg(cst.to_reg()),
-                    dst,
-                ));
+                    // and cst, dst
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::reg(cst.to_reg()),
+                        dst,
+                    ));
 
-                // mov $0x0101_0101_0101_0101, cst
-                ctx.emit(Inst::imm(OperandSize::Size64, 0x0101010101010101, cst));
+                    // mov $0x0101_0101_0101_0101, cst
+                    ctx.emit(Inst::imm(OperandSize::Size64, 0x0101010101010101, cst));
 
-                // mul cst, dst
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Mul,
-                    RegMemImm::reg(cst.to_reg()),
-                    dst,
-                ));
+                    // mul cst, dst
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Mul,
+                        RegMemImm::reg(cst.to_reg()),
+                        dst,
+                    ));
 
-                // shr $56, dst
-                ctx.emit(Inst::shift_r(
-                    8,
-                    ShiftKind::ShiftRightLogical,
-                    Some(56),
-                    dst,
-                ));
+                    // shr $56, dst
+                    ctx.emit(Inst::shift_r(
+                        8,
+                        ShiftKind::ShiftRightLogical,
+                        Some(56),
+                        dst,
+                    ));
+                } else {
+                    assert_eq!(ty, types::I32);
+                    let is_64 = false;
+
+                    let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                    let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+
+                    // mov src, tmp1
+                    ctx.emit(Inst::mov64_rm_r(src.clone(), tmp1));
+
+                    // shr $1, tmp1
+                    ctx.emit(Inst::shift_r(
+                        4,
+                        ShiftKind::ShiftRightLogical,
+                        Some(1),
+                        tmp1,
+                    ));
+
+                    // andq $0x7777_7777, tmp1
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::imm(0x77777777),
+                        tmp1,
+                    ));
+
+                    // mov src, tmp2
+                    ctx.emit(Inst::mov64_rm_r(src, tmp2));
+
+                    // sub tmp1, tmp2
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Sub,
+                        RegMemImm::reg(tmp1.to_reg()),
+                        tmp2,
+                    ));
+
+                    // shr $1, tmp1
+                    ctx.emit(Inst::shift_r(
+                        4,
+                        ShiftKind::ShiftRightLogical,
+                        Some(1),
+                        tmp1,
+                    ));
+
+                    // and 0x7777_7777, tmp1
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::imm(0x77777777),
+                        tmp1,
+                    ));
+
+                    // sub tmp1, tmp2
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Sub,
+                        RegMemImm::reg(tmp1.to_reg()),
+                        tmp2,
+                    ));
+
+                    // shr $1, tmp1
+                    ctx.emit(Inst::shift_r(
+                        4,
+                        ShiftKind::ShiftRightLogical,
+                        Some(1),
+                        tmp1,
+                    ));
+
+                    // and $0x7777_7777, tmp1
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::imm(0x77777777),
+                        tmp1,
+                    ));
+
+                    // sub tmp1, tmp2
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Sub,
+                        RegMemImm::reg(tmp1.to_reg()),
+                        tmp2,
+                    ));
+
+                    // mov tmp2, dst
+                    ctx.emit(Inst::mov64_rm_r(RegMem::reg(tmp2.to_reg()), dst));
+
+                    // shr $4, dst
+                    ctx.emit(Inst::shift_r(4, ShiftKind::ShiftRightLogical, Some(4), dst));
+
+                    // add tmp2, dst
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Add,
+                        RegMemImm::reg(tmp2.to_reg()),
+                        dst,
+                    ));
+
+                    // and $0x0F0F_0F0F, dst
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::And,
+                        RegMemImm::imm(0x0F0F0F0F),
+                        dst,
+                    ));
+
+                    // mul $0x0101_0101, dst
+                    ctx.emit(Inst::alu_rmi_r(
+                        is_64,
+                        AluRmiROpcode::Mul,
+                        RegMemImm::imm(0x01010101),
+                        dst,
+                    ));
+
+                    // shr $24, dst
+                    ctx.emit(Inst::shift_r(
+                        4,
+                        ShiftKind::ShiftRightLogical,
+                        Some(24),
+                        dst,
+                    ));
+                }
+            }
+
+            if dsts.len() == 1 {
+                let final_dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                ctx.emit(Inst::gen_move(final_dst, dsts[0], types::I64));
             } else {
-                assert_eq!(ty, types::I32);
-                let is_64 = false;
-
-                let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-                let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-
-                // mov src, tmp1
-                ctx.emit(Inst::mov64_rm_r(src.clone(), tmp1));
-
-                // shr $1, tmp1
-                ctx.emit(Inst::shift_r(
-                    4,
-                    ShiftKind::ShiftRightLogical,
-                    Some(1),
-                    tmp1,
-                ));
-
-                // andq $0x7777_7777, tmp1
+                assert!(dsts.len() == 2);
+                let final_dst = get_output_reg(ctx, outputs[0]);
+                ctx.emit(Inst::gen_move(final_dst.regs()[0], dsts[0], types::I64));
                 ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::imm(0x77777777),
-                    tmp1,
-                ));
-
-                // mov src, tmp2
-                ctx.emit(Inst::mov64_rm_r(src, tmp2));
-
-                // sub tmp1, tmp2
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Sub,
-                    RegMemImm::reg(tmp1.to_reg()),
-                    tmp2,
-                ));
-
-                // shr $1, tmp1
-                ctx.emit(Inst::shift_r(
-                    4,
-                    ShiftKind::ShiftRightLogical,
-                    Some(1),
-                    tmp1,
-                ));
-
-                // and 0x7777_7777, tmp1
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::imm(0x77777777),
-                    tmp1,
-                ));
-
-                // sub tmp1, tmp2
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Sub,
-                    RegMemImm::reg(tmp1.to_reg()),
-                    tmp2,
-                ));
-
-                // shr $1, tmp1
-                ctx.emit(Inst::shift_r(
-                    4,
-                    ShiftKind::ShiftRightLogical,
-                    Some(1),
-                    tmp1,
-                ));
-
-                // and $0x7777_7777, tmp1
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::imm(0x77777777),
-                    tmp1,
-                ));
-
-                // sub tmp1, tmp2
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Sub,
-                    RegMemImm::reg(tmp1.to_reg()),
-                    tmp2,
-                ));
-
-                // mov tmp2, dst
-                ctx.emit(Inst::mov64_rm_r(RegMem::reg(tmp2.to_reg()), dst));
-
-                // shr $4, dst
-                ctx.emit(Inst::shift_r(4, ShiftKind::ShiftRightLogical, Some(4), dst));
-
-                // add tmp2, dst
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
+                    true,
                     AluRmiROpcode::Add,
-                    RegMemImm::reg(tmp2.to_reg()),
-                    dst,
+                    RegMemImm::reg(dsts[1]),
+                    final_dst.regs()[0],
                 ));
-
-                // and $0x0F0F_0F0F, dst
                 ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::And,
-                    RegMemImm::imm(0x0F0F0F0F),
-                    dst,
+                    true,
+                    AluRmiROpcode::Xor,
+                    RegMemImm::reg(final_dst.regs()[1].to_reg()),
+                    final_dst.regs()[1],
                 ));
+            }
+        }
 
-                // mul $0x0101_0101, dst
-                ctx.emit(Inst::alu_rmi_r(
-                    is_64,
-                    AluRmiROpcode::Mul,
-                    RegMemImm::imm(0x01010101),
-                    dst,
-                ));
+        Opcode::Bitrev => {
+            let ty = ctx.input_ty(insn, 0);
+            assert!(
+                ty == types::I8
+                    || ty == types::I16
+                    || ty == types::I32
+                    || ty == types::I64
+                    || ty == types::I128
+            );
 
-                // shr $24, dst
-                ctx.emit(Inst::shift_r(
-                    4,
-                    ShiftKind::ShiftRightLogical,
-                    Some(24),
-                    dst,
-                ));
+            if ty == types::I128 {
+                let src = put_input_in_regs(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]);
+                emit_bitrev(ctx, src.regs()[0], dst.regs()[1], types::I64);
+                emit_bitrev(ctx, src.regs()[1], dst.regs()[0], types::I64);
+            } else {
+                let src = put_input_in_reg(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                emit_bitrev(ctx, src, dst, ty);
             }
         }
 
@@ -1827,63 +2734,112 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let src_ty = ctx.input_ty(insn, 0);
             let dst_ty = ctx.output_ty(insn, 0);
 
-            // Sextend requires a sign-extended move, but all the other opcodes are simply a move
-            // from a zero-extended source. Here is why this works, in each case:
-            //
-            // - Bint: Bool-to-int. We always represent a bool as a 0 or 1, so we merely need to
-            // zero-extend here.
-            //
-            // - Breduce, Bextend: changing width of a boolean. We represent a bool as a 0 or 1, so
-            // again, this is a zero-extend / no-op.
-            //
-            // - Ireduce: changing width of an integer. Smaller ints are stored with undefined
-            // high-order bits, so we can simply do a copy.
+            if src_ty == types::I128 {
+                assert!(dst_ty.bits() <= 64);
+                assert!(op == Opcode::Ireduce);
+                let src = put_input_in_regs(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                ctx.emit(Inst::gen_move(dst, src.regs()[0], types::I64));
+            } else if dst_ty == types::I128 {
+                assert!(src_ty.bits() <= 64);
+                let src = put_input_in_reg(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]);
+                assert!(op == Opcode::Uextend || op == Opcode::Sextend || op == Opcode::Bint);
+                // Extend to 64 bits first.
 
-            if src_ty == types::I32 && dst_ty == types::I64 && op != Opcode::Sextend {
-                // As a particular x64 extra-pattern matching opportunity, all the ALU opcodes on
-                // 32-bits will zero-extend the upper 32-bits, so we can even not generate a
-                // zero-extended move in this case.
-                // TODO add loads and shifts here.
-                if let Some(_) = matches_input_any(
-                    ctx,
-                    inputs[0],
-                    &[
-                        Opcode::Iadd,
-                        Opcode::IaddIfcout,
-                        Opcode::Isub,
-                        Opcode::Imul,
-                        Opcode::Band,
-                        Opcode::Bor,
-                        Opcode::Bxor,
-                    ],
-                ) {
-                    let src = put_input_in_reg(ctx, inputs[0]);
-                    let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-                    ctx.emit(Inst::gen_move(dst, src, types::I64));
-                    return Ok(());
-                }
-            }
-
-            let src = input_to_reg_mem(ctx, inputs[0]);
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-
-            let ext_mode = ExtMode::new(src_ty.bits(), dst_ty.bits());
-            assert_eq!(
-                src_ty.bits() < dst_ty.bits(),
-                ext_mode.is_some(),
-                "unexpected extension: {} -> {}",
-                src_ty,
-                dst_ty
-            );
-
-            if let Some(ext_mode) = ext_mode {
-                if op == Opcode::Sextend {
-                    ctx.emit(Inst::movsx_rm_r(ext_mode, src, dst));
+                let ext_mode = ExtMode::new(src_ty.bits(), /* dst bits = */ 64);
+                if let Some(ext_mode) = ext_mode {
+                    if op == Opcode::Sextend {
+                        ctx.emit(Inst::movsx_rm_r(ext_mode, RegMem::reg(src), dst.regs()[0]));
+                    } else {
+                        ctx.emit(Inst::movzx_rm_r(ext_mode, RegMem::reg(src), dst.regs()[0]));
+                    }
                 } else {
-                    ctx.emit(Inst::movzx_rm_r(ext_mode, src, dst));
+                    ctx.emit(Inst::mov64_rm_r(RegMem::reg(src), dst.regs()[0]));
+                }
+
+                // Now generate the top 64 bits.
+                if op == Opcode::Sextend {
+                    // Sign-extend: move dst[0] into dst[1] and arithmetic-shift right by 63 bits
+                    // to spread the sign bit across all bits.
+                    ctx.emit(Inst::gen_move(
+                        dst.regs()[1],
+                        dst.regs()[0].to_reg(),
+                        types::I64,
+                    ));
+                    ctx.emit(Inst::shift_r(
+                        8,
+                        ShiftKind::ShiftRightArithmetic,
+                        Some(63),
+                        dst.regs()[1],
+                    ));
+                } else {
+                    // Zero-extend: just zero the top word.
+                    ctx.emit(Inst::alu_rmi_r(
+                        true,
+                        AluRmiROpcode::Xor,
+                        RegMemImm::reg(dst.regs()[1].to_reg()),
+                        dst.regs()[1],
+                    ));
                 }
             } else {
-                ctx.emit(Inst::mov64_rm_r(src, dst));
+                // Sextend requires a sign-extended move, but all the other opcodes are simply a move
+                // from a zero-extended source. Here is why this works, in each case:
+                //
+                // - Bint: Bool-to-int. We always represent a bool as a 0 or 1, so we merely need to
+                // zero-extend here.
+                //
+                // - Breduce, Bextend: changing width of a boolean. We represent a bool as a 0 or 1, so
+                // again, this is a zero-extend / no-op.
+                //
+                // - Ireduce: changing width of an integer. Smaller ints are stored with undefined
+                // high-order bits, so we can simply do a copy.
+                if src_ty == types::I32 && dst_ty == types::I64 && op != Opcode::Sextend {
+                    // As a particular x64 extra-pattern matching opportunity, all the ALU opcodes on
+                    // 32-bits will zero-extend the upper 32-bits, so we can even not generate a
+                    // zero-extended move in this case.
+                    // TODO add loads and shifts here.
+                    if let Some(_) = matches_input_any(
+                        ctx,
+                        inputs[0],
+                        &[
+                            Opcode::Iadd,
+                            Opcode::IaddIfcout,
+                            Opcode::Isub,
+                            Opcode::Imul,
+                            Opcode::Band,
+                            Opcode::Bor,
+                            Opcode::Bxor,
+                        ],
+                    ) {
+                        let src = put_input_in_reg(ctx, inputs[0]);
+                        let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                        ctx.emit(Inst::gen_move(dst, src, types::I64));
+                        return Ok(());
+                    }
+                }
+
+                let src = input_to_reg_mem(ctx, inputs[0]);
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+
+                let ext_mode = ExtMode::new(src_ty.bits(), dst_ty.bits());
+                assert_eq!(
+                    src_ty.bits() < dst_ty.bits(),
+                    ext_mode.is_some(),
+                    "unexpected extension: {} -> {}",
+                    src_ty,
+                    dst_ty
+                );
+
+                if let Some(ext_mode) = ext_mode {
+                    if op == Opcode::Sextend {
+                        ctx.emit(Inst::movsx_rm_r(ext_mode, src, dst));
+                    } else {
+                        ctx.emit(Inst::movzx_rm_r(ext_mode, src, dst));
+                    }
+                } else {
+                    ctx.emit(Inst::mov64_rm_r(src, dst));
+                }
             }
         }
 
@@ -1892,7 +2848,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ctx.input_ty(insn, 0);
             if !ty.is_vector() {
-                emit_cmp(ctx, insn);
+                let condcode = emit_cmp(ctx, insn, condcode);
                 let cc = CC::from_intcc(condcode);
                 ctx.emit(Inst::setcc(cc, dst));
             } else {
@@ -2099,10 +3055,19 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::FallthroughReturn | Opcode::Return => {
             for i in 0..ctx.num_inputs(insn) {
-                let src_reg = put_input_in_reg(ctx, inputs[i]);
+                let src_reg = put_input_in_regs(ctx, inputs[i]);
                 let retval_reg = ctx.retval(i);
                 let ty = ctx.input_ty(insn, i);
-                ctx.emit(Inst::gen_move(retval_reg.only_reg().unwrap(), src_reg, ty));
+                assert!(src_reg.len() == retval_reg.len());
+                let (_, tys) = Inst::rc_for_type(ty)?;
+                for ((&src, &dst), &ty) in src_reg
+                    .regs()
+                    .iter()
+                    .zip(retval_reg.regs().iter())
+                    .zip(tys.iter())
+                {
+                    ctx.emit(Inst::gen_move(dst, src, ty));
+                }
             }
             // N.B.: the Ret itself is generated by the ABI.
         }
@@ -2138,13 +3103,13 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             abi.emit_stack_pre_adjust(ctx);
             assert_eq!(inputs.len(), abi.num_args());
             for (i, input) in inputs.iter().enumerate() {
-                let arg_reg = put_input_in_reg(ctx, *input);
-                abi.emit_copy_regs_to_arg(ctx, i, ValueRegs::one(arg_reg));
+                let arg_regs = put_input_in_regs(ctx, *input);
+                abi.emit_copy_regs_to_arg(ctx, i, arg_regs);
             }
             abi.emit_call(ctx);
             for (i, output) in outputs.iter().enumerate() {
-                let retval_reg = get_output_reg(ctx, *output).only_reg().unwrap();
-                abi.emit_copy_retval_to_regs(ctx, i, ValueRegs::one(retval_reg));
+                let retval_regs = get_output_reg(ctx, *output);
+                abi.emit_copy_retval_to_regs(ctx, i, retval_regs);
             }
             abi.emit_stack_post_adjust(ctx);
         }
@@ -2171,11 +3136,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 ctx.emit_safepoint(Inst::TrapIf { trap_code, cc });
             } else if op == Opcode::Trapif {
                 let cond_code = ctx.data(insn).cond_code().unwrap();
-                let cc = CC::from_intcc(cond_code);
 
                 // Verification ensures that the input is always a single-def ifcmp.
                 let ifcmp = matches_input(ctx, inputs[0], Opcode::Ifcmp).unwrap();
-                emit_cmp(ctx, ifcmp);
+                let cond_code = emit_cmp(ctx, ifcmp, cond_code);
+                let cc = CC::from_intcc(cond_code);
 
                 ctx.emit_safepoint(Inst::TrapIf { trap_code, cc });
             } else {
@@ -3386,59 +4351,64 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 _ => unreachable!(),
             };
 
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let is_xmm = elem_ty.is_float() || elem_ty.is_vector();
-
-            match (sign_extend, is_xmm) {
-                (true, false) => {
-                    // The load is sign-extended only when the output size is lower than 64 bits,
-                    // so ext-mode is defined in this case.
-                    ctx.emit(Inst::movsx_rm_r(ext_mode.unwrap(), RegMem::mem(amode), dst));
-                }
-                (false, false) => {
-                    if elem_ty.bytes() == 8 {
-                        // Use a plain load.
-                        ctx.emit(Inst::mov64_m_r(amode, dst))
-                    } else {
-                        // Use a zero-extended load.
-                        ctx.emit(Inst::movzx_rm_r(ext_mode.unwrap(), RegMem::mem(amode), dst))
+            if elem_ty == types::I128 {
+                let dsts = get_output_reg(ctx, outputs[0]);
+                ctx.emit(Inst::mov64_m_r(amode, dsts.regs()[0]));
+                ctx.emit(Inst::mov64_m_r(amode.offset(8), dsts.regs()[1]));
+            } else {
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                let is_xmm = elem_ty.is_float() || elem_ty.is_vector();
+                match (sign_extend, is_xmm) {
+                    (true, false) => {
+                        // The load is sign-extended only when the output size is lower than 64 bits,
+                        // so ext-mode is defined in this case.
+                        ctx.emit(Inst::movsx_rm_r(ext_mode.unwrap(), RegMem::mem(amode), dst));
                     }
-                }
-                (_, true) => {
-                    ctx.emit(match elem_ty {
-                        types::F32 => Inst::xmm_mov(SseOpcode::Movss, RegMem::mem(amode), dst),
-                        types::F64 => Inst::xmm_mov(SseOpcode::Movsd, RegMem::mem(amode), dst),
-                        types::I8X8 => {
-                            if sign_extend == true {
-                                Inst::xmm_mov(SseOpcode::Pmovsxbw, RegMem::mem(amode), dst)
-                            } else {
-                                Inst::xmm_mov(SseOpcode::Pmovzxbw, RegMem::mem(amode), dst)
+                    (false, false) => {
+                        if elem_ty.bytes() == 8 {
+                            // Use a plain load.
+                            ctx.emit(Inst::mov64_m_r(amode, dst))
+                        } else {
+                            // Use a zero-extended load.
+                            ctx.emit(Inst::movzx_rm_r(ext_mode.unwrap(), RegMem::mem(amode), dst))
+                        }
+                    }
+                    (_, true) => {
+                        ctx.emit(match elem_ty {
+                            types::F32 => Inst::xmm_mov(SseOpcode::Movss, RegMem::mem(amode), dst),
+                            types::F64 => Inst::xmm_mov(SseOpcode::Movsd, RegMem::mem(amode), dst),
+                            types::I8X8 => {
+                                if sign_extend == true {
+                                    Inst::xmm_mov(SseOpcode::Pmovsxbw, RegMem::mem(amode), dst)
+                                } else {
+                                    Inst::xmm_mov(SseOpcode::Pmovzxbw, RegMem::mem(amode), dst)
+                                }
                             }
-                        }
-                        types::I16X4 => {
-                            if sign_extend == true {
-                                Inst::xmm_mov(SseOpcode::Pmovsxwd, RegMem::mem(amode), dst)
-                            } else {
-                                Inst::xmm_mov(SseOpcode::Pmovzxwd, RegMem::mem(amode), dst)
+                            types::I16X4 => {
+                                if sign_extend == true {
+                                    Inst::xmm_mov(SseOpcode::Pmovsxwd, RegMem::mem(amode), dst)
+                                } else {
+                                    Inst::xmm_mov(SseOpcode::Pmovzxwd, RegMem::mem(amode), dst)
+                                }
                             }
-                        }
-                        types::I32X2 => {
-                            if sign_extend == true {
-                                Inst::xmm_mov(SseOpcode::Pmovsxdq, RegMem::mem(amode), dst)
-                            } else {
-                                Inst::xmm_mov(SseOpcode::Pmovzxdq, RegMem::mem(amode), dst)
+                            types::I32X2 => {
+                                if sign_extend == true {
+                                    Inst::xmm_mov(SseOpcode::Pmovsxdq, RegMem::mem(amode), dst)
+                                } else {
+                                    Inst::xmm_mov(SseOpcode::Pmovzxdq, RegMem::mem(amode), dst)
+                                }
                             }
-                        }
-                        _ if elem_ty.is_vector() && elem_ty.bits() == 128 => {
-                            Inst::xmm_mov(SseOpcode::Movups, RegMem::mem(amode), dst)
-                        }
-                        // TODO Specialize for different types: MOVUPD, MOVDQU
-                        _ => unreachable!(
-                            "unexpected type for load: {:?} - {:?}",
-                            elem_ty,
-                            elem_ty.bits()
-                        ),
-                    });
+                            _ if elem_ty.is_vector() && elem_ty.bits() == 128 => {
+                                Inst::xmm_mov(SseOpcode::Movups, RegMem::mem(amode), dst)
+                            }
+                            // TODO Specialize for different types: MOVUPD, MOVDQU
+                            _ => unreachable!(
+                                "unexpected type for load: {:?} - {:?}",
+                                elem_ty,
+                                elem_ty.bits()
+                            ),
+                        });
+                    }
                 }
             }
         }
@@ -3485,17 +4455,23 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 _ => unreachable!(),
             };
 
-            let src = put_input_in_reg(ctx, inputs[0]);
+            if elem_ty == types::I128 {
+                let srcs = put_input_in_regs(ctx, inputs[0]);
+                ctx.emit(Inst::mov_r_m(8, srcs.regs()[0], addr));
+                ctx.emit(Inst::mov_r_m(8, srcs.regs()[1], addr.offset(8)));
+            } else {
+                let src = put_input_in_reg(ctx, inputs[0]);
 
-            ctx.emit(match elem_ty {
-                types::F32 => Inst::xmm_mov_r_m(SseOpcode::Movss, src, addr),
-                types::F64 => Inst::xmm_mov_r_m(SseOpcode::Movsd, src, addr),
-                _ if elem_ty.is_vector() && elem_ty.bits() == 128 => {
-                    // TODO Specialize for different types: MOVUPD, MOVDQU, etc.
-                    Inst::xmm_mov_r_m(SseOpcode::Movups, src, addr)
-                }
-                _ => Inst::mov_r_m(elem_ty.bytes() as u8, src, addr),
-            });
+                ctx.emit(match elem_ty {
+                    types::F32 => Inst::xmm_mov_r_m(SseOpcode::Movss, src, addr),
+                    types::F64 => Inst::xmm_mov_r_m(SseOpcode::Movsd, src, addr),
+                    _ if elem_ty.is_vector() && elem_ty.bits() == 128 => {
+                        // TODO Specialize for different types: MOVUPD, MOVDQU, etc.
+                        Inst::xmm_mov_r_m(SseOpcode::Movups, src, addr)
+                    }
+                    _ => Inst::mov_r_m(elem_ty.bytes() as u8, src, addr),
+                });
+            }
         }
 
         Opcode::AtomicRmw => {
@@ -3662,17 +4638,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 };
 
                 let ty = ctx.output_ty(insn, 0);
-                let rhs = put_input_in_reg(ctx, rhs_input);
-                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-                let lhs = if is_int_or_ref_ty(ty) && ty.bytes() < 4 {
-                    // Special case: since the higher bits are undefined per CLIF semantics, we
-                    // can just apply a 32-bit cmove here. Force inputs into registers, to
-                    // avoid partial spilling out-of-bounds with memory accesses, though.
-                    // Sign-extend operands to 32, then do a cmove of size 4.
-                    RegMem::reg(put_input_in_reg(ctx, lhs_input))
-                } else {
-                    input_to_reg_mem(ctx, lhs_input)
-                };
+                let rhs = put_input_in_regs(ctx, rhs_input);
+                let dst = get_output_reg(ctx, outputs[0]);
+                let lhs = put_input_in_regs(ctx, lhs_input);
 
                 // We request inversion of Equal to NotEqual here: taking LHS if equal would mean
                 // take it if both CC::NP and CC::Z are set, the conjunction of which can't be
@@ -3685,15 +4653,20 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert_eq!(cond_code, FloatCC::Equal);
                 }
 
-                ctx.emit(Inst::gen_move(dst, rhs, ty));
+                emit_moves(ctx, dst, rhs, ty);
 
                 match fcmp_results {
                     FcmpCondResult::Condition(cc) => {
-                        if is_int_or_ref_ty(ty) {
-                            let size = u8::max(ty.bytes() as u8, 4);
-                            ctx.emit(Inst::cmove(size, cc, lhs, dst));
+                        if is_int_or_ref_ty(ty) || ty == types::I128 {
+                            let size = ty.bytes() as u8;
+                            emit_cmoves(ctx, size, cc, lhs, dst);
                         } else {
-                            ctx.emit(Inst::xmm_cmove(ty == types::F64, cc, lhs, dst));
+                            ctx.emit(Inst::xmm_cmove(
+                                ty == types::F64,
+                                cc,
+                                RegMem::reg(lhs.only_reg().unwrap()),
+                                dst.only_reg().unwrap(),
+                            ));
                         }
                     }
                     FcmpCondResult::AndConditions(_, _) => {
@@ -3703,40 +4676,37 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     }
                     FcmpCondResult::InvertedEqualOrConditions(cc1, cc2)
                     | FcmpCondResult::OrConditions(cc1, cc2) => {
-                        if is_int_or_ref_ty(ty) {
-                            let size = u8::max(ty.bytes() as u8, 4);
-                            ctx.emit(Inst::cmove(size, cc1, lhs.clone(), dst));
-                            ctx.emit(Inst::cmove(size, cc2, lhs, dst));
+                        if is_int_or_ref_ty(ty) || ty == types::I128 {
+                            let size = ty.bytes() as u8;
+                            emit_cmoves(ctx, size, cc1, lhs.clone(), dst);
+                            emit_cmoves(ctx, size, cc2, lhs, dst);
                         } else {
-                            ctx.emit(Inst::xmm_cmove(ty == types::F64, cc1, lhs.clone(), dst));
-                            ctx.emit(Inst::xmm_cmove(ty == types::F64, cc2, lhs, dst));
+                            ctx.emit(Inst::xmm_cmove(
+                                ty == types::F64,
+                                cc1,
+                                RegMem::reg(lhs.only_reg().unwrap()),
+                                dst.only_reg().unwrap(),
+                            ));
+                            ctx.emit(Inst::xmm_cmove(
+                                ty == types::F64,
+                                cc2,
+                                RegMem::reg(lhs.only_reg().unwrap()),
+                                dst.only_reg().unwrap(),
+                            ));
                         }
                     }
                 }
             } else {
                 let ty = ty.unwrap();
 
-                let mut size = ty.bytes() as u8;
-                let lhs = if is_int_or_ref_ty(ty) {
-                    if size < 4 {
-                        // Special case: since the higher bits are undefined per CLIF semantics, we
-                        // can just apply a 32-bit cmove here. Force inputs into registers, to
-                        // avoid partial spilling out-of-bounds with memory accesses, though.
-                        size = 4;
-                        RegMem::reg(put_input_in_reg(ctx, inputs[1]))
-                    } else {
-                        input_to_reg_mem(ctx, inputs[1])
-                    }
-                } else {
-                    input_to_reg_mem(ctx, inputs[1])
-                };
-
-                let rhs = put_input_in_reg(ctx, inputs[2]);
-                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                let size = ty.bytes() as u8;
+                let lhs = put_input_in_regs(ctx, inputs[1]);
+                let rhs = put_input_in_regs(ctx, inputs[2]);
+                let dst = get_output_reg(ctx, outputs[0]);
 
                 let cc = if let Some(icmp) = matches_input(ctx, flag_input, Opcode::Icmp) {
-                    emit_cmp(ctx, icmp);
                     let cond_code = ctx.data(icmp).cond_code().unwrap();
+                    let cond_code = emit_cmp(ctx, icmp, cond_code);
                     CC::from_intcc(cond_code)
                 } else {
                     // The input is a boolean value, compare it against zero.
@@ -3747,21 +4717,26 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 };
 
                 // This doesn't affect the flags.
-                ctx.emit(Inst::gen_move(dst, rhs, ty));
+                emit_moves(ctx, dst, rhs, ty);
 
-                if is_int_or_ref_ty(ty) {
-                    ctx.emit(Inst::cmove(size, cc, lhs, dst));
+                if is_int_or_ref_ty(ty) || ty == types::I128 {
+                    emit_cmoves(ctx, size, cc, lhs, dst);
                 } else {
                     debug_assert!(ty == types::F32 || ty == types::F64);
-                    ctx.emit(Inst::xmm_cmove(ty == types::F64, cc, lhs, dst));
+                    ctx.emit(Inst::xmm_cmove(
+                        ty == types::F64,
+                        cc,
+                        RegMem::reg(lhs.only_reg().unwrap()),
+                        dst.only_reg().unwrap(),
+                    ));
                 }
             }
         }
 
         Opcode::Selectif | Opcode::SelectifSpectreGuard => {
-            let lhs = input_to_reg_mem(ctx, inputs[1]);
-            let rhs = put_input_in_reg(ctx, inputs[2]);
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+            let lhs = put_input_in_regs(ctx, inputs[1]);
+            let rhs = put_input_in_regs(ctx, inputs[2]);
+            let dst = get_output_reg(ctx, outputs[0]);
             let ty = ctx.output_ty(insn, 0);
 
             // Verification ensures that the input is always a single-def ifcmp.
@@ -3771,26 +4746,24 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 .unwrap()
                 .0;
             debug_assert_eq!(ctx.data(cmp_insn).opcode(), Opcode::Ifcmp);
-            emit_cmp(ctx, cmp_insn);
+            let cond_code = ctx.data(insn).cond_code().unwrap();
+            let cond_code = emit_cmp(ctx, cmp_insn, cond_code);
 
-            let cc = CC::from_intcc(ctx.data(insn).cond_code().unwrap());
+            let cc = CC::from_intcc(cond_code);
 
-            if is_int_or_ref_ty(ty) {
+            if is_int_or_ref_ty(ty) || ty == types::I128 {
                 let size = ty.bytes() as u8;
-                if size == 1 {
-                    // Sign-extend operands to 32, then do a cmove of size 4.
-                    let lhs_se = ctx.alloc_tmp(types::I32).only_reg().unwrap();
-                    ctx.emit(Inst::movsx_rm_r(ExtMode::BL, lhs, lhs_se));
-                    ctx.emit(Inst::movsx_rm_r(ExtMode::BL, RegMem::reg(rhs), dst));
-                    ctx.emit(Inst::cmove(4, cc, RegMem::reg(lhs_se.to_reg()), dst));
-                } else {
-                    ctx.emit(Inst::gen_move(dst, rhs, ty));
-                    ctx.emit(Inst::cmove(size, cc, lhs, dst));
-                }
+                emit_moves(ctx, dst, rhs, ty);
+                emit_cmoves(ctx, size, cc, lhs, dst);
             } else {
                 debug_assert!(ty == types::F32 || ty == types::F64);
-                ctx.emit(Inst::gen_move(dst, rhs, ty));
-                ctx.emit(Inst::xmm_cmove(ty == types::F64, cc, lhs, dst));
+                emit_moves(ctx, dst, rhs, ty);
+                ctx.emit(Inst::xmm_cmove(
+                    ty == types::F64,
+                    cc,
+                    RegMem::reg(lhs.only_reg().unwrap()),
+                    dst.only_reg().unwrap(),
+                ));
             }
         }
 
@@ -4229,6 +5202,38 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         }
 
+        Opcode::Iconcat => {
+            let ty = ctx.output_ty(insn, 0);
+            assert_eq!(
+                ty,
+                types::I128,
+                "Iconcat not expected to be used for non-128-bit type"
+            );
+            assert_eq!(ctx.input_ty(insn, 0), types::I64);
+            assert_eq!(ctx.input_ty(insn, 1), types::I64);
+            let lo = put_input_in_reg(ctx, inputs[0]);
+            let hi = put_input_in_reg(ctx, inputs[1]);
+            let dst = get_output_reg(ctx, outputs[0]);
+            ctx.emit(Inst::gen_move(dst.regs()[0], lo, types::I64));
+            ctx.emit(Inst::gen_move(dst.regs()[1], hi, types::I64));
+        }
+
+        Opcode::Isplit => {
+            let ty = ctx.input_ty(insn, 0);
+            assert_eq!(
+                ty,
+                types::I128,
+                "Iconcat not expected to be used for non-128-bit type"
+            );
+            assert_eq!(ctx.output_ty(insn, 0), types::I64);
+            assert_eq!(ctx.output_ty(insn, 1), types::I64);
+            let src = put_input_in_regs(ctx, inputs[0]);
+            let dst_lo = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+            let dst_hi = get_output_reg(ctx, outputs[1]).only_reg().unwrap();
+            ctx.emit(Inst::gen_move(dst_lo, src.regs()[0], types::I64));
+            ctx.emit(Inst::gen_move(dst_hi, src.regs()[1], types::I64));
+        }
+
         Opcode::IaddImm
         | Opcode::ImulImm
         | Opcode::UdivImm
@@ -4316,9 +5321,9 @@ impl LowerBackend for X64Backend {
                     let src_ty = ctx.input_ty(branches[0], 0);
 
                     if let Some(icmp) = matches_input(ctx, flag_input, Opcode::Icmp) {
-                        emit_cmp(ctx, icmp);
-
                         let cond_code = ctx.data(icmp).cond_code().unwrap();
+                        let cond_code = emit_cmp(ctx, icmp, cond_code);
+
                         let cond_code = if op0 == Opcode::Brz {
                             cond_code.inverse()
                         } else {
@@ -4348,6 +5353,32 @@ impl LowerBackend for X64Backend {
                             }
                             FcmpCondResult::InvertedEqualOrConditions(_, _) => unreachable!(),
                         }
+                    } else if src_ty == types::I128 {
+                        let src = put_input_in_regs(
+                            ctx,
+                            InsnInput {
+                                insn: branches[0],
+                                input: 0,
+                            },
+                        );
+                        let (half_cc, comb_op) = match op0 {
+                            Opcode::Brz => (CC::Z, AluRmiROpcode::And8),
+                            Opcode::Brnz => (CC::NZ, AluRmiROpcode::Or8),
+                            _ => unreachable!(),
+                        };
+                        let tmp1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                        let tmp2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+                        ctx.emit(Inst::cmp_rmi_r(8, RegMemImm::imm(0), src.regs()[0]));
+                        ctx.emit(Inst::setcc(half_cc, tmp1));
+                        ctx.emit(Inst::cmp_rmi_r(8, RegMemImm::imm(0), src.regs()[1]));
+                        ctx.emit(Inst::setcc(half_cc, tmp2));
+                        ctx.emit(Inst::alu_rmi_r(
+                            false,
+                            comb_op,
+                            RegMemImm::reg(tmp1.to_reg()),
+                            tmp2,
+                        ));
+                        ctx.emit(Inst::jmp_cond(CC::NZ, taken, not_taken));
                     } else if is_int_or_ref_ty(src_ty) || is_bool_ty(src_ty) {
                         let src = put_input_in_reg(
                             ctx,
@@ -4404,8 +5435,8 @@ impl LowerBackend for X64Backend {
                     };
 
                     if let Some(ifcmp) = matches_input(ctx, flag_input, Opcode::Ifcmp) {
-                        emit_cmp(ctx, ifcmp);
                         let cond_code = ctx.data(branches[0]).cond_code().unwrap();
+                        let cond_code = emit_cmp(ctx, ifcmp, cond_code);
                         let cc = CC::from_intcc(cond_code);
                         ctx.emit(Inst::jmp_cond(cc, taken, not_taken));
                     } else if let Some(ifcmp_sp) = matches_input(ctx, flag_input, Opcode::IfcmpSp) {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -1073,7 +1073,7 @@ fn emit_vm_call<C: LowerCtx<I = Inst>>(
     let sig = make_libcall_sig(ctx, insn, call_conv, types::I64);
     let caller_conv = ctx.abi().call_conv();
 
-    let mut abi = X64ABICaller::from_func(&sig, &extname, dist, caller_conv)?;
+    let mut abi = X64ABICaller::from_func(&sig, &extname, dist, caller_conv, flags)?;
 
     abi.emit_stack_pre_adjust(ctx);
 
@@ -3081,7 +3081,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert_eq!(inputs.len(), sig.params.len());
                     assert_eq!(outputs.len(), sig.returns.len());
                     (
-                        X64ABICaller::from_func(sig, &extname, dist, caller_conv)?,
+                        X64ABICaller::from_func(sig, &extname, dist, caller_conv, flags)?,
                         &inputs[..],
                     )
                 }
@@ -3092,7 +3092,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                     assert_eq!(inputs.len() - 1, sig.params.len());
                     assert_eq!(outputs.len(), sig.returns.len());
                     (
-                        X64ABICaller::from_ptr(sig, ptr, op, caller_conv)?,
+                        X64ABICaller::from_ptr(sig, ptr, op, caller_conv, flags)?,
                         &inputs[1..],
                     )
                 }
@@ -3102,8 +3102,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
             abi.emit_stack_pre_adjust(ctx);
             assert_eq!(inputs.len(), abi.num_args());
-            for (i, input) in inputs.iter().enumerate() {
-                let arg_regs = put_input_in_regs(ctx, *input);
+            for i in abi.get_copy_to_arg_order() {
+                let input = inputs[i];
+                let arg_regs = put_input_in_regs(ctx, input);
                 abi.emit_copy_regs_to_arg(ctx, i, arg_regs);
             }
             abi.emit_call(ctx);

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -5234,6 +5234,14 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             ctx.emit(Inst::gen_move(dst_hi, src.regs()[1], types::I64));
         }
 
+        Opcode::TlsValue => {
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+            let (name, _, _) = ctx.symbol_value(insn).unwrap();
+            let symbol = name.clone();
+            ctx.emit(Inst::ElfTlsGetAddr { symbol });
+            ctx.emit(Inst::gen_move(dst, regs::rax(), types::I64));
+        }
+
         Opcode::IaddImm
         | Opcode::ImulImm
         | Opcode::UdivImm

--- a/cranelift/codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift/codegen/src/isa/x86/enc_tables.rs
@@ -1856,12 +1856,13 @@ fn convert_i64x2_imul(
     }
 }
 
+/// Expand a `tls_value` instruction.
 fn expand_tls_value(
     inst: ir::Inst,
     func: &mut ir::Function,
     _cfg: &mut ControlFlowGraph,
     isa: &dyn TargetIsa,
-) {
+) -> bool {
     use crate::settings::TlsModel;
 
     assert!(
@@ -1882,13 +1883,15 @@ fn expand_tls_value(
             TlsModel::None => panic!("tls_model flag is not set."),
             TlsModel::ElfGd => {
                 func.dfg.replace(inst).x86_elf_tls_get_addr(global_value);
+                true
             }
             TlsModel::Macho => {
                 func.dfg.replace(inst).x86_macho_tls_get_addr(global_value);
+                true
             }
             model => unimplemented!("tls_value for tls model {:?}", model),
         }
     } else {
-        unreachable!();
+        false
     }
 }

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1,7 +1,7 @@
 //! ABI definitions.
 
 use crate::binemit::StackMap;
-use crate::ir::StackSlot;
+use crate::ir::{Signature, StackSlot};
 use crate::isa::CallConv;
 use crate::machinst::*;
 use crate::settings;
@@ -22,6 +22,9 @@ pub trait ABICallee {
     /// may be provided with a temp vreg, which can only be allocated once the
     /// lowering context exists.
     fn init(&mut self, maybe_tmp: Option<Writable<Reg>>);
+
+    /// Access the (possibly legalized) signature.
+    fn signature(&self) -> &Signature;
 
     /// Accumulate outgoing arguments.  This ensures that at least SIZE bytes
     /// are allocated in the prologue to be available for use in function calls
@@ -202,6 +205,9 @@ pub trait ABICaller {
     /// Get the number of arguments expected.
     fn num_args(&self) -> usize;
 
+    /// Access the (possibly legalized) signature.
+    fn signature(&self) -> &Signature;
+
     /// Emit a copy of an argument value from a source register, prior to the call.
     fn emit_copy_regs_to_arg<C: LowerCtx<I = Self::I>>(
         &self,
@@ -209,6 +215,11 @@ pub trait ABICaller {
         idx: usize,
         from_reg: ValueRegs<Reg>,
     );
+
+    /// Specific order for copying into arguments at callsites. We must be
+    /// careful to copy into StructArgs first, because we need to be able
+    /// to invoke memcpy() before we've loaded other arg regs (see above).
+    fn get_copy_to_arg_order(&self) -> SmallVec<[usize; 8]>;
 
     /// Emit a copy a return value into a destination register, after the call returns.
     fn emit_copy_retval_to_regs<C: LowerCtx<I = Self::I>>(

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -126,9 +126,9 @@ use std::mem;
 /// A location for an argument or return value.
 #[derive(Clone, Copy, Debug)]
 pub enum ABIArg {
-    /// In a real register.
+    /// In a real register (or set of registers).
     Reg(
-        RealReg,
+        ValueRegs<RealReg>,
         ir::Type,
         ir::ArgumentExtension,
         ir::ArgumentPurpose,
@@ -181,6 +181,17 @@ pub enum StackAMode {
     /// Offset from the real stack pointer, possibly making use of a specific
     /// type for a scaled indexing operation.
     SPOffset(i64, ir::Type),
+}
+
+impl StackAMode {
+    /// Offset by an addend.
+    pub fn offset(self, addend: i64) -> Self {
+        match self {
+            StackAMode::FPOffset(off, ty) => StackAMode::FPOffset(off + addend, ty),
+            StackAMode::NominalSPOffset(off, ty) => StackAMode::NominalSPOffset(off + addend, ty),
+            StackAMode::SPOffset(off, ty) => StackAMode::SPOffset(off + addend, ty),
+        }
+    }
 }
 
 /// Trait implemented by machine-specific backend to provide information about
@@ -498,7 +509,7 @@ fn get_special_purpose_param_register(
 ) -> Option<Reg> {
     let idx = f.signature.special_param_index(purpose)?;
     match abi.args[idx] {
-        ABIArg::Reg(reg, ..) => Some(reg.to_reg()),
+        ABIArg::Reg(regs, ..) => Some(regs.only_reg().unwrap().to_reg()),
         ABIArg::Stack(..) => None,
     }
 }
@@ -709,11 +720,76 @@ fn ty_from_ty_hint_or_reg_class<M: ABIMachineSpec>(r: Reg, ty: Option<Type>) -> 
     }
 }
 
+fn gen_move_multi<M: ABIMachineSpec>(
+    dst: ValueRegs<Writable<Reg>>,
+    src: ValueRegs<Reg>,
+    ty: Type,
+) -> Vec<M::I> {
+    let mut ret = vec![];
+    let (_, tys) = M::I::rc_for_type(ty).unwrap();
+    for ((&dst, &src), &ty) in dst.regs().iter().zip(src.regs().iter()).zip(tys.iter()) {
+        ret.push(M::gen_move(dst, src, ty));
+    }
+    ret
+}
+
+fn gen_load_stack_multi<M: ABIMachineSpec>(
+    from: StackAMode,
+    dst: ValueRegs<Writable<Reg>>,
+    ty: Type,
+) -> Vec<M::I> {
+    let mut ret = vec![];
+    let (_, tys) = M::I::rc_for_type(ty).unwrap();
+    let mut offset = 0;
+    // N.B.: registers are given in the `ValueRegs` in target endian order.
+    for (&dst, &ty) in dst.regs().iter().zip(tys.iter()) {
+        ret.push(M::gen_load_stack(from.offset(offset), dst, ty));
+        offset += ty.bytes() as i64;
+    }
+    ret
+}
+
+fn gen_store_stack_multi<M: ABIMachineSpec>(
+    from: StackAMode,
+    src: ValueRegs<Reg>,
+    ty: Type,
+) -> Vec<M::I> {
+    let mut ret = vec![];
+    let (_, tys) = M::I::rc_for_type(ty).unwrap();
+    let mut offset = 0;
+    // N.B.: registers are given in the `ValueRegs` in target endian order.
+    for (&src, &ty) in src.regs().iter().zip(tys.iter()) {
+        ret.push(M::gen_store_stack(from.offset(offset), src, ty));
+        offset += ty.bytes() as i64;
+    }
+    ret
+}
+
+fn gen_store_base_offset_multi<M: ABIMachineSpec>(
+    base: Reg,
+    mut offset: i32,
+    src: ValueRegs<Reg>,
+    ty: Type,
+) -> Vec<M::I> {
+    let mut ret = vec![];
+    let (_, tys) = M::I::rc_for_type(ty).unwrap();
+    // N.B.: registers are given in the `ValueRegs` in target endian order.
+    for (&src, &ty) in src.regs().iter().zip(tys.iter()) {
+        ret.push(M::gen_store_base_offset(base, offset, src, ty));
+        offset += ty.bytes() as i32;
+    }
+    ret
+}
+
 impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
     type I = M::I;
 
-    fn temp_needed(&self) -> bool {
-        self.sig.stack_ret_arg.is_some()
+    fn temp_needed(&self) -> Option<Type> {
+        if self.sig.stack_ret_arg.is_some() {
+            Some(M::word_type())
+        } else {
+            None
+        }
     }
 
     fn init(&mut self, maybe_tmp: Option<Writable<Reg>>) {
@@ -740,8 +816,10 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
     fn liveins(&self) -> Set<RealReg> {
         let mut set: Set<RealReg> = Set::empty();
         for &arg in &self.sig.args {
-            if let ABIArg::Reg(r, ..) = arg {
-                set.insert(r);
+            if let ABIArg::Reg(regs, ..) = arg {
+                for &r in regs.regs() {
+                    set.insert(r);
+                }
             }
         }
         set
@@ -750,8 +828,10 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
     fn liveouts(&self) -> Set<RealReg> {
         let mut set: Set<RealReg> = Set::empty();
         for &ret in &self.sig.rets {
-            if let ABIArg::Reg(r, ..) = ret {
-                set.insert(r);
+            if let ABIArg::Reg(regs, ..) = ret {
+                for &r in regs.regs() {
+                    set.insert(r);
+                }
             }
         }
         set
@@ -769,12 +849,14 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         self.stackslots.len()
     }
 
-    fn gen_copy_arg_to_reg(&self, idx: usize, into_reg: Writable<Reg>) -> Self::I {
+    fn gen_copy_arg_to_regs(&self, idx: usize, into_reg: ValueRegs<Writable<Reg>>) -> Vec<Self::I> {
         match &self.sig.args[idx] {
             // Extension mode doesn't matter (we're copying out, not in; we
             // ignore high bits by convention).
-            &ABIArg::Reg(r, ty, ..) => M::gen_move(into_reg, r.to_reg(), ty),
-            &ABIArg::Stack(off, ty, ..) => M::gen_load_stack(
+            &ABIArg::Reg(regs, ty, ..) => {
+                gen_move_multi::<M>(into_reg, regs.map(|r| r.to_reg()), ty)
+            }
+            &ABIArg::Stack(off, ty, ..) => gen_load_stack_multi::<M>(
                 StackAMode::FPOffset(M::fp_to_arg_offset(self.call_conv, &self.flags) + off, ty),
                 into_reg,
                 ty,
@@ -792,19 +874,29 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         }
     }
 
-    fn gen_copy_reg_to_retval(&self, idx: usize, from_reg: Writable<Reg>) -> Vec<Self::I> {
+    fn gen_copy_regs_to_retval(
+        &self,
+        idx: usize,
+        from_regs: ValueRegs<Writable<Reg>>,
+    ) -> Vec<Self::I> {
         let mut ret = Vec::new();
         let word_bits = M::word_bits() as u8;
         match &self.sig.rets[idx] {
-            &ABIArg::Reg(r, ty, ext, ..) => {
+            &ABIArg::Reg(regs, ty, ext, ..) => {
                 let from_bits = ty_bits(ty) as u8;
-                let dest_reg = Writable::from_reg(r.to_reg());
+                let dest_regs = writable_value_regs(regs.map(|r| r.to_reg()));
                 let ext = M::get_ext_mode(self.sig.call_conv, ext);
                 match (ext, from_bits) {
                     (ArgumentExtension::Uext, n) | (ArgumentExtension::Sext, n)
                         if n < word_bits =>
                     {
                         let signed = ext == ArgumentExtension::Sext;
+                        let dest_reg = dest_regs
+                            .only_reg()
+                            .expect("extension only possible from one-reg value");
+                        let from_reg = from_regs
+                            .only_reg()
+                            .expect("extension only possible from one-reg value");
                         ret.push(M::gen_extend(
                             dest_reg,
                             from_reg.to_reg(),
@@ -813,7 +905,10 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
                             /* to_bits = */ word_bits,
                         ));
                     }
-                    _ => ret.push(M::gen_move(dest_reg, from_reg.to_reg(), ty)),
+                    _ => ret.extend(
+                        gen_move_multi::<M>(dest_regs, non_writable_value_regs(from_regs), ty)
+                            .into_iter(),
+                    ),
                 };
             }
             &ABIArg::Stack(off, mut ty, ext, ..) => {
@@ -829,6 +924,9 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
                     (ArgumentExtension::Uext, n) | (ArgumentExtension::Sext, n)
                         if n < word_bits =>
                     {
+                        let from_reg = from_regs
+                            .only_reg()
+                            .expect("extension only possible from one-reg value");
                         assert_eq!(M::word_reg_class(), from_reg.to_reg().get_class());
                         let signed = ext == ArgumentExtension::Sext;
                         ret.push(M::gen_extend(
@@ -843,12 +941,15 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
                     }
                     _ => {}
                 };
-                ret.push(M::gen_store_base_offset(
-                    self.ret_area_ptr.unwrap().to_reg(),
-                    off,
-                    from_reg.to_reg(),
-                    ty,
-                ));
+                ret.extend(
+                    gen_store_base_offset_multi::<M>(
+                        self.ret_area_ptr.unwrap().to_reg(),
+                        off,
+                        non_writable_value_regs(from_regs),
+                        ty,
+                    )
+                    .into_iter(),
+                );
             }
         }
         ret
@@ -856,7 +957,8 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
 
     fn gen_retval_area_setup(&self) -> Option<Self::I> {
         if let Some(i) = self.sig.stack_ret_arg {
-            let inst = self.gen_copy_arg_to_reg(i, self.ret_area_ptr.unwrap());
+            let insts = self.gen_copy_arg_to_regs(i, ValueRegs::one(self.ret_area_ptr.unwrap()));
+            let inst = insts.into_iter().next().unwrap();
             trace!(
                 "gen_retval_area_setup: inst {:?}; ptr reg is {:?}",
                 inst,
@@ -891,24 +993,30 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         slot: StackSlot,
         offset: u32,
         ty: Type,
-        into_reg: Writable<Reg>,
-    ) -> Self::I {
+        into_regs: ValueRegs<Writable<Reg>>,
+    ) -> Vec<Self::I> {
         // Offset from beginning of stackslot area, which is at nominal SP (see
         // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
         let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
         let sp_off: i64 = stack_off + (offset as i64);
         trace!("load_stackslot: slot {} -> sp_off {}", slot, sp_off);
-        M::gen_load_stack(StackAMode::NominalSPOffset(sp_off, ty), into_reg, ty)
+        gen_load_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), into_regs, ty)
     }
 
     /// Store to a stackslot.
-    fn store_stackslot(&self, slot: StackSlot, offset: u32, ty: Type, from_reg: Reg) -> Self::I {
+    fn store_stackslot(
+        &self,
+        slot: StackSlot,
+        offset: u32,
+        ty: Type,
+        from_regs: ValueRegs<Reg>,
+    ) -> Vec<Self::I> {
         // Offset from beginning of stackslot area, which is at nominal SP (see
         // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
         let stack_off = self.stackslots[slot.as_u32() as usize] as i64;
         let sp_off: i64 = stack_off + (offset as i64);
         trace!("store_stackslot: slot {} -> sp_off {}", slot, sp_off);
-        M::gen_store_stack(StackAMode::NominalSPOffset(sp_off, ty), from_reg, ty)
+        gen_store_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), from_regs, ty)
     }
 
     /// Produce an instruction that computes a stackslot address.
@@ -921,23 +1029,33 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
     }
 
     /// Load from a spillslot.
-    fn load_spillslot(&self, slot: SpillSlot, ty: Type, into_reg: Writable<Reg>) -> Self::I {
+    fn load_spillslot(
+        &self,
+        slot: SpillSlot,
+        ty: Type,
+        into_regs: ValueRegs<Writable<Reg>>,
+    ) -> Vec<Self::I> {
         // Offset from beginning of spillslot area, which is at nominal SP + stackslots_size.
         let islot = slot.get() as i64;
         let spill_off = islot * M::word_bytes() as i64;
         let sp_off = self.stackslots_size as i64 + spill_off;
         trace!("load_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
-        M::gen_load_stack(StackAMode::NominalSPOffset(sp_off, ty), into_reg, ty)
+        gen_load_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), into_regs, ty)
     }
 
     /// Store to a spillslot.
-    fn store_spillslot(&self, slot: SpillSlot, ty: Type, from_reg: Reg) -> Self::I {
+    fn store_spillslot(
+        &self,
+        slot: SpillSlot,
+        ty: Type,
+        from_regs: ValueRegs<Reg>,
+    ) -> Vec<Self::I> {
         // Offset from beginning of spillslot area, which is at nominal SP + stackslots_size.
         let islot = slot.get() as i64;
         let spill_off = islot * M::word_bytes() as i64;
         let sp_off = self.stackslots_size as i64 + spill_off;
         trace!("store_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
-        M::gen_store_stack(StackAMode::NominalSPOffset(sp_off, ty), from_reg, ty)
+        gen_store_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), from_regs, ty)
     }
 
     fn spillslots_to_stack_map(
@@ -1079,7 +1197,10 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
 
     fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, ty: Option<Type>) -> Self::I {
         let ty = ty_from_ty_hint_or_reg_class::<M>(from_reg.to_reg(), ty);
-        self.store_spillslot(to_slot, ty, from_reg.to_reg())
+        self.store_spillslot(to_slot, ty, ValueRegs::one(from_reg.to_reg()))
+            .into_iter()
+            .next()
+            .unwrap()
     }
 
     fn gen_reload(
@@ -1089,7 +1210,14 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         ty: Option<Type>,
     ) -> Self::I {
         let ty = ty_from_ty_hint_or_reg_class::<M>(to_reg.to_reg().to_reg(), ty);
-        self.load_spillslot(from_slot, ty, to_reg.map(|r| r.to_reg()))
+        self.load_spillslot(
+            from_slot,
+            ty,
+            writable_value_regs(ValueRegs::one(to_reg.to_reg().to_reg())),
+        )
+        .into_iter()
+        .next()
+        .unwrap()
     }
 
     fn unwind_info_kind(&self) -> UnwindInfoKind {
@@ -1110,7 +1238,7 @@ fn abisig_to_uses_and_defs<M: ABIMachineSpec>(sig: &ABISig) -> (Vec<Reg>, Vec<Wr
     let mut uses = Vec::new();
     for arg in &sig.args {
         match arg {
-            &ABIArg::Reg(reg, ..) => uses.push(reg.to_reg()),
+            &ABIArg::Reg(regs, ..) => uses.extend(regs.regs().iter().map(|r| r.to_reg())),
             _ => {}
         }
     }
@@ -1119,7 +1247,9 @@ fn abisig_to_uses_and_defs<M: ABIMachineSpec>(sig: &ABISig) -> (Vec<Reg>, Vec<Wr
     let mut defs = M::get_regs_clobbered_by_call(sig.call_conv);
     for ret in &sig.rets {
         match ret {
-            &ABIArg::Reg(reg, ..) => defs.push(Writable::from_reg(reg.to_reg())),
+            &ABIArg::Reg(regs, ..) => {
+                defs.extend(regs.regs().iter().map(|r| Writable::from_reg(r.to_reg())))
+            }
             _ => {}
         }
     }
@@ -1238,18 +1368,19 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
         adjust_stack_and_nominal_sp::<M, C>(ctx, off as i32, /* is_sub = */ false)
     }
 
-    fn emit_copy_reg_to_arg<C: LowerCtx<I = Self::I>>(
+    fn emit_copy_regs_to_arg<C: LowerCtx<I = Self::I>>(
         &self,
         ctx: &mut C,
         idx: usize,
-        from_reg: Reg,
+        from_regs: ValueRegs<Reg>,
     ) {
         let word_rc = M::word_reg_class();
         let word_bits = M::word_bits() as usize;
         match &self.sig.args[idx] {
-            &ABIArg::Reg(reg, ty, ext, _) => {
+            &ABIArg::Reg(regs, ty, ext, _) => {
                 let ext = M::get_ext_mode(self.sig.call_conv, ext);
                 if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
+                    let reg = regs.only_reg().unwrap();
                     assert_eq!(word_rc, reg.get_class());
                     let signed = match ext {
                         ir::ArgumentExtension::Uext => false,
@@ -1258,18 +1389,27 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
                     };
                     ctx.emit(M::gen_extend(
                         Writable::from_reg(reg.to_reg()),
-                        from_reg,
+                        from_regs.only_reg().unwrap(),
                         signed,
                         ty_bits(ty) as u8,
                         word_bits as u8,
                     ));
                 } else {
-                    ctx.emit(M::gen_move(Writable::from_reg(reg.to_reg()), from_reg, ty));
+                    for insn in gen_move_multi::<M>(
+                        writable_value_regs(regs.map(|r| r.to_reg())),
+                        from_regs,
+                        ty,
+                    ) {
+                        ctx.emit(insn);
+                    }
                 }
             }
             &ABIArg::Stack(off, mut ty, ext, _) => {
                 let ext = M::get_ext_mode(self.sig.call_conv, ext);
                 if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
+                    let from_reg = from_regs
+                        .only_reg()
+                        .expect("only one reg for sub-word value width");
                     assert_eq!(word_rc, from_reg.get_class());
                     let signed = match ext {
                         ir::ArgumentExtension::Uext => false,
@@ -1289,32 +1429,37 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
                     // Store the extended version.
                     ty = M::word_type();
                 }
-                ctx.emit(M::gen_store_stack(
-                    StackAMode::SPOffset(off, ty),
-                    from_reg,
-                    ty,
-                ));
+                for insn in gen_store_stack_multi::<M>(StackAMode::SPOffset(off, ty), from_regs, ty)
+                {
+                    ctx.emit(insn);
+                }
             }
         }
     }
 
-    fn emit_copy_retval_to_reg<C: LowerCtx<I = Self::I>>(
+    fn emit_copy_retval_to_regs<C: LowerCtx<I = Self::I>>(
         &self,
         ctx: &mut C,
         idx: usize,
-        into_reg: Writable<Reg>,
+        into_regs: ValueRegs<Writable<Reg>>,
     ) {
         match &self.sig.rets[idx] {
             // Extension mode doesn't matter because we're copying out, not in,
             // and we ignore high bits in our own registers by convention.
-            &ABIArg::Reg(reg, ty, _, _) => ctx.emit(M::gen_move(into_reg, reg.to_reg(), ty)),
+            &ABIArg::Reg(regs, ty, _, _) => {
+                for insn in gen_move_multi::<M>(into_regs, regs.map(|r| r.to_reg()), ty) {
+                    ctx.emit(insn);
+                }
+            }
             &ABIArg::Stack(off, ty, _, _) => {
                 let ret_area_base = self.sig.stack_arg_space;
-                ctx.emit(M::gen_load_stack(
+                for insn in gen_load_stack_multi::<M>(
                     StackAMode::SPOffset(off + ret_area_base, ty),
-                    into_reg,
+                    into_regs,
                     ty,
-                ));
+                ) {
+                    ctx.emit(insn);
+                }
             }
         }
     }
@@ -1324,19 +1469,18 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
             mem::replace(&mut self.uses, Default::default()),
             mem::replace(&mut self.defs, Default::default()),
         );
-        let word_rc = M::word_reg_class();
         let word_type = M::word_type();
         if let Some(i) = self.sig.stack_ret_arg {
-            let rd = ctx.alloc_tmp(word_rc, word_type);
+            let rd = ctx.alloc_tmp(word_type).only_reg().unwrap();
             let ret_area_base = self.sig.stack_arg_space;
             ctx.emit(M::gen_get_stack_addr(
                 StackAMode::SPOffset(ret_area_base, I8),
                 rd,
                 I8,
             ));
-            self.emit_copy_reg_to_arg(ctx, i, rd.to_reg());
+            self.emit_copy_regs_to_arg(ctx, i, ValueRegs::one(rd.to_reg()));
         }
-        let tmp = ctx.alloc_tmp(word_rc, word_type);
+        let tmp = ctx.alloc_tmp(word_type).only_reg().unwrap();
         for (is_safepoint, inst) in M::gen_call(
             &self.dest,
             uses,

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -111,7 +111,7 @@
 use super::abi::*;
 use crate::binemit::StackMap;
 use crate::ir::types::*;
-use crate::ir::{ArgumentExtension, StackSlot};
+use crate::ir::{ArgumentExtension, ArgumentPurpose, StackSlot};
 use crate::machinst::*;
 use crate::settings;
 use crate::CodegenResult;
@@ -127,22 +127,58 @@ use std::mem;
 #[derive(Clone, Copy, Debug)]
 pub enum ABIArg {
     /// In a real register (or set of registers).
-    Reg(
-        ValueRegs<RealReg>,
-        ir::Type,
-        ir::ArgumentExtension,
-        ir::ArgumentPurpose,
-    ),
+    Reg {
+        /// Register(s) that hold this arg.
+        regs: ValueRegs<RealReg>,
+        /// Value type of this arg.
+        ty: ir::Type,
+        /// Should this arg be zero- or sign-extended?
+        extension: ir::ArgumentExtension,
+        /// Purpose of this arg.
+        purpose: ir::ArgumentPurpose,
+    },
     /// Arguments only: on stack, at given offset from SP at entry.
-    Stack(i64, ir::Type, ir::ArgumentExtension, ir::ArgumentPurpose),
+    Stack {
+        /// Offset of this arg relative to the base of stack args.
+        offset: i64,
+        /// Value type of this arg.
+        ty: ir::Type,
+        /// Should this arg be zero- or sign-extended?
+        extension: ir::ArgumentExtension,
+        /// Purpose of this arg.
+        purpose: ir::ArgumentPurpose,
+    },
+    /// Structure argument. We reserve stack space for it, but the CLIF-level
+    /// semantics are a little weird: the value passed to the call instruction,
+    /// and received in the corresponding block param, is a *pointer*. On the
+    /// caller side, we memcpy the data from the passed-in pointer to the stack
+    /// area; on the callee side, we compute a pointer to this stack area and
+    /// provide that as the argument's value.
+    StructArg {
+        /// Offset of this arg relative to base of stack args.
+        offset: i64,
+        /// Size of this arg on the stack.
+        size: u64,
+        /// Purpose of this arg.
+        purpose: ir::ArgumentPurpose,
+    },
 }
 
 impl ABIArg {
     /// Get the purpose of this arg.
     fn get_purpose(self) -> ir::ArgumentPurpose {
         match self {
-            ABIArg::Reg(_, _, _, purpose) => purpose,
-            ABIArg::Stack(_, _, _, purpose) => purpose,
+            ABIArg::Reg { purpose, .. } => purpose,
+            ABIArg::Stack { purpose, .. } => purpose,
+            ABIArg::StructArg { purpose, .. } => purpose,
+        }
+    }
+
+    /// Is this a StructArg?
+    fn is_struct_arg(self) -> bool {
+        match self {
+            ABIArg::StructArg { .. } => true,
+            _ => false,
         }
     }
 }
@@ -370,6 +406,16 @@ pub trait ABIMachineSpec {
         callee_conv: isa::CallConv,
     ) -> SmallVec<[(InstIsSafepoint, Self::I); 2]>;
 
+    /// Generate a memcpy invocation. Used to set up struct args. May clobber
+    /// caller-save registers; we only memcpy before we start to set up args for
+    /// a call.
+    fn gen_memcpy(
+        call_conv: isa::CallConv,
+        dst: Reg,
+        src: Reg,
+        size: usize,
+    ) -> SmallVec<[Self::I; 8]>;
+
     /// Get the number of spillslots required for the given register-class and
     /// type.
     fn get_number_of_spillslots_for_value(rc: RegClass, ty: Type) -> u32;
@@ -454,6 +500,8 @@ impl ABISig {
 
 /// ABI object for a function body.
 pub struct ABICalleeImpl<M: ABIMachineSpec> {
+    /// CLIF-level signature, possibly normalized.
+    ir_sig: ir::Signature,
     /// Signature: arg and retval regs.
     sig: ABISig,
     /// Offsets to each stackslot.
@@ -509,8 +557,8 @@ fn get_special_purpose_param_register(
 ) -> Option<Reg> {
     let idx = f.signature.special_param_index(purpose)?;
     match abi.args[idx] {
-        ABIArg::Reg(regs, ..) => Some(regs.only_reg().unwrap().to_reg()),
-        ABIArg::Stack(..) => None,
+        ABIArg::Reg { regs, .. } => Some(regs.only_reg().unwrap().to_reg()),
+        _ => None,
     }
 }
 
@@ -519,7 +567,8 @@ impl<M: ABIMachineSpec> ABICalleeImpl<M> {
     pub fn new(f: &ir::Function, flags: settings::Flags) -> CodegenResult<Self> {
         debug!("ABI: func signature {:?}", f.signature);
 
-        let sig = ABISig::from_func_sig::<M>(&f.signature)?;
+        let ir_sig = legalize_signature(&f.signature);
+        let sig = ABISig::from_func_sig::<M>(&ir_sig)?;
 
         let call_conv = f.signature.call_conv;
         // Only these calling conventions are supported.
@@ -566,6 +615,7 @@ impl<M: ABIMachineSpec> ABICalleeImpl<M> {
         };
 
         Ok(Self {
+            ir_sig,
             sig,
             stackslots,
             stackslots_size: stack_offset,
@@ -781,8 +831,26 @@ fn gen_store_base_offset_multi<M: ABIMachineSpec>(
     ret
 }
 
+fn legalize_signature(sig: &ir::Signature) -> ir::Signature {
+    let params_structret = sig
+        .params
+        .iter()
+        .find(|p| p.purpose == ArgumentPurpose::StructReturn);
+    let rets_have_structret =
+        sig.returns.len() > 0 && sig.returns[0].purpose == ArgumentPurpose::StructReturn;
+    let mut sig = sig.clone();
+    if params_structret.is_some() && !rets_have_structret {
+        sig.returns.insert(0, params_structret.unwrap().clone());
+    }
+    sig
+}
+
 impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
     type I = M::I;
+
+    fn signature(&self) -> &ir::Signature {
+        &self.ir_sig
+    }
 
     fn temp_needed(&self) -> Option<Type> {
         if self.sig.stack_ret_arg.is_some() {
@@ -816,7 +884,7 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
     fn liveins(&self) -> Set<RealReg> {
         let mut set: Set<RealReg> = Set::empty();
         for &arg in &self.sig.args {
-            if let ABIArg::Reg(regs, ..) = arg {
+            if let ABIArg::Reg { regs, .. } = arg {
                 for &r in regs.regs() {
                     set.insert(r);
                 }
@@ -828,7 +896,7 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
     fn liveouts(&self) -> Set<RealReg> {
         let mut set: Set<RealReg> = Set::empty();
         for &ret in &self.sig.rets {
-            if let ABIArg::Reg(regs, ..) = ret {
+            if let ABIArg::Reg { regs, .. } = ret {
                 for &r in regs.regs() {
                     set.insert(r);
                 }
@@ -853,14 +921,25 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         match &self.sig.args[idx] {
             // Extension mode doesn't matter (we're copying out, not in; we
             // ignore high bits by convention).
-            &ABIArg::Reg(regs, ty, ..) => {
+            &ABIArg::Reg { regs, ty, .. } => {
                 gen_move_multi::<M>(into_reg, regs.map(|r| r.to_reg()), ty)
             }
-            &ABIArg::Stack(off, ty, ..) => gen_load_stack_multi::<M>(
-                StackAMode::FPOffset(M::fp_to_arg_offset(self.call_conv, &self.flags) + off, ty),
+            &ABIArg::Stack { offset, ty, .. } => gen_load_stack_multi::<M>(
+                StackAMode::FPOffset(
+                    M::fp_to_arg_offset(self.call_conv, &self.flags) + offset,
+                    ty,
+                ),
                 into_reg,
                 ty,
             ),
+            &ABIArg::StructArg { offset, .. } => vec![M::gen_get_stack_addr(
+                StackAMode::FPOffset(
+                    M::fp_to_arg_offset(self.call_conv, &self.flags) + offset,
+                    I8,
+                ),
+                into_reg.only_reg().unwrap(),
+                I8,
+            )],
         }
     }
 
@@ -882,10 +961,15 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         let mut ret = Vec::new();
         let word_bits = M::word_bits() as u8;
         match &self.sig.rets[idx] {
-            &ABIArg::Reg(regs, ty, ext, ..) => {
+            &ABIArg::Reg {
+                regs,
+                ty,
+                extension,
+                ..
+            } => {
                 let from_bits = ty_bits(ty) as u8;
                 let dest_regs = writable_value_regs(regs.map(|r| r.to_reg()));
-                let ext = M::get_ext_mode(self.sig.call_conv, ext);
+                let ext = M::get_ext_mode(self.sig.call_conv, extension);
                 match (ext, from_bits) {
                     (ArgumentExtension::Uext, n) | (ArgumentExtension::Sext, n)
                         if n < word_bits =>
@@ -911,14 +995,20 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
                     ),
                 };
             }
-            &ABIArg::Stack(off, mut ty, ext, ..) => {
+            &ABIArg::Stack {
+                offset,
+                ty,
+                extension,
+                ..
+            } => {
+                let mut ty = ty;
                 let from_bits = ty_bits(ty) as u8;
                 // A machine ABI implementation should ensure that stack frames
                 // have "reasonable" size. All current ABIs for machinst
                 // backends (aarch64 and x64) enforce a 128MB limit.
-                let off = i32::try_from(off)
+                let off = i32::try_from(offset)
                     .expect("Argument stack offset greater than 2GB; should hit impl limit first");
-                let ext = M::get_ext_mode(self.sig.call_conv, ext);
+                let ext = M::get_ext_mode(self.sig.call_conv, extension);
                 // Trash the from_reg; it should be its last use.
                 match (ext, from_bits) {
                     (ArgumentExtension::Uext, n) | (ArgumentExtension::Sext, n)
@@ -951,6 +1041,7 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
                     .into_iter(),
                 );
             }
+            &ABIArg::StructArg { .. } => panic!("Unexpected StructArg location for return value"),
         }
         ret
     }
@@ -1238,7 +1329,7 @@ fn abisig_to_uses_and_defs<M: ABIMachineSpec>(sig: &ABISig) -> (Vec<Reg>, Vec<Wr
     let mut uses = Vec::new();
     for arg in &sig.args {
         match arg {
-            &ABIArg::Reg(regs, ..) => uses.extend(regs.regs().iter().map(|r| r.to_reg())),
+            &ABIArg::Reg { regs, .. } => uses.extend(regs.regs().iter().map(|r| r.to_reg())),
             _ => {}
         }
     }
@@ -1247,7 +1338,7 @@ fn abisig_to_uses_and_defs<M: ABIMachineSpec>(sig: &ABISig) -> (Vec<Reg>, Vec<Wr
     let mut defs = M::get_regs_clobbered_by_call(sig.call_conv);
     for ret in &sig.rets {
         match ret {
-            &ABIArg::Reg(regs, ..) => {
+            &ABIArg::Reg { regs, .. } => {
                 defs.extend(regs.regs().iter().map(|r| Writable::from_reg(r.to_reg())))
             }
             _ => {}
@@ -1259,6 +1350,8 @@ fn abisig_to_uses_and_defs<M: ABIMachineSpec>(sig: &ABISig) -> (Vec<Reg>, Vec<Wr
 
 /// ABI object for a callsite.
 pub struct ABICallerImpl<M: ABIMachineSpec> {
+    /// CLIF-level signature, possibly normalized.
+    ir_sig: ir::Signature,
     /// The called function's signature.
     sig: ABISig,
     /// All uses for the callsite, i.e., function args.
@@ -1271,6 +1364,8 @@ pub struct ABICallerImpl<M: ABIMachineSpec> {
     opcode: ir::Opcode,
     /// Caller's calling convention.
     caller_conv: isa::CallConv,
+    /// The settings controlling compilation.
+    flags: settings::Flags,
 
     _mach: PhantomData<M>,
 }
@@ -1291,16 +1386,20 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
         extname: &ir::ExternalName,
         dist: RelocDistance,
         caller_conv: isa::CallConv,
+        flags: &settings::Flags,
     ) -> CodegenResult<ABICallerImpl<M>> {
-        let sig = ABISig::from_func_sig::<M>(sig)?;
+        let ir_sig = legalize_signature(sig);
+        let sig = ABISig::from_func_sig::<M>(&ir_sig)?;
         let (uses, defs) = abisig_to_uses_and_defs::<M>(&sig);
         Ok(ABICallerImpl {
+            ir_sig,
             sig,
             uses,
             defs,
             dest: CallDest::ExtName(extname.clone(), dist),
             opcode: ir::Opcode::Call,
             caller_conv,
+            flags: flags.clone(),
             _mach: PhantomData,
         })
     }
@@ -1312,16 +1411,20 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
         ptr: Reg,
         opcode: ir::Opcode,
         caller_conv: isa::CallConv,
+        flags: &settings::Flags,
     ) -> CodegenResult<ABICallerImpl<M>> {
-        let sig = ABISig::from_func_sig::<M>(sig)?;
+        let ir_sig = legalize_signature(sig);
+        let sig = ABISig::from_func_sig::<M>(&ir_sig)?;
         let (uses, defs) = abisig_to_uses_and_defs::<M>(&sig);
         Ok(ABICallerImpl {
+            ir_sig,
             sig,
             uses,
             defs,
             dest: CallDest::Reg(ptr),
             opcode,
             caller_conv,
+            flags: flags.clone(),
             _mach: PhantomData,
         })
     }
@@ -1344,6 +1447,10 @@ fn adjust_stack_and_nominal_sp<M: ABIMachineSpec, C: LowerCtx<I = M::I>>(
 
 impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
     type I = M::I;
+
+    fn signature(&self) -> &ir::Signature {
+        &self.ir_sig
+    }
 
     fn num_args(&self) -> usize {
         if self.sig.stack_ret_arg.is_some() {
@@ -1377,8 +1484,13 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
         let word_rc = M::word_reg_class();
         let word_bits = M::word_bits() as usize;
         match &self.sig.args[idx] {
-            &ABIArg::Reg(regs, ty, ext, _) => {
-                let ext = M::get_ext_mode(self.sig.call_conv, ext);
+            &ABIArg::Reg {
+                regs,
+                ty,
+                extension,
+                ..
+            } => {
+                let ext = M::get_ext_mode(self.sig.call_conv, extension);
                 if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
                     let reg = regs.only_reg().unwrap();
                     assert_eq!(word_rc, reg.get_class());
@@ -1404,8 +1516,14 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
                     }
                 }
             }
-            &ABIArg::Stack(off, mut ty, ext, _) => {
-                let ext = M::get_ext_mode(self.sig.call_conv, ext);
+            &ABIArg::Stack {
+                offset,
+                ty,
+                extension,
+                ..
+            } => {
+                let mut ty = ty;
+                let ext = M::get_ext_mode(self.sig.call_conv, extension);
                 if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
                     let from_reg = from_regs
                         .only_reg()
@@ -1429,12 +1547,53 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
                     // Store the extended version.
                     ty = M::word_type();
                 }
-                for insn in gen_store_stack_multi::<M>(StackAMode::SPOffset(off, ty), from_regs, ty)
+                for insn in
+                    gen_store_stack_multi::<M>(StackAMode::SPOffset(offset, ty), from_regs, ty)
+                {
+                    ctx.emit(insn);
+                }
+            }
+            &ABIArg::StructArg { offset, size, .. } => {
+                let src_ptr = from_regs.only_reg().unwrap();
+                let dst_ptr = ctx.alloc_tmp(M::word_type()).only_reg().unwrap();
+                ctx.emit(M::gen_get_stack_addr(
+                    StackAMode::SPOffset(offset, I8),
+                    dst_ptr,
+                    I8,
+                ));
+                // Emit a memcpy from `src_ptr` to `dst_ptr` of `size` bytes.
+                // N.B.: because we process StructArg params *first*, this is
+                // safe w.r.t. clobbers: we have not yet filled in any other
+                // arg regs.
+                //
+                // TODO: we assume that the signature of the callee is also the
+                // signature of the memcpy() function. Can we do better?
+                for insn in
+                    M::gen_memcpy(self.sig.call_conv, dst_ptr.to_reg(), src_ptr, size as usize)
+                        .into_iter()
                 {
                     ctx.emit(insn);
                 }
             }
         }
+    }
+
+    fn get_copy_to_arg_order(&self) -> SmallVec<[usize; 8]> {
+        let mut ret = SmallVec::new();
+        for (i, arg) in self.sig.args.iter().enumerate() {
+            // Struct args.
+            if arg.is_struct_arg() {
+                ret.push(i);
+            }
+        }
+        for (i, arg) in self.sig.args.iter().enumerate() {
+            // Non-struct args. Skip an appended return-area arg for multivalue
+            // returns, if any.
+            if !arg.is_struct_arg() && i < self.ir_sig.params.len() {
+                ret.push(i);
+            }
+        }
+        ret
     }
 
     fn emit_copy_retval_to_regs<C: LowerCtx<I = Self::I>>(
@@ -1446,21 +1605,22 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
         match &self.sig.rets[idx] {
             // Extension mode doesn't matter because we're copying out, not in,
             // and we ignore high bits in our own registers by convention.
-            &ABIArg::Reg(regs, ty, _, _) => {
+            &ABIArg::Reg { regs, ty, .. } => {
                 for insn in gen_move_multi::<M>(into_regs, regs.map(|r| r.to_reg()), ty) {
                     ctx.emit(insn);
                 }
             }
-            &ABIArg::Stack(off, ty, _, _) => {
+            &ABIArg::Stack { offset, ty, .. } => {
                 let ret_area_base = self.sig.stack_arg_space;
                 for insn in gen_load_stack_multi::<M>(
-                    StackAMode::SPOffset(off + ret_area_base, ty),
+                    StackAMode::SPOffset(offset + ret_area_base, ty),
                     into_regs,
                     ty,
                 ) {
                     ctx.emit(insn);
                 }
             }
+            &ABIArg::StructArg { .. } => panic!("Unexpected StructArg location for return value"),
         }
     }
 

--- a/cranelift/codegen/src/machinst/helpers.rs
+++ b/cranelift/codegen/src/machinst/helpers.rs
@@ -1,6 +1,6 @@
 //! Miscellaneous helpers for machine backends.
 
-use super::{InsnOutput, LowerCtx, VCodeInst};
+use super::{InsnOutput, LowerCtx, VCodeInst, ValueRegs};
 use crate::ir::Type;
 use regalloc::{Reg, Writable};
 
@@ -23,6 +23,6 @@ pub(crate) fn ty_has_float_or_vec_representation(ty: Type) -> bool {
 pub(crate) fn get_output_reg<I: VCodeInst, C: LowerCtx<I = I>>(
     ctx: &mut C,
     spec: InsnOutput,
-) -> Writable<Reg> {
+) -> ValueRegs<Writable<Reg>> {
     ctx.get_output(spec.insn, spec.output)
 }

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -5,29 +5,27 @@
 // TODO: separate the IR-query core of `LowerCtx` from the lowering logic built
 // on top of it, e.g. the side-effect/coloring analysis and the scan support.
 
+use crate::data_value::DataValue;
 use crate::entity::SecondaryMap;
 use crate::fx::{FxHashMap, FxHashSet};
 use crate::inst_predicates::{has_lowering_side_effect, is_constant_64bit};
 use crate::ir::instructions::BranchInfo;
-use crate::ir::types::I64;
 use crate::ir::{
     ArgumentPurpose, Block, Constant, ConstantData, ExternalName, Function, GlobalValueData, Inst,
     InstructionData, MemFlags, Opcode, Signature, SourceLoc, Type, Value, ValueDef,
 };
 use crate::machinst::{
-    ABICallee, BlockIndex, BlockLoweringOrder, LoweredBlock, MachLabel, VCode, VCodeBuilder,
-    VCodeConstant, VCodeConstantData, VCodeConstants, VCodeInst,
+    writable_value_regs, ABICallee, BlockIndex, BlockLoweringOrder, LoweredBlock, MachLabel, VCode,
+    VCodeBuilder, VCodeConstant, VCodeConstantData, VCodeConstants, VCodeInst, ValueRegs,
 };
 use crate::CodegenResult;
-
-use regalloc::{Reg, RegClass, StackmapRequestInfo, VirtualReg, Writable};
-
-use crate::data_value::DataValue;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::convert::TryInto;
 use log::debug;
+use regalloc::{Reg, StackmapRequestInfo, Writable};
 use smallvec::SmallVec;
+use std::fmt::Debug;
 
 /// An "instruction color" partitions CLIF instructions by side-effecting ops.
 /// All instructions with the same "color" are guaranteed not to be separated by
@@ -71,7 +69,7 @@ pub trait LowerCtx {
     /// instruction should lower into a sequence that fills this register. (Why
     /// not allow the backend to specify its own result register for the return?
     /// Because there may be multiple return points.)
-    fn retval(&self, idx: usize) -> Writable<Reg>;
+    fn retval(&self, idx: usize) -> ValueRegs<Writable<Reg>>;
     /// Returns the vreg containing the VmContext parameter, if there's one.
     fn get_vm_context(&self) -> Option<Reg>;
 
@@ -118,7 +116,7 @@ pub trait LowerCtx {
     ///
     /// The instruction input may be available in either of these forms.  It may
     /// be available in neither form, if the conditions are not met; if so, use
-    /// `put_input_in_reg()` instead to get it in a register.
+    /// `put_input_in_regs()` instead to get it in a register.
     ///
     /// If the backend merges the effect of a side-effecting instruction, it
     /// must call `sink_inst()`. When this is called, it indicates that the
@@ -127,7 +125,7 @@ pub trait LowerCtx {
     /// not be codegen'd (it has been integrated into the current instruction).
     fn get_input_as_source_or_const(&self, ir_inst: Inst, idx: usize) -> NonRegInput;
     /// Put the `idx`th input into a register and return the assigned register.
-    fn put_input_in_reg(&mut self, ir_inst: Inst, idx: usize) -> Reg;
+    fn put_input_in_regs(&mut self, ir_inst: Inst, idx: usize) -> ValueRegs<Reg>;
     /// Get the `idx`th output register of the given IR instruction. When
     /// `backend.lower_inst_to_regs(ctx, inst)` is called, it is expected that
     /// the backend will write results to these output register(s).  This
@@ -135,20 +133,20 @@ pub trait LowerCtx {
     /// any of the inputs, and can be freely used as a scratch register within
     /// the lowered instruction sequence, as long as its final value is the
     /// result of the computation.
-    fn get_output(&self, ir_inst: Inst, idx: usize) -> Writable<Reg>;
+    fn get_output(&self, ir_inst: Inst, idx: usize) -> ValueRegs<Writable<Reg>>;
 
     // Codegen primitives: allocate temps, emit instructions, set result registers,
     // ask for an input to be gen'd into a register.
 
     /// Get a new temp.
-    fn alloc_tmp(&mut self, rc: RegClass, ty: Type) -> Writable<Reg>;
+    fn alloc_tmp(&mut self, ty: Type) -> ValueRegs<Writable<Reg>>;
     /// Emit a machine instruction.
     fn emit(&mut self, mach_inst: Self::I);
     /// Emit a machine instruction that is a safepoint.
     fn emit_safepoint(&mut self, mach_inst: Self::I);
     /// Indicate that the side-effect of an instruction has been sunk to the
     /// current scan location. This should only be done with the instruction's
-    /// original results are not used (i.e., `put_input_in_reg` is not invoked
+    /// original results are not used (i.e., `put_input_in_regs` is not invoked
     /// for the input produced by the sunk instruction), otherwise the
     /// side-effect will occur twice.
     fn sink_inst(&mut self, ir_inst: Inst);
@@ -234,10 +232,10 @@ pub struct Lower<'func, I: VCodeInst> {
     vcode: VCodeBuilder<I>,
 
     /// Mapping from `Value` (SSA value in IR) to virtual register.
-    value_regs: SecondaryMap<Value, Reg>,
+    value_regs: SecondaryMap<Value, ValueRegs<Reg>>,
 
     /// Return-value vregs.
-    retval_regs: Vec<Reg>,
+    retval_regs: Vec<ValueRegs<Reg>>,
 
     /// Instruction colors at block exits. From this map, we can recover all
     /// instruction colors by scanning backward from the block end and
@@ -306,20 +304,30 @@ pub enum RelocDistance {
     Far,
 }
 
-fn alloc_vreg(
-    value_regs: &mut SecondaryMap<Value, Reg>,
-    regclass: RegClass,
-    value: Value,
+fn alloc_vregs<I: VCodeInst>(
+    ty: Type,
     next_vreg: &mut u32,
-) -> VirtualReg {
-    if value_regs[value].is_invalid() {
-        // default value in map.
-        let v = *next_vreg;
-        *next_vreg += 1;
-        value_regs[value] = Reg::new_virtual(regclass, v);
-        debug!("value {} gets vreg {:?}", value, v);
+    vcode: &mut VCodeBuilder<I>,
+) -> CodegenResult<ValueRegs<Reg>> {
+    let v = *next_vreg;
+    let (regclasses, tys) = I::rc_for_type(ty)?;
+    *next_vreg += regclasses.len() as u32;
+    let regs = match regclasses {
+        &[rc0] => ValueRegs::one(Reg::new_virtual(rc0, v)),
+        &[rc0, rc1] => ValueRegs::two(Reg::new_virtual(rc0, v), Reg::new_virtual(rc1, v + 1)),
+        #[cfg(feature = "arm32")]
+        &[rc0, rc1, rc2, rc3] => ValueRegs::four(
+            Reg::new_virtual(rc0, v),
+            Reg::new_virtual(rc1, v + 1),
+            Reg::new_virtual(rc2, v + 2),
+            Reg::new_virtual(rc3, v + 3),
+        ),
+        _ => panic!("Value must reside in 1, 2 or 4 registers"),
+    };
+    for (&reg_ty, &reg) in tys.iter().zip(regs.regs().iter()) {
+        vcode.set_vreg_type(reg.to_virtual_reg(), reg_ty);
     }
-    value_regs[value].as_virtual_reg().unwrap()
+    Ok(regs)
 }
 
 enum GenerateReturn {
@@ -340,26 +348,29 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
 
         let mut next_vreg: u32 = 0;
 
-        let mut value_regs = SecondaryMap::with_default(Reg::invalid());
+        let mut value_regs = SecondaryMap::with_default(ValueRegs::invalid());
 
         // Assign a vreg to each block param and each inst result.
         for bb in f.layout.blocks() {
             for &param in f.dfg.block_params(bb) {
                 let ty = f.dfg.value_type(param);
-                let vreg = alloc_vreg(&mut value_regs, I::rc_for_type(ty)?, param, &mut next_vreg);
-                vcode.set_vreg_type(vreg, ty);
-                debug!("bb {} param {}: vreg {:?}", bb, param, vreg);
+                if value_regs[param].is_invalid() {
+                    let regs = alloc_vregs(ty, &mut next_vreg, &mut vcode)?;
+                    value_regs[param] = regs;
+                    debug!("bb {} param {}: regs {:?}", bb, param, regs);
+                }
             }
             for inst in f.layout.block_insts(bb) {
                 for &result in f.dfg.inst_results(inst) {
                     let ty = f.dfg.value_type(result);
-                    let vreg =
-                        alloc_vreg(&mut value_regs, I::rc_for_type(ty)?, result, &mut next_vreg);
-                    vcode.set_vreg_type(vreg, ty);
-                    debug!(
-                        "bb {} inst {} ({:?}): result vreg {:?}",
-                        bb, inst, f.dfg[inst], vreg
-                    );
+                    if value_regs[result].is_invalid() {
+                        let regs = alloc_vregs(ty, &mut next_vreg, &mut vcode)?;
+                        value_regs[result] = regs;
+                        debug!(
+                            "bb {} inst {} ({:?}): result regs {:?}",
+                            bb, inst, f.dfg[inst], regs,
+                        );
+                    }
                 }
             }
         }
@@ -370,18 +381,15 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             .map(|vm_context_index| {
                 let entry_block = f.layout.entry_block().unwrap();
                 let param = f.dfg.block_params(entry_block)[vm_context_index];
-                value_regs[param]
+                value_regs[param].only_reg().unwrap()
             });
 
-        // Assign a vreg to each return value.
+        // Assign vreg(s) to each return value.
         let mut retval_regs = vec![];
         for ret in &f.signature.returns {
-            let v = next_vreg;
-            next_vreg += 1;
-            let regclass = I::rc_for_type(ret.value_type)?;
-            let vreg = Reg::new_virtual(regclass, v);
-            retval_regs.push(vreg);
-            vcode.set_vreg_type(vreg.as_virtual_reg().unwrap(), ret.value_type);
+            let regs = alloc_vregs(ret.value_type, &mut next_vreg, &mut vcode)?;
+            retval_regs.push(regs);
+            debug!("retval gets regs {:?}", regs);
         }
 
         // Compute instruction colors, find constant instructions, and find instructions with
@@ -453,9 +461,10 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 if !self.vcode.abi().arg_is_needed_in_body(i) {
                     continue;
                 }
-                let reg = Writable::from_reg(self.value_regs[*param]);
-                let insn = self.vcode.abi().gen_copy_arg_to_reg(i, reg);
-                self.emit(insn);
+                let regs = writable_value_regs(self.value_regs[*param]);
+                for insn in self.vcode.abi().gen_copy_arg_to_regs(i, regs).into_iter() {
+                    self.emit(insn);
+                }
             }
             if let Some(insn) = self.vcode.abi().gen_retval_area_setup() {
                 self.emit(insn);
@@ -465,10 +474,14 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
 
     fn gen_retval_setup(&mut self, gen_ret_inst: GenerateReturn) {
         let retval_regs = self.retval_regs.clone();
-        for (i, reg) in retval_regs.into_iter().enumerate() {
-            let reg = Writable::from_reg(reg);
-            let insns = self.vcode.abi().gen_copy_reg_to_retval(i, reg);
-            for insn in insns {
+        for (i, regs) in retval_regs.into_iter().enumerate() {
+            let regs = writable_value_regs(regs);
+            for insn in self
+                .vcode
+                .abi()
+                .gen_copy_regs_to_retval(i, regs)
+                .into_iter()
+            {
                 self.emit(insn);
             }
         }
@@ -499,8 +512,8 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         //
         // * one for dsts whose sources are non-constants.
 
-        let mut const_bundles = SmallVec::<[(Type, Writable<Reg>, u64); 16]>::new();
-        let mut var_bundles = SmallVec::<[(Type, Writable<Reg>, Reg); 16]>::new();
+        let mut const_bundles: SmallVec<[_; 16]> = SmallVec::new();
+        let mut var_bundles: SmallVec<[_; 16]> = SmallVec::new();
 
         let mut i = 0;
         for (dst_val, src_val) in self
@@ -514,7 +527,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             let ty = self.f.dfg.value_type(src_val);
 
             debug_assert!(ty == self.f.dfg.value_type(*dst_val));
-            let dst_reg = self.value_regs[*dst_val];
+            let dst_regs = self.value_regs[*dst_val];
 
             let input = self.get_value_as_source_or_const(src_val);
             debug!("jump arg {} is {}", i, src_val);
@@ -522,15 +535,15 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
 
             if let Some(c) = input.constant {
                 debug!(" -> constant {}", c);
-                const_bundles.push((ty, Writable::from_reg(dst_reg), c));
+                const_bundles.push((ty, writable_value_regs(dst_regs), c));
             } else {
-                let src_reg = self.put_value_in_reg(src_val);
-                debug!(" -> reg {:?}", src_reg);
+                let src_regs = self.put_value_in_regs(src_val);
+                debug!(" -> reg {:?}", src_regs);
                 // Skip self-assignments.  Not only are they pointless, they falsely trigger the
                 // overlap-check below and hence can cause a lot of unnecessary copying through
                 // temporaries.
-                if dst_reg != src_reg {
-                    var_bundles.push((ty, Writable::from_reg(dst_reg), src_reg));
+                if dst_regs != src_regs {
+                    var_bundles.push((ty, writable_value_regs(dst_regs), src_regs));
                 }
             }
         }
@@ -541,41 +554,69 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         // for cases of up to circa 16 args.  Currently not possible because regalloc.rs
         // does not export it.
         let mut src_reg_set = FxHashSet::<Reg>::default();
-        for (_, _, src_reg) in &var_bundles {
-            src_reg_set.insert(*src_reg);
+        for (_, _, src_regs) in &var_bundles {
+            for &reg in src_regs.regs() {
+                src_reg_set.insert(reg);
+            }
         }
         let mut overlaps = false;
-        for (_, dst_reg, _) in &var_bundles {
-            if src_reg_set.contains(&dst_reg.to_reg()) {
-                overlaps = true;
-                break;
+        'outer: for (_, dst_regs, _) in &var_bundles {
+            for &reg in dst_regs.regs() {
+                if src_reg_set.contains(&reg.to_reg()) {
+                    overlaps = true;
+                    break 'outer;
+                }
             }
         }
 
         // If, as is mostly the case, the source and destination register sets are non
         // overlapping, then we can copy directly, so as to save the register allocator work.
         if !overlaps {
-            for (ty, dst_reg, src_reg) in &var_bundles {
-                self.emit(I::gen_move(*dst_reg, *src_reg, *ty));
+            for (ty, dst_regs, src_regs) in &var_bundles {
+                let (_, reg_tys) = I::rc_for_type(*ty)?;
+                for ((dst, src), reg_ty) in dst_regs
+                    .regs()
+                    .iter()
+                    .zip(src_regs.regs().iter())
+                    .zip(reg_tys.iter())
+                {
+                    self.emit(I::gen_move(*dst, *src, *reg_ty));
+                }
             }
         } else {
             // There's some overlap, so play safe and copy via temps.
-            let mut tmp_regs = SmallVec::<[Writable<Reg>; 16]>::new();
+            let mut tmp_regs = SmallVec::<[ValueRegs<Writable<Reg>>; 16]>::new();
             for (ty, _, _) in &var_bundles {
-                tmp_regs.push(self.alloc_tmp(I::rc_for_type(*ty)?, *ty));
+                tmp_regs.push(self.alloc_tmp(*ty));
             }
             for ((ty, _, src_reg), tmp_reg) in var_bundles.iter().zip(tmp_regs.iter()) {
-                self.emit(I::gen_move(*tmp_reg, *src_reg, *ty));
+                let (_, reg_tys) = I::rc_for_type(*ty)?;
+                for ((tmp, src), reg_ty) in tmp_reg
+                    .regs()
+                    .iter()
+                    .zip(src_reg.regs().iter())
+                    .zip(reg_tys.iter())
+                {
+                    self.emit(I::gen_move(*tmp, *src, *reg_ty));
+                }
             }
             for ((ty, dst_reg, _), tmp_reg) in var_bundles.iter().zip(tmp_regs.iter()) {
-                self.emit(I::gen_move(*dst_reg, (*tmp_reg).to_reg(), *ty));
+                let (_, reg_tys) = I::rc_for_type(*ty)?;
+                for ((dst, tmp), reg_ty) in dst_reg
+                    .regs()
+                    .iter()
+                    .zip(tmp_reg.regs().iter())
+                    .zip(reg_tys.iter())
+                {
+                    self.emit(I::gen_move(*dst, tmp.to_reg(), *reg_ty));
+                }
             }
         }
 
         // Now, finally, deal with the moves whose sources are constants.
-        for (ty, dst_reg, const_u64) in &const_bundles {
-            for inst in I::gen_constant(*dst_reg, *const_u64, *ty, |reg_class, ty| {
-                self.alloc_tmp(reg_class, ty)
+        for (ty, dst_reg, const_val) in &const_bundles {
+            for inst in I::gen_constant(*dst_reg, *const_val as u128, *ty, |_reg_class, ty| {
+                self.alloc_tmp(ty).only_reg().unwrap()
             })
             .into_iter()
             {
@@ -766,8 +807,8 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         debug!("about to lower function: {:?}", self.f);
 
         // Initialize the ABI object, giving it a temp if requested.
-        let maybe_tmp = if self.vcode.abi().temp_needed() {
-            Some(self.alloc_tmp(RegClass::I64, I64))
+        let maybe_tmp = if let Some(temp_ty) = self.vcode.abi().temp_needed() {
+            Some(self.alloc_tmp(temp_ty).only_reg().unwrap())
         } else {
             None
         };
@@ -848,11 +889,11 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         Ok((vcode, stack_map_info))
     }
 
-    fn put_value_in_reg(&mut self, val: Value) -> Reg {
-        debug!("put_value_in_reg: val {}", val,);
-        let mut reg = self.value_regs[val];
-        debug!(" -> reg {:?}", reg);
-        assert!(reg.is_valid());
+    fn put_value_in_regs(&mut self, val: Value) -> ValueRegs<Reg> {
+        debug!("put_value_in_reg: val {}", val);
+        let mut regs = self.value_regs[val];
+        debug!(" -> regs {:?}", regs);
+        assert!(regs.is_valid());
 
         self.value_lowered_uses[val] += 1;
 
@@ -864,12 +905,12 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         if let ValueDef::Result(i, 0) = self.f.dfg.value_def(val) {
             if self.f.dfg[i].opcode() == Opcode::GetPinnedReg {
                 if let Some(pr) = self.pinned_reg {
-                    reg = pr;
+                    regs = ValueRegs::one(pr);
                 }
             }
         }
 
-        reg
+        regs
     }
 
     /// Get the actual inputs for a value. This is the implementation for
@@ -944,8 +985,8 @@ impl<'func, I: VCodeInst> LowerCtx for Lower<'func, I> {
         self.vcode.abi()
     }
 
-    fn retval(&self, idx: usize) -> Writable<Reg> {
-        Writable::from_reg(self.retval_regs[idx])
+    fn retval(&self, idx: usize) -> ValueRegs<Writable<Reg>> {
+        writable_value_regs(self.retval_regs[idx])
     }
 
     fn get_vm_context(&self) -> Option<Reg> {
@@ -1050,23 +1091,19 @@ impl<'func, I: VCodeInst> LowerCtx for Lower<'func, I> {
         self.get_value_as_source_or_const(val)
     }
 
-    fn put_input_in_reg(&mut self, ir_inst: Inst, idx: usize) -> Reg {
+    fn put_input_in_regs(&mut self, ir_inst: Inst, idx: usize) -> ValueRegs<Reg> {
         let val = self.f.dfg.inst_args(ir_inst)[idx];
         let val = self.f.dfg.resolve_aliases(val);
-        self.put_value_in_reg(val)
+        self.put_value_in_regs(val)
     }
 
-    fn get_output(&self, ir_inst: Inst, idx: usize) -> Writable<Reg> {
+    fn get_output(&self, ir_inst: Inst, idx: usize) -> ValueRegs<Writable<Reg>> {
         let val = self.f.dfg.inst_results(ir_inst)[idx];
-        Writable::from_reg(self.value_regs[val])
+        writable_value_regs(self.value_regs[val])
     }
 
-    fn alloc_tmp(&mut self, rc: RegClass, ty: Type) -> Writable<Reg> {
-        let v = self.next_vreg;
-        self.next_vreg += 1;
-        let vreg = Reg::new_virtual(rc, v);
-        self.vcode.set_vreg_type(vreg.as_virtual_reg().unwrap(), ty);
-        Writable::from_reg(vreg)
+    fn alloc_tmp(&mut self, ty: Type) -> ValueRegs<Writable<Reg>> {
+        writable_value_regs(alloc_vregs(ty, &mut self.next_vreg, &mut self.vcode).unwrap())
     }
 
     fn emit(&mut self, mach_inst: I) {
@@ -1131,8 +1168,7 @@ impl<'func, I: VCodeInst> LowerCtx for Lower<'func, I> {
         if reg.is_virtual() {
             reg
         } else {
-            let rc = reg.get_class();
-            let new_reg = self.alloc_tmp(rc, ty);
+            let new_reg = self.alloc_tmp(ty).only_reg().unwrap();
             self.emit(I::gen_move(new_reg, reg, ty));
             new_reg.to_reg()
         }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -135,6 +135,8 @@ pub mod helpers;
 pub use helpers::*;
 pub mod inst_common;
 pub use inst_common::*;
+pub mod valueregs;
+pub use valueregs::*;
 
 /// A machine instruction.
 pub trait MachInst: Clone + Debug {
@@ -166,8 +168,8 @@ pub trait MachInst: Clone + Debug {
 
     /// Generate a constant into a reg.
     fn gen_constant<F: FnMut(RegClass, Type) -> Writable<Reg>>(
-        to_reg: Writable<Reg>,
-        value: u64,
+        to_regs: ValueRegs<Writable<Reg>>,
+        value: u128,
         ty: Type,
         alloc_tmp: F,
     ) -> SmallVec<[Self; 4]>;
@@ -180,9 +182,19 @@ pub trait MachInst: Clone + Debug {
     /// (e.g., add directly from or directly to memory), like x86.
     fn maybe_direct_reload(&self, reg: VirtualReg, slot: SpillSlot) -> Option<Self>;
 
-    /// Determine a register class to store the given Cranelift type.
-    /// May return an error if the type isn't supported by this backend.
-    fn rc_for_type(ty: Type) -> CodegenResult<RegClass>;
+    /// Determine register class(es) to store the given Cranelift type, and the
+    /// Cranelift type actually stored in the underlying register(s).  May return
+    /// an error if the type isn't supported by this backend.
+    ///
+    /// If the type requires multiple registers, then the list of registers is
+    /// returned in little-endian order.
+    ///
+    /// Note that the type actually stored in the register(s) may differ in the
+    /// case that a value is split across registers: for example, on a 32-bit
+    /// target, an I64 may be stored in two registers, each of which holds an
+    /// I32. The actually-stored types are used only to inform the backend when
+    /// generating spills and reloads for individual registers.
+    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])>;
 
     /// Generate a jump to another target. Used during lowering of
     /// control flow.

--- a/cranelift/codegen/src/machinst/valueregs.rs
+++ b/cranelift/codegen/src/machinst/valueregs.rs
@@ -1,0 +1,210 @@
+//! Data structure for tracking the (possibly multiple) registers that hold one
+//! SSA `Value`.
+
+use regalloc::{RealReg, Reg, VirtualReg, Writable};
+use std::fmt::Debug;
+
+#[cfg(feature = "arm32")]
+const VALUE_REGS_PARTS: usize = 4;
+
+#[cfg(not(feature = "arm32"))]
+const VALUE_REGS_PARTS: usize = 2;
+
+/// Location at which a `Value` is stored in register(s): the value is located
+/// in one or more registers, depending on its width. A value may be stored in
+/// more than one register if the machine has no registers wide enough
+/// otherwise: for example, on a 32-bit architecture, we may store `I64` values
+/// in two registers, and `I128` values in four.
+///
+/// By convention, the register parts are kept in machine-endian order here.
+///
+/// N.B.: we cap the capacity of this at four (when any 32-bit target is
+/// enabled) or two (otherwise), and we use special in-band sentinal `Reg`
+/// values (`Reg::invalid()`) to avoid the need to carry a separate length. This
+/// allows the struct to be `Copy` (no heap or drop overhead) and be only 16 or
+/// 8 bytes, which is important for compiler performance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ValueRegs<R: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel> {
+    parts: [R; VALUE_REGS_PARTS],
+}
+
+/// A type with an "invalid" sentinel value.
+pub trait InvalidSentinel: Copy + Eq {
+    /// The invalid sentinel value.
+    fn invalid_sentinel() -> Self;
+    /// Is this the invalid sentinel?
+    fn is_invalid_sentinel(self) -> bool {
+        self == Self::invalid_sentinel()
+    }
+}
+impl InvalidSentinel for Reg {
+    fn invalid_sentinel() -> Self {
+        Reg::invalid()
+    }
+}
+impl InvalidSentinel for VirtualReg {
+    fn invalid_sentinel() -> Self {
+        VirtualReg::invalid()
+    }
+}
+impl InvalidSentinel for RealReg {
+    fn invalid_sentinel() -> Self {
+        RealReg::invalid()
+    }
+}
+impl InvalidSentinel for Writable<Reg> {
+    fn invalid_sentinel() -> Self {
+        Writable::from_reg(Reg::invalid_sentinel())
+    }
+}
+
+#[cfg(feature = "arm32")]
+impl<R: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel> ValueRegs<R> {
+    /// Create an invalid Value-in-Reg.
+    pub fn invalid() -> Self {
+        ValueRegs {
+            parts: [R::invalid_sentinel(); 4],
+        }
+    }
+    /// Create a Value-in-R location for a value stored in one register.
+    pub fn one(reg: R) -> Self {
+        ValueRegs {
+            parts: [
+                reg,
+                R::invalid_sentinel(),
+                R::invalid_sentinel(),
+                R::invalid_sentinel(),
+            ],
+        }
+    }
+    /// Create a Value-in-R location for a value stored in two registers.
+    pub fn two(r1: R, r2: R) -> Self {
+        ValueRegs {
+            parts: [r1, r2, R::invalid_sentinel(), R::invalid_sentinel()],
+        }
+    }
+    /// Create a Value-in-R location for a value stored in four registers.
+    pub fn four(r1: R, r2: R, r3: R, r4: R) -> Self {
+        ValueRegs {
+            parts: [r1, r2, r3, r4],
+        }
+    }
+
+    /// Is this Value-to-Reg mapping valid?
+    pub fn is_valid(self) -> bool {
+        !self.parts[0].is_invalid_sentinel()
+    }
+    /// Is this Value-to-Reg mapping invalid?
+    pub fn is_invalid(self) -> bool {
+        self.parts[0].is_invalid_sentinel()
+    }
+
+    /// Return the number of registers used.
+    pub fn len(self) -> usize {
+        // If rustc/LLVM is smart enough, this might even be vectorized...
+        (self.parts[0] != R::invalid_sentinel()) as usize
+            + (self.parts[1] != R::invalid_sentinel()) as usize
+            + (self.parts[2] != R::invalid_sentinel()) as usize
+            + (self.parts[3] != R::invalid_sentinel()) as usize
+    }
+
+    /// Return the single register used for this value, if any.
+    pub fn only_reg(self) -> Option<R> {
+        if self.len() == 1 {
+            Some(self.parts[0])
+        } else {
+            None
+        }
+    }
+
+    /// Return an iterator over the registers storing this value.
+    pub fn regs(&self) -> &[R] {
+        &self.parts[0..self.len()]
+    }
+
+    /// Map individual registers via a map function.
+    pub fn map<NewR, F>(self, f: F) -> ValueRegs<NewR>
+    where
+        NewR: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel,
+        F: Fn(R) -> NewR,
+    {
+        ValueRegs {
+            parts: [
+                f(self.parts[0]),
+                f(self.parts[1]),
+                f(self.parts[2]),
+                f(self.parts[3]),
+            ],
+        }
+    }
+}
+
+#[cfg(not(feature = "arm32"))]
+impl<R: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel> ValueRegs<R> {
+    /// Create an invalid Value-in-Reg.
+    pub fn invalid() -> Self {
+        ValueRegs {
+            parts: [R::invalid_sentinel(); 2],
+        }
+    }
+    /// Create a Value-in-R location for a value stored in one register.
+    pub fn one(reg: R) -> Self {
+        ValueRegs {
+            parts: [reg, R::invalid_sentinel()],
+        }
+    }
+    /// Create a Value-in-R location for a value stored in two registers.
+    pub fn two(r1: R, r2: R) -> Self {
+        ValueRegs { parts: [r1, r2] }
+    }
+    /// Is this Value-to-Reg mapping valid?
+    pub fn is_valid(self) -> bool {
+        !self.parts[0].is_invalid_sentinel()
+    }
+    /// Is this Value-to-Reg mapping invalid?
+    pub fn is_invalid(self) -> bool {
+        self.parts[0].is_invalid_sentinel()
+    }
+
+    /// Return the number of registers used.
+    pub fn len(self) -> usize {
+        // If rustc/LLVM is smart enough, this might even be vectorized...
+        (self.parts[0] != R::invalid_sentinel()) as usize
+            + (self.parts[1] != R::invalid_sentinel()) as usize
+    }
+
+    /// Return the single register used for this value, if any.
+    pub fn only_reg(self) -> Option<R> {
+        if self.len() == 1 {
+            Some(self.parts[0])
+        } else {
+            None
+        }
+    }
+
+    /// Return an iterator over the registers storing this value.
+    pub fn regs(&self) -> &[R] {
+        &self.parts[0..self.len()]
+    }
+
+    /// Map individual registers via a map function.
+    pub fn map<NewR, F>(self, f: F) -> ValueRegs<NewR>
+    where
+        NewR: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel,
+        F: Fn(R) -> NewR,
+    {
+        ValueRegs {
+            parts: [f(self.parts[0]), f(self.parts[1])],
+        }
+    }
+}
+
+/// Create a writable ValueRegs.
+pub(crate) fn writable_value_regs(regs: ValueRegs<Reg>) -> ValueRegs<Writable<Reg>> {
+    regs.map(|r| Writable::from_reg(r))
+}
+
+/// Strip a writable ValueRegs down to a readonly ValueRegs.
+pub(crate) fn non_writable_value_regs(regs: ValueRegs<Writable<Reg>>) -> ValueRegs<Reg> {
+    regs.map(|r| r.to_reg())
+}

--- a/cranelift/filetests/filetests/isa/x64/bitops-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitops-i128-run.clif
@@ -1,0 +1,107 @@
+test run
+target x86_64
+feature "experimental_x64"
+
+function %ctz1() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00000000
+    v1 = iconst.i64 0x00000001_00000000
+    v2 = iconcat v0, v1
+    v3 = ctz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 96
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run
+
+function %ctz2() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00010000
+    v1 = iconst.i64 0x00000001_00000000
+    v2 = iconcat v0, v1
+    v3 = ctz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 16
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run
+
+function %ctz3() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00010000
+    v1 = iconst.i64 0x00000000_00000000
+    v2 = iconcat v0, v1
+    v3 = ctz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 16
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run
+
+function %ctz4() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00000000
+    v1 = iconst.i64 0x00000000_00000000
+    v2 = iconcat v0, v1
+    v3 = ctz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 128
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run
+
+function %clz1() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00000000
+    v1 = iconst.i64 0x00000001_00000000
+    v2 = iconcat v0, v1
+    v3 = clz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 31
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run
+
+function %clz2() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00010000
+    v1 = iconst.i64 0x00000001_00000000
+    v2 = iconcat v0, v1
+    v3 = clz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 31
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run
+
+function %clz3() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00010000
+    v1 = iconst.i64 0x00000000_00000000
+    v2 = iconcat v0, v1
+    v3 = clz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 111
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run
+
+function %clz4() -> b1 {
+block0:
+    v0 = iconst.i64 0x00000000_00000000
+    v1 = iconst.i64 0x00000000_00000000
+    v2 = iconcat v0, v1
+    v3 = clz.i128 v2
+    v4 = ireduce.i64 v3
+    v5 = iconst.i64 128
+    v6 = icmp eq v4, v5
+    return v6
+}
+; run

--- a/cranelift/filetests/filetests/isa/x64/bitrev-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitrev-i128-run.clif
@@ -1,0 +1,47 @@
+test run
+target x86_64
+feature "experimental_x64"
+
+function %reverse_bits_zero() -> b1 {
+block0:
+    v0 = iconst.i64 0
+    v1 = iconcat v0, v0
+    v2 = bitrev.i128 v1
+    v3 = icmp eq v2, v1
+    return v3
+}
+; run
+
+function %reverse_bits_one() -> b1 {
+block0:
+    v0 = iconst.i64 0
+    v1 = iconst.i64 1
+    v2 = iconcat v0, v1
+
+    v3 = bitrev.i128 v2
+
+    v4 = iconst.i64 0x8000_0000_0000_0000
+    v5 = iconst.i64 0
+    v6 = iconcat v4, v5
+
+    v7 = icmp eq v3, v6
+    return v7
+}
+; run
+
+function %reverse_bits() -> b1 {
+block0:
+    v0 = iconst.i64 0x06AD_8667_69EC_41BA
+    v1 = iconst.i64 0x6C83_D81A_6E28_83AB
+    v2 = iconcat v0, v1
+
+    v3 = bitrev.i128 v2
+
+    v4 = iconst.i64 0xD5C11476581BC136
+    v5 = iconst.i64 0x5D823796E661B560
+    v6 = iconcat v4, v5
+
+    v7 = icmp eq v3, v6
+    return v7
+}
+; run

--- a/cranelift/filetests/filetests/isa/x64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/x64/floating-point.clif
@@ -1,0 +1,26 @@
+test compile
+target x86_64
+feature "experimental_x64"
+
+function %f(f64) -> f64 {
+block0(v0: f64):
+    v1 = fabs.f64 v0
+    return v1
+}
+; check:  movabsq $$9223372036854775807, %rsi
+; nextln: movq    %rsi, %xmm1
+; nextln: andpd   %xmm0, %xmm1
+; nextln: movaps  %xmm1, %xmm0
+
+
+function %f(i64) -> f64 {
+block0(v0: i64):
+    v1 = load.f64 v0
+    v2 = fabs.f64 v1
+    return v2
+}
+; check:  movsd   0(%rdi), %xmm0
+; nextln: movabsq $$9223372036854775807, %rsi
+; nextln: movq    %rsi, %xmm1
+; nextln: andpd   %xmm0, %xmm1
+; nextln: movaps  %xmm1, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1006,7 +1006,7 @@ block0(v0: i128, v1: i128):
 ; nextln: movq    %rsp, %rbp
 ; nextln: subq    $$16, %rsp
 ; nextln: movq    %r12, 0(%rsp)
-; nextln: virtual_sp_offset_adjust 8
+; nextln: virtual_sp_offset_adjust 16
 ; nextln: movq    %r8, %r12
 ; nextln: subq    $$16, %rsp
 ; nextln: virtual_sp_offset_adjust 16

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1,0 +1,1082 @@
+test compile
+target x86_64
+feature "experimental_x64"
+
+function %f0(i128, i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i128):
+
+    v2 = iadd v0, v1
+; nextln:  addq    %rdx, %rdi
+; nextln:  adcq    %rcx, %rsi
+
+    return v2
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f1(i128, i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i128):
+
+    v2 = isub v0, v1
+; nextln:  subq    %rdx, %rdi
+; nextln:  sbbq    %rcx, %rsi
+
+    return v2
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f2(i128, i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i128):
+
+    v2 = band v0, v1
+; nextln:  andq    %rdx, %rdi
+; nextln:  andq    %rcx, %rsi
+
+    return v2
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f3(i128, i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i128):
+
+    v2 = bor v0, v1
+; nextln:  orq     %rdx, %rdi
+; nextln:  orq     %rcx, %rsi
+
+    return v2
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f4(i128, i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i128):
+
+    v2 = bxor v0, v1
+; nextln:  xorq    %rdx, %rdi
+; nextln:  xorq    %rcx, %rsi
+
+    return v2
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f5(i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+
+    v1 = bnot v0
+; nextln:  notq    %rdi
+; nextln:  notq    %rsi
+
+    return v1
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f6(i128, i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i128):
+; v0 in rdi:rsi, v1 in rdx:rcx
+
+    v2 = imul v0, v1
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rcx, %r8
+; nextln:  movq    %rdi, %rsi
+; nextln:  imulq   %rdx, %rsi
+; nextln:  movq    %rdi, %rcx
+; nextln:  imulq   %r8, %rcx
+; nextln:  imulq   %rdx, %rax
+; nextln:  addq    %rax, %rcx
+; nextln:  movq    %rdi, %rax
+; nextln:  mul     %rdx
+; nextln:  addq    %rdx, %rcx
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rcx, %rdx
+
+    return v2
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f7(i64, i64) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i64, v1: i64):
+    v2 = iconcat.i64 v0, v1
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+
+    return v2
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f8(i128) -> i64, i64 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    v1, v2 = isplit.i128 v0
+; nextln:  movq    %rdi, %rax
+; nextln:  movq    %rsi, %rdx
+
+    return v1, v2
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f9(i128, i128) -> b1 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i128):
+    v2 = icmp eq v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setz    %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setz    %r8b
+; nextln: andq    %rax, %r8
+; nextln: andq    $$1, %r8
+; nextln: setnz   %al
+
+    v3 = icmp ne v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setnz   %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setnz   %r8b
+; nextln: orq     %rax, %r8
+; nextln: andq    $$1, %r8
+; nextln: setnz   %r8b
+ 
+    v4 = icmp slt v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setl    %r9b
+; nextln: setz    %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setb    %r10b
+; nextln: andq    %rax, %r10
+; nextln: orq     %r9, %r10
+; nextln: andq    $$1, %r10
+; nextln: setnz   %r9b
+ 
+    v5 = icmp sle v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setl    %r10b
+; nextln: setz    %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setbe   %r11b
+; nextln: andq    %rax, %r11
+; nextln: orq     %r10, %r11
+; nextln: andq    $$1, %r11
+; nextln: setnz   %r10b
+ 
+    v6 = icmp sgt v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setnle  %r11b
+; nextln: setz    %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setnbe  %r12b
+; nextln: andq    %rax, %r12
+; nextln: orq     %r11, %r12
+; nextln: andq    $$1, %r12
+; nextln: setnz   %r11b
+
+	v7 = icmp sge v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setnle  %r12b
+; nextln: setz    %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setnb   %r13b
+; nextln: andq    %rax, %r13
+; nextln: orq     %r12, %r13
+; nextln: andq    $$1, %r13
+; nextln: setnz   %r12b
+
+    v8 = icmp ult v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setb    %r13b
+; nextln: setz    %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setb    %r14b
+; nextln: andq    %rax, %r14
+; nextln: orq     %r13, %r14
+; nextln: andq    $$1, %r14
+; nextln: setnz   %r13b
+
+    v9 = icmp ule v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setb    %r14b
+; nextln: setz    %al
+; nextln: cmpq    %rdx, %rdi
+; nextln: setbe   %bl
+; nextln: andq    %rax, %rbx
+; nextln: orq     %r14, %rbx
+; nextln: andq    $$1, %rbx
+; nextln: setnz   %r14b
+
+    v10 = icmp ugt v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setnbe  %bl
+; nextln: setz    %r15b
+; nextln: cmpq    %rdx, %rdi
+; nextln: setnbe  %al
+; nextln: andq    %r15, %rax
+; nextln: orq     %rbx, %rax
+; nextln: andq    $$1, %rax
+; nextln: setnz   %bl
+
+    v11 = icmp uge v0, v1
+; check:  cmpq    %rcx, %rsi
+; nextln: setnbe  %sil
+; nextln: setz    %cl
+; nextln: cmpq    %rdx, %rdi
+; nextln: setnb   %dil
+; nextln: andq    %rcx, %rdi
+; nextln: orq     %rsi, %rdi
+; nextln: andq    $$1, %rdi
+; nextln: setnz   %sil
+
+    v12 = band v2, v3
+    v13 = band v4, v5
+    v14 = band v6, v7
+    v15 = band v8, v9
+    v16 = band v10, v11
+    v17 = band v12, v13
+    v18 = band v14, v15
+    v19 = band v17, v18
+    v20 = band v19, v16
+
+    return v20
+; check:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f10(i128) -> i32 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    brz v0, block1
+; check:  cmpq    $$0, %rdi
+; nextln: setz    %dil
+; nextln: cmpq    $$0, %rsi
+; nextln: setz    %sil
+; nextln: andb    %dil, %sil
+; nextln: jnz     label1; j label2
+ 
+    jump block2
+
+block1:
+    v1 = iconst.i32 1
+    return v1
+
+block2:
+    v2 = iconst.i32 2
+    return v2
+
+; check:   movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f11(i128) -> i32 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    brnz v0, block1
+; check:  cmpq    $$0, %rdi
+; nextln: setnz   %dil
+; nextln: cmpq    $$0, %rsi
+; nextln: setnz   %sil
+; nextln: orb     %dil, %sil
+; nextln: jnz     label1; j label2
+    jump block2
+
+block1:
+    v1 = iconst.i32 1
+    return v1
+
+block2:
+    v2 = iconst.i32 2
+    return v2
+
+; check:   movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f12(i64) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i64):
+    v1 = uextend.i128 v0
+    return v1
+
+; nextln:  movq    %rdi, %rsi
+; nextln:  xorq    %rdi, %rdi
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f13(i64) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i64):
+    v1 = sextend.i128 v0
+    return v1
+
+; nextln:  movq    %rdi, %rsi
+; nextln:  movq    %rsi, %rdi
+; nextln:  sarq    $$63, %rdi
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f14(i8) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i8):
+    v1 = sextend.i128 v0
+    return v1
+
+; nextln:  movsbq  %dil, %rsi
+; nextln:  movq    %rsi, %rdi
+; nextln:  sarq    $$63, %rdi
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f15(i8) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i8):
+    v1 = uextend.i128 v0
+    return v1
+
+; nextln:  movzbq  %dil, %rsi
+; nextln:  xorq    %rdi, %rdi
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+
+}
+
+function %f16(i128) -> i64 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    v1 = ireduce.i64 v0
+    return v1
+
+; nextln:  movq    %rdi, %rax
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f17(i128) -> i8 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    v1 = ireduce.i8 v0
+    return v1
+
+; nextln:  movq    %rdi, %rax
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f18(b1) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: b1):
+    v1 = bint.i128 v0
+    return v1
+
+; check:  movzbq  %dil, %rsi
+; nextln: xorq    %rdi, %rdi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f19(i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    v1 = popcnt.i128 v0
+    return v1
+
+; check:  movq    %rsi, %rdx
+; nextln: movq    %rdi, %rsi
+; nextln: shrq    $$1, %rsi
+; nextln: movabsq $$8608480567731124087, %rcx
+; nextln: andq    %rcx, %rsi
+; nextln: movq    %rdi, %rax
+; nextln: subq    %rsi, %rax
+; nextln: shrq    $$1, %rsi
+; nextln: andq    %rcx, %rsi
+; nextln: subq    %rsi, %rax
+; nextln: shrq    $$1, %rsi
+; nextln: andq    %rcx, %rsi
+; nextln: subq    %rsi, %rax
+; nextln: movq    %rax, %rsi
+; nextln: shrq    $$4, %rsi
+; nextln: addq    %rax, %rsi
+; nextln: movabsq $$1085102592571150095, %rdi
+; nextln: andq    %rdi, %rsi
+; nextln: movabsq $$72340172838076673, %rdi
+; nextln: imulq   %rdi, %rsi
+; nextln: shrq    $$56, %rsi
+; nextln: movq    %rdx, %rax
+; nextln: shrq    $$1, %rax
+; nextln: movabsq $$8608480567731124087, %rcx
+; nextln: andq    %rcx, %rax
+; nextln: movq    %rdx, %rdi
+; nextln: subq    %rax, %rdi
+; nextln: shrq    $$1, %rax
+; nextln: andq    %rcx, %rax
+; nextln: subq    %rax, %rdi
+; nextln: shrq    $$1, %rax
+; nextln: andq    %rcx, %rax
+; nextln: subq    %rax, %rdi
+; nextln: movq    %rdi, %rax
+; nextln: shrq    $$4, %rax
+; nextln: addq    %rdi, %rax
+; nextln: movabsq $$1085102592571150095, %rdi
+; nextln: andq    %rdi, %rax
+; nextln: movabsq $$72340172838076673, %rdi
+; nextln: imulq   %rdi, %rax
+; nextln: shrq    $$56, %rax
+; nextln: addq    %rax, %rsi
+; nextln: xorq    %rdi, %rdi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdi, %rdx
+
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+
+function %f20(i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    v1 = bitrev.i128 v0
+    return v1
+
+; check:  movq    %rdi, %rcx
+; nextln: movq    %rcx, %rdi
+; nextln: movabsq $$6148914691236517205, %rax
+; nextln: shrq    $$1, %rdi
+; nextln: andq    %rax, %rdi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$1, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rdi, %rcx
+; nextln: movq    %rcx, %rdi
+; nextln: movabsq $$3689348814741910323, %rax
+; nextln: shrq    $$2, %rdi
+; nextln: andq    %rax, %rdi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$2, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rdi, %rcx
+; nextln: movq    %rcx, %rdi
+; nextln: movabsq $$1085102592571150095, %rax
+; nextln: shrq    $$4, %rdi
+; nextln: andq    %rax, %rdi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$4, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rdi, %rcx
+; nextln: movq    %rcx, %rdi
+; nextln: movabsq $$71777214294589695, %rax
+; nextln: shrq    $$8, %rdi
+; nextln: andq    %rax, %rdi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$8, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rdi, %rcx
+; nextln: movq    %rcx, %rdi
+; nextln: movabsq $$281470681808895, %rax
+; nextln: shrq    $$16, %rdi
+; nextln: andq    %rax, %rdi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$16, %rax
+; nextln: orq     %rdi, %rax
+; nextln: movq    %rax, %rcx
+; nextln: movl    $$-1, %edi
+; nextln: shrq    $$32, %rcx
+; nextln: andq    %rdi, %rcx
+; nextln: andq    %rax, %rdi
+; nextln: shlq    $$32, %rdi
+; nextln: orq     %rcx, %rdi
+; nextln: movq    %rsi, %rcx
+; nextln: movq    %rcx, %rsi
+; nextln: movabsq $$6148914691236517205, %rax
+; nextln: shrq    $$1, %rsi
+; nextln: andq    %rax, %rsi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$1, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rsi, %rcx
+; nextln: movq    %rcx, %rsi
+; nextln: movabsq $$3689348814741910323, %rax
+; nextln: shrq    $$2, %rsi
+; nextln: andq    %rax, %rsi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$2, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rsi, %rcx
+; nextln: movq    %rcx, %rsi
+; nextln: movabsq $$1085102592571150095, %rax
+; nextln: shrq    $$4, %rsi
+; nextln: andq    %rax, %rsi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$4, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rsi, %rcx
+; nextln: movq    %rcx, %rsi
+; nextln: movabsq $$71777214294589695, %rax
+; nextln: shrq    $$8, %rsi
+; nextln: andq    %rax, %rsi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$8, %rax
+; nextln: movq    %rax, %rcx
+; nextln: orq     %rsi, %rcx
+; nextln: movq    %rcx, %rsi
+; nextln: movabsq $$281470681808895, %rax
+; nextln: shrq    $$16, %rsi
+; nextln: andq    %rax, %rsi
+; nextln: andq    %rcx, %rax
+; nextln: shlq    $$16, %rax
+; nextln: orq     %rsi, %rax
+; nextln: movq    %rax, %rsi
+; nextln: movl    $$-1, %ecx
+; nextln: shrq    $$32, %rsi
+; nextln: andq    %rcx, %rsi
+; nextln: andq    %rax, %rcx
+; nextln: shlq    $$32, %rcx
+; nextln: orq     %rsi, %rcx
+; nextln: movq    %rcx, %rax
+; nextln: movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f21(i128, i32) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i32):
+    v2 = ushr v0, v1
+    return v2
+
+; check:  movq    %rdi, %rax
+; nextln: movq    %rsi, %rdi
+; nextln: movq    %rdi, %rsi
+; nextln: movq    %rdx, %rcx
+; nextln: shrq    %cl, %rsi
+; nextln: movq    %rdx, %rcx
+; nextln: shrq    %cl, %rax
+; nextln: movl    $$64, %ecx
+; nextln: subq    %rdx, %rcx
+; nextln: shlq    %cl, %rdi
+; nextln: orq     %rax, %rdi
+; nextln: xorq    %rax, %rax
+; nextln: xorq    %rcx, %rcx
+; nextln: andq    $$64, %rdx
+; nextln: cmovzq  %rsi, %rax
+; nextln: cmovzq  %rdi, %rcx
+; nextln: cmovnzq %rsi, %rcx
+; nextln: movq    %rax, %rdx
+; nextln: movq    %rcx, %rax
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f22(i128, i32) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i32):
+    v2 = ishl v0, v1
+    return v2
+
+; check:  movq    %rsi, %rax
+; nextln: movq    %rdi, %rsi
+; nextln: movq    %rdx, %rcx
+; nextln: shlq    %cl, %rsi
+; nextln: movq    %rdx, %rcx
+; nextln: shlq    %cl, %rax
+; nextln: movl    $$64, %ecx
+; nextln: subq    %rdx, %rcx
+; nextln: shrq    %cl, %rdi
+; nextln: orq     %rax, %rdi
+; nextln: xorq    %rax, %rax
+; nextln: xorq    %rcx, %rcx
+; nextln: andq    $$64, %rdx
+; nextln: cmovzq  %rdi, %rcx
+; nextln: cmovzq  %rsi, %rax
+; nextln: cmovnzq %rsi, %rcx
+; nextln: movq    %rcx, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f23(i128, i32) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i32):
+    v2 = sshr v0, v1
+    return v2
+
+; check:  movq    %rdi, %r8
+; nextln: movq    %rsi, %rdi
+; nextln: movq    %rdi, %rsi
+; nextln: movq    %rdx, %rcx
+; nextln: sarq    %cl, %rsi
+; nextln: movq    %rdx, %rcx
+; nextln: sarq    %cl, %r8
+; nextln: movl    $$64, %ecx
+; nextln: subq    %rdx, %rcx
+; nextln: movq    %rdi, %rax
+; nextln: shlq    %cl, %rax
+; nextln: orq     %r8, %rax
+; nextln: sarq    $$63, %rdi
+; nextln: xorq    %rcx, %rcx
+; nextln: andq    $$64, %rdx
+; nextln: cmovzq  %rsi, %rdi
+; nextln: cmovzq  %rax, %rcx
+; nextln: cmovnzq %rsi, %rcx
+; nextln: movq    %rcx, %rax
+; nextln: movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f24(i128, i32) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i32):
+    v2 = rotr.i128 v0, v1
+    return v2
+
+; check:  movq    %rsi, %r9
+; nextln: movq    %rdx, %rcx
+; nextln: shrq    %cl, %r9
+; nextln: movq    %rdi, %rax
+; nextln: movq    %rdx, %rcx
+; nextln: shrq    %cl, %rax
+; nextln: movl    $$64, %ecx
+; nextln: subq    %rdx, %rcx
+; nextln: movq    %rsi, %r10
+; nextln: shlq    %cl, %r10
+; nextln: orq     %rax, %r10
+; nextln: xorq    %r8, %r8
+; nextln: xorq    %rax, %rax
+; nextln: movq    %rdx, %rcx
+; nextln: andq    $$64, %rcx
+; nextln: cmovzq  %r9, %r8
+; nextln: cmovzq  %r10, %rax
+; nextln: cmovnzq %r9, %rax
+; nextln: movl    $$128, %r9d
+; nextln: subq    %rdx, %r9
+; nextln: movq    %rdi, %rdx
+; nextln: movq    %r9, %rcx
+; nextln: shlq    %cl, %rdx
+; nextln: movq    %r9, %rcx
+; nextln: shlq    %cl, %rsi
+; nextln: movl    $$64, %ecx
+; nextln: subq    %r9, %rcx
+; nextln: movq    %rdi, %r10
+; nextln: shrq    %cl, %r10
+; nextln: orq     %rsi, %r10
+; nextln: xorq    %rsi, %rsi
+; nextln: xorq    %rdi, %rdi
+; nextln: andq    $$64, %r9
+; nextln: cmovzq  %r10, %rdi
+; nextln: cmovzq  %rdx, %rsi
+; nextln: cmovnzq %rdx, %rdi
+; nextln: orq     %rax, %rsi
+; nextln: orq     %r8, %rdi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f25(i128, i32) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i32):
+    v2 = rotl.i128 v0, v1
+    return v2
+
+; check:  movq    %rdi, %r9
+; nextln: movq    %rdx, %rcx
+; nextln: shlq    %cl, %r9
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdx, %rcx
+; nextln: shlq    %cl, %rax
+; nextln: movl    $$64, %ecx
+; nextln: subq    %rdx, %rcx
+; nextln: movq    %rdi, %r10
+; nextln: shrq    %cl, %r10
+; nextln: orq     %rax, %r10
+; nextln: xorq    %r8, %r8
+; nextln: xorq    %rax, %rax
+; nextln: movq    %rdx, %rcx
+; nextln: andq    $$64, %rcx
+; nextln: cmovzq  %r10, %rax
+; nextln: cmovzq  %r9, %r8
+; nextln: cmovnzq %r9, %rax
+; nextln: movl    $$128, %r9d
+; nextln: subq    %rdx, %r9
+; nextln: movq    %rsi, %rdx
+; nextln: movq    %r9, %rcx
+; nextln: shrq    %cl, %rdx
+; nextln: movq    %r9, %rcx
+; nextln: shrq    %cl, %rdi
+; nextln: movl    $$64, %ecx
+; nextln: subq    %r9, %rcx
+; nextln: shlq    %cl, %rsi
+; nextln: orq     %rdi, %rsi
+; nextln: xorq    %rdi, %rdi
+; nextln: xorq    %rcx, %rcx
+; nextln: andq    $$64, %r9
+; nextln: cmovzq  %rdx, %rdi
+; nextln: cmovzq  %rsi, %rcx
+; nextln: cmovnzq %rdx, %rcx
+; nextln: orq     %r8, %rcx
+; nextln: orq     %rax, %rdi
+; nextln: movq    %rcx, %rax
+; nextln: movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f26(i128, i64) {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128, v1: i64):
+    store.i128 v0, v1
+    return
+
+; check:  movq    %rdi, 0(%rdx)
+; nextln: movq    %rsi, 8(%rdx)
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f27(i64) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i64):
+    v1 = load.i128 v0
+    return v1
+
+; check:  movq    0(%rdi), %rsi
+; nextln: movq    8(%rdi), %rdi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdi, %rdx
+
+; nextln:  movq    %rbp, %rsp
+; nextln:  popq    %rbp
+; nextln:  ret
+}
+
+function %f28(i128, b1) -> i128 {
+block0(v0: i128, v1: b1):
+    v2 = iconst.i128 0
+    brnz v1, block1(v2)
+    jump block2(v2)
+
+block1(v3: i128):
+    v4 = iconst.i128 1
+    v5 = iadd.i128 v3, v4
+    return v5
+
+block2(v6: i128):
+    v7 = iconst.i128 2
+    v8 = iadd.i128 v6, v7
+    return v8
+
+; check: pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: cmpb    $$0, %dl
+; nextln: jnz     label1; j label2
+; check: Block 1:
+; check:  movl    $$0, %esi
+; nextln: movl    $$0, %edi
+; nextln: movl    $$1, %eax
+; nextln: movl    $$0, %ecx
+; nextln: addq    %rax, %rsi
+; nextln: adcq    %rcx, %rdi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdi, %rdx
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+; check: Block 2:
+; check:  movl    $$0, %esi
+; nextln: movl    $$0, %edi
+; nextln: movl    $$2, %eax
+; nextln: movl    $$0, %ecx
+; nextln: addq    %rax, %rsi
+; nextln: adcq    %rcx, %rdi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdi, %rdx
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+ 
+}
+
+function %f29(i128, i128, i64, i128, i128, i128) -> i128 {
+
+block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
+    v6 = iadd.i128 v0, v1
+    v7 = uextend.i128 v2
+    v8 = iadd.i128 v3, v7
+    v9 = iadd.i128 v4, v5
+    v10 = iadd.i128 v6, v8
+    v11 = iadd.i128 v9, v10
+    return v11
+
+; check:  movq    %rsp, %rbp
+; nextln: subq    $$16, %rsp
+; nextln: movq    %r12, 0(%rsp)
+; nextln: movq    %r13, 8(%rsp)
+; nextln: virtual_sp_offset_adjust 16
+; nextln: movq    16(%rbp), %r9
+; nextln: movq    24(%rbp), %r10
+; nextln: movq    32(%rbp), %r12
+; nextln: movq    40(%rbp), %r11
+; nextln: movq    48(%rbp), %rax
+; nextln: movq    56(%rbp), %r13
+; nextln: addq    %rdx, %rdi
+; nextln: adcq    %rcx, %rsi
+; nextln: xorq    %rcx, %rcx
+; nextln: addq    %r8, %r9
+; nextln: adcq    %rcx, %r10
+; nextln: addq    %rax, %r12
+; nextln: adcq    %r13, %r11
+; nextln: addq    %r9, %rdi
+; nextln: adcq    %r10, %rsi
+; nextln: addq    %rdi, %r12
+; nextln: adcq    %rsi, %r11
+; nextln: movq    %r12, %rax
+; nextln: movq    %r11, %rdx
+; nextln: movq    0(%rsp), %r12
+; nextln: movq    8(%rsp), %r13
+; nextln: addq    $$16, %rsp
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+
+}
+
+function %f30(i128) -> i128, i128, i128, i64, i128, i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i128):
+    v1 = ireduce.i64 v0
+    return v0, v0, v0, v1, v0, v0
+
+; likely to change with regalloc -- just check the stores into the retval area:
+
+; check:  movq    %r8, 0(%rsi)
+; nextln: movq    %r9, 8(%rsi)
+; nextln: movq    %r10, 16(%rsi)
+; nextln: movq    %r11, 24(%rsi)
+; nextln: movq    %r12, 32(%rsi)
+; nextln: movq    %r13, 48(%rsi)
+; nextln: movq    %r14, 56(%rsi)
+; nextln: movq    %rdi, 64(%rsi)
+; nextln: movq    %rbx, 72(%rsi)
+
+}
+
+function %f31(i128, i128) -> i128, i128 {
+    fn0 = %g(i128, i128) -> i128, i128
+block0(v0: i128, v1: i128):
+    v2, v3 = call fn0(v0, v1)
+    return v2, v3
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: subq    $$16, %rsp
+; nextln: movq    %r12, 0(%rsp)
+; nextln: virtual_sp_offset_adjust 8
+; nextln: movq    %r8, %r12
+; nextln: subq    $$16, %rsp
+; nextln: virtual_sp_offset_adjust 16
+; nextln: lea     0(%rsp), %r8
+; nextln: movaps  %g+0, %rax
+; nextln: call    *%rax
+; nextln: movq    0(%rsp), %rsi
+; nextln: movq    8(%rsp), %rdi
+; nextln: addq    $$16, %rsp
+; nextln: virtual_sp_offset_adjust -16
+; nextln: movq    %rsi, 0(%r12)
+; nextln: movq    %rdi, 8(%r12)
+; nextln: movq    0(%rsp), %r12
+; nextln: addq    $$16, %rsp
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+
+}
+
+function %f32(i128) -> i128 {
+block0(v0: i128):
+    v1 = clz.i128 v0
+    return v1
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: movabsq $$-1, %rcx
+; nextln: bsrq    %rsi, %rax
+; nextln: cmovzq  %rcx, %rax
+; nextln: movl    $$63, %esi
+; nextln: subq    %rax, %rsi
+; nextln: movabsq $$-1, %rcx
+; nextln: bsrq    %rdi, %rax
+; nextln: cmovzq  %rcx, %rax
+; nextln: movl    $$63, %edi
+; nextln: subq    %rax, %rdi
+; nextln: addq    $$64, %rdi
+; nextln: cmpq    $$64, %rsi
+; nextln: cmovnzq %rsi, %rdi
+; nextln: xorq    %rsi, %rsi
+; nextln: movq    %rdi, %rax
+; nextln: movq    %rsi, %rdx
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+
+}
+
+function %f33(i128) -> i128 {
+block0(v0: i128):
+    v1 = ctz.i128 v0
+    return v1
+}
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: movq    %rsi, %rax
+; nextln: movl    $$64, %ecx
+; nextln: bsfq    %rdi, %rsi
+; nextln: cmovzq  %rcx, %rsi
+; nextln: movl    $$64, %ecx
+; nextln: bsfq    %rax, %rdi
+; nextln: cmovzq  %rcx, %rdi
+; nextln: addq    $$64, %rdi
+; nextln: cmpq    $$64, %rsi
+; nextln: cmovzq  %rdi, %rsi
+; nextln: xorq    %rdi, %rdi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rdi, %rdx
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -1,0 +1,30 @@
+test compile
+target x86_64
+feature "experimental_x64"
+
+function %f0(i32, i128, i128) -> i128 {
+; check:   pushq   %rbp
+; nextln:  movq    %rsp, %rbp
+
+block0(v0: i32, v1: i128, v2: i128):
+
+    v3 = iconst.i32 42
+    v4 = icmp.i32 eq v0, v3
+; nextln: cmpl    $$42, %edi
+
+    v5 = select.i128 v4, v1, v2
+; nextln: movq    %rcx, %rdi
+; nextln: movq    %r8, %rax
+; nextln: cmovzq  %rsi, %rdi
+; nextln: cmovzq  %rdx, %rax
+
+    return v5
+; nextln: movq    %rax, %rdx
+; nextln: movq    %rdi, %rax
+
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+ 
+}
+

--- a/cranelift/filetests/filetests/isa/x64/shift-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/shift-i128-run.clif
@@ -1,0 +1,106 @@
+test run
+target x86_64
+feature "experimental_x64"
+
+function %ishl1() -> b1 {
+block0:
+    v0 = iconst.i64 0x01010101_01010101
+    v1 = iconcat v0, v0
+    v2 = iconst.i32 2
+    v3 = ishl.i128 v1, v2
+    v4 = iconst.i64 0x04040404_04040404
+    v5 = iconcat v4, v4
+    v6 = icmp eq v3, v5
+    return v6
+}
+; run
+
+function %ishl2() -> b1 {
+block0:
+    v0 = iconst.i64 0x01010101_01010101
+    v1 = iconst.i64 0x01010101_01010101
+    v2 = iconcat v0, v1
+    v3 = iconst.i32 9
+    v4 = ishl.i128 v2, v3
+    v5 = iconst.i64 0x02020202_02020200
+    v6 = iconst.i64 0x02020202_02020202
+    v7 = iconcat v5, v6
+    v8 = icmp eq v4, v7
+    return v8
+}
+; run
+
+function %ishl3() -> b1 {
+block0:
+    v0 = iconst.i64 0x01010101_01010101
+    v1 = iconst.i64 0xffffffff_ffffffff
+    v2 = iconcat v0, v1
+    v3 = iconst.i32 66
+    v4 = ishl.i128 v2, v3
+    v5 = iconst.i64 0x00000000_00000000
+    v6 = iconst.i64 0x04040404_04040404
+    v7 = iconcat v5, v6
+    v8 = icmp eq v4, v7
+    return v8
+}
+; run
+
+function %ushr1() -> b1 {
+block0:
+    v0 = iconst.i64 0x01010101_01010101
+    v1 = iconst.i64 0x01010101_01010101
+    v2 = iconcat v0, v1
+    v3 = iconst.i32 2
+    v4 = ushr.i128 v2, v3
+    v5 = iconst.i64 0x40404040_40404040
+    v6 = iconst.i64 0x00404040_40404040
+    v7 = iconcat v5, v6
+    v8 = icmp eq v4, v7
+    return v8
+}
+; run
+
+function %ushr2() -> b1 {
+block0:
+    v0 = iconst.i64 0x01010101_01010101
+    v1 = iconst.i64 0x01010101_01010101
+    v2 = iconcat v0, v1
+    v3 = iconst.i32 66
+    v4 = ushr.i128 v2, v3
+    v5 = iconst.i64 0x00404040_40404040
+    v6 = iconst.i64 0x00000000_00000000
+    v7 = iconcat v5, v6
+    v8 = icmp eq v4, v7
+    return v8
+}
+; run
+
+function %sshr1() -> b1 {
+block0:
+    v0 = iconst.i64 0x01010101_01010101
+    v1 = iconst.i64 0x81010101_01010101
+    v2 = iconcat v0, v1
+    v3 = iconst.i32 2
+    v4 = sshr.i128 v2, v3
+    v5 = iconst.i64 0x40404040_40404040
+    v6 = iconst.i64 0xe0404040_40404040
+    v7 = iconcat v5, v6
+    v8 = icmp eq v4, v7
+    return v8
+}
+; run
+
+function %sshr2() -> b1 {
+block0:
+    v0 = iconst.i64 0x12345678_9abcdef0
+    v1 = iconst.i64 0x80101010_10101010
+    v2 = iconcat v0, v1
+    v3 = iconst.i32 66
+    v4 = sshr.i128 v2, v3
+    v5 = iconst.i64 0xe0040404_04040404
+    v6 = iconst.i64 0xffffffff_ffffffff
+    v7 = iconcat v5, v6
+    v8 = icmp eq v4, v7
+    return v8
+}
+; run

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -1,0 +1,91 @@
+test compile
+target x86_64
+feature "experimental_x64"
+
+function u0:0(i64 sarg(64)) -> i8 system_v {
+block0(v0: i64):
+    v1 = load.i8 v0
+    return v1
+}
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: lea     16(%rbp), %rsi
+; nextln: movzbq  0(%rsi), %rsi
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+
+function u0:1(i64 sarg(64), i64) -> i8 system_v {
+block0(v0: i64, v1: i64):
+    v2 = load.i8 v1
+	v3 = load.i8 v0
+	v4 = iadd.i8 v2, v3
+    return v4
+}
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: lea     16(%rbp), %rsi
+; nextln: movzbq  0(%rdi), %rdi
+; nextln: movzbq  0(%rsi), %rsi
+; nextln: addl    %esi, %edi
+; nextln: movq    %rdi, %rax
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+
+function u0:2(i64) -> i8 system_v {
+fn1 = colocated u0:0(i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64):
+    v1 = call fn1(v0)
+    return v1
+}
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: movq    %rdi, %rsi
+; nextln: subq    $$64, %rsp
+; nextln: virtual_sp_offset_adjust 64
+; nextln: lea     0(%rsp), %rdi
+; nextln: movl    $$64, %edx
+; nextln: movaps  %Memcpy+0, %rcx
+; nextln: call    *%rcx
+; nextln: call    User { namespace: 0, index: 0 }
+; nextln: addq    $$64, %rsp
+; nextln: virtual_sp_offset_adjust -64
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret
+
+function u0:3(i64, i64) -> i8 system_v {
+fn1 = colocated u0:0(i64, i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64, v1: i64):
+    v2 = call fn1(v0, v1)
+    return v2
+}
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: subq    $$16, %rsp
+; nextln: movq    %r12, 0(%rsp)
+; nextln: virtual_sp_offset_adjust 16
+; nextln: movq    %rdi, %r12
+; nextln: subq    $$64, %rsp
+; nextln: virtual_sp_offset_adjust 64
+; nextln: lea     0(%rsp), %rdi
+; nextln: movl    $$64, %edx
+; nextln: movaps  %Memcpy+0, %rcx
+; nextln: call    *%rcx
+; nextln: movq    %r12, %rdi
+; nextln: call    User { namespace: 0, index: 0 }
+; nextln: addq    $$64, %rsp
+; nextln: virtual_sp_offset_adjust -64
+; nextln: movq    0(%rsp), %r12
+; nextln: addq    $$16, %rsp
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -1,0 +1,19 @@
+test compile
+target x86_64
+feature "experimental_x64"
+
+function %f0(i64 sret) {
+block0(v0: i64):
+    v1 = iconst.i64 42
+    store v1, v0
+    return
+}
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: movq    %rdi, %rax
+; nextln: movl    $$42, %esi
+; nextln: movq    %rsi, 0(%rdi)
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret

--- a/cranelift/filetests/filetests/isa/x64/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_elf.clif
@@ -1,0 +1,19 @@
+test compile
+set tls_model=elf_gd
+target x86_64
+feature "experimental_x64"
+
+function u0:0(i32) -> i64 {
+gv0 = symbol colocated tls u1:0
+
+block0(v0: i32):
+    v1 = global_value.i64 gv0
+    return v1
+}
+
+; check:  pushq   %rbp
+; nextln: movq    %rsp, %rbp
+; nextln: elf_tls_get_addr User { namespace: 1, index: 0 }
+; nextln: movq    %rbp, %rsp
+; nextln: popq    %rbp
+; nextln: ret


### PR DESCRIPTION
This PR generalizes all of the `MachInst` framework to reason about SSA `Value`s as being located in *multiple* registers (one, two or four, currently, in an efficient packed form). This is necessary in order to handle CLIF with values wider than the machine width (`I128` on 64/32-bit machines and `I64` on 32-bit machines), unless we legalize it beforehand.

It also adds support for some basic 128-bit ALU ops to the x64 backend, loewring these directly to open-coded instruction sequences (add/adc, sub/sbb, etc.).

@julian-seward1 and @bnjbvr: this is the approach we had discussed a long time ago (in January, I think!). It follows from the "every backend accepts the same IR" philosophy, with the idea that maybe we will get to the point where legalization is largely not necessary.

*However*: I must say that I'm not super-happy with the level of complexity this has added to the framework. The fact that the work we do in the x64 backend to support this will have to be repeated on aarch64 is kind of unfortunate; and this all feels somewhat silly given that we still have the legalization framework's narrowing support, and could use that instead. Philosophically, I think that legalization is actually the right approach here: we should be able to factor out "general machine-independent algorithm for 128-bit multiply with 64-bit pieces" from the specific machine backends.

So I'm inclined *not* to go in this direction, but (i) want to see what thoughts anyone might have, and (ii) save this for the record, in case we wire up the old legalizations for now but reconsider or need multi-reg values in the future.