### PR TITLE
Add filestat_get for stdout, stdin and stderr

### DIFF
--- a/crates/wasi-common/src/sys/stdio.rs
+++ b/crates/wasi-common/src/sys/stdio.rs
@@ -17,7 +17,7 @@
 // TODO it might worth re-investigating the suitability of this type on Windows.
 
 use super::{fd, AsFile};
-use crate::handle::{Fdflags, Filetype, Handle, HandleRights, Rights, RightsExt, Size};
+use crate::handle::{Fdflags, Filestat, Filetype, Handle, HandleRights, Rights, RightsExt, Size};
 use crate::sandboxed_tty_writer::SandboxedTTYWriter;
 use crate::{Error, Result};
 use std::any::Any;
@@ -65,6 +65,9 @@ impl Handle for Stdin {
         }
         Ok(())
     }
+    fn filestat_get(&self) -> Result<Filestat> {
+        fd::filestat_get(&*self.as_file()?)
+    }
     fn read_vectored(&self, iovs: &mut [io::IoSliceMut]) -> Result<usize> {
         let nread = io::stdin().read_vectored(iovs)?;
         Ok(nread)
@@ -110,6 +113,9 @@ impl Handle for Stdout {
             panic!("Tried updating Fdflags on Stdio handle by re-opening as file!");
         }
         Ok(())
+    }
+    fn filestat_get(&self) -> Result<Filestat> {
+        fd::filestat_get(&*self.as_file()?)
     }
     fn write_vectored(&self, iovs: &[io::IoSlice]) -> Result<usize> {
         // lock for the duration of the scope
@@ -164,6 +170,9 @@ impl Handle for Stderr {
             panic!("Tried updating Fdflags on Stdio handle by re-opening as file!");
         }
         Ok(())
+    }
+    fn filestat_get(&self) -> Result<Filestat> {
+        fd::filestat_get(&*self.as_file()?)
     }
     fn write_vectored(&self, iovs: &[io::IoSlice]) -> Result<usize> {
         // Always sanitize stderr, even if it's not directly connected to a tty,


### PR DESCRIPTION
This makes fstat work for stdout, stdin and stderr as expected.
This seemed like the only reasonable functions to implement from the
filestat_* set, for stdout, stdin and stderr.

Fixes #2515

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
