### PR TITLE
machinst lowering: update inst color when scanning across branch to allow more load-op merging.

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -683,10 +683,6 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 has_side_effect,
                 value_needed,
             );
-            // Skip lowering branches; these are handled separately.
-            if self.f.dfg[inst].opcode().is_branch() {
-                continue;
-            }
 
             // Update scan state to color prior to this inst (as we are scanning
             // backward).
@@ -697,6 +693,12 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                     .get(&inst)
                     .expect("every side-effecting inst should have a color-map entry");
                 self.cur_scan_entry_color = Some(entry_color);
+            }
+
+            // Skip lowering branches; these are handled separately
+            // (see `lower_clif_branches()` below).
+            if self.f.dfg[inst].opcode().is_branch() {
+                continue;
             }
 
             // Normal instruction: codegen if the instruction is side-effecting

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -59,3 +59,14 @@ block0(v0: i64, v1: i64):
   ; nextln: movq    0(%rax,%rdi,1), %rsi
   ; nextln: movq    %rsi, %rax
 }
+
+function %merge_scalar_to_vector(i64) -> i32x4 {
+block0(v0: i64):
+  v1 = load.i32 v0
+  v2 = scalar_to_vector.i32x4 v1
+  ; check: movss   0(%rdi), %xmm0
+
+  jump block1
+block1:
+  return v2
+}


### PR DESCRIPTION
A branch is considered side-effecting and so updates the instruction
color (which is our way of computing how far instructions can sink).
However, in the lowering loop, we did not update current instruction
color when scanning backward across branches, which are side-effecting.
As a result, the color was stale and fewer load-op merges were permitted
than are actually possible.

Note that this would not have resulted in any correctness issues, as the
stale color is too high (so no merges are permitted that should have
been disallowed).

Fixes #2562.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
