### PR TITLE
Fix `fd_readdir` to properly truncate directory entry names.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -1,5 +1,5 @@
 use more_asserts::assert_gt;
-use std::{cmp::min, env, mem, process, slice, str};
+use std::{env, mem, process, slice, str};
 use wasi_tests::open_scratch_directory;
 
 const BUF_LEN: usize = 256;
@@ -59,7 +59,9 @@ unsafe fn exec_fd_readdir(fd: wasi::Fd, cookie: wasi::Dircookie) -> (Vec<DirEntr
     let bufused =
         wasi::fd_readdir(fd, buf.as_mut_ptr(), BUF_LEN, cookie).expect("failed fd_readdir");
 
-    let sl = slice::from_raw_parts(buf.as_ptr(), min(BUF_LEN, bufused));
+    assert!(bufused <= BUF_LEN);
+
+    let sl = slice::from_raw_parts(buf.as_ptr(), bufused);
     let dirs: Vec<_> = ReadDir::from_slice(sl).collect();
     let eof = bufused < BUF_LEN;
     (dirs, eof)

--- a/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
+++ b/crates/wasi-common/src/snapshots/wasi_snapshot_preview1.rs
@@ -304,7 +304,6 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             let dirent_len: types::Size = dirent_raw.len().try_into()?;
             let name_raw = name.as_bytes();
             let name_len = name_raw.len().try_into()?;
-            let offset = dirent_len.checked_add(name_len).ok_or(Error::Overflow)?;
 
             // Copy as many bytes of the dirent as we can, up to the end of the buffer.
             let dirent_copy_len = min(dirent_len, buf_len - bufused);
@@ -318,6 +317,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             }
 
             buf = buf.add(dirent_copy_len)?;
+            bufused += dirent_copy_len;
 
             // Copy as many bytes of the name as we can, up to the end of the buffer.
             let name_copy_len = min(name_len, buf_len - bufused);
@@ -331,8 +331,7 @@ impl<'a> WasiSnapshotPreview1 for WasiCtx {
             }
 
             buf = buf.add(name_copy_len)?;
-
-            bufused += offset;
+            bufused += name_copy_len;
         }
 
         Ok(bufused)


### PR DESCRIPTION
Previously, `fd_readdir` was truncating directory entry names based on the
calculation of `min(name_len, buf_len - bufused)`, but `bufused` was not being
updated after writing in the `dirent` structure to the buffer.

This allowed `bufused` to be incremented beyond `buf_len` and returned as the
number of bytes written to the buffer, which is invalid.

This fix adjusts `bufused` when the buffer is written to for the `dirent` so
that name truncation happens as expected.

Fixes #2618.