### PR TITLE
add non-default object_read feature to cranelift-object

### DIFF
--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -23,3 +23,9 @@ cranelift-entity = { path = "../entity", version = "0.69.0" }
 
 [badges]
 maintenance = { status = "experimental" }
+
+[features]
+default = []
+# cranelift-object re-exports object (`pub use object` at top level). Use this
+# feature to enable that re-export to contain object's read features as well.
+object_read = ["object/read"]


### PR DESCRIPTION
cranelift-object re-exports object (`pub use object` at top level). Use this
feature to enable that re-export to contain object's read features as well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
