### PR TITLE
Only handle signals at pcs with trap information

### DIFF
--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -432,7 +432,7 @@ pub unsafe trait TrapInfo {
 
     /// Returns whether the given program counter lies within wasm code,
     /// indicating whether we should handle a trap or not.
-    fn is_wasm_code(&self, pc: usize) -> bool;
+    fn is_wasm_trap(&self, pc: usize) -> bool;
 
     /// Uses `call` to call a custom signal handler, if one is specified.
     ///
@@ -635,7 +635,7 @@ impl<'a> CallThreadState<'a> {
         }
 
         // If this fault wasn't in wasm code, then it's not our problem
-        if !self.trap_info.is_wasm_code(pc as usize) {
+        if !self.trap_info.is_wasm_trap(pc as usize) {
             return ptr::null();
         }
 

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -191,8 +191,9 @@ impl Store {
             None => return,
         };
         // Only register this module if it hasn't already been registered.
-        if !self.is_wasm_code(first_pc) {
-            self.inner.frame_info.borrow_mut().register(module);
+        let mut info = self.inner.frame_info.borrow_mut();
+        if !info.contains_pc(first_pc) {
+            info.register(module);
         }
     }
 
@@ -400,8 +401,8 @@ unsafe impl TrapInfo for Store {
         self
     }
 
-    fn is_wasm_code(&self, addr: usize) -> bool {
-        self.frame_info().borrow().contains_pc(addr)
+    fn is_wasm_trap(&self, addr: usize) -> bool {
+        self.frame_info().borrow().lookup_trap_info(addr).is_some()
     }
 
     fn custom_signal_handler(&self, call: &dyn Fn(&SignalHandler) -> bool) -> bool {


### PR DESCRIPTION
Previously wasmtime would handle any signal originating from wasm JIT
code. This would, however, handle bugs in JIT code as-if they were wasm
traps. Instead this commit switches signal handling to specifically
check for whether the precise program counter is expected to be a trap.
This way if a program counter traps and it's not expected to trap the
signal isn't handled and the process is aborted (presumably leading to
further debugging of whomever happens to work on the JIT at that time).
