### PR TITLE
cranelift-native crate: add API variant allowing backend selection.

### DIFF
--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -34,10 +34,26 @@ use raw_cpuid::CpuId;
 /// machine, or `Err(())` if the host machine is not supported
 /// in the current configuration.
 pub fn builder() -> Result<isa::Builder, &'static str> {
-    let mut isa_builder = isa::lookup(Triple::host()).map_err(|err| match err {
-        isa::LookupError::SupportDisabled => "support for architecture disabled at compile time",
-        isa::LookupError::Unsupported => "unsupported architecture",
-    })?;
+    builder_with_backend_variant(isa::BackendVariant::Any)
+}
+
+/// Return an `isa` builder configured for the current host
+/// machine, or `Err(())` if the host machine is not supported
+/// in the current configuration.
+///
+/// Selects the given backend variant specifically; this is
+/// useful when more than oen backend exists for a given target
+/// (e.g., on x86-64).
+pub fn builder_with_backend_variant(
+    variant: isa::BackendVariant,
+) -> Result<isa::Builder, &'static str> {
+    let mut isa_builder =
+        isa::lookup_variant(Triple::host(), variant).map_err(|err| match err {
+            isa::LookupError::SupportDisabled => {
+                "support for architecture disabled at compile time"
+            }
+            isa::LookupError::Unsupported => "unsupported architecture",
+        })?;
 
     if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
         parse_x86_cpuid(&mut isa_builder)?;


### PR DESCRIPTION
One more PR necessary for Lucet differential backend fuzzing: allow selection
of a backend variant when all other details are selected by `cranelift-native` (for
the native host CPU/features).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
