### PR TITLE
Refactor instantiation to be more async-friendly

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -527,6 +527,10 @@ impl Module {
         &self.inner.module
     }
 
+    pub(crate) fn env_module(&self) -> &wasmtime_environ::Module {
+        self.compiled_module().module()
+    }
+
     pub(crate) fn types(&self) -> &Arc<TypeTables> {
         &self.inner.types
     }


### PR DESCRIPTION
Instantiation right now uses a recursive `instantiate` function since it
was relatively easy to write that way, but this is unfortunately not
factored in a way friendly to the async implementation in #2434. This
commit refactors the function to instead use an iterative loop and
refactors code in such a way that it should be easy to rebase #2434 on
top of this change. The main goal is to make the body of `Instance::new`
as small as possible since it needs to be duplicated with
`Instance::new_async`.

