### PR TITLE
cranelift-native: Use libstd feature detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,6 @@ name = "cranelift-native"
 version = "0.69.0"
 dependencies = [
  "cranelift-codegen",
- "raw-cpuid",
  "target-lexicon",
 ]
 
@@ -2143,15 +2142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -14,9 +14,6 @@ edition = "2018"
 cranelift-codegen = { path = "../codegen", version = "0.69.0", default-features = false }
 target-lexicon = "0.11"
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-raw-cpuid = "9.0.0"
-
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std"]


### PR DESCRIPTION
This commit switches cranelift-native to useing the
`is_x86_feature_detected!` macro in the standard library instead of the
`raw-cpuid` crate.

