### PR TITLE
Fix jitdump header magic field on big-endian platforms

### DIFF
--- a/crates/profiling/src/jitdump_linux.rs
+++ b/crates/profiling/src/jitdump_linux.rs
@@ -249,11 +249,7 @@ impl State {
         let header = FileHeader {
             timestamp: self.get_time_stamp(),
             e_machine: self.get_e_machine(),
-            magic: if cfg!(target_endian = "little") {
-                0x4A695444
-            } else {
-                0x4454694a
-            },
+            magic: 0x4A695444,
             version: 1,
             size: mem::size_of::<FileHeader>() as u32,
             pad1: 0,


### PR DESCRIPTION
The jitdump header contains a "magic" field that is defined to hold
the value 0x4A695444 as u32 in native endianness.  (This allows
consumers of the file to detect the endianness of the platform
where the file was written, and apply it when reading other fields.)

However, current code always writes 0x4A695444 in little-endian
byte order, even on big-endian system.  This makes consumers fail
when attempting to read files written on big-endian platforms.

Fixed by always writing the magic in native endianness.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
