### PR TITLE
Upgrade shellexpand dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,11 +1951,11 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
 dependencies = [
- "dirs",
+ "dirs-next",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -14,7 +14,6 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 ignore = [
-    "RUSTSEC-2020-0053", # dirs is unmaintained
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html


### PR DESCRIPTION
The previous version depended on the deprecated `dirs` crate.

A follow up from https://github.com/bytecodealliance/wasmtime/issues/2225