### PR TITLE
wasmtime-wiggle: missing memory can just Trap

### DIFF
--- a/crates/wasi-nn/src/lib.rs
+++ b/crates/wasi-nn/src/lib.rs
@@ -21,6 +21,4 @@ wasmtime_wiggle::wasmtime_integration!({
           function_override: {}
         }
     },
-    // Error to return when caller module is missing memory export:
-    missing_memory: { witx::types::Errno::MissingMemory },
 });

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -33,8 +33,6 @@ resolution.",
           }
         },
     },
-    // Error to return when caller module is missing memory export:
-    missing_memory: { wasi_common::wasi::types::Errno::Inval },
 });
 
 pub fn is_wasi_module(name: &str) -> bool {

--- a/crates/wasi/src/old/snapshot_0.rs
+++ b/crates/wasi/src/old/snapshot_0.rs
@@ -32,8 +32,6 @@ resolution.",
           }
         },
     },
-    // Error to return when caller module is missing memory export:
-    missing_memory: { wasi_common::wasi::types::Errno::Inval },
 });
 
 pub fn is_wasi_module(name: &str) -> bool {


### PR DESCRIPTION
The missing memory behavior was always a silly thing that was created long ago because I didn't understand the wasmtime API very well. Instead of creating a weird warning and returning an error code to the caller wasm, we now return a Err(Trap::new("missing memory")) to wasmtime to handle this error case.

Users will need to remove the `missing_memory` field from their invocation of `wasmtime_wiggle::wasmtime_integration!`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
