### PR TITLE
wiggle: introduce Trap enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "diff",

--- a/crates/wasi-common/src/error.rs
+++ b/crates/wasi-common/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     #[error("GetRandom: {0}")]
     GetRandom(#[from] getrandom::Error),
 
+    /// Some corners of the WASI standard are unsupported.
+    #[error("Unsupported: {0}")]
+    Unsupported(&'static str),
+
     /// The host OS may return an io error that doesn't match one of the
     /// wasi errno variants we expect. We do not expose the details of this
     /// error to the user.

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -717,7 +717,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
     fn proc_exit(&self, status: types::Exitcode) -> wiggle::Trap {
         // Check that the status is within WASI's range.
         if status < 126 {
-            wiggle::Trap::I32(status as i32)
+            wiggle::Trap::I32Exit(status as i32)
         } else {
             wiggle::Trap::String("exit with invalid exit status outside of [0..126)".to_owned())
         }

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -714,10 +714,13 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         Ok(nevents)
     }
 
-    fn proc_exit(&self, _rval: types::Exitcode) -> std::result::Result<(), ()> {
-        // proc_exit is special in that it's expected to unwind the stack, which
-        // typically requires runtime-specific logic.
-        unimplemented!("runtimes are expected to override this implementation")
+    fn proc_exit(&self, status: types::Exitcode) -> wiggle::Trap {
+        // Check that the status is within WASI's range.
+        if status < 126 {
+            wiggle::Trap::I32(status as i32)
+        } else {
+            wiggle::Trap::String("exit with invalid exit status outside of [0..126)".to_owned())
+        }
     }
 
     fn proc_raise(&self, _sig: types::Signal) -> Result<()> {

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -724,7 +724,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn proc_raise(&self, _sig: types::Signal) -> Result<()> {
-        unimplemented!("proc_raise")
+        Err(Error::Unsupported("proc_raise"))
     }
 
     fn sched_yield(&self) -> Result<()> {
@@ -744,7 +744,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         _ri_data: &types::IovecArray<'_>,
         _ri_flags: types::Riflags,
     ) -> Result<(types::Size, types::Roflags)> {
-        unimplemented!("sock_recv")
+        Err(Error::Unsupported("sock_recv"))
     }
 
     fn sock_send(
@@ -753,11 +753,11 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
         _si_data: &types::CiovecArray<'_>,
         _si_flags: types::Siflags,
     ) -> Result<types::Size> {
-        unimplemented!("sock_send")
+        Err(Error::Unsupported("sock_send"))
     }
 
     fn sock_shutdown(&self, _fd: types::Fd, _how: types::Sdflags) -> Result<()> {
-        unimplemented!("sock_shutdown")
+        Err(Error::Unsupported("sock_shutdown"))
     }
 }
 
@@ -804,7 +804,7 @@ impl WasiCtx {
                         Err(error) => {
                             events.push(types::Event {
                                 userdata: subscription.userdata,
-                                error: error.into(),
+                                error: error.try_into().expect("non-trapping error"),
                                 type_: types::Eventtype::FdRead,
                                 fd_readwrite: types::EventFdReadwrite {
                                     nbytes: 0,
@@ -830,7 +830,7 @@ impl WasiCtx {
                         Err(error) => {
                             events.push(types::Event {
                                 userdata: subscription.userdata,
-                                error: error.into(),
+                                error: error.try_into().expect("non-trapping error"),
                                 type_: types::Eventtype::FdWrite,
                                 fd_readwrite: types::EventFdReadwrite {
                                     nbytes: 0,

--- a/crates/wasi-common/src/snapshots/wasi_unstable.rs
+++ b/crates/wasi-common/src/snapshots/wasi_unstable.rs
@@ -25,13 +25,14 @@ impl types::GuestErrorConversion for WasiCtx {
 impl types::UserErrorConversion for WasiCtx {
     fn errno_from_error(&self, e: Error) -> Result<Errno, wiggle::Trap> {
         tracing::debug!("Error: {:?}", e);
-        Ok(e.into())
+        e.try_into()
     }
 }
 
-impl From<Error> for Errno {
-    fn from(e: Error) -> Errno {
-        types_new::Errno::from(e).into()
+impl TryFrom<Error> for Errno {
+    type Error = wiggle::Trap;
+    fn try_from(e: Error) -> Result<Errno, wiggle::Trap> {
+        Ok(types_new::Errno::try_from(e)?.into())
     }
 }
 

--- a/crates/wasi-common/src/snapshots/wasi_unstable.rs
+++ b/crates/wasi-common/src/snapshots/wasi_unstable.rs
@@ -23,7 +23,7 @@ impl types::GuestErrorConversion for WasiCtx {
 }
 
 impl types::UserErrorConversion for WasiCtx {
-    fn errno_from_error(&self, e: Error) -> Result<Errno, String> {
+    fn errno_from_error(&self, e: Error) -> Result<Errno, wiggle::Trap> {
         tracing::debug!("Error: {:?}", e);
         Ok(e.into())
     }
@@ -346,7 +346,7 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         Ok(nevents)
     }
 
-    fn proc_exit(&self, rval: Exitcode) -> Result<(), ()> {
+    fn proc_exit(&self, rval: Exitcode) -> wiggle::Trap {
         WasiSnapshotPreview1::proc_exit(self, rval)
     }
 

--- a/crates/wasi-common/src/sys/unix/poll.rs
+++ b/crates/wasi-common/src/sys/unix/poll.rs
@@ -117,7 +117,7 @@ fn handle_fd_event(
         let output_event = if revents.contains(PollFlags::POLLNVAL) {
             Event {
                 userdata: fd_event.userdata,
-                error: Error::Badf.into(),
+                error: Error::Badf.try_into().unwrap(),
                 type_: fd_event.r#type,
                 fd_readwrite: EventFdReadwrite {
                     nbytes: 0,
@@ -127,7 +127,7 @@ fn handle_fd_event(
         } else if revents.contains(PollFlags::POLLERR) {
             Event {
                 userdata: fd_event.userdata,
-                error: Error::Io.into(),
+                error: Error::Io.try_into().unwrap(),
                 type_: fd_event.r#type,
                 fd_readwrite: EventFdReadwrite {
                     nbytes: 0,

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -23,7 +23,7 @@ impl types::GuestErrorConversion for WasiCtx {
 }
 
 impl types::UserErrorConversion for WasiCtx {
-    fn errno_from_error(&self, e: Error) -> Result<Errno, String> {
+    fn errno_from_error(&self, e: Error) -> Result<Errno, wiggle::Trap> {
         debug!("Error: {:?}", e);
         Ok(e.into())
     }

--- a/crates/wasi-common/src/wasi.rs
+++ b/crates/wasi-common/src/wasi.rs
@@ -1,4 +1,5 @@
 use crate::{Error, WasiCtx};
+use std::convert::{TryFrom, TryInto};
 use tracing::debug;
 
 wiggle::from_witx!({
@@ -25,45 +26,49 @@ impl types::GuestErrorConversion for WasiCtx {
 impl types::UserErrorConversion for WasiCtx {
     fn errno_from_error(&self, e: Error) -> Result<Errno, wiggle::Trap> {
         debug!("Error: {:?}", e);
-        Ok(e.into())
+        e.try_into()
     }
 }
 
-impl From<Error> for Errno {
-    fn from(e: Error) -> Errno {
+impl TryFrom<Error> for Errno {
+    type Error = wiggle::Trap;
+    fn try_from(e: Error) -> Result<Errno, wiggle::Trap> {
         match e {
-            Error::Guest(e) => e.into(),
-            Error::TryFromInt(_) => Errno::Overflow,
-            Error::Utf8(_) => Errno::Ilseq,
-            Error::UnexpectedIo(_) => Errno::Io,
-            Error::GetRandom(_) => Errno::Io,
-            Error::TooBig => Errno::TooBig,
-            Error::Acces => Errno::Acces,
-            Error::Badf => Errno::Badf,
-            Error::Busy => Errno::Busy,
-            Error::Exist => Errno::Exist,
-            Error::Fault => Errno::Fault,
-            Error::Fbig => Errno::Fbig,
-            Error::Ilseq => Errno::Ilseq,
-            Error::Inval => Errno::Inval,
-            Error::Io => Errno::Io,
-            Error::Isdir => Errno::Isdir,
-            Error::Loop => Errno::Loop,
-            Error::Mfile => Errno::Mfile,
-            Error::Mlink => Errno::Mlink,
-            Error::Nametoolong => Errno::Nametoolong,
-            Error::Nfile => Errno::Nfile,
-            Error::Noent => Errno::Noent,
-            Error::Nomem => Errno::Nomem,
-            Error::Nospc => Errno::Nospc,
-            Error::Notdir => Errno::Notdir,
-            Error::Notempty => Errno::Notempty,
-            Error::Notsup => Errno::Notsup,
-            Error::Overflow => Errno::Overflow,
-            Error::Pipe => Errno::Pipe,
-            Error::Perm => Errno::Perm,
-            Error::Spipe => Errno::Spipe,
-            Error::Notcapable => Errno::Notcapable,
+            Error::Guest(e) => Ok(e.into()),
+            Error::TryFromInt(_) => Ok(Errno::Overflow),
+            Error::Utf8(_) => Ok(Errno::Ilseq),
+            Error::UnexpectedIo(_) => Ok(Errno::Io),
+            Error::GetRandom(_) => Ok(Errno::Io),
+            Error::TooBig => Ok(Errno::TooBig),
+            Error::Acces => Ok(Errno::Acces),
+            Error::Badf => Ok(Errno::Badf),
+            Error::Busy => Ok(Errno::Busy),
+            Error::Exist => Ok(Errno::Exist),
+            Error::Fault => Ok(Errno::Fault),
+            Error::Fbig => Ok(Errno::Fbig),
+            Error::Ilseq => Ok(Errno::Ilseq),
+            Error::Inval => Ok(Errno::Inval),
+            Error::Io => Ok(Errno::Io),
+            Error::Isdir => Ok(Errno::Isdir),
+            Error::Loop => Ok(Errno::Loop),
+            Error::Mfile => Ok(Errno::Mfile),
+            Error::Mlink => Ok(Errno::Mlink),
+            Error::Nametoolong => Ok(Errno::Nametoolong),
+            Error::Nfile => Ok(Errno::Nfile),
+            Error::Noent => Ok(Errno::Noent),
+            Error::Nomem => Ok(Errno::Nomem),
+            Error::Nospc => Ok(Errno::Nospc),
+            Error::Notdir => Ok(Errno::Notdir),
+            Error::Notempty => Ok(Errno::Notempty),
+            Error::Notsup => Ok(Errno::Notsup),
+            Error::Overflow => Ok(Errno::Overflow),
+            Error::Pipe => Ok(Errno::Pipe),
+            Error::Perm => Ok(Errno::Perm),
+            Error::Spipe => Ok(Errno::Spipe),
+            Error::Notcapable => Ok(Errno::Notcapable),
+            Error::Unsupported(feature) => {
+                Err(wiggle::Trap::String(format!("unsupported: {}", feature)))
+            }
         }
     }
 }
@@ -80,8 +85,8 @@ impl From<wiggle::GuestError> for Errno {
             PtrBorrowed { .. } => Self::Fault,
             InvalidUtf8 { .. } => Self::Ilseq,
             TryFromIntError { .. } => Self::Overflow,
-            InFunc { .. } => Self::Inval,
-            InDataField { .. } => Self::Inval,
+            InFunc { err, .. } => Errno::from(*err),
+            InDataField { err, .. } => Errno::from(*err),
             SliceLengthsDiffer { .. } => Self::Fault,
             BorrowCheckerOutOfHandles { .. } => Self::Fault,
         }

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -22,7 +22,7 @@ impl types::GuestErrorConversion for WasiNnCtx {
 }
 
 impl<'a> types::UserErrorConversion for WasiNnCtx {
-    fn errno_from_wasi_nn_error(&self, e: WasiNnError) -> Result<Errno, String> {
+    fn errno_from_wasi_nn_error(&self, e: WasiNnError) -> Result<Errno, wiggle::Trap> {
         eprintln!("Host error: {:?}", e);
         match e {
             WasiNnError::OpenvinoError(_) => unimplemented!(),

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -1,5 +1,3 @@
-use wasmtime::Trap;
-
 pub mod old;
 
 pub use wasi_common::virtfs;
@@ -26,12 +24,7 @@ modules. This structure exports all that various fields of the wasi instance
 as fields which can be used to implement your own instantiation logic, if
 necessary. Additionally [`Wasi::get_export`] can be used to do name-based
 resolution.",
-        // Don't use the wiggle generated code to implement proc_exit, we need
-        // to hook directly into the runtime there:
-          function_override: {
-            proc_exit => wasi_proc_exit
-          }
-        },
+        }
     },
 });
 
@@ -40,18 +33,4 @@ pub fn is_wasi_module(name: &str) -> bool {
     // we're figuring out how to support multiple revisions, this should do the
     // trick.
     name.starts_with("wasi")
-}
-
-/// Implement the WASI `proc_exit` function. This function is implemented here
-/// instead of in wasi-common so that we can use the runtime to perform an
-/// unwind rather than exiting the host process.
-fn wasi_proc_exit(status: i32) -> Result<(), Trap> {
-    // Check that the status is within WASI's range.
-    if status >= 0 && status < 126 {
-        Err(Trap::i32_exit(status))
-    } else {
-        Err(Trap::new(
-            "exit with invalid exit status outside of [0..126)",
-        ))
-    }
 }

--- a/crates/wasi/src/old/snapshot_0.rs
+++ b/crates/wasi/src/old/snapshot_0.rs
@@ -1,8 +1,6 @@
 pub use wasi_common::virtfs;
 pub use wasi_common::{WasiCtx, WasiCtxBuilder};
 
-use crate::wasi_proc_exit;
-
 // Defines a `struct Wasi` with member fields and appropriate APIs for dealing
 // with all the various WASI exports.
 wasmtime_wiggle::wasmtime_integration!({
@@ -25,12 +23,7 @@ modules. This structure exports all that various fields of the wasi instance
 as fields which can be used to implement your own instantiation logic, if
 necessary. Additionally [`Wasi::get_export`] can be used to do name-based
 resolution.",
-        // Don't use the wiggle generated code to implement proc_exit, we need
-        // to hook directly into the runtime there:
-          function_override: {
-            proc_exit => wasi_proc_exit
-          }
-        },
+        }
     },
 });
 

--- a/crates/wiggle/README.md
+++ b/crates/wiggle/README.md
@@ -5,3 +5,14 @@ invoked as a Rust procedural macro.
 
 Wiggle is not specialized to any particular WebAssembly runtime. It is usable
 in at least Wasmtime and Lucet.
+
+## Learning more
+
+Read the docs on [docs.rs](https://docs.rs/wiggle/).
+
+There are child crates for [integrating with Wasmtime](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wiggle/wasmtime) and [Lucet](https://github.com/bytecodealliance/lucet/tree/main/lucet-wiggle).
+
+The [wasi-common crate](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi-common) is implemented using Wiggle and the [wasmtime-wasi
+crate](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi) integrates wasi-common with the Wasmtime engine.
+
+Andrew Brown wrote a great [blog post](https://bytecodealliance.org/articles/implementing-wasi-nn-in-wasmtime) on using Wiggle with Wasmtime.

--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -40,7 +40,7 @@ pub fn generate(doc: &witx::Document, names: &Names, errs: &ErrorTransform) -> T
         let abi_typename = names.type_ref(&errtype.abi_type(), anon_lifetime());
         let user_typename = errtype.typename();
         let methodname = names.user_error_conversion_method(&errtype);
-        quote!(fn #methodname(&self, e: super::#user_typename) -> Result<#abi_typename, String>;)
+        quote!(fn #methodname(&self, e: super::#user_typename) -> Result<#abi_typename, wiggle::Trap>;)
     });
     let user_error_conversion = quote! {
         pub trait UserErrorConversion {

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -929,8 +929,15 @@ impl Pointee for str {
     }
 }
 
-#[derive(Debug, Clone)]
+/// A runtime-independent way for Wiggle to terminate WebAssembly execution.
+/// Functions that are marked `(@witx noreturn)` will always return a Trap.
+/// Other functions that want to Trap can do so via their `UserErrorConversion`
+/// trait, which transforms the user's own error type into a `Result<abierror, Trap>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Trap {
-    I32(i32),
+    /// A Trap which indicates an i32 (posix-style) exit code. Runtimes may have a
+    /// special way of dealing with this for WASI embeddings and otherwise.
+    I32Exit(i32),
+    /// Any other Trap is just an unstructured String, for reporting and debugging.
     String(String),
 }

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -928,3 +928,9 @@ impl Pointee for str {
         <[u8]>::debug(pointer, f)
     }
 }
+
+#[derive(Debug, Clone)]
+pub enum Trap {
+    I32(i32),
+    String(String),
+}

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -36,7 +36,7 @@ impl_errno!(types::Errno, types::GuestErrorConversion);
 /// When the `errors` mapping in witx is non-empty, we need to impl the
 /// types::UserErrorConversion trait that wiggle generates from that mapping.
 impl<'a> types::UserErrorConversion for WasiCtx<'a> {
-    fn errno_from_rich_error(&self, e: RichError) -> Result<types::Errno, String> {
+    fn errno_from_rich_error(&self, e: RichError) -> Result<types::Errno, wiggle::Trap> {
         wiggle::tracing::debug!(
             rich_error = wiggle::tracing::field::debug(&e),
             "error conversion"

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -199,8 +199,9 @@ fn generate_func(
                         #(#arg_names),*
                     );
                     match result {
-                        Ok(r) => {return Ok(r.into());},
-                        Err(err) => { return Err(wasmtime::Trap::new(err)); },
+                        Ok(r) => Ok(r.into()),
+                        Err(wasmtime_wiggle::Trap::String(err)) => Err(wasmtime::Trap::new(err)),
+                        Err(wasmtime_wiggle::Trap::I32(err)) => Err(wasmtime::Trap::i32_exit(err)),
                     }
                 }
             }

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -201,7 +201,7 @@ fn generate_func(
                     match result {
                         Ok(r) => Ok(r.into()),
                         Err(wasmtime_wiggle::Trap::String(err)) => Err(wasmtime::Trap::new(err)),
-                        Err(wasmtime_wiggle::Trap::I32(err)) => Err(wasmtime::Trap::i32_exit(err)),
+                        Err(wasmtime_wiggle::Trap::I32Exit(err)) => Err(wasmtime::Trap::i32_exit(err)),
                     }
                 }
             }

--- a/tests/wasm/exit125_wasi_snapshot0.wat
+++ b/tests/wasm/exit125_wasi_snapshot0.wat
@@ -1,6 +1,7 @@
 (module
   (import "wasi_unstable" "proc_exit"
     (func $__wasi_proc_exit (param i32)))
+  (memory (export "memory") 0)
   (func $_start
     (call $__wasi_proc_exit (i32.const 125))
   )

--- a/tests/wasm/exit125_wasi_snapshot1.wat
+++ b/tests/wasm/exit125_wasi_snapshot1.wat
@@ -1,6 +1,7 @@
 (module
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $__wasi_proc_exit (param i32)))
+  (memory (export "memory") 0)
   (func $_start
     (call $__wasi_proc_exit (i32.const 125))
   )

--- a/tests/wasm/exit126_wasi_snapshot0.wat
+++ b/tests/wasm/exit126_wasi_snapshot0.wat
@@ -1,6 +1,7 @@
 (module
   (import "wasi_unstable" "proc_exit"
     (func $__wasi_proc_exit (param i32)))
+  (memory (export "memory") 0)
   (func $_start
     (call $__wasi_proc_exit (i32.const 126))
   )

--- a/tests/wasm/exit126_wasi_snapshot1.wat
+++ b/tests/wasm/exit126_wasi_snapshot1.wat
@@ -1,6 +1,7 @@
 (module
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $__wasi_proc_exit (param i32)))
+  (memory (export "memory") 0)
   (func $_start
     (call $__wasi_proc_exit (i32.const 126))
   )

--- a/tests/wasm/exit2_wasi_snapshot0.wat
+++ b/tests/wasm/exit2_wasi_snapshot0.wat
@@ -1,6 +1,7 @@
 (module
   (import "wasi_unstable" "proc_exit"
     (func $__wasi_proc_exit (param i32)))
+  (memory (export "memory") 0)
   (func $_start
     (call $__wasi_proc_exit (i32.const 2))
   )

--- a/tests/wasm/exit2_wasi_snapshot1.wat
+++ b/tests/wasm/exit2_wasi_snapshot1.wat
@@ -1,6 +1,7 @@
 (module
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $__wasi_proc_exit (param i32)))
+  (memory (export "memory") 0)
   (func $_start
     (call $__wasi_proc_exit (i32.const 2))
   )

--- a/tests/wasm/exit_with_saved_fprs.wat
+++ b/tests/wasm/exit_with_saved_fprs.wat
@@ -3,6 +3,7 @@
     (type (func (param i32)))
     
     (import "wasi_snapshot_preview1" "proc_exit" (func (type 0)))
+    (memory (export "memory") 0)
     
     (func $exit (param i32)
         local.get 0


### PR DESCRIPTION
This improves the design of Wiggle's ability to terminate WebAssembly execution by introducing a new
`enum Trap { I32Exit(i32), String(String) }`. This is just a simple version of Wasmtime's own `Trap`, which will be compatible with Lucet as well.

Previously, Wiggle users could terminate WebAssembly by giving an `Err(String)` in the `UserErrorConversion` impl. This has evolved into `Err(wiggle::Trap)`, so that the termination can either give a human-readable trap, or an i32 exit code.

Additionally, functions which are `(@witx noreturn)` now have a return type of `wiggle::Trap`, using the type system to enforce that they terminate WebAssembly execution.

The big win here is we can finally implement wasi's `proc_exit` function in "pure" Wiggle, without the function override facility. So, this change has been threaded through the `wasi-common` crate and then into `wasi-wasmtime`.

I even uncovered some cli tests that technically didn't conform to the Wasi command spec because they didn't export a memory - wiggle now catches this, the old proc_exit override did not. These were trivially fixed.

Finally, instead of leaving the `unimplemented!` macro in the several spots in the wasi trait, I replaced them with an `Error::Unsupported` variant that produces a `Trap`.

The function override facility has been left in Wiggle for the time being, but I expect to remove it soon.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
