### PR TITLE
Update reference in README to simplejit-demo

### DIFF
--- a/cranelift/README.md
+++ b/cranelift/README.md
@@ -19,7 +19,7 @@ For more information, see [the documentation](docs/index.md).
 For an example of how to use the JIT, see the [JIT Demo], which
 implements a toy language.
 
-[JIT Demo]: https://github.com/bytecodealliance/simplejit-demo
+[JIT Demo]: https://github.com/bytecodealliance/cranelift-jit-demo
 
 For an example of how to use Cranelift to run WebAssembly code, see
 [Wasmtime], which implements a standalone, embeddable, VM using Cranelift.


### PR DESCRIPTION
This PR is updating the reference to the JIT demo, the repository has changed to `cranelift-jit-demo`. 

This PR should **not** be merged before https://github.com/bytecodealliance/cranelift-jit-demo/pull/53