### PR TITLE
Fix code in WASI-tutorial.md

### DIFF
--- a/docs/WASI-tutorial.md
+++ b/docs/WASI-tutorial.md
@@ -121,14 +121,14 @@ use std::io::{Read, Write};
 
 fn process(input_fname: &str, output_fname: &str) -> Result<(), String> {
     let mut input_file =
-        fs::File::open(input_fname).map_err(|err| format!("error opening input: {}", err))?;
+        fs::File::open(input_fname).map_err(|err| format!("error opening input {}: {}", input_fname, err))?;
     let mut contents = Vec::new();
     input_file
         .read_to_end(&mut contents)
         .map_err(|err| format!("read error: {}", err))?;
 
     let mut output_file = fs::File::create(output_fname)
-        .map_err(|err| format!("error opening output '{}': {}", output_fname, err))?;
+        .map_err(|err| format!("error opening output {}: {}", output_fname, err))?;
     output_file
         .write_all(&contents)
         .map_err(|err| format!("write error: {}", err))
@@ -139,7 +139,7 @@ fn main() {
     let program = args[0].clone();
 
     if args.len() < 3 {
-        eprintln!("{} <input_file> <output_file>", program);
+        eprintln!("usage: {} <input_file> <output_file>", program);
         return;
     }
 


### PR DESCRIPTION
In WASI-tutorial.md, the error content of the Rust code has been adjusted to the C code.
This will match the error in the 'Executing in wasmtime runtime' part.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
