### PR TITLE
wasmtime-bench-api: Randomize the locations of heap objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
+name = "shuffling-allocator"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848c0a454373d16ebfaa740c99d4faebe25ea752a35e0c6e341168fe67f987f8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand",
+ "winapi",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2442,7 @@ name = "wasmtime-bench-api"
 version = "0.19.0"
 dependencies = [
  "anyhow",
+ "shuffling-allocator",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -16,10 +16,13 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 anyhow = "1.0"
+shuffling-allocator = { version = "1.1.1", optional = true }
 wasmtime = { path = "../wasmtime", default-features = false }
 wasmtime-wasi = { path = "../wasi" }
 wasi-common = { path = "../wasi-common" }
 
-
 [dev-dependencies]
 wat = "1.0"
+
+[features]
+default = ["shuffling-allocator"]

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -83,6 +83,14 @@ pub type ExitCode = c_int;
 pub const OK: ExitCode = 0;
 pub const ERR: ExitCode = -1;
 
+// Randomize the location of heap objects to avoid accidental locality being an
+// uncontrolled variable that obscures performance evaluation in our
+// experiments.
+#[cfg(feature = "shuffling-allocator")]
+#[global_allocator]
+static ALLOC: shuffling_allocator::ShufflingAllocator<std::alloc::System> =
+    shuffling_allocator::wrap!(&std::alloc::System);
+
 /// Exposes a C-compatible way of creating the engine from the bytes of a single
 /// Wasm module.
 ///


### PR DESCRIPTION
This helps us avoid measurement bias due to accidental locality of unrelated heap objects. See *Stabilizer: Statistically Sound Performance Evaluation* by Curtsinger and Berger for details (although Stabilizer deals with much more than just the location of heap allocations): https://people.cs.umass.edu/~emery/pubs/stabilizer-asplos13.pdf

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
