### PR TITLE
Update WebAssembly C API submodule to latest commit.

### DIFF
--- a/crates/c-api/include/doc-wasm.h
+++ b/crates/c-api/include/doc-wasm.h
@@ -316,6 +316,12 @@
  *
  * \fn wasm_name_new_new_uninitialized
  * \brief Convenience alias
+ * 
+ * \fn wasm_name_new_from_string
+ * \brief Create a new name from a C string.
+ * 
+ * \fn wasm_name_new_from_string_nt
+ * \brief Create a new name from a C string with null terminator.
  *
  * \fn wasm_name_copy
  * \brief Convenience alias
@@ -1520,8 +1526,6 @@
  * and types of results as the original type signature. It is undefined behavior
  * to return other types or different numbers of values.
  *
- * This function takes ownership of all of the parameters given. It's expected
- * that the caller will invoke `wasm_val_delete` for each one provided.
  * Ownership of the results and the trap returned, if any, is passed to the
  * caller of this function.
  *
@@ -1608,7 +1612,7 @@
  * \fn size_t wasm_func_result_arity(const wasm_func_t *);
  * \brief Returns the number of results returned by this function.
  *
- * \fn own wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_t args[], const wasm_val_t results[]);
+* \fn own wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_vec_t *args, wasm_val_vec_t *results);
  * \brief Calls the provided function with the arguments given.
  *
  * This function is used to call WebAssembly from the host. The parameter array
@@ -2164,7 +2168,7 @@
  * \fn wasm_ref_as_instance_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn own wasm_instance_t *wasm_instance_new(wasm_store_t *, const wasm_module_t *, const wasm_extern_t *const[], wasm_trap_t **);
+ * \fn own wasm_instance_t *wasm_instance_new(wasm_store_t *, const wasm_module_t *, const wasm_extern_vec_t *, wasm_trap_t **);
  * \brief Instantiates a module with the provided imports.
  *
  * This function will instantiate the provided #wasm_module_t into the provided

--- a/crates/c-api/include/doc-wasm.h
+++ b/crates/c-api/include/doc-wasm.h
@@ -413,7 +413,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_valtype_t* wasm_valtype_copy(wasm_valtype_t *)
+ * \fn own wasm_valtype_t* wasm_valtype_copy(const wasm_valtype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -483,7 +483,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_functype_t* wasm_functype_copy(wasm_functype_t *)
+ * \fn own wasm_functype_t* wasm_functype_copy(const wasm_functype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -554,7 +554,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_globaltype_t* wasm_globaltype_copy(wasm_globaltype_t *)
+ * \fn own wasm_globaltype_t* wasm_globaltype_copy(const wasm_globaltype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -631,7 +631,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_tabletype_t* wasm_tabletype_copy(wasm_tabletype_t *)
+ * \fn own wasm_tabletype_t* wasm_tabletype_copy(const wasm_tabletype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -717,7 +717,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_memorytype_t* wasm_memorytype_copy(wasm_memorytype_t *)
+ * \fn own wasm_memorytype_t* wasm_memorytype_copy(const wasm_memorytype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -786,7 +786,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_externtype_t* wasm_externtype_copy(wasm_externtype_t *)
+ * \fn own wasm_externtype_t* wasm_externtype_copy(const wasm_externtype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -963,7 +963,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_importtype_t* wasm_importtype_copy(wasm_importtype_t *)
+ * \fn own wasm_importtype_t* wasm_importtype_copy(const wasm_importtype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -1044,7 +1044,7 @@
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_exporttype_t* wasm_exporttype_copy(wasm_exporttype_t *)
+ * \fn own wasm_exporttype_t* wasm_exporttype_copy(const wasm_exporttype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -2197,4 +2197,30 @@
  * the caller, which are exported from the instance. The `out` list will have
  * the same length as #wasm_module_exports called on the original module. Each
  * element is 1:1 matched with the elements in the list of #wasm_module_exports.
+ */
+
+/**
+ * \def WASM_EMPTY_VEC
+ * \brief Used to initialize an empty vector type.
+ *
+ * \def WASM_ARRAY_VEC
+ * \brief Used to initialize a vector type from a C array.
+ *
+ * \def WASM_I32_VAL
+ * \brief Used to initialize a 32-bit integer wasm_val_t value.
+ *
+ * \def WASM_I64_VAL
+ * \brief Used to initialize a 64-bit integer wasm_val_t value.
+ *
+ * \def WASM_F32_VAL
+ * \brief Used to initialize a 32-bit floating point wasm_val_t value.
+ *
+ * \def WASM_F64_VAL
+ * \brief Used to initialize a 64-bit floating point wasm_val_t value.
+ *
+ * \def WASM_REF_VAL
+ * \brief Used to initialize an externref wasm_val_t value.
+ *
+ * \def WASM_INIT_VAL
+ * \brief Used to initialize a null externref wasm_val_t value.
  */

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -1011,7 +1011,7 @@ WASM_API_EXTERN own wasmtime_error_t *wasmtime_module_deserialize(
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_instancetype_t* wasm_instancetype_copy(wasm_instancetype_t *)
+ * \fn own wasm_instancetype_t* wasm_instancetype_copy(const wasm_instancetype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.
@@ -1108,7 +1108,7 @@ WASM_API_EXTERN const wasm_instancetype_t* wasm_externtype_as_instancetype_const
  *
  * See #wasm_byte_vec_delete for more information.
  *
- * \fn own wasm_moduletype_t* wasm_moduletype_copy(wasm_moduletype_t *)
+ * \fn own wasm_moduletype_t* wasm_moduletype_copy(const wasm_moduletype_t *)
  * \brief Creates a new value which matches the provided one.
  *
  * The caller is responsible for deleting the returned value.

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -671,7 +671,6 @@ WASM_API_EXTERN const wasm_name_t *wasmtime_frame_module_name(const wasm_frame_t
  *
  * This function is similar to #wasm_func_call, but with a few tweaks:
  *
- * * `args` and `results` have a size parameter saying how big the arrays are
  * * An error *and* a trap can be returned
  * * Errors are returned if `args` have the wrong types, if the args/results
  *   arrays have the wrong lengths, or if values come from the wrong store.
@@ -697,10 +696,8 @@ WASM_API_EXTERN const wasm_name_t *wasmtime_frame_module_name(const wasm_frame_t
  */
 WASM_API_EXTERN own wasmtime_error_t *wasmtime_func_call(
     wasm_func_t *func,
-    const wasm_val_t *args,
-    size_t num_args,
-    wasm_val_t *results,
-    size_t num_results,
+    const wasm_val_vec_t *args,
+    wasm_val_vec_t *results,
     own wasm_trap_t **trap
 );
 
@@ -741,7 +738,6 @@ WASM_API_EXTERN own wasmtime_error_t *wasmtime_global_set(
  * This function is similar to #wasm_instance_new, but with a few tweaks:
  *
  * * An error message can be returned from this function.
- * * The number of imports specified is passed as an argument
  * * The `trap` pointer is required to not be NULL.
  *
  * The states of return values from this function are similar to
@@ -759,8 +755,7 @@ WASM_API_EXTERN own wasmtime_error_t *wasmtime_global_set(
 WASM_API_EXTERN own wasmtime_error_t *wasmtime_instance_new(
     wasm_store_t *store,
     const wasm_module_t *module,
-    const wasm_extern_t* const imports[],
-    size_t num_imports,
+    const wasm_extern_vec_t* imports,
     own wasm_instance_t **instance,
     own wasm_trap_t **trap
 );

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -4,6 +4,7 @@ use crate::{
     wasm_moduletype_t, wasm_tabletype_t, wasm_val_t, wasm_valtype_t,
 };
 use std::mem;
+use std::mem::MaybeUninit;
 use std::ptr;
 use std::slice;
 
@@ -51,6 +52,18 @@ macro_rules! declare_vecs {
                 } else {
                     assert!(!self.data.is_null());
                     unsafe { slice::from_raw_parts(self.data, self.size) }
+                }
+            }
+
+            pub fn as_uninit_slice(&mut self) -> &mut [MaybeUninit<$elem_ty>] {
+                // Note that we're careful to not create a slice with a null
+                // pointer as the data pointer, since that isn't defined
+                // behavior in Rust.
+                if self.size == 0 {
+                    &mut []
+                } else {
+                    assert!(!self.data.is_null());
+                    unsafe { slice::from_raw_parts_mut(self.data as _, self.size) }
                 }
             }
 

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -75,7 +75,8 @@ int main() {
   printf("Instantiating module...\n");
   wasm_trap_t *trap = NULL;
   wasm_instance_t *instance = NULL;
-  error = wasmtime_instance_new(store, module, NULL, 0, &instance, &trap);
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
+  error = wasmtime_instance_new(store, module, &imports, &instance, &trap);
   if (instance == NULL)
     exit_with_error("failed to instantiate", error, trap);
 
@@ -139,10 +140,11 @@ int main() {
   assert(func != NULL);
 
   // And call it!
-  wasm_val_t args[1];
-  wasm_val_copy(&args[0], &externref);
+  wasm_val_t args[1] = { externref };
   wasm_val_t results[1];
-  error = wasmtime_func_call(func, args, 1, results, 1, &trap);
+  wasm_val_vec_t args_vec = WASM_ARRAY_VEC(args);
+  wasm_val_vec_t results_vec = WASM_ARRAY_VEC(results);
+  error = wasmtime_func_call(func, &args_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call function", error, trap);
 
@@ -161,7 +163,6 @@ int main() {
   ret = 0;
 
   wasm_val_delete(&results[0]);
-  wasm_val_delete(&args[0]);
   wasm_val_delete(&global_val);
   wasm_val_delete(&elem);
   wasm_extern_vec_delete(&externs);

--- a/examples/fib-debug/main.c
+++ b/examples/fib-debug/main.c
@@ -71,7 +71,8 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   wasm_instance_t* instance = NULL;
   wasm_trap_t *trap = NULL;
-  error = wasmtime_instance_new(store, module, NULL, 0, &instance, &trap);
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
+  error = wasmtime_instance_new(store, module, &imports, &instance, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to instantiate", error, trap);
   wasm_module_delete(module);
@@ -95,9 +96,11 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling fib...\n");
-  wasm_val_t params[1] = { {.kind = WASM_I32, .of = {.i32 = 6}} };
+  wasm_val_t params[1] = { WASM_I32_VAL(6) };
   wasm_val_t results[1];
-  error = wasmtime_func_call(run_func, params, 1, results, 1, &trap);
+  wasm_val_vec_t params_vec = WASM_ARRAY_VEC(params);
+  wasm_val_vec_t results_vec = WASM_ARRAY_VEC(results);
+  error = wasmtime_func_call(run_func, &params_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call function", error, trap);
 

--- a/examples/gcd.c
+++ b/examples/gcd.c
@@ -65,7 +65,8 @@ int main() {
   wasm_byte_vec_delete(&wasm);
   wasm_trap_t *trap = NULL;
   wasm_instance_t *instance = NULL;
-  error = wasmtime_instance_new(store, module, NULL, 0, &instance, &trap);
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
+  error = wasmtime_instance_new(store, module, &imports, &instance, &trap);
   if (instance == NULL)
     exit_with_error("failed to instantiate", error, trap);
 
@@ -79,13 +80,11 @@ int main() {
   // And call it!
   int a = 6;
   int b = 27;
-  wasm_val_t params[2];
+  wasm_val_t params[2] = { WASM_I32_VAL(a), WASM_I32_VAL(b) };
   wasm_val_t results[1];
-  params[0].kind = WASM_I32;
-  params[0].of.i32 = a;
-  params[1].kind = WASM_I32;
-  params[1].of.i32 = b;
-  error = wasmtime_func_call(gcd, params, 2, results, 1, &trap);
+  wasm_val_vec_t params_vec = WASM_ARRAY_VEC(params);
+  wasm_val_vec_t results_vec = WASM_ARRAY_VEC(results);
+  error = wasmtime_func_call(gcd, &params_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call gcd", error, trap);
   assert(results[0].kind == WASM_I32);

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -26,7 +26,7 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
 
-static wasm_trap_t* hello_callback(const wasm_val_t args[], wasm_val_t results[]) {
+static wasm_trap_t* hello_callback(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -86,8 +86,9 @@ int main() {
   printf("Instantiating module...\n");
   wasm_trap_t *trap = NULL;
   wasm_instance_t *instance = NULL;
-  const wasm_extern_t *imports[] = { wasm_func_as_extern(hello) };
-  error = wasmtime_instance_new(store, module, imports, 1, &instance, &trap);
+  wasm_extern_t* imports[] = { wasm_func_as_extern(hello) };
+  wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
+  error = wasmtime_instance_new(store, module, &imports_vec, &instance, &trap);
   if (instance == NULL)
     exit_with_error("failed to instantiate", error, trap);
 
@@ -101,7 +102,9 @@ int main() {
 
   // And call it!
   printf("Calling export...\n");
-  error = wasmtime_func_call(run, NULL, 0, NULL, 0, &trap);
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  error = wasmtime_func_call(run, &args_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call function", error, trap);
 

--- a/examples/hello.cc
+++ b/examples/hello.cc
@@ -26,7 +26,7 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
 
-static wasm_trap_t* hello_callback(const wasm_val_t args[], wasm_val_t results[]) {
+static wasm_trap_t* hello_callback(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -86,8 +86,9 @@ int main() {
   printf("Instantiating module...\n");
   wasm_trap_t *trap = NULL;
   wasm_instance_t *instance = NULL;
-  const wasm_extern_t *imports[] = { wasm_func_as_extern(hello) };
-  error = wasmtime_instance_new(store, module, imports, 1, &instance, &trap);
+  wasm_extern_t* imports[] = { wasm_func_as_extern(hello) };
+  wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
+  error = wasmtime_instance_new(store, module, &imports_vec, &instance, &trap);
   if (instance == NULL)
     exit_with_error("failed to instantiate", error, trap);
 
@@ -101,7 +102,9 @@ int main() {
 
   // And call it!
   printf("Calling export...\n");
-  error = wasmtime_func_call(run, NULL, 0, NULL, 0, &trap);
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  error = wasmtime_func_call(run, &args_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call function", error, trap);
 

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -42,6 +42,7 @@ static void* helper(void *_handle) {
   printf("Sending an interrupt\n");
   wasmtime_interrupt_handle_interrupt(handle);
   wasmtime_interrupt_handle_delete(handle);
+  return 0;
 }
 
 static void spawn_interrupt(wasmtime_interrupt_handle_t *handle) {
@@ -89,11 +90,12 @@ int main() {
   wasm_module_t *module = NULL;
   wasm_trap_t *trap = NULL;
   wasm_instance_t *instance = NULL;
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
   error = wasmtime_module_new(engine, &wasm, &module);
   wasm_byte_vec_delete(&wasm);
   if (error != NULL)
     exit_with_error("failed to compile module", error, NULL);
-  error = wasmtime_instance_new(store, module, NULL, 0, &instance, &trap);
+  error = wasmtime_instance_new(store, module, &imports, &instance, &trap);
   if (instance == NULL)
     exit_with_error("failed to instantiate", error, trap);
 
@@ -109,7 +111,9 @@ int main() {
 
   // And call it!
   printf("Entering infinite loop...\n");
-  error = wasmtime_func_call(run, NULL, 0, NULL, 0, &trap);
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  error = wasmtime_func_call(run, &args_vec, &results_vec, &trap);
   assert(error == NULL);
   assert(trap != NULL);
   printf("Got a trap!...\n");

--- a/examples/linking.c
+++ b/examples/linking.c
@@ -100,7 +100,9 @@ int main() {
   assert(linking1_externs.size == 1);
   wasm_func_t *run = wasm_extern_as_func(linking1_externs.data[0]);
   assert(run != NULL);
-  error = wasmtime_func_call(run, NULL, 0, NULL, 0, &trap);
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  error = wasmtime_func_call(run, &args_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call run", error, trap);
 

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -54,10 +54,11 @@ void check(bool success) {
   }
 }
 
-void check_call(wasm_func_t* func, wasm_val_t args[], size_t num_args, int32_t expected) {
+void check_call(wasm_func_t* func, const wasm_val_vec_t* args_vec, int32_t expected) {
   wasm_val_t results[1];
+  wasm_val_vec_t results_vec = WASM_ARRAY_VEC(results);
   wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(func, args, num_args, results, 1, &trap);
+  wasmtime_error_t *error = wasmtime_func_call(func, args_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call function", error, trap);
   if (results[0].of.i32 != expected) {
@@ -67,42 +68,44 @@ void check_call(wasm_func_t* func, wasm_val_t args[], size_t num_args, int32_t e
 }
 
 void check_call0(wasm_func_t* func, int32_t expected) {
-  check_call(func, NULL, 0, expected);
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  check_call(func, &args_vec, expected);
 }
 
 void check_call1(wasm_func_t* func, int32_t arg, int32_t expected) {
-  wasm_val_t args[] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
-  check_call(func, args, 1, expected);
+  wasm_val_t args[] = { WASM_I32_VAL(arg) };
+  wasm_val_vec_t args_vec = WASM_ARRAY_VEC(args);
+  check_call(func, &args_vec, expected);
 }
 
 void check_call2(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
-  check_call(func, args, 2, expected);
+  wasm_val_t args[] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
+  wasm_val_vec_t args_vec = WASM_ARRAY_VEC(args);
+  check_call(func, &args_vec, expected);
 }
 
-void check_ok(wasm_func_t* func, wasm_val_t args[], size_t num_args) {
+void check_ok(wasm_func_t* func, const wasm_val_vec_t* args_vec) {
   wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(func, args, num_args, NULL, 0, &trap);
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  wasmtime_error_t *error = wasmtime_func_call(func, args_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call function", error, trap);
 }
 
 void check_ok2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
-  check_ok(func, args, 2);
+  wasm_val_t args[] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
+  wasm_val_vec_t args_vec = WASM_ARRAY_VEC(args);
+  check_ok(func, &args_vec);
 }
 
-void check_trap(wasm_func_t* func, wasm_val_t args[], size_t num_args, size_t num_results) {
-  wasm_val_t results[1];
+void check_trap(wasm_func_t* func, const wasm_val_vec_t* args_vec, size_t num_results) {
   assert(num_results <= 1);
+  wasm_val_t results[1];
+  wasm_val_vec_t results_vec;
+  results_vec.data = results;
+  results_vec.size = num_results;
   wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(func, args, num_args, results, num_results, &trap);
+  wasmtime_error_t *error = wasmtime_func_call(func, args_vec, &results_vec, &trap);
   if (error != NULL)
     exit_with_error("failed to call function", error, NULL);
   if (trap == NULL) {
@@ -113,16 +116,15 @@ void check_trap(wasm_func_t* func, wasm_val_t args[], size_t num_args, size_t nu
 }
 
 void check_trap1(wasm_func_t* func, int32_t arg) {
-  wasm_val_t args[1] = { {.kind = WASM_I32, .of = {.i32 = arg}} };
-  check_trap(func, args, 1, 1);
+  wasm_val_t args[] = { WASM_I32_VAL(arg) };
+  wasm_val_vec_t args_vec = WASM_ARRAY_VEC(args);
+  check_trap(func, &args_vec, 1);
 }
 
 void check_trap2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = {
-    {.kind = WASM_I32, .of = {.i32 = arg1}},
-    {.kind = WASM_I32, .of = {.i32 = arg2}}
-  };
-  check_trap(func, args, 2, 0);
+  wasm_val_t args[] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
+  wasm_val_vec_t args_vec = WASM_ARRAY_VEC(args);
+  check_trap(func, &args_vec, 0);
 }
 
 int main(int argc, const char* argv[]) {
@@ -167,7 +169,8 @@ int main(int argc, const char* argv[]) {
   printf("Instantiating module...\n");
   wasm_instance_t* instance = NULL;
   wasm_trap_t *trap = NULL;
-  error = wasmtime_instance_new(store, module, NULL, 0, &instance, &trap);
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
+  error = wasmtime_instance_new(store, module, &imports, &instance, &trap);
   if (!instance)
     exit_with_error("failed to instantiate", error, trap);
 

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -26,7 +26,7 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
 
-static wasm_trap_t* hello_callback(const wasm_val_t args[], wasm_val_t results[]) {
+static wasm_trap_t* hello_callback(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -111,8 +111,9 @@ int deserialize(wasm_byte_vec_t* buffer) {
   printf("Instantiating module...\n");
   wasm_trap_t *trap = NULL;
   wasm_instance_t *instance = NULL;
-  const wasm_extern_t *imports[] = { wasm_func_as_extern(hello) };
-  error = wasmtime_instance_new(store, module, imports, 1, &instance, &trap);
+  wasm_extern_t *imports[] = { wasm_func_as_extern(hello) };
+  wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
+  error = wasmtime_instance_new(store, module, &imports_vec, &instance, &trap);
   if (instance == NULL)
     exit_with_error("failed to instantiate", error, trap);
 
@@ -126,7 +127,9 @@ int deserialize(wasm_byte_vec_t* buffer) {
 
   // And call it!
   printf("Calling export...\n");
-  error = wasmtime_func_call(run, NULL, 0, NULL, 0, &trap);
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  error = wasmtime_func_call(run, &args_vec, &results_vec, &trap);
   if (error != NULL || trap != NULL)
     exit_with_error("failed to call function", error, trap);
 

--- a/examples/wasi-fs/main.c
+++ b/examples/wasi-fs/main.c
@@ -91,7 +91,10 @@ int main() {
   wasmtime_linker_get_default(linker, &empty, &func);
   if (error != NULL)
     exit_with_error("failed to locate default export for module", error, NULL);
-  error = wasmtime_func_call(func, NULL, 0, NULL, 0, &trap);
+
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  error = wasmtime_func_call(func, &args_vec, &results_vec, &trap);
   if (error != NULL)
     exit_with_error("error calling default export", error, trap);
 

--- a/examples/wasi/main.c
+++ b/examples/wasi/main.c
@@ -90,7 +90,10 @@ int main() {
   wasmtime_linker_get_default(linker, &empty, &func);
   if (error != NULL)
     exit_with_error("failed to locate default export for module", error, NULL);
-  error = wasmtime_func_call(func, NULL, 0, NULL, 0, &trap);
+
+  wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+  wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+  error = wasmtime_func_call(func, &args_vec, &results_vec, &trap);
   if (error != NULL)
     exit_with_error("error calling default export", error, trap);
 


### PR DESCRIPTION
This PR updates the WebAssembly C API submodule (for `wasm.h`) to the
latest commit out of master.

This fixes the behavior of `wasm_name_new_from_string` such that it no longer
copies the null character into the name, which caused unexpected failures when
using the Wasmtime linker as imports wouldn't resolve when the null was
present.

Along with this change were breaking changes to `wasm_func_call`, the host
callback signatures, and `wasm_instance_new` to take a vector type instead of a
pointer to an unsized array.

As a result, Wasmtime language bindings based on the C API will need to be
updated once this change is pulled in.

Fixes #2211.
Fixes #2131.