### PR TITLE
Replace MachInst::gen_zero_len_nop with gen_nop(0)

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2907,11 +2907,10 @@ impl MachInst for Inst {
         }
     }
 
-    fn gen_zero_len_nop() -> Inst {
-        Inst::Nop0
-    }
-
     fn gen_nop(preferred_size: usize) -> Inst {
+        if preferred_size == 0 {
+            return Inst::Nop0;
+        }
         // We can't give a NOP (or any insn) < 4 bytes.
         assert!(preferred_size >= 4);
         Inst::Nop4

--- a/cranelift/codegen/src/isa/arm32/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/mod.rs
@@ -831,11 +831,10 @@ impl MachInst for Inst {
         }
     }
 
-    fn gen_zero_len_nop() -> Inst {
-        Inst::Nop0
-    }
-
     fn gen_nop(preferred_size: usize) -> Inst {
+        if preferred_size == 0 {
+            return Inst::Nop0;
+        }
         assert!(preferred_size >= 2);
         Inst::Nop2
     }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2601,10 +2601,6 @@ impl MachInst for Inst {
         }
     }
 
-    fn gen_zero_len_nop() -> Inst {
-        Inst::nop(0)
-    }
-
     fn gen_nop(preferred_size: usize) -> Inst {
         Inst::nop(std::cmp::min(preferred_size, 15) as u8)
     }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -148,9 +148,6 @@ pub trait MachInst: Clone + Debug {
         alloc_tmp: F,
     ) -> SmallVec<[Self; 4]>;
 
-    /// Generate a zero-length no-op.
-    fn gen_zero_len_nop() -> Self;
-
     /// Possibly operate on a value directly in a spill-slot rather than a
     /// register. Useful if the machine has register-memory instruction forms
     /// (e.g., add directly from or directly to memory), like x86.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -726,7 +726,7 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
     }
 
     fn gen_zero_len_nop(&self) -> I {
-        I::gen_zero_len_nop()
+        I::gen_nop(0)
     }
 
     fn maybe_direct_reload(&self, insn: &I, reg: VirtualReg, slot: SpillSlot) -> Option<I> {


### PR DESCRIPTION
Follow up to discussion in #2614. 

Folds gen_zero_len_nop into gen_nop.
The remaining definition of gen_zero_len_nop in vcode.rs is necessary to satisfy the regalloc::Function trait.