### PR TITLE
Update a number of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -94,9 +94,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -388,7 +388,7 @@ dependencies = [
  "souper-ir",
  "target-lexicon",
  "thiserror",
- "wast 31.0.0",
+ "wast 32.0.0",
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "hashbrown",
- "itertools",
+ "itertools 0.10.0",
  "log",
  "serde",
  "smallvec",
@@ -890,13 +890,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.4",
  "winapi",
 ]
 
@@ -917,19 +917,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi",
-]
 
 [[package]]
 name = "generic-array"
@@ -1072,6 +1059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,7 +1147,7 @@ dependencies = [
  "dynasm",
  "dynasmrt",
  "iter-enum",
- "itertools",
+ "itertools 0.10.0",
  "lazy_static",
  "memoffset",
  "more-asserts",
@@ -1170,19 +1166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1320,9 +1303,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 dependencies = [
  "crc32fast",
  "indexmap",
@@ -1393,7 +1376,7 @@ dependencies = [
  "peepmatic-test-operator",
  "peepmatic-traits",
  "serde",
- "wast 31.0.0",
+ "wast 32.0.0",
  "z3",
 ]
 
@@ -1419,9 +1402,9 @@ dependencies = [
  "peepmatic-test",
  "peepmatic-test-operator",
  "peepmatic-traits",
- "rand",
+ "rand 0.8.2",
  "serde",
- "wast 31.0.0",
+ "wast 32.0.0",
 ]
 
 [[package]]
@@ -1446,7 +1429,7 @@ dependencies = [
  "serde",
  "serde_test",
  "thiserror",
- "wast 31.0.0",
+ "wast 32.0.0",
 ]
 
 [[package]]
@@ -1458,7 +1441,7 @@ dependencies = [
  "peepmatic",
  "peepmatic-test-operator",
  "souper-ir",
- "wast 31.0.0",
+ "wast 32.0.0",
 ]
 
 [[package]]
@@ -1479,7 +1462,7 @@ version = "0.69.0"
 dependencies = [
  "peepmatic-traits",
  "serde",
- "wast 31.0.0",
+ "wast 32.0.0",
 ]
 
 [[package]]
@@ -1553,8 +1536,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error",
- "rand",
- "rand_chacha",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1578,21 +1561,20 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quickcheck"
-version = "0.9.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger 0.8.2",
  "log",
- "rand",
- "rand_core",
+ "rand 0.8.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -1605,10 +1587,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.15",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
- "rand_pcg",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1618,7 +1611,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1631,21 +1634,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.0",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
-name = "rand_pcg"
-version = "0.2.1"
+name = "rand_hc"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1654,7 +1666,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1700,13 +1712,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom 0.1.15",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -1840,12 +1861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,18 +1903,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1941,12 +1956,11 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -1972,7 +1986,7 @@ checksum = "848c0a454373d16ebfaa740c99d4faebe25ea752a35e0c6e341168fe67f987f8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand",
+ "rand 0.7.3",
  "winapi",
 ]
 
@@ -2029,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2046,14 +2060,14 @@ checksum = "4ee5a98e506fb7231a304c3a1bd7c132a55016cf65001e0282480665870dfcb9"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand",
- "redox_syscall",
+ "rand 0.8.2",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi",
 ]
@@ -2395,15 +2409,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdf4d872d407f9fb44956e540582eeaf0dc4fb8142f1f0f64e2c37196bada01"
+checksum = "a15011eb23c404cdc1f6f60124a15921a11b060cca195486e36f4dc62e83c61d"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c139586e3b80b899f5aaaa3720c7a236ea9073e315292e01d099da12efacc5"
+checksum = "c467ab13e60cc347a17ed2c60bf761501eb45314d8916cad0d53ccc31078b20d"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -2755,7 +2769,7 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 31.0.0",
+ "wast 32.0.0",
 ]
 
 [[package]]
@@ -2791,20 +2805,20 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9beb1f6b63f08c523a1e8e76fc70058af4d2a34ef1c504f56cdac7b6970228b9"
+checksum = "c24a3ee360d01d60ed0a0f960ab76a6acce64348cdb0bf8699c2a866fad57c7c"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b3044da73d3b84a822d955afad356759b2fee454b6882722008dace80b68e"
+checksum = "5e8f7f34773fa6318e8897283abf7941c1f250faae4e1a52f82df09c3bad7cce"
 dependencies = [
- "wast 31.0.0",
+ "wast 32.0.0",
 ]
 
 [[package]]
@@ -2984,6 +2998,6 @@ checksum = "ec24a9273d24437afb8e71b16f3d9a5d569193cccdb7896213b59f552f387674"
 dependencies = [
  "cc",
  "glob",
- "itertools",
+ "itertools 0.9.0",
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,17 +33,17 @@ wasmtime-wasi = { path = "crates/wasi", version = "0.22.0" }
 wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.22.0", optional = true }
 wasi-common = { path = "crates/wasi-common", version = "0.22.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
-object = { version = "0.22.0", default-features = false, features = ["write"] }
+object = { version = "0.23.0", default-features = false, features = ["write"] }
 anyhow = "1.0.19"
 target-lexicon = { version = "0.11.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.32"
+wat = "1.0.33"
 libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.2.1"
 humantime = "2.0.0"
-wasmparser = "0.72.0"
+wasmparser = "0.73.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/build.rs
+++ b/build.rs
@@ -243,9 +243,12 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
                 return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
             }
 
+            // Waiting for an update to the spec testsuite to not use old
+            // instruction names.
+            ("simd", "simd_boolean") | ("simd", "simd_lane") => return true,
+
             // These are only implemented on aarch64 and x64.
-            ("simd", "simd_boolean")
-            | ("simd", "simd_f32x4_pmin_pmax")
+            ("simd", "simd_f32x4_pmin_pmax")
             | ("simd", "simd_f64x2_pmin_pmax")
             | ("simd", "simd_f32x4_rounding")
             | ("simd", "simd_f64x2_rounding")

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -30,7 +30,7 @@ peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, versi
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.69.0" }
 regalloc = { version = "0.0.31" }
 souper-ir = { version = "2.1.0", optional = true }
-wast = { version = "31.0.0", optional = true }
+wast = { version = "32.0.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 cranelift-module = { path = "../module", version = "0.69.0" }
 cranelift-codegen = { path = "../codegen", version = "0.69.0", default-features = false, features = ["std"] }
-object = { version = "0.22.0", default-features = false, features = ["write"] }
+object = { version = "0.23.0", default-features = false, features = ["write"] }
 target-lexicon = "0.11"
 anyhow = "1.0"
 log = { version = "0.4.6", default-features = false }

--- a/cranelift/peepmatic/Cargo.toml
+++ b/cranelift/peepmatic/Cargo.toml
@@ -15,7 +15,7 @@ peepmatic-macro = { version = "0.69.0", path = "crates/macro" }
 peepmatic-runtime = { version = "0.69.0", path = "crates/runtime", features = ["construct"] }
 peepmatic-traits = { version = "0.69.0", path = "crates/traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "31.0.0"
+wast = "32.0.0"
 z3 = { version = "0.7.1", features = ["static-link-z3"] }
 
 [dev-dependencies]

--- a/cranelift/peepmatic/crates/fuzzing/Cargo.toml
+++ b/cranelift/peepmatic/crates/fuzzing/Cargo.toml
@@ -19,6 +19,6 @@ peepmatic-runtime = { path = "../runtime", features = ["construct"] }
 peepmatic-test = { path = "../test" }
 peepmatic-test-operator = { path = "../test-operator" }
 peepmatic-traits = { path = "../traits" }
-rand = { version = "0.7.3", features = ["small_rng"] }
+rand = { version = "0.8.2", features = ["small_rng"] }
 serde = "1.0.106"
-wast = "31.0.0"
+wast = "32.0.0"

--- a/cranelift/peepmatic/crates/runtime/Cargo.toml
+++ b/cranelift/peepmatic/crates/runtime/Cargo.toml
@@ -16,7 +16,7 @@ peepmatic-automata = { version = "0.69.0", path = "../automata", features = ["se
 peepmatic-traits = { version = "0.69.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
 thiserror = "1.0.15"
-wast = { version = "31.0.0", optional = true }
+wast = { version = "32.0.0", optional = true }
 
 [dev-dependencies]
 peepmatic-test-operator = { version = "0.69.0", path = "../test-operator" }

--- a/cranelift/peepmatic/crates/souper/Cargo.toml
+++ b/cranelift/peepmatic/crates/souper/Cargo.toml
@@ -16,4 +16,4 @@ log = "0.4.8"
 [dev-dependencies]
 peepmatic = { path = "../..", version = "0.69.0" }
 peepmatic-test-operator = { version = "0.69.0", path = "../test-operator" }
-wast = "31.0.0"
+wast = "32.0.0"

--- a/cranelift/peepmatic/crates/test-operator/Cargo.toml
+++ b/cranelift/peepmatic/crates/test-operator/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 [dependencies]
 peepmatic-traits = { version = "0.69.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "31.0.0"
+wast = "32.0.0"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.72", default-features = false }
+wasmparser = { version = "0.73", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.69.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.69.0" }
 cranelift-frontend = { path = "../frontend", version = "0.69.0", default-features = false }
 hashbrown = { version = "0.9.1", optional = true }
-itertools = "0.9.0"
+itertools = "0.10.0"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 smallvec = "1.6.1"

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1626,7 +1626,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             // operands must match (hence the bitcast).
             state.push1(builder.ins().bitselect(bitcast_c, bitcast_a, bitcast_b))
         }
-        Operator::I8x16AnyTrue | Operator::I16x8AnyTrue | Operator::I32x4AnyTrue => {
+        Operator::V128AnyTrue => {
             let a = pop1_with_bitcast(state, type_of(op), builder);
             let bool_result = builder.ins().vany_true(a);
             state.push1(builder.ins().bint(I32, bool_result))
@@ -1824,7 +1824,21 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = pop2_with_bitcast(state, I16X8, builder);
             state.push1(builder.ins().widening_pairwise_dot_product_s(a, b));
         }
-        Operator::I16x8ExtMulLowI8x16S
+        Operator::I64x2Bitmask
+        | Operator::I64x2WidenLowI32x4S
+        | Operator::I64x2WidenHighI32x4S
+        | Operator::I64x2WidenLowI32x4U
+        | Operator::I64x2WidenHighI32x4U
+        | Operator::V128Load8Lane { .. }
+        | Operator::V128Load16Lane { .. }
+        | Operator::V128Load32Lane { .. }
+        | Operator::V128Load64Lane { .. }
+        | Operator::V128Store8Lane { .. }
+        | Operator::V128Store16Lane { .. }
+        | Operator::V128Store32Lane { .. }
+        | Operator::V128Store64Lane { .. }
+        | Operator::I16x8Q15MulrSatS
+        | Operator::I16x8ExtMulLowI8x16S
         | Operator::I16x8ExtMulHighI8x16S
         | Operator::I16x8ExtMulLowI8x16U
         | Operator::I16x8ExtMulHighI8x16U
@@ -2522,7 +2536,6 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I8x16GeU
         | Operator::I8x16Neg
         | Operator::I8x16Abs
-        | Operator::I8x16AnyTrue
         | Operator::I8x16AllTrue
         | Operator::I8x16Shl
         | Operator::I8x16ShrS
@@ -2557,7 +2570,6 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I16x8GeU
         | Operator::I16x8Neg
         | Operator::I16x8Abs
-        | Operator::I16x8AnyTrue
         | Operator::I16x8AllTrue
         | Operator::I16x8Shl
         | Operator::I16x8ShrS
@@ -2592,7 +2604,6 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I32x4GeU
         | Operator::I32x4Neg
         | Operator::I32x4Abs
-        | Operator::I32x4AnyTrue
         | Operator::I32x4AllTrue
         | Operator::I32x4Shl
         | Operator::I32x4ShrS

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.23.0"
-wasmparser = "0.72"
-object = { version = "0.22.0", default-features = false, features = ["read_core", "elf", "write"] }
+wasmparser = "0.73"
+object = { version = "0.23.0", default-features = false, features = ["read_core", "elf", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.22.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
 anyhow = "1.0"

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.69.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.69.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.69.0", features = ["enable-serde"] }
-wasmparser = "0.72"
+wasmparser = "0.73"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,8 +13,8 @@ arbitrary = { version = "0.4.1", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.72"
-wasmprinter = "0.2.17"
+wasmparser = "0.73"
+wasmprinter = "0.2.20"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 wasm-encoder = "0.4"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -28,13 +28,13 @@ rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.72"
+wasmparser = "0.73"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "1.0"
 log = "0.4"
 gimli = { version = "0.23.0", default-features = false, features = ["write"] }
-object = { version = "0.22.0", default-features = false, features = ["write"] }
+object = { version = "0.23.0", default-features = false, features = ["write"] }
 serde = { version = "1.0.94", features = ["derive"] }
 addr2line = { version = "0.14", default-features = false }
 

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -18,18 +18,18 @@ derive_more = "0.99"
 dynasm = "1.0.0"
 dynasmrt = "1.0.0"
 iter-enum = "0.2"
-itertools = "0.9.0"
+itertools = "0.10.0"
 memoffset = "0.6.0"
 more-asserts = "0.2.1"
 smallvec = "1.6.1"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.72"
+wasmparser = "0.73"
 
 [dev-dependencies]
 lazy_static = "1.2"
 wat = "1.0.23"
-quickcheck = "0.9.0"
+quickcheck = "1.0.0"
 anyhow = "1.0"
 
 [badges]

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 lightbeam = { path = "..", version = "0.22.0" }
-wasmparser = "0.72"
+wasmparser = "0.73"
 cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.69.0" }
 wasmtime-environ = { path = "../../environ", version = "0.22.0" }

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 wasmtime-environ = { path = "../environ", version = "0.22.0" }
-object = { version = "0.22.0", default-features = false, features = ["write"] }
+object = { version = "0.23.0", default-features = false, features = ["write"] }
 more-asserts = "0.2.1"
 target-lexicon = { version = "0.11.0", default-features = false }
 wasmtime-debug = { path = "../debug", version = "0.22.0" }

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime-runtime = { path = "../runtime", version = "0.22.0" }
 ittapi-rs = { version = "0.1.5", optional = true }
 
 [dependencies.object]
-version = "0.22.0"
+version = "0.23.0"
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'std']

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -16,7 +16,7 @@ wasmtime-jit = { path = "../jit", version = "0.22.0" }
 wasmtime-cache = { path = "../cache", version = "0.22.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.22.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmparser = "0.72"
+wasmparser = "0.73"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.22.0", default-features = false }
-wast = "31.0.0"
+wast = "32.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/deny.toml
+++ b/deny.toml
@@ -42,4 +42,8 @@ skip = [
     { name = "humantime" }, # caused by env_logger
     { name = "getrandom" }, # rand not updates to 0.2 yet
     { name = "wast" }, # old one pulled in by witx
+    { name = "rand" }, # 0.7 pulled in by transitive deps
+    { name = "rand_core" }, # 0.7 pulled in by transitive deps
+    { name = "rand_chacha" }, # 0.7 pulled in by transitive deps
+    { name = "itertools" }, # 0.9 pulled in by zstd-sys
 ]

--- a/tests/misc_testsuite/multi-memory/simple.wast
+++ b/tests/misc_testsuite/multi-memory/simple.wast
@@ -5,20 +5,20 @@
   (func (export "store1") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store $m1)
+      i64.store (memory $m1))
 
   (func (export "store2") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store $m2)
+      i64.store (memory $m2))
 
   (func (export "load1") (param i32) (result i64)
       local.get 0
-      i64.load $m1)
+      i64.load (memory $m1))
 
   (func (export "load2") (param i32) (result i64)
       local.get 0
-      i64.load $m2)
+      i64.load (memory $m2))
 )
 
 (invoke "store1" (i32.const 0) (i64.const 1))
@@ -64,20 +64,20 @@
   (func (export "store1") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store $m1)
+      i64.store (memory $m1))
 
   (func (export "store2") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store $m2)
+      i64.store (memory $m2))
 
   (func (export "load1") (param i32) (result i64)
       local.get 0
-      i64.load $m1)
+      i64.load (memory $m1))
 
   (func (export "load2") (param i32) (result i64)
       local.get 0
-      i64.load $m2)
+      i64.load (memory $m2))
 )
 
 (invoke "store1" (i32.const 0) (i64.const 1))
@@ -92,11 +92,11 @@
 
   (func (export "grow1") (param i32) (result i32)
       local.get 0
-      memory.grow $m1)
+      memory.grow (memory $m1))
 
   (func (export "grow2") (param i32) (result i32)
       local.get 0
-      memory.grow $m2)
+      memory.grow (memory $m2))
 
   (func (export "size1") (result i32) memory.size $m1)
   (func (export "size2") (result i32) memory.size $m2)
@@ -128,7 +128,7 @@
       i32.const 4
       memory.init $d $m2
       i32.const 1
-      i32.load $m2)
+      i32.load (memory $m2))
 
   (data $d "\01\00\00\00" "\02\00\00\00")
 )
@@ -154,7 +154,7 @@
       i32.const 2
       memory.fill $m2
       i32.const 1
-      i32.load $m2)
+      i32.load (memory $m2))
 )
 
 (assert_return (invoke "fill1") (i32.const 0x01010101))


### PR DESCRIPTION
This commit goes through the dependencies that wasmtime has and updates
versions where possible. This notably brings in a wasmparser/wast update
which has some simd spec changes with new instructions. Otherwise most
of these are just routine updates.
