### PR TITLE
wasm->CLIF: fn translate_operator: Select/TypedSelect: add missing bi…

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -201,14 +201,26 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             state.pop1();
         }
         Operator::Select => {
-            let (arg1, arg2, cond) = state.pop3();
+            let (mut arg1, mut arg2, cond) = state.pop3();
+            if builder.func.dfg.value_type(arg1).is_vector() {
+                arg1 = optionally_bitcast_vector(arg1, I8X16, builder);
+            }
+            if builder.func.dfg.value_type(arg2).is_vector() {
+                arg2 = optionally_bitcast_vector(arg2, I8X16, builder);
+            }
             state.push1(builder.ins().select(cond, arg1, arg2));
         }
         Operator::TypedSelect { ty: _ } => {
             // We ignore the explicit type parameter as it is only needed for
             // validation, which we require to have been performed before
             // translation.
-            let (arg1, arg2, cond) = state.pop3();
+            let (mut arg1, mut arg2, cond) = state.pop3();
+            if builder.func.dfg.value_type(arg1).is_vector() {
+                arg1 = optionally_bitcast_vector(arg1, I8X16, builder);
+            }
+            if builder.func.dfg.value_type(arg2).is_vector() {
+                arg2 = optionally_bitcast_vector(arg2, I8X16, builder);
+            }
             state.push1(builder.ins().select(cond, arg1, arg2));
         }
         Operator::Nop => {

--- a/cranelift/wasmtests/pr2559.wat
+++ b/cranelift/wasmtests/pr2559.wat
@@ -1,0 +1,51 @@
+(module
+  (type (;0;) (func (result v128 v128 v128)))
+
+  (func $main1 (type 0) (result v128 v128 v128)
+    call $main1
+    i8x16.add
+    call $main1
+    i8x16.ge_u
+    i16x8.ne
+    i32.const 13
+    br_if 0 (;@0;)
+    i32.const 43
+    br_if 0 (;@0;)
+    i32.const 13
+    br_if 0 (;@0;)
+    i32.const 87
+    select
+    unreachable
+    i32.const 0
+    br_if 0 (;@0;)
+    i32.const 13
+    br_if 0 (;@0;)
+    i32.const 43
+    br_if 0 (;@0;)
+  )
+  (export "main1" (func $main1))
+
+  (func $main2 (type 0) (result v128 v128 v128)
+    call $main2
+    i8x16.add
+    call $main2
+    i8x16.ge_u
+    i16x8.ne
+    i32.const 13
+    br_if 0 (;@0;)
+    i32.const 43
+    br_if 0 (;@0;)
+    i32.const 13
+    br_if 0 (;@0;)
+    i32.const 87
+    select (result v128)
+    unreachable
+    i32.const 0
+    br_if 0 (;@0;)
+    i32.const 13
+    br_if 0 (;@0;)
+    i32.const 43
+    br_if 0 (;@0;)
+  )
+  (export "main2" (func $main2))
+)


### PR DESCRIPTION
…tcasts

The translation of Operator::Select and Operator::TypedSelect for vector-typed
operands, lacks the relevant bitcasting of the operands to I8X16.  This commit
adds it.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
