### PR TITLE
Lint deps tree with cargo deny

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,19 @@ jobs:
     - run: rustup component add rustfmt
     - run: cargo fmt --all -- --check
 
+  # Lint dependency graph for security advisories, duplicate versions, and
+  # incompatible licences
+  cargo_deny:
+    name: Cargo deny
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - run: cargo install cargo-deny
+    - run: cargo deny check
+
   # Build `mdBook` documentation for `wasmtime`, and upload it as a temporary
   # build artifact
   doc_book:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,11 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: cargo install cargo-deny
+    - run: |
+        set -e
+        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.8.5/cargo-deny-0.8.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+        mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
+        echo `pwd` >> $GITHUB_PATH
     - run: cargo deny check
 
   # Build `mdBook` documentation for `wasmtime`, and upload it as a temporary

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 name = "wasmtime-fuzzing"
 publish = false
 version = "0.19.0"
+license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
 anyhow = "1.0.22"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Wasmtime Project Developers"]
 readme = "README.md"
 edition = "2018"
 publish = false
+license = "Apache-2.0 WITH LLVM-exception"
 
 [build-dependencies]
 cfg-if = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,48 @@
+# Documentation for this configuration file can be found here
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "aarch64-linux-android" },
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+ignore = [
+    "RUSTSEC-2020-0053", # dirs is unmaintained
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+allow = [
+    "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "CC0-1.0",
+    "MIT",
+    "MPL-2.0",
+    "Zlib",
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+deny = []
+
+# Skip some multiple-versions checks, until they can be fixed.
+skip = [
+    { name = "ansi_term" },
+    { name = "cfg-if" },
+    { name = "env_logger" },
+    { name = "getrandom" },
+    { name = "humantime" },
+    { name = "memoffset" },
+    { name = "wasmparser" },
+    { name = "wast" },
+]


### PR DESCRIPTION
Hello everyone!

This PR adds configuration and a GitHub actions workflow job to run [cargo-deny](https://github.com/EmbarkStudios/cargo-deny), a tool that lints the dependency graph for security advisories, duplicate versions, and incompatible licences

Preceding issue: https://github.com/bytecodealliance/wasmtime/issues/2225#issuecomment-746913790

Currently there are multiple versions of these crates in the dep tree
- `ansi_term`
- `cfg-if`
- `env_logger`
- `getrandom`
- `humantime`
- `memoffset`
- `wasmparser`
- `wast`

One unmaintained crate is in the dep tree, `dirs`.

If this PR looks good I can open another one fixing these issues afterwards.

I don't know who should be the reviewer of this PR.

Thanks,
Louis