### PR TITLE
[Cranelift][Atomics] Add address folding for atomic notify/wait.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,7 @@ fn main() -> anyhow::Result<()> {
             test_directory_module(out, "tests/misc_testsuite/reference-types", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/multi-memory", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/module-linking", strategy)?;
+            test_directory_module(out, "tests/misc_testsuite/threads", strategy)?;
             Ok(())
         })?;
 

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -45,6 +45,18 @@ macro_rules! foreach_builtin_function {
             externref_global_get(vmctx, i32) -> (reference);
             /// Returns an index for Wasm's `global.get` instruction for `externref`s.
             externref_global_set(vmctx, i32, reference) -> ();
+            /// Returns an index for wasm's `memory.atomic.notify` for locally defined memories.
+            memory_atomic_notify(vmctx, i32, i32, i32) -> (i32);
+            /// Returns an index for wasm's `memory.atomic.notify` for imported memories.
+            imported_memory_atomic_notify(vmctx, i32, i32, i32) -> (i32);
+            /// Returns an index for wasm's `memory.atomic.wait32` for locally defined memories.
+            memory_atomic_wait32(vmctx, i32, i32, i32, i64) -> (i32);
+            /// Returns an index for wasm's `memory.atomic.wait32` for imported memories.
+            imported_memory_atomic_wait32(vmctx, i32, i32, i32, i64) -> (i32);
+            /// Returns an index for wasm's `memory.atomic.wait64` for locally defined memories.
+            memory_atomic_wait64(vmctx, i32, i32, i64, i64) -> (i32);
+            /// Returns an index for wasm's `memory.atomic.wait64` for imported memories.
+            imported_memory_atomic_wait64(vmctx, i32, i32, i64, i64) -> (i32);
         }
     };
 }

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -58,7 +58,7 @@
 
 use crate::externref::VMExternRef;
 use crate::table::Table;
-use crate::traphandlers::raise_lib_trap;
+use crate::traphandlers::{raise_lib_trap, Trap};
 use crate::vmcontext::{VMCallerCheckedAnyfunc, VMContext};
 use std::mem;
 use std::ptr::{self, NonNull};
@@ -495,4 +495,89 @@ pub unsafe extern "C" fn wasmtime_externref_global_set(
     // it observing a halfway-deinitialized value).
     let old = mem::replace((*global).as_externref_mut(), externref);
     drop(old);
+}
+
+#[derive(Debug)]
+struct Unimplemented(&'static str);
+impl std::error::Error for Unimplemented {}
+impl std::fmt::Display for Unimplemented {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(f, "unimplemented: {}", self.0)
+    }
+}
+
+/// Implementation of `memory.atomic.notify` for locally defined memories.
+pub unsafe extern "C" fn wasmtime_memory_atomic_notify(
+    _vmctx: *mut VMContext,
+    _memory_index: u32,
+    _addr: u32,
+    _count: u32,
+) -> u32 {
+    raise_lib_trap(Trap::User(Box::new(Unimplemented(
+        "wasm atomics (fn wasmtime_memory_atomic_notify) unsupported",
+    ))));
+}
+
+/// Implementation of `memory.atomic.notify` for imported memories.
+pub unsafe extern "C" fn wasmtime_imported_memory_atomic_notify(
+    _vmctx: *mut VMContext,
+    _memory_index: u32,
+    _addr: u32,
+    _count: u32,
+) -> u32 {
+    raise_lib_trap(Trap::User(Box::new(Unimplemented(
+        "wasm atomics (fn wasmtime_imported_memory_atomic_notify) unsupported",
+    ))));
+}
+
+/// Implementation of `memory.atomic.wait32` for locally defined memories.
+pub unsafe extern "C" fn wasmtime_memory_atomic_wait32(
+    _vmctx: *mut VMContext,
+    _memory_index: u32,
+    _addr: u32,
+    _expected: u32,
+    _timeout: u64,
+) -> u32 {
+    raise_lib_trap(Trap::User(Box::new(Unimplemented(
+        "wasm atomics (fn wasmtime_memory_atomic_wait32) unsupported",
+    ))));
+}
+
+/// Implementation of `memory.atomic.wait32` for imported memories.
+pub unsafe extern "C" fn wasmtime_imported_memory_atomic_wait32(
+    _vmctx: *mut VMContext,
+    _memory_index: u32,
+    _addr: u32,
+    _expected: u32,
+    _timeout: u64,
+) -> u32 {
+    raise_lib_trap(Trap::User(Box::new(Unimplemented(
+        "wasm atomics (fn wasmtime_imported_memory_atomic_wait32) unsupported",
+    ))));
+}
+
+/// Implementation of `memory.atomic.wait64` for locally defined memories.
+pub unsafe extern "C" fn wasmtime_memory_atomic_wait64(
+    _vmctx: *mut VMContext,
+    _memory_index: u32,
+    _addr: u32,
+    _expected: u64,
+    _timeout: u64,
+) -> u32 {
+    raise_lib_trap(Trap::User(Box::new(Unimplemented(
+        "wasm atomics (fn wasmtime_memory_atomic_wait32) unsupported",
+    ))));
+}
+
+/// Implementation of `memory.atomic.wait32` for imported memories.
+pub unsafe extern "C" fn wasmtime_imported_memory_atomic_wait64(
+    _vmctx: *mut VMContext,
+    _memory_index: u32,
+    _addr: u32,
+    _expected: u64,
+    _timeout: u64,
+) -> u32 {
+    raise_lib_trap(Trap::User(Box::new(Unimplemented(
+        "wasm atomics (fn wasmtime_imported_memory_atomic_wait64) unsupported",
+    ))));
 }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -600,6 +600,18 @@ impl VMBuiltinFunctionsArray {
             wasmtime_table_fill as usize;
         ptrs[BuiltinFunctionIndex::table_fill_funcref().index() as usize] =
             wasmtime_table_fill as usize;
+        ptrs[BuiltinFunctionIndex::memory_atomic_notify().index() as usize] =
+            wasmtime_memory_atomic_notify as usize;
+        ptrs[BuiltinFunctionIndex::imported_memory_atomic_notify().index() as usize] =
+            wasmtime_imported_memory_atomic_notify as usize;
+        ptrs[BuiltinFunctionIndex::memory_atomic_wait32().index() as usize] =
+            wasmtime_memory_atomic_wait32 as usize;
+        ptrs[BuiltinFunctionIndex::imported_memory_atomic_wait32().index() as usize] =
+            wasmtime_imported_memory_atomic_wait32 as usize;
+        ptrs[BuiltinFunctionIndex::memory_atomic_wait64().index() as usize] =
+            wasmtime_memory_atomic_wait64 as usize;
+        ptrs[BuiltinFunctionIndex::imported_memory_atomic_wait64().index() as usize] =
+            wasmtime_imported_memory_atomic_wait64 as usize;
 
         if cfg!(debug_assertions) {
             for i in 0..ptrs.len() {

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -14,6 +14,7 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
 
     let multi_memory = wast.iter().any(|s| s == "multi-memory");
     let module_linking = wast.iter().any(|s| s == "module-linking");
+    let threads = wast.iter().any(|s| s == "threads");
     let bulk_mem = multi_memory || wast.iter().any(|s| s == "bulk-memory-operations");
 
     // Some simd tests assume support for multiple tables, which are introduced
@@ -26,6 +27,7 @@ fn run_wast(wast: &str, strategy: Strategy) -> anyhow::Result<()> {
         .wasm_reference_types(reftypes || module_linking)
         .wasm_multi_memory(multi_memory || module_linking)
         .wasm_module_linking(module_linking)
+        .wasm_threads(threads)
         .strategy(strategy)?
         .cranelift_debug_verifier(true);
 

--- a/tests/misc_testsuite/threads/atomics_wait_address.wast
+++ b/tests/misc_testsuite/threads/atomics_wait_address.wast
@@ -1,0 +1,52 @@
+;; From https://bugzilla.mozilla.org/show_bug.cgi?id=1684861.
+;;
+
+(module
+  (type (;0;) (func))
+  (func $main (type 0)
+    i32.const -64
+    i32.const -63
+    memory.atomic.notify offset=1
+    unreachable)
+  (memory (;0;) 4 4)
+  (export "main" (func $main))
+)
+
+(assert_trap (invoke "main") "misaligned memory access")
+
+
+(module
+  (type (;0;) (func))
+  (func $main (type 0)
+    i32.const -64
+    i32.const -63
+    memory.atomic.notify offset=65536
+    unreachable)
+  (memory (;0;) 4 4)
+  (export "main" (func $main))
+)
+
+(assert_trap (invoke "main") "out of bounds memory access")
+
+
+(module
+  (type (;0;) (func))
+  (func $wait32 (type 0)
+    i32.const -64
+    i32.const 42
+    i64.const 0
+    memory.atomic.wait32 offset=1
+    unreachable)
+  (func $wait64 (type 0)
+    i32.const -64
+    i64.const 43
+    i64.const 0
+    memory.atomic.wait64 offset=3
+    unreachable)
+  (memory (;0;) 4 4)
+  (export "wait32" (func $wait32))
+  (export "wait64" (func $wait64))
+)
+
+(assert_trap (invoke "wait32") "misaligned memory access")
+(assert_trap (invoke "wait64") "misaligned memory access")


### PR DESCRIPTION
Related isseue https://bugzilla.mozilla.org/show_bug.cgi?id=1684861

There are two parts:
- cranelift/wasm/src/code_translator.rs the logic required for SM to work properly
- rest of it is testing of the broken logic

I don't think it is necessary to check alignment in the `fold_atomic_mem_addr` though it is the only way at this moment to verify/test fix in the wasmtime.

Does it make sense for `wasmtime_memory_atomic_` to operate with 64-bit address instead of 32-bit one? But that's different question we have to address.

TODO:
 - [x] check for i32 address overflow?