### PR TITLE
Avoid creating 0-sized nops in x64's gen_nop().

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -566,7 +566,7 @@ impl Inst {
 
 impl Inst {
     pub(crate) fn nop(len: u8) -> Self {
-        debug_assert!(len <= 16);
+        debug_assert!(len <= 15);
         Self::Nop { len }
     }
 
@@ -2594,11 +2594,11 @@ impl MachInst for Inst {
     }
 
     fn gen_zero_len_nop() -> Inst {
-        Inst::Nop { len: 0 }
+        Inst::nop(0)
     }
 
     fn gen_nop(preferred_size: usize) -> Inst {
-        Inst::nop((preferred_size % 16) as u8)
+        Inst::nop(std::cmp::min(preferred_size, 15) as u8)
     }
 
     fn maybe_direct_reload(&self, _reg: VirtualReg, _slot: SpillSlot) -> Option<Inst> {

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -178,7 +178,7 @@ pub trait MachInst: Clone + Debug {
     /// request a NOP of that size, or as close to it as possible. The machine
     /// backend may return a NOP whose binary encoding is smaller than the
     /// preferred size, but must not return a NOP that is larger. However,
-    /// the instruction must have a nonzero size.
+    /// the instruction must have a nonzero size if preferred_size is nonzero.
     fn gen_nop(preferred_size: usize) -> Self;
 
     /// Get the register universe for this backend.


### PR DESCRIPTION
By contract, the result of gen_nop() must be nonzero:
https://github.com/bytecodealliance/wasmtime/blob/503129ad9103028cd0b56ae969848ec1bbf25bc7/cranelift/codegen/src/machinst/mod.rs#L181

Otherwise. [emit](https://github.com/bytecodealliance/wasmtime/blob/95822a54f2d31c6bb02f1519059eb2a6b4c163ce/cranelift/codegen/src/machinst/vcode.rs#L514) could get stuck in an infinite loop.

This should not change generated code at all since all generated instructions will still be 1-15 bytes. 
