### PR TITLE
Add additional tests for icmp-i128. Fixes #1136.

### DIFF
--- a/cranelift/filetests/filetests/isa/x64/icmp-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/icmp-i128-run.clif
@@ -1,0 +1,95 @@
+test run
+target x86_64
+feature "experimental_x64"
+
+function %test_icmp_eq_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x0
+    v12 = iconst.i64 0x0
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x0
+    v22 = iconst.i64 0x0
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 eq v1, v2
+    return v10
+}
+
+; run
+
+function %test_icmp_imm_eq_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x0
+    v12 = iconst.i64 0x0
+    v1 = iconcat v11, v12
+    v10 = icmp_imm.i128 eq v1, 0x0
+    return v10
+}
+
+; run
+
+function %test_icmp_ne_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x0
+    v12 = iconst.i64 0x0
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x0
+    v22 = iconst.i64 0x1
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 ne v1, v2
+    return v10
+}
+
+; run
+
+function %test_icmp_imm_ne_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x0
+    v12 = iconst.i64 0x0
+    v1 = iconcat v11, v12
+    v10 = icmp_imm.i128 ne v1, 0x1
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_eq_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x1
+    v22 = iconst.i64 0x1
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 eq v1, v2
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_gt_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x1
+    v22 = iconst.i64 0x2
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 ugt v2, v1
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_ge_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x1
+    v22 = iconst.i64 0x1
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 uge v1, v2
+    return v10
+}
+
+; run

--- a/cranelift/filetests/filetests/isa/x86/icmp-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/icmp-i128.clif
@@ -50,3 +50,45 @@ block0:
 }
 
 ; run
+
+function %test_icmp_nz_eq_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x1
+    v22 = iconst.i64 0x1
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 eq v1, v2
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_gt_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x1
+    v22 = iconst.i64 0x2
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 ugt v2, v1
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_ge_i128() -> b1 {
+block0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x1
+    v22 = iconst.i64 0x1
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 uge v1, v2
+    return v10
+}
+
+; run


### PR DESCRIPTION
Tests added:
  * eq with nonzero values
  * gt with nonzero values
  * ge with nonzero values

The b1 legalization issues referenced in the discussion of #1136 appear to be resolved.

closes #1136