### PR TITLE
fix broken link -- js-polyfill is a 404

### DIFF
--- a/docs/WASI-intro.md
+++ b/docs/WASI-intro.md
@@ -54,7 +54,7 @@ or `cargo run --bin wasmtime foo.wasm`.
 
 The polyfill is online [here](https://wasi.dev/polyfill/).
 
-The source is [here](#FIXME).
+The source is [here](https://github.com/bytecodealliance/wasmtime/tree/177af5357880c33863cbe3363754000dbd23bddb/crates/wasi-c).
 
 ## Where can I learn more?
 

--- a/docs/WASI-intro.md
+++ b/docs/WASI-intro.md
@@ -54,7 +54,7 @@ or `cargo run --bin wasmtime foo.wasm`.
 
 The polyfill is online [here](https://wasi.dev/polyfill/).
 
-The source is [here](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi-c/js-polyfill).
+The source is [here](#FIXME).
 
 ## Where can I learn more?
 


### PR DESCRIPTION
I can't find this in the source presently to replace it: the link to `js-polyfill` is a 404
Can someone put a working link?

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
