### PR TITLE
Fix fuzzer expectation about valid modules

### DIFF
--- a/fuzz/fuzz_targets/instantiate-maybe-invalid.rs
+++ b/fuzz/fuzz_targets/instantiate-maybe-invalid.rs
@@ -9,6 +9,7 @@ use wasmtime_fuzzing::oracles;
 fuzz_target!(|module: MaybeInvalidModule| {
     oracles::instantiate_with_config(
         &module.to_bytes(),
+        false,
         wasmtime_fuzzing::fuzz_default_config(Strategy::Auto).unwrap(),
         Some(Duration::from_secs(20)),
     );

--- a/fuzz/fuzz_targets/instantiate-swarm.rs
+++ b/fuzz/fuzz_targets/instantiate-swarm.rs
@@ -9,5 +9,5 @@ use wasmtime_fuzzing::oracles;
 fuzz_target!(|module: ConfiguredModule<SwarmConfig>| {
     let mut cfg = wasmtime_fuzzing::fuzz_default_config(Strategy::Auto).unwrap();
     cfg.wasm_multi_memory(true);
-    oracles::instantiate_with_config(&module.to_bytes(), cfg, Some(Duration::from_secs(20)));
+    oracles::instantiate_with_config(&module.to_bytes(), true, cfg, Some(Duration::from_secs(20)));
 });

--- a/fuzz/fuzz_targets/instantiate-wasm-smith.rs
+++ b/fuzz/fuzz_targets/instantiate-wasm-smith.rs
@@ -9,5 +9,5 @@ fuzz_target!(|module: Module| {
     let mut module = module;
     module.ensure_termination(1000);
     let wasm_bytes = module.to_bytes();
-    oracles::instantiate(&wasm_bytes, Strategy::Auto);
+    oracles::instantiate(&wasm_bytes, true, Strategy::Auto);
 });

--- a/fuzz/fuzz_targets/instantiate.rs
+++ b/fuzz/fuzz_targets/instantiate.rs
@@ -5,5 +5,5 @@ use wasmtime::Strategy;
 use wasmtime_fuzzing::oracles;
 
 fuzz_target!(|data: &[u8]| {
-    oracles::instantiate(data, Strategy::Auto);
+    oracles::instantiate(data, false, Strategy::Auto);
 });

--- a/tests/all/fuzzing.rs
+++ b/tests/all/fuzzing.rs
@@ -11,13 +11,13 @@ use wasmtime_fuzzing::oracles;
 #[test]
 fn instantiate_empty_module() {
     let data = wat::parse_str(include_str!("./fuzzing/empty.wat")).unwrap();
-    oracles::instantiate(&data, Strategy::Auto);
+    oracles::instantiate(&data, true, Strategy::Auto);
 }
 
 #[test]
 fn instantiate_empty_module_with_memory() {
     let data = wat::parse_str(include_str!("./fuzzing/empty_with_memory.wat")).unwrap();
-    oracles::instantiate(&data, Strategy::Auto);
+    oracles::instantiate(&data, true, Strategy::Auto);
 }
 
 #[test]
@@ -26,5 +26,5 @@ fn instantiate_module_that_compiled_to_x64_has_register_32() {
     let mut config = Config::new();
     config.debug_info(true);
     let data = wat::parse_str(include_str!("./fuzzing/issue694.wat")).unwrap();
-    oracles::instantiate_with_config(&data, config, None);
+    oracles::instantiate_with_config(&data, true, config, None);
 }


### PR DESCRIPTION
Recent changes to fuzzers made expectations more strict about handling
errors while fuzzing, but this erroneously changed a module compilation
step to always assume that the input wasm is valid. Instead a flag is
now passed through indicating whether the wasm blob is known valid or
invalid, and only if compilation fails and it's known valid do we panic.
