### PR TITLE
Implement limiting WebAssembly execution with fuel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,6 +3138,7 @@ dependencies = [
  "wasmtime-wasi-crypto",
  "wasmtime-wasi-nn",
  "wasmtime-wast",
+ "wast 32.0.0",
  "wat",
 ]
 
@@ -3149,6 +3150,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-wasm",
+ "wasmparser",
  "wasmtime-environ",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ test-programs = { path = "crates/test-programs" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
 wasmtime-runtime = { path = "crates/runtime" }
 tracing-subscriber = "0.2.0"
+wast = "32.0.0"
 
 [build-dependencies]
 anyhow = "1.0.19"

--- a/cranelift/src/souper_harvest.rs
+++ b/cranelift/src/souper_harvest.rs
@@ -12,7 +12,7 @@ static WASM_MAGIC: &[u8] = &[0x00, 0x61, 0x73, 0x6D];
 /// Harvest candidates for superoptimization from a Wasm or Clif file.
 ///
 /// Candidates are emitted in Souper's text format:
-/// https://github.com/google/souper
+/// <https://github.com/google/souper>
 #[derive(StructOpt)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -261,7 +261,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 .extend_from_slice(builder.block_params(loop_body));
 
             builder.switch_to_block(loop_body);
-            environ.translate_loop_header(builder.cursor())?;
+            environ.translate_loop_header(builder)?;
         }
         Operator::If { ty } => {
             let val = state.pop1();

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -643,7 +643,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     ///
     /// This can be used to insert explicit interrupt or safepoint checking at
     /// the beginnings of loops.
-    fn translate_loop_header(&mut self, _pos: FuncCursor) -> WasmResult<()> {
+    fn translate_loop_header(&mut self, _builder: &mut FunctionBuilder) -> WasmResult<()> {
         // By default, don't emit anything.
         Ok(())
     }

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -295,6 +295,12 @@ pub trait FuncEnvironment: TargetEnvironment {
         ReturnMode::NormalReturns
     }
 
+    /// Called after the locals for a function have been parsed, and the number
+    /// of variables defined by this function is provided.
+    fn after_locals(&mut self, num_locals_defined: usize) {
+        drop(num_locals_defined);
+    }
+
     /// Set up the necessary preamble definitions in `func` to access the global variable
     /// identified by `index`.
     ///

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -170,6 +170,8 @@ fn parse_local_decls<FE: FuncEnvironment + ?Sized>(
         declare_locals(builder, count, ty, &mut next_local, environ)?;
     }
 
+    environ.after_locals(next_local);
+
     Ok(())
 }
 

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -17,3 +17,4 @@ cranelift-wasm = { path = "../../cranelift/wasm", version = "0.69.0" }
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.69.0" }
 cranelift-frontend = { path = "../../cranelift/frontend", version = "0.69.0" }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.69.0" }
+wasmparser = "0.73.0"

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -558,6 +558,15 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             // This is a normal instruction where the fuel is buffered to later
             // get added to `self.fuel_var`.
             //
+            // Note that we generally ignore instructions which may trap and
+            // therefore result in exiting a block early. Current usage of fuel
+            // means that it's not too important to account for a precise amount
+            // of fuel consumed but rather "close to the actual amount" is good
+            // enough. For 100% precise counting, however, we'd probably need to
+            // not only increment but also save the fuel amount more often
+            // around trapping instructions. (see the `unreachable` instruction
+            // case above)
+            //
             // Note that `Block` is specifically omitted from incrementing the
             // fuel variable. Control flow entering a `block` is unconditional
             // which means it's effectively executing straight-line code. We'll

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -57,6 +57,8 @@ macro_rules! foreach_builtin_function {
             memory_atomic_wait64(vmctx, i32, i32, i64, i64) -> (i32);
             /// Returns an index for wasm's `memory.atomic.wait64` for imported memories.
             imported_memory_atomic_wait64(vmctx, i32, i32, i64, i64) -> (i32);
+            /// Invoked when fuel has run out while executing a function.
+            out_of_gas(vmctx) -> ();
         }
     };
 }

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -23,6 +23,10 @@ pub struct Tunables {
     /// calls and interrupts are implemented through the `VMInterrupts`
     /// structure, or `InterruptHandle` in the `wasmtime` crate.
     pub interruptable: bool,
+
+    /// Whether or not fuel is enabled for generated code, meaning that fuel
+    /// will be consumed every time a wasm instruction is executed.
+    pub consume_fuel: bool,
 }
 
 impl Default for Tunables {
@@ -57,6 +61,7 @@ impl Default for Tunables {
             generate_native_debuginfo: false,
             parse_wasm_debuginfo: true,
             interruptable: false,
+            consume_fuel: false,
         }
     }
 }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -258,6 +258,11 @@ impl VMOffsets {
     pub fn vminterrupts_stack_limit(&self) -> u8 {
         0
     }
+
+    /// Return the offset of the `fuel_consumed` field of `VMInterrupts`
+    pub fn vminterrupts_fuel_consumed(&self) -> u8 {
+        self.pointer_size
+    }
 }
 
 /// Offsets for `VMCallerCheckedAnyfunc`.

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -64,6 +64,8 @@ pub struct Config {
     debug_info: bool,
     canonicalize_nans: bool,
     interruptable: bool,
+    #[allow(missing_docs)]
+    pub consume_fuel: bool,
 
     // Note that we use 32-bit values here to avoid blowing the 64-bit address
     // space by requesting ungodly-large sizes/guards.
@@ -82,7 +84,8 @@ impl Config {
             .dynamic_memory_guard_size(self.dynamic_memory_guard_size.unwrap_or(0).into())
             .cranelift_nan_canonicalization(self.canonicalize_nans)
             .cranelift_opt_level(self.opt_level.to_wasmtime())
-            .interruptable(self.interruptable);
+            .interruptable(self.interruptable)
+            .consume_fuel(self.consume_fuel);
         return cfg;
     }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -95,7 +95,7 @@ pub fn instantiate_with_config(
 
     let mut timeout_state = SignalOnDrop::default();
     match timeout {
-        Timeout::Fuel(fuel) => store.set_fuel_remaining(fuel),
+        Timeout::Fuel(fuel) => store.add_fuel(fuel),
         // If a timeout is requested then we spawn a helper thread to wait for
         // the requested time and then send us a signal to get interrupted. We
         // also arrange for the thread's sleep to get interrupted if we return
@@ -418,7 +418,7 @@ pub fn spectest(fuzz_config: crate::generators::Config, test: crate::generators:
     config.wasm_bulk_memory(false);
     let store = Store::new(&Engine::new(&config));
     if fuzz_config.consume_fuel {
-        store.set_fuel_remaining(i64::max_value() as u64);
+        store.add_fuel(u64::max_value());
     }
     let mut wast_context = WastContext::new(store);
     wast_context.register_spectest().unwrap();
@@ -442,7 +442,7 @@ pub fn table_ops(
         let engine = Engine::new(&config);
         let store = Store::new(&engine);
         if fuzz_config.consume_fuel {
-            store.set_fuel_remaining(i64::max_value() as u64);
+            store.add_fuel(u64::max_value());
         }
 
         let wasm = ops.to_wasm_binary();
@@ -557,7 +557,7 @@ pub fn differential_wasmi_execution(wasm: &[u8], config: &crate::generators::Con
     let wasmtime_engine = Engine::new(&wasmtime_config);
     let wasmtime_store = Store::new(&wasmtime_engine);
     if config.consume_fuel {
-        wasmtime_store.set_fuel_remaining(i64::max_value() as u64);
+        wasmtime_store.add_fuel(u64::max_value());
     }
     let wasmtime_module =
         Module::new(&wasmtime_engine, &wasm).expect("Wasmtime can compile module");

--- a/crates/profiling/src/jitdump_linux.rs
+++ b/crates/profiling/src/jitdump_linux.rs
@@ -1,6 +1,6 @@
 //! Support for jitdump files which can be used by perf for profiling jitted code.
 //! Spec definitions for the output format is as described here:
-//! https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jitdump-specification.txt
+//! <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jitdump-specification.txt>
 //!
 //! Usage Example:
 //!     Record

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -97,7 +97,7 @@
 //!
 //! For more general information on deferred reference counting, see *An
 //! Examination of Deferred Reference Counting and Cycle Detection* by Quinane:
-//! https://openresearch-repository.anu.edu.au/bitstream/1885/42030/2/hon-thesis.pdf
+//! <https://openresearch-repository.anu.edu.au/bitstream/1885/42030/2/hon-thesis.pdf>
 
 use std::alloc::Layout;
 use std::any::Any;

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -581,3 +581,8 @@ pub unsafe extern "C" fn wasmtime_imported_memory_atomic_wait64(
         "wasm atomics (fn wasmtime_imported_memory_atomic_wait64) unsupported",
     ))));
 }
+
+/// Hook for when an instance runs out of fuel.
+pub unsafe extern "C" fn wasmtime_out_of_gas(_vmctx: *mut VMContext) {
+    crate::traphandlers::out_of_gas()
+}

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -410,6 +410,13 @@ pub fn with_last_info<R>(func: impl FnOnce(Option<&dyn Any>) -> R) -> R {
     tls::with(|state| func(state.map(|s| s.trap_info.as_any())))
 }
 
+/// Invokes the contextually-defined context's out-of-gas function.
+///
+/// (basically delegates to `wasmtime::Store::out_of_gas`)
+pub fn out_of_gas() {
+    tls::with(|state| state.unwrap().trap_info.out_of_gas())
+}
+
 /// Temporary state stored on the stack which is registered in the `tls` module
 /// below for calls into wasm.
 pub struct CallThreadState<'a> {
@@ -442,6 +449,12 @@ pub unsafe trait TrapInfo {
     /// Returns the maximum size, in bytes, the wasm native stack is allowed to
     /// grow to.
     fn max_wasm_stack(&self) -> usize;
+
+    /// Callback invoked whenever WebAssembly has entirely consumed the fuel
+    /// that it was allotted.
+    ///
+    /// This function may return, and it may also `raise_lib_trap`.
+    fn out_of_gas(&self);
 }
 
 enum UnwindReason {

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -4,6 +4,7 @@
 use crate::externref::VMExternRef;
 use crate::instance::Instance;
 use std::any::Any;
+use std::cell::UnsafeCell;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::u32;
@@ -668,6 +669,9 @@ pub struct VMInterrupts {
     /// This is used to control both stack overflow as well as interrupting wasm
     /// modules. For more information see `crates/environ/src/cranelift.rs`.
     pub stack_limit: AtomicUsize,
+
+    /// TODO
+    pub fuel_consumed: UnsafeCell<u64>,
 }
 
 impl VMInterrupts {
@@ -682,6 +686,7 @@ impl Default for VMInterrupts {
     fn default() -> VMInterrupts {
         VMInterrupts {
             stack_limit: AtomicUsize::new(usize::max_value()),
+            fuel_consumed: UnsafeCell::new(0),
         }
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -152,6 +152,8 @@ impl Config {
     /// executing some code.
     ///
     /// By default this option is `false`.
+    ///
+    /// [`Store`]: crate::Store
     pub fn consume_fuel(&mut self, enable: bool) -> &mut Self {
         self.tunables.consume_fuel = enable;
         self

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -137,6 +137,26 @@ impl Config {
         self
     }
 
+    /// Configures whether execution of WebAssembly will "consume fuel" to
+    /// either halt or yield execution as desired.
+    ///
+    /// This option is similar in purpose to [`Config::interruptable`] where
+    /// you can prevent infinitely-executing WebAssembly code. The difference
+    /// is that this option allows deterministic execution of WebAssembly code
+    /// by instrumenting generated code consume fuel as it executes. When fuel
+    /// runs out the behavior is defined by configuration within a [`Store`],
+    /// and by default a trap is raised.
+    ///
+    /// Note that a [`Store`] starts with no fuel, so if you enable this option
+    /// you'll have to be sure to pour some fuel into [`Store`] before
+    /// executing some code.
+    ///
+    /// By default this option is `false`.
+    pub fn consume_fuel(&mut self, enable: bool) -> &mut Self {
+        self.tunables.consume_fuel = enable;
+        self
+    }
+
     /// Configures the maximum amount of native stack space available to
     /// executing WebAssembly code.
     ///

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -439,7 +439,7 @@ impl Store {
     /// If fuel consumption is not enabled via
     /// [`Config::consume_fuel`](crate::Config::consume_fuel) then this
     /// function will return `None`. Also note that fuel, if enabled, must be
-    /// originally configured via [`Store::set_fuel_remaining`].
+    /// originally configured via [`Store::add_fuel`].
     pub fn fuel_consumed(&self) -> Option<u64> {
         if !self.engine().config().tunables.consume_fuel {
             return None;

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -436,9 +436,10 @@ impl Store {
 
     /// Returns the amount of fuel consumed by this store's execution so far.
     ///
-    /// If fuel consumption is not enabled via [`Config::consume_fuel`] then
-    /// this function will return `None`. Also note that fuel, if enabled, must
-    /// be originally configured via [`Store::set_fuel_remaining`].
+    /// If fuel consumption is not enabled via
+    /// [`Config::consume_fuel`](crate::Config::consume_fuel) then this
+    /// function will return `None`. Also note that fuel, if enabled, must be
+    /// originally configured via [`Store::set_fuel_remaining`].
     ///
     /// Finally, this will only return the amount of fuel consumed since
     /// [`Store::set_fuel_remaining`] was last called, so this does not return
@@ -456,18 +457,18 @@ impl Store {
     /// wasm to consume while executing.
     ///
     /// For this method to work fuel consumption must be enabled via
-    /// [`Config::consume_fuel`]. By default a [`Store`] starts with 0 fuel for
-    /// wasm to execute with (meaning it will immediately trap). This function
-    /// must be called for the store to have some fuel to allow WebAssembly to
-    /// execute.
+    /// [`Config::consume_fuel`](crate::Config::consume_fuel). By default a
+    /// [`Store`] starts with 0 fuel for wasm to execute with (meaning it will
+    /// immediately trap). This function must be called for the store to have
+    /// some fuel to allow WebAssembly to execute.
     ///
     /// Note that at this time when fuel is entirely consumed it will cause
     /// wasm to trap. More usages of fuel are planned for the future.
     ///
     /// # Panics
     ///
-    /// This function will panic if the store's [`Config`] did not have fuel
-    /// consumption enabled.
+    /// This function will panic if the store's [`Config`](crate::Config) did
+    /// not have fuel consumption enabled.
     ///
     /// This funtion will also panic if `remaining` is larger than
     /// `i64::max_value()`.

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -427,6 +427,15 @@ impl Store {
             );
         }
     }
+
+    /// TODO
+    pub fn fuel_consumed(&self) -> Option<u64> {
+        if self.engine().config().tunables.consume_fuel {
+            Some(unsafe { *self.inner.interrupts.fuel_consumed.get() })
+        } else {
+            None
+        }
+    }
 }
 
 unsafe impl TrapInfo for Store {
@@ -480,6 +489,13 @@ impl Drop for StoreInner {
 pub struct InterruptHandle {
     interrupts: Arc<VMInterrupts>,
 }
+
+// The `VMInterrupts` type is a pod-type with no destructor, and we only access
+// `interrupts` from other threads, so add in these trait impls which are
+// otherwise not available due to the `fuel_consumed` variable in
+// `VMInterrupts`.
+unsafe impl Send for InterruptHandle {}
+unsafe impl Sync for InterruptHandle {}
 
 impl InterruptHandle {
     /// Flags that execution within this handle's original [`Store`] should be

--- a/fuzz/fuzz_targets/instantiate-maybe-invalid.rs
+++ b/fuzz/fuzz_targets/instantiate-maybe-invalid.rs
@@ -4,13 +4,18 @@ use libfuzzer_sys::fuzz_target;
 use std::time::Duration;
 use wasm_smith::MaybeInvalidModule;
 use wasmtime::Strategy;
-use wasmtime_fuzzing::oracles;
+use wasmtime_fuzzing::oracles::{self, Timeout};
 
-fuzz_target!(|module: MaybeInvalidModule| {
+fuzz_target!(|pair: (bool, MaybeInvalidModule)| {
+    let (timeout_with_time, module) = pair;
     oracles::instantiate_with_config(
         &module.to_bytes(),
         false,
         wasmtime_fuzzing::fuzz_default_config(Strategy::Auto).unwrap(),
-        Some(Duration::from_secs(20)),
+        if timeout_with_time {
+            Timeout::Time(Duration::from_secs(20))
+        } else {
+            Timeout::Fuel(100_000)
+        },
     );
 });

--- a/fuzz/fuzz_targets/instantiate-swarm.rs
+++ b/fuzz/fuzz_targets/instantiate-swarm.rs
@@ -4,11 +4,21 @@ use libfuzzer_sys::fuzz_target;
 use std::time::Duration;
 use wasm_smith::{Config, ConfiguredModule, SwarmConfig};
 use wasmtime::Strategy;
-use wasmtime_fuzzing::oracles;
+use wasmtime_fuzzing::oracles::{self, Timeout};
 
-fuzz_target!(|module: ConfiguredModule<SwarmConfig>| {
+fuzz_target!(|pair: (bool, ConfiguredModule<SwarmConfig>)| {
+    let (timeout_with_time, module) = pair;
     let mut cfg = wasmtime_fuzzing::fuzz_default_config(Strategy::Auto).unwrap();
     cfg.wasm_multi_memory(true);
     cfg.wasm_module_linking(module.config().module_linking_enabled());
-    oracles::instantiate_with_config(&module.to_bytes(), true, cfg, Some(Duration::from_secs(20)));
+    oracles::instantiate_with_config(
+        &module.to_bytes(),
+        true,
+        cfg,
+        if timeout_with_time {
+            Timeout::Time(Duration::from_secs(20))
+        } else {
+            Timeout::Fuel(100_000)
+        },
+    );
 });

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -7,7 +7,7 @@ mod kw {
 }
 
 struct FuelWast<'a> {
-    assertions: Vec<(u64, wast::Module<'a>)>,
+    assertions: Vec<(wast::Span, u64, wast::Module<'a>)>,
 }
 
 impl<'a> Parse<'a> for FuelWast<'a> {
@@ -15,8 +15,8 @@ impl<'a> Parse<'a> for FuelWast<'a> {
         let mut assertions = Vec::new();
         while !parser.is_empty() {
             assertions.push(parser.parens(|p| {
-                p.parse::<kw::assert_fuel>()?;
-                Ok((p.parse()?, p.parens(|p| p.parse())?))
+                let span = p.parse::<kw::assert_fuel>()?.0;
+                Ok((span, p.parse()?, p.parens(|p| p.parse())?))
             })?);
         }
         Ok(FuelWast { assertions })
@@ -28,18 +28,31 @@ fn run() -> Result<()> {
     let test = std::fs::read_to_string("tests/all/fuel.wast")?;
     let buf = ParseBuffer::new(&test)?;
     let mut wast = parser::parse::<FuelWast<'_>>(&buf)?;
-    for (fuel, module) in wast.assertions.iter_mut() {
-        assert_fuel(*fuel, &module.encode()?);
+    for (span, fuel, module) in wast.assertions.iter_mut() {
+        let consumed = fuel_consumed(&module.encode()?);
+        if consumed == *fuel {
+            continue;
+        }
+        let (line, col) = span.linecol_in(&test);
+        panic!(
+            "tests/all/fuel.wast:{}:{} - expected {} fuel, found {}",
+            line + 1,
+            col + 1,
+            fuel,
+            consumed
+        );
     }
     Ok(())
 }
 
-fn assert_fuel(fuel: u64, wasm: &[u8]) {
+fn fuel_consumed(wasm: &[u8]) -> u64 {
+    const MAX: u64 = 10_000;
     let mut config = Config::new();
     config.consume_fuel(true);
     let engine = Engine::new(&config);
     let module = Module::new(&engine, wasm).unwrap();
     let store = Store::new(&engine);
+    store.set_fuel_remaining(MAX);
     drop(Instance::new(&store, &module, &[]));
-    assert_eq!(store.fuel_consumed(), Some(fuel));
+    store.fuel_consumed().unwrap()
 }

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -46,13 +46,12 @@ fn run() -> Result<()> {
 }
 
 fn fuel_consumed(wasm: &[u8]) -> u64 {
-    const MAX: u64 = 10_000;
     let mut config = Config::new();
     config.consume_fuel(true);
     let engine = Engine::new(&config);
     let module = Module::new(&engine, wasm).unwrap();
     let store = Store::new(&engine);
-    store.set_fuel_remaining(MAX);
+    store.add_fuel(u64::max_value());
     drop(Instance::new(&store, &module, &[]));
     store.fuel_consumed().unwrap()
 }
@@ -114,7 +113,7 @@ fn iloop() {
         let engine = Engine::new(&config);
         let module = Module::new(&engine, wat).unwrap();
         let store = Store::new(&engine);
-        store.set_fuel_remaining(10_000);
+        store.add_fuel(10_000);
         let error = Instance::new(&store, &module, &[]).err().unwrap();
         assert!(
             error.to_string().contains("all fuel consumed"),

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -56,3 +56,70 @@ fn fuel_consumed(wasm: &[u8]) -> u64 {
     drop(Instance::new(&store, &module, &[]));
     store.fuel_consumed().unwrap()
 }
+
+#[test]
+fn iloop() {
+    iloop_aborts(
+        r#"
+            (module
+                (start 0)
+                (func loop br 0 end)
+            )
+        "#,
+    );
+    iloop_aborts(
+        r#"
+            (module
+                (start 0)
+                (func loop i32.const 1 br_if 0 end)
+            )
+        "#,
+    );
+    iloop_aborts(
+        r#"
+            (module
+                (start 0)
+                (func loop i32.const 0 br_table 0 end)
+            )
+        "#,
+    );
+    iloop_aborts(
+        r#"
+            (module
+                (start 0)
+                (func $f0 call $f1 call $f1)
+                (func $f1 call $f2 call $f2)
+                (func $f2 call $f3 call $f3)
+                (func $f3 call $f4 call $f4)
+                (func $f4 call $f5 call $f5)
+                (func $f5 call $f6 call $f6)
+                (func $f6 call $f7 call $f7)
+                (func $f7 call $f8 call $f8)
+                (func $f8 call $f9 call $f9)
+                (func $f9 call $f10 call $f10)
+                (func $f10 call $f11 call $f11)
+                (func $f11 call $f12 call $f12)
+                (func $f12 call $f13 call $f13)
+                (func $f13 call $f14 call $f14)
+                (func $f14 call $f15 call $f15)
+                (func $f15 call $f16 call $f16)
+                (func $f16)
+            )
+        "#,
+    );
+
+    fn iloop_aborts(wat: &str) {
+        let mut config = Config::new();
+        config.consume_fuel(true);
+        let engine = Engine::new(&config);
+        let module = Module::new(&engine, wat).unwrap();
+        let store = Store::new(&engine);
+        store.set_fuel_remaining(10_000);
+        let error = Instance::new(&store, &module, &[]).err().unwrap();
+        assert!(
+            error.to_string().contains("all fuel consumed"),
+            "bad error: {}",
+            error
+        );
+    }
+}

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use wasmtime::*;
+use wast::parser::{self, Parse, ParseBuffer, Parser};
+
+mod kw {
+    wast::custom_keyword!(assert_fuel);
+}
+
+struct FuelWast<'a> {
+    assertions: Vec<(u64, wast::Module<'a>)>,
+}
+
+impl<'a> Parse<'a> for FuelWast<'a> {
+    fn parse(parser: Parser<'a>) -> parser::Result<Self> {
+        let mut assertions = Vec::new();
+        while !parser.is_empty() {
+            assertions.push(parser.parens(|p| {
+                p.parse::<kw::assert_fuel>()?;
+                Ok((p.parse()?, p.parens(|p| p.parse())?))
+            })?);
+        }
+        Ok(FuelWast { assertions })
+    }
+}
+
+#[test]
+fn run() -> Result<()> {
+    let test = std::fs::read_to_string("tests/all/fuel.wast")?;
+    let buf = ParseBuffer::new(&test)?;
+    let mut wast = parser::parse::<FuelWast<'_>>(&buf)?;
+    for (fuel, module) in wast.assertions.iter_mut() {
+        assert_fuel(*fuel, &module.encode()?);
+    }
+    Ok(())
+}
+
+fn assert_fuel(fuel: u64, wasm: &[u8]) {
+    let mut config = Config::new();
+    config.consume_fuel(true);
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, wasm).unwrap();
+    let store = Store::new(&engine);
+    drop(Instance::new(&store, &module, &[]));
+    assert_eq!(store.fuel_consumed(), Some(fuel));
+}

--- a/tests/all/fuel.wast
+++ b/tests/all/fuel.wast
@@ -1,0 +1,208 @@
+(assert_fuel 0 (module))
+
+(assert_fuel 1
+  (module
+    (func $f)
+    (start $f)))
+
+(assert_fuel 2
+  (module
+    (func $f
+      i32.const 0
+      drop
+    )
+    (start $f)))
+
+(assert_fuel 1
+  (module
+    (func $f
+      block
+      end
+    )
+    (start $f)))
+
+(assert_fuel 1
+  (module
+    (func $f
+      unreachable
+    )
+    (start $f)))
+
+(assert_fuel 7
+  (module
+    (func $f
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      unreachable
+    )
+    (start $f)))
+
+(assert_fuel 1
+  (module
+    (func $f
+      return
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      unreachable
+    )
+    (start $f)))
+
+(assert_fuel 3
+  (module
+    (func $f
+      i32.const 0
+      if
+        call $f
+      end
+    )
+    (start $f)))
+
+(assert_fuel 4
+  (module
+    (func $f
+      i32.const 1
+      if
+        i32.const 0
+        drop
+      end
+    )
+    (start $f)))
+
+(assert_fuel 4
+  (module
+    (func $f
+      i32.const 1
+      if
+        i32.const 0
+        drop
+      else
+        call $f
+      end
+    )
+    (start $f)))
+
+(assert_fuel 4
+  (module
+    (func $f
+      i32.const 0
+      if
+        call $f
+      else
+        i32.const 0
+        drop
+      end
+    )
+    (start $f)))
+
+(assert_fuel 3
+  (module
+    (func $f
+      block
+        i32.const 1
+        br_if 0
+        i32.const 0
+        drop
+      end
+    )
+    (start $f)))
+
+(assert_fuel 4
+  (module
+    (func $f
+      block
+        i32.const 0
+        br_if 0
+        i32.const 0
+        drop
+      end
+    )
+    (start $f)))
+
+;; count code before unreachable
+(assert_fuel 2
+  (module
+    (func $f
+      i32.const 0
+      unreachable
+    )
+    (start $f)))
+
+;; count code before return
+(assert_fuel 2
+  (module
+    (func $f
+      i32.const 0
+      return
+    )
+    (start $f)))
+
+;; cross-function fuel works
+(assert_fuel 3
+  (module
+    (func $f
+      call $other
+    )
+    (func $other)
+    (start $f)))
+(assert_fuel 5
+  (module
+    (func $f
+      i32.const 0
+      call $other
+      i32.const 0
+      drop
+    )
+    (func $other (param i32))
+    (start $f)))
+(assert_fuel 4
+  (module
+    (func $f
+      call $other
+      drop
+    )
+    (func $other (result i32)
+      i32.const 0
+    )
+    (start $f)))
+(assert_fuel 4
+  (module
+    (func $f
+      i32.const 0
+      call_indirect
+    )
+    (func $other)
+    (table funcref (elem $other))
+    (start $f)))
+
+;; loops!
+(assert_fuel 1
+  (module
+    (func $f
+      loop
+      end
+    )
+    (start $f)))
+(assert_fuel 53 ;; 5 loop instructions, 10 iterations, 2 header instrs, 1 func
+  (module
+    (func $f
+      (local i32)
+      i32.const 10
+      local.set 0
+
+      loop
+        local.get 0
+        i32.const 1
+        i32.sub
+        local.tee 0
+        br_if 0
+      end
+    )
+    (start $f)))

--- a/tests/all/fuzzing.rs
+++ b/tests/all/fuzzing.rs
@@ -6,7 +6,7 @@
 //! `include_bytes!("./fuzzing/some-descriptive-name.wasm")`.
 
 use wasmtime::{Config, Strategy};
-use wasmtime_fuzzing::oracles;
+use wasmtime_fuzzing::oracles::{self, Timeout};
 
 #[test]
 fn instantiate_empty_module() {
@@ -26,5 +26,5 @@ fn instantiate_module_that_compiled_to_x64_has_register_32() {
     let mut config = Config::new();
     config.debug_info(true);
     let data = wat::parse_str(include_str!("./fuzzing/issue694.wat")).unwrap();
-    oracles::instantiate_with_config(&data, true, config, None);
+    oracles::instantiate_with_config(&data, true, config, Timeout::None);
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -2,6 +2,7 @@ mod cli_tests;
 mod custom_signal_handler;
 mod debug;
 mod externals;
+mod fuel;
 mod func;
 mod fuzzing;
 mod globals;


### PR DESCRIPTION
This PR lifts a feature from Lucet to wasmtime where generated code can count instructions or account for "fuel" during execution. The purpose of this feature is similar to the interrupt support via `InterruptHandle`, but it mainly allows deterministically interrupting a wasm module instead of relying on a timer. Additionally a future goal of this PR is to extend the `async` support of wasmtime to leverage fuel to periodically "interrupt" executing wasm code to yield back to the host. This would enable wasmtime futures to never take "too long" in `Future::poll` since if they would otherwise take awhile they'd yield back to the host and allow preemption and/or other things like future timeouts.

Thee implementation here is nearly copied verbatim from Lucet itself, with tweaks as appropriate for the different vmctx representation in Wasmtime. The main difference is that Wasmtime's fuel counter is two levels of indirection away from the vmctx rather than one in Lucet. To help with this a new `Variable` stores the `VMInterrupts` pointer value to avoid reloading the same value each time from the vmctx.

Support for this feature is exposed through a few new APIs:

* `Config::consume_fuel` - enables codegen options for wasm to consume fuel, and behaves similar to `interruptable`.
* `Store::set_fuel_remaining` - this is how fuel is injected into a `Store` for execution of wasm. Note that stores always start with 0 fuel so this is required to be called.
* `Store::fuel_consumed` - this can be used to check how much fuel has been consumed so far.

The current behavior, which cannot be changed, is that when fuel runs out a wasm trap is generated. I hope to make this configurable in the future so that for async stores when fuel runs out it's automatically re-injected with fuel but only after a yield back to the host happens.

I've done a bit of benchmarking with this using criterion and the benchmarks here -- https://github.com/bytecodealliance/sightglass/tree/main/benchmarks-next. The benchmarks are relatively limited at this time but were able to produce some useful data in the meantime. This shows to be a 35-45% slowdown on my personal laptop for the runtime execution of the benchmarked porttion of the code for blake3-scalar and shootout-ackermann. At least for ackermann this is somewhat expected because the loops/function calls are all tiny, so the overhead is quite noticeable. For blake3-scalar I assume it's similar but haven't dug in yet. Note that these numbers were with the new backend since the old x86 backend seems significantly worse than the x64 one.

I do think there might be some relatively low-hanging fruit with respect to performance, but further tweaks would require changes to cranelift itself to optimize instruction selection. For example one optimization might be to not have a `fuel_var` and instead periodically do `addq $fuel_consumed, offset(%vminterrupts_ptr)` which avoids consuming extra registers. Similarly `cmpq $0, offset(%vminterrupts_ptr)` could be generated as well. I couldn't get the x64 backend to emit those forms of instructions at this time though. I'm also not 100% certain that it'll be faster.

Note that for now this doesn't depend on the `async` PR, but I plan on having a future PR after these two land which implements the periodically-yield option.