### PR TITLE
ci: bump nightly version and update x64 experimental script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,10 +77,7 @@ jobs:
     # nightly-only feature right now.
     - uses: ./.github/actions/install-rust
       with:
-        # TODO (rust-lang/rust#79661): We are seeing an internal compiler error when
-        # building with the latest (2020-12-06) nightly; pin on a slightly older
-        # version for now.
-        toolchain: nightly-2020-11-29
+        toolchain: nightly-2021-01-26
     - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
     - run: cargo doc --package cranelift-codegen-meta --document-private-items
     - uses: actions/upload-artifact@v1
@@ -165,7 +162,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-11-29
+        toolchain: nightly-2021-01-26
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
@@ -222,7 +219,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2020-11-29
+            rust: nightly-2021-01-26
           - build: macos
             os: macos-latest
             rust: stable
@@ -321,7 +318,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-11-29
+        toolchain: nightly-2021-01-26
     - uses: ./.github/actions/define-llvm-env
 
     # Install wasm32 targets in order to build various tests throughout the
@@ -332,7 +329,7 @@ jobs:
     # Run the x64 CI script.
     - run: ./ci/run-experimental-x64-ci.sh
       env:
-        CARGO_VERSION: "+nightly-2020-11-29"
+        CARGO_VERSION: "+nightly-2021-01-26"
         RUST_BACKTRACE: 1
 
   # Build and test the wasi-nn module.
@@ -345,7 +342,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/install-rust
         with:
-          toolchain: nightly-2020-11-29
+          toolchain: nightly-2021-01-26
       - run: rustup target add wasm32-wasi
       - uses: ./.github/actions/install-openvino
       - run: ./ci/run-wasi-nn-example.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
   "examples/wasi-fs/wasm",
   "fuzz",
 ]
+resolver = "2"
 
 [features]
 default = ["jitdump", "wasmtime/wat", "wasmtime/parallel-compilation"]

--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -7,7 +7,7 @@ CARGO_VERSION=${CARGO_VERSION:-"+nightly"}
 
 cargo $CARGO_VERSION \
             --locked \
-            -Zfeatures=all -Zpackage-features \
+            -Zfeatures=all \
             test \
             --features test-programs/test_programs \
             --features experimental_x64 \


### PR DESCRIPTION
The -Z flag that I've removed in the x64 script doesn't exist anymore. I've checked that even though I've removed it, we're still taking the x64 paths in codegen (checked by putting explicit panics there, and seeing the spec tests failing).

Let's see if the nightly bump works.