### PR TITLE
wasi-common: add preopened_handle, to be able to open any handle

### DIFF
--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -268,6 +268,22 @@ impl WasiCtxBuilder {
         self
     }
 
+    /// Add a preopened handle.
+    ///
+    /// This is the most generic function for adding a directory, but also the less easy to use.
+    pub fn preopened_handle<P: AsRef<Path>, T: 'static + Handle>(
+        &mut self,
+        dir: T,
+        guest_path: P,
+    ) -> &mut Self {
+        let preopen = PendingPreopen::new(move || Ok(Box::new(dir)));
+        self.preopens
+            .as_mut()
+            .unwrap()
+            .push((guest_path.as_ref().to_owned(), preopen));
+        self
+    }
+
     /// Build a `WasiCtx`, consuming this `WasiCtxBuilder`.
     ///
     /// If any of the arguments or environment variables in this builder cannot be converted into


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

This is a follow-up to https://github.com/bytecodealliance/wasmtime/pull/1600 ; that also makes it possible to write custom Handles for directories. For my specific case, it is so as to be able to have a wasmtime-async-compatible WASI.

I've raised the question on zulip #wasmtime without answer yet (not sure whether #general should be preferred?), so I've just decided to go on with this PR, and will start using my fork and checking whether I can make things work properly with it starting now :)