### PR TITLE
Make cranelift-codegen-shared no_std

### DIFF
--- a/cranelift/codegen/shared/src/condcodes.rs
+++ b/cranelift/codegen/shared/src/condcodes.rs
@@ -313,7 +313,7 @@ impl FromStr for FloatCC {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     static INT_ALL: [IntCC; 12] = [
         IntCC::Equal,

--- a/cranelift/codegen/shared/src/constant_hash.rs
+++ b/cranelift/codegen/shared/src/constant_hash.rs
@@ -10,7 +10,8 @@
 //! This module provides build meta support for lookups in these tables, as well as the shared hash
 //! function used for probing.
 
-use std::iter;
+use alloc::{vec, vec::Vec};
+use core::iter;
 
 /// A primitive hash function for matching opcodes.
 pub fn simple_hash(s: &str) -> usize {
@@ -57,6 +58,7 @@ pub fn generate_table<'cont, T, I: iter::Iterator<Item = &'cont T>, H: Fn(&T) ->
 #[cfg(test)]
 mod tests {
     use super::{generate_table, simple_hash};
+    use alloc::{string::ToString, vec};
 
     #[test]
     fn basic() {

--- a/cranelift/codegen/shared/src/isa/x86/encoding_bits.rs
+++ b/cranelift/codegen/shared/src/isa/x86/encoding_bits.rs
@@ -1,6 +1,6 @@
 //! Provides a named interface to the `u16` Encoding bits.
 
-use std::ops::RangeInclusive;
+use core::ops::RangeInclusive;
 
 /// Named interface to the `u16` Encoding bits, representing an opcode.
 ///

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -18,6 +18,9 @@
         clippy::use_self
     )
 )]
+#![no_std]
+
+extern crate alloc;
 
 pub mod condcodes;
 pub mod constant_hash;


### PR DESCRIPTION
I've noticed that `cranelift-codegen` is already marked `#![no_std]`.
This small pull request also marks `cranelift-codgen-shared` as `no_std`.

I know that no-std-compatibility isn't a goal of `wasmtime`, so feel free to close this PR if it is inappropriate.
