### PR TITLE
Add support for the experimental wasi-crypto APIs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,6 +274,7 @@ jobs:
             --exclude lightbeam \
             --exclude wasmtime-lightbeam \
             --exclude wasmtime-wasi-nn \
+            --exclude wasmtime-wasi-crypto \
             --exclude peepmatic \
             --exclude peepmatic-automata \
             --exclude peepmatic-fuzzing \
@@ -342,6 +343,21 @@ jobs:
       - run: ./ci/run-wasi-nn-example.sh
         env:
           RUST_BACKTRACE: 1
+
+  # Build and test the wasi-crypto module.
+  test_wasi_crypto:
+    name: Test wasi-crypto module
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - run: rustup target add wasm32-wasi
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - run: ./ci/run-wasi-crypto-example.sh
+      env:
+        RUST_BACKTRACE: 1
 
   # Verify that cranelift's code generation is deterministic
   meta_determinist_check:
@@ -451,6 +467,7 @@ jobs:
             --exclude lightbeam \
             --exclude wasmtime-lightbeam \
             --exclude wasmtime-wasi-nn \
+            --exclude wasmtime-wasi-crypto \
             --exclude peepmatic \
             --exclude peepmatic-automata \
             --exclude peepmatic-fuzzing \

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "crates/wasi-nn/spec"]
 	path = crates/wasi-nn/spec
 	url = https://github.com/WebAssembly/wasi-nn
+[submodule "wasm"]
+	path = crates/wasi-crypto/spec
+	url = https://github.com/WebAssembly/wasi-crypto.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 [submodule "crates/wasi-nn/spec"]
 	path = crates/wasi-nn/spec
 	url = https://github.com/WebAssembly/wasi-nn
-[submodule "wasm"]
+[submodule "crates/wasi-crypto/spec"]
 	path = crates/wasi-crypto/spec
 	url = https://github.com/WebAssembly/wasi-crypto.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arbitrary"
@@ -85,6 +139,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -168,6 +228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
+dependencies = [
+ "funty",
+ "radium",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,9 +266,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "capstone"
@@ -250,6 +321,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed8738f14471a99f0e316c327e68fc82a3611cc2895fcb604b89eedaf8f39d95"
+dependencies = [
+ "cipher",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fc18e6d90c40164bf6c317476f2a98f04661e310e79830366b7e914c58a8e"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +354,15 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -299,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
+checksum = "7cc80946b3480f421c2f17ed1cb841753a371c7c5104f51d507e13f532c856aa"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -310,14 +413,19 @@ dependencies = [
  "terminal_size",
  "unicode-width",
  "winapi",
- "winapi-util",
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.4"
+name = "const-oid"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "c5d82796b70971fbb603900a5edc797a4d9be0f9ec1257f83a1dba0aa374e3e9"
+
+[[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -350,6 +458,12 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift"
@@ -645,9 +759,41 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -657,6 +803,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac344c7efccb80cd25bc61b2170aec26f2f693fd40e765a539a1243db48c71"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "der"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
+name = "derivative"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaed5874effa6cde088c644ddcdcb4ffd1511391c5be4fdd7a5ccd02c7e4a183"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -683,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "derive_utils"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64196eb9f551916167225134f1e8a90f0b5774331d3c900d6328fd94bafe3544"
+checksum = "532b4c15dccee12c7044f1fcad956e98410860b22231e44a3b827464797ca7bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -744,18 +910,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.3.5",
  "winapi",
 ]
 
 [[package]]
 name = "dirs-sys-next"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.0",
  "winapi",
 ]
 
@@ -767,9 +933,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dynasm"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a59fbab09460c1569eeea9b5e4cf62f13f5198b1c2ba0e5196dd7fdd17cd42"
+checksum = "3d7d1242462849390bb2ad38aeed769499f1afc7383affa2ab0c1baa894c0200"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -782,13 +948,47 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bec3edae2841d37b1c3dc7f3fd403c9061f26e9ffeeee97a3ea909b1bb2ef1"
+checksum = "c1dd4d1d5ca12258cef339a57a7643e8b233a42dea9bb849630ddd9dd7726aa9"
 dependencies = [
  "byteorder",
  "dynasm",
- "memmap",
+ "memmap2",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+dependencies = [
+ "elliptic-curve",
+ "hmac",
+ "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -796,6 +996,23 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b1c857559479c056b73a3053c717108a70e4dce320ad28c79c63f5c2e62ba"
+dependencies = [
+ "bitvec",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -823,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
- "humantime 2.0.1",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -867,6 +1084,17 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "ff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+dependencies = [
+ "bitvec",
+ "rand_core 0.5.1",
+ "subtle",
+]
 
 [[package]]
 name = "file-per-thread-logger"
@@ -913,6 +1141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d79238883cf0307100b90aba4a755d8051a3182305dfe7f649a1e9dc0517006f"
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,24 +1164,34 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi 0.10.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -968,6 +1212,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "group"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+dependencies = [
+ "ff",
+ "rand_core 0.5.1",
+ "subtle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,20 +1233,40 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest",
 ]
 
 [[package]]
@@ -1005,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "id-arena"
@@ -1021,7 +1296,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "hashbrown",
  "serde",
 ]
@@ -1039,10 +1314,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "iter-enum"
-version = "0.2.5"
+name = "instant"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a94bc12a53bf84b705acee29eb8697a5ea7b4587d836152499e5db0a6d52b9"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "iter-enum"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad34f24d3b48ceffdff38af2df5ce1b7d1d9cc113e503d8e86fe8cdb889c871"
 dependencies = [
  "derive_utils",
  "quote",
@@ -1069,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "ittapi-rs"
@@ -1092,10 +1376,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -1127,13 +1425,19 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "lightbeam"
@@ -1160,10 +1464,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.11"
+name = "lock_api"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -1203,12 +1516,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73be3b7d04a0123e933fea1d50d126cc7196bbc0362c0ce426694f777194eee"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1224,7 +1546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1249,9 +1571,39 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d51546d704f52ef14b3c962b5776e53d5b862e5790e40a350d366c209bd7f7a"
+dependencies = [
+ "autocfg 0.1.7",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.7.3",
+ "serde",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -1260,7 +1612,18 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1270,8 +1633,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg",
- "num-bigint",
+ "autocfg 1.0.1",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
 ]
@@ -1282,7 +1645,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1325,9 +1688,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openvino"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a74f90f07f134153e3ad2ffa724a3ebda92cdc6e099f7fe7d9185cf960f028"
+checksum = "43eeb44285b7ce8e2012b92bec32968622e1dad452e812e6edea9e001e5e9410"
 dependencies = [
  "openvino-sys",
  "thiserror",
@@ -1335,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "openvino-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72a2e5bd353bd3cf39b2663767e0ae0325a7588c47fd496cbf9a09237ef7ca8"
+checksum = "8fb64bef270a1ff665b0b2e28ebfa213e6205a007ce88223d020730225d6008f"
 dependencies = [
  "bindgen",
  "cmake",
@@ -1354,10 +1717,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca0196a204bb3f33305ba4a48b38f6e6e621cba8603a4e0650e6532e0949de4"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -1470,16 +1869,87 @@ name = "peepmatic-traits"
 version = "0.69.0"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.0"
+name = "pem"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
+dependencies = [
+ "base64",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+
+[[package]]
+name = "pkcs8"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+dependencies = [
+ "der",
+ "subtle-encoding",
+ "zeroize",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+dependencies = [
+ "cpuid-bool 0.2.0",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool 0.2.0",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pqcrypto"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3874384bf37d988b83f806d632e2f7fca69a8cd0338efaa64e8e7664573052"
+dependencies = [
+ "pqcrypto-kyber",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-kyber"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33550a5b6e0844d1b2363f67e15e4ca64586bb4fb2363a83af762e6c2d092bff"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-traits"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e1563eff60a9ae869cacee0a33fa5c4ba27861fec6e3e23de95eb0ae805e4b"
 
 [[package]]
 name = "pretty_env_logger"
@@ -1580,12 +2050,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -1630,7 +2106,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1639,7 +2115,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1681,12 +2157,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawbytes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26d81f4c222fd11ad63bf56cbda89d1810aecf1a720a423ff7eb2020475d8bb"
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1726,9 +2208,19 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "redox_syscall 0.1.57",
  "rust-argon2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.2",
+ "redox_syscall 0.2.4",
 ]
 
 [[package]]
@@ -1745,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1767,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "region"
@@ -1790,6 +2282,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rsa"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3648b669b10afeab18972c105e284a7b953a669b0be3514c27f9b17acab2f9cd"
+dependencies = [
+ "byteorder",
+ "digest",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pem",
+ "rand 0.7.3",
+ "sha2",
+ "simple_asn1 0.4.1",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa-export"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "358de25c89a5a71597ebc85f7ad222e2c67ed553e0ce31170104c3a77296a01c"
+dependencies = [
+ "num-bigint-dig",
+ "pem",
+ "rsa",
+ "simple_asn1 0.5.1",
 ]
 
 [[package]]
@@ -1923,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1934,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f3f8714511d29f60be0ea965bc784df1b6903da5bbac801df36b1bbc7b4880"
+checksum = "3dd7d96489b14fa2f4a89be299ac117c8023d1ead9aaee963a2dde72dad4d14b"
 dependencies = [
  "serde",
 ]
@@ -1949,7 +2475,7 @@ checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpuid-bool 0.1.2",
  "digest",
  "opaque-debug",
 ]
@@ -1980,14 +2506,47 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "shuffling-allocator"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848c0a454373d16ebfaa740c99d4faebe25ea752a35e0c6e341168fe67f987f8"
+checksum = "4ee9977fa98489d9006f4ab26fc5cbe2a139985baed09d2ec08dee6e506fc496"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
+ "rand 0.8.2",
  "winapi",
+]
+
+[[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+dependencies = [
+ "digest",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+dependencies = [
+ "chrono",
+ "num-bigint 0.2.6",
+ "num-traits",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8d597fce66eb0f19dd129b9956e4054cba21aeaf97d4116595027b670fac50"
+dependencies = [
+ "chrono",
+ "num-bigint 0.3.1",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]
@@ -2004,6 +2563,12 @@ checksum = "a50c18ce33988e1973003afbaa66e6a465ad7a614dc33f246879ccc209c2c044"
 dependencies = [
  "id-arena",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2042,6 +2607,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+
+[[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2629,18 @@ checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 
@@ -2093,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi",
@@ -2128,18 +2720,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2148,29 +2740,28 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -2291,6 +2882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-any"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,9 +2940,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasi-common"
@@ -2351,7 +2952,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpu-time",
  "filetime",
- "getrandom 0.2.0",
+ "getrandom 0.2.2",
  "lazy_static",
  "libc",
  "thiserror",
@@ -2360,6 +2961,37 @@ dependencies = [
  "winapi",
  "winx",
  "yanix",
+]
+
+[[package]]
+name = "wasi-crypto"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9560882ac741fb72330bc4bd4bffa92ab4c7c412ebe24a2f442ef57262ab3667"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "bincode",
+ "byteorder",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "derivative",
+ "ed25519-dalek",
+ "hkdf",
+ "hmac",
+ "k256",
+ "p256",
+ "parking_lot",
+ "pqcrypto",
+ "rand_core 0.5.1",
+ "rsa",
+ "rsa-export",
+ "serde",
+ "sha2",
+ "subtle",
+ "thiserror",
+ "xoodyak",
+ "zeroize",
 ]
 
 [[package]]
@@ -2518,7 +3150,7 @@ dependencies = [
  "env_logger 0.8.2",
  "file-per-thread-logger",
  "filecheck",
- "humantime 2.0.1",
+ "humantime 2.1.0",
  "libc",
  "log",
  "more-asserts",
@@ -2541,6 +3173,7 @@ dependencies = [
  "wasmtime-obj",
  "wasmtime-runtime",
  "wasmtime-wasi",
+ "wasmtime-wasi-crypto",
  "wasmtime-wasi-nn",
  "wasmtime-wast",
  "wat",
@@ -2748,6 +3381,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-wasi-crypto"
+version = "0.22.0"
+dependencies = [
+ "anyhow",
+ "wasi-crypto",
+ "wasmtime",
+ "wasmtime-wiggle",
+ "wiggle",
+]
+
+[[package]]
 name = "wasmtime-wasi-nn"
 version = "0.22.0"
 dependencies = [
@@ -2941,6 +3585,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "xoodyak"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9c85605c3a376cec858899f7d284f453359743adaeddf09c7d6ef18474a481"
+dependencies = [
+ "rawbytes",
+ "zeroize",
+]
+
+[[package]]
 name = "yanix"
 version = "0.22.0"
 dependencies = [
@@ -2969,6 +3629,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa18ba5fbd4933e41ffb440c3fd91f91fe9cdb7310cce3ddfb6648563811de0"
 dependencies = [
  "cmake",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,9 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-crypto"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9560882ac741fb72330bc4bd4bffa92ab4c7c412ebe24a2f442ef57262ab3667"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ wasmtime-jit = { path = "crates/jit", version = "0.22.0" }
 wasmtime-obj = { path = "crates/obj", version = "0.22.0" }
 wasmtime-wast = { path = "crates/wast", version = "0.22.0" }
 wasmtime-wasi = { path = "crates/wasi", version = "0.22.0" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "0.22.0", optional = true }
 wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.22.0", optional = true }
 wasi-common = { path = "crates/wasi-common", version = "0.22.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
@@ -82,6 +83,7 @@ default = ["jitdump", "wasmtime/wat", "wasmtime/parallel-compilation"]
 lightbeam = ["wasmtime/lightbeam"]
 jitdump = ["wasmtime/jitdump"]
 vtune = ["wasmtime/vtune"]
+wasi-crypto = ["wasmtime-wasi-crypto"]
 wasi-nn = ["wasmtime-wasi-nn"]
 
 # Try the experimental, work-in-progress new x86_64 backend. This is not stable

--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -14,6 +14,7 @@ cargo $CARGO_VERSION \
             --all \
             --exclude wasmtime-lightbeam \
             --exclude wasmtime-wasi-nn \
+            --exclude wasmtime-wasi-crypto \
             --exclude peepmatic \
             --exclude peepmatic-automata \
             --exclude peepmatic-fuzzing \

--- a/ci/run-wasi-crypto-example.sh
+++ b/ci/run-wasi-crypto-example.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -e
+
+RUST_BINDINGS="crates/wasi-crypto/spec/implementations/bindings/rust"
+pushd "$RUST_BINDINGS"
+cargo build --release --target=wasm32-wasi
+popd
+
+cargo run --features wasi-crypto -- run "$RUST_BINDINGS/target/wasm32-wasi/release/wasi-crypto-guest.wasm"

--- a/crates/misc/run-examples/src/main.rs
+++ b/crates/misc/run-examples/src/main.rs
@@ -83,7 +83,8 @@ fn main() -> anyhow::Result<()> {
                     .arg("userenv.lib")
                     .arg("ntdll.lib")
                     .arg("shell32.lib")
-                    .arg("ole32.lib");
+                    .arg("ole32.lib")
+                    .arg("bcrypt.lib");
                 if is_dir {
                     "main.exe".to_string()
                 } else {

--- a/crates/wasi-crypto/Cargo.toml
+++ b/crates/wasi-crypto/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "wasmtime-wasi-crypto"
+version = "0.22.0"
+authors = ["The Wasmtime Project Developers"]
+description = "Wasmtime implementation of the wasi-crypto API"
+documentation = "https://docs.rs/wasmtime-wasi-crypto"
+license = "Apache-2.0 WITH LLVM-exception"
+categories = ["wasm", "cryptography"]
+keywords = ["webassembly", "wasm", "crypto"]
+repository = "https://github.com/bytecodealliance/wasmtime"
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+wasi-crypto = "0.1.3"
+wasmtime = { path = "../wasmtime", version = "0.22.0", default-features = false }
+wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.22.0" }
+wiggle = { path = "../wiggle", version = "0.22.0" }
+
+[badges]
+maintenance = { status = "experimental" }

--- a/crates/wasi-crypto/Cargo.toml
+++ b/crates/wasi-crypto/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasi-crypto = "0.1.3"
+wasi-crypto = { path = "spec/implementations/hostcalls/rust", version = "0.1.4" }
 wasmtime = { path = "../wasmtime", version = "0.22.0", default-features = false }
 wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.22.0" }
 wiggle = { path = "../wiggle", version = "0.22.0" }

--- a/crates/wasi-crypto/LICENSE
+++ b/crates/wasi-crypto/LICENSE
@@ -1,0 +1,220 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+

--- a/crates/wasi-crypto/README.md
+++ b/crates/wasi-crypto/README.md
@@ -1,0 +1,56 @@
+# wasmtime-wasi-crypto
+
+This crate enables support for the [wasi-crypto] APIs in Wasmtime.
+
+The sole purpose of the implementation is to allow bindings and
+application developers to test the proposed APIs. This implementation
+is not meant to be used in production. Like the specification, it is
+currently experimental and its functionality can quickly change.
+
+Since the [wasi-crypto] API is expected to be an optional feature of
+WASI, this crate is currently separate from the [wasi-common] crate.
+
+* [documentation]
+* [interfaces reference]
+* [interfaces reference (compact)]
+
+[wasi-crypto]: https://github.com/WebAssembly/wasi-crypto
+[wasi-common]: ../../wasi-common
+[documentation]: ../spec/docs/wasi-crypto.md
+[interfaces reference]: ../spec/witx/wasi_ephemeral_crypto.md
+[interfaces reference (compact)]: ../spec/witx/wasi_ephemeral_crypto.txt
+
+## Wasmtime integration
+
+Use the Wasmtime APIs to instantiate a Wasm module and link the
+`wasi-crypto` modules as follows:
+
+```rust
+use wasmtime_wasi_crypto::{
+    WasiCryptoAsymmetricCommon, WasiCryptoCommon, WasiCryptoCtx, WasiCryptoSignatures,
+    WasiCryptoSymmetric,
+};
+
+let cx_crypto = WasiCryptoCtx::new();
+WasiCryptoCommon::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+WasiCryptoAsymmetricCommon::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+WasiCryptoSignatures::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+WasiCryptoSymmetric::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+
+let wasi = wasmtime_wasi::old::snapshot_0::Wasi::new(linker.store(), mk_cx()?);
+wasi.add_to_linker(linker)?;
+```
+
+## Building Wasmtime
+
+Wasmtime must be compiled with the `wasi-crypto` feature flag
+(disabled by default) in order to include the crypto APIs.
+
+## Examples
+
+Example [rust bindings] and [assemblyscript bindings] are provided to
+demonstrate how these APIs can be used and exposed to applications in
+an idiomatic way.
+
+[rust bindings]: ../spec/implementations/bindings/rust
+[assemblyscript bindings]: ../spec/implementations/bindings/assemblyscript

--- a/crates/wasi-crypto/src/lib.rs
+++ b/crates/wasi-crypto/src/lib.rs
@@ -1,0 +1,31 @@
+mod wiggle_interfaces;
+
+pub use wiggle_interfaces::WasiCryptoCtx;
+
+wasmtime_wiggle::wasmtime_integration!({
+    target: wiggle_interfaces::wasi_modules,
+    witx: ["$CARGO_MANIFEST_DIR/spec/witx/wasi_ephemeral_crypto.witx"],
+    ctx: WasiCryptoCtx,
+    modules: {
+        wasi_ephemeral_crypto_common =>
+            {
+                name: WasiCryptoCommon,
+                docs: "wasi-crypto - Common module."
+            },
+        wasi_ephemeral_crypto_asymmetric_common =>
+            {
+                name: WasiCryptoAsymmetricCommon,
+                docs: "wasi-crypto - Common module for asymmetric operations."
+            },
+        wasi_ephemeral_crypto_signatures =>
+            {
+                name: WasiCryptoSignatures,
+                docs: "wasi-crypto - Signature module."
+            },
+        wasi_ephemeral_crypto_symmetric =>
+            {
+                name: WasiCryptoSymmetric,
+                docs: "wasi-crypto - Symmetric cryptography module."
+            }
+    }
+});

--- a/crates/wasi-crypto/src/wiggle_interfaces/asymmetric_common.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/asymmetric_common.rs
@@ -1,0 +1,292 @@
+use super::{guest_types, WasiCryptoCtx};
+
+use std::convert::TryInto;
+use wasi_crypto::{ensure, CryptoError, KeyPairEncoding, PublicKeyEncoding, SecretKeyEncoding};
+
+impl super::wasi_ephemeral_crypto_asymmetric_common::WasiEphemeralCryptoAsymmetricCommon
+    for WasiCryptoCtx
+{
+    // --- keypair_manager
+
+    fn keypair_generate_managed(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        alg_type: guest_types::AlgorithmType,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        options_handle: &guest_types::OptOptions,
+    ) -> Result<guest_types::Keypair, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let options_handle = match *options_handle {
+            guest_types::OptOptions::Some(options_handle) => Some(options_handle),
+            guest_types::OptOptions::None => None,
+        };
+        Ok(self
+            .ctx
+            .keypair_generate_managed(
+                secrets_manager_handle.into(),
+                alg_type.into(),
+                alg_str,
+                options_handle.map(Into::into),
+            )?
+            .into())
+    }
+
+    fn keypair_store_managed(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        kp_handle: guest_types::Keypair,
+        kp_id_ptr: &wiggle::GuestPtr<'_, u8>,
+        kp_id_max_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let key_id_buf = &mut *kp_id_ptr.as_array(kp_id_max_len).as_slice_mut()?;
+        Ok(self.ctx.keypair_store_managed(
+            secrets_manager_handle.into(),
+            kp_handle.into(),
+            key_id_buf,
+        )?)
+    }
+
+    fn keypair_replace_managed(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        kp_old_handle: guest_types::Keypair,
+        kp_new_handle: guest_types::Keypair,
+    ) -> Result<guest_types::Version, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .keypair_replace_managed(
+                secrets_manager_handle.into(),
+                kp_old_handle.into(),
+                kp_new_handle.into(),
+            )?
+            .into())
+    }
+
+    fn keypair_from_id(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        kp_id_ptr: &wiggle::GuestPtr<'_, u8>,
+        kp_id_len: guest_types::Size,
+        kp_version: guest_types::Version,
+    ) -> Result<guest_types::Keypair, guest_types::CryptoErrno> {
+        let kp_id = &*kp_id_ptr.as_array(kp_id_len).as_slice()?;
+        Ok(self
+            .ctx
+            .keypair_from_id(secrets_manager_handle.into(), kp_id, kp_version.into())?
+            .into())
+    }
+
+    // --- keypair
+
+    fn keypair_generate(
+        &self,
+        alg_type: guest_types::AlgorithmType,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        options_handle: &guest_types::OptOptions,
+    ) -> Result<guest_types::Keypair, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let options_handle = match *options_handle {
+            guest_types::OptOptions::Some(options_handle) => Some(options_handle),
+            guest_types::OptOptions::None => None,
+        };
+        Ok(self
+            .ctx
+            .keypair_generate(alg_type.into(), alg_str, options_handle.map(Into::into))?
+            .into())
+    }
+
+    fn keypair_import(
+        &self,
+        alg_type: guest_types::AlgorithmType,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        encoded_ptr: &wiggle::GuestPtr<'_, u8>,
+        encoded_len: guest_types::Size,
+        encoding: guest_types::KeypairEncoding,
+    ) -> Result<guest_types::Keypair, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        Ok(self
+            .ctx
+            .keypair_import(alg_type.into(), alg_str, encoded, encoding.into())?
+            .into())
+    }
+
+    fn keypair_id(
+        &self,
+        kp_handle: guest_types::Keypair,
+        kp_id_ptr: &wiggle::GuestPtr<'_, u8>,
+        kp_id_max_len: guest_types::Size,
+    ) -> Result<(guest_types::Size, guest_types::Version), guest_types::CryptoErrno> {
+        let kp_id_buf = &mut *kp_id_ptr.as_array(kp_id_max_len as _).as_slice_mut()?;
+        let (kp_id, version) = self.ctx.keypair_id(kp_handle.into())?;
+        ensure!(kp_id.len() <= kp_id_buf.len(), CryptoError::Overflow.into());
+        kp_id_buf.copy_from_slice(&kp_id);
+        Ok((kp_id.len().try_into()?, version.into()))
+    }
+
+    fn keypair_export(
+        &self,
+        kp_handle: guest_types::Keypair,
+        encoding: guest_types::KeypairEncoding,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .keypair_export(kp_handle.into(), encoding.into())?
+            .into())
+    }
+
+    fn keypair_publickey(
+        &self,
+        kp_handle: guest_types::Keypair,
+    ) -> Result<guest_types::Publickey, guest_types::CryptoErrno> {
+        Ok(self.ctx.keypair_publickey(kp_handle.into())?.into())
+    }
+
+    fn keypair_close(
+        &self,
+        kp_handle: guest_types::Keypair,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.keypair_close(kp_handle.into())?)
+    }
+
+    // --- publickey
+
+    fn publickey_import(
+        &self,
+        alg_type: guest_types::AlgorithmType,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        encoded_ptr: &wiggle::GuestPtr<'_, u8>,
+        encoded_len: guest_types::Size,
+        encoding: guest_types::PublickeyEncoding,
+    ) -> Result<guest_types::Publickey, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        Ok(self
+            .ctx
+            .publickey_import(alg_type.into(), alg_str, encoded, encoding.into())?
+            .into())
+    }
+
+    fn publickey_export(
+        &self,
+        pk_handle: guest_types::Publickey,
+        encoding: guest_types::PublickeyEncoding,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .publickey_export(pk_handle.into(), encoding.into())?
+            .into())
+    }
+
+    fn publickey_from_secretkey(
+        &self,
+        sk_handle: guest_types::Secretkey,
+    ) -> Result<guest_types::Publickey, guest_types::CryptoErrno> {
+        Ok(self.ctx.keypair_publickey(sk_handle.into())?.into())
+    }
+
+    fn publickey_verify(
+        &self,
+        pk_handle: guest_types::Publickey,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.publickey_verify(pk_handle.into())?)
+    }
+
+    fn publickey_close(
+        &self,
+        pk_handle: guest_types::Publickey,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.publickey_close(pk_handle.into())?)
+    }
+
+    // --- secretkey
+
+    fn secretkey_import(
+        &self,
+        alg_type: guest_types::AlgorithmType,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        encoded_ptr: &wiggle::GuestPtr<'_, u8>,
+        encoded_len: guest_types::Size,
+        encoding: guest_types::SecretkeyEncoding,
+    ) -> Result<guest_types::Secretkey, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        Ok(self
+            .ctx
+            .secretkey_import(alg_type.into(), alg_str, encoded, encoding.into())?
+            .into())
+    }
+
+    fn secretkey_export(
+        &self,
+        sk_handle: guest_types::Secretkey,
+        encoding: guest_types::SecretkeyEncoding,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .secretkey_export(sk_handle.into(), encoding.into())?
+            .into())
+    }
+
+    fn secretkey_close(
+        &self,
+        sk_handle: guest_types::Secretkey,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.secretkey_close(sk_handle.into())?)
+    }
+
+    fn keypair_from_pk_and_sk(
+        &self,
+        pk_handle: guest_types::Publickey,
+        sk_handle: guest_types::Secretkey,
+    ) -> Result<guest_types::Keypair, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .keypair_from_pk_and_sk(pk_handle.into(), sk_handle.into())?
+            .into())
+    }
+
+    fn keypair_secretkey(
+        &self,
+        kp_handle: guest_types::Keypair,
+    ) -> Result<guest_types::Secretkey, guest_types::CryptoErrno> {
+        Ok(self.ctx.keypair_secretkey(kp_handle.into())?.into())
+    }
+}
+
+impl From<guest_types::KeypairEncoding> for KeyPairEncoding {
+    fn from(encoding: guest_types::KeypairEncoding) -> Self {
+        match encoding {
+            guest_types::KeypairEncoding::Raw => KeyPairEncoding::Raw,
+            guest_types::KeypairEncoding::Pkcs8 => KeyPairEncoding::Pkcs8,
+            guest_types::KeypairEncoding::Pem => KeyPairEncoding::Pem,
+            guest_types::KeypairEncoding::Local => KeyPairEncoding::Local,
+        }
+    }
+}
+
+impl From<guest_types::PublickeyEncoding> for PublicKeyEncoding {
+    fn from(encoding: guest_types::PublickeyEncoding) -> Self {
+        match encoding {
+            guest_types::PublickeyEncoding::Raw => PublicKeyEncoding::Raw,
+            guest_types::PublickeyEncoding::Pkcs8 => PublicKeyEncoding::Pkcs8,
+            guest_types::PublickeyEncoding::Pem => PublicKeyEncoding::Pem,
+            guest_types::PublickeyEncoding::Sec => PublicKeyEncoding::Sec,
+            guest_types::PublickeyEncoding::CompressedSec => PublicKeyEncoding::CompressedSec,
+            guest_types::PublickeyEncoding::Local => PublicKeyEncoding::Local,
+        }
+    }
+}
+
+impl From<guest_types::SecretkeyEncoding> for SecretKeyEncoding {
+    fn from(encoding: guest_types::SecretkeyEncoding) -> Self {
+        match encoding {
+            guest_types::SecretkeyEncoding::Raw => SecretKeyEncoding::Raw,
+            guest_types::SecretkeyEncoding::Pkcs8 => SecretKeyEncoding::Pkcs8,
+            guest_types::SecretkeyEncoding::Pem => SecretKeyEncoding::Pem,
+            guest_types::SecretkeyEncoding::Sec => SecretKeyEncoding::Sec,
+            guest_types::SecretkeyEncoding::CompressedSec => SecretKeyEncoding::CompressedSec,
+            guest_types::SecretkeyEncoding::Local => SecretKeyEncoding::Local,
+        }
+    }
+}

--- a/crates/wasi-crypto/src/wiggle_interfaces/common.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/common.rs
@@ -1,0 +1,150 @@
+use super::{guest_types, WasiCryptoCtx};
+
+use std::convert::TryInto;
+use wasi_crypto::{AlgorithmType, Version};
+
+impl super::wasi_ephemeral_crypto_common::WasiEphemeralCryptoCommon for WasiCryptoCtx {
+    // --- options
+
+    fn options_open(
+        &self,
+        options_type: guest_types::AlgorithmType,
+    ) -> Result<guest_types::Options, guest_types::CryptoErrno> {
+        Ok(self.ctx.options_open(options_type.into())?.into())
+    }
+
+    fn options_close(
+        &self,
+        options_handle: guest_types::Options,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.options_close(options_handle.into())?)
+    }
+
+    fn options_set(
+        &self,
+        options_handle: guest_types::Options,
+        name_str: &wiggle::GuestPtr<'_, str>,
+        value_ptr: &wiggle::GuestPtr<'_, u8>,
+        value_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let name_str: &str = &*name_str.as_str()?;
+        let value: &[u8] = { &*value_ptr.as_array(value_len).as_slice()? };
+        Ok(self
+            .ctx
+            .options_set(options_handle.into(), name_str, value)?)
+    }
+
+    fn options_set_guest_buffer(
+        &self,
+        options_handle: guest_types::Options,
+        name_str: &wiggle::GuestPtr<'_, str>,
+        buffer_ptr: &wiggle::GuestPtr<'_, u8>,
+        buffer_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let name_str: &str = &*name_str.as_str()?;
+        let buffer: &'static mut [u8] =
+            unsafe { std::mem::transmute(&mut *buffer_ptr.as_array(buffer_len).as_slice_mut()?) };
+        Ok(self
+            .ctx
+            .options_set_guest_buffer(options_handle.into(), name_str, buffer)?)
+    }
+
+    fn options_set_u64(
+        &self,
+        options_handle: guest_types::Options,
+        name_str: &wiggle::GuestPtr<'_, str>,
+        value: u64,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let name_str: &str = &*name_str.as_str()?;
+        Ok(self
+            .ctx
+            .options_set_u64(options_handle.into(), name_str, value)?)
+    }
+
+    // --- array
+
+    fn array_output_len(
+        &self,
+        array_output_handle: guest_types::ArrayOutput,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .array_output_len(array_output_handle.into())?
+            .try_into()?)
+    }
+
+    fn array_output_pull(
+        &self,
+        array_output_handle: guest_types::ArrayOutput,
+        buf_ptr: &wiggle::GuestPtr<'_, u8>,
+        buf_len: guest_types::Size,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        let buf: &mut [u8] = { &mut *buf_ptr.as_array(buf_len).as_slice_mut()? };
+        Ok(self
+            .ctx
+            .array_output_pull(array_output_handle.into(), buf)?
+            .try_into()?)
+    }
+
+    // --- secrets_manager
+
+    fn secrets_manager_open(
+        &self,
+        options_handle: &guest_types::OptOptions,
+    ) -> Result<guest_types::SecretsManager, guest_types::CryptoErrno> {
+        let options_handle = match *options_handle {
+            guest_types::OptOptions::Some(options_handle) => Some(options_handle),
+            guest_types::OptOptions::None => None,
+        };
+        Ok(self
+            .ctx
+            .secrets_manager_open(options_handle.map(Into::into))?
+            .into())
+    }
+
+    fn secrets_manager_close(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .secrets_manager_close(secrets_manager_handle.into())?)
+    }
+
+    fn secrets_manager_invalidate(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        key_id_ptr: &wiggle::GuestPtr<'_, u8>,
+        key_id_len: guest_types::Size,
+        key_version: guest_types::Version,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let key_id: &[u8] = { &*key_id_ptr.as_array(key_id_len).as_slice()? };
+        Ok(self.ctx.secrets_manager_invalidate(
+            secrets_manager_handle.into(),
+            key_id,
+            key_version.into(),
+        )?)
+    }
+}
+
+impl From<guest_types::AlgorithmType> for AlgorithmType {
+    fn from(options_type: guest_types::AlgorithmType) -> Self {
+        match options_type {
+            guest_types::AlgorithmType::Signatures => AlgorithmType::Signatures,
+            guest_types::AlgorithmType::Symmetric => AlgorithmType::Symmetric,
+            guest_types::AlgorithmType::KeyExchange => AlgorithmType::KeyExchange,
+        }
+    }
+}
+
+impl From<guest_types::Version> for Version {
+    fn from(version: guest_types::Version) -> Self {
+        Version(version.into())
+    }
+}
+
+impl From<Version> for guest_types::Version {
+    fn from(version: Version) -> Self {
+        version.into()
+    }
+}

--- a/crates/wasi-crypto/src/wiggle_interfaces/error.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/error.rs
@@ -1,0 +1,67 @@
+use super::{guest_types, WasiCryptoCtx};
+
+use std::num::TryFromIntError;
+use wasi_crypto::CryptoError;
+
+impl From<CryptoError> for guest_types::CryptoErrno {
+    fn from(e: CryptoError) -> Self {
+        match e {
+            CryptoError::Success => guest_types::CryptoErrno::Success,
+            CryptoError::GuestError(_wiggle_error) => guest_types::CryptoErrno::GuestError,
+            CryptoError::NotImplemented => guest_types::CryptoErrno::NotImplemented,
+            CryptoError::UnsupportedFeature => guest_types::CryptoErrno::UnsupportedFeature,
+            CryptoError::ProhibitedOperation => guest_types::CryptoErrno::ProhibitedOperation,
+            CryptoError::UnsupportedEncoding => guest_types::CryptoErrno::UnsupportedEncoding,
+            CryptoError::UnsupportedAlgorithm => guest_types::CryptoErrno::UnsupportedAlgorithm,
+            CryptoError::UnsupportedOption => guest_types::CryptoErrno::UnsupportedOption,
+            CryptoError::InvalidKey => guest_types::CryptoErrno::InvalidKey,
+            CryptoError::InvalidLength => guest_types::CryptoErrno::InvalidLength,
+            CryptoError::VerificationFailed => guest_types::CryptoErrno::VerificationFailed,
+            CryptoError::RNGError => guest_types::CryptoErrno::RngError,
+            CryptoError::AlgorithmFailure => guest_types::CryptoErrno::AlgorithmFailure,
+            CryptoError::InvalidSignature => guest_types::CryptoErrno::InvalidSignature,
+            CryptoError::Closed => guest_types::CryptoErrno::Closed,
+            CryptoError::InvalidHandle => guest_types::CryptoErrno::InvalidHandle,
+            CryptoError::Overflow => guest_types::CryptoErrno::Overflow,
+            CryptoError::InternalError => guest_types::CryptoErrno::InternalError,
+            CryptoError::TooManyHandles => guest_types::CryptoErrno::TooManyHandles,
+            CryptoError::KeyNotSupported => guest_types::CryptoErrno::KeyNotSupported,
+            CryptoError::KeyRequired => guest_types::CryptoErrno::KeyRequired,
+            CryptoError::InvalidTag => guest_types::CryptoErrno::InvalidTag,
+            CryptoError::InvalidOperation => guest_types::CryptoErrno::InvalidOperation,
+            CryptoError::NonceRequired => guest_types::CryptoErrno::NonceRequired,
+            CryptoError::InvalidNonce => guest_types::CryptoErrno::InvalidNonce,
+            CryptoError::OptionNotSet => guest_types::CryptoErrno::OptionNotSet,
+            CryptoError::NotFound => guest_types::CryptoErrno::NotFound,
+            CryptoError::ParametersMissing => guest_types::CryptoErrno::ParametersMissing,
+            CryptoError::IncompatibleKeys => guest_types::CryptoErrno::IncompatibleKeys,
+            CryptoError::Expired => guest_types::CryptoErrno::Expired,
+        }
+    }
+}
+
+impl From<TryFromIntError> for guest_types::CryptoErrno {
+    fn from(_: TryFromIntError) -> Self {
+        CryptoError::Overflow.into()
+    }
+}
+
+impl<'a> wiggle::GuestErrorType for guest_types::CryptoErrno {
+    fn success() -> Self {
+        guest_types::CryptoErrno::Success
+    }
+}
+
+impl guest_types::GuestErrorConversion for WasiCryptoCtx {
+    fn into_crypto_errno(&self, e: wiggle::GuestError) -> guest_types::CryptoErrno {
+        eprintln!("GuestError (witx) {:?}", e);
+        guest_types::CryptoErrno::GuestError
+    }
+}
+
+impl From<wiggle::GuestError> for guest_types::CryptoErrno {
+    fn from(e: wiggle::GuestError) -> Self {
+        eprintln!("GuestError (impl) {:?}", e);
+        guest_types::CryptoErrno::GuestError
+    }
+}

--- a/crates/wasi-crypto/src/wiggle_interfaces/key_exchange.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/key_exchange.rs
@@ -1,0 +1,40 @@
+use super::{guest_types, WasiCryptoCtx};
+
+impl super::wasi_ephemeral_crypto_kx::WasiEphemeralCryptoKx for WasiCryptoCtx {
+    // --- key exchange
+
+    fn kx_dh(
+        &self,
+        pk_handle: guest_types::Publickey,
+        sk_handle: guest_types::Secretkey,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        Ok(self.ctx.kx_dh(pk_handle.into(), sk_handle.into())?.into())
+    }
+
+    // --- Key encapsulation
+
+    fn kx_encapsulate(
+        &self,
+        pk_handle: guest_types::Publickey,
+    ) -> Result<(guest_types::ArrayOutput, guest_types::ArrayOutput), guest_types::CryptoErrno>
+    {
+        let (secret_handle, encapsulated_secret_handle) =
+            self.ctx.kx_encapsulate(pk_handle.into())?;
+        Ok((secret_handle.into(), encapsulated_secret_handle.into()))
+    }
+
+    fn kx_decapsulate(
+        &self,
+        sk_handle: guest_types::Secretkey,
+        encapsulated_secret_ptr: &wiggle::GuestPtr<'_, u8>,
+        encapsulated_secret_len: guest_types::Size,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        let encapsulated_secret = &*encapsulated_secret_ptr
+            .as_array(encapsulated_secret_len)
+            .as_slice()?;
+        Ok(self
+            .ctx
+            .kx_decapsulate(sk_handle.into(), encapsulated_secret)?
+            .into())
+    }
+}

--- a/crates/wasi-crypto/src/wiggle_interfaces/mod.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/mod.rs
@@ -1,0 +1,38 @@
+use std::rc::Rc;
+
+use wasi_crypto::CryptoCtx;
+
+wiggle::from_witx!({
+    witx: ["$CARGO_MANIFEST_DIR/spec/witx/wasi_ephemeral_crypto.witx"],
+    ctx: WasiCryptoCtx
+});
+
+pub mod wasi_modules {
+    pub use super::{
+        wasi_ephemeral_crypto_asymmetric_common, wasi_ephemeral_crypto_common,
+        wasi_ephemeral_crypto_kx, wasi_ephemeral_crypto_signatures,
+        wasi_ephemeral_crypto_symmetric,
+    };
+}
+
+pub use types as guest_types;
+
+#[derive(Clone)]
+pub struct WasiCryptoCtx {
+    ctx: Rc<CryptoCtx>,
+}
+
+impl WasiCryptoCtx {
+    pub fn new() -> Self {
+        WasiCryptoCtx {
+            ctx: Rc::new(CryptoCtx::new()),
+        }
+    }
+}
+
+mod asymmetric_common;
+mod common;
+mod error;
+mod key_exchange;
+mod signatures;
+mod symmetric;

--- a/crates/wasi-crypto/src/wiggle_interfaces/signatures.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/signatures.rs
@@ -1,0 +1,129 @@
+use super::{guest_types, WasiCryptoCtx};
+
+use wasi_crypto::SignatureEncoding;
+
+impl super::wasi_ephemeral_crypto_signatures::WasiEphemeralCryptoSignatures for WasiCryptoCtx {
+    // --- signature
+
+    fn signature_export(
+        &self,
+        signature_handle: guest_types::Signature,
+        encoding: guest_types::SignatureEncoding,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .signature_export(signature_handle.into(), encoding.into())?
+            .into())
+    }
+
+    fn signature_import(
+        &self,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        encoded_ptr: &wiggle::GuestPtr<'_, u8>,
+        encoded_len: guest_types::Size,
+        encoding: guest_types::SignatureEncoding,
+    ) -> Result<guest_types::Signature, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        Ok(self
+            .ctx
+            .signature_import(alg_str, encoded, encoding.into())?
+            .into())
+    }
+
+    fn signature_state_open(
+        &self,
+        kp_handle: guest_types::Keypair,
+    ) -> Result<guest_types::SignatureState, guest_types::CryptoErrno> {
+        Ok(self.ctx.signature_state_open(kp_handle.into())?.into())
+    }
+
+    fn signature_state_update(
+        &self,
+        state_handle: guest_types::SignatureState,
+        input_ptr: &wiggle::GuestPtr<'_, u8>,
+        input_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let input = &*input_ptr.as_array(input_len).as_slice()?;
+        Ok(self
+            .ctx
+            .signature_state_update(state_handle.into(), input)?)
+    }
+
+    fn signature_state_sign(
+        &self,
+        signature_state_handle: guest_types::SignatureState,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .signature_state_sign(signature_state_handle.into())?
+            .into())
+    }
+
+    fn signature_state_close(
+        &self,
+        signature_state_handle: guest_types::SignatureState,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .signature_state_close(signature_state_handle.into())?)
+    }
+
+    fn signature_verification_state_open(
+        &self,
+        pk_handle: guest_types::Publickey,
+    ) -> Result<guest_types::SignatureVerificationState, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .signature_verification_state_open(pk_handle.into())?
+            .into())
+    }
+
+    fn signature_verification_state_update(
+        &self,
+        verification_state_handle: guest_types::SignatureVerificationState,
+        input_ptr: &wiggle::GuestPtr<'_, u8>,
+        input_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let input: &[u8] = &*input_ptr.as_array(input_len).as_slice()?;
+        Ok(self
+            .ctx
+            .signature_verification_state_update(verification_state_handle.into(), input)?)
+    }
+
+    fn signature_verification_state_verify(
+        &self,
+        verification_state_handle: guest_types::SignatureVerificationState,
+        signature_handle: guest_types::Signature,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.signature_verification_state_verify(
+            verification_state_handle.into(),
+            signature_handle.into(),
+        )?)
+    }
+
+    fn signature_verification_state_close(
+        &self,
+        verification_state_handle: guest_types::SignatureVerificationState,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .signature_verification_state_close(verification_state_handle.into())?)
+    }
+
+    fn signature_close(
+        &self,
+        signature_handle: guest_types::Signature,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.signature_close(signature_handle.into())?)
+    }
+}
+
+impl From<guest_types::SignatureEncoding> for SignatureEncoding {
+    fn from(encoding: guest_types::SignatureEncoding) -> Self {
+        match encoding {
+            guest_types::SignatureEncoding::Raw => SignatureEncoding::Raw,
+            guest_types::SignatureEncoding::Der => SignatureEncoding::Der,
+        }
+    }
+}

--- a/crates/wasi-crypto/src/wiggle_interfaces/symmetric.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/symmetric.rs
@@ -1,0 +1,384 @@
+use super::{guest_types, WasiCryptoCtx};
+
+use std::convert::TryInto;
+use wasi_crypto::{ensure, CryptoError};
+
+impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for WasiCryptoCtx {
+    // --- secrets_manager
+
+    fn symmetric_key_generate_managed(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        options_handle: &guest_types::OptOptions,
+    ) -> Result<guest_types::SymmetricKey, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let options_handle = match *options_handle {
+            guest_types::OptOptions::Some(options_handle) => Some(options_handle),
+            guest_types::OptOptions::None => None,
+        };
+        Ok(self
+            .ctx
+            .symmetric_key_generate_managed(
+                secrets_manager_handle.into(),
+                alg_str,
+                options_handle.map(Into::into),
+            )?
+            .into())
+    }
+
+    fn symmetric_key_store_managed(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        symmetric_key_handle: guest_types::SymmetricKey,
+        symmetric_key_id_ptr: &wiggle::GuestPtr<'_, u8>,
+        symmetric_key_id_max_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let key_id_buf = &mut *symmetric_key_id_ptr
+            .as_array(symmetric_key_id_max_len)
+            .as_slice_mut()?;
+        Ok(self.ctx.symmetric_key_store_managed(
+            secrets_manager_handle.into(),
+            symmetric_key_handle.into(),
+            key_id_buf,
+        )?)
+    }
+
+    fn symmetric_key_replace_managed(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        symmetric_key_old_handle: guest_types::SymmetricKey,
+        symmetric_key_new_handle: guest_types::SymmetricKey,
+    ) -> Result<guest_types::Version, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .symmetric_key_replace_managed(
+                secrets_manager_handle.into(),
+                symmetric_key_old_handle.into(),
+                symmetric_key_new_handle.into(),
+            )?
+            .into())
+    }
+
+    fn symmetric_key_from_id(
+        &self,
+        secrets_manager_handle: guest_types::SecretsManager,
+        symmetric_key_id_ptr: &wiggle::GuestPtr<'_, u8>,
+        symmetric_key_id_len: guest_types::Size,
+        symmetric_key_version: guest_types::Version,
+    ) -> Result<guest_types::SymmetricKey, guest_types::CryptoErrno> {
+        let symmetric_key_id = &*symmetric_key_id_ptr
+            .as_array(symmetric_key_id_len)
+            .as_slice()?;
+        Ok(self
+            .ctx
+            .symmetric_key_from_id(
+                secrets_manager_handle.into(),
+                symmetric_key_id,
+                symmetric_key_version.into(),
+            )?
+            .into())
+    }
+
+    // --- key
+
+    fn symmetric_key_generate(
+        &self,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        options_handle: &guest_types::OptOptions,
+    ) -> Result<guest_types::SymmetricKey, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let options_handle = match *options_handle {
+            guest_types::OptOptions::Some(options_handle) => Some(options_handle),
+            guest_types::OptOptions::None => None,
+        };
+        Ok(self
+            .ctx
+            .symmetric_key_generate(alg_str, options_handle.map(Into::into))?
+            .into())
+    }
+
+    fn symmetric_key_import(
+        &self,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        raw_ptr: &wiggle::GuestPtr<'_, u8>,
+        raw_len: guest_types::Size,
+    ) -> Result<guest_types::SymmetricKey, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let raw = &*raw_ptr.as_array(raw_len).as_slice()?;
+        Ok(self.ctx.symmetric_key_import(alg_str, raw)?.into())
+    }
+
+    fn symmetric_key_export(
+        &self,
+        symmetric_key_handle: guest_types::SymmetricKey,
+    ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .symmetric_key_export(symmetric_key_handle.into())?
+            .into())
+    }
+
+    fn symmetric_key_id(
+        &self,
+        symmetric_key_handle: guest_types::SymmetricKey,
+        symmetric_key_id_ptr: &wiggle::GuestPtr<'_, u8>,
+        symmetric_key_id_max_len: guest_types::Size,
+    ) -> Result<(guest_types::Size, guest_types::Version), guest_types::CryptoErrno> {
+        let key_id_buf = &mut *symmetric_key_id_ptr
+            .as_array(symmetric_key_id_max_len)
+            .as_slice_mut()?;
+        let (key_id, version) = self.ctx.symmetric_key_id(symmetric_key_handle.into())?;
+        ensure!(
+            key_id.len() <= key_id_buf.len(),
+            CryptoError::Overflow.into()
+        );
+        key_id_buf.copy_from_slice(&key_id);
+        Ok((key_id.len().try_into()?, version.into()))
+    }
+
+    fn symmetric_key_close(
+        &self,
+        key_handle: guest_types::SymmetricKey,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.symmetric_key_close(key_handle.into())?)
+    }
+
+    // --- state
+
+    fn symmetric_state_open(
+        &self,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+        key_handle: &guest_types::OptSymmetricKey,
+        options_handle: &guest_types::OptOptions,
+    ) -> Result<guest_types::SymmetricState, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        let key_handle = match *key_handle {
+            guest_types::OptSymmetricKey::Some(key_handle) => Some(key_handle),
+            guest_types::OptSymmetricKey::None => None,
+        };
+        let options_handle = match *options_handle {
+            guest_types::OptOptions::Some(options_handle) => Some(options_handle),
+            guest_types::OptOptions::None => None,
+        };
+        Ok(self
+            .ctx
+            .symmetric_state_open(
+                alg_str,
+                key_handle.map(Into::into),
+                options_handle.map(Into::into),
+            )?
+            .into())
+    }
+
+    fn symmetric_state_options_get(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        name_str: &wiggle::GuestPtr<'_, str>,
+        value_ptr: &wiggle::GuestPtr<'_, u8>,
+        value_max_len: guest_types::Size,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        let name_str: &str = &*name_str.as_str()?;
+        let value = &mut *value_ptr.as_array(value_max_len).as_slice_mut()?;
+        Ok(self
+            .ctx
+            .options_get(symmetric_state_handle.into(), name_str, value)?
+            .try_into()?)
+    }
+
+    fn symmetric_state_options_get_u64(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        name_str: &wiggle::GuestPtr<'_, str>,
+    ) -> Result<u64, guest_types::CryptoErrno> {
+        let name_str: &str = &*name_str.as_str()?;
+        Ok(self
+            .ctx
+            .options_get_u64(symmetric_state_handle.into(), name_str)?)
+    }
+
+    fn symmetric_state_close(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .symmetric_state_close(symmetric_state_handle.into())?)
+    }
+
+    fn symmetric_state_absorb(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        data_ptr: &wiggle::GuestPtr<'_, u8>,
+        data_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        Ok(self
+            .ctx
+            .symmetric_state_absorb(symmetric_state_handle.into(), data)?)
+    }
+
+    fn symmetric_state_squeeze(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        out_ptr: &wiggle::GuestPtr<'_, u8>,
+        out_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
+        Ok(self
+            .ctx
+            .symmetric_state_squeeze(symmetric_state_handle.into(), out)?)
+    }
+
+    fn symmetric_state_squeeze_tag(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+    ) -> Result<guest_types::SymmetricTag, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .symmetric_state_squeeze_tag(symmetric_state_handle.into())?
+            .into())
+    }
+
+    fn symmetric_state_squeeze_key(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        alg_str: &wiggle::GuestPtr<'_, str>,
+    ) -> Result<guest_types::SymmetricKey, guest_types::CryptoErrno> {
+        let alg_str = &*alg_str.as_str()?;
+        Ok(self
+            .ctx
+            .symmetric_state_squeeze_key(symmetric_state_handle.into(), alg_str)?
+            .into())
+    }
+
+    fn symmetric_state_max_tag_len(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .symmetric_state_max_tag_len(symmetric_state_handle.into())?
+            .try_into()?)
+    }
+
+    fn symmetric_state_encrypt(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        out_ptr: &wiggle::GuestPtr<'_, u8>,
+        out_len: guest_types::Size,
+        data_ptr: &wiggle::GuestPtr<'_, u8>,
+        data_len: guest_types::Size,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
+        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        Ok(self
+            .ctx
+            .symmetric_state_encrypt(symmetric_state_handle.into(), out, data)?
+            .try_into()?)
+    }
+
+    fn symmetric_state_encrypt_detached(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        out_ptr: &wiggle::GuestPtr<'_, u8>,
+        out_len: guest_types::Size,
+        data_ptr: &wiggle::GuestPtr<'_, u8>,
+        data_len: guest_types::Size,
+    ) -> Result<guest_types::SymmetricTag, guest_types::CryptoErrno> {
+        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
+        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        Ok(self
+            .ctx
+            .symmetric_state_encrypt_detached(symmetric_state_handle.into(), out, data)?
+            .into())
+    }
+
+    fn symmetric_state_decrypt(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        out_ptr: &wiggle::GuestPtr<'_, u8>,
+        out_len: guest_types::Size,
+        data_ptr: &wiggle::GuestPtr<'_, u8>,
+        data_len: guest_types::Size,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
+        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        Ok(self
+            .ctx
+            .symmetric_state_decrypt(symmetric_state_handle.into(), out, data)?
+            .try_into()?)
+    }
+
+    fn symmetric_state_decrypt_detached(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+        out_ptr: &wiggle::GuestPtr<'_, u8>,
+        out_len: guest_types::Size,
+        data_ptr: &wiggle::GuestPtr<'_, u8>,
+        data_len: guest_types::Size,
+        raw_tag_ptr: &wiggle::GuestPtr<'_, u8>,
+        raw_tag_len: guest_types::Size,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
+        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        let raw_tag: &[u8] = &*raw_tag_ptr.as_array(raw_tag_len).as_slice()?;
+        Ok(self
+            .ctx
+            .symmetric_state_decrypt_detached(symmetric_state_handle.into(), out, data, raw_tag)?
+            .try_into()?)
+    }
+
+    fn symmetric_state_ratchet(
+        &self,
+        symmetric_state_handle: guest_types::SymmetricState,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .symmetric_state_ratchet(symmetric_state_handle.into())?)
+    }
+
+    // --- tag
+
+    fn symmetric_tag_len(
+        &self,
+        symmetric_tag_handle: guest_types::SymmetricTag,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        Ok(self
+            .ctx
+            .symmetric_tag_len(symmetric_tag_handle.into())?
+            .try_into()?)
+    }
+
+    fn symmetric_tag_pull(
+        &self,
+        symmetric_tag_handle: guest_types::SymmetricTag,
+        buf_ptr: &wiggle::GuestPtr<'_, u8>,
+        buf_len: guest_types::Size,
+    ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
+        let buf = &mut *buf_ptr.as_array(buf_len).as_slice_mut()?;
+        Ok(self
+            .ctx
+            .symmetric_tag_pull(symmetric_tag_handle.into(), buf)?
+            .try_into()?)
+    }
+
+    fn symmetric_tag_verify(
+        &self,
+        symmetric_tag_handle: guest_types::SymmetricTag,
+        expected_raw_ptr: &wiggle::GuestPtr<'_, u8>,
+        expected_raw_len: guest_types::Size,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        let expected_raw = &*expected_raw_ptr.as_array(expected_raw_len).as_slice()?;
+        Ok(self
+            .ctx
+            .symmetric_tag_verify(symmetric_tag_handle.into(), expected_raw)?)
+    }
+
+    fn symmetric_tag_close(
+        &self,
+        symmetric_tag_handle: guest_types::SymmetricTag,
+    ) -> Result<(), guest_types::CryptoErrno> {
+        Ok(self.ctx.symmetric_tag_close(symmetric_tag_handle.into())?)
+    }
+}

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -65,6 +65,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wasmtime-wiggle",
     "wasmtime-wasi",
     "wasmtime-wasi-nn",
+    "wasmtime-wasi-crypto",
     "wasmtime-rust-macro",
     "wasmtime-rust",
     "wasmtime-wast",
@@ -176,7 +177,7 @@ fn read_crate(manifest: &Path) -> Crate {
     } else {
         version.clone()
     };
-    if name == "witx" {
+    if ["witx", "wasi-crypto"].contains(&&name[..]) {
         publish = false;
     }
     Crate {

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -300,6 +300,13 @@ fn verify(crates: &[Crate]) {
         .unwrap();
     verify_and_vendor(&witx);
 
+    // Vendor wasi-crypto which is also a path dependency
+    let wasi_crypto = crates
+        .iter()
+        .find(|c| c.name == "wasi-crypto")
+        .unwrap();
+    verify_and_vendor(&wasi_crypto);
+
     for krate in crates {
         if !krate.publish {
             continue;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -18,6 +18,12 @@ use wasmtime_wasi::Wasi;
 #[cfg(feature = "wasi-nn")]
 use wasmtime_wasi_nn::{WasiNn, WasiNnCtx};
 
+#[cfg(feature = "wasi-crypto")]
+use wasmtime_wasi_crypto::{
+    WasiCryptoAsymmetricCommon, WasiCryptoCommon, WasiCryptoCtx, WasiCryptoSignatures,
+    WasiCryptoSymmetric,
+};
+
 fn parse_module(s: &OsStr) -> Result<PathBuf, OsString> {
     // Do not accept wasmtime subcommand names as the module name
     match s.to_str() {
@@ -362,6 +368,15 @@ fn populate_with_wasi(
     {
         let wasi_nn = WasiNn::new(linker.store(), WasiNnCtx::new()?);
         wasi_nn.add_to_linker(linker)?;
+    }
+
+    #[cfg(feature = "wasi-crypto")]
+    {
+        let cx_crypto = WasiCryptoCtx::new();
+        WasiCryptoCommon::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+        WasiCryptoAsymmetricCommon::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+        WasiCryptoSignatures::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+        WasiCryptoSymmetric::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
     }
 
     let wasi = wasmtime_wasi::old::snapshot_0::Wasi::new(linker.store(), mk_cx()?);


### PR DESCRIPTION
Add support for the experimental wasi-crypto APIs.

This new PR imports only the wiggle/wasmtime integration bits into the `wasmtime` repository.

The purpose of the implementation is to allow bindings and application developers to test the proposed APIs. Rust and AssemblyScript bindings are also available as examples.

Like `wasi-nn`, it is currently disabled by default, and requires the `wasi-crypto` feature flag to be compiled in.