### PR TITLE
Bugfix of issue #2575

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,9 +1115,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 wasmtime-environ = { path = "../environ", version = "0.22.0" }
 region = "2.1.0"
-libc = { version = "0.2.70", default-features = false }
+libc = { version = "0.2.82", default-features = false }
 log = "0.4.8"
 memoffset = "0.6.0"
 indexmap = "1.0.2"

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -164,9 +164,15 @@ cfg_if::cfg_if! {
                 } else if #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))] {
                     let cx = &*(cx as *const libc::ucontext_t);
                     cx.uc_mcontext.pc as *const u8
-                } else if #[cfg(target_os = "macos")] {
+                } else if #[cfg(all(target_os = "macos", target_arch = "x86_64"))] {
                     let cx = &*(cx as *const libc::ucontext_t);
                     (*cx.uc_mcontext).__ss.__rip as *const u8
+                } else if #[cfg(all(target_os = "macos", target_arch = "x86"))] {
+                    let cx = &*(cx as *const libc::ucontext_t);
+                    (*cx.uc_mcontext).__ss.__eip as *const u8
+                } else if #[cfg(all(target_os = "macos", target_arch = "aarch64"))] {
+                    let cx = &*(cx as *const libc::ucontext_t);
+                    (*cx.uc_mcontext).__ss.__pc as *const u8
                 } else if #[cfg(all(target_os = "freebsd", target_arch = "x86_64"))] {
                     let cx = &*(cx as *const libc::ucontext_t);
                     cx.uc_mcontext.mc_rip as *const u8


### PR DESCRIPTION
Bugfix of issue #2575.

Use libc 0.2.82 on aarch64-apple-darwin Apple Silicon platform, and local test with MacBook M1 passes.


- [x] This has been discussed in issue #2575 
- [x] Added aarch64 support for macos 