### PR TITLE
Update support for the module linking proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
  "souper-ir",
  "target-lexicon",
  "thiserror",
- "wast 29.0.0",
+ "wast 31.0.0",
 ]
 
 [[package]]
@@ -1393,7 +1393,7 @@ dependencies = [
  "peepmatic-test-operator",
  "peepmatic-traits",
  "serde",
- "wast 29.0.0",
+ "wast 31.0.0",
  "z3",
 ]
 
@@ -1421,7 +1421,7 @@ dependencies = [
  "peepmatic-traits",
  "rand",
  "serde",
- "wast 29.0.0",
+ "wast 31.0.0",
 ]
 
 [[package]]
@@ -1446,7 +1446,7 @@ dependencies = [
  "serde",
  "serde_test",
  "thiserror",
- "wast 29.0.0",
+ "wast 31.0.0",
 ]
 
 [[package]]
@@ -1458,7 +1458,7 @@ dependencies = [
  "peepmatic",
  "peepmatic-test-operator",
  "souper-ir",
- "wast 29.0.0",
+ "wast 31.0.0",
 ]
 
 [[package]]
@@ -1479,7 +1479,7 @@ version = "0.69.0"
 dependencies = [
  "peepmatic-traits",
  "serde",
- "wast 29.0.0",
+ "wast 31.0.0",
 ]
 
 [[package]]
@@ -2350,20 +2350,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed89eaf99e08b84f96e477a16588a07dd3b51dc5f07291c3706782f62a10a5e1"
+checksum = "c75fa62cf1464aa6655479ae454202a159cc82b7b4d66e8f174409669c0654c5"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509904d9c4c4659ac238a3f27c3656dd6d3931697eddd4b0f32e335769c298d0"
+checksum = "0b9b9b796bf4da5eb0523b136d6f0cc9a59c16a66ece8e0d5a14a9cdccf2864e"
 dependencies = [
  "arbitrary",
+ "indexmap",
  "leb128",
  "wasm-encoder",
 ]
@@ -2394,15 +2395,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.71.0"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a30c99437829ede826802bfcf28500cf58df00e66cb9114df98813bc145ff1"
+checksum = "2cdf4d872d407f9fb44956e540582eeaf0dc4fb8142f1f0f64e2c37196bada01"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0515db67c610037f3c53ec36976edfd1eb01bac6b1226914b17ce609480e729f"
+checksum = "a0c139586e3b80b899f5aaaa3720c7a236ea9073e315292e01d099da12efacc5"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -2754,7 +2755,7 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 29.0.0",
+ "wast 31.0.0",
 ]
 
 [[package]]
@@ -2790,29 +2791,20 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "29.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf2268937131d63c3d833242bf5e075406f9ed868b4265f3280e15dac29ac18"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b79907b22f740634810e882d8d1d9d0f9563095a8ab94e786e370242bff5cd2"
+checksum = "9beb1f6b63f08c523a1e8e76fc70058af4d2a34ef1c504f56cdac7b6970228b9"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8279a02835bf12e61ed2b3c3cbc6ecf9918762fd97e036917c11a09ec20ca44"
+checksum = "2a0b3044da73d3b84a822d955afad356759b2fee454b6882722008dace80b68e"
 dependencies = [
- "wast 30.0.0",
+ "wast 31.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ anyhow = "1.0.19"
 target-lexicon = { version = "0.11.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.30"
+wat = "1.0.32"
 libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"
 humantime = "2.0.0"
-wasmparser = "0.71.0"
+wasmparser = "0.72.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -30,7 +30,7 @@ peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, versi
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.69.0" }
 regalloc = { version = "0.0.31" }
 souper-ir = { version = "2.1.0", optional = true }
-wast = { version = "29.0.0", optional = true }
+wast = { version = "31.0.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/peepmatic/Cargo.toml
+++ b/cranelift/peepmatic/Cargo.toml
@@ -15,7 +15,7 @@ peepmatic-macro = { version = "0.69.0", path = "crates/macro" }
 peepmatic-runtime = { version = "0.69.0", path = "crates/runtime", features = ["construct"] }
 peepmatic-traits = { version = "0.69.0", path = "crates/traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "29.0.0"
+wast = "31.0.0"
 z3 = { version = "0.7.1", features = ["static-link-z3"] }
 
 [dev-dependencies]

--- a/cranelift/peepmatic/crates/fuzzing/Cargo.toml
+++ b/cranelift/peepmatic/crates/fuzzing/Cargo.toml
@@ -21,4 +21,4 @@ peepmatic-test-operator = { path = "../test-operator" }
 peepmatic-traits = { path = "../traits" }
 rand = { version = "0.7.3", features = ["small_rng"] }
 serde = "1.0.106"
-wast = "29.0.0"
+wast = "31.0.0"

--- a/cranelift/peepmatic/crates/runtime/Cargo.toml
+++ b/cranelift/peepmatic/crates/runtime/Cargo.toml
@@ -16,7 +16,7 @@ peepmatic-automata = { version = "0.69.0", path = "../automata", features = ["se
 peepmatic-traits = { version = "0.69.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
 thiserror = "1.0.15"
-wast = { version = "29.0.0", optional = true }
+wast = { version = "31.0.0", optional = true }
 
 [dev-dependencies]
 peepmatic-test-operator = { version = "0.69.0", path = "../test-operator" }

--- a/cranelift/peepmatic/crates/souper/Cargo.toml
+++ b/cranelift/peepmatic/crates/souper/Cargo.toml
@@ -16,4 +16,4 @@ log = "0.4.8"
 [dev-dependencies]
 peepmatic = { path = "../..", version = "0.69.0" }
 peepmatic-test-operator = { version = "0.69.0", path = "../test-operator" }
-wast = "29.0.0"
+wast = "31.0.0"

--- a/cranelift/peepmatic/crates/test-operator/Cargo.toml
+++ b/cranelift/peepmatic/crates/test-operator/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 [dependencies]
 peepmatic-traits = { version = "0.69.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "29.0.0"
+wast = "31.0.0"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.71", default-features = false }
+wasmparser = { version = "0.72", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.69.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.69.0" }
 cranelift-frontend = { path = "../frontend", version = "0.69.0", default-features = false }

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -205,25 +205,34 @@ pub enum ReturnMode {
 
 /// An entry in the alias section of a wasm module (from the module linking
 /// proposal)
-pub enum Alias {
-    /// A parent's module is being aliased into our own index space.
-    ///
-    /// Note that the index here is in the parent's index space, not our own.
-    ParentModule(ModuleIndex),
+pub enum Alias<'a> {
+    /// An outer module's module is being aliased into our own index space.
+    OuterModule {
+        /// The number of modules above us that we're referencing.
+        relative_depth: u32,
+        /// The module index in the outer module's index space we're referencing.
+        index: ModuleIndex,
+    },
 
-    /// A parent's type is being aliased into our own index space
+    /// An outer module's type is being aliased into our own index space
     ///
-    /// Note that the index here is in the parent's index space, not our own.
-    ParentType(TypeIndex),
+    /// Note that the index here is in the outer module's index space, not our
+    /// own.
+    OuterType {
+        /// The number of modules above us that we're referencing.
+        relative_depth: u32,
+        /// The type index in the outer module's index space we're referencing.
+        index: TypeIndex,
+    },
 
     /// A previously created instance is having one of its exports aliased into
     /// our index space.
-    Child {
+    InstanceExport {
         /// The index we're aliasing.
         instance: InstanceIndex,
         /// The nth export that we're inserting into our own index space
         /// locally.
-        export: usize,
+        export: &'a str,
     },
 }
 
@@ -1014,30 +1023,15 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         drop(amount);
     }
 
-    /// Declares that a module will come later with the type signature provided.
-    fn declare_module(&mut self, ty: TypeIndex) -> WasmResult<()> {
-        drop(ty);
-        Err(WasmError::Unsupported("module linking".to_string()))
-    }
-
     /// Called at the beginning of translating a module.
     ///
-    /// The `index` argument is a monotonically increasing index which
-    /// corresponds to the nth module that's being translated. This is not the
-    /// 32-bit index in the current module's index space. For example the first
-    /// call to `module_start` will have index 0.
-    ///
     /// Note that for nested modules this may be called multiple times.
-    fn module_start(&mut self, index: usize) {
-        drop(index);
-    }
+    fn module_start(&mut self) {}
 
     /// Called at the end of translating a module.
     ///
     /// Note that for nested modules this may be called multiple times.
-    fn module_end(&mut self, index: usize) {
-        drop(index);
-    }
+    fn module_end(&mut self) {}
 
     /// Indicates that this module will have `amount` instances.
     fn reserve_instances(&mut self, amount: u32) {
@@ -1046,7 +1040,11 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
 
     /// Declares a new instance which this module will instantiate before it's
     /// instantiated.
-    fn declare_instance(&mut self, module: ModuleIndex, args: Vec<EntityIndex>) -> WasmResult<()> {
+    fn declare_instance(
+        &mut self,
+        module: ModuleIndex,
+        args: Vec<(&'data str, EntityIndex)>,
+    ) -> WasmResult<()> {
         drop((module, args));
         Err(WasmError::Unsupported("wasm instance".to_string()))
     }
@@ -1056,7 +1054,7 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
     /// The alias comes from the `instance` specified (or the parent if `None`
     /// is supplied) and the index is either in the module's own index spaces
     /// for the parent or an index into the exports for nested instances.
-    fn declare_alias(&mut self, alias: Alias) -> WasmResult<()> {
+    fn declare_alias(&mut self, alias: Alias<'data>) -> WasmResult<()> {
         drop(alias);
         Err(WasmError::Unsupported("wasm alias".to_string()))
     }

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.23.0"
-wasmparser = "0.71"
+wasmparser = "0.72"
 object = { version = "0.22.0", default-features = false, features = ["read_core", "elf", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.22.0" }
 target-lexicon = { version = "0.11.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.69.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.69.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.69.0", features = ["enable-serde"] }
-wasmparser = "0.71"
+wasmparser = "0.72"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -142,12 +142,6 @@ impl ModuleType {
 /// memory initializers.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
-    /// The parent index of this module, used for the module linking proposal.
-    ///
-    /// This index is into the list of modules returned from compilation of a
-    /// single wasm file with nested modules.
-    pub parent: Option<usize>,
-
     /// The name of this wasm module, often found in the wasm file.
     pub name: Option<String>,
 
@@ -213,25 +207,26 @@ pub struct Module {
 pub enum Initializer {
     /// An imported item is required to be provided.
     Import {
-        /// Module name of this import
-        module: String,
-        /// Optional field name of this import
+        /// Name of this import
+        name: String,
+        /// The field name projection of this import. When module-linking is
+        /// enabled this is always `None`. Otherwise this is always `Some`.
         field: Option<String>,
         /// Where this import will be placed, which also has type information
         /// about the import.
         index: EntityIndex,
     },
 
-    /// A module from the parent's declared modules is inserted into our own
+    /// An export from a previously defined instance is being inserted into our
     /// index space.
-    AliasParentModule(ModuleIndex),
-
-    /// A module from the parent's declared modules is inserted into our own
-    /// index space.
-    #[allow(missing_docs)]
+    ///
+    /// Note that when the module linking proposal is enabled two-level imports
+    /// will implicitly desugar to this initializer.
     AliasInstanceExport {
+        /// The instance that we're referencing.
         instance: InstanceIndex,
-        export: usize,
+        /// Which export is being inserted into our index space.
+        export: String,
     },
 
     /// A module is being instantiated with previously configured intializers
@@ -239,8 +234,9 @@ pub enum Initializer {
     Instantiate {
         /// The module that this instance is instantiating.
         module: ModuleIndex,
-        /// The arguments provided to instantiation.
-        args: Vec<EntityIndex>,
+        /// The arguments provided to instantiation, along with their name in
+        /// the instance being instantiated.
+        args: IndexMap<String, EntityIndex>,
     },
 
     /// A module is defined into the module index space, and which module is
@@ -351,11 +347,9 @@ impl Module {
     /// module name, field name, and type that's being imported.
     pub fn imports(&self) -> impl Iterator<Item = (&str, Option<&str>, EntityType)> {
         self.initializers.iter().filter_map(move |i| match i {
-            Initializer::Import {
-                module,
-                field,
-                index,
-            } => Some((module.as_str(), field.as_deref(), self.type_of(*index))),
+            Initializer::Import { name, field, index } => {
+                Some((name.as_str(), field.as_deref(), self.type_of(*index)))
+            }
             _ => None,
         })
     }
@@ -389,16 +383,16 @@ pub struct TypeTables {
 /// The type signature of known modules.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleSignature {
-    /// All imports in this module, listed in order with their module/name and
+    /// All imports in this module, listed in order with their name and
     /// what type they're importing.
-    pub imports: Vec<(String, Option<String>, EntityType)>,
+    pub imports: IndexMap<String, EntityType>,
     /// Exports are what an instance type conveys, so we go through an
     /// indirection over there.
     pub exports: InstanceTypeIndex,
 }
 
 /// The type signature of known instances.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct InstanceSignature {
     /// The name of what's being exported as well as its type signature.
     pub exports: IndexMap<String, EntityType>,

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,12 +13,12 @@ arbitrary = { version = "0.4.1", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.71"
+wasmparser = "0.72"
 wasmprinter = "0.2.17"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
-wasm-encoder = "0.2"
-wasm-smith = "0.3.0"
+wasm-encoder = "0.4"
+wasm-smith = "0.3.1"
 wasmi = "0.7.0"
 
 [dev-dependencies]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -28,7 +28,7 @@ rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.71"
+wasmparser = "0.72"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "1.0"

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -105,8 +105,8 @@ impl CompilationArtifacts {
     pub fn build(
         compiler: &Compiler,
         data: &[u8],
-    ) -> Result<(Vec<CompilationArtifacts>, TypeTables), SetupError> {
-        let (translations, types) = ModuleEnvironment::new(
+    ) -> Result<(usize, Vec<CompilationArtifacts>, TypeTables), SetupError> {
+        let (main_module, translations, types) = ModuleEnvironment::new(
             compiler.frontend_config(),
             compiler.tunables(),
             compiler.features(),
@@ -166,6 +166,7 @@ impl CompilationArtifacts {
             })
             .collect::<Result<Vec<_>, SetupError>>()?;
         Ok((
+            main_module,
             list,
             TypeTables {
                 wasm_signatures: types.wasm_signatures,

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ more-asserts = "0.2.1"
 smallvec = "1.6.1"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.71"
+wasmparser = "0.72"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 lightbeam = { path = "..", version = "0.22.0" }
-wasmparser = "0.71"
+wasmparser = "0.72"
 cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.69.0" }
 wasmtime-environ = { path = "../../environ", version = "0.22.0" }

--- a/crates/runtime/src/export.rs
+++ b/crates/runtime/src/export.rs
@@ -1,14 +1,14 @@
 use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
 };
-use crate::InstanceHandle;
+use crate::RuntimeInstance;
 use std::any::Any;
 use std::ptr::NonNull;
 use wasmtime_environ::wasm::Global;
 use wasmtime_environ::{MemoryPlan, TablePlan};
 
 /// The value of an export passed from one instance to another.
-pub enum Export<'a> {
+pub enum Export {
     /// A function export value.
     Function(ExportFunction),
 
@@ -22,10 +22,10 @@ pub enum Export<'a> {
     Global(ExportGlobal),
 
     /// An instance
-    Instance(&'a InstanceHandle),
+    Instance(RuntimeInstance),
 
     /// A module
-    Module(&'a dyn Any),
+    Module(Box<dyn Any>),
 }
 
 /// A function export value.
@@ -38,8 +38,8 @@ pub struct ExportFunction {
     pub anyfunc: NonNull<VMCallerCheckedAnyfunc>,
 }
 
-impl<'a> From<ExportFunction> for Export<'a> {
-    fn from(func: ExportFunction) -> Export<'a> {
+impl From<ExportFunction> for Export {
+    fn from(func: ExportFunction) -> Export {
         Export::Function(func)
     }
 }
@@ -55,8 +55,8 @@ pub struct ExportTable {
     pub table: TablePlan,
 }
 
-impl<'a> From<ExportTable> for Export<'a> {
-    fn from(func: ExportTable) -> Export<'a> {
+impl From<ExportTable> for Export {
+    fn from(func: ExportTable) -> Export {
         Export::Table(func)
     }
 }
@@ -72,8 +72,8 @@ pub struct ExportMemory {
     pub memory: MemoryPlan,
 }
 
-impl<'a> From<ExportMemory> for Export<'a> {
-    fn from(func: ExportMemory) -> Export<'a> {
+impl From<ExportMemory> for Export {
+    fn from(func: ExportMemory) -> Export {
         Export::Memory(func)
     }
 }
@@ -89,8 +89,8 @@ pub struct ExportGlobal {
     pub global: Global,
 }
 
-impl<'a> From<ExportGlobal> for Export<'a> {
-    fn from(func: ExportGlobal) -> Export<'a> {
+impl From<ExportGlobal> for Export {
+    fn from(func: ExportGlobal) -> Export {
         Export::Global(func)
     }
 }

--- a/crates/runtime/src/imports.rs
+++ b/crates/runtime/src/imports.rs
@@ -1,8 +1,4 @@
 use crate::vmcontext::{VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport};
-use crate::InstanceHandle;
-use std::any::Any;
-use wasmtime_environ::entity::PrimaryMap;
-use wasmtime_environ::wasm::{InstanceIndex, ModuleIndex};
 
 /// Resolved import pointers.
 ///
@@ -28,15 +24,4 @@ pub struct Imports<'a> {
 
     /// Resolved addresses for imported globals.
     pub globals: &'a [VMGlobalImport],
-
-    /// Resolved imported instances.
-    pub instances: PrimaryMap<InstanceIndex, InstanceHandle>,
-
-    /// Resolved imported modules.
-    ///
-    /// Note that `Box<Any>` here is chosen to allow the embedder of this crate
-    /// to pick an appropriate representation of what module type should be. For
-    /// example for the `wasmtime` crate it's `wasmtime::Module` but that's not
-    /// defined way down here in this low crate.
-    pub modules: PrimaryMap<ModuleIndex, Box<dyn Any>>,
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub mod libcalls;
 pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
-pub use crate::instance::{InstanceHandle, InstantiationError, LinkError};
+pub use crate::instance::{InstanceHandle, InstantiationError, LinkError, RuntimeInstance};
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -16,7 +16,7 @@ wasmtime-jit = { path = "../jit", version = "0.22.0" }
 wasmtime-cache = { path = "../cache", version = "0.22.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.22.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.71"
+wasmparser = "0.72"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -371,8 +371,8 @@ impl Func {
     ///
     /// Finally you can also optionally take [`Caller`] as the first argument of
     /// your closure. If inserted then you're able to inspect the caller's
-    /// state, for example the [`Memory`] it has exported so you can read what
-    /// pointers point to.
+    /// state, for example the [`Memory`](crate::Memory) it has exported so you
+    /// can read what pointers point to.
     ///
     /// Note that when using this API, the intention is to create as thin of a
     /// layer as possible for when WebAssembly calls the function provided. With

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -308,7 +308,7 @@ impl Instance {
             bail!("cross-`Engine` instantiation is not currently supported");
         }
 
-        // Perform some pre-flight checks before we geet into the meat of
+        // Perform some pre-flight checks before we get into the meat of
         // instantiation.
         let expected = module.compiled_module().module().imports().count();
         if expected != imports.len() {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -245,12 +245,14 @@ impl Module {
     /// ```
     pub fn from_binary(engine: &Engine, binary: &[u8]) -> Result<Module> {
         #[cfg(feature = "cache")]
-        let (artifacts, types) = ModuleCacheEntry::new("wasmtime", engine.cache_config())
-            .get_data((engine.compiler(), binary), |(compiler, binary)| {
-                CompilationArtifacts::build(compiler, binary)
-            })?;
+        let (main_module, artifacts, types) =
+            ModuleCacheEntry::new("wasmtime", engine.cache_config())
+                .get_data((engine.compiler(), binary), |(compiler, binary)| {
+                    CompilationArtifacts::build(compiler, binary)
+                })?;
         #[cfg(not(feature = "cache"))]
-        let (artifacts, types) = CompilationArtifacts::build(engine.compiler(), binary)?;
+        let (main_module, artifacts, types) =
+            CompilationArtifacts::build(engine.compiler(), binary)?;
 
         let modules = CompiledModule::from_artifacts_list(
             artifacts,
@@ -261,7 +263,7 @@ impl Module {
         let types = Arc::new(types);
         Ok(Module {
             engine: engine.clone(),
-            index: 0,
+            index: main_module,
             data: Arc::new(ModuleData { types, modules }),
         })
     }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use wasmtime_environ::wasm;
 use wasmtime_jit::{CompiledModule, ModuleCode, TypeTables};
 use wasmtime_runtime::{
-    InstanceHandle, RuntimeMemoryCreator, SignalHandler, StackMapRegistry, TrapInfo, VMExternRef,
-    VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex,
+    InstanceHandle, RuntimeMemoryCreator, SignalHandler, StackMapRegistry, TrapInfo, VMContext,
+    VMExternRef, VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex,
 };
 
 /// A `Store` is a collection of WebAssembly instances and host-defined items.
@@ -232,6 +232,10 @@ impl Store {
             store: self.clone(),
             handle,
         }
+    }
+
+    pub(crate) unsafe fn existing_vmctx(&self, cx: *mut VMContext) -> StoreInstanceHandle {
+        self.existing_instance_handle(InstanceHandle::from_vmctx(cx))
     }
 
     pub(crate) fn weak(&self) -> Weak<StoreInner> {

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -48,7 +48,7 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
                 module
                     .initializers
                     .push(wasmtime_environ::Initializer::Import {
-                        module: "".into(),
+                        name: "".into(),
                         field: None,
                         index: wasm::EntityIndex::Function(func_index),
                     });
@@ -80,7 +80,7 @@ pub fn create_global(store: &Store, gt: &GlobalType, val: Val) -> Result<StoreIn
     )?;
 
     if let Some(x) = externref_init {
-        match handle.lookup("").unwrap() {
+        match handle.lookup_by_declaration(&wasm::EntityIndex::Global(global_id)) {
             wasmtime_runtime::Export::Global(g) => unsafe {
                 *(*g.definition).as_externref_mut() = Some(x.inner);
             },

--- a/crates/wasmtime/src/trampoline/mod.rs
+++ b/crates/wasmtime/src/trampoline/mod.rs
@@ -16,6 +16,7 @@ use crate::{FuncType, GlobalType, MemoryType, Store, TableType, Trap, Val};
 use anyhow::Result;
 use std::any::Any;
 use std::ops::Deref;
+use wasmtime_environ::wasm;
 use wasmtime_runtime::{InstanceHandle, VMContext, VMFunctionBody, VMTrampoline};
 
 /// A wrapper around `wasmtime_runtime::InstanceHandle` which pairs it with the
@@ -55,7 +56,8 @@ pub fn generate_func_export(
     VMTrampoline,
 )> {
     let (instance, trampoline) = create_handle_with_function(ft, func, store)?;
-    match instance.lookup("").expect("trampoline export") {
+    let idx = wasm::EntityIndex::Function(wasm::FuncIndex::from_u32(0));
+    match instance.lookup_by_declaration(&idx) {
         wasmtime_runtime::Export::Function(f) => Ok((instance, f, trampoline)),
         _ => unreachable!(),
     }
@@ -72,7 +74,8 @@ pub unsafe fn generate_raw_func_export(
     state: Box<dyn Any>,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportFunction)> {
     let instance = func::create_handle_with_raw_function(ft, func, trampoline, store, state)?;
-    match instance.lookup("").expect("trampoline export") {
+    let idx = wasm::EntityIndex::Function(wasm::FuncIndex::from_u32(0));
+    match instance.lookup_by_declaration(&idx) {
         wasmtime_runtime::Export::Function(f) => Ok((instance, f)),
         _ => unreachable!(),
     }
@@ -84,7 +87,8 @@ pub fn generate_global_export(
     val: Val,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportGlobal)> {
     let instance = create_global(store, gt, val)?;
-    match instance.lookup("").expect("global export") {
+    let idx = wasm::EntityIndex::Global(wasm::GlobalIndex::from_u32(0));
+    match instance.lookup_by_declaration(&idx) {
         wasmtime_runtime::Export::Global(g) => Ok((instance, g)),
         _ => unreachable!(),
     }
@@ -95,7 +99,8 @@ pub fn generate_memory_export(
     m: &MemoryType,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportMemory)> {
     let instance = create_handle_with_memory(store, m)?;
-    match instance.lookup("").expect("memory export") {
+    let idx = wasm::EntityIndex::Memory(wasm::MemoryIndex::from_u32(0));
+    match instance.lookup_by_declaration(&idx) {
         wasmtime_runtime::Export::Memory(m) => Ok((instance, m)),
         _ => unreachable!(),
     }
@@ -106,7 +111,8 @@ pub fn generate_table_export(
     t: &TableType,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportTable)> {
     let instance = create_handle_with_table(store, t)?;
-    match instance.lookup("").expect("table export") {
+    let idx = wasm::EntityIndex::Table(wasm::TableIndex::from_u32(0));
+    match instance.lookup_by_declaration(&idx) {
         wasmtime_runtime::Export::Table(t) => Ok((instance, t)),
         _ => unreachable!(),
     }

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -23,6 +23,7 @@ pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<Stor
 
     let table_plan = wasmtime_environ::TablePlan::for_table(table, &tunable);
     let table_id = module.table_plans.push(table_plan);
+    // TODO: can this `exports.insert` get removed?
     module
         .exports
         .insert(String::new(), wasm::EntityIndex::Table(table_id));

--- a/crates/wasmtime/src/types/matching.rs
+++ b/crates/wasmtime/src/types/matching.rs
@@ -1,5 +1,5 @@
-use crate::Store;
-use std::sync::Arc;
+use crate::{Extern, Store};
+use anyhow::{bail, Context, Result};
 use wasmtime_environ::wasm::{
     EntityType, Global, InstanceTypeIndex, Memory, ModuleTypeIndex, SignatureIndex, Table,
 };
@@ -11,22 +11,27 @@ pub struct MatchCx<'a> {
 }
 
 impl MatchCx<'_> {
-    pub fn global(&self, expected: &Global, actual: &crate::Global) -> bool {
+    pub fn global(&self, expected: &Global, actual: &crate::Global) -> Result<()> {
         self.global_ty(expected, actual.wasmtime_ty())
     }
 
-    fn global_ty(&self, expected: &Global, actual: &Global) -> bool {
-        expected.ty == actual.ty
+    fn global_ty(&self, expected: &Global, actual: &Global) -> Result<()> {
+        if expected.ty == actual.ty
             && expected.wasm_ty == actual.wasm_ty
             && expected.mutability == actual.mutability
+        {
+            Ok(())
+        } else {
+            bail!("global types incompatible")
+        }
     }
 
-    pub fn table(&self, expected: &Table, actual: &crate::Table) -> bool {
+    pub fn table(&self, expected: &Table, actual: &crate::Table) -> Result<()> {
         self.table_ty(expected, actual.wasmtime_ty())
     }
 
-    fn table_ty(&self, expected: &Table, actual: &Table) -> bool {
-        expected.wasm_ty == actual.wasm_ty
+    fn table_ty(&self, expected: &Table, actual: &Table) -> Result<()> {
+        if expected.wasm_ty == actual.wasm_ty
             && expected.ty == actual.ty
             && expected.minimum <= actual.minimum
             && match expected.maximum {
@@ -36,14 +41,19 @@ impl MatchCx<'_> {
                 },
                 None => true,
             }
+        {
+            Ok(())
+        } else {
+            bail!("table types incompatible")
+        }
     }
 
-    pub fn memory(&self, expected: &Memory, actual: &crate::Memory) -> bool {
+    pub fn memory(&self, expected: &Memory, actual: &crate::Memory) -> Result<()> {
         self.memory_ty(expected, actual.wasmtime_ty())
     }
 
-    fn memory_ty(&self, expected: &Memory, actual: &Memory) -> bool {
-        expected.shared == actual.shared
+    fn memory_ty(&self, expected: &Memory, actual: &Memory) -> Result<()> {
+        if expected.shared == actual.shared
             && expected.minimum <= actual.minimum
             && match expected.maximum {
                 Some(expected) => match actual.maximum {
@@ -52,10 +62,15 @@ impl MatchCx<'_> {
                 },
                 None => true,
             }
+        {
+            Ok(())
+        } else {
+            bail!("memory types incompatible")
+        }
     }
 
-    pub fn func(&self, expected: SignatureIndex, actual: &crate::Func) -> bool {
-        match self
+    pub fn func(&self, expected: SignatureIndex, actual: &crate::Func) -> Result<()> {
+        let matches = match self
             .store
             .signatures()
             .borrow()
@@ -65,31 +80,50 @@ impl MatchCx<'_> {
             // If our expected signature isn't registered, then there's no way
             // that `actual` can match it.
             None => false,
+        };
+        if matches {
+            Ok(())
+        } else {
+            bail!("function types incompatible")
         }
     }
 
-    pub fn instance(&self, expected: InstanceTypeIndex, actual: &crate::Instance) -> bool {
-        let module = actual.handle.module();
-        self.exports_match(
-            expected,
-            actual
-                .handle
-                .host_state()
-                .downcast_ref::<Arc<TypeTables>>()
-                .unwrap(),
-            |name| module.exports.get(name).map(|idx| module.type_of(*idx)),
-        )
+    pub fn instance(&self, expected: InstanceTypeIndex, actual: &crate::Instance) -> Result<()> {
+        for (name, expected) in self.types.instance_signatures[expected].exports.iter() {
+            match actual.items.get(name) {
+                Some(item) => {
+                    let item = unsafe { Extern::from_wasmtime_export(item, self.store) };
+                    self.extern_(expected, &item)
+                        .with_context(|| format!("instance export {:?} incompatible", name))?;
+                }
+                None => bail!("instance type missing export {:?}", name),
+            }
+        }
+        Ok(())
     }
 
     /// Validates that the type signature of `actual` matches the `expected`
     /// module type signature.
-    pub fn module(&self, expected: ModuleTypeIndex, actual: &crate::Module) -> bool {
+    pub fn module(&self, expected: ModuleTypeIndex, actual: &crate::Module) -> Result<()> {
+        // This should only ever be invoked with module linking, and this is an
+        // early check that our `field` assertion below should always work as
+        // well.
+        assert!(self.store.engine().config().features.module_linking);
+
         let expected_sig = &self.types.module_signatures[expected];
         let module = actual.compiled_module().module();
-        self.imports_match(expected, actual.types(), module.imports())
-            && self.exports_match(expected_sig.exports, actual.types(), |name| {
-                module.exports.get(name).map(|idx| module.type_of(*idx))
-            })
+        self.imports_match(
+            expected,
+            actual.types(),
+            module.imports().map(|(name, field, ty)| {
+                assert!(field.is_none()); // should be true if module linking is enabled
+                (name, ty)
+            }),
+        )?;
+        self.exports_match(expected_sig.exports, actual.types(), |name| {
+            module.exports.get(name).map(|idx| module.type_of(*idx))
+        })?;
+        Ok(())
     }
 
     /// Validates that the `actual_imports` list of module imports matches the
@@ -100,19 +134,25 @@ impl MatchCx<'_> {
         &self,
         expected: ModuleTypeIndex,
         actual_types: &TypeTables,
-        mut actual_imports: impl Iterator<Item = (&'a str, Option<&'a str>, EntityType)>,
-    ) -> bool {
+        actual_imports: impl Iterator<Item = (&'a str, EntityType)>,
+    ) -> Result<()> {
+        // Imports match if all of the actual imports are satisfied by the
+        // expected set of imports. Note that we're reversing the order of the
+        // subtytpe matching here too.
         let expected_sig = &self.types.module_signatures[expected];
-        for (_, _, expected) in expected_sig.imports.iter() {
-            let (_, _, ty) = match actual_imports.next() {
-                Some(e) => e,
-                None => return false,
+        for (name, actual_ty) in actual_imports {
+            let expected_ty = match expected_sig.imports.get(name) {
+                Some(ty) => ty,
+                None => bail!("expected type doesn't import {:?}", name),
             };
-            if !self.extern_ty_matches(expected, &ty, actual_types) {
-                return false;
+            MatchCx {
+                types: actual_types,
+                store: self.store,
             }
+            .extern_ty_matches(&actual_ty, expected_ty, self.types)
+            .with_context(|| format!("module import {:?} incompatible", name))?;
         }
-        actual_imports.next().is_none()
+        Ok(())
     }
 
     /// Validates that all exports in `expected` are defined by `lookup` within
@@ -122,16 +162,19 @@ impl MatchCx<'_> {
         expected: InstanceTypeIndex,
         actual_types: &TypeTables,
         lookup: impl Fn(&str) -> Option<EntityType>,
-    ) -> bool {
+    ) -> Result<()> {
         // The `expected` type must be a subset of `actual`, meaning that all
         // names in `expected` must be present in `actual`. Note that we do
         // name-based lookup here instead of index-based lookup.
-        self.types.instance_signatures[expected].exports.iter().all(
-            |(name, expected)| match lookup(name) {
-                Some(ty) => self.extern_ty_matches(expected, &ty, actual_types),
-                None => false,
-            },
-        )
+        for (name, expected) in self.types.instance_signatures[expected].exports.iter() {
+            match lookup(name) {
+                Some(ty) => self
+                    .extern_ty_matches(expected, &ty, actual_types)
+                    .with_context(|| format!("export {:?} incompatible", name))?,
+                None => bail!("failed to find export {:?}", name),
+            }
+        }
+        Ok(())
     }
 
     /// Validates that the `expected` entity matches the `actual_ty` defined
@@ -141,34 +184,49 @@ impl MatchCx<'_> {
         expected: &EntityType,
         actual_ty: &EntityType,
         actual_types: &TypeTables,
-    ) -> bool {
+    ) -> Result<()> {
+        let actual_desc = match actual_ty {
+            EntityType::Global(_) => "global",
+            EntityType::Module(_) => "module",
+            EntityType::Memory(_) => "memory",
+            EntityType::Event(_) => "event",
+            EntityType::Instance(_) => "instance",
+            EntityType::Table(_) => "table",
+            EntityType::Function(_) => "function",
+        };
         match expected {
             EntityType::Global(expected) => match actual_ty {
                 EntityType::Global(actual) => self.global_ty(expected, actual),
-                _ => false,
+                _ => bail!("expected global, but found {}", actual_desc),
             },
             EntityType::Table(expected) => match actual_ty {
                 EntityType::Table(actual) => self.table_ty(expected, actual),
-                _ => false,
+                _ => bail!("expected table, but found {}", actual_desc),
             },
             EntityType::Memory(expected) => match actual_ty {
                 EntityType::Memory(actual) => self.memory_ty(expected, actual),
-                _ => false,
+                _ => bail!("expected memory, but found {}", actual_desc),
             },
             EntityType::Function(expected) => match *actual_ty {
                 EntityType::Function(actual) => {
-                    self.types.wasm_signatures[*expected] == actual_types.wasm_signatures[actual]
+                    if self.types.wasm_signatures[*expected] == actual_types.wasm_signatures[actual]
+                    {
+                        Ok(())
+                    } else {
+                        bail!("function types incompatible")
+                    }
                 }
-                _ => false,
+                _ => bail!("expected function, but found {}", actual_desc),
             },
             EntityType::Instance(expected) => match actual_ty {
                 EntityType::Instance(actual) => {
                     let sig = &actual_types.instance_signatures[*actual];
                     self.exports_match(*expected, actual_types, |name| {
                         sig.exports.get(name).cloned()
-                    })
+                    })?;
+                    Ok(())
                 }
-                _ => false,
+                _ => bail!("expected instance, but found {}", actual_desc),
             },
             EntityType::Module(expected) => match actual_ty {
                 EntityType::Module(actual) => {
@@ -180,14 +238,48 @@ impl MatchCx<'_> {
                     self.imports_match(
                         *expected,
                         actual_types,
-                        actual_module_sig.imports.iter().map(|(module, field, ty)| {
-                            (module.as_str(), field.as_deref(), ty.clone())
-                        }),
-                    ) && self.exports_match(expected_module_sig.exports, actual_types, |name| {
+                        actual_module_sig
+                            .imports
+                            .iter()
+                            .map(|(module, ty)| (module.as_str(), ty.clone())),
+                    )?;
+                    self.exports_match(expected_module_sig.exports, actual_types, |name| {
                         actual_instance_sig.exports.get(name).cloned()
-                    })
+                    })?;
+                    Ok(())
                 }
-                _ => false,
+                _ => bail!("expected module, but found {}", actual_desc),
+            },
+            EntityType::Event(_) => unimplemented!(),
+        }
+    }
+
+    /// Validates that the `expected` type matches the type of `actual`
+    pub fn extern_(&self, expected: &EntityType, actual: &Extern) -> Result<()> {
+        match expected {
+            EntityType::Global(expected) => match actual {
+                Extern::Global(actual) => self.global(expected, actual),
+                _ => bail!("expected global, but found {}", actual.desc()),
+            },
+            EntityType::Table(expected) => match actual {
+                Extern::Table(actual) => self.table(expected, actual),
+                _ => bail!("expected table, but found {}", actual.desc()),
+            },
+            EntityType::Memory(expected) => match actual {
+                Extern::Memory(actual) => self.memory(expected, actual),
+                _ => bail!("expected memory, but found {}", actual.desc()),
+            },
+            EntityType::Function(expected) => match actual {
+                Extern::Func(actual) => self.func(*expected, actual),
+                _ => bail!("expected func, but found {}", actual.desc()),
+            },
+            EntityType::Instance(expected) => match actual {
+                Extern::Instance(actual) => self.instance(*expected, actual),
+                _ => bail!("expected instance, but found {}", actual.desc()),
+            },
+            EntityType::Module(expected) => match actual {
+                Extern::Module(actual) => self.module(*expected, actual),
+                _ => bail!("expected module, but found {}", actual.desc()),
             },
             EntityType::Event(_) => unimplemented!(),
         }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.22.0", default-features = false }
-wast = "29.0.0"
+wast = "31.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ target-lexicon = "0.11"
 peepmatic-fuzzing = { path = "../cranelift/peepmatic/crates/fuzzing", optional = true }
 wasmtime = { path = "../crates/wasmtime" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }
-wasm-smith = "0.3.0"
+wasm-smith = "0.3.1"
 
 [features]
 experimental_x64 = ["wasmtime-fuzzing/experimental_x64"]

--- a/fuzz/fuzz_targets/instantiate-swarm.rs
+++ b/fuzz/fuzz_targets/instantiate-swarm.rs
@@ -2,12 +2,13 @@
 
 use libfuzzer_sys::fuzz_target;
 use std::time::Duration;
-use wasm_smith::{ConfiguredModule, SwarmConfig};
+use wasm_smith::{Config, ConfiguredModule, SwarmConfig};
 use wasmtime::Strategy;
 use wasmtime_fuzzing::oracles;
 
 fuzz_target!(|module: ConfiguredModule<SwarmConfig>| {
     let mut cfg = wasmtime_fuzzing::fuzz_default_config(Strategy::Auto).unwrap();
     cfg.wasm_multi_memory(true);
+    cfg.wasm_module_linking(module.config().module_linking_enabled());
     oracles::instantiate_with_config(&module.to_bytes(), true, cfg, Some(Duration::from_secs(20)));
 });

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -65,7 +65,7 @@ pub fn compile_to_obj(
     );
 
     let environ = ModuleEnvironment::new(compiler.isa().frontend_config(), &tunables, &features);
-    let (mut translation, types) = environ
+    let (_main_module, mut translation, types) = environ
         .translate(wasm)
         .context("failed to translate module")?;
     assert_eq!(translation.len(), 1);

--- a/tests/all/module_linking.rs
+++ b/tests/all/module_linking.rs
@@ -105,8 +105,13 @@ fn imports_exports() -> Result<()> {
     assert_eq!(i.len(), 1);
     let import = i.next().unwrap();
     assert_eq!(import.module(), "");
-    assert_eq!(import.name(), Some("a"));
-    let module_ty = match import.ty() {
+    assert_eq!(import.name(), None);
+    let instance_ty = match import.ty() {
+        ExternType::Instance(t) => t,
+        _ => panic!("unexpected type"),
+    };
+    assert_eq!(instance_ty.exports().len(), 1);
+    let module_ty = match instance_ty.exports().next().unwrap().ty() {
         ExternType::Module(m) => m,
         _ => panic!("unexpected type"),
     };
@@ -148,8 +153,13 @@ fn imports_exports() -> Result<()> {
     assert_eq!(i.len(), 1);
     let import = i.next().unwrap();
     assert_eq!(import.module(), "");
-    assert_eq!(import.name(), Some("b"));
+    assert_eq!(import.name(), None);
     let instance_ty = match import.ty() {
+        ExternType::Instance(t) => t,
+        _ => panic!("unexpected type"),
+    };
+    assert_eq!(instance_ty.exports().len(), 1);
+    let instance_ty = match instance_ty.exports().next().unwrap().ty() {
         ExternType::Instance(m) => m,
         _ => panic!("unexpected type"),
     };

--- a/tests/misc_testsuite/module-linking/import-subtyping.wast
+++ b/tests/misc_testsuite/module-linking/import-subtyping.wast
@@ -9,22 +9,36 @@
 
 (module
   (import "a" "m" (module))
+)
+(module
   (import "a" "m" (module (export "" (func))))
+)
+(module
   (import "a" "m" (module (export "a" (func))))
+)
+(module
   (import "a" "m" (module (export "b" (global i32))))
+)
+(module
   (import "a" "m" (module
     (export "" (func))
     (export "a" (func))
   ))
+)
+(module
   (import "a" "m" (module
     (export "a" (func))
     (export "" (func))
   ))
+)
+(module
   (import "a" "m" (module
     (export "a" (func))
     (export "" (func))
     (export "b" (global i32))
   ))
+)
+(module
   (import "a" "m" (module
     (export "b" (global i32))
     (export "a" (func))
@@ -37,64 +51,60 @@
   (module (export "m")
     (func (export ""))))
 
-(module
-  (import "a" "m" (module))
-  (import "a" "m" (module (export "" (func))))
-)
+(module (import "a" "m" (module)))
+(module (import "a" "m" (module (export "" (func)))))
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (func (param i32))))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (func (result i32))))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (global i32)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (table 1 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 1)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (module)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (instance)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 
 (module $a
   (module (export "m")
     (global (export "") i32 (i32.const 0))))
 
 ;; globals
-(module
-  (import "a" "m" (module))
-  (import "a" "m" (module (export "" (global i32))))
-)
+(module (import "a" "m" (module)))
+(module (import "a" "m" (module (export "" (global i32)))))
 (assert_unlinkable
   (module
     (import "a" "m" (module (export "" (global (mut i32)))))
   )
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (global f32)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (func)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (table 1 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 1)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (module)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (instance)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 
 ;; tables
 (module $a
@@ -105,40 +115,52 @@
 )
 (module
   (import "a" "m" (module))
+)
+(module
   (import "a" "m" (module (export "" (table 1 funcref))))
+)
+(module
   (import "a" "m" (module (export "" (table 0 funcref))))
+)
+(module
   (import "a" "m" (module (export "max" (table 1 10 funcref))))
+)
+(module
   (import "a" "m" (module (export "max" (table 0 10 funcref))))
+)
+(module
   (import "a" "m" (module (export "max" (table 0 11 funcref))))
+)
+(module
   (import "a" "m" (module (export "max" (table 0 funcref))))
 )
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (global f32)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (func)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (table 2 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (table 1 10 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "max" (table 2 10 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "max" (table 1 9 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 1)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (module)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (instance)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 
 ;; memories
 (module $a
@@ -149,40 +171,52 @@
 )
 (module
   (import "a" "m" (module))
+)
+(module
   (import "a" "m" (module (export "" (memory 1))))
+)
+(module
   (import "a" "m" (module (export "" (memory 0))))
+)
+(module
   (import "a" "m" (module (export "max" (memory 1 10))))
+)
+(module
   (import "a" "m" (module (export "max" (memory 0 10))))
+)
+(module
   (import "a" "m" (module (export "max" (memory 0 11))))
+)
+(module
   (import "a" "m" (module (export "max" (memory 0))))
 )
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (global f32)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (func)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (table 1 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 2)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 1 10)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "max" (memory 2 10)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "max" (memory 2)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (module)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (instance)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 
 ;; modules
 (module $a
@@ -206,72 +240,102 @@
     )
     ;; import a mixture
     (module (export "e")
-      (import "" (func))
-      (import "" (func))
-      (import "" (global i32))
+      (import "a" (func))
+      (import "b" (func))
+      (import "c" (global i32))
     )
   )
 )
 (module
   (import "a" "m" (module))
+)
+(module
   (import "a" "m" (module (export "a" (module))))
+)
+(module
   (import "a" "m" (module (export "b" (module))))
+)
+(module
   (import "a" "m" (module (export "b" (module (export "" (func))))))
+)
+(module
   (import "a" "m" (module (export "c" (module))))
+)
+(module
   (import "a" "m" (module (export "c" (module
     (export "a" (func))
   ))))
+)
+(module
   (import "a" "m" (module (export "c" (module
     (export "a" (func))
     (export "b" (func (result i32)))
   ))))
+)
+(module
   (import "a" "m" (module (export "c" (module
     (export "c" (global i32))
   ))))
+)
+(module
   (import "a" "m" (module (export "c" (module
     (export "c" (global i32))
     (export "a" (func))
   ))))
-
-  ;; for now import strings aren't matched at all, imports must simply pairwise
-  ;; line up
-  (import "a" "m" (module (export "d" (module (import "" (func))))))
-  (import "a" "m" (module (export "d" (module (import "x" (func))))))
-  (import "a" "m" (module (export "d" (module (import "x" "y" (func))))))
-
-  (import "a" "m" (module (export "e" (module
-    (import "x" "y" (func))
+)
+(module
+  (import "a" "m" (module (export "d" (module
+    (import "" (func))
     (import "a" (func))
-    (import "z" (global i32))
+  ))))
+)
+(module
+  (import "a" "m" (module (export "d" (module (import "" (func))))))
+)
+(assert_unlinkable
+  (module
+    (import "a" "m" (module (export "d" (module (import "x" (func))))))
+  )
+  "incompatible import type for `a`")
+(assert_unlinkable
+  (module
+    (import "a" "m" (module (export "d" (module (import "x" "y" (func))))))
+  )
+  "incompatible import type for `a`")
+(module
+  (import "a" "m" (module (export "e" (module
+    (import "a" (func))
+    (import "b" (func))
+    (import "c" (global i32))
   ))))
 )
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (module (export "a" (func)))))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "d" (module)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "d" (module (import "" (module)))))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (global f32)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (func)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (table 1 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 2)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (module (export "foo" (func)))))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (instance)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 
 ;; instances
 (module $a
@@ -303,46 +367,65 @@
 )
 (module
   (import "a" "a" (instance))
+)
+(module
   (import "a" "b" (instance))
+)
+(module
   (import "a" "b" (instance (export "" (func))))
+)
+(module
   (import "a" "c" (instance))
+)
+(module
   (import "a" "c" (instance (export "a" (func))))
+)
+(module
   (import "a" "c" (instance (export "b" (func (result i32)))))
+)
+(module
   (import "a" "c" (instance (export "c" (global i32))))
+)
+(module
   (import "a" "c" (instance
     (export "a" (func))
     (export "b" (func (result i32)))
     (export "c" (global i32))
   ))
+)
+(module
   (import "a" "c" (instance
     (export "c" (global i32))
     (export "a" (func))
   ))
-
+)
+(module
   (import "a" "m" (module (export "i" (instance))))
+)
+(module
   (import "a" "m" (module (export "i" (instance (export "" (func))))))
 )
 (assert_unlinkable
   (module (import "a" "a" (instance (export "" (global f32)))))
-  "instance types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "i" (instance (export "x" (func)))))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (func)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (table 1 funcref)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 2)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (memory 1 10)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "max" (memory 2 10)))))
-  "module types incompatible")
+  "incompatible import type for `a`")
 (assert_unlinkable
   (module (import "a" "m" (module (export "" (module)))))
-  "module types incompatible")
+  "incompatible import type for `a`")


### PR DESCRIPTION
This commit updates the various tooling used by wasmtime which has new
updates to the module linking proposal. This is done primarily to sync
with WebAssembly/module-linking#26. The main change implemented here is
that wasmtime now supports creating instances from a set of values, nott
just from instantiating a module. Additionally subtyping handling of
modules with respect to imports is now properly handled by desugaring
two-level imports to imports of instances.

A number of small refactorings are included here as well, but most of
them are in accordance with the changes to `wasmparser` and the updated
binary format for module linking.

