### PR TITLE
Add an instance limit to `Config`

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -275,6 +275,14 @@ WASMTIME_CONFIG_PROP(void, static_memory_guard_size, uint64_t)
 WASMTIME_CONFIG_PROP(void, dynamic_memory_guard_size, uint64_t)
 
 /**
+ * \brief Configures the maximum number of instances that cana be created.
+ *
+ * For more information see the Rust documentation at
+ * https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Config.html#method.max_instances.
+ */
+WASMTIME_CONFIG_PROP(void, max_instances, size_t)
+
+/**
  * \brief Enables Wasmtime's cache and loads configuration from the specified
  * path.
  *

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -275,7 +275,7 @@ WASMTIME_CONFIG_PROP(void, static_memory_guard_size, uint64_t)
 WASMTIME_CONFIG_PROP(void, dynamic_memory_guard_size, uint64_t)
 
 /**
- * \brief Configures the maximum number of instances that cana be created.
+ * \brief Configures the maximum number of instances that can be created.
  *
  * For more information see the Rust documentation at
  * https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Config.html#method.max_instances.

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -171,3 +171,8 @@ pub extern "C" fn wasmtime_config_static_memory_guard_size_set(c: &mut wasm_conf
 pub extern "C" fn wasmtime_config_dynamic_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
     c.config.dynamic_memory_guard_size(size);
 }
+
+#[no_mangle]
+pub extern "C" fn wasmtime_config_max_instances(c: &mut wasm_config_t, limit: usize) {
+    c.config.max_instances(limit);
+}

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -33,6 +33,7 @@ pub struct Config {
     pub(crate) max_wasm_stack: usize,
     pub(crate) features: WasmFeatures,
     pub(crate) wasm_backtrace_details_env_used: bool,
+    pub(crate) max_instances: usize,
 }
 
 impl Config {
@@ -79,6 +80,7 @@ impl Config {
                 multi_value: true,
                 ..WasmFeatures::default()
             },
+            max_instances: 10_000,
         };
         ret.wasm_backtrace_details(WasmBacktraceDetails::Environment);
         return ret;
@@ -632,6 +634,15 @@ impl Config {
         self.tunables.dynamic_memory_offset_guard_size = guard_size;
         self.tunables.static_memory_offset_guard_size =
             cmp::max(guard_size, self.tunables.static_memory_offset_guard_size);
+        self
+    }
+
+    /// Configures the maximum number of instances which can be created within
+    /// this `Store`.
+    ///
+    /// Instantiation will fail with an error if this limit is exceeded.
+    pub fn max_instances(&mut self, instances: usize) -> &mut Self {
+        self.max_instances = instances;
         self
     }
 

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -46,6 +46,8 @@ fn instantiate(
         &mut ImportsBuilder<'_>,
     ) -> Result<()>,
 ) -> Result<RuntimeInstance, Error> {
+    store.bump_instance_count()?;
+
     let compiled_module = module.compiled_module();
     let env_module = compiled_module.module();
 


### PR DESCRIPTION
This commit adds a new parameter to `Config` which limits the number of
instances that can be created within a store connected to that `Config`.
The intention here is to provide a default safeguard against
module-linking modules that recursively create too many instances.
