### PR TITLE
Implement Mach-O TLS access for x64 newBE

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -3016,6 +3016,19 @@ pub(crate) fn emit(
             );
             sink.put4(0); // offset
         }
+
+        Inst::MachOTlsGetAddr { ref symbol } => {
+            // movq gv@tlv(%rip), %rdi
+            sink.put1(0x48); // REX.w
+            sink.put1(0x8b); // MOV
+            sink.put1(0x3d); // ModRM byte
+            emit_reloc(sink, state, Reloc::MachOX86_64Tlv, symbol, -4);
+            sink.put4(0); // offset
+
+            // callq *(%rdi)
+            sink.put1(0xff);
+            sink.put1(0x17);
+        }
     }
 
     state.clear_post_insn();

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3915,6 +3915,17 @@ fn test_x64_emit() {
         "elf_tls_get_addr User { namespace: 0, index: 0 }",
     ));
 
+    insns.push((
+        Inst::MachOTlsGetAddr {
+            symbol: ExternalName::User {
+                namespace: 0,
+                index: 0,
+            },
+        },
+        "488B3D00000000FF17",
+        "macho_tls_get_addr User { namespace: 0, index: 0 }",
+    ));
+
     // ========================================================
     // Actually run the tests!
     let mut flag_builder = settings::builder();

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -5333,6 +5333,13 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 ctx.emit(Inst::ElfTlsGetAddr { symbol });
                 ctx.emit(Inst::gen_move(dst, regs::rax(), types::I64));
             }
+            TlsModel::Macho => {
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                let (name, _, _) = ctx.symbol_value(insn).unwrap();
+                let symbol = name.clone();
+                ctx.emit(Inst::MachOTlsGetAddr { symbol });
+                ctx.emit(Inst::gen_move(dst, regs::rax(), types::I64));
+            }
             _ => {
                 todo!(
                     "Unimplemented TLS model in x64 backend: {:?}",


### PR DESCRIPTION
Required for switching cg_clif to x64 newBE. I have verified on CI that cg_clif passes all tests with this on macOS.

r? @cfallin