### PR TITLE
Disable module-linking in plain instantiate fuzzers

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -47,12 +47,11 @@ fn log_wasm(wasm: &[u8]) {
 ///
 /// You can control which compiler is used via passing a `Strategy`.
 pub fn instantiate(wasm: &[u8], known_valid: bool, strategy: Strategy) {
-    instantiate_with_config(
-        wasm,
-        known_valid,
-        crate::fuzz_default_config(strategy).unwrap(),
-        None,
-    );
+    // Explicitly disable module linking for now since it's a breaking change to
+    // pre-module-linking modules due to imports
+    let mut cfg = crate::fuzz_default_config(strategy).unwrap();
+    cfg.wasm_module_linking(false);
+    instantiate_with_config(wasm, known_valid, cfg, None);
 }
 
 /// Instantiate the Wasm buffer, and implicitly fail if we have an unexpected


### PR DESCRIPTION
We already cover module linking with the `instantiate-swarm` target and
otherwise enabling module linking is preventing otherwise-valid modules
from being compiled because of the breaking change in the module linking
proposal with respect to imports.