### PR TITLE
module-linking: Implement outer module aliases

### DIFF
--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -239,9 +239,29 @@ pub enum Initializer {
         args: IndexMap<String, EntityIndex>,
     },
 
-    /// A module is defined into the module index space, and which module is
-    /// being defined is specified by the index payload.
+    /// A module is being created from a set of compiled artifacts.
+    CreateModule {
+        /// The index of the artifact that's being convereted into a module.
+        artifact_index: usize,
+        /// The list of artifacts that this module value will be inheriting.
+        artifacts: Vec<usize>,
+        /// The list of modules that this module value will inherit.
+        modules: Vec<ModuleUpvar>,
+    },
+
+    /// A module is created from a closed-over-module value, defined when this
+    /// module was created.
     DefineModule(usize),
+}
+
+/// Where module values can come from when creating a new module from a compiled
+/// artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ModuleUpvar {
+    /// A module value is inherited from the module creating the new module.
+    Inherit(usize),
+    /// A module value comes from the instance-to-be-created module index space.
+    Local(ModuleIndex),
 }
 
 impl Module {

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -221,7 +221,7 @@ impl CompiledModule {
         artifacts: Vec<CompilationArtifacts>,
         isa: &dyn TargetIsa,
         profiler: &dyn ProfilingAgent,
-    ) -> Result<Vec<Self>, SetupError> {
+    ) -> Result<Vec<Arc<Self>>, SetupError> {
         maybe_parallel!(artifacts.(into_iter | into_par_iter))
             .map(|a| CompiledModule::from_artifacts(a, isa, profiler))
             .collect()
@@ -232,7 +232,7 @@ impl CompiledModule {
         artifacts: CompilationArtifacts,
         isa: &dyn TargetIsa,
         profiler: &dyn ProfilingAgent,
-    ) -> Result<Self, SetupError> {
+    ) -> Result<Arc<Self>, SetupError> {
         // Allocate all of the compiled functions into executable memory,
         // copying over their contents.
         let (code_memory, code_range, finished_functions, trampolines) = build_code_memory(
@@ -266,7 +266,7 @@ impl CompiledModule {
 
         let finished_functions = FinishedFunctions(finished_functions);
 
-        Ok(Self {
+        Ok(Arc::new(Self {
             module: Arc::new(artifacts.module.clone()),
             artifacts,
             code: Arc::new(ModuleCode {
@@ -275,7 +275,7 @@ impl CompiledModule {
             }),
             finished_functions,
             trampolines,
-        })
+        }))
     }
 
     /// Crate an `Instance` from this `CompiledModule`.

--- a/tests/misc_testsuite/module-linking/alias-outer.wast
+++ b/tests/misc_testsuite/module-linking/alias-outer.wast
@@ -1,0 +1,67 @@
+(module $a
+  (module $m1)
+  (module $b
+    (module $m2)
+    (module $c
+      (instance (instantiate (module outer $a $m1)))
+      (instance (instantiate (module outer $b $m2)))
+    )
+    (instance (instantiate $c))
+  )
+  (instance (instantiate $b))
+)
+
+(module $a
+  (module (export "m"))
+)
+
+(module $PARENT
+  (import "a" "m" (module $b))
+  (module $c
+    (module $d
+      (instance (instantiate (module outer $PARENT $b)))
+    )
+    (instance (instantiate $d))
+  )
+  (instance (instantiate $c))
+)
+
+;; Instantiate `$b` here below twice with two different imports. Ensure the
+;; exported modules close over the captured state correctly to ensure that we
+;; get the right functions.
+(module $a
+  (module $b (export "close_over_imports")
+    (import "m" (module $m (export "f" (func (result i32)))))
+    (module (export "m")
+      (instance $a (instantiate (module outer $b $m)))
+      (func (export "f") (result i32)
+        call (func $a "f"))
+    )
+  )
+)
+
+(module
+  (import "a" "close_over_imports" (module $m0
+    (import "m" (module (export "f" (func (result i32)))))
+    (export "m" (module (export "f" (func (result i32)))))
+  ))
+
+  (module $m1
+    (func (export "f") (result i32)
+      i32.const 0))
+  (instance $m_g1 (instantiate $m0 "m" (module $m1)))
+  (instance $g1 (instantiate (module $m_g1 "m")))
+  (module $m2
+    (func (export "f") (result i32)
+      i32.const 1))
+  (instance $m_g2 (instantiate $m0 "m" (module $m2)))
+  (instance $g2 (instantiate (module $m_g2 "m")))
+
+  (func (export "get1") (result i32)
+    call (func $g1 "f"))
+  (func (export "get2") (result i32)
+    call (func $g2 "f"))
+)
+
+(assert_return (invoke "get1") (i32.const 0))
+(assert_return (invoke "get2") (i32.const 1))

--- a/tests/misc_testsuite/module-linking/alias.wast
+++ b/tests/misc_testsuite/module-linking/alias.wast
@@ -93,8 +93,7 @@
   (instance $a (instantiate $m))
 )
 
-;; alias parent -- module
-(; TODO
+;; alias outer -- module
 (module
   (module $a)
   (module $m
@@ -102,7 +101,6 @@
   )
   (instance (instantiate $m))
 )
-;)
 
 ;; The alias, import, type, module, and instance sections can all be interleaved
 (module $ROOT


### PR DESCRIPTION
This commit fully implements outer aliases of the module linking
proposal. Outer aliases can now handle multiple-level-up aliases and now
properly also handle closed-over-values of modules that are either
imported or defined.

The structure of `wasmtime::Module` was altered as part of this commit.
It is now a compiled module plus two lists of "upvars", or closed over
values used when instantiating the module. One list of upvars is
compiled artifacts which are submodules that could be used. Another is
module values that are injected via outer aliases. Serialization and
such have been updated as appropriate to handle this.
