### PR TITLE
Implement the pooling instance allocator.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,6 +122,7 @@ jobs:
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features jitdump
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features cache
     - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features async
+    - run: cargo check --manifest-path crates/wasmtime/Cargo.toml --features uffd
 
     # Check some feature combinations of the `wasmtime-c-api` crate
     - run: cargo check --manifest-path crates/c-api/Cargo.toml --no-default-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -304,6 +304,14 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+    # Test uffd functionality on Linux
+    - run: |
+        cargo test --features uffd -p wasmtime-runtime instance::allocator::pooling
+        cargo test --features uffd -p wasmtime-cli pooling_allocator
+      if: matrix.os == 'ubuntu-latest'
+      env:
+        RUST_BACKTRACE: 1
+
     # Build and test lightbeam. Note that
     # Lightbeam tests fail right now, but we don't want to block on that.
     - run: cargo build --package lightbeam

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,14 +73,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    # Note that we use nightly Rust here to get intra-doc links which are a
-    # nightly-only feature right now.
+    # Note that we use nightly Rust for the doc_cfg feature (enabled via `nightlydoc` above)
+    # This version is an older nightly for the new x64 backend (see below)
     - uses: ./.github/actions/install-rust
       with:
-        # TODO (rust-lang/rust#79661): We are seeing an internal compiler error when
-        # building with the latest (2020-12-06) nightly; pin on a slightly older
-        # version for now.
-        toolchain: nightly-2020-11-29
+        toolchain: nightly-2020-12-26
     - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
     - run: cargo doc --package cranelift-codegen-meta --document-private-items
     - uses: actions/upload-artifact@v1
@@ -168,7 +165,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-11-29
+        toolchain: nightly
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
@@ -225,7 +222,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2020-11-29
+            rust: nightly
           - build: macos
             os: macos-latest
             rust: stable
@@ -321,8 +318,10 @@ jobs:
         RUST_BACKTRACE: 1
 
   # Perform all tests (debug mode) for `wasmtime` with the experimental x64
-  # backend. This runs on the nightly channel of Rust (because of issues with
-  # unifying Cargo features on stable) on Ubuntu.
+  # backend. This runs on an older nightly of Rust (because of issues with
+  # unifying Cargo features on stable) on Ubuntu such that it's new enough
+  # to build Wasmtime, but old enough where the -Z options being used
+  # haven't been stabilized yet.
   test_x64:
     name: Test x64 new backend
     runs-on: ubuntu-latest
@@ -332,7 +331,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-11-29
+        toolchain: nightly-2020-12-26
     - uses: ./.github/actions/define-llvm-env
 
     # Install wasm32 targets in order to build various tests throughout the
@@ -343,7 +342,7 @@ jobs:
     # Run the x64 CI script.
     - run: ./ci/run-experimental-x64-ci.sh
       env:
-        CARGO_VERSION: "+nightly-2020-11-29"
+        CARGO_VERSION: "+nightly-2020-12-26"
         RUST_BACKTRACE: 1
 
   # Build and test the wasi-nn module.
@@ -356,7 +355,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/install-rust
         with:
-          toolchain: nightly-2020-11-29
+          toolchain: nightly
       - run: rustup target add wasm32-wasi
       - uses: ./.github/actions/install-openvino
       - run: ./ci/run-wasi-nn-example.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,6 +305,7 @@ jobs:
     - run: |
         cargo test --features uffd -p wasmtime-runtime instance::allocator::pooling
         cargo test --features uffd -p wasmtime-cli pooling_allocator
+        cargo test --features uffd -p wasmtime-cli wast::Cranelift
       if: matrix.os == 'ubuntu-latest'
       env:
         RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,6 +3450,7 @@ dependencies = [
 name = "wasmtime-runtime"
 version = "0.24.0"
 dependencies = [
+ "anyhow",
  "backtrace",
  "cc",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1576,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,7 +1735,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb64bef270a1ff665b0b2e28ebfa213e6205a007ce88223d020730225d6008f"
 dependencies = [
- "bindgen",
+ "bindgen 0.55.1",
  "cmake",
 ]
 
@@ -2919,6 +2951,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "userfaultfd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d8164d4a8198fa546e7553b529f53e82907214a25fafda4a6f90d978b30a5c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "nix",
+ "thiserror",
+ "userfaultfd-sys",
+]
+
+[[package]]
+name = "userfaultfd-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ada4f4ae167325015f52cc65f9fb6c251b868d8fb3b6dd0ce2d60e497c4870a"
+dependencies = [
+ "bindgen 0.57.0",
+ "cc",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +2985,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
@@ -3397,8 +3459,10 @@ dependencies = [
  "memoffset",
  "more-asserts",
  "psm",
+ "rand 0.7.3",
  "region",
  "thiserror",
+ "userfaultfd",
  "wasmtime-environ",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,6 +3324,7 @@ dependencies = [
  "indexmap",
  "log",
  "more-asserts",
+ "region",
  "serde",
  "thiserror",
  "wasmparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ jitdump = ["wasmtime/jitdump"]
 vtune = ["wasmtime/vtune"]
 wasi-crypto = ["wasmtime-wasi-crypto"]
 wasi-nn = ["wasmtime-wasi-nn"]
+uffd = ["wasmtime/uffd"]
 
 # Try the experimental, work-in-progress new x86_64 backend. This is not stable
 # as of June 2020.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <p>
     <a href="https://github.com/bytecodealliance/wasmtime/actions?query=workflow%3ACI"><img src="https://github.com/bytecodealliance/wasmtime/workflows/CI/badge.svg" alt="build status" /></a>
     <a href="https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen.svg" alt="zulip chat" /></a>
-    <img src="https://img.shields.io/badge/rustc-1.37+-green.svg" alt="min rustc" />
+    <img src="https://img.shields.io/badge/rustc-stable+-green.svg" alt="supported rustc stable" />
     <a href="https://docs.rs/wasmtime"><img src="https://docs.rs/wasmtime/badge.svg" alt="Documentation Status" /></a>
   </p>
 

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -101,6 +101,8 @@ pub fn translate_module<'data>(
 
             Payload::DataCountSection { count, range } => {
                 validator.data_count_section(count, &range)?;
+
+                // NOTE: the count here is the total segment count, not the passive segment count
                 environ.reserve_passive_data(count)?;
             }
 

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -401,6 +401,12 @@ pub fn parse_element_section<'data>(
                         ));
                     }
                 };
+                // Check for offset + len overflow
+                if offset.checked_add(segments.len()).is_none() {
+                    return Err(wasm_unsupported!(
+                        "element segment offset and length overflows"
+                    ));
+                }
                 environ.declare_table_elements(
                     TableIndex::from_u32(table_index),
                     base,
@@ -447,6 +453,12 @@ pub fn parse_data_section<'data>(
                         ))
                     }
                 };
+                // Check for offset + len overflow
+                if offset.checked_add(data.len()).is_none() {
+                    return Err(wasm_unsupported!(
+                        "data segment offset and length overflows"
+                    ));
+                }
                 environ.declare_data_initialization(
                     MemoryIndex::from_u32(memory_index),
                     base,

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -61,8 +61,8 @@ pub extern "C" fn wasmtime_config_consume_fuel_set(c: &mut wasm_config_t, enable
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_max_wasm_stack_set(c: &mut wasm_config_t, size: usize) {
-    c.config.max_wasm_stack(size);
+pub extern "C" fn wasmtime_config_max_wasm_stack_set(c: &mut wasm_config_t, size: usize) -> bool {
+    c.config.max_wasm_stack(size).is_ok()
 }
 
 #[no_mangle]

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -43,7 +43,7 @@ impl<'config> ModuleCacheEntry<'config> {
     }
 
     /// Gets cached data if state matches, otherwise calls the `compute`.
-    pub fn get_data<T, U, E>(&self, state: T, compute: fn(T) -> Result<U, E>) -> Result<U, E>
+    pub fn get_data<T, U, E>(&self, state: T, compute: impl Fn(T) -> Result<U, E>) -> Result<U, E>
     where
         T: Hash,
         U: Serialize + for<'a> Deserialize<'a>,

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -43,7 +43,7 @@ impl<'config> ModuleCacheEntry<'config> {
     }
 
     /// Gets cached data if state matches, otherwise calls the `compute`.
-    pub fn get_data<T, U, E>(&self, state: T, compute: impl Fn(T) -> Result<U, E>) -> Result<U, E>
+    pub fn get_data<T, U, E>(&self, state: T, compute: fn(T) -> Result<U, E>) -> Result<U, E>
     where
         T: Hash,
         U: Serialize + for<'a> Deserialize<'a>,

--- a/crates/cache/src/tests.rs
+++ b/crates/cache/src/tests.rs
@@ -65,28 +65,68 @@ fn test_write_read_cache() {
     let entry1 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler1, &cache_config));
     let entry2 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler2, &cache_config));
 
-    entry1.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry1.get_data::<_, i32, i32>(2, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry1.get_data::<_, i32, i32>(3, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry1.get_data::<_, i32, i32>(4, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
+    entry1
+        .get_data(4, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(4, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 
-    entry2.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
-    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
-    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
-    entry2.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry2
+        .get_data(1, |_| -> Result<i32, ()> { Ok(100) })
+        .unwrap();
+    entry1
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(2, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(3, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry1
+        .get_data(4, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
+    entry2
+        .get_data(1, |_| -> Result<i32, ()> { panic!() })
+        .unwrap();
 }

--- a/crates/cache/src/tests.rs
+++ b/crates/cache/src/tests.rs
@@ -65,68 +65,28 @@ fn test_write_read_cache() {
     let entry1 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler1, &cache_config));
     let entry2 = ModuleCacheEntry::from_inner(ModuleCacheEntryInner::new(compiler2, &cache_config));
 
-    entry1
-        .get_data(1, |_| -> Result<i32, ()> { Ok(100) })
-        .unwrap();
-    entry1
-        .get_data(1, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
 
-    entry1
-        .get_data(2, |_| -> Result<i32, ()> { Ok(100) })
-        .unwrap();
-    entry1
-        .get_data(1, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(2, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
 
-    entry1
-        .get_data(3, |_| -> Result<i32, ()> { Ok(100) })
-        .unwrap();
-    entry1
-        .get_data(1, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(2, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(3, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
 
-    entry1
-        .get_data(4, |_| -> Result<i32, ()> { Ok(100) })
-        .unwrap();
-    entry1
-        .get_data(1, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(2, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(3, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(4, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
+    entry1.get_data::<_, i32, i32>(4, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
 
-    entry2
-        .get_data(1, |_| -> Result<i32, ()> { Ok(100) })
-        .unwrap();
-    entry1
-        .get_data(1, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(2, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(3, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry1
-        .get_data(4, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
-    entry2
-        .get_data(1, |_| -> Result<i32, ()> { panic!() })
-        .unwrap();
+    entry2.get_data::<_, i32, i32>(1, |_| Ok(100)).unwrap();
+    entry1.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(2, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(3, |_| panic!()).unwrap();
+    entry1.get_data::<_, i32, i32>(4, |_| panic!()).unwrap();
+    entry2.get_data::<_, i32, i32>(1, |_| panic!()).unwrap();
 }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+region = "2.2.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.71.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.71.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.71.0", features = ["enable-serde"] }

--- a/crates/environ/src/data_structures.rs
+++ b/crates/environ/src/data_structures.rs
@@ -20,7 +20,7 @@ pub mod isa {
 }
 
 pub mod entity {
-    pub use cranelift_entity::{packed_option, BoxedSlice, EntityRef, PrimaryMap};
+    pub use cranelift_entity::{packed_option, BoxedSlice, EntityRef, EntitySet, PrimaryMap};
 }
 
 pub mod wasm {

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -1,7 +1,7 @@
 //! Data structures for representing decoded wasm modules.
 
 use crate::tunables::Tunables;
-use crate::WASM_MAX_PAGES;
+use crate::{DataInitializer, WASM_MAX_PAGES, WASM_PAGE_SIZE};
 use cranelift_codegen::ir;
 use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_wasm::*;
@@ -9,19 +9,6 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-
-/// A WebAssembly table initializer.
-#[derive(Clone, Debug, Hash, Serialize, Deserialize)]
-pub struct TableElements {
-    /// The index of a table to initialize.
-    pub table_index: TableIndex,
-    /// Optionally, a global variable giving a base index.
-    pub base: Option<GlobalIndex>,
-    /// The offset to add to the base.
-    pub offset: usize,
-    /// The values to write into the table elements.
-    pub elements: Box<[FuncIndex]>,
-}
 
 /// Implemenation styles for WebAssembly linear memory.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
@@ -92,6 +79,164 @@ impl MemoryPlan {
     }
 }
 
+/// A WebAssembly linear memory initializer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryInitializer {
+    /// The index of a linear memory to initialize.
+    pub memory_index: MemoryIndex,
+    /// Optionally, a global variable giving a base index.
+    pub base: Option<GlobalIndex>,
+    /// The offset to add to the base.
+    pub offset: usize,
+    /// The data to write into the linear memory.
+    pub data: Box<[u8]>,
+}
+
+impl From<DataInitializer<'_>> for MemoryInitializer {
+    fn from(initializer: DataInitializer) -> Self {
+        Self {
+            memory_index: initializer.memory_index,
+            base: initializer.base,
+            offset: initializer.offset,
+            data: initializer.data.into(),
+        }
+    }
+}
+
+/// The type of WebAssembly linear memory initialization.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum MemoryInitialization {
+    /// Memory initialization is paged.
+    ///
+    /// To be paged, the following requirements must be met:
+    ///
+    /// * All data segments must reference defined memories.
+    /// * All data segments must not use a global base.
+    /// * All data segments must be in bounds.
+    ///
+    /// Paged initialization is performed by memcopying individual pages to the linear memory.
+    Paged {
+        /// The size of each page stored in the map.
+        /// This is expected to be the host page size.
+        page_size: usize,
+        /// The map of defined memory index to a list of page data.
+        /// The list of page data is sparse, with None representing a zero page.
+        /// The size of the list will be the maximum page written to by a data segment.
+        map: PrimaryMap<DefinedMemoryIndex, Vec<Option<Box<[u8]>>>>,
+    },
+    /// Memory initialization is out of bounds.
+    ///
+    /// To be out of bounds, the following requirements must be met:
+    ///
+    /// * All data segments must reference defined memories.
+    /// * All data segments must not use a global base.
+    /// * At least one data segments was out of bounds.
+    ///
+    /// This can be used to quickly return an error when the module is instantiated.
+    OutOfBounds,
+    /// Memory initialization is segmented.
+    ///
+    /// To be segmented, at least one of the following requirements must be met:
+    ///
+    /// * A data segment referenced an imported memory.
+    /// * A data segment uses a global base.
+    ///
+    /// Segmented initialization is performed by processing the complete set of data segments
+    /// when the module is instantiated.
+    ///
+    /// This ensures that initialization side-effects are observed according to the bulk-memory proposal.
+    Segmented(Box<[MemoryInitializer]>),
+}
+
+impl MemoryInitialization {
+    /// Creates a new memory initialization for a module and its data initializers.
+    pub fn new(module: &Module, initializers: Vec<DataInitializer>) -> Self {
+        let page_size = region::page::size();
+        let num_defined_memories = module.memory_plans.len() - module.num_imported_memories;
+        let mut out_of_bounds = false;
+        let mut memories = PrimaryMap::with_capacity(num_defined_memories);
+
+        for _ in 0..num_defined_memories {
+            memories.push(Vec::new());
+        }
+
+        for initializer in &initializers {
+            match (
+                module.defined_memory_index(initializer.memory_index),
+                initializer.base.is_some(),
+            ) {
+                (None, _) | (_, true) => {
+                    // If the initializer references an imported memory or uses a global base,
+                    // the complete set of segments will need to be processed at module instantiation
+                    return Self::Segmented(
+                        initializers
+                            .into_iter()
+                            .map(Into::into)
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    );
+                }
+                (Some(index), false) => {
+                    if out_of_bounds {
+                        continue;
+                    }
+
+                    // Perform a bounds check on the segment
+                    if (initializer.offset + initializer.data.len())
+                        > ((module.memory_plans[initializer.memory_index].memory.minimum as usize)
+                            * (WASM_PAGE_SIZE as usize))
+                    {
+                        out_of_bounds = true;
+                        continue;
+                    }
+
+                    let pages = &mut memories[index];
+                    let mut page_index = initializer.offset / page_size;
+                    let mut page_offset = initializer.offset % page_size;
+                    let mut data_offset = 0;
+                    let mut data_remaining = initializer.data.len();
+
+                    if data_remaining == 0 {
+                        continue;
+                    }
+
+                    // Copy the initialization data by each page
+                    loop {
+                        if page_index >= pages.len() {
+                            pages.resize(page_index + 1, None);
+                        }
+
+                        let page = pages[page_index]
+                            .get_or_insert_with(|| vec![0; page_size].into_boxed_slice());
+                        let len = std::cmp::min(data_remaining, page_size - page_offset);
+
+                        page[page_offset..page_offset + len]
+                            .copy_from_slice(&initializer.data[data_offset..(data_offset + len)]);
+
+                        if len == data_remaining {
+                            break;
+                        }
+
+                        page_index += 1;
+                        page_offset = 0;
+                        data_offset += len;
+                        data_remaining -= len;
+                    }
+                }
+            };
+        }
+
+        if out_of_bounds {
+            Self::OutOfBounds
+        } else {
+            Self::Paged {
+                page_size,
+                map: memories,
+            }
+        }
+    }
+}
+
 /// Implemenation styles for WebAssembly tables.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
 pub enum TableStyle {
@@ -122,6 +267,19 @@ impl TablePlan {
         let style = TableStyle::for_table(table, tunables);
         Self { table, style }
     }
+}
+
+/// A WebAssembly table initializer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TableInitializer {
+    /// The index of a table to initialize.
+    pub table_index: TableIndex,
+    /// Optionally, a global variable giving a base index.
+    pub base: Option<GlobalIndex>,
+    /// The offset to add to the base.
+    pub offset: usize,
+    /// The values to write into the table elements.
+    pub elements: Box<[FuncIndex]>,
 }
 
 /// Different types that can appear in a module.
@@ -164,7 +322,10 @@ pub struct Module {
     pub start_func: Option<FuncIndex>,
 
     /// WebAssembly table initializers.
-    pub table_elements: Vec<TableElements>,
+    pub table_initializers: Vec<TableInitializer>,
+
+    /// WebAssembly linear memory initializer.
+    pub memory_initialization: Option<MemoryInitialization>,
 
     /// WebAssembly passive elements.
     pub passive_elements: Vec<Box<[FuncIndex]>>,

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -33,7 +33,7 @@ impl MemoryStyle {
         let maximum = std::cmp::min(
             memory.maximum.unwrap_or(WASM_MAX_PAGES),
             if tunables.static_memory_bound_is_maximum {
-                tunables.static_memory_bound
+                std::cmp::min(tunables.static_memory_bound, WASM_MAX_PAGES)
             } else {
                 WASM_MAX_PAGES
             },

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -42,8 +42,16 @@ impl MemoryStyle {
         // A heap with a maximum that doesn't exceed the static memory bound specified by the
         // tunables make it static.
         //
-        // If the module doesn't declare an explicit maximum treat it as 4GiB.
-        let maximum = memory.maximum.unwrap_or(WASM_MAX_PAGES);
+        // If the module doesn't declare an explicit maximum treat it as 4GiB when not
+        // requested to use the static memory bound itself as the maximum.
+        let maximum = memory
+            .maximum
+            .unwrap_or(if tunables.static_memory_bound_is_maximum {
+                tunables.static_memory_bound
+            } else {
+                WASM_MAX_PAGES
+            });
+
         if maximum <= tunables.static_memory_bound {
             assert_ge!(tunables.static_memory_bound, memory.minimum);
             return (

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -27,6 +27,9 @@ pub struct Tunables {
     /// Whether or not fuel is enabled for generated code, meaning that fuel
     /// will be consumed every time a wasm instruction is executed.
     pub consume_fuel: bool,
+
+    /// Whether or not to treat the static memory bound as the maximum for unbounded heaps.
+    pub static_memory_bound_is_maximum: bool,
 }
 
 impl Default for Tunables {
@@ -62,6 +65,7 @@ impl Default for Tunables {
             parse_wasm_debuginfo: true,
             interruptable: false,
             consume_fuel: false,
+            static_memory_bound_is_maximum: false,
         }
     }
 }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -50,6 +50,7 @@ fn align(offset: u32, width: u32) -> u32 {
 
 /// This class computes offsets to fields within `VMContext` and other
 /// related structs that JIT code accesses directly.
+#[derive(Debug, Clone, Copy)]
 pub struct VMOffsets {
     /// The size in bytes of a pointer on the target.
     pub pointer_size: u8,

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -66,7 +66,7 @@ impl<'a, Resume, Yield, Return> Fiber<'a, Resume, Yield, Return> {
         func: impl FnOnce(Resume, &Suspend<Resume, Yield, Return>) -> Return + 'a,
     ) -> io::Result<Fiber<'a, Resume, Yield, Return>> {
         Ok(Fiber {
-            inner: imp::Fiber::new_with_stack(top_of_stack, func),
+            inner: imp::Fiber::new_with_stack(top_of_stack, func)?,
             done: Cell::new(false),
             _phantom: PhantomData,
         })

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -75,7 +75,7 @@ impl Fiber {
         Ok(fiber)
     }
 
-    pub fn new_with_stack<F, A, B, C>(top_of_stack: *mut u8, func: F) -> Self
+    pub fn new_with_stack<F, A, B, C>(top_of_stack: *mut u8, func: F) -> io::Result<Self>
     where
         F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
     {
@@ -86,7 +86,7 @@ impl Fiber {
 
         fiber.init(func);
 
-        fiber
+        Ok(fiber)
     }
 
     fn init<F, A, B, C>(&self, func: F)

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -35,10 +35,10 @@ use std::io;
 use std::ptr;
 
 pub struct Fiber {
-    // Description of the mmap region we own. This should be abstracted
-    // eventually so we aren't personally mmap-ing this region.
-    mmap: *mut libc::c_void,
-    mmap_len: usize,
+    // The top of the stack; for stacks allocated by the fiber implementation itself,
+    // the base address of the allocation will be `top_of_stack.sub(alloc_len.unwrap())`
+    top_of_stack: *mut u8,
+    alloc_len: Option<usize>,
 }
 
 pub struct Suspend {
@@ -66,21 +66,40 @@ where
 }
 
 impl Fiber {
-    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Fiber>
+    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Self>
     where
         F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
     {
-        let fiber = Fiber::alloc_with_stack(stack_size)?;
+        let fiber = Self::alloc_with_stack(stack_size)?;
+        fiber.init(func);
+        Ok(fiber)
+    }
+
+    pub fn new_with_stack<F, A, B, C>(top_of_stack: *mut u8, func: F) -> Self
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
+        let fiber = Self {
+            top_of_stack,
+            alloc_len: None,
+        };
+
+        fiber.init(func);
+
+        fiber
+    }
+
+    fn init<F, A, B, C>(&self, func: F)
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
         unsafe {
-            // Initialize the top of the stack to be resumed from
-            let top_of_stack = fiber.top_of_stack();
             let data = Box::into_raw(Box::new(func)).cast();
-            wasmtime_fiber_init(top_of_stack, fiber_start::<F, A, B, C>, data);
-            Ok(fiber)
+            wasmtime_fiber_init(self.top_of_stack, fiber_start::<F, A, B, C>, data);
         }
     }
 
-    fn alloc_with_stack(stack_size: usize) -> io::Result<Fiber> {
+    fn alloc_with_stack(stack_size: usize) -> io::Result<Self> {
         unsafe {
             // Round up our stack size request to the nearest multiple of the
             // page size.
@@ -104,7 +123,10 @@ impl Fiber {
             if mmap == libc::MAP_FAILED {
                 return Err(io::Error::last_os_error());
             }
-            let ret = Fiber { mmap, mmap_len };
+            let ret = Self {
+                top_of_stack: mmap.cast::<u8>().add(mmap_len),
+                alloc_len: Some(mmap_len),
+            };
             let res = libc::mprotect(
                 mmap.cast::<u8>().add(page_size).cast(),
                 stack_size,
@@ -124,27 +146,24 @@ impl Fiber {
             // stack, otherwise known as our reserved slot for this information.
             //
             // In the diagram above this is updating address 0xAff8
-            let top_of_stack = self.top_of_stack();
-            let addr = top_of_stack.cast::<usize>().offset(-1);
+            let addr = self.top_of_stack.cast::<usize>().offset(-1);
             addr.write(result as *const _ as usize);
 
-            wasmtime_fiber_switch(top_of_stack);
+            wasmtime_fiber_switch(self.top_of_stack);
 
             // null this out to help catch use-after-free
             addr.write(0);
         }
-    }
-
-    unsafe fn top_of_stack(&self) -> *mut u8 {
-        self.mmap.cast::<u8>().add(self.mmap_len)
     }
 }
 
 impl Drop for Fiber {
     fn drop(&mut self) {
         unsafe {
-            let ret = libc::munmap(self.mmap, self.mmap_len);
-            debug_assert!(ret == 0);
+            if let Some(alloc_len) = self.alloc_len {
+                let ret = libc::munmap(self.top_of_stack.sub(alloc_len) as _, alloc_len);
+                debug_assert!(ret == 0);
+            }
         }
     }
 }

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -40,7 +40,7 @@ where
 }
 
 impl Fiber {
-    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Fiber>
+    pub fn new<F, A, B, C>(stack_size: usize, func: F) -> io::Result<Self>
     where
         F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
     {
@@ -61,9 +61,17 @@ impl Fiber {
                 drop(Box::from_raw(state.initial_closure.get().cast::<F>()));
                 Err(io::Error::last_os_error())
             } else {
-                Ok(Fiber { fiber, state })
+                Ok(Self { fiber, state })
             }
         }
+    }
+
+    pub fn new_with_stack<F, A, B, C>(_top_of_stack: *mut u8, _func: F) -> Self
+    where
+        F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
+    {
+        // Windows fibers have no support for custom stacks
+        unimplemented!()
     }
 
     pub(crate) fn resume<A, B, C>(&self, result: &Cell<RunResult<A, B, C>>) {

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -3,6 +3,7 @@ use std::cell::Cell;
 use std::io;
 use std::ptr;
 use winapi::shared::minwindef::*;
+use winapi::shared::winerror::ERROR_NOT_SUPPORTED;
 use winapi::um::fibersapi::*;
 use winapi::um::winbase::*;
 
@@ -66,12 +67,11 @@ impl Fiber {
         }
     }
 
-    pub fn new_with_stack<F, A, B, C>(_top_of_stack: *mut u8, _func: F) -> Self
+    pub fn new_with_stack<F, A, B, C>(_top_of_stack: *mut u8, _func: F) -> io::Result<Self>
     where
         F: FnOnce(A, &super::Suspend<A, B, C>) -> C,
     {
-        // Windows fibers have no support for custom stacks
-        unimplemented!()
+        Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }
 
     pub(crate) fn resume<A, B, C>(&self, result: &Cell<RunResult<A, B, C>>) {

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -25,7 +25,7 @@ wasmtime-debug = { path = "../debug", version = "0.24.0" }
 wasmtime-profiling = { path = "../profiling", version = "0.24.0" }
 wasmtime-obj = { path = "../obj", version = "0.24.0" }
 rayon = { version = "1.0", optional = true }
-region = "2.1.0"
+region = "2.2.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.11.0", default-features = false }
 wasmparser = "0.76"

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -25,7 +25,7 @@ struct CodeMemoryEntry {
 
 impl CodeMemoryEntry {
     fn with_capacity(cap: usize) -> Result<Self, String> {
-        let mmap = ManuallyDrop::new(Mmap::with_at_least(cap)?);
+        let mmap = ManuallyDrop::new(Mmap::with_at_least(cap).map_err(|e| e.to_string())?);
         let registry = ManuallyDrop::new(UnwindRegistry::new(mmap.as_ptr() as usize));
         Ok(Self {
             mmap,

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -133,9 +133,9 @@ impl CompilationArtifacts {
                 }
 
                 let obj = obj.write().map_err(|_| {
-                    SetupError::Instantiate(InstantiationError::Resource(
-                        "failed to create image memory".to_string(),
-                    ))
+                    SetupError::Instantiate(InstantiationError::Resource(anyhow::anyhow!(
+                        "failed to create image memory"
+                    )))
                 })?;
 
                 Ok(CompilationArtifacts {
@@ -236,7 +236,7 @@ impl CompiledModule {
             &artifacts.unwind_info,
         )
         .map_err(|message| {
-            SetupError::Instantiate(InstantiationError::Resource(format!(
+            SetupError::Instantiate(InstantiationError::Resource(anyhow::anyhow!(
                 "failed to build code memory for functions: {}",
                 message
             )))

--- a/crates/jit/src/trampoline.rs
+++ b/crates/jit/src/trampoline.rs
@@ -38,7 +38,9 @@ pub fn make_trampoline(
     assert!(compiled_function.relocations.is_empty());
     let ptr = code_memory
         .allocate_for_function(&compiled_function)
-        .map_err(|message| SetupError::Instantiate(InstantiationError::Resource(message)))?
+        .map_err(|message| {
+            SetupError::Instantiate(InstantiationError::Resource(anyhow::anyhow!(message)))
+        })?
         .as_ptr();
     Ok(unsafe { std::mem::transmute::<*const VMFunctionBody, VMTrampoline>(ptr) })
 }

--- a/crates/obj/src/data_segment.rs
+++ b/crates/obj/src/data_segment.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use object::write::{Object, StandardSection, Symbol, SymbolSection};
 use object::{SymbolFlags, SymbolKind, SymbolScope};
-use wasmtime_environ::DataInitializer;
+use wasmtime_environ::MemoryInitializer;
 
 /// Declares data segment symbol
 pub fn declare_data_segment(
     obj: &mut Object,
-    _data_initaliazer: &DataInitializer,
+    _memory_initializer: &MemoryInitializer,
     index: usize,
 ) -> Result<()> {
     let name = format!("_memory_{}", index);
@@ -26,12 +26,12 @@ pub fn declare_data_segment(
 /// Emit segment data and initialization location
 pub fn emit_data_segment(
     obj: &mut Object,
-    data_initaliazer: &DataInitializer,
+    memory_initializer: &MemoryInitializer,
     index: usize,
 ) -> Result<()> {
     let name = format!("_memory_{}", index);
     let symbol_id = obj.symbol_id(name.as_bytes()).unwrap();
     let section_id = obj.section_id(StandardSection::Data);
-    obj.add_symbol_data(symbol_id, section_id, data_initaliazer.data, 1);
+    obj.add_symbol_data(symbol_id, section_id, &memory_initializer.data, 1);
     Ok(())
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,6 +25,7 @@ backtrace = "0.3.55"
 lazy_static = "1.3.0"
 psm = "0.1.11"
 rand = "0.7.3"
+anyhow = "1.0.38"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi"] }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -24,9 +24,13 @@ cfg-if = "1.0"
 backtrace = "0.3.55"
 lazy_static = "1.3.0"
 psm = "0.1.11"
+rand = "0.7.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+userfaultfd = { version = "0.3.0", optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -37,3 +37,9 @@ cc = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+default = []
+
+# Enables support for userfaultfd in the pooling allocator when building on Linux
+uffd = ["userfaultfd"]

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -351,8 +351,35 @@ impl VMExternRef {
         ptr
     }
 
+    /// Consume this `VMExternRef` into a raw, untyped pointer.
+    ///
+    /// # Safety
+    ///
+    /// This method forgets self, so it is possible to create a leak of the
+    /// underlying reference counted data if not used carefully.
+    ///
+    /// Use `from_raw` to recreate the `VMExternRef`.
+    pub unsafe fn into_raw(self) -> *mut u8 {
+        let ptr = self.0.cast::<u8>().as_ptr();
+        std::mem::forget(self);
+        ptr
+    }
+
     /// Recreate a `VMExternRef` from a pointer returned from a previous call to
-    /// `VMExternRef::as_raw`.
+    /// `as_raw`.
+    ///
+    /// # Safety
+    ///
+    /// Unlike `clone_from_raw`, this does not increment the reference count of the
+    /// underlying data.  It is not safe to continue to use the pointer passed to this
+    /// function.
+    pub unsafe fn from_raw(ptr: *mut u8) -> Self {
+        debug_assert!(!ptr.is_null());
+        VMExternRef(NonNull::new_unchecked(ptr).cast())
+    }
+
+    /// Recreate a `VMExternRef` from a pointer returned from a previous call to
+    /// `as_raw`.
     ///
     /// # Safety
     ///

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -834,12 +834,12 @@ impl Instance {
     ///
     /// Resetting the guard pages is required before growing memory.
     #[cfg(all(feature = "uffd", target_os = "linux"))]
-    pub(crate) fn reset_guard_pages(&self) -> Result<(), String> {
+    pub(crate) fn reset_guard_pages(&self) -> anyhow::Result<()> {
         let mut faults = self.guard_page_faults.borrow_mut();
         for (addr, len, reset) in faults.drain(..) {
             unsafe {
                 if !reset(addr, len) {
-                    return Err("failed to reset previously faulted memory guard page".into());
+                    anyhow::bail!("failed to reset previously faulted memory guard page");
                 }
             }
         }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -4,12 +4,11 @@
 
 use crate::export::Export;
 use crate::externref::{StackMapRegistry, VMExternRefActivationsTable};
-use crate::imports::Imports;
-use crate::memory::{DefaultMemoryCreator, RuntimeLinearMemory, RuntimeMemoryCreator};
+use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 use crate::table::{Table, TableElement};
 use crate::traphandlers::Trap;
 use crate::vmcontext::{
-    VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport,
+    VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionImport,
     VMGlobalDefinition, VMGlobalImport, VMInterrupts, VMMemoryDefinition, VMMemoryImport,
     VMSharedSignatureIndex, VMTableDefinition, VMTableImport,
 };
@@ -17,23 +16,24 @@ use crate::{ExportFunction, ExportGlobal, ExportMemory, ExportTable};
 use indexmap::IndexMap;
 use memoffset::offset_of;
 use more_asserts::assert_lt;
-use std::alloc::{self, Layout};
+use std::alloc::Layout;
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{mem, ptr, slice};
-use thiserror::Error;
-use wasmtime_environ::entity::{packed_option::ReservedValue, BoxedSlice, EntityRef, PrimaryMap};
+use wasmtime_environ::entity::{packed_option::ReservedValue, BoxedSlice, EntityRef, EntitySet};
 use wasmtime_environ::wasm::{
-    DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex,
-    ElemIndex, EntityIndex, FuncIndex, GlobalIndex, GlobalInit, MemoryIndex, SignatureIndex,
-    TableElementType, TableIndex, WasmType,
+    DataIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, ElemIndex, EntityIndex,
+    FuncIndex, GlobalIndex, MemoryIndex, TableElementType, TableIndex,
 };
-use wasmtime_environ::{ir, DataInitializer, Module, ModuleType, TableElements, VMOffsets};
+use wasmtime_environ::{ir, Module, VMOffsets};
+
+mod allocator;
+
+pub use allocator::*;
 
 /// Runtime representation of an instance value, which erases all `Instance`
 /// information since instances are just a collection of values.
@@ -56,14 +56,13 @@ pub(crate) struct Instance {
     /// WebAssembly table data.
     tables: BoxedSlice<DefinedTableIndex, Table>,
 
-    /// Passive elements in this instantiation. As `elem.drop`s happen, these
-    /// entries get removed. A missing entry is considered equivalent to an
-    /// empty slice.
-    passive_elements: RefCell<HashMap<ElemIndex, Box<[*mut VMCallerCheckedAnyfunc]>>>,
+    /// Stores the dropped passive element segments in this instantiation by index.
+    /// If the index is present in the set, the segment has been dropped.
+    dropped_elements: RefCell<EntitySet<ElemIndex>>,
 
-    /// Passive data segments from our module. As `data.drop`s happen, entries
-    /// get removed. A missing entry is considered equivalent to an empty slice.
-    passive_data: RefCell<HashMap<DataIndex, Arc<[u8]>>>,
+    /// Stores the dropped passive data segments in this instantiation by index.
+    /// If the index is present in the set, the segment has been dropped.
+    dropped_data: RefCell<EntitySet<DataIndex>>,
 
     /// Hosts can store arbitrary per-instance information here.
     host_state: Box<dyn Any>,
@@ -551,11 +550,21 @@ impl Instance {
         // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-table-init
 
         let table = self.get_table(table_index);
-        let passive_elements = self.passive_elements.borrow();
-        let elem = passive_elements
-            .get(&elem_index)
-            .map(|e| &**e)
-            .unwrap_or_else(|| &[]);
+        let elem_index = self.module.passive_elements_map.get(&elem_index);
+        let elem = match elem_index {
+            Some(index) => {
+                if self
+                    .dropped_elements
+                    .borrow()
+                    .contains(ElemIndex::new(*index))
+                {
+                    &[]
+                } else {
+                    self.module.passive_elements[*index].as_ref()
+                }
+            }
+            None => &[],
+        };
 
         if src
             .checked_add(len)
@@ -567,8 +576,14 @@ impl Instance {
 
         // TODO(#983): investigate replacing this get/set loop with a `memcpy`.
         for (dst, src) in (dst..dst + len).zip(src..src + len) {
+            let elem = self
+                .get_caller_checked_anyfunc(elem[src as usize])
+                .map_or(ptr::null_mut(), |f: &VMCallerCheckedAnyfunc| {
+                    f as *const VMCallerCheckedAnyfunc as *mut _
+                });
+
             table
-                .set(dst, TableElement::FuncRef(elem[src as usize]))
+                .set(dst, TableElement::FuncRef(elem))
                 .expect("should never panic because we already did the bounds check above");
         }
 
@@ -579,10 +594,14 @@ impl Instance {
     pub(crate) fn elem_drop(&self, elem_index: ElemIndex) {
         // https://webassembly.github.io/reference-types/core/exec/instructions.html#exec-elem-drop
 
-        let mut passive_elements = self.passive_elements.borrow_mut();
-        passive_elements.remove(&elem_index);
-        // Note that we don't check that we actually removed an element because
-        // dropping a non-passive element is a no-op (not a trap).
+        if let Some(index) = self.module.passive_elements_map.get(&elem_index) {
+            self.dropped_elements
+                .borrow_mut()
+                .insert(ElemIndex::new(*index));
+        }
+
+        // Note that we don't check that we actually removed a segment because
+        // dropping a non-passive segment is a no-op (not a trap).
     }
 
     /// Do a `memory.copy`
@@ -701,10 +720,17 @@ impl Instance {
         // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-memory-init
 
         let memory = self.get_memory(memory_index);
-        let passive_data = self.passive_data.borrow();
-        let data = passive_data
-            .get(&data_index)
-            .map_or(&[][..], |data| &**data);
+        let data_index = self.module.passive_data_map.get(&data_index);
+        let data = match data_index {
+            Some(index) => {
+                if self.dropped_data.borrow().contains(DataIndex::new(*index)) {
+                    &[]
+                } else {
+                    self.module.passive_data[*index].as_ref()
+                }
+            }
+            None => &[],
+        };
 
         if src
             .checked_add(len)
@@ -729,8 +755,14 @@ impl Instance {
 
     /// Drop the given data segment, truncating its length to zero.
     pub(crate) fn data_drop(&self, data_index: DataIndex) {
-        let mut passive_data = self.passive_data.borrow_mut();
-        passive_data.remove(&data_index);
+        if let Some(index) = self.module.passive_data_map.get(&data_index) {
+            self.dropped_data
+                .borrow_mut()
+                .insert(DataIndex::new(*index));
+        }
+
+        // Note that we don't check that we actually removed a segment because
+        // dropping a non-passive segment is a no-op (not a trap).
     }
 
     /// Get a table by index regardless of whether it is locally-defined or an
@@ -780,197 +812,8 @@ pub struct InstanceHandle {
 }
 
 impl InstanceHandle {
-    /// Create a new `InstanceHandle` pointing at a new `Instance`.
-    ///
-    /// # Unsafety
-    ///
-    /// This method is not necessarily inherently unsafe to call, but in general
-    /// the APIs of an `Instance` are quite unsafe and have not been really
-    /// audited for safety that much. As a result the unsafety here on this
-    /// method is a low-overhead way of saying "this is an extremely unsafe type
-    /// to work with".
-    ///
-    /// Extreme care must be taken when working with `InstanceHandle` and it's
-    /// recommended to have relatively intimate knowledge of how it works
-    /// internally if you'd like to do so. If possible it's recommended to use
-    /// the `wasmtime` crate API rather than this type since that is vetted for
-    /// safety.
-    ///
-    /// It is your responsibility to ensure that the given raw
-    /// `externref_activations_table` and `stack_map_registry` outlive this
-    /// instance.
-    pub unsafe fn new(
-        module: Arc<Module>,
-        finished_functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
-        imports: Imports,
-        mem_creator: Option<&dyn RuntimeMemoryCreator>,
-        lookup_shared_signature: &dyn Fn(SignatureIndex) -> VMSharedSignatureIndex,
-        host_state: Box<dyn Any>,
-        interrupts: *const VMInterrupts,
-        externref_activations_table: *mut VMExternRefActivationsTable,
-        stack_map_registry: *mut StackMapRegistry,
-    ) -> Result<Self, InstantiationError> {
-        debug_assert!(!externref_activations_table.is_null());
-        debug_assert!(!stack_map_registry.is_null());
-
-        let tables = create_tables(&module);
-        let memories = create_memories(&module, mem_creator.unwrap_or(&DefaultMemoryCreator {}))?;
-
-        let vmctx_tables = tables
-            .values()
-            .map(Table::vmtable)
-            .collect::<PrimaryMap<DefinedTableIndex, _>>()
-            .into_boxed_slice();
-
-        let vmctx_memories = memories
-            .values()
-            .map(|a| a.vmmemory())
-            .collect::<PrimaryMap<DefinedMemoryIndex, _>>()
-            .into_boxed_slice();
-
-        let vmctx_globals = create_globals(&module);
-
-        let offsets = VMOffsets::new(mem::size_of::<*const u8>() as u8, &module);
-
-        let passive_data = RefCell::new(module.passive_data.clone());
-
-        let handle = {
-            let instance = Instance {
-                module,
-                offsets,
-                memories,
-                tables,
-                passive_elements: Default::default(),
-                passive_data,
-                host_state,
-                vmctx: VMContext {},
-            };
-            let layout = instance.alloc_layout();
-            let instance_ptr = alloc::alloc(layout) as *mut Instance;
-            if instance_ptr.is_null() {
-                alloc::handle_alloc_error(layout);
-            }
-            ptr::write(instance_ptr, instance);
-            InstanceHandle {
-                instance: instance_ptr,
-            }
-        };
-        let instance = handle.instance();
-
-        let mut ptr = instance.signature_ids_ptr();
-        for sig in handle.module().types.values() {
-            *ptr = match sig {
-                ModuleType::Function(sig) => lookup_shared_signature(*sig),
-                _ => VMSharedSignatureIndex::new(u32::max_value()),
-            };
-            ptr = ptr.add(1);
-        }
-
-        debug_assert_eq!(imports.functions.len(), handle.module().num_imported_funcs);
-        ptr::copy(
-            imports.functions.as_ptr(),
-            instance.imported_functions_ptr() as *mut VMFunctionImport,
-            imports.functions.len(),
-        );
-        debug_assert_eq!(imports.tables.len(), handle.module().num_imported_tables);
-        ptr::copy(
-            imports.tables.as_ptr(),
-            instance.imported_tables_ptr() as *mut VMTableImport,
-            imports.tables.len(),
-        );
-        debug_assert_eq!(
-            imports.memories.len(),
-            handle.module().num_imported_memories
-        );
-        ptr::copy(
-            imports.memories.as_ptr(),
-            instance.imported_memories_ptr() as *mut VMMemoryImport,
-            imports.memories.len(),
-        );
-        debug_assert_eq!(imports.globals.len(), handle.module().num_imported_globals);
-        ptr::copy(
-            imports.globals.as_ptr(),
-            instance.imported_globals_ptr() as *mut VMGlobalImport,
-            imports.globals.len(),
-        );
-        ptr::copy(
-            vmctx_tables.values().as_slice().as_ptr(),
-            instance.tables_ptr() as *mut VMTableDefinition,
-            vmctx_tables.len(),
-        );
-        ptr::copy(
-            vmctx_memories.values().as_slice().as_ptr(),
-            instance.memories_ptr() as *mut VMMemoryDefinition,
-            vmctx_memories.len(),
-        );
-        ptr::copy(
-            vmctx_globals.values().as_slice().as_ptr(),
-            instance.globals_ptr() as *mut VMGlobalDefinition,
-            vmctx_globals.len(),
-        );
-        ptr::write(
-            instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
-            VMBuiltinFunctionsArray::initialized(),
-        );
-        *instance.interrupts() = interrupts;
-        *instance.externref_activations_table() = externref_activations_table;
-        *instance.stack_map_registry() = stack_map_registry;
-
-        for (index, sig) in instance.module.functions.iter() {
-            let type_index = lookup_shared_signature(*sig);
-
-            let (func_ptr, vmctx) =
-                if let Some(def_index) = instance.module.defined_func_index(index) {
-                    (
-                        NonNull::new(finished_functions[def_index] as *mut _).unwrap(),
-                        instance.vmctx_ptr(),
-                    )
-                } else {
-                    let import = instance.imported_function(index);
-                    (import.body, import.vmctx)
-                };
-
-            ptr::write(
-                instance.anyfunc_ptr(index),
-                VMCallerCheckedAnyfunc {
-                    func_ptr,
-                    type_index,
-                    vmctx,
-                },
-            );
-        }
-
-        // Perform infallible initialization in this constructor, while fallible
-        // initialization is deferred to the `initialize` method.
-        initialize_passive_elements(instance);
-        initialize_globals(instance);
-
-        Ok(handle)
-    }
-
-    /// Finishes the instantiation process started by `Instance::new`.
-    ///
-    /// Only safe to call immediately after instantiation.
-    pub unsafe fn initialize(
-        &self,
-        is_bulk_memory: bool,
-        data_initializers: &[DataInitializer<'_>],
-    ) -> Result<(), InstantiationError> {
-        // Check initializer bounds before initializing anything. Only do this
-        // when bulk memory is disabled, since the bulk memory proposal changes
-        // instantiation such that the intermediate results of failed
-        // initializations are visible.
-        if !is_bulk_memory {
-            check_table_init_bounds(self.instance())?;
-            check_memory_init_bounds(self.instance(), data_initializers)?;
-        }
-
-        // Apply fallible initializers. Note that this can "leak" state even if
-        // it fails.
-        initialize_tables(self.instance())?;
-        initialize_memories(self.instance(), data_initializers)?;
-
-        Ok(())
+    pub(crate) unsafe fn new(instance: *mut Instance) -> Self {
+        Self { instance }
     }
 
     /// Create a new `InstanceHandle` pointing at the instance
@@ -1126,305 +969,4 @@ impl InstanceHandle {
             instance: self.instance,
         }
     }
-
-    /// Deallocates memory associated with this instance.
-    ///
-    /// Note that this is unsafe because there might be other handles to this
-    /// `InstanceHandle` elsewhere, and there's nothing preventing usage of
-    /// this handle after this function is called.
-    pub unsafe fn dealloc(&self) {
-        let instance = self.instance();
-        let layout = instance.alloc_layout();
-        ptr::drop_in_place(self.instance);
-        alloc::dealloc(self.instance.cast(), layout);
-    }
-}
-
-fn check_table_init_bounds(instance: &Instance) -> Result<(), InstantiationError> {
-    for init in &instance.module().table_elements {
-        let start = get_table_init_start(init, instance);
-        let table = instance.get_table(init.table_index);
-
-        let size = usize::try_from(table.size()).unwrap();
-        if size < start + init.elements.len() {
-            return Err(InstantiationError::Link(LinkError(
-                "table out of bounds: elements segment does not fit".to_owned(),
-            )));
-        }
-    }
-
-    Ok(())
-}
-
-/// Compute the offset for a memory data initializer.
-fn get_memory_init_start(init: &DataInitializer<'_>, instance: &Instance) -> usize {
-    let mut start = init.location.offset;
-
-    if let Some(base) = init.location.base {
-        let val = unsafe {
-            if let Some(def_index) = instance.module.defined_global_index(base) {
-                *instance.global(def_index).as_u32()
-            } else {
-                *(*instance.imported_global(base).from).as_u32()
-            }
-        };
-        start += usize::try_from(val).unwrap();
-    }
-
-    start
-}
-
-/// Return a byte-slice view of a memory's data.
-unsafe fn get_memory_slice<'instance>(
-    init: &DataInitializer<'_>,
-    instance: &'instance Instance,
-) -> &'instance mut [u8] {
-    let memory = if let Some(defined_memory_index) = instance
-        .module
-        .defined_memory_index(init.location.memory_index)
-    {
-        instance.memory(defined_memory_index)
-    } else {
-        let import = instance.imported_memory(init.location.memory_index);
-        let foreign_instance = (&mut *(import).vmctx).instance();
-        let foreign_memory = &mut *(import).from;
-        let foreign_index = foreign_instance.memory_index(foreign_memory);
-        foreign_instance.memory(foreign_index)
-    };
-    slice::from_raw_parts_mut(memory.base, memory.current_length)
-}
-
-fn check_memory_init_bounds(
-    instance: &Instance,
-    data_initializers: &[DataInitializer<'_>],
-) -> Result<(), InstantiationError> {
-    for init in data_initializers {
-        let start = get_memory_init_start(init, instance);
-        unsafe {
-            let mem_slice = get_memory_slice(init, instance);
-            if mem_slice.get_mut(start..start + init.data.len()).is_none() {
-                return Err(InstantiationError::Link(LinkError(
-                    "memory out of bounds: data segment does not fit".into(),
-                )));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Allocate memory for just the tables of the current module.
-fn create_tables(module: &Module) -> BoxedSlice<DefinedTableIndex, Table> {
-    let num_imports = module.num_imported_tables;
-    let mut tables: PrimaryMap<DefinedTableIndex, _> =
-        PrimaryMap::with_capacity(module.table_plans.len() - num_imports);
-    for table in &module.table_plans.values().as_slice()[num_imports..] {
-        tables.push(Table::new(table));
-    }
-    tables.into_boxed_slice()
-}
-
-/// Compute the offset for a table element initializer.
-fn get_table_init_start(init: &TableElements, instance: &Instance) -> usize {
-    let mut start = init.offset;
-
-    if let Some(base) = init.base {
-        let val = unsafe {
-            if let Some(def_index) = instance.module.defined_global_index(base) {
-                *instance.global(def_index).as_u32()
-            } else {
-                *(*instance.imported_global(base).from).as_u32()
-            }
-        };
-        start += usize::try_from(val).unwrap();
-    }
-
-    start
-}
-
-/// Initialize the table memory from the provided initializers.
-fn initialize_tables(instance: &Instance) -> Result<(), InstantiationError> {
-    for init in &instance.module().table_elements {
-        let start = get_table_init_start(init, instance);
-        let table = instance.get_table(init.table_index);
-
-        if start
-            .checked_add(init.elements.len())
-            .map_or(true, |end| end > table.size() as usize)
-        {
-            return Err(InstantiationError::Trap(Trap::wasm(
-                ir::TrapCode::TableOutOfBounds,
-            )));
-        }
-
-        for (i, func_idx) in init.elements.iter().enumerate() {
-            let item = match table.element_type() {
-                TableElementType::Func => instance
-                    .get_caller_checked_anyfunc(*func_idx)
-                    .map_or(ptr::null_mut(), |f: &VMCallerCheckedAnyfunc| {
-                        f as *const VMCallerCheckedAnyfunc as *mut VMCallerCheckedAnyfunc
-                    })
-                    .into(),
-                TableElementType::Val(_) => {
-                    assert!(*func_idx == FuncIndex::reserved_value());
-                    TableElement::ExternRef(None)
-                }
-            };
-            table.set(u32::try_from(start + i).unwrap(), item).unwrap();
-        }
-    }
-
-    Ok(())
-}
-
-/// Initialize the `Instance::passive_elements` map by resolving the
-/// `Module::passive_elements`'s `FuncIndex`s into `VMCallerCheckedAnyfunc`s for
-/// this instance.
-fn initialize_passive_elements(instance: &Instance) {
-    let mut passive_elements = instance.passive_elements.borrow_mut();
-    debug_assert!(
-        passive_elements.is_empty(),
-        "should only be called once, at initialization time"
-    );
-
-    passive_elements.extend(
-        instance
-            .module
-            .passive_elements
-            .iter()
-            .filter(|(_, segments)| !segments.is_empty())
-            .map(|(idx, segments)| {
-                (
-                    *idx,
-                    segments
-                        .iter()
-                        .map(|s| {
-                            instance.get_caller_checked_anyfunc(*s).map_or(
-                                ptr::null_mut(),
-                                |f: &VMCallerCheckedAnyfunc| {
-                                    f as *const VMCallerCheckedAnyfunc as *mut _
-                                },
-                            )
-                        })
-                        .collect(),
-                )
-            }),
-    );
-}
-
-/// Allocate memory for just the memories of the current module.
-fn create_memories(
-    module: &Module,
-    mem_creator: &dyn RuntimeMemoryCreator,
-) -> Result<BoxedSlice<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>, InstantiationError> {
-    let num_imports = module.num_imported_memories;
-    let mut memories: PrimaryMap<DefinedMemoryIndex, _> =
-        PrimaryMap::with_capacity(module.memory_plans.len() - num_imports);
-    for plan in &module.memory_plans.values().as_slice()[num_imports..] {
-        memories.push(
-            mem_creator
-                .new_memory(plan)
-                .map_err(InstantiationError::Resource)?,
-        );
-    }
-    Ok(memories.into_boxed_slice())
-}
-
-/// Initialize the table memory from the provided initializers.
-fn initialize_memories(
-    instance: &Instance,
-    data_initializers: &[DataInitializer<'_>],
-) -> Result<(), InstantiationError> {
-    for init in data_initializers {
-        let memory = instance.get_memory(init.location.memory_index);
-
-        let start = get_memory_init_start(init, instance);
-        if start
-            .checked_add(init.data.len())
-            .map_or(true, |end| end > memory.current_length)
-        {
-            return Err(InstantiationError::Trap(Trap::wasm(
-                ir::TrapCode::HeapOutOfBounds,
-            )));
-        }
-
-        unsafe {
-            let mem_slice = get_memory_slice(init, instance);
-            let end = start + init.data.len();
-            let to_init = &mut mem_slice[start..end];
-            to_init.copy_from_slice(init.data);
-        }
-    }
-
-    Ok(())
-}
-
-/// Allocate memory for just the globals of the current module,
-/// with initializers applied.
-fn create_globals(module: &Module) -> BoxedSlice<DefinedGlobalIndex, VMGlobalDefinition> {
-    let num_imports = module.num_imported_globals;
-    let mut vmctx_globals = PrimaryMap::with_capacity(module.globals.len() - num_imports);
-
-    for _ in &module.globals.values().as_slice()[num_imports..] {
-        vmctx_globals.push(VMGlobalDefinition::new());
-    }
-
-    vmctx_globals.into_boxed_slice()
-}
-
-fn initialize_globals(instance: &Instance) {
-    let module = instance.module();
-    let num_imports = module.num_imported_globals;
-    for (index, global) in module.globals.iter().skip(num_imports) {
-        let def_index = module.defined_global_index(index).unwrap();
-        unsafe {
-            let to = instance.global_ptr(def_index);
-            match global.initializer {
-                GlobalInit::I32Const(x) => *(*to).as_i32_mut() = x,
-                GlobalInit::I64Const(x) => *(*to).as_i64_mut() = x,
-                GlobalInit::F32Const(x) => *(*to).as_f32_bits_mut() = x,
-                GlobalInit::F64Const(x) => *(*to).as_f64_bits_mut() = x,
-                GlobalInit::V128Const(x) => *(*to).as_u128_bits_mut() = x.0,
-                GlobalInit::GetGlobal(x) => {
-                    let from = if let Some(def_x) = module.defined_global_index(x) {
-                        instance.global(def_x)
-                    } else {
-                        *instance.imported_global(x).from
-                    };
-                    *to = from;
-                }
-                GlobalInit::RefFunc(f) => {
-                    *(*to).as_anyfunc_mut() = instance.get_caller_checked_anyfunc(f).unwrap()
-                        as *const VMCallerCheckedAnyfunc;
-                }
-                GlobalInit::RefNullConst => match global.wasm_ty {
-                    WasmType::FuncRef => *(*to).as_anyfunc_mut() = ptr::null(),
-                    WasmType::ExternRef => *(*to).as_externref_mut() = None,
-                    ty => panic!("unsupported reference type for global: {:?}", ty),
-                },
-                GlobalInit::Import => panic!("locally-defined global initialized as import"),
-            }
-        }
-    }
-}
-
-/// An link error while instantiating a module.
-#[derive(Error, Debug)]
-#[error("Link error: {0}")]
-pub struct LinkError(pub String);
-
-/// An error while instantiating a module.
-#[derive(Error, Debug)]
-pub enum InstantiationError {
-    /// Insufficient resources available for execution.
-    #[error("Insufficient resources: {0}")]
-    Resource(String),
-
-    /// A wasm link error occured.
-    #[error("Failed to link module")]
-    Link(#[from] LinkError),
-
-    /// A trap ocurred during instantiation, after linking.
-    #[error("Trap occurred during instantiation")]
-    Trap(Trap),
 }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -4,7 +4,7 @@
 
 use crate::export::Export;
 use crate::externref::{StackMapRegistry, VMExternRefActivationsTable};
-use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
+use crate::memory::{Memory, RuntimeMemoryCreator};
 use crate::table::{Table, TableElement};
 use crate::traphandlers::Trap;
 use crate::vmcontext::{
@@ -51,7 +51,7 @@ pub(crate) struct Instance {
     offsets: VMOffsets,
 
     /// WebAssembly linear memory data.
-    memories: PrimaryMap<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>,
+    memories: PrimaryMap<DefinedMemoryIndex, Memory>,
 
     /// WebAssembly table data.
     tables: PrimaryMap<DefinedTableIndex, Table>,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -24,7 +24,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{mem, ptr, slice};
-use wasmtime_environ::entity::{packed_option::ReservedValue, BoxedSlice, EntityRef, EntitySet};
+use wasmtime_environ::entity::{packed_option::ReservedValue, EntityRef, EntitySet, PrimaryMap};
 use wasmtime_environ::wasm::{
     DataIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, ElemIndex, EntityIndex,
     FuncIndex, GlobalIndex, MemoryIndex, TableElementType, TableIndex,
@@ -51,10 +51,10 @@ pub(crate) struct Instance {
     offsets: VMOffsets,
 
     /// WebAssembly linear memory data.
-    memories: BoxedSlice<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>,
+    memories: PrimaryMap<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>,
 
     /// WebAssembly table data.
-    tables: BoxedSlice<DefinedTableIndex, Table>,
+    tables: PrimaryMap<DefinedTableIndex, Table>,
 
     /// Stores the dropped passive element segments in this instantiation by index.
     /// If the index is present in the set, the segment has been dropped.

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -67,6 +67,11 @@ pub(crate) struct Instance {
     /// Hosts can store arbitrary per-instance information here.
     host_state: Box<dyn Any>,
 
+    /// Stores guard page faults in memory relating to the instance.
+    /// This is used for the pooling allocator with uffd enabled on Linux.
+    #[cfg(all(feature = "uffd", target_os = "linux"))]
+    guard_page_faults: RefCell<Vec<(*mut u8, usize, unsafe fn(*mut u8, usize) -> bool)>>,
+
     /// Additional context used by compiled wasm code. This field is last, and
     /// represents a dynamically-sized array that extends beyond the nominal
     /// end of the struct (similar to a flexible array member).
@@ -376,6 +381,10 @@ impl Instance {
     /// Returns `None` if memory can't be grown by the specified amount
     /// of pages.
     pub(crate) fn memory_grow(&self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
+        // Reset all guard pages before growing any memory
+        #[cfg(all(feature = "uffd", target_os = "linux"))]
+        self.reset_guard_pages().ok()?;
+
         let result = self
             .memories
             .get(memory_index)
@@ -802,6 +811,40 @@ impl Instance {
             let foreign_table_index = foreign_instance.table_index(foreign_table_def);
             (foreign_table_index, foreign_instance)
         }
+    }
+
+    /// Records a faulted guard page.
+    ///
+    /// This is used to track faulted guard pages that need to be reset.
+    #[cfg(all(feature = "uffd", target_os = "linux"))]
+    pub(crate) fn record_guard_page_fault(
+        &self,
+        page_addr: *mut u8,
+        size: usize,
+        reset: unsafe fn(*mut u8, usize) -> bool,
+    ) {
+        self.guard_page_faults
+            .borrow_mut()
+            .push((page_addr, size, reset));
+    }
+
+    /// Resets previously faulted guard pages.
+    ///
+    /// This is used to reset the protection of any guard pages that were previously faulted.
+    ///
+    /// Resetting the guard pages is required before growing memory.
+    #[cfg(all(feature = "uffd", target_os = "linux"))]
+    pub(crate) fn reset_guard_pages(&self) -> Result<(), String> {
+        let mut faults = self.guard_page_faults.borrow_mut();
+        for (addr, len, reset) in faults.drain(..) {
+            unsafe {
+                if !reset(addr, len) {
+                    return Err("failed to reset previously faulted memory guard page".into());
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -24,7 +24,9 @@ use wasmtime_environ::wasm::{
     DefinedFuncIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GlobalInit, SignatureIndex,
     TableElementType, WasmType,
 };
-use wasmtime_environ::{ir, Module, ModuleType, OwnedDataInitializer, TableElements, VMOffsets};
+use wasmtime_environ::{
+    ir, Module, ModuleTranslation, ModuleType, OwnedDataInitializer, TableElements, VMOffsets,
+};
 
 /// Represents a request for a new runtime instance.
 pub struct InstanceAllocationRequest<'a> {
@@ -80,6 +82,21 @@ pub enum InstantiationError {
 ///
 /// This trait is unsafe as it requires knowledge of Wasmtime's runtime internals to implement correctly.
 pub unsafe trait InstanceAllocator: Send + Sync {
+    /// Validates a module translation.
+    ///
+    /// This is used to ensure a module being compiled is supported by the instance allocator.
+    fn validate_module(&self, translation: &ModuleTranslation) -> Result<(), String> {
+        drop(translation);
+        Ok(())
+    }
+
+    /// Adjusts the tunables prior to creation of any JIT compiler.
+    ///
+    /// This method allows the instance allocator control over tunables passed to a `wasmtime_jit::Compiler`.
+    fn adjust_tunables(&self, tunables: &mut wasmtime_environ::Tunables) {
+        drop(tunables);
+    }
+
     /// Allocates an instance for the given allocation request.
     ///
     /// # Safety

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -1,0 +1,536 @@
+use crate::externref::{StackMapRegistry, VMExternRefActivationsTable};
+use crate::imports::Imports;
+use crate::instance::{Instance, InstanceHandle, RuntimeMemoryCreator};
+use crate::memory::{DefaultMemoryCreator, RuntimeLinearMemory};
+use crate::table::{Table, TableElement};
+use crate::traphandlers::Trap;
+use crate::vmcontext::{
+    VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport,
+    VMGlobalDefinition, VMGlobalImport, VMInterrupts, VMMemoryDefinition, VMMemoryImport,
+    VMSharedSignatureIndex, VMTableDefinition, VMTableImport,
+};
+use std::alloc;
+use std::any::Any;
+use std::cell::RefCell;
+use std::convert::TryFrom;
+use std::ptr::{self, NonNull};
+use std::slice;
+use std::sync::Arc;
+use thiserror::Error;
+use wasmtime_environ::entity::{
+    packed_option::ReservedValue, BoxedSlice, EntityRef, EntitySet, PrimaryMap,
+};
+use wasmtime_environ::wasm::{
+    DefinedFuncIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GlobalInit, SignatureIndex,
+    TableElementType, WasmType,
+};
+use wasmtime_environ::{ir, Module, ModuleType, OwnedDataInitializer, TableElements, VMOffsets};
+
+/// Represents a request for a new runtime instance.
+pub struct InstanceAllocationRequest<'a> {
+    /// The module being instantiated.
+    pub module: Arc<Module>,
+
+    /// The finished (JIT) functions for the module.
+    pub finished_functions: &'a PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+
+    /// The imports to use for the instantiation.
+    pub imports: Imports<'a>,
+
+    /// A callback for looking up shared signature indexes.
+    pub lookup_shared_signature: &'a dyn Fn(SignatureIndex) -> VMSharedSignatureIndex,
+
+    /// The host state to associate with the instance.
+    pub host_state: Box<dyn Any>,
+
+    /// The pointer to the VM interrupts structure to use for the instance.
+    pub interrupts: *const VMInterrupts,
+
+    /// The pointer to the reference activations table to use for the instance.
+    pub externref_activations_table: *mut VMExternRefActivationsTable,
+
+    /// The pointer to the stack map registry to use for the instance.
+    pub stack_map_registry: *mut StackMapRegistry,
+}
+
+/// An link error while instantiating a module.
+#[derive(Error, Debug)]
+#[error("Link error: {0}")]
+pub struct LinkError(pub String);
+
+/// An error while instantiating a module.
+#[derive(Error, Debug)]
+pub enum InstantiationError {
+    /// Insufficient resources available for execution.
+    #[error("Insufficient resources: {0}")]
+    Resource(String),
+
+    /// A wasm link error occured.
+    #[error("Failed to link module")]
+    Link(#[from] LinkError),
+
+    /// A trap ocurred during instantiation, after linking.
+    #[error("Trap occurred during instantiation")]
+    Trap(Trap),
+}
+
+/// Represents a runtime instance allocator.
+///
+/// # Safety
+///
+/// This trait is unsafe as it requires knowledge of Wasmtime's runtime internals to implement correctly.
+pub unsafe trait InstanceAllocator: Send + Sync {
+    /// Allocates an instance for the given allocation request.
+    ///
+    /// # Safety
+    ///
+    /// This method is not inherently unsafe, but care must be made to ensure
+    /// pointers passed in the allocation request outlive the returned instance.
+    unsafe fn allocate(
+        &self,
+        req: InstanceAllocationRequest,
+    ) -> Result<InstanceHandle, InstantiationError>;
+
+    /// Finishes the instantiation process started by an instance allocator.
+    ///
+    /// # Safety
+    ///
+    /// This method is only safe to call immediately after an instance has been allocated.
+    unsafe fn initialize(
+        &self,
+        handle: &InstanceHandle,
+        is_bulk_memory: bool,
+        data_initializers: &Arc<[OwnedDataInitializer]>,
+    ) -> Result<(), InstantiationError>;
+
+    /// Deallocates a previously allocated instance.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because there are no guarantees that the given handle
+    /// is the only owner of the underlying instance to deallocate.
+    ///
+    /// Use extreme care when deallocating an instance so that there are no dangling instance pointers.
+    unsafe fn deallocate(&self, handle: &InstanceHandle);
+}
+
+unsafe fn initialize_vmcontext(
+    instance: &Instance,
+    functions: &[VMFunctionImport],
+    tables: &[VMTableImport],
+    memories: &[VMMemoryImport],
+    globals: &[VMGlobalImport],
+    finished_functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    lookup_shared_signature: &dyn Fn(SignatureIndex) -> VMSharedSignatureIndex,
+    interrupts: *const VMInterrupts,
+    externref_activations_table: *mut VMExternRefActivationsTable,
+    stack_map_registry: *mut StackMapRegistry,
+    get_mem_def: impl Fn(DefinedMemoryIndex) -> VMMemoryDefinition,
+    get_table_def: impl Fn(DefinedTableIndex) -> VMTableDefinition,
+) {
+    let module = &instance.module;
+
+    *instance.interrupts() = interrupts;
+    *instance.externref_activations_table() = externref_activations_table;
+    *instance.stack_map_registry() = stack_map_registry;
+
+    // Initialize shared signatures
+    let mut ptr = instance.signature_ids_ptr();
+    for sig in module.types.values() {
+        *ptr = match sig {
+            ModuleType::Function(sig) => lookup_shared_signature(*sig),
+            _ => VMSharedSignatureIndex::new(u32::max_value()),
+        };
+        ptr = ptr.add(1);
+    }
+
+    // Initialize the built-in functions
+    ptr::write(
+        instance.builtin_functions_ptr() as *mut VMBuiltinFunctionsArray,
+        VMBuiltinFunctionsArray::initialized(),
+    );
+
+    // Initialize the imports
+    debug_assert_eq!(functions.len(), module.num_imported_funcs);
+    ptr::copy(
+        functions.as_ptr(),
+        instance.imported_functions_ptr() as *mut VMFunctionImport,
+        functions.len(),
+    );
+    debug_assert_eq!(tables.len(), module.num_imported_tables);
+    ptr::copy(
+        tables.as_ptr(),
+        instance.imported_tables_ptr() as *mut VMTableImport,
+        tables.len(),
+    );
+    debug_assert_eq!(memories.len(), module.num_imported_memories);
+    ptr::copy(
+        memories.as_ptr(),
+        instance.imported_memories_ptr() as *mut VMMemoryImport,
+        memories.len(),
+    );
+    debug_assert_eq!(globals.len(), module.num_imported_globals);
+    ptr::copy(
+        globals.as_ptr(),
+        instance.imported_globals_ptr() as *mut VMGlobalImport,
+        globals.len(),
+    );
+
+    // Initialize the defined functions
+    for (index, sig) in instance.module.functions.iter() {
+        let type_index = lookup_shared_signature(*sig);
+
+        let (func_ptr, vmctx) = if let Some(def_index) = instance.module.defined_func_index(index) {
+            (
+                NonNull::new(finished_functions[def_index] as *mut _).unwrap(),
+                instance.vmctx_ptr(),
+            )
+        } else {
+            let import = instance.imported_function(index);
+            (import.body, import.vmctx)
+        };
+
+        ptr::write(
+            instance.anyfunc_ptr(index),
+            VMCallerCheckedAnyfunc {
+                func_ptr,
+                type_index,
+                vmctx,
+            },
+        );
+    }
+
+    // Initialize the defined tables
+    let mut ptr = instance.tables_ptr();
+    for i in 0..module.table_plans.len() - module.num_imported_tables {
+        ptr::write(ptr, get_table_def(DefinedTableIndex::new(i)));
+        ptr = ptr.add(1);
+    }
+
+    // Initialize the defined memories
+    let mut ptr = instance.memories_ptr();
+    for i in 0..module.memory_plans.len() - module.num_imported_memories {
+        ptr::write(ptr, get_mem_def(DefinedMemoryIndex::new(i)));
+        ptr = ptr.add(1);
+    }
+
+    // Initialize the defined globals
+    initialize_vmcontext_globals(instance);
+}
+
+unsafe fn initialize_vmcontext_globals(instance: &Instance) {
+    let module = &instance.module;
+    let num_imports = module.num_imported_globals;
+    for (index, global) in module.globals.iter().skip(num_imports) {
+        let def_index = module.defined_global_index(index).unwrap();
+        let to = instance.global_ptr(def_index);
+
+        // Initialize the global before writing to it
+        ptr::write(to, VMGlobalDefinition::new());
+
+        match global.initializer {
+            GlobalInit::I32Const(x) => *(*to).as_i32_mut() = x,
+            GlobalInit::I64Const(x) => *(*to).as_i64_mut() = x,
+            GlobalInit::F32Const(x) => *(*to).as_f32_bits_mut() = x,
+            GlobalInit::F64Const(x) => *(*to).as_f64_bits_mut() = x,
+            GlobalInit::V128Const(x) => *(*to).as_u128_bits_mut() = x.0,
+            GlobalInit::GetGlobal(x) => {
+                let from = if let Some(def_x) = module.defined_global_index(x) {
+                    instance.global(def_x)
+                } else {
+                    *instance.imported_global(x).from
+                };
+                *to = from;
+            }
+            GlobalInit::RefFunc(f) => {
+                *(*to).as_anyfunc_mut() = instance.get_caller_checked_anyfunc(f).unwrap()
+                    as *const VMCallerCheckedAnyfunc;
+            }
+            GlobalInit::RefNullConst => match global.wasm_ty {
+                WasmType::FuncRef => *(*to).as_anyfunc_mut() = ptr::null(),
+                WasmType::ExternRef => *(*to).as_externref_mut() = None,
+                ty => panic!("unsupported reference type for global: {:?}", ty),
+            },
+            GlobalInit::Import => panic!("locally-defined global initialized as import"),
+        }
+    }
+}
+
+/// Represents the on-demand instance allocator.
+#[derive(Clone)]
+pub struct OnDemandInstanceAllocator {
+    mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
+}
+
+impl OnDemandInstanceAllocator {
+    /// Creates a new on-demand instance allocator.
+    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>) -> Self {
+        Self { mem_creator }
+    }
+
+    fn create_tables(module: &Module) -> BoxedSlice<DefinedTableIndex, Table> {
+        let num_imports = module.num_imported_tables;
+        let mut tables: PrimaryMap<DefinedTableIndex, _> =
+            PrimaryMap::with_capacity(module.table_plans.len() - num_imports);
+        for table in &module.table_plans.values().as_slice()[num_imports..] {
+            tables.push(Table::new(table));
+        }
+        tables.into_boxed_slice()
+    }
+
+    fn create_memories(
+        &self,
+        module: &Module,
+    ) -> Result<BoxedSlice<DefinedMemoryIndex, Box<dyn RuntimeLinearMemory>>, InstantiationError>
+    {
+        let creator = self
+            .mem_creator
+            .as_deref()
+            .unwrap_or_else(|| &DefaultMemoryCreator);
+        let num_imports = module.num_imported_memories;
+        let mut memories: PrimaryMap<DefinedMemoryIndex, _> =
+            PrimaryMap::with_capacity(module.memory_plans.len() - num_imports);
+        for plan in &module.memory_plans.values().as_slice()[num_imports..] {
+            memories.push(
+                creator
+                    .new_memory(plan)
+                    .map_err(InstantiationError::Resource)?,
+            );
+        }
+        Ok(memories.into_boxed_slice())
+    }
+
+    fn check_table_init_bounds(instance: &Instance) -> Result<(), InstantiationError> {
+        for init in &instance.module.table_elements {
+            let start = Self::get_table_init_start(init, instance);
+            let table = instance.get_table(init.table_index);
+
+            let size = usize::try_from(table.size()).unwrap();
+            if size < start + init.elements.len() {
+                return Err(InstantiationError::Link(LinkError(
+                    "table out of bounds: elements segment does not fit".to_owned(),
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_memory_init_start(init: &OwnedDataInitializer, instance: &Instance) -> usize {
+        let mut start = init.location.offset;
+
+        if let Some(base) = init.location.base {
+            let val = unsafe {
+                if let Some(def_index) = instance.module.defined_global_index(base) {
+                    *instance.global(def_index).as_u32()
+                } else {
+                    *(*instance.imported_global(base).from).as_u32()
+                }
+            };
+            start += usize::try_from(val).unwrap();
+        }
+
+        start
+    }
+
+    unsafe fn get_memory_slice<'instance>(
+        init: &OwnedDataInitializer,
+        instance: &'instance Instance,
+    ) -> &'instance mut [u8] {
+        let memory = if let Some(defined_memory_index) = instance
+            .module
+            .defined_memory_index(init.location.memory_index)
+        {
+            instance.memory(defined_memory_index)
+        } else {
+            let import = instance.imported_memory(init.location.memory_index);
+            let foreign_instance = (&mut *(import).vmctx).instance();
+            let foreign_memory = &mut *(import).from;
+            let foreign_index = foreign_instance.memory_index(foreign_memory);
+            foreign_instance.memory(foreign_index)
+        };
+        slice::from_raw_parts_mut(memory.base, memory.current_length)
+    }
+
+    fn check_memory_init_bounds(
+        instance: &Instance,
+        data_initializers: &[OwnedDataInitializer],
+    ) -> Result<(), InstantiationError> {
+        for init in data_initializers {
+            let start = Self::get_memory_init_start(init, instance);
+            unsafe {
+                let mem_slice = Self::get_memory_slice(init, instance);
+                if mem_slice.get_mut(start..start + init.data.len()).is_none() {
+                    return Err(InstantiationError::Link(LinkError(
+                        "memory out of bounds: data segment does not fit".into(),
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_table_init_start(init: &TableElements, instance: &Instance) -> usize {
+        let mut start = init.offset;
+
+        if let Some(base) = init.base {
+            let val = unsafe {
+                if let Some(def_index) = instance.module.defined_global_index(base) {
+                    *instance.global(def_index).as_u32()
+                } else {
+                    *(*instance.imported_global(base).from).as_u32()
+                }
+            };
+            start += usize::try_from(val).unwrap();
+        }
+
+        start
+    }
+
+    fn initialize_tables(instance: &Instance) -> Result<(), InstantiationError> {
+        for init in &instance.module.table_elements {
+            let start = Self::get_table_init_start(init, instance);
+            let table = instance.get_table(init.table_index);
+
+            if start
+                .checked_add(init.elements.len())
+                .map_or(true, |end| end > table.size() as usize)
+            {
+                return Err(InstantiationError::Trap(Trap::wasm(
+                    ir::TrapCode::TableOutOfBounds,
+                )));
+            }
+
+            for (i, func_idx) in init.elements.iter().enumerate() {
+                let item = match table.element_type() {
+                    TableElementType::Func => instance
+                        .get_caller_checked_anyfunc(*func_idx)
+                        .map_or(ptr::null_mut(), |f: &VMCallerCheckedAnyfunc| {
+                            f as *const VMCallerCheckedAnyfunc as *mut VMCallerCheckedAnyfunc
+                        })
+                        .into(),
+                    TableElementType::Val(_) => {
+                        assert!(*func_idx == FuncIndex::reserved_value());
+                        TableElement::ExternRef(None)
+                    }
+                };
+                table.set(u32::try_from(start + i).unwrap(), item).unwrap();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Initialize the table memory from the provided initializers.
+    fn initialize_memories(
+        instance: &Instance,
+        data_initializers: &[OwnedDataInitializer],
+    ) -> Result<(), InstantiationError> {
+        for init in data_initializers {
+            let memory = instance.get_memory(init.location.memory_index);
+
+            let start = Self::get_memory_init_start(init, instance);
+            if start
+                .checked_add(init.data.len())
+                .map_or(true, |end| end > memory.current_length)
+            {
+                return Err(InstantiationError::Trap(Trap::wasm(
+                    ir::TrapCode::HeapOutOfBounds,
+                )));
+            }
+
+            unsafe {
+                let mem_slice = Self::get_memory_slice(init, instance);
+                let end = start + init.data.len();
+                let to_init = &mut mem_slice[start..end];
+                to_init.copy_from_slice(&init.data);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
+    unsafe fn allocate(
+        &self,
+        req: InstanceAllocationRequest,
+    ) -> Result<InstanceHandle, InstantiationError> {
+        debug_assert!(!req.externref_activations_table.is_null());
+        debug_assert!(!req.stack_map_registry.is_null());
+
+        let memories = self.create_memories(&req.module)?;
+        let tables = Self::create_tables(&req.module);
+
+        let handle = {
+            let instance = Instance {
+                module: req.module.clone(),
+                offsets: VMOffsets::new(std::mem::size_of::<*const u8>() as u8, &req.module),
+                memories,
+                tables,
+                dropped_elements: RefCell::new(EntitySet::with_capacity(
+                    req.module.passive_elements.len(),
+                )),
+                dropped_data: RefCell::new(EntitySet::with_capacity(req.module.passive_data.len())),
+                host_state: req.host_state,
+                vmctx: VMContext {},
+            };
+            let layout = instance.alloc_layout();
+            let instance_ptr = alloc::alloc(layout) as *mut Instance;
+            if instance_ptr.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
+            ptr::write(instance_ptr, instance);
+            InstanceHandle::new(instance_ptr)
+        };
+
+        let instance = handle.instance();
+        initialize_vmcontext(
+            instance,
+            req.imports.functions,
+            req.imports.tables,
+            req.imports.memories,
+            req.imports.globals,
+            req.finished_functions,
+            req.lookup_shared_signature,
+            req.interrupts,
+            req.externref_activations_table,
+            req.stack_map_registry,
+            &|index| instance.memories[index].vmmemory(),
+            &|index| instance.tables[index].vmtable(),
+        );
+
+        Ok(handle)
+    }
+
+    unsafe fn initialize(
+        &self,
+        handle: &InstanceHandle,
+        is_bulk_memory: bool,
+        data_initializers: &Arc<[OwnedDataInitializer]>,
+    ) -> Result<(), InstantiationError> {
+        // Check initializer bounds before initializing anything. Only do this
+        // when bulk memory is disabled, since the bulk memory proposal changes
+        // instantiation such that the intermediate results of failed
+        // initializations are visible.
+        if !is_bulk_memory {
+            Self::check_table_init_bounds(handle.instance())?;
+            Self::check_memory_init_bounds(handle.instance(), data_initializers.as_ref())?;
+        }
+
+        // Apply fallible initializers. Note that this can "leak" state even if
+        // it fails.
+        Self::initialize_tables(handle.instance())?;
+        Self::initialize_memories(handle.instance(), data_initializers.as_ref())?;
+
+        Ok(())
+    }
+
+    unsafe fn deallocate(&self, handle: &InstanceHandle) {
+        let instance = handle.instance();
+        let layout = instance.alloc_layout();
+        ptr::drop_in_place(instance as *const Instance as *mut Instance);
+        alloc::dealloc(instance as *const Instance as *mut _, layout);
+    }
+}

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -602,8 +602,6 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
                 )),
                 dropped_data: RefCell::new(EntitySet::with_capacity(req.module.passive_data.len())),
                 host_state,
-                #[cfg(all(feature = "uffd", target_os = "linux"))]
-                guard_page_faults: RefCell::new(Vec::new()),
                 vmctx: VMContext {},
             };
             let layout = instance.alloc_layout();

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -290,7 +290,7 @@ impl OnDemandInstanceAllocator {
         let mut tables: PrimaryMap<DefinedTableIndex, _> =
             PrimaryMap::with_capacity(module.table_plans.len() - num_imports);
         for table in &module.table_plans.values().as_slice()[num_imports..] {
-            tables.push(Table::new(table));
+            tables.push(Table::new_dynamic(table));
         }
         tables.into_boxed_slice()
     }

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -549,8 +549,10 @@ impl OnDemandInstanceAllocator {
         let mut memories: PrimaryMap<DefinedMemoryIndex, _> =
             PrimaryMap::with_capacity(module.memory_plans.len() - num_imports);
         for plan in &module.memory_plans.values().as_slice()[num_imports..] {
-            memories
-                .push(Memory::new_dynamic(plan, creator).map_err(InstantiationError::Resource)?);
+            memories.push(
+                Memory::new_dynamic(plan, creator)
+                    .map_err(|e| InstantiationError::Resource(e.to_string()))?,
+            );
         }
         Ok(memories)
     }

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -525,6 +525,8 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
                 )),
                 dropped_data: RefCell::new(EntitySet::with_capacity(req.module.passive_data.len())),
                 host_state: req.host_state,
+                #[cfg(all(feature = "uffd", target_os = "linux"))]
+                guard_page_faults: RefCell::new(Vec::new()),
                 vmctx: VMContext {},
             };
             let layout = instance.alloc_layout();

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -55,53 +55,37 @@ fn round_up_to_pow2(n: usize, to: usize) -> usize {
 /// Represents the limits placed on a module for compiling with the pooling instance allocator.
 #[derive(Debug, Copy, Clone)]
 pub struct ModuleLimits {
-    /// The maximum number of imported functions for a module (default is 1000).
+    /// The maximum number of imported functions for a module.
     pub imported_functions: u32,
 
-    /// The maximum number of imported tables for a module (default is 0).
+    /// The maximum number of imported tables for a module.
     pub imported_tables: u32,
 
-    /// The maximum number of imported linear memories for a module (default is 0).
+    /// The maximum number of imported linear memories for a module.
     pub imported_memories: u32,
 
-    /// The maximum number of imported globals for a module (default is 0).
+    /// The maximum number of imported globals for a module.
     pub imported_globals: u32,
 
-    /// The maximum number of defined types for a module (default is 100).
+    /// The maximum number of defined types for a module.
     pub types: u32,
 
-    /// The maximum number of defined functions for a module (default is 10000).
+    /// The maximum number of defined functions for a module.
     pub functions: u32,
 
-    /// The maximum number of defined tables for a module (default is 1).
+    /// The maximum number of defined tables for a module.
     pub tables: u32,
 
-    /// The maximum number of defined linear memories for a module (default is 1).
+    /// The maximum number of defined linear memories for a module.
     pub memories: u32,
 
-    /// The maximum number of defined globals for a module (default is 10).
+    /// The maximum number of defined globals for a module.
     pub globals: u32,
 
-    /// The maximum table elements for any table defined in a module (default is 10000).
-    ///
-    /// If a table's minimum element limit is greater than this value, the module will
-    /// fail to compile.
-    ///
-    /// If a table's maximum element limit is unbounded or greater than this value,
-    /// the maximum will be `table_elements` for the purpose of any `table.grow` instruction.
+    /// The maximum table elements for any table defined in a module.
     pub table_elements: u32,
 
-    /// The maximum number of pages for any linear memory defined in a module (default is 160).
-    ///
-    /// The default of 160 means at most 10 MiB of host memory may be committed for each instance.
-    ///
-    /// If a memory's minimum page limit is greater than this value, the module will
-    /// fail to compile.
-    ///
-    /// If a memory's maximum page limit is unbounded or greater than this value,
-    /// the maximum will be `memory_pages` for the purpose of any `memory.grow` instruction.
-    ///
-    /// This value cannot exceed any memory reservation size limits placed on instances.
+    /// The maximum number of pages for any linear memory defined in a module.
     pub memory_pages: u32,
 }
 
@@ -224,7 +208,7 @@ impl ModuleLimits {
 
 impl Default for ModuleLimits {
     fn default() -> Self {
-        // See doc comments for `ModuleLimits` for these default values
+        // See doc comments for `wasmtime::ModuleLimits` for these default values
         Self {
             imported_functions: 1000,
             imported_tables: 0,
@@ -244,32 +228,16 @@ impl Default for ModuleLimits {
 /// Represents the limits placed on instances by the pooling instance allocator.
 #[derive(Debug, Copy, Clone)]
 pub struct InstanceLimits {
-    /// The maximum number of concurrent instances supported (default is 1000).
+    /// The maximum number of concurrent instances supported.
     pub count: u32,
 
     /// The maximum size, in bytes, of host address space to reserve for each linear memory of an instance.
-    ///
-    /// Note: this value has important performance ramifications.
-    ///
-    /// On 64-bit platforms, the default for this value will be 6 GiB.  A value of less than 4 GiB will
-    /// force runtime bounds checking for memory accesses and thus will negatively impact performance.
-    /// Any value above 4 GiB will start eliding bounds checks provided the `offset` of the memory access is
-    /// less than (`memory_reservation_size` - 4 GiB).  A value of 8 GiB will completely elide *all* bounds
-    /// checks; consequently, 8 GiB will be the maximum supported value. The default of 6 GiB reserves
-    /// less host address space for each instance, but a memory access with an offet above 2 GiB will incur
-    /// runtime bounds checks.
-    ///
-    /// On 32-bit platforms, the default for this value will be 10 MiB. A 32-bit host has very limited address
-    /// space to reserve for a lot of concurrent instances.  As a result, runtime bounds checking will be used
-    /// for all memory accesses.  For better runtime performance, a 64-bit host is recommended.
-    ///
-    /// This value will be rounded up by the WebAssembly page size (64 KiB).
     pub memory_reservation_size: u64,
 }
 
 impl Default for InstanceLimits {
     fn default() -> Self {
-        // See doc comments for `InstanceLimits` for these default values
+        // See doc comments for `wasmtime::InstanceLimits` for these default values
         Self {
             count: 1000,
             #[cfg(target_pointer_width = "32")]

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -485,7 +485,7 @@ impl InstancePool {
                     max_pages,
                     commit_memory_pages,
                 )
-                .map_err(|e| InstantiationError::Resource(e.to_string()))?,
+                .map_err(InstantiationError::Resource)?,
             );
         }
 
@@ -509,7 +509,7 @@ impl InstancePool {
             let base = tables.next().unwrap();
 
             commit_table_pages(base, max_elements as usize * mem::size_of::<*mut u8>())
-                .map_err(|e| InstantiationError::Resource(e.to_string()))?;
+                .map_err(InstantiationError::Resource)?;
 
             instance
                 .tables
@@ -785,7 +785,7 @@ impl StackPool {
                 .add((index * self.stack_size) + self.page_size);
 
             commit_stack_pages(bottom_of_stack, size_without_guard)
-                .map_err(|e| FiberStackError::Resource(e.to_string()))?;
+                .map_err(FiberStackError::Resource)?;
 
             // The top of the stack should be returned
             Ok(bottom_of_stack.add(size_without_guard))

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -1557,7 +1557,7 @@ mod test {
         Ok(())
     }
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
     fn test_stack_pool() -> Result<(), String> {
         let pool = StackPool::new(
@@ -1680,7 +1680,7 @@ mod test {
     }
 
     #[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
-    #[cfg(unix)]
+    #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
     fn test_stack_zeroed() -> Result<(), String> {
         let allocator = PoolingInstanceAllocator::new(

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -1,0 +1,1666 @@
+//! Implements the pooling instance allocator.
+//!
+//! The pooling instance allocator maps memory in advance
+//! and allocates instances, memories, tables, and stacks from
+//! a pool of available resources.
+//!
+//! Using the pooling instance allocator can speed up module instantiation
+//! when modules can be constrained based on configurable limits.
+
+use super::{
+    initialize_vmcontext, FiberStackError, InstanceAllocationRequest, InstanceAllocator,
+    InstanceHandle, InstantiationError,
+};
+use crate::{
+    instance::Instance, table::max_table_element_size, Memory, Mmap, OnDemandInstanceAllocator,
+    Table, VMContext,
+};
+use rand::Rng;
+use std::cell::RefCell;
+use std::cmp::min;
+use std::convert::TryFrom;
+use std::mem;
+use std::sync::{Arc, Mutex};
+use wasmtime_environ::{
+    entity::{EntitySet, PrimaryMap},
+    MemoryStyle, Module, ModuleTranslation, OwnedDataInitializer, Tunables, VMOffsets,
+    WASM_PAGE_SIZE,
+};
+
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        mod windows;
+        use windows as imp;
+    } else if #[cfg(target_os = "linux")] {
+        mod linux;
+        use linux as imp;
+    } else {
+        mod unix;
+        use unix as imp;
+    }
+}
+
+use imp::{create_memory_map, decommit, make_accessible};
+
+fn round_up_to_pow2(n: usize, to: usize) -> usize {
+    debug_assert!(to > 0);
+    debug_assert!(to.is_power_of_two());
+    (n + to - 1) & !(to - 1)
+}
+
+/// Represents the limits placed on a module for compiling with the pooling instance allocator.
+#[derive(Debug, Copy, Clone)]
+pub struct ModuleLimits {
+    /// The maximum number of imported functions for a module (default is 1000).
+    pub imported_functions: u32,
+
+    /// The maximum number of imported tables for a module (default is 0).
+    pub imported_tables: u32,
+
+    /// The maximum number of imported memories for a module (default is 0).
+    pub imported_memories: u32,
+
+    /// The maximum number of imported globals for a module (default is 0).
+    pub imported_globals: u32,
+
+    /// The maximum number of defined types for a module (default is 100).
+    pub types: u32,
+
+    /// The maximum number of defined functions for a module (default is 10000).
+    pub functions: u32,
+
+    /// The maximum number of defined tables for a module (default is 1).
+    pub tables: u32,
+
+    /// The maximum number of defined memories for a module (default is 1).
+    pub memories: u32,
+
+    /// The maximum number of defined globals for a module (default is 10).
+    pub globals: u32,
+
+    /// The maximum table elements for any table defined in a module (default is 10000).
+    ///
+    /// If a table's minimum element limit is greater than this value, the module will
+    /// fail to compile.
+    ///
+    /// If a table's maximum element limit is unbounded or greater than this value,
+    /// the maximum will be `table_elements` for the purpose of any `table.grow` instruction.
+    pub table_elements: u32,
+
+    /// The maximum number of pages for any memory defined in a module (default is 160).
+    ///
+    /// The default of 160 means at most 10 MiB of host memory may be committed for each instance.
+    ///
+    /// If a memory's minimum page limit is greater than this value, the module will
+    /// fail to compile.
+    ///
+    /// If a memory's maximum page limit is unbounded or greater than this value,
+    /// the maximum will be `memory_pages` for the purpose of any `memory.grow` instruction.
+    ///
+    /// This value cannot exceed any address space limits placed on instances.
+    pub memory_pages: u32,
+}
+
+impl ModuleLimits {
+    fn validate_module(&self, module: &Module) -> Result<(), String> {
+        if module.num_imported_funcs > self.imported_functions as usize {
+            return Err(format!(
+                "imported function count of {} exceeds the limit of {}",
+                module.num_imported_funcs, self.imported_functions
+            ));
+        }
+
+        if module.num_imported_tables > self.imported_tables as usize {
+            return Err(format!(
+                "imported tables count of {} exceeds the limit of {}",
+                module.num_imported_tables, self.imported_tables
+            ));
+        }
+
+        if module.num_imported_memories > self.imported_memories as usize {
+            return Err(format!(
+                "imported memories count of {} exceeds the limit of {}",
+                module.num_imported_memories, self.imported_memories
+            ));
+        }
+
+        if module.num_imported_globals > self.imported_globals as usize {
+            return Err(format!(
+                "imported globals count of {} exceeds the limit of {}",
+                module.num_imported_globals, self.imported_globals
+            ));
+        }
+
+        if module.types.len() > self.types as usize {
+            return Err(format!(
+                "defined types count of {} exceeds the limit of {}",
+                module.types.len(),
+                self.types
+            ));
+        }
+
+        let functions = module.functions.len() - module.num_imported_funcs;
+        if functions > self.functions as usize {
+            return Err(format!(
+                "defined functions count of {} exceeds the limit of {}",
+                functions, self.functions
+            ));
+        }
+
+        let tables = module.table_plans.len() - module.num_imported_tables;
+        if tables > self.tables as usize {
+            return Err(format!(
+                "defined tables count of {} exceeds the limit of {}",
+                tables, self.tables
+            ));
+        }
+
+        let memories = module.memory_plans.len() - module.num_imported_memories;
+        if memories > self.memories as usize {
+            return Err(format!(
+                "defined memories count of {} exceeds the limit of {}",
+                memories, self.memories
+            ));
+        }
+
+        let globals = module.globals.len() - module.num_imported_globals;
+        if globals > self.globals as usize {
+            return Err(format!(
+                "defined globals count of {} exceeds the limit of {}",
+                globals, self.globals
+            ));
+        }
+
+        for (i, plan) in module.table_plans.values().as_slice()[module.num_imported_tables..]
+            .iter()
+            .enumerate()
+        {
+            if plan.table.minimum > self.table_elements {
+                return Err(format!(
+                    "table index {} has a minimum element size of {} which exceeds the limit of {}",
+                    i, plan.table.minimum, self.table_elements
+                ));
+            }
+        }
+
+        for (i, plan) in module.memory_plans.values().as_slice()[module.num_imported_memories..]
+            .iter()
+            .enumerate()
+        {
+            if plan.memory.minimum > self.memory_pages {
+                return Err(format!(
+                    "memory index {} has a minimum page size of {} which exceeds the limit of {}",
+                    i, plan.memory.minimum, self.memory_pages
+                ));
+            }
+
+            if let MemoryStyle::Dynamic = plan.style {
+                return Err(format!(
+                    "memory index {} has an unsupported dynamic memory plan style",
+                    i,
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for ModuleLimits {
+    fn default() -> Self {
+        // See doc comments for `ModuleLimits` for these default values
+        Self {
+            imported_functions: 1000,
+            imported_tables: 0,
+            imported_memories: 0,
+            imported_globals: 0,
+            types: 100,
+            functions: 10000,
+            tables: 1,
+            memories: 1,
+            globals: 10,
+            table_elements: 10000,
+            memory_pages: 160,
+        }
+    }
+}
+
+/// Represents the limits placed on instances by the pooling instance allocator.
+#[derive(Debug, Copy, Clone)]
+pub struct InstanceLimits {
+    /// The maximum number of concurrent instances supported (default is 1000).
+    pub count: u32,
+
+    /// The maximum reserved host address space size to use for each instance in bytes.
+    ///
+    /// Note: this value has important performance ramifications.
+    ///
+    /// On 64-bit platforms, the default for this value will be 6 GiB.  A value of less than 4 GiB will
+    /// force runtime bounds checking for memory accesses and thus will negatively impact performance.
+    /// Any value above 4 GiB will start eliding bounds checks provided the `offset` of the memory access is
+    /// less than (`address_space_size` - 4 GiB).  A value of 8 GiB will completely elide *all* bounds
+    /// checks; consequently, 8 GiB will be the maximum supported value. The default of 6 GiB reserves
+    /// less host address space for each instance, but a memory access with an offet above 2 GiB will incur
+    /// runtime bounds checks.
+    ///
+    /// On 32-bit platforms, the default for this value will be 10 MiB. A 32-bit host has very limited address
+    /// space to reserve for a lot of concurrent instances.  As a result, runtime bounds checking will be used
+    /// for all memory accesses.  For better runtime performance, a 64-bit host is recommended.
+    ///
+    /// This value will be rounded up by the WebAssembly page size (64 KiB).
+    pub address_space_size: u64,
+}
+
+impl Default for InstanceLimits {
+    fn default() -> Self {
+        // See doc comments for `InstanceLimits` for these default values
+        Self {
+            count: 1000,
+            #[cfg(target_pointer_width = "32")]
+            address_space_size: 0xA00000,
+            #[cfg(target_pointer_width = "64")]
+            address_space_size: 0x180000000,
+        }
+    }
+}
+
+/// The allocation strategy to use for the pooling instance allocator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolingAllocationStrategy {
+    /// Allocate from the next available instance.
+    NextAvailable,
+    /// Allocate from a random available instance.
+    Random,
+}
+
+impl PoolingAllocationStrategy {
+    fn next(&self, free_count: usize) -> usize {
+        debug_assert!(free_count > 0);
+
+        match self {
+            Self::NextAvailable => free_count - 1,
+            Self::Random => rand::thread_rng().gen_range(0, free_count),
+        }
+    }
+}
+
+impl Default for PoolingAllocationStrategy {
+    fn default() -> Self {
+        Self::NextAvailable
+    }
+}
+
+// Used to iterate the base address of instance memories and tables.
+struct BasePointerIterator {
+    base: *mut u8,
+    current: usize,
+    num: usize,
+    size: usize,
+}
+
+impl BasePointerIterator {
+    fn new(base: *mut u8, num: usize, size: usize) -> Self {
+        Self {
+            base,
+            current: 0,
+            num,
+            size,
+        }
+    }
+}
+
+impl Iterator for BasePointerIterator {
+    type Item = *mut u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.current;
+        if current == self.num {
+            return None;
+        }
+
+        self.current += 1;
+
+        Some(unsafe { self.base.add(current * self.size) })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.num - self.current;
+        (remaining, Some(remaining))
+    }
+}
+
+/// Represents a pool of maximal `Instance` structures.
+///
+/// Each index in the pool provides enough space for a maximal `Instance`
+/// structure depending on the limits used to create the pool.
+///
+/// The pool maintains a free list for fast instance allocation.
+#[derive(Debug)]
+struct InstancePool {
+    mapping: Mmap,
+    offsets: VMOffsets,
+    instance_size: usize,
+    max_instances: usize,
+    free_list: Mutex<Vec<usize>>,
+    memories: MemoryPool,
+    tables: TablePool,
+}
+
+impl InstancePool {
+    fn new(module_limits: &ModuleLimits, instance_limits: &InstanceLimits) -> Result<Self, String> {
+        let page_size = region::page::size();
+
+        // Calculate the maximum size of an Instance structure given the limits
+        let offsets = VMOffsets {
+            pointer_size: std::mem::size_of::<*const u8>() as u8,
+            num_signature_ids: module_limits.types,
+            num_imported_functions: module_limits.imported_functions,
+            num_imported_tables: module_limits.imported_tables,
+            num_imported_memories: module_limits.imported_memories,
+            num_imported_globals: module_limits.imported_globals,
+            num_defined_functions: module_limits.functions,
+            num_defined_tables: module_limits.tables,
+            num_defined_memories: module_limits.memories,
+            num_defined_globals: module_limits.globals,
+        };
+
+        let instance_size = round_up_to_pow2(
+            mem::size_of::<Instance>()
+                .checked_add(offsets.size_of_vmctx() as usize)
+                .ok_or_else(|| "instance size exceeds addressable memory".to_string())?,
+            page_size,
+        );
+
+        let max_instances = instance_limits.count as usize;
+
+        let allocation_size = instance_size
+            .checked_mul(max_instances)
+            .ok_or_else(|| "total size of instance data exceeds addressable memory".to_string())?;
+
+        let pool = Self {
+            mapping: create_memory_map(allocation_size, allocation_size)?,
+            offsets,
+            instance_size,
+            max_instances,
+            free_list: Mutex::new((0..max_instances).collect()),
+            memories: MemoryPool::new(module_limits, instance_limits)?,
+            tables: TablePool::new(module_limits, instance_limits)?,
+        };
+
+        // Use a default module to initialize the instances to start
+        let module = Arc::new(Module::default());
+        for i in 0..instance_limits.count as usize {
+            pool.initialize(i, &module);
+        }
+
+        Ok(pool)
+    }
+
+    fn initialize(&self, index: usize, module: &Arc<Module>) {
+        debug_assert!(index < self.max_instances);
+
+        unsafe {
+            let instance_ptr = self.mapping.as_mut_ptr().add(index * self.instance_size);
+
+            // Write a default instance with preallocated memory/table map storage to the ptr
+            std::ptr::write(
+                instance_ptr as _,
+                Instance {
+                    module: module.clone(),
+                    offsets: self.offsets,
+                    memories: PrimaryMap::with_capacity(self.offsets.num_defined_memories as usize),
+                    tables: PrimaryMap::with_capacity(self.offsets.num_defined_tables as usize),
+                    dropped_elements: RefCell::new(EntitySet::new()),
+                    dropped_data: RefCell::new(EntitySet::new()),
+                    host_state: Box::new(()),
+                    vmctx: VMContext {},
+                },
+            );
+        }
+    }
+
+    fn allocate(
+        &self,
+        strategy: PoolingAllocationStrategy,
+        req: InstanceAllocationRequest,
+    ) -> Result<InstanceHandle, InstantiationError> {
+        let index = {
+            let mut free_list = self.free_list.lock().unwrap();
+            if free_list.is_empty() {
+                return Err(InstantiationError::Limit(self.max_instances as u32));
+            }
+            let free_index = strategy.next(free_list.len());
+            free_list.swap_remove(free_index)
+        };
+
+        unsafe {
+            debug_assert!(index < self.max_instances);
+            let instance =
+                &mut *(self.mapping.as_mut_ptr().add(index * self.instance_size) as *mut Instance);
+
+            instance.module = req.module;
+            instance.offsets = VMOffsets::new(
+                std::mem::size_of::<*const u8>() as u8,
+                instance.module.as_ref(),
+            );
+            instance.host_state = req.host_state;
+
+            Self::set_instance_memories(
+                instance,
+                self.memories.get(index),
+                self.memories.max_wasm_pages,
+            )?;
+            Self::set_instance_tables(instance, self.tables.get(index), self.tables.max_elements)?;
+
+            initialize_vmcontext(
+                instance,
+                req.imports.functions,
+                req.imports.tables,
+                req.imports.memories,
+                req.imports.globals,
+                req.finished_functions,
+                req.lookup_shared_signature,
+                req.interrupts,
+                req.externref_activations_table,
+                req.stack_map_registry,
+                &|index| instance.memories[index].vmmemory(),
+                &|index| instance.tables[index].vmtable(),
+            );
+
+            Ok(InstanceHandle::new(instance as _))
+        }
+    }
+
+    fn deallocate(&self, handle: &InstanceHandle) {
+        let addr = handle.instance as usize;
+        let base = self.mapping.as_ptr() as usize;
+
+        debug_assert!(addr >= base && addr < base + self.mapping.len());
+        debug_assert!((addr - base) % self.instance_size == 0);
+
+        let index = (addr - base) / self.instance_size;
+        debug_assert!(index < self.max_instances);
+
+        unsafe {
+            // Decommit any linear memories that were used
+            for (mem, base) in (*handle.instance)
+                .memories
+                .values()
+                .zip(self.memories.get(index))
+            {
+                let size = (mem.size() * WASM_PAGE_SIZE) as usize;
+                if size > 0 {
+                    decommit(base, size);
+                }
+            }
+
+            // Decommit any tables that were used
+            let table_element_size = max_table_element_size();
+            for (table, base) in (*handle.instance)
+                .tables
+                .values()
+                .zip(self.tables.get(index))
+            {
+                let size = round_up_to_pow2(
+                    table.size() as usize * table_element_size,
+                    self.tables.page_size,
+                );
+                if size > 0 {
+                    decommit(base, size);
+                }
+            }
+        }
+
+        {
+            self.free_list.lock().unwrap().push(index);
+        }
+    }
+
+    fn set_instance_memories(
+        instance: &mut Instance,
+        mut memories: BasePointerIterator,
+        max_pages: u32,
+    ) -> Result<(), InstantiationError> {
+        let module = instance.module.as_ref();
+
+        instance.memories.clear();
+
+        for plan in
+            (&module.memory_plans.values().as_slice()[module.num_imported_memories..]).iter()
+        {
+            instance.memories.push(
+                Memory::new_static(plan, memories.next().unwrap(), max_pages, make_accessible)
+                    .map_err(InstantiationError::Resource)?,
+            );
+        }
+
+        let mut dropped_data = instance.dropped_data.borrow_mut();
+        dropped_data.clear();
+        dropped_data.resize(module.passive_data.len());
+
+        Ok(())
+    }
+
+    fn set_instance_tables(
+        instance: &mut Instance,
+        mut tables: BasePointerIterator,
+        max_elements: u32,
+    ) -> Result<(), InstantiationError> {
+        let module = instance.module.as_ref();
+
+        instance.tables.clear();
+
+        for plan in (&module.table_plans.values().as_slice()[module.num_imported_tables..]).iter() {
+            let base = tables.next().unwrap();
+
+            // Make the table data accessible
+            if unsafe { !make_accessible(base, max_elements as usize * max_table_element_size()) } {
+                return Err(InstantiationError::Resource(
+                    "failed to make instance memory accessible".into(),
+                ));
+            }
+
+            instance
+                .tables
+                .push(Table::new_static(plan, base, max_elements));
+        }
+
+        let mut dropped_elements = instance.dropped_elements.borrow_mut();
+        dropped_elements.clear();
+        dropped_elements.resize(module.passive_elements.len());
+
+        Ok(())
+    }
+}
+
+impl Drop for InstancePool {
+    fn drop(&mut self) {
+        unsafe {
+            for i in 0..self.max_instances {
+                let ptr = self.mapping.as_mut_ptr().add(i * self.instance_size) as *mut Instance;
+                std::ptr::drop_in_place(ptr);
+            }
+        }
+    }
+}
+
+/// Represents a pool of WebAssembly linear memories.
+///
+/// A linear memory is divided into accessible pages and guard pages.
+///
+/// Each instance index into the pool returns an iterator over the base addresses
+/// of the instance's linear memories.
+#[derive(Debug)]
+struct MemoryPool {
+    mapping: Mmap,
+    memory_size: usize,
+    max_memories: usize,
+    max_instances: usize,
+    max_wasm_pages: u32,
+}
+
+impl MemoryPool {
+    fn new(module_limits: &ModuleLimits, instance_limits: &InstanceLimits) -> Result<Self, String> {
+        let memory_size = usize::try_from(instance_limits.address_space_size)
+            .map_err(|_| "address space size exceeds addressable memory".to_string())?;
+
+        debug_assert!(
+            memory_size % region::page::size() == 0,
+            "memory size {} is not a multiple of system page size",
+            memory_size
+        );
+
+        let max_instances = instance_limits.count as usize;
+        let max_memories = module_limits.memories as usize;
+
+        let allocation_size = memory_size
+            .checked_mul(max_memories)
+            .and_then(|c| c.checked_mul(max_instances))
+            .ok_or_else(|| {
+                "total size of instance address space exceeds addressable memory".to_string()
+            })?;
+
+        Ok(Self {
+            mapping: create_memory_map(0, allocation_size)?,
+            memory_size,
+            max_memories,
+            max_instances,
+            max_wasm_pages: module_limits.memory_pages,
+        })
+    }
+
+    fn get(&self, instance_index: usize) -> BasePointerIterator {
+        debug_assert!(instance_index < self.max_instances);
+
+        let base = unsafe {
+            self.mapping
+                .as_mut_ptr()
+                .add(instance_index * self.memory_size * self.max_memories) as _
+        };
+
+        BasePointerIterator::new(base, self.max_memories, self.memory_size)
+    }
+}
+
+/// Represents a pool of WebAssembly tables.
+///
+/// Each instance index into the pool returns an iterator over the base addresses
+/// of the instance's tables.
+#[derive(Debug)]
+struct TablePool {
+    mapping: Mmap,
+    table_size: usize,
+    max_tables: usize,
+    max_instances: usize,
+    page_size: usize,
+    max_elements: u32,
+}
+
+impl TablePool {
+    fn new(module_limits: &ModuleLimits, instance_limits: &InstanceLimits) -> Result<Self, String> {
+        let page_size = region::page::size();
+
+        let table_size = round_up_to_pow2(
+            max_table_element_size()
+                .checked_mul(module_limits.table_elements as usize)
+                .ok_or_else(|| "table size exceeds addressable memory".to_string())?,
+            page_size,
+        );
+
+        let max_instances = instance_limits.count as usize;
+        let max_tables = module_limits.tables as usize;
+
+        let allocation_size = table_size
+            .checked_mul(max_tables)
+            .and_then(|c| c.checked_mul(max_instances))
+            .ok_or_else(|| {
+                "total size of instance tables exceeds addressable memory".to_string()
+            })?;
+
+        Ok(Self {
+            mapping: create_memory_map(0, allocation_size)?,
+            table_size,
+            max_tables,
+            max_instances,
+            page_size: region::page::size(),
+            max_elements: module_limits.table_elements,
+        })
+    }
+
+    fn get(&self, instance_index: usize) -> BasePointerIterator {
+        debug_assert!(instance_index < self.max_instances);
+
+        let base = unsafe {
+            self.mapping
+                .as_mut_ptr()
+                .add(instance_index * self.table_size * self.max_tables) as _
+        };
+
+        BasePointerIterator::new(base, self.max_tables, self.table_size)
+    }
+}
+
+/// Represents a pool of execution stacks (used for the async fiber implementation).
+///
+/// Each index into the pool represents a single execution stack. The maximum number of
+/// stacks is the same as the maximum number of instances.
+///
+/// As stacks grow downwards, each stack starts (lowest address) with a guard page
+/// that can be used to detect stack overflow.
+///
+/// The top of the stack (starting stack pointer) is returned when a stack is allocated
+/// from the pool.
+#[derive(Debug)]
+struct StackPool {
+    mapping: Mmap,
+    stack_size: usize,
+    max_instances: usize,
+    page_size: usize,
+    free_list: Mutex<Vec<usize>>,
+}
+
+impl StackPool {
+    fn new(instance_limits: &InstanceLimits, stack_size: usize) -> Result<Self, String> {
+        let page_size = region::page::size();
+
+        // On Windows, don't allocate any fiber stacks as native fibers are always used
+        // Add a page to the stack size for the guard page when using fiber stacks
+        let stack_size = if cfg!(windows) || stack_size == 0 {
+            0
+        } else {
+            round_up_to_pow2(stack_size, page_size)
+                .checked_add(page_size)
+                .ok_or_else(|| "stack size exceeds addressable memory".to_string())?
+        };
+
+        let max_instances = instance_limits.count as usize;
+
+        let allocation_size = stack_size.checked_mul(max_instances).ok_or_else(|| {
+            "total size of execution stacks exceeds addressable memory".to_string()
+        })?;
+
+        Ok(Self {
+            mapping: create_memory_map(0, allocation_size)?,
+            stack_size,
+            max_instances,
+            page_size,
+            free_list: Mutex::new((0..max_instances).collect()),
+        })
+    }
+
+    fn allocate(&self, strategy: PoolingAllocationStrategy) -> Result<*mut u8, FiberStackError> {
+        // Stacks are not supported if nothing was allocated
+        if self.stack_size == 0 {
+            return Err(FiberStackError::NotSupported);
+        }
+
+        let index = {
+            let mut free_list = self.free_list.lock().unwrap();
+            if free_list.is_empty() {
+                return Err(FiberStackError::Limit(self.max_instances as u32));
+            }
+            let free_index = strategy.next(free_list.len());
+            free_list.swap_remove(free_index)
+        };
+
+        debug_assert!(index < self.max_instances);
+
+        unsafe {
+            // Remove the guard page from the size
+            let size_without_guard = self.stack_size - self.page_size;
+
+            let bottom_of_stack = self
+                .mapping
+                .as_mut_ptr()
+                .add((index * self.stack_size) + self.page_size);
+
+            // Make the stack accessible (excluding the guard page)
+            if !make_accessible(bottom_of_stack, size_without_guard) {
+                return Err(FiberStackError::Resource(
+                    "failed to make instance memory accessible".into(),
+                ));
+            }
+
+            // The top of the stack should be returned
+            Ok(bottom_of_stack.add(size_without_guard))
+        }
+    }
+
+    fn deallocate(&self, top_of_stack: *mut u8) {
+        debug_assert!(!top_of_stack.is_null());
+
+        unsafe {
+            // Remove the guard page from the size
+            let stack_size = self.stack_size - self.page_size;
+            let bottom_of_stack = top_of_stack.sub(stack_size);
+
+            let base = self.mapping.as_ptr() as usize;
+            let start_of_stack = (bottom_of_stack as usize) - self.page_size;
+
+            debug_assert!(start_of_stack >= base && start_of_stack < (base + self.mapping.len()));
+            debug_assert!((start_of_stack - base) % self.stack_size == 0);
+
+            let index = (start_of_stack - base) / self.stack_size;
+            debug_assert!(index < self.max_instances);
+
+            decommit(bottom_of_stack, stack_size);
+
+            {
+                self.free_list.lock().unwrap().push(index);
+            }
+        }
+    }
+}
+
+/// Implements the pooling instance allocator.
+///
+/// This allocator interinally maintains pools of instances, memories, tables, and stacks.
+///
+/// Note: the resource pools are manually dropped so that the fault handler terminates correctly.
+#[derive(Debug)]
+pub struct PoolingInstanceAllocator {
+    strategy: PoolingAllocationStrategy,
+    module_limits: ModuleLimits,
+    instance_limits: InstanceLimits,
+    instances: mem::ManuallyDrop<InstancePool>,
+    stacks: mem::ManuallyDrop<StackPool>,
+}
+
+impl PoolingInstanceAllocator {
+    /// Creates a new pooling instance allocator with the given strategy and limits.
+    pub fn new(
+        strategy: PoolingAllocationStrategy,
+        module_limits: ModuleLimits,
+        mut instance_limits: InstanceLimits,
+        stack_size: usize,
+    ) -> Result<Self, String> {
+        if instance_limits.count == 0 {
+            return Err("the instance count limit cannot be zero".into());
+        }
+
+        // Round the instance address space size to the nearest Wasm page size
+        instance_limits.address_space_size = u64::try_from(round_up_to_pow2(
+            usize::try_from(instance_limits.address_space_size).unwrap(),
+            WASM_PAGE_SIZE as usize,
+        ))
+        .unwrap();
+
+        // Cap the instance address space size to 8 GiB (maximum 4 GiB address space + 4 GiB of guard region)
+        instance_limits.address_space_size = min(instance_limits.address_space_size, 0x200000000);
+
+        // The maximum module memory page count cannot exceed 65536 pages
+        if module_limits.memory_pages > 0x10000 {
+            return Err(format!(
+                "module memory page limit of {} exceeds the maximum of 65536",
+                module_limits.memory_pages
+            ));
+        }
+
+        // The maximum module memory page count cannot exceed the instance address space size
+        if (module_limits.memory_pages * WASM_PAGE_SIZE) as u64 > instance_limits.address_space_size
+        {
+            return Err(format!(
+                "module memory page limit of {} pages exeeds the instance address space size limit of {} bytes",
+                module_limits.memory_pages,
+                instance_limits.address_space_size
+            ));
+        }
+
+        Ok(Self {
+            strategy,
+            module_limits,
+            instance_limits,
+            instances: mem::ManuallyDrop::new(InstancePool::new(&module_limits, &instance_limits)?),
+            stacks: mem::ManuallyDrop::new(StackPool::new(&instance_limits, stack_size)?),
+        })
+    }
+}
+
+impl Drop for PoolingInstanceAllocator {
+    fn drop(&mut self) {
+        // There are manually dropped for the future uffd implementation
+        unsafe {
+            mem::ManuallyDrop::drop(&mut self.instances);
+            mem::ManuallyDrop::drop(&mut self.stacks);
+        }
+    }
+}
+
+unsafe impl InstanceAllocator for PoolingInstanceAllocator {
+    fn validate_module(&self, translation: &ModuleTranslation) -> Result<(), String> {
+        self.module_limits.validate_module(&translation.module)
+    }
+
+    fn adjust_tunables(&self, tunables: &mut Tunables) {
+        let address_space_size = self.instance_limits.address_space_size;
+
+        // For address spaces larger than 4 GiB, use a guard region to elide
+        if address_space_size >= 0x100000000 {
+            tunables.static_memory_bound = 0x10000; // in Wasm pages
+            tunables.static_memory_offset_guard_size = address_space_size - 0x100000000;
+        } else {
+            tunables.static_memory_bound =
+                u32::try_from(address_space_size).unwrap() / WASM_PAGE_SIZE;
+            tunables.static_memory_offset_guard_size = 0;
+        }
+
+        // Treat the static memory bound as the maximum for unbounded Wasm memories
+        // Because we guarantee a module cannot compile unless it fits in the limits of
+        // the pool allocator, this ensures all memories are treated as static (i.e. immovable).
+        tunables.static_memory_bound_is_maximum = true;
+    }
+
+    unsafe fn allocate(
+        &self,
+        req: InstanceAllocationRequest,
+    ) -> Result<InstanceHandle, InstantiationError> {
+        self.instances.allocate(self.strategy, req)
+    }
+
+    unsafe fn initialize(
+        &self,
+        handle: &InstanceHandle,
+        is_bulk_memory: bool,
+        data_initializers: &Arc<[OwnedDataInitializer]>,
+    ) -> Result<(), InstantiationError> {
+        // TODO: refactor this implementation
+
+        // Check initializer bounds before initializing anything. Only do this
+        // when bulk memory is disabled, since the bulk memory proposal changes
+        // instantiation such that the intermediate results of failed
+        // initializations are visible.
+        if !is_bulk_memory {
+            OnDemandInstanceAllocator::check_table_init_bounds(handle.instance())?;
+            OnDemandInstanceAllocator::check_memory_init_bounds(
+                handle.instance(),
+                data_initializers.as_ref(),
+            )?;
+        }
+
+        // Apply fallible initializers. Note that this can "leak" state even if
+        // it fails.
+        OnDemandInstanceAllocator::initialize_tables(handle.instance())?;
+        OnDemandInstanceAllocator::initialize_memories(
+            handle.instance(),
+            data_initializers.as_ref(),
+        )?;
+
+        Ok(())
+    }
+
+    unsafe fn deallocate(&self, handle: &InstanceHandle) {
+        self.instances.deallocate(handle);
+    }
+
+    fn allocate_fiber_stack(&self) -> Result<*mut u8, FiberStackError> {
+        self.stacks.allocate(self.strategy)
+    }
+
+    unsafe fn deallocate_fiber_stack(&self, stack: *mut u8) {
+        self.stacks.deallocate(stack);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Imports, VMSharedSignatureIndex};
+    use wasmtime_environ::{
+        entity::EntityRef,
+        ir::Type,
+        wasm::{Global, GlobalInit, Memory, SignatureIndex, Table, TableElementType, WasmType},
+        MemoryPlan, ModuleType, TablePlan, TableStyle,
+    };
+
+    #[test]
+    fn test_module_imported_functions_limit() {
+        let limits = ModuleLimits {
+            imported_functions: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+
+        module.functions.push(SignatureIndex::new(0));
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.num_imported_funcs = 1;
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("imported function count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_imported_tables_limit() {
+        let limits = ModuleLimits {
+            imported_tables: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+
+        module.table_plans.push(TablePlan {
+            style: TableStyle::CallerChecksSignature,
+            table: Table {
+                wasm_ty: WasmType::FuncRef,
+                ty: TableElementType::Func,
+                minimum: 0,
+                maximum: None,
+            },
+        });
+
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.num_imported_tables = 1;
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("imported tables count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_imported_memories_limit() {
+        let limits = ModuleLimits {
+            imported_memories: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+
+        module.memory_plans.push(MemoryPlan {
+            style: MemoryStyle::Static { bound: 0 },
+            memory: Memory {
+                minimum: 0,
+                maximum: None,
+                shared: false,
+            },
+            offset_guard_size: 0,
+        });
+
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.num_imported_memories = 1;
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("imported memories count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_imported_globals_limit() {
+        let limits = ModuleLimits {
+            imported_globals: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+
+        module.globals.push(Global {
+            wasm_ty: WasmType::I32,
+            ty: Type::int(32).unwrap(),
+            mutability: false,
+            initializer: GlobalInit::I32Const(0),
+        });
+
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.num_imported_globals = 1;
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("imported globals count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_defined_types_limit() {
+        let limits = ModuleLimits {
+            types: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module
+            .types
+            .push(ModuleType::Function(SignatureIndex::new(0)));
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("defined types count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_defined_functions_limit() {
+        let limits = ModuleLimits {
+            functions: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.functions.push(SignatureIndex::new(0));
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("defined functions count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_defined_tables_limit() {
+        let limits = ModuleLimits {
+            tables: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.table_plans.push(TablePlan {
+            style: TableStyle::CallerChecksSignature,
+            table: Table {
+                wasm_ty: WasmType::FuncRef,
+                ty: TableElementType::Func,
+                minimum: 0,
+                maximum: None,
+            },
+        });
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("defined tables count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_defined_memories_limit() {
+        let limits = ModuleLimits {
+            memories: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.memory_plans.push(MemoryPlan {
+            style: MemoryStyle::Static { bound: 0 },
+            memory: Memory {
+                minimum: 0,
+                maximum: None,
+                shared: false,
+            },
+            offset_guard_size: 0,
+        });
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("defined memories count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_defined_globals_limit() {
+        let limits = ModuleLimits {
+            globals: 0,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        assert_eq!(limits.validate_module(&module), Ok(()));
+
+        module.globals.push(Global {
+            wasm_ty: WasmType::I32,
+            ty: Type::int(32).unwrap(),
+            mutability: false,
+            initializer: GlobalInit::I32Const(0),
+        });
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("defined globals count of 1 exceeds the limit of 0".into())
+        );
+    }
+
+    #[test]
+    fn test_module_table_minimum_elements_limit() {
+        let limits = ModuleLimits {
+            tables: 1,
+            table_elements: 10,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        module.table_plans.push(TablePlan {
+            style: TableStyle::CallerChecksSignature,
+            table: Table {
+                wasm_ty: WasmType::FuncRef,
+                ty: TableElementType::Func,
+                minimum: 11,
+                maximum: None,
+            },
+        });
+        assert_eq!(
+            limits.validate_module(&module),
+            Err(
+                "table index 0 has a minimum element size of 11 which exceeds the limit of 10"
+                    .into()
+            )
+        );
+    }
+
+    #[test]
+    fn test_module_memory_minimum_size_limit() {
+        let limits = ModuleLimits {
+            memories: 1,
+            memory_pages: 5,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        module.memory_plans.push(MemoryPlan {
+            style: MemoryStyle::Static { bound: 0 },
+            memory: Memory {
+                minimum: 6,
+                maximum: None,
+                shared: false,
+            },
+            offset_guard_size: 0,
+        });
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("memory index 0 has a minimum page size of 6 which exceeds the limit of 5".into())
+        );
+    }
+
+    #[test]
+    fn test_module_with_dynamic_memory_style() {
+        let limits = ModuleLimits {
+            memories: 1,
+            memory_pages: 5,
+            ..Default::default()
+        };
+
+        let mut module = Module::default();
+        module.memory_plans.push(MemoryPlan {
+            style: MemoryStyle::Dynamic,
+            memory: Memory {
+                minimum: 1,
+                maximum: None,
+                shared: false,
+            },
+            offset_guard_size: 0,
+        });
+        assert_eq!(
+            limits.validate_module(&module),
+            Err("memory index 0 has an unsupported dynamic memory plan style".into())
+        );
+    }
+
+    #[test]
+    fn test_next_available_allocation_strategy() {
+        let strat = PoolingAllocationStrategy::NextAvailable;
+        assert_eq!(strat.next(10), 9);
+        assert_eq!(strat.next(5), 4);
+        assert_eq!(strat.next(1), 0);
+    }
+
+    #[test]
+    fn test_random_allocation_strategy() {
+        let strat = PoolingAllocationStrategy::Random;
+        assert!(strat.next(100) < 100);
+        assert_eq!(strat.next(1), 0);
+    }
+
+    #[test]
+    fn test_base_pointer_iterator() {
+        let mut iter = BasePointerIterator::new(std::ptr::null_mut(), 5, 3);
+
+        assert_eq!(iter.next(), Some(0usize as _));
+        assert_eq!(iter.next(), Some(3usize as _));
+        assert_eq!(iter.next(), Some(6usize as _));
+        assert_eq!(iter.next(), Some(9usize as _));
+        assert_eq!(iter.next(), Some(12usize as _));
+        assert_eq!(iter.next(), None);
+
+        let mut iter = BasePointerIterator::new(std::ptr::null_mut(), 0, 10);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_instance_pool() -> Result<(), String> {
+        let module_limits = ModuleLimits {
+            imported_functions: 0,
+            imported_tables: 0,
+            imported_memories: 0,
+            imported_globals: 0,
+            types: 0,
+            functions: 0,
+            tables: 1,
+            memories: 1,
+            globals: 0,
+            table_elements: 10,
+            memory_pages: 10,
+        };
+        let instance_limits = InstanceLimits {
+            count: 3,
+            address_space_size: 4096,
+        };
+
+        let instances = InstancePool::new(&module_limits, &instance_limits)?;
+
+        assert_eq!(
+            instances.offsets.pointer_size,
+            std::mem::size_of::<*const u8>() as u8
+        );
+        assert_eq!(instances.offsets.num_signature_ids, 0);
+        assert_eq!(instances.offsets.num_imported_functions, 0);
+        assert_eq!(instances.offsets.num_imported_tables, 0);
+        assert_eq!(instances.offsets.num_imported_memories, 0);
+        assert_eq!(instances.offsets.num_imported_globals, 0);
+        assert_eq!(instances.offsets.num_defined_functions, 0);
+        assert_eq!(instances.offsets.num_defined_tables, 1);
+        assert_eq!(instances.offsets.num_defined_memories, 1);
+        assert_eq!(instances.offsets.num_defined_globals, 0);
+        assert_eq!(instances.instance_size, 4096);
+        assert_eq!(instances.max_instances, 3);
+
+        assert_eq!(
+            &*instances
+                .free_list
+                .lock()
+                .map_err(|_| "failed to lock".to_string())?,
+            &[0, 1, 2],
+        );
+
+        let mut handles = Vec::new();
+        let module = Arc::new(Module::default());
+        let finished_functions = &PrimaryMap::new();
+
+        for _ in (0..3).rev() {
+            handles.push(
+                instances
+                    .allocate(
+                        PoolingAllocationStrategy::NextAvailable,
+                        InstanceAllocationRequest {
+                            module: module.clone(),
+                            finished_functions,
+                            imports: Imports {
+                                functions: &[],
+                                tables: &[],
+                                memories: &[],
+                                globals: &[],
+                            },
+                            lookup_shared_signature: &|_| VMSharedSignatureIndex::default(),
+                            host_state: Box::new(()),
+                            interrupts: std::ptr::null(),
+                            externref_activations_table: std::ptr::null_mut(),
+                            stack_map_registry: std::ptr::null_mut(),
+                        },
+                    )
+                    .expect("allocation should succeed"),
+            );
+        }
+
+        assert_eq!(
+            &*instances
+                .free_list
+                .lock()
+                .map_err(|_| "failed to lock".to_string())?,
+            &[],
+        );
+
+        match instances.allocate(
+            PoolingAllocationStrategy::NextAvailable,
+            InstanceAllocationRequest {
+                module: module.clone(),
+                finished_functions,
+                imports: Imports {
+                    functions: &[],
+                    tables: &[],
+                    memories: &[],
+                    globals: &[],
+                },
+                lookup_shared_signature: &|_| VMSharedSignatureIndex::default(),
+                host_state: Box::new(()),
+                interrupts: std::ptr::null(),
+                externref_activations_table: std::ptr::null_mut(),
+                stack_map_registry: std::ptr::null_mut(),
+            },
+        ) {
+            Err(InstantiationError::Limit(3)) => {}
+            _ => panic!("unexpected error"),
+        };
+
+        for handle in handles.drain(..) {
+            instances.deallocate(&handle);
+        }
+
+        assert_eq!(
+            &*instances
+                .free_list
+                .lock()
+                .map_err(|_| "failed to lock".to_string())?,
+            &[2, 1, 0],
+        );
+
+        Ok(())
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_memory_pool() -> Result<(), String> {
+        let pool = MemoryPool::new(
+            &ModuleLimits {
+                imported_functions: 0,
+                imported_tables: 0,
+                imported_memories: 0,
+                imported_globals: 0,
+                types: 0,
+                functions: 0,
+                tables: 0,
+                memories: 3,
+                globals: 0,
+                table_elements: 0,
+                memory_pages: 10,
+            },
+            &InstanceLimits {
+                count: 5,
+                address_space_size: WASM_PAGE_SIZE as u64,
+            },
+        )?;
+
+        assert_eq!(pool.memory_size, WASM_PAGE_SIZE as usize);
+        assert_eq!(pool.max_memories, 3);
+        assert_eq!(pool.max_instances, 5);
+        assert_eq!(pool.max_wasm_pages, 10);
+
+        let base = pool.mapping.as_ptr() as usize;
+
+        for i in 0..5 {
+            let mut iter = pool.get(i);
+
+            for j in 0..3 {
+                assert_eq!(
+                    iter.next().unwrap() as usize - base,
+                    ((i * 3) + j) * pool.memory_size
+                );
+            }
+
+            assert_eq!(iter.next(), None);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_table_pool() -> Result<(), String> {
+        let pool = TablePool::new(
+            &ModuleLimits {
+                imported_functions: 0,
+                imported_tables: 0,
+                imported_memories: 0,
+                imported_globals: 0,
+                types: 0,
+                functions: 0,
+                tables: 4,
+                memories: 0,
+                globals: 0,
+                table_elements: 100,
+                memory_pages: 0,
+            },
+            &InstanceLimits {
+                count: 7,
+                address_space_size: WASM_PAGE_SIZE as u64,
+            },
+        )?;
+
+        assert_eq!(pool.table_size, 4096);
+        assert_eq!(pool.max_tables, 4);
+        assert_eq!(pool.max_instances, 7);
+        assert_eq!(pool.page_size, 4096);
+        assert_eq!(pool.max_elements, 100);
+
+        let base = pool.mapping.as_ptr() as usize;
+
+        for i in 0..7 {
+            let mut iter = pool.get(i);
+
+            for j in 0..4 {
+                assert_eq!(
+                    iter.next().unwrap() as usize - base,
+                    ((i * 4) + j) * pool.table_size
+                );
+            }
+
+            assert_eq!(iter.next(), None);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_stack_pool() -> Result<(), String> {
+        let pool = StackPool::new(
+            &InstanceLimits {
+                count: 10,
+                address_space_size: 0,
+            },
+            1,
+        )?;
+
+        assert_eq!(pool.stack_size, 8192);
+        assert_eq!(pool.max_instances, 10);
+        assert_eq!(pool.page_size, 4096);
+
+        assert_eq!(
+            &*pool
+                .free_list
+                .lock()
+                .map_err(|_| "failed to lock".to_string())?,
+            &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        );
+
+        let base = pool.mapping.as_ptr() as usize;
+
+        let mut stacks = Vec::new();
+        for i in (0..10).rev() {
+            let stack = pool
+                .allocate(PoolingAllocationStrategy::NextAvailable)
+                .expect("allocation should succeed");
+            assert_eq!(((stack as usize - base) / pool.stack_size) - 1, i);
+            stacks.push(stack);
+        }
+
+        assert_eq!(
+            &*pool
+                .free_list
+                .lock()
+                .map_err(|_| "failed to lock".to_string())?,
+            &[],
+        );
+
+        match pool
+            .allocate(PoolingAllocationStrategy::NextAvailable)
+            .unwrap_err()
+        {
+            FiberStackError::Limit(10) => {}
+            _ => panic!("unexpected error"),
+        };
+
+        for stack in stacks {
+            pool.deallocate(stack);
+        }
+
+        assert_eq!(
+            &*pool
+                .free_list
+                .lock()
+                .map_err(|_| "failed to lock".to_string())?,
+            &[9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_pooling_allocator_with_zero_instance_count() {
+        assert_eq!(
+            PoolingInstanceAllocator::new(
+                PoolingAllocationStrategy::Random,
+                ModuleLimits::default(),
+                InstanceLimits {
+                    count: 0,
+                    ..Default::default()
+                },
+                4096
+            )
+            .expect_err("expected a failure constructing instance allocator"),
+            "the instance count limit cannot be zero"
+        );
+    }
+
+    #[test]
+    fn test_pooling_allocator_with_memory_pages_exeeded() {
+        assert_eq!(
+            PoolingInstanceAllocator::new(
+                PoolingAllocationStrategy::Random,
+                ModuleLimits {
+                    memory_pages: 0x10001,
+                    ..Default::default()
+                },
+                InstanceLimits {
+                    count: 1,
+                    address_space_size: 1,
+                },
+                4096
+            )
+            .expect_err("expected a failure constructing instance allocator"),
+            "module memory page limit of 65537 exceeds the maximum of 65536"
+        );
+    }
+
+    #[test]
+    fn test_pooling_allocator_with_address_space_exeeded() {
+        assert_eq!(
+            PoolingInstanceAllocator::new(
+                PoolingAllocationStrategy::Random,
+                ModuleLimits {
+                    memory_pages: 2,
+                    ..Default::default()
+                },
+                InstanceLimits {
+                    count: 1,
+                    address_space_size: 1,
+                },
+                4096,
+            )
+            .expect_err("expected a failure constructing instance allocator"),
+            "module memory page limit of 2 pages exeeds the instance address space size limit of 65536 bytes"
+        );
+    }
+
+    #[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
+    #[cfg(unix)]
+    #[test]
+    fn test_stack_zeroed() -> Result<(), String> {
+        let allocator = PoolingInstanceAllocator::new(
+            PoolingAllocationStrategy::NextAvailable,
+            ModuleLimits {
+                imported_functions: 0,
+                types: 0,
+                functions: 0,
+                tables: 0,
+                memories: 0,
+                globals: 0,
+                table_elements: 0,
+                memory_pages: 0,
+                ..Default::default()
+            },
+            InstanceLimits {
+                count: 1,
+                address_space_size: 1,
+            },
+            4096,
+        )?;
+
+        unsafe {
+            for _ in 0..10 {
+                let stack = allocator
+                    .allocate_fiber_stack()
+                    .map_err(|e| format!("failed to allocate stack: {}", e))?;
+
+                // The stack pointer is at the top, so decerement it first
+                let addr = stack.sub(1);
+
+                assert_eq!(*addr, 0);
+                *addr = 1;
+
+                allocator.deallocate_fiber_stack(stack);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/runtime/src/instance/allocator/pooling/linux.rs
+++ b/crates/runtime/src/instance/allocator/pooling/linux.rs
@@ -1,4 +1,5 @@
 use crate::Mmap;
+use anyhow::{anyhow, Result};
 
 pub unsafe fn make_accessible(addr: *mut u8, len: usize) -> bool {
     region::protect(addr, len, region::Protection::READ_WRITE).is_ok()
@@ -16,7 +17,7 @@ pub unsafe fn decommit(addr: *mut u8, len: usize) {
     );
 }
 
-pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap, String> {
+pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap> {
     Mmap::accessible_reserved(accessible_size, mapping_size)
-        .map_err(|e| format!("failed to allocate pool memory: {}", e))
+        .map_err(|e| anyhow!("failed to allocate pool memory: {}", e))
 }

--- a/crates/runtime/src/instance/allocator/pooling/linux.rs
+++ b/crates/runtime/src/instance/allocator/pooling/linux.rs
@@ -1,0 +1,22 @@
+use crate::Mmap;
+
+pub unsafe fn make_accessible(addr: *mut u8, len: usize) -> bool {
+    region::protect(addr, len, region::Protection::READ_WRITE).is_ok()
+}
+
+pub unsafe fn decommit(addr: *mut u8, len: usize) {
+    region::protect(addr, len, region::Protection::NONE).unwrap();
+
+    // On Linux, this is enough to cause the kernel to initialize the pages to 0 on next access
+    assert_eq!(
+        libc::madvise(addr as _, len, libc::MADV_DONTNEED),
+        0,
+        "madvise failed to mark pages as missing: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap, String> {
+    Mmap::accessible_reserved(accessible_size, mapping_size)
+        .map_err(|e| format!("failed to allocate pool memory: {}", e))
+}

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -1,0 +1,752 @@
+//! Implements user-mode page fault handling with the `userfaultfd` ("uffd") system call on Linux.
+//!
+//! Handling page faults for memory accesses in regions relating to WebAssembly instances
+//! enables the implementation of guard pages in user space rather than kernel space.
+//!
+//! This reduces the number of system calls and kernel locks needed to provide correct
+//! WebAssembly memory semantics.
+//!
+//! Additionally, linear memories and WebAssembly tables can be lazy-initialized upon access.
+//!
+//! This feature requires a Linux kernel 4.11 or newer to use.
+
+use super::{InstancePool, StackPool};
+use crate::{instance::Instance, Mmap};
+use std::convert::TryInto;
+use std::ptr;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::thread;
+use userfaultfd::{Event, FeatureFlags, IoctlFlags, Uffd, UffdBuilder};
+use wasmtime_environ::{wasm::DefinedMemoryIndex, WASM_PAGE_SIZE};
+
+pub unsafe fn make_accessible(_addr: *mut u8, _len: usize) -> bool {
+    // A no-op when userfaultfd is used
+    true
+}
+
+pub unsafe fn reset_guard_page(addr: *mut u8, len: usize) -> bool {
+    // Guard pages are READ_WRITE with uffd until faulted
+    region::protect(addr, len, region::Protection::READ_WRITE).is_ok()
+}
+
+pub unsafe fn decommit(addr: *mut u8, len: usize) {
+    // Use MADV_DONTNEED to mark the pages as missing
+    // This will cause a missing page fault for next access on any page in the given range
+    assert_eq!(
+        libc::madvise(addr as _, len, libc::MADV_DONTNEED),
+        0,
+        "madvise failed to mark pages as missing: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+pub fn create_memory_map(_accessible_size: usize, mapping_size: usize) -> Result<Mmap, String> {
+    // Allocate a single read-write region at once
+    // As writable pages need to count towards commit charge, use MAP_NORESERVE to override.
+    // This implies that the kernel is configured to allow overcommit or else
+    // this allocation will almost certainly fail without a plethora of physical memory to back the alloction.
+    // The consequence of not reserving is that our process may segfault on any write to a memory
+    // page that cannot be backed (i.e. out of memory conditions).
+
+    if mapping_size == 0 {
+        return Ok(Mmap::new());
+    }
+
+    unsafe {
+        let ptr = libc::mmap(
+            ptr::null_mut(),
+            mapping_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANON | libc::MAP_NORESERVE,
+            -1,
+            0,
+        );
+
+        if ptr as isize == -1_isize {
+            return Err(format!(
+                "failed to allocate pool memory: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        Ok(Mmap::from_raw(ptr as usize, mapping_size))
+    }
+}
+
+/// Represents a location of a page fault within monitored regions of memory.
+enum AddressLocation<'a> {
+    /// The address location is in a WebAssembly table page.
+    /// The fault handler will zero the page as tables are initialized at instantiation-time.
+    TablePage {
+        /// The address of the page being accessed.
+        page_addr: *mut u8,
+        /// The length of the page being accessed.
+        len: usize,
+    },
+    /// The address location is in a WebAssembly linear memory page.
+    /// The fault handler will copy the pages from initialization data if necessary.
+    MemoryPage {
+        /// The address of the page being accessed.
+        page_addr: *mut u8,
+        /// The length of the page being accessed.
+        len: usize,
+        /// The instance related to the memory page that was accessed.
+        instance: &'a Instance,
+        /// The index of the memory that was accessed.
+        memory_index: usize,
+        /// The Wasm page index to initialize if the access was not a guard page.
+        page_index: Option<usize>,
+    },
+    /// The address location is in an execution stack.
+    /// The fault handler will zero the page.
+    StackPage {
+        /// The address of the page being accessed.
+        page_addr: *mut u8,
+        /// The length of the page being accessed.
+        len: usize,
+        /// The index of the stack that was accessed.
+        index: usize,
+        /// Whether or not the access was to a guard page.
+        guard_page: bool,
+    },
+}
+
+/// Used to resolve fault addresses to address locations.
+///
+/// This implementation relies heavily on how the various resource pools utilize their memory.
+///
+/// `usize` is used here instead of pointers to keep this `Send` as it gets sent to the handler thread.
+struct AddressLocator {
+    instances_start: usize,
+    instance_size: usize,
+    max_instances: usize,
+    memories_start: usize,
+    memories_end: usize,
+    memory_size: usize,
+    max_memories: usize,
+    tables_start: usize,
+    tables_end: usize,
+    table_size: usize,
+    stacks_start: usize,
+    stacks_end: usize,
+    stack_size: usize,
+    page_size: usize,
+}
+
+impl AddressLocator {
+    fn new(instances: &InstancePool, stacks: &StackPool) -> Self {
+        let instances_start = instances.mapping.as_ptr() as usize;
+        let memories_start = instances.memories.mapping.as_ptr() as usize;
+        let memories_end = memories_start + instances.memories.mapping.len();
+        let tables_start = instances.tables.mapping.as_ptr() as usize;
+        let tables_end = tables_start + instances.tables.mapping.len();
+        let stacks_start = stacks.mapping.as_ptr() as usize;
+        let stacks_end = stacks_start + stacks.mapping.len();
+        let stack_size = stacks.stack_size;
+
+        // Should always have instances
+        debug_assert!(instances_start != 0);
+
+        Self {
+            instances_start,
+            instance_size: instances.instance_size,
+            max_instances: instances.max_instances,
+            memories_start,
+            memories_end,
+            memory_size: instances.memories.memory_size,
+            max_memories: instances.memories.max_memories,
+            tables_start,
+            tables_end,
+            table_size: instances.tables.table_size,
+            stacks_start,
+            stacks_end,
+            stack_size,
+            page_size: instances.tables.page_size,
+        }
+    }
+
+    // This is super-duper unsafe as it is used from the handler thread
+    // to access instance data without any locking primitives.
+    ///
+    /// It is assumed that the thread that owns the instance being accessed is
+    /// currently suspended waiting on a fault to be handled.
+    ///
+    /// Of course a stray faulting memory access from a thread that does not own
+    /// the instance might introduce a race, but this implementation considers
+    /// such to be a serious bug.
+    ///
+    /// If the assumption holds true, accessing the instance data from the handler thread
+    /// should, in theory, be safe.
+    unsafe fn get_instance(&self, index: usize) -> &mut Instance {
+        debug_assert!(index < self.max_instances);
+        &mut *((self.instances_start + (index * self.instance_size)) as *mut Instance)
+    }
+
+    unsafe fn get_location(&self, addr: usize) -> Option<AddressLocation> {
+        // Check for a memory location
+        if addr >= self.memories_start && addr < self.memories_end {
+            let index = (addr - self.memories_start) / self.memory_size;
+            let memory_index = index % self.max_memories;
+            let memory_start = self.memories_start + (index * self.memory_size);
+            let page_index = (addr - memory_start) / (WASM_PAGE_SIZE as usize);
+            let instance = self.get_instance(index / self.max_memories);
+
+            let init_page_index = instance
+                .memories
+                .get(
+                    DefinedMemoryIndex::from_u32(memory_index as u32)
+                        .try_into()
+                        .unwrap(),
+                )
+                .and_then(|m| {
+                    if page_index < m.size() as usize {
+                        Some(page_index)
+                    } else {
+                        None
+                    }
+                });
+
+            return Some(AddressLocation::MemoryPage {
+                page_addr: (memory_start + page_index * (WASM_PAGE_SIZE as usize)) as _,
+                len: WASM_PAGE_SIZE as usize,
+                instance,
+                memory_index,
+                page_index: init_page_index,
+            });
+        }
+
+        // Check for a table location
+        if addr >= self.tables_start && addr < self.tables_end {
+            let index = (addr - self.tables_start) / self.table_size;
+            let table_start = self.tables_start + (index * self.table_size);
+            let table_offset = addr - table_start;
+            let page_index = table_offset / self.page_size;
+
+            return Some(AddressLocation::TablePage {
+                page_addr: (table_start + (page_index * self.page_size)) as _,
+                len: self.page_size,
+            });
+        }
+
+        // Check for a stack location
+        if addr >= self.stacks_start && addr < self.stacks_end {
+            let index = (addr - self.stacks_start) / self.stack_size;
+            let stack_start = self.stacks_start + (index * self.stack_size);
+            let stack_offset = addr - stack_start;
+            let page_offset = (stack_offset / self.page_size) * self.page_size;
+
+            return Some(AddressLocation::StackPage {
+                page_addr: (stack_start + page_offset) as _,
+                len: self.page_size,
+                index,
+                guard_page: stack_offset < self.page_size,
+            });
+        }
+
+        None
+    }
+}
+
+fn wake_guard_page_access(uffd: &Uffd, page_addr: *const u8, len: usize) -> Result<(), String> {
+    unsafe {
+        // Set the page to NONE to induce a SIGSEV for the access on the next retry
+        region::protect(page_addr, len, region::Protection::NONE)
+            .map_err(|e| format!("failed to change guard page protection: {}", e))?;
+
+        uffd.wake(page_addr as _, len).map_err(|e| {
+            format!(
+                "failed to wake page at {:p} with length {}: {}",
+                page_addr, len, e
+            )
+        })?;
+
+        Ok(())
+    }
+}
+
+fn handler_thread(
+    uffd: Uffd,
+    locator: AddressLocator,
+    mut registrations: usize,
+    faulted_stack_guard_pages: Arc<[AtomicBool]>,
+) -> Result<(), String> {
+    loop {
+        match uffd.read_event().expect("failed to read event") {
+            Some(Event::Unmap { start, end }) => {
+                log::trace!("memory region unmapped: {:p}-{:p}", start, end);
+
+                let (start, end) = (start as usize, end as usize);
+
+                if (start == locator.memories_start && end == locator.memories_end)
+                    || (start == locator.tables_start && end == locator.tables_end)
+                    || (start == locator.stacks_start && end == locator.stacks_end)
+                {
+                    registrations -= 1;
+                    if registrations == 0 {
+                        break;
+                    }
+                } else {
+                    panic!("unexpected memory region unmapped");
+                }
+            }
+            Some(Event::Pagefault {
+                addr: access_addr, ..
+            }) => {
+                unsafe {
+                    match locator.get_location(access_addr as usize) {
+                        Some(AddressLocation::TablePage { page_addr, len }) => {
+                            log::trace!(
+                                "handling fault in table at address {:p} on page {:p}",
+                                access_addr,
+                                page_addr,
+                            );
+
+                            // Tables are always initialized upon instantiation, so zero the page
+                            uffd.zeropage(page_addr as _, len, true).map_err(|e| {
+                                format!(
+                                    "failed to zero page at {:p} with length {}: {}",
+                                    page_addr, len, e
+                                )
+                            })?;
+                        }
+                        Some(AddressLocation::MemoryPage {
+                            page_addr,
+                            len,
+                            instance,
+                            memory_index,
+                            page_index,
+                        }) => {
+                            log::trace!(
+                                "handling fault in linear memory at address {:p} on page {:p}",
+                                access_addr,
+                                page_addr
+                            );
+
+                            match page_index {
+                                Some(page_index) => {
+                                    // TODO: copy the memory initialization data rather than zero the page
+                                    uffd.zeropage(page_addr as _, len, true).map_err(|e| {
+                                        format!(
+                                            "failed to zero page at {:p} with length {}: {}",
+                                            page_addr, len, e
+                                        )
+                                    })?;
+                                }
+                                None => {
+                                    log::trace!("out of bounds memory access at {:p}", access_addr);
+
+                                    // Record the guard page fault with the instance so it can be reset later.
+                                    instance.record_guard_page_fault(
+                                        page_addr,
+                                        len,
+                                        reset_guard_page,
+                                    );
+                                    wake_guard_page_access(&uffd, page_addr, len)?;
+                                }
+                            }
+                        }
+                        Some(AddressLocation::StackPage {
+                            page_addr,
+                            len,
+                            index,
+                            guard_page,
+                        }) => {
+                            log::trace!(
+                                "handling fault in stack {} at address {:p}",
+                                index,
+                                access_addr,
+                            );
+
+                            if guard_page {
+                                // Logging as trace as stack guard pages might be a trap condition in the future
+                                log::trace!("stack overflow fault at {:p}", access_addr);
+
+                                // Mark the stack as having a faulted guard page
+                                // The next time the stack is used the guard page will be reset
+                                faulted_stack_guard_pages[index].store(true, Ordering::SeqCst);
+                                wake_guard_page_access(&uffd, page_addr, len)?;
+                                continue;
+                            }
+
+                            // Always zero stack pages
+                            uffd.zeropage(page_addr as _, len, true).map_err(|e| {
+                                format!(
+                                    "failed to zero page at {:p} with length {}: {}",
+                                    page_addr, len, e
+                                )
+                            })?;
+                        }
+                        None => {
+                            return Err(format!(
+                                "failed to locate fault address {:p} in registered memory regions",
+                                access_addr
+                            ));
+                        }
+                    }
+                }
+            }
+            Some(_) => continue,
+            None => break,
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct PageFaultHandler {
+    thread: Option<thread::JoinHandle<Result<(), String>>>,
+}
+
+impl PageFaultHandler {
+    pub(super) fn new(instances: &InstancePool, stacks: &StackPool) -> Result<Self, String> {
+        let uffd = UffdBuilder::new()
+            .close_on_exec(true)
+            .require_features(FeatureFlags::EVENT_UNMAP)
+            .create()
+            .map_err(|e| format!("failed to create user fault descriptor: {}", e))?;
+
+        // Register the ranges with the userfault fd
+        let mut registrations = 0;
+        for (start, len) in &[
+            (
+                instances.memories.mapping.as_ptr() as usize,
+                instances.memories.mapping.len(),
+            ),
+            (
+                instances.tables.mapping.as_ptr() as usize,
+                instances.tables.mapping.len(),
+            ),
+            (stacks.mapping.as_ptr() as usize, stacks.mapping.len()),
+        ] {
+            if *start == 0 || *len == 0 {
+                continue;
+            }
+
+            let ioctls = uffd
+                .register(*start as _, *len)
+                .map_err(|e| format!("failed to register user fault range: {}", e))?;
+
+            if !ioctls.contains(IoctlFlags::WAKE | IoctlFlags::COPY | IoctlFlags::ZEROPAGE) {
+                return Err(format!(
+                    "required user fault ioctls not supported; found: {:?}",
+                    ioctls,
+                ));
+            }
+
+            registrations += 1;
+        }
+
+        let thread = if registrations == 0 {
+            log::trace!("user fault handling disabled as there are no regions to monitor");
+            None
+        } else {
+            log::trace!(
+                "user fault handling enabled on {} memory regions",
+                registrations
+            );
+
+            let locator = AddressLocator::new(&instances, &stacks);
+
+            let faulted_stack_guard_pages = stacks.faulted_guard_pages.clone();
+
+            Some(
+                thread::Builder::new()
+                    .name("page fault handler".into())
+                    .spawn(move || {
+                        handler_thread(uffd, locator, registrations, faulted_stack_guard_pages)
+                    })
+                    .map_err(|e| format!("failed to spawn page fault handler thread: {}", e))?,
+            )
+        };
+
+        Ok(Self { thread })
+    }
+}
+
+impl Drop for PageFaultHandler {
+    fn drop(&mut self) {
+        if let Some(thread) = self.thread.take() {
+            thread
+                .join()
+                .expect("failed to join page fault handler thread")
+                .expect("fault handler thread failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        table::max_table_element_size, Imports, InstanceAllocationRequest, InstanceLimits,
+        ModuleLimits, PoolingAllocationStrategy, VMSharedSignatureIndex,
+    };
+    use wasmtime_environ::{
+        entity::PrimaryMap,
+        wasm::{Memory, Table, TableElementType, WasmType},
+        MemoryPlan, MemoryStyle, Module, TablePlan, TableStyle,
+    };
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_address_locator() {
+        let module_limits = ModuleLimits {
+            imported_functions: 0,
+            imported_tables: 0,
+            imported_memories: 0,
+            imported_globals: 0,
+            types: 0,
+            functions: 0,
+            tables: 3,
+            memories: 2,
+            globals: 0,
+            table_elements: 1000,
+            memory_pages: 2,
+        };
+        let instance_limits = InstanceLimits {
+            count: 3,
+            address_space_size: (WASM_PAGE_SIZE * 10) as u64,
+        };
+
+        let instances =
+            InstancePool::new(&module_limits, &instance_limits).expect("should allocate");
+        let stacks = StackPool::new(&instance_limits, 8192).expect("should allocate");
+
+        let locator = AddressLocator::new(&instances, &stacks);
+
+        assert_eq!(locator.instances_start, instances.mapping.as_ptr() as usize);
+        assert_eq!(locator.instance_size, 4096);
+        assert_eq!(locator.max_instances, 3);
+        assert_eq!(
+            locator.memories_start,
+            instances.memories.mapping.as_ptr() as usize
+        );
+        assert_eq!(
+            locator.memories_end,
+            locator.memories_start + instances.memories.mapping.len()
+        );
+        assert_eq!(locator.memory_size, (WASM_PAGE_SIZE * 10) as usize);
+        assert_eq!(locator.max_memories, 2);
+        assert_eq!(
+            locator.tables_start,
+            instances.tables.mapping.as_ptr() as usize
+        );
+        assert_eq!(
+            locator.tables_end,
+            locator.tables_start + instances.tables.mapping.len()
+        );
+        assert_eq!(locator.table_size, 8192);
+
+        assert_eq!(locator.stacks_start, stacks.mapping.as_ptr() as usize);
+        assert_eq!(
+            locator.stacks_end,
+            locator.stacks_start + stacks.mapping.len()
+        );
+        assert_eq!(locator.stack_size, 12288);
+
+        unsafe {
+            assert!(locator.get_location(0).is_none());
+            assert!(locator
+                .get_location(std::cmp::max(
+                    locator.memories_end,
+                    std::cmp::max(locator.tables_end, locator.stacks_end)
+                ))
+                .is_none());
+
+            let mut module = Module::new();
+
+            for _ in 0..module_limits.memories {
+                module.memory_plans.push(MemoryPlan {
+                    memory: Memory {
+                        minimum: 2,
+                        maximum: Some(2),
+                        shared: false,
+                    },
+                    style: MemoryStyle::Static { bound: 1 },
+                    offset_guard_size: 0,
+                });
+            }
+
+            for _ in 0..module_limits.tables {
+                module.table_plans.push(TablePlan {
+                    table: Table {
+                        wasm_ty: WasmType::FuncRef,
+                        ty: TableElementType::Func,
+                        minimum: 800,
+                        maximum: Some(900),
+                    },
+                    style: TableStyle::CallerChecksSignature,
+                });
+            }
+
+            module_limits
+                .validate_module(&module)
+                .expect("should validate");
+
+            let mut handles = Vec::new();
+            let module = Arc::new(module);
+            let finished_functions = &PrimaryMap::new();
+
+            // Allocate the maximum number of instances with the maxmimum number of memories and tables
+            for _ in 0..instances.max_instances {
+                handles.push(
+                    instances
+                        .allocate(
+                            PoolingAllocationStrategy::Random,
+                            InstanceAllocationRequest {
+                                module: module.clone(),
+                                finished_functions,
+                                imports: Imports {
+                                    functions: &[],
+                                    tables: &[],
+                                    memories: &[],
+                                    globals: &[],
+                                },
+                                lookup_shared_signature: &|_| VMSharedSignatureIndex::default(),
+                                host_state: Box::new(()),
+                                interrupts: std::ptr::null(),
+                                externref_activations_table: std::ptr::null_mut(),
+                                stack_map_registry: std::ptr::null_mut(),
+                            },
+                        )
+                        .expect("instance should allocate"),
+                );
+            }
+
+            // Validate memory locations
+            for instance_index in 0..instances.max_instances {
+                for memory_index in 0..instances.memories.max_memories {
+                    let memory_start = locator.memories_start
+                        + (instance_index * locator.memory_size * locator.max_memories)
+                        + (memory_index * locator.memory_size);
+
+                    // Test for access to first page
+                    match locator.get_location(memory_start + 10000) {
+                        Some(AddressLocation::MemoryPage {
+                            page_addr,
+                            len,
+                            instance: _,
+                            memory_index: mem_index,
+                            page_index,
+                        }) => {
+                            assert_eq!(page_addr, memory_start as _);
+                            assert_eq!(len, WASM_PAGE_SIZE as usize);
+                            assert_eq!(mem_index, memory_index);
+                            assert_eq!(page_index, Some(0));
+                        }
+                        _ => panic!("expected a memory page location"),
+                    }
+
+                    // Test for access to second page
+                    match locator.get_location(memory_start + 1024 + WASM_PAGE_SIZE as usize) {
+                        Some(AddressLocation::MemoryPage {
+                            page_addr,
+                            len,
+                            instance: _,
+                            memory_index: mem_index,
+                            page_index,
+                        }) => {
+                            assert_eq!(page_addr, (memory_start + WASM_PAGE_SIZE as usize) as _);
+                            assert_eq!(len, WASM_PAGE_SIZE as usize);
+                            assert_eq!(mem_index, memory_index);
+                            assert_eq!(page_index, Some(1));
+                        }
+                        _ => panic!("expected a memory page location"),
+                    }
+
+                    // Test for guard page
+                    match locator.get_location(memory_start + 10 + 9 * WASM_PAGE_SIZE as usize) {
+                        Some(AddressLocation::MemoryPage {
+                            page_addr,
+                            len,
+                            instance: _,
+                            memory_index: mem_index,
+                            page_index,
+                        }) => {
+                            assert_eq!(
+                                page_addr,
+                                (memory_start + (9 * WASM_PAGE_SIZE as usize)) as _
+                            );
+                            assert_eq!(len, WASM_PAGE_SIZE as usize);
+                            assert_eq!(mem_index, memory_index);
+                            assert_eq!(page_index, None);
+                        }
+                        _ => panic!("expected a memory page location"),
+                    }
+                }
+            }
+
+            // Validate table locations
+            for instance_index in 0..instances.max_instances {
+                for table_index in 0..instances.tables.max_tables {
+                    let table_start = locator.tables_start
+                        + (instance_index * locator.table_size * instances.tables.max_tables)
+                        + (table_index * locator.table_size);
+
+                    // Check for an access of index 107 (first page)
+                    match locator.get_location(table_start + (107 * max_table_element_size())) {
+                        Some(AddressLocation::TablePage { page_addr, len }) => {
+                            assert_eq!(page_addr, table_start as _);
+                            assert_eq!(len, locator.page_size);
+                        }
+                        _ => panic!("expected a table page location"),
+                    }
+
+                    // Check for an access of index 799 (second page)
+                    match locator.get_location(table_start + (799 * max_table_element_size())) {
+                        Some(AddressLocation::TablePage { page_addr, len }) => {
+                            assert_eq!(page_addr, (table_start + locator.page_size) as _);
+                            assert_eq!(len, locator.page_size);
+                        }
+                        _ => panic!("expected a table page location"),
+                    }
+                }
+            }
+
+            // Validate stack locations
+            for stack_index in 0..instances.max_instances {
+                let stack_start = locator.stacks_start + (stack_index * locator.stack_size);
+
+                // Check for stack page location
+                match locator.get_location(stack_start + locator.page_size * 2) {
+                    Some(AddressLocation::StackPage {
+                        page_addr,
+                        len,
+                        index,
+                        guard_page,
+                    }) => {
+                        assert_eq!(page_addr, (stack_start + locator.page_size * 2) as _);
+                        assert_eq!(len, locator.page_size);
+                        assert_eq!(index, stack_index);
+                        assert!(!guard_page);
+                    }
+                    _ => panic!("expected a stack page location"),
+                }
+
+                // Check for guard page
+                match locator.get_location(stack_start) {
+                    Some(AddressLocation::StackPage {
+                        page_addr,
+                        len,
+                        index,
+                        guard_page,
+                    }) => {
+                        assert_eq!(page_addr, stack_start as _);
+                        assert_eq!(len, locator.page_size);
+                        assert_eq!(index, stack_index);
+                        assert!(guard_page);
+                    }
+                    _ => panic!("expected a stack page location"),
+                }
+            }
+
+            for handle in handles.drain(..) {
+                instances.deallocate(&handle);
+            }
+        }
+    }
+}

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -313,8 +313,12 @@ unsafe fn handle_page_fault(
                 None => {
                     log::trace!("out of bounds memory access at {:p}", addr);
 
-                    // Record the guard page fault with the instance so it can be reset later.
-                    instance.record_guard_page_fault(page_addr, len, reset_guard_page);
+                    // Record the guard page fault so the page protection level can be reset later
+                    instance.memories[memory_index].record_guard_page_fault(
+                        page_addr,
+                        len,
+                        reset_guard_page,
+                    );
                     wake_guard_page_access(&uffd, page_addr, len)?;
                 }
             }

--- a/crates/runtime/src/instance/allocator/pooling/unix.rs
+++ b/crates/runtime/src/instance/allocator/pooling/unix.rs
@@ -1,0 +1,26 @@
+use crate::Mmap;
+
+pub unsafe fn make_accessible(addr: *mut u8, len: usize) -> bool {
+    region::protect(addr, len, region::Protection::READ_WRITE).is_ok()
+}
+
+pub unsafe fn decommit(addr: *mut u8, len: usize) {
+    assert_eq!(
+        libc::mmap(
+            addr as _,
+            len,
+            libc::PROT_NONE,
+            libc::MAP_PRIVATE | libc::MAP_ANON | libc::MAP_FIXED,
+            -1,
+            0,
+        ) as *mut u8,
+        addr,
+        "mmap failed to remap pages: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap, String> {
+    Mmap::accessible_reserved(accessible_size, mapping_size)
+        .map_err(|e| format!("failed to allocate pool memory: {}", e))
+}

--- a/crates/runtime/src/instance/allocator/pooling/unix.rs
+++ b/crates/runtime/src/instance/allocator/pooling/unix.rs
@@ -1,4 +1,5 @@
 use crate::Mmap;
+use anyhow::{anyhow, Result};
 
 pub unsafe fn make_accessible(addr: *mut u8, len: usize) -> bool {
     region::protect(addr, len, region::Protection::READ_WRITE).is_ok()
@@ -20,7 +21,7 @@ pub unsafe fn decommit(addr: *mut u8, len: usize) {
     );
 }
 
-pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap, String> {
+pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap> {
     Mmap::accessible_reserved(accessible_size, mapping_size)
-        .map_err(|e| format!("failed to allocate pool memory: {}", e))
+        .map_err(|e| anyhow!("failed to allocate pool memory: {}", e))
 }

--- a/crates/runtime/src/instance/allocator/pooling/unix.rs
+++ b/crates/runtime/src/instance/allocator/pooling/unix.rs
@@ -5,6 +5,10 @@ fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
         return Ok(());
     }
 
+    // By creating a new mapping at the same location, this will discard the
+    // mapping for the pages in the given range.
+    // The new mapping will be to the CoW zero page, so this effectively
+    // zeroes the pages.
     if unsafe {
         libc::mmap(
             addr as _,

--- a/crates/runtime/src/instance/allocator/pooling/windows.rs
+++ b/crates/runtime/src/instance/allocator/pooling/windows.rs
@@ -1,4 +1,5 @@
 use crate::Mmap;
+use anyhow::{anyhow, Result};
 use winapi::um::memoryapi::{VirtualAlloc, VirtualFree};
 use winapi::um::winnt::{MEM_COMMIT, MEM_DECOMMIT, PAGE_READWRITE};
 
@@ -15,7 +16,7 @@ pub unsafe fn decommit(addr: *mut u8, len: usize) {
     );
 }
 
-pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap, String> {
+pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap> {
     Mmap::accessible_reserved(accessible_size, mapping_size)
-        .map_err(|e| format!("failed to allocate pool memory: {}", e))
+        .map_err(|e| anyhow!("failed to allocate pool memory: {}", e))
 }

--- a/crates/runtime/src/instance/allocator/pooling/windows.rs
+++ b/crates/runtime/src/instance/allocator/pooling/windows.rs
@@ -1,0 +1,21 @@
+use crate::Mmap;
+use winapi::um::memoryapi::{VirtualAlloc, VirtualFree};
+use winapi::um::winnt::{MEM_COMMIT, MEM_DECOMMIT, PAGE_READWRITE};
+
+pub unsafe fn make_accessible(addr: *mut u8, len: usize) -> bool {
+    // This doesn't use the `region` crate because the memory needs to be committed
+    !VirtualAlloc(addr as _, len, MEM_COMMIT, PAGE_READWRITE).is_null()
+}
+
+pub unsafe fn decommit(addr: *mut u8, len: usize) {
+    assert!(
+        VirtualFree(addr as _, len, MEM_DECOMMIT) != 0,
+        "failed to decommit memory pages: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+pub fn create_memory_map(accessible_size: usize, mapping_size: usize) -> Result<Mmap, String> {
+    Mmap::accessible_reserved(accessible_size, mapping_size)
+        .map_err(|e| format!("failed to allocate pool memory: {}", e))
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -42,7 +42,7 @@ pub use crate::instance::{
     OnDemandInstanceAllocator, RuntimeInstance,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
-pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
+pub use crate::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -38,8 +38,9 @@ pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
 pub use crate::instance::{
-    FiberStackError, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
-    InstantiationError, LinkError, OnDemandInstanceAllocator, RuntimeInstance,
+    FiberStackError, InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstanceLimits,
+    InstantiationError, LinkError, ModuleLimits, OnDemandInstanceAllocator,
+    PoolingAllocationStrategy, PoolingInstanceAllocator, RuntimeInstance,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -38,8 +38,8 @@ pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
 pub use crate::instance::{
-    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstantiationError, LinkError,
-    OnDemandInstanceAllocator, RuntimeInstance,
+    FiberStackError, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
+    InstantiationError, LinkError, OnDemandInstanceAllocator, RuntimeInstance,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -37,7 +37,10 @@ pub mod libcalls;
 pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
-pub use crate::instance::{InstanceHandle, InstantiationError, LinkError, RuntimeInstance};
+pub use crate::instance::{
+    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstantiationError, LinkError,
+    OnDemandInstanceAllocator, RuntimeInstance,
+};
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -52,10 +52,6 @@ pub struct MmapMemory {
     // Size in bytes of extra guard pages after the end to optimize loads and stores with
     // constant offsets.
     offset_guard_size: usize,
-
-    // Records whether we're using a bounds-checking strategy which requires
-    // handlers to catch trapping accesses.
-    pub(crate) needs_signal_handlers: bool,
 }
 
 #[derive(Debug)]
@@ -74,15 +70,6 @@ impl MmapMemory {
         assert!(plan.memory.maximum.is_none() || plan.memory.maximum.unwrap() <= WASM_MAX_PAGES);
 
         let offset_guard_bytes = plan.offset_guard_size as usize;
-
-        // If we have an offset guard, or if we're doing the static memory
-        // allocation strategy, we need signal handlers to catch out of bounds
-        // acceses.
-        let needs_signal_handlers = offset_guard_bytes > 0
-            || match plan.style {
-                MemoryStyle::Dynamic => false,
-                MemoryStyle::Static { .. } => true,
-            };
 
         let minimum_pages = match plan.style {
             MemoryStyle::Dynamic => plan.memory.minimum,
@@ -105,7 +92,6 @@ impl MmapMemory {
             mmap: mmap.into(),
             maximum: plan.memory.maximum,
             offset_guard_size: offset_guard_bytes,
-            needs_signal_handlers,
         })
     }
 }

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -124,6 +124,10 @@ impl Mmap {
         use winapi::um::memoryapi::VirtualAlloc;
         use winapi::um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_NOACCESS, PAGE_READWRITE};
 
+        if mapping_size == 0 {
+            return Ok(Self::new());
+        }
+
         let page_size = region::page::size();
         assert_le!(accessible_size, mapping_size);
         assert_eq!(mapping_size & (page_size - 1), 0);

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -234,7 +234,7 @@ impl Mmap {
     }
 
     /// Return the allocated memory as a mutable pointer to u8.
-    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+    pub fn as_mut_ptr(&self) -> *mut u8 {
         self.ptr as *mut u8
     }
 
@@ -246,6 +246,11 @@ impl Mmap {
     /// Return whether any memory has been allocated.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    #[allow(dead_code)]
+    pub(crate) unsafe fn from_raw(ptr: usize, len: usize) -> Self {
+        Self { ptr, len }
     }
 }
 

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -1,6 +1,7 @@
 //! Low-level abstraction for allocating and managing zero-filled pages
 //! of memory.
 
+use anyhow::{bail, Result};
 use more_asserts::assert_le;
 use more_asserts::assert_lt;
 use std::io;
@@ -38,7 +39,7 @@ impl Mmap {
     }
 
     /// Create a new `Mmap` pointing to at least `size` bytes of page-aligned accessible memory.
-    pub fn with_at_least(size: usize) -> Result<Self, String> {
+    pub fn with_at_least(size: usize) -> Result<Self> {
         let page_size = region::page::size();
         let rounded_size = round_up_to_page_size(size, page_size);
         Self::accessible_reserved(rounded_size, rounded_size)
@@ -48,10 +49,7 @@ impl Mmap {
     /// within a reserved mapping of `mapping_size` bytes. `accessible_size` and `mapping_size`
     /// must be native page-size multiples.
     #[cfg(not(target_os = "windows"))]
-    pub fn accessible_reserved(
-        accessible_size: usize,
-        mapping_size: usize,
-    ) -> Result<Self, String> {
+    pub fn accessible_reserved(accessible_size: usize, mapping_size: usize) -> Result<Self> {
         let page_size = region::page::size();
         assert_le!(accessible_size, mapping_size);
         assert_eq!(mapping_size & (page_size - 1), 0);
@@ -76,7 +74,7 @@ impl Mmap {
                 )
             };
             if ptr as isize == -1_isize {
-                return Err(io::Error::last_os_error().to_string());
+                bail!("mmap failed: {}", io::Error::last_os_error());
             }
 
             Self {
@@ -96,7 +94,7 @@ impl Mmap {
                 )
             };
             if ptr as isize == -1_isize {
-                return Err(io::Error::last_os_error().to_string());
+                bail!("mmap failed: {}", io::Error::last_os_error());
             }
 
             let mut result = Self {
@@ -117,10 +115,7 @@ impl Mmap {
     /// within a reserved mapping of `mapping_size` bytes. `accessible_size` and `mapping_size`
     /// must be native page-size multiples.
     #[cfg(target_os = "windows")]
-    pub fn accessible_reserved(
-        accessible_size: usize,
-        mapping_size: usize,
-    ) -> Result<Self, String> {
+    pub fn accessible_reserved(accessible_size: usize, mapping_size: usize) -> Result<Self> {
         use winapi::um::memoryapi::VirtualAlloc;
         use winapi::um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_NOACCESS, PAGE_READWRITE};
 
@@ -144,7 +139,7 @@ impl Mmap {
                 )
             };
             if ptr.is_null() {
-                return Err(io::Error::last_os_error().to_string());
+                bail!("VirtualAlloc failed: {}", io::Error::last_os_error());
             }
 
             Self {
@@ -156,7 +151,7 @@ impl Mmap {
             let ptr =
                 unsafe { VirtualAlloc(ptr::null_mut(), mapping_size, MEM_RESERVE, PAGE_NOACCESS) };
             if ptr.is_null() {
-                return Err(io::Error::last_os_error().to_string());
+                bail!("VirtualAlloc failed: {}", io::Error::last_os_error());
             }
 
             let mut result = Self {
@@ -177,7 +172,7 @@ impl Mmap {
     /// `start` and `len` must be native page-size multiples and describe a range within
     /// `self`'s reserved memory.
     #[cfg(not(target_os = "windows"))]
-    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
+    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
         let page_size = region::page::size();
         assert_eq!(start & (page_size - 1), 0);
         assert_eq!(len & (page_size - 1), 0);
@@ -186,15 +181,18 @@ impl Mmap {
 
         // Commit the accessible size.
         let ptr = self.ptr as *const u8;
-        unsafe { region::protect(ptr.add(start), len, region::Protection::READ_WRITE) }
-            .map_err(|e| e.to_string())
+        unsafe {
+            region::protect(ptr.add(start), len, region::Protection::READ_WRITE)?;
+        }
+
+        Ok(())
     }
 
     /// Make the memory starting at `start` and extending for `len` bytes accessible.
     /// `start` and `len` must be native page-size multiples and describe a range within
     /// `self`'s reserved memory.
     #[cfg(target_os = "windows")]
-    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
+    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
         use winapi::ctypes::c_void;
         use winapi::um::memoryapi::VirtualAlloc;
         use winapi::um::winnt::{MEM_COMMIT, PAGE_READWRITE};
@@ -216,7 +214,7 @@ impl Mmap {
         }
         .is_null()
         {
-            return Err(io::Error::last_os_error().to_string());
+            bail!("VirtualAlloc failed: {}", io::Error::last_os_error());
         }
 
         Ok(())

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -66,6 +66,20 @@ enum TableElements {
     ExternRefs(Vec<Option<VMExternRef>>),
 }
 
+// Ideally this should be static assertion that table elements are pointer-sized
+#[inline(always)]
+pub(crate) fn max_table_element_size() -> usize {
+    debug_assert_eq!(
+        std::mem::size_of::<*mut VMCallerCheckedAnyfunc>(),
+        std::mem::size_of::<*const ()>()
+    );
+    debug_assert_eq!(
+        std::mem::size_of::<Option<VMExternRef>>(),
+        std::mem::size_of::<*const ()>()
+    );
+    std::mem::size_of::<*const ()>()
+}
+
 #[derive(Debug)]
 enum TableStorage {
     Static {

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -180,30 +180,18 @@ impl Table {
         }
 
         match val {
-            TableElement::FuncRef(r) => {
-                unsafe {
-                    self.with_funcrefs_mut(move |elements| {
-                        let elements = elements.unwrap();
-
-                        // TODO: replace this with slice::fill (https://github.com/rust-lang/rust/issues/70758) when stabilized
-                        for e in &mut elements[start as usize..end as usize] {
-                            *e = r;
-                        }
-                    });
-                }
-            }
-            TableElement::ExternRef(r) => {
-                unsafe {
-                    self.with_externrefs_mut(move |elements| {
-                        let elements = elements.unwrap();
-
-                        // TODO: replace this with slice::fill (https://github.com/rust-lang/rust/issues/70758) when stabilized
-                        for e in &mut elements[start as usize..end as usize] {
-                            *e = r.clone();
-                        }
-                    });
-                }
-            }
+            TableElement::FuncRef(r) => unsafe {
+                self.with_funcrefs_mut(move |elements| {
+                    let elements = elements.unwrap();
+                    elements[start as usize..end as usize].fill(r);
+                });
+            },
+            TableElement::ExternRef(r) => unsafe {
+                self.with_externrefs_mut(move |elements| {
+                    let elements = elements.unwrap();
+                    elements[start as usize..end as usize].fill(r);
+                });
+            },
         }
 
         Ok(())

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -372,11 +372,13 @@ impl Table {
         }
     }
 
-    fn set_raw(ty: TableElementType, e: &mut *mut u8, val: TableElement) {
+    fn set_raw(ty: TableElementType, elem: &mut *mut u8, val: TableElement) {
         unsafe {
-            // Drop the existing element
-            let _ = TableElement::from_raw(ty, *e);
-            *e = val.into_raw();
+            let old = *elem;
+            *elem = val.into_raw();
+
+            // Drop the old element
+            let _ = TableElement::from_raw(ty, old);
         }
     }
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -750,7 +750,7 @@ impl VMContext {
     }
 }
 
-///
+/// Trampoline function pointer type.
 pub type VMTrampoline = unsafe extern "C" fn(
     *mut VMContext,        // callee vmctx
     *mut VMContext,        // caller vmctx

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -73,3 +73,6 @@ experimental_x64 = ["wasmtime-jit/experimental_x64"]
 # Enables support for "async stores" as well as defining host functions as
 # `async fn` and calling functions asynchronously.
 async = ["wasmtime-fiber"]
+
+# Enables userfaultfd support in the runtime's pooling allocator when building on Linux
+uffd = ["wasmtime-runtime/uffd"]

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -627,15 +627,12 @@ impl Config {
                 #[cfg(not(feature = "async"))]
                 let stack_size = 0;
 
-                Some(Arc::new(
-                    PoolingInstanceAllocator::new(
-                        strategy,
-                        module_limits,
-                        instance_limits,
-                        stack_size,
-                    )
-                    .map_err(|e| anyhow::anyhow!(e))?,
-                ))
+                Some(Arc::new(PoolingInstanceAllocator::new(
+                    strategy,
+                    module_limits,
+                    instance_limits,
+                    stack_size,
+                )?))
             }
         };
         Ok(self)

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -764,7 +764,9 @@ impl Config {
 
     pub(crate) fn build_compiler(&self) -> Compiler {
         let isa = self.target_isa();
-        Compiler::new(isa, self.strategy, self.tunables.clone(), self.features)
+        let mut tunables = self.tunables.clone();
+        self.instance_allocator().adjust_tunables(&mut tunables);
+        Compiler::new(isa, self.strategy, tunables, self.features)
     }
 
     pub(crate) fn instance_allocator(&self) -> &dyn InstanceAllocator {

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -826,6 +826,12 @@ impl Config {
     }
 
     /// Sets the instance allocation strategy to use.
+    ///
+    /// When using the pooling instance allocation strategy, all linear memories will be created as "static".
+    ///
+    /// This means the [`Config::static_memory_maximum_size`] and [`Config::static_memory_guard_size`] options
+    /// will be ignored in favor of [`InstanceLimits::memory_reservation_size`] when the pooling instance
+    /// allocation strategy is used.
     pub fn with_allocation_strategy(
         &mut self,
         strategy: InstanceAllocationStrategy,

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -547,10 +547,13 @@ impl Table {
             bail!("cross-`Store` table copies are not supported");
         }
 
+        if dst_table.ty() != src_table.ty() {
+            bail!("tables do not have the same element type");
+        }
+
         // NB: We must use the `dst_table`'s `wasmtime_handle` for the
         // `dst_table_index` and vice versa for `src_table` since each table can
         // come from different modules.
-
         let dst_table_index = dst_table.wasmtime_table_index();
         let dst_table_index = dst_table.instance.get_defined_table(dst_table_index);
 
@@ -577,6 +580,11 @@ impl Table {
     pub fn fill(&self, dst: u32, val: Val, len: u32) -> Result<()> {
         if !val.comes_from_same_store(&self.instance.store) {
             bail!("cross-`Store` table fills are not supported");
+        }
+
+        // Ensure the fill value is the correct type
+        if self.ty().element() != &val.ty() {
+            bail!("mismatched element fill type");
         }
 
         let table_index = self.wasmtime_table_index();

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -520,7 +520,7 @@ impl<'a> Instantiator<'a> {
             // initializers may have run which placed elements into other instance's
             // tables. This means that from this point on, regardless of whether
             // initialization is successful, we need to keep the instance alive.
-            let instance = self.store.add_instance(instance);
+            let instance = self.store.add_instance(instance, false);
             allocator
                 .initialize(
                     &instance.handle,

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -522,11 +522,7 @@ impl<'a> Instantiator<'a> {
             // initialization is successful, we need to keep the instance alive.
             let instance = self.store.add_instance(instance, false);
             allocator
-                .initialize(
-                    &instance.handle,
-                    config.features.bulk_memory,
-                    &compiled_module.data_initializers(),
-                )
+                .initialize(&instance.handle, config.features.bulk_memory)
                 .map_err(|e| -> Error {
                     match e {
                         InstantiationError::Trap(trap) => {

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -172,6 +172,12 @@
 //! * `vtune` - Not enabled by default, this feature compiles in support for
 //!   supporting VTune profiling of JIT code.
 //!
+//! * `uffd` - Not enabled by default. This feature enables `userfaultfd` support
+//!   when using the pooling instance allocator. As handling page faults in userspace
+//!   comes with a performance penalty, this feature should only be enabled when kernel
+//!   lock contention is hampering multithreading throughput. This feature is only
+//!   supported on Linux and requires a Linux kernel version 4.11 or higher.
+//!
 //! ## Examples
 //!
 //! In addition to the examples below be sure to check out the [online embedding

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -173,7 +173,7 @@
 //!   supporting VTune profiling of JIT code.
 //!
 //! * `uffd` - Not enabled by default. This feature enables `userfaultfd` support
-//!   when using the pooling instance allocator. As handling page faults in userspace
+//!   when using the pooling instance allocator. As handling page faults in user space
 //!   comes with a performance penalty, this feature should only be enabled when kernel
 //!   lock contention is hampering multithreading throughput. This feature is only
 //!   supported on Linux and requires a Linux kernel version 4.11 or higher.

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -754,12 +754,14 @@ impl Store {
     /// that the various comments are illuminating as to what's going on here.
     #[cfg(feature = "async")]
     pub(crate) async fn on_fiber<R>(&self, func: impl FnOnce() -> R) -> Result<R, Trap> {
-        debug_assert!(self.is_async());
+        let config = self.inner.engine.config();
 
-        // TODO: allocation of a fiber should be much more abstract where we
-        // shouldn't be allocating huge stacks on every async wasm function call.
+        debug_assert!(self.is_async());
+        debug_assert!(config.async_stack_size > 0);
+
+        type SuspendType = wasmtime_fiber::Suspend<Result<(), Trap>, (), Result<(), Trap>>;
         let mut slot = None;
-        let fiber = wasmtime_fiber::Fiber::new(10 * 1024 * 1024, |keep_going, suspend| {
+        let func = |keep_going, suspend: &SuspendType| {
             // First check and see if we were interrupted/dropped, and only
             // continue if we haven't been.
             keep_going?;
@@ -777,18 +779,46 @@ impl Store {
 
             slot = Some(func());
             Ok(())
-        })
-        .map_err(|e| Trap::from(anyhow::Error::from(e)))?;
+        };
+
+        let (fiber, stack) = match config.instance_allocator().allocate_fiber_stack() {
+            Ok(stack) => {
+                // Use the returned stack and deallocate it when finished
+                (
+                    unsafe {
+                        wasmtime_fiber::Fiber::new_with_stack(stack, func)
+                            .map_err(|e| Trap::from(anyhow::Error::from(e)))?
+                    },
+                    stack,
+                )
+            }
+            Err(wasmtime_runtime::FiberStackError::NotSupported) => {
+                // The allocator doesn't support custom fiber stacks for the current platform
+                // Request that the fiber itself allocate the stack
+                (
+                    wasmtime_fiber::Fiber::new(config.async_stack_size, func)
+                        .map_err(|e| Trap::from(anyhow::Error::from(e)))?,
+                    std::ptr::null_mut(),
+                )
+            }
+            Err(e) => return Err(Trap::from(anyhow::Error::from(e))),
+        };
 
         // Once we have the fiber representing our synchronous computation, we
         // wrap that in a custom future implementation which does the
         // translation from the future protocol to our fiber API.
-        FiberFuture { fiber, store: self }.await?;
+        FiberFuture {
+            fiber,
+            store: self,
+            stack,
+        }
+        .await?;
         return Ok(slot.unwrap());
 
         struct FiberFuture<'a> {
             fiber: wasmtime_fiber::Fiber<'a, Result<(), Trap>, (), Result<(), Trap>>,
             store: &'a Store,
+            stack: *mut u8,
         }
 
         impl Future for FiberFuture<'_> {
@@ -845,15 +875,23 @@ impl Store {
         // completion.
         impl Drop for FiberFuture<'_> {
             fn drop(&mut self) {
-                if self.fiber.done() {
-                    return;
+                if !self.fiber.done() {
+                    let result = self.fiber.resume(Err(Trap::new("future dropped")));
+                    // This resumption with an error should always complete the
+                    // fiber. While it's technically possible for host code to catch
+                    // the trap and re-resume, we'd ideally like to signal that to
+                    // callers that they shouldn't be doing that.
+                    debug_assert!(result.is_ok());
                 }
-                let result = self.fiber.resume(Err(Trap::new("future dropped")));
-                // This resumption with an error should always complete the
-                // fiber. While it's technically possible for host code to catch
-                // the trap and re-resume, we'd ideally like to signal that to
-                // callers that they shouldn't be doing that.
-                debug_assert!(result.is_ok());
+                if !self.stack.is_null() {
+                    unsafe {
+                        self.store
+                            .engine()
+                            .config()
+                            .instance_allocator()
+                            .deallocate_fiber_stack(self.stack)
+                    };
+                }
             }
         }
     }

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -44,6 +44,6 @@ pub(crate) fn create_handle(
                 stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
             })?;
 
-        Ok(store.add_instance(handle))
+        Ok(store.add_instance(handle, true))
     }
 }

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -27,6 +27,8 @@ pub(crate) fn create_handle(
 
     unsafe {
         // Use the default allocator when creating handles associated with host objects
+        // The configured instance allocator should only be used when creating module instances
+        // as we don't want host objects to count towards instance limits.
         let handle = store
             .engine()
             .config()

--- a/crates/wasmtime/src/trampoline/create_handle.rs
+++ b/crates/wasmtime/src/trampoline/create_handle.rs
@@ -9,15 +9,15 @@ use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::wasm::DefinedFuncIndex;
 use wasmtime_environ::Module;
 use wasmtime_runtime::{
-    Imports, InstanceHandle, StackMapRegistry, VMExternRefActivationsTable, VMFunctionBody,
-    VMFunctionImport, VMSharedSignatureIndex,
+    Imports, InstanceAllocationRequest, InstanceAllocator, StackMapRegistry,
+    VMExternRefActivationsTable, VMFunctionBody, VMFunctionImport, VMSharedSignatureIndex,
 };
 
 pub(crate) fn create_handle(
     module: Module,
     store: &Store,
     finished_functions: PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
-    state: Box<dyn Any>,
+    host_state: Box<dyn Any>,
     func_imports: &[VMFunctionImport],
     shared_signature_id: Option<VMSharedSignatureIndex>,
 ) -> Result<StoreInstanceHandle> {
@@ -26,17 +26,24 @@ pub(crate) fn create_handle(
     let module = Arc::new(module);
 
     unsafe {
-        let handle = InstanceHandle::new(
-            module,
-            &finished_functions,
-            imports,
-            store.memory_creator(),
-            &|_| shared_signature_id.unwrap(),
-            state,
-            store.interrupts(),
-            store.externref_activations_table() as *const VMExternRefActivationsTable as *mut _,
-            store.stack_map_registry() as *const StackMapRegistry as *mut _,
-        )?;
+        // Use the default allocator when creating handles associated with host objects
+        let handle = store
+            .engine()
+            .config()
+            .default_instance_allocator
+            .allocate(InstanceAllocationRequest {
+                module: module.clone(),
+                finished_functions: &finished_functions,
+                imports,
+                lookup_shared_signature: &|_| shared_signature_id.unwrap(),
+                host_state,
+                interrupts: store.interrupts(),
+                externref_activations_table: store.externref_activations_table()
+                    as *const VMExternRefActivationsTable
+                    as *mut _,
+                stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
+            })?;
+
         Ok(store.add_instance(handle))
     }
 }

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -54,9 +54,7 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
 }
 
 #[derive(Clone)]
-pub(crate) struct MemoryCreatorProxy {
-    pub(crate) mem_creator: Arc<dyn MemoryCreator>,
-}
+pub(crate) struct MemoryCreatorProxy(pub Arc<dyn MemoryCreator>);
 
 impl RuntimeMemoryCreator for MemoryCreatorProxy {
     fn new_memory(&self, plan: &MemoryPlan) -> Result<Box<dyn RuntimeLinearMemory>, String> {
@@ -65,7 +63,7 @@ impl RuntimeMemoryCreator for MemoryCreatorProxy {
             MemoryStyle::Static { bound } => Some(bound as u64 * WASM_PAGE_SIZE as u64),
             MemoryStyle::Dynamic => None,
         };
-        self.mem_creator
+        self.0
             .new_memory(ty, reserved_size_in_bytes, plan.offset_guard_size)
             .map(|mem| Box::new(LinearMemoryProxy { mem }) as Box<dyn RuntimeLinearMemory>)
     }

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -378,7 +378,7 @@ fn async_with_pooling_stacks() {
             },
             instance_limits: InstanceLimits {
                 count: 1,
-                address_space_size: 1,
+                memory_reservation_size: 1,
             },
         })
         .expect("pooling allocator created");

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -18,6 +18,7 @@ mod module;
 mod module_linking;
 mod module_serialize;
 mod name;
+mod pooling_allocator;
 mod stack_overflow;
 mod table;
 mod traps;

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -48,7 +48,10 @@ fn memory_limit() -> Result<()> {
     // Module should fail to validate because the minimum is greater than the configured limit
     match Module::new(&engine, r#"(module (memory 4))"#) {
         Ok(_) => panic!("module compilation should fail"),
-        Err(e) => assert_eq!(e.to_string(), "Validation error: memory index 0 has a minimum page size of 4 which exceeds the limit of 3")
+        Err(e) => assert_eq!(
+            e.to_string(),
+            "memory index 0 has a minimum page size of 4 which exceeds the limit of 3"
+        ),
     }
 
     let module = Module::new(
@@ -243,7 +246,10 @@ fn table_limit() -> Result<()> {
     // Module should fail to validate because the minimum is greater than the configured limit
     match Module::new(&engine, r#"(module (table 31 funcref))"#) {
         Ok(_) => panic!("module compilation should fail"),
-        Err(e) => assert_eq!(e.to_string(), "Validation error: table index 0 has a minimum element size of 31 which exceeds the limit of 10")
+        Err(e) => assert_eq!(
+            e.to_string(),
+            "table index 0 has a minimum element size of 31 which exceeds the limit of 10"
+        ),
     }
 
     let module = Module::new(

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -13,7 +13,7 @@ fn successful_instantiation() -> Result<()> {
         },
         instance_limits: InstanceLimits {
             count: 1,
-            address_space_size: 1,
+            memory_reservation_size: 1,
         },
     })?;
 
@@ -39,7 +39,7 @@ fn memory_limit() -> Result<()> {
         },
         instance_limits: InstanceLimits {
             count: 1,
-            address_space_size: 196608,
+            memory_reservation_size: 196608,
         },
     })?;
 
@@ -191,7 +191,7 @@ fn memory_zeroed() -> Result<()> {
         },
         instance_limits: InstanceLimits {
             count: 1,
-            address_space_size: 1,
+            memory_reservation_size: 1,
         },
     })?;
 
@@ -234,7 +234,7 @@ fn table_limit() -> Result<()> {
         },
         instance_limits: InstanceLimits {
             count: 1,
-            address_space_size: 1,
+            memory_reservation_size: 1,
         },
     })?;
 
@@ -349,7 +349,7 @@ fn table_zeroed() -> Result<()> {
         },
         instance_limits: InstanceLimits {
             count: 1,
-            address_space_size: 1,
+            memory_reservation_size: 1,
         },
     })?;
 
@@ -391,7 +391,7 @@ fn instantiation_limit() -> Result<()> {
         },
         instance_limits: InstanceLimits {
             count: INSTANCE_LIMIT,
-            address_space_size: 1,
+            memory_reservation_size: 1,
         },
     })?;
 

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -1,0 +1,430 @@
+use anyhow::Result;
+use wasmtime::*;
+
+#[test]
+fn successful_instantiation() -> Result<()> {
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 1,
+            table_elements: 10,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            address_space_size: 1,
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, r#"(module (memory 1) (table 10 funcref))"#)?;
+
+    // Module should instantiate
+    let store = Store::new(&engine);
+    Instance::new(&store, &module, &[])?;
+
+    Ok(())
+}
+
+#[test]
+fn memory_limit() -> Result<()> {
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 3,
+            table_elements: 10,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            address_space_size: 196608,
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+
+    // Module should fail to validate because the minimum is greater than the configured limit
+    match Module::new(&engine, r#"(module (memory 4))"#) {
+        Ok(_) => panic!("module compilation should fail"),
+        Err(e) => assert_eq!(e.to_string(), "Validation error: memory index 0 has a minimum page size of 4 which exceeds the limit of 3")
+    }
+
+    let module = Module::new(
+        &engine,
+        r#"(module (memory (export "m") 0) (func (export "f") (result i32) (memory.grow (i32.const 1))))"#,
+    )?;
+
+    // Instantiate the module and grow the memory via the `f` function
+    {
+        let store = Store::new(&engine);
+        let instance = Instance::new(&store, &module, &[])?;
+        let f = instance.get_func("f").unwrap().get0::<i32>().unwrap();
+
+        assert_eq!(f().expect("function should not trap"), 0);
+        assert_eq!(f().expect("function should not trap"), 1);
+        assert_eq!(f().expect("function should not trap"), 2);
+        assert_eq!(f().expect("function should not trap"), -1);
+        assert_eq!(f().expect("function should not trap"), -1);
+    }
+
+    // Instantiate the module and grow the memory via the Wasmtime API
+    let store = Store::new(&engine);
+    let instance = Instance::new(&store, &module, &[])?;
+
+    let memory = instance.get_memory("m").unwrap();
+    assert_eq!(memory.size(), 0);
+    assert_eq!(memory.grow(1).expect("memory should grow"), 0);
+    assert_eq!(memory.size(), 1);
+    assert_eq!(memory.grow(1).expect("memory should grow"), 1);
+    assert_eq!(memory.size(), 2);
+    assert_eq!(memory.grow(1).expect("memory should grow"), 2);
+    assert_eq!(memory.size(), 3);
+    assert!(memory.grow(1).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn memory_init() -> Result<()> {
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 2,
+            table_elements: 0,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            ..Default::default()
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+
+    let module = Module::new(
+        &engine,
+        r#"(module (memory (export "m") 2) (data (i32.const 65530) "this data spans multiple pages") (data (i32.const 10) "hello world"))"#,
+    )?;
+
+    let store = Store::new(&engine);
+    let instance = Instance::new(&store, &module, &[])?;
+    let memory = instance.get_memory("m").unwrap();
+
+    unsafe {
+        assert_eq!(
+            &memory.data_unchecked()[65530..65560],
+            b"this data spans multiple pages"
+        );
+        assert_eq!(&memory.data_unchecked()[10..21], b"hello world");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn memory_guard_page_trap() -> Result<()> {
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 2,
+            table_elements: 0,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            ..Default::default()
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+
+    let module = Module::new(
+        &engine,
+        r#"(module (memory (export "m") 0) (func (export "f") (param i32) local.get 0 i32.load drop))"#,
+    )?;
+
+    // Instantiate the module and check for out of bounds trap
+    for _ in 0..10 {
+        let store = Store::new(&engine);
+        let instance = Instance::new(&store, &module, &[])?;
+        let m = instance.get_memory("m").unwrap();
+        let f = instance.get_func("f").unwrap().get1::<i32, ()>().unwrap();
+
+        let trap = f(0).expect_err("function should trap");
+        assert!(trap.to_string().contains("out of bounds"));
+
+        let trap = f(1).expect_err("function should trap");
+        assert!(trap.to_string().contains("out of bounds"));
+
+        m.grow(1).expect("memory should grow");
+        f(0).expect("function should not trap");
+
+        let trap = f(65536).expect_err("function should trap");
+        assert!(trap.to_string().contains("out of bounds"));
+
+        let trap = f(65537).expect_err("function should trap");
+        assert!(trap.to_string().contains("out of bounds"));
+
+        m.grow(1).expect("memory should grow");
+        f(65536).expect("function should not trap");
+
+        m.grow(1).expect_err("memory should be at the limit");
+    }
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
+fn memory_zeroed() -> Result<()> {
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 1,
+            table_elements: 0,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            address_space_size: 1,
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+
+    let module = Module::new(&engine, r#"(module (memory (export "m") 1))"#)?;
+
+    // Instantiate the module repeatedly after writing data to the entire memory
+    for _ in 0..10 {
+        let store = Store::new(&engine);
+        let instance = Instance::new(&store, &module, &[])?;
+        let memory = instance.get_memory("m").unwrap();
+
+        assert_eq!(memory.size(), 1);
+        assert_eq!(memory.data_size(), 65536);
+
+        let ptr = memory.data_ptr();
+
+        unsafe {
+            for i in 0..8192 {
+                assert_eq!(*ptr.cast::<u64>().offset(i), 0);
+            }
+            std::ptr::write_bytes(ptr, 0xFE, memory.data_size());
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn table_limit() -> Result<()> {
+    const TABLE_ELEMENTS: u32 = 10;
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 1,
+            table_elements: TABLE_ELEMENTS,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            address_space_size: 1,
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+
+    // Module should fail to validate because the minimum is greater than the configured limit
+    match Module::new(&engine, r#"(module (table 31 funcref))"#) {
+        Ok(_) => panic!("module compilation should fail"),
+        Err(e) => assert_eq!(e.to_string(), "Validation error: table index 0 has a minimum element size of 31 which exceeds the limit of 10")
+    }
+
+    let module = Module::new(
+        &engine,
+        r#"(module (table (export "t") 0 funcref) (func (export "f") (result i32) (table.grow (ref.null func) (i32.const 1))))"#,
+    )?;
+
+    // Instantiate the module and grow the table via the `f` function
+    {
+        let store = Store::new(&engine);
+        let instance = Instance::new(&store, &module, &[])?;
+        let f = instance.get_func("f").unwrap().get0::<i32>().unwrap();
+
+        for i in 0..TABLE_ELEMENTS {
+            assert_eq!(f().expect("function should not trap"), i as i32);
+        }
+
+        assert_eq!(f().expect("function should not trap"), -1);
+        assert_eq!(f().expect("function should not trap"), -1);
+    }
+
+    // Instantiate the module and grow the table via the Wasmtime API
+    let store = Store::new(&engine);
+    let instance = Instance::new(&store, &module, &[])?;
+
+    let table = instance.get_table("t").unwrap();
+
+    for i in 0..TABLE_ELEMENTS {
+        assert_eq!(table.size(), i);
+        assert_eq!(
+            table
+                .grow(1, Val::FuncRef(None))
+                .expect("table should grow"),
+            i
+        );
+    }
+
+    assert_eq!(table.size(), TABLE_ELEMENTS);
+    assert!(table.grow(1, Val::FuncRef(None)).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn table_init() -> Result<()> {
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 0,
+            table_elements: 6,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            ..Default::default()
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+
+    let module = Module::new(
+        &engine,
+        r#"(module (table (export "t") 6 funcref) (elem (i32.const 1) 1 2 3 4) (elem (i32.const 0) 0) (func) (func (param i32)) (func (param i32 i32)) (func (param i32 i32 i32)) (func (param i32 i32 i32 i32)))"#,
+    )?;
+
+    let store = Store::new(&engine);
+    let instance = Instance::new(&store, &module, &[])?;
+    let table = instance.get_table("t").unwrap();
+
+    for i in 0..5 {
+        let v = table.get(i).expect("table should have entry");
+        let f = v
+            .funcref()
+            .expect("expected funcref")
+            .expect("expected non-null value");
+        assert_eq!(f.ty().params().len(), i as usize);
+    }
+
+    assert!(
+        table
+            .get(5)
+            .expect("table should have entry")
+            .funcref()
+            .expect("expected funcref")
+            .is_none(),
+        "funcref should be null"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
+fn table_zeroed() -> Result<()> {
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 1,
+            table_elements: 10,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            address_space_size: 1,
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+
+    let module = Module::new(&engine, r#"(module (table (export "t") 10 funcref))"#)?;
+
+    // Instantiate the module repeatedly after filling table elements
+    for _ in 0..10 {
+        let store = Store::new(&engine);
+        let instance = Instance::new(&store, &module, &[])?;
+        let table = instance.get_table("t").unwrap();
+        let f = Func::wrap(&store, || {});
+
+        assert_eq!(table.size(), 10);
+
+        for i in 0..10 {
+            match table.get(i).unwrap() {
+                Val::FuncRef(r) => assert!(r.is_none()),
+                _ => panic!("expected a funcref"),
+            }
+            table.set(i, Val::FuncRef(Some(f.clone()))).unwrap();
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn instantiation_limit() -> Result<()> {
+    const INSTANCE_LIMIT: u32 = 10;
+    let mut config = Config::new();
+    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 1,
+            table_elements: 10,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: INSTANCE_LIMIT,
+            address_space_size: 1,
+        },
+    })?;
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, r#"(module)"#)?;
+
+    // Instantiate to the limit
+    {
+        let store = Store::new(&engine);
+
+        for _ in 0..INSTANCE_LIMIT {
+            Instance::new(&store, &module, &[])?;
+        }
+
+        match Instance::new(&store, &module, &[]) {
+            Ok(_) => panic!("instantiation should fail"),
+            Err(e) => assert_eq!(
+                e.to_string(),
+                format!(
+                    "Limit of {} concurrent instances has been reached",
+                    INSTANCE_LIMIT
+                )
+            ),
+        }
+    }
+
+    // With the above store dropped, ensure instantiations can be made
+
+    let store = Store::new(&engine);
+
+    for _ in 0..INSTANCE_LIMIT {
+        Instance::new(&store, &module, &[])?;
+    }
+
+    Ok(())
+}

--- a/tests/all/table.rs
+++ b/tests/all/table.rs
@@ -11,3 +11,42 @@ fn get_none() {
     }
     assert!(table.get(1).is_none());
 }
+
+#[test]
+fn fill_wrong() {
+    let store = Store::default();
+    let ty = TableType::new(ValType::FuncRef, Limits::new(1, None));
+    let table = Table::new(&store, ty, Val::FuncRef(None)).unwrap();
+    assert_eq!(
+        table
+            .fill(0, Val::ExternRef(None), 1)
+            .map_err(|e| e.to_string())
+            .unwrap_err(),
+        "mismatched element fill type"
+    );
+
+    let ty = TableType::new(ValType::ExternRef, Limits::new(1, None));
+    let table = Table::new(&store, ty, Val::ExternRef(None)).unwrap();
+    assert_eq!(
+        table
+            .fill(0, Val::FuncRef(None), 1)
+            .map_err(|e| e.to_string())
+            .unwrap_err(),
+        "mismatched element fill type"
+    );
+}
+
+#[test]
+fn copy_wrong() {
+    let store = Store::default();
+    let ty = TableType::new(ValType::FuncRef, Limits::new(1, None));
+    let table1 = Table::new(&store, ty, Val::FuncRef(None)).unwrap();
+    let ty = TableType::new(ValType::ExternRef, Limits::new(1, None));
+    let table2 = Table::new(&store, ty, Val::ExternRef(None)).unwrap();
+    assert_eq!(
+        Table::copy(&table1, 0, &table2, 0, 1)
+            .map_err(|e| e.to_string())
+            .unwrap_err(),
+        "tables do not have the same element type"
+    );
+}


### PR DESCRIPTION
This PR implements the pooling instance allocator.

The allocation strategy can be set with `Config::with_allocation_strategy`.

The pooling strategy uses the pooling instance allocator to preallocate a
contiguous region of memory for instantiating modules that adhere to various
limits.

The intention of the pooling instance allocator is to reserve as much of the
host address space needed for instantiating modules ahead of time.

This PR also implements the `uffd` feature in Wasmtime that enables
handling page faults in user space; this can help to reduce kernel lock
contention and thus increase throughput when many threads are
continually allocating and deallocating instances.

See [the related RFC](https://github.com/bytecodealliance/rfcs/pull/5).