### PR TITLE
Refactor x64::Inst to use OperandSize uniformly

### DIFF
--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -339,7 +339,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
     fn gen_stack_lower_bound_trap(limit_reg: Reg) -> SmallInstVec<Self::I> {
         smallvec![
-            Inst::cmp_rmi_r(/* bytes = */ 8, RegMemImm::reg(regs::rsp()), limit_reg),
+            Inst::cmp_rmi_r(OperandSize::Size64, RegMemImm::reg(regs::rsp()), limit_reg),
             Inst::TrapIf {
                 // NBE == "> unsigned"; args above are reversed; this tests limit_reg > rsp.
                 cc: CC::NBE,
@@ -474,7 +474,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             match r_reg.get_class() {
                 RegClass::I64 => {
                     insts.push(Inst::mov_r_m(
-                        /* bytes = */ 8,
+                        OperandSize::Size64,
                         r_reg.to_reg(),
                         Amode::imm_reg(cur_offset, regs::rsp()),
                     ));

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -329,7 +329,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             ret.push(Inst::gen_move(into_reg, from_reg, I64));
         }
         ret.push(Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             AluRmiROpcode::Add,
             RegMemImm::imm(imm),
             into_reg,
@@ -388,7 +388,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         let amount = amount as u32;
 
         smallvec![Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             alu_op,
             RegMemImm::imm(amount),
             Writable::from_reg(regs::rsp()),
@@ -409,14 +409,14 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // RSP before the call will be 0 % 16.  So here, it is 8 % 16.
         insts.push(Inst::push64(RegMemImm::reg(r_rbp)));
         // RSP is now 0 % 16
-        insts.push(Inst::mov_r_r(true, r_rsp, w_rbp));
+        insts.push(Inst::mov_r_r(OperandSize::Size64, r_rsp, w_rbp));
         insts
     }
 
     fn gen_epilogue_frame_restore() -> SmallInstVec<Self::I> {
         let mut insts = SmallVec::new();
         insts.push(Inst::mov_r_r(
-            true,
+            OperandSize::Size64,
             regs::rbp(),
             Writable::from_reg(regs::rsp()),
         ));
@@ -461,7 +461,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // instruction.
         if stack_size > 0 {
             insts.push(Inst::alu_rmi_r(
-                true,
+                OperandSize::Size64,
                 AluRmiROpcode::Sub,
                 RegMemImm::imm(stack_size),
                 Writable::from_reg(regs::rsp()),
@@ -520,7 +520,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // Adjust RSP back upward.
         if stack_size > 0 {
             insts.push(Inst::alu_rmi_r(
-                true,
+                OperandSize::Size64,
                 AluRmiROpcode::Add,
                 RegMemImm::imm(stack_size),
                 Writable::from_reg(regs::rsp()),

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1323,6 +1323,8 @@ impl RoundImm {
 /// An operand's size in bits.
 #[derive(Clone, Copy, PartialEq)]
 pub enum OperandSize {
+    Size8,
+    Size16,
     Size32,
     Size64,
 }
@@ -1330,24 +1332,35 @@ pub enum OperandSize {
 impl OperandSize {
     pub(crate) fn from_bytes(num_bytes: u32) -> Self {
         match num_bytes {
-            1 | 2 | 4 => OperandSize::Size32,
+            1 => OperandSize::Size8,
+            2 => OperandSize::Size16,
+            4 => OperandSize::Size32,
             8 => OperandSize::Size64,
             _ => unreachable!(),
         }
     }
 
+    // Check that the value of self is one of the allowed sizes.
+    pub(crate) fn is_size(&self, sizes: &[Self]) -> bool {
+        for val in sizes.iter() {
+            if *self == *val {
+                return true;
+            }
+        }
+        false
+    }
+
     pub(crate) fn to_bytes(&self) -> u8 {
         match self {
+            Self::Size8 => 1,
+            Self::Size16 => 2,
             Self::Size32 => 4,
             Self::Size64 => 8,
         }
     }
 
     pub(crate) fn to_bits(&self) -> u8 {
-        match self {
-            Self::Size32 => 32,
-            Self::Size64 => 64,
-        }
+        self.to_bytes() * 8
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1347,13 +1347,8 @@ impl OperandSize {
     }
 
     // Check that the value of self is one of the allowed sizes.
-    pub(crate) fn is_size(&self, sizes: &[Self]) -> bool {
-        for val in sizes.iter() {
-            if *self == *val {
-                return true;
-            }
-        }
-        false
+    pub(crate) fn is_one_of(&self, sizes: &[Self]) -> bool {
+        sizes.iter().any(|val| *self == *val)
     }
 
     pub(crate) fn to_bytes(&self) -> u8 {

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -3,7 +3,7 @@
 use super::regs::{self, show_ireg_sized};
 use super::EmitState;
 use crate::ir::condcodes::{FloatCC, IntCC};
-use crate::ir::MemFlags;
+use crate::ir::{MemFlags, Type};
 use crate::isa::x64::inst::Inst;
 use crate::machinst::*;
 use regalloc::{
@@ -1336,8 +1336,14 @@ impl OperandSize {
             2 => OperandSize::Size16,
             4 => OperandSize::Size32,
             8 => OperandSize::Size64,
-            _ => unreachable!(),
+            _ => unreachable!("Invalid OperandSize: {}", num_bytes),
         }
+    }
+
+    // Computes the OperandSize for a given type.
+    // For vectors, the OperandSize of the lanes is returned.
+    pub(crate) fn from_ty(ty: Type) -> Self {
+        Self::from_bytes(ty.lane_type().bytes())
     }
 
     // Check that the value of self is one of the allowed sizes.

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1211,12 +1211,22 @@ fn test_x64_emit() {
     // UnaryRmR
 
     insns.push((
-        Inst::unary_rm_r(4, UnaryRmROpcode::Bsr, RegMem::reg(rsi), w_rdi),
+        Inst::unary_rm_r(
+            OperandSize::Size32,
+            UnaryRmROpcode::Bsr,
+            RegMem::reg(rsi),
+            w_rdi,
+        ),
         "0FBDFE",
         "bsrl    %esi, %edi",
     ));
     insns.push((
-        Inst::unary_rm_r(8, UnaryRmROpcode::Bsr, RegMem::reg(r15), w_rax),
+        Inst::unary_rm_r(
+            OperandSize::Size64,
+            UnaryRmROpcode::Bsr,
+            RegMem::reg(r15),
+            w_rax,
+        ),
         "490FBDC7",
         "bsrq    %r15, %rax",
     ));
@@ -1224,32 +1234,32 @@ fn test_x64_emit() {
     // ========================================================
     // Not
     insns.push((
-        Inst::not(4, Writable::from_reg(regs::rsi())),
+        Inst::not(OperandSize::Size32, Writable::from_reg(regs::rsi())),
         "F7D6",
         "notl    %esi",
     ));
     insns.push((
-        Inst::not(8, Writable::from_reg(regs::r15())),
+        Inst::not(OperandSize::Size64, Writable::from_reg(regs::r15())),
         "49F7D7",
         "notq    %r15",
     ));
     insns.push((
-        Inst::not(4, Writable::from_reg(regs::r14())),
+        Inst::not(OperandSize::Size32, Writable::from_reg(regs::r14())),
         "41F7D6",
         "notl    %r14d",
     ));
     insns.push((
-        Inst::not(2, Writable::from_reg(regs::rdi())),
+        Inst::not(OperandSize::Size16, Writable::from_reg(regs::rdi())),
         "66F7D7",
         "notw    %di",
     ));
     insns.push((
-        Inst::not(1, Writable::from_reg(regs::rdi())),
+        Inst::not(OperandSize::Size8, Writable::from_reg(regs::rdi())),
         "40F6D7",
         "notb    %dil",
     ));
     insns.push((
-        Inst::not(1, Writable::from_reg(regs::rax())),
+        Inst::not(OperandSize::Size8, Writable::from_reg(regs::rax())),
         "F6D0",
         "notb    %al",
     ));
@@ -1257,32 +1267,32 @@ fn test_x64_emit() {
     // ========================================================
     // Neg
     insns.push((
-        Inst::neg(4, Writable::from_reg(regs::rsi())),
+        Inst::neg(OperandSize::Size32, Writable::from_reg(regs::rsi())),
         "F7DE",
         "negl    %esi",
     ));
     insns.push((
-        Inst::neg(8, Writable::from_reg(regs::r15())),
+        Inst::neg(OperandSize::Size64, Writable::from_reg(regs::r15())),
         "49F7DF",
         "negq    %r15",
     ));
     insns.push((
-        Inst::neg(4, Writable::from_reg(regs::r14())),
+        Inst::neg(OperandSize::Size32, Writable::from_reg(regs::r14())),
         "41F7DE",
         "negl    %r14d",
     ));
     insns.push((
-        Inst::neg(2, Writable::from_reg(regs::rdi())),
+        Inst::neg(OperandSize::Size16, Writable::from_reg(regs::rdi())),
         "66F7DF",
         "negw    %di",
     ));
     insns.push((
-        Inst::neg(1, Writable::from_reg(regs::rdi())),
+        Inst::neg(OperandSize::Size8, Writable::from_reg(regs::rdi())),
         "40F6DF",
         "negb    %dil",
     ));
     insns.push((
-        Inst::neg(1, Writable::from_reg(regs::rax())),
+        Inst::neg(OperandSize::Size8, Writable::from_reg(regs::rax())),
         "F6D8",
         "negb    %al",
     ));
@@ -1290,32 +1300,48 @@ fn test_x64_emit() {
     // ========================================================
     // Div
     insns.push((
-        Inst::div(4, true /*signed*/, RegMem::reg(regs::rsi())),
+        Inst::div(
+            OperandSize::Size32,
+            true, /*signed*/
+            RegMem::reg(regs::rsi()),
+        ),
         "F7FE",
         "idiv    %esi",
     ));
     insns.push((
-        Inst::div(8, true /*signed*/, RegMem::reg(regs::r15())),
+        Inst::div(
+            OperandSize::Size64,
+            true, /*signed*/
+            RegMem::reg(regs::r15()),
+        ),
         "49F7FF",
         "idiv    %r15",
     ));
     insns.push((
-        Inst::div(4, false /*signed*/, RegMem::reg(regs::r14())),
+        Inst::div(
+            OperandSize::Size32,
+            false, /*signed*/
+            RegMem::reg(regs::r14()),
+        ),
         "41F7F6",
         "div     %r14d",
     ));
     insns.push((
-        Inst::div(8, false /*signed*/, RegMem::reg(regs::rdi())),
+        Inst::div(
+            OperandSize::Size64,
+            false, /*signed*/
+            RegMem::reg(regs::rdi()),
+        ),
         "48F7F7",
         "div     %rdi",
     ));
     insns.push((
-        Inst::div(1, false, RegMem::reg(regs::rax())),
+        Inst::div(OperandSize::Size8, false, RegMem::reg(regs::rax())),
         "F6F0",
         "div     %al",
     ));
     insns.push((
-        Inst::div(1, false, RegMem::reg(regs::rsi())),
+        Inst::div(OperandSize::Size8, false, RegMem::reg(regs::rsi())),
         "40F6F6",
         "div     %sil",
     ));
@@ -1323,35 +1349,51 @@ fn test_x64_emit() {
     // ========================================================
     // MulHi
     insns.push((
-        Inst::mul_hi(4, true /*signed*/, RegMem::reg(regs::rsi())),
+        Inst::mul_hi(
+            OperandSize::Size32,
+            true, /*signed*/
+            RegMem::reg(regs::rsi()),
+        ),
         "F7EE",
         "imul    %esi",
     ));
     insns.push((
-        Inst::mul_hi(8, true /*signed*/, RegMem::reg(regs::r15())),
+        Inst::mul_hi(
+            OperandSize::Size64,
+            true, /*signed*/
+            RegMem::reg(regs::r15()),
+        ),
         "49F7EF",
         "imul    %r15",
     ));
     insns.push((
-        Inst::mul_hi(4, false /*signed*/, RegMem::reg(regs::r14())),
+        Inst::mul_hi(
+            OperandSize::Size32,
+            false, /*signed*/
+            RegMem::reg(regs::r14()),
+        ),
         "41F7E6",
         "mul     %r14d",
     ));
     insns.push((
-        Inst::mul_hi(8, false /*signed*/, RegMem::reg(regs::rdi())),
+        Inst::mul_hi(
+            OperandSize::Size64,
+            false, /*signed*/
+            RegMem::reg(regs::rdi()),
+        ),
         "48F7E7",
         "mul     %rdi",
     ));
 
     // ========================================================
     // cbw
-    insns.push((Inst::sign_extend_data(1), "6698", "cbw"));
+    insns.push((Inst::sign_extend_data(OperandSize::Size8), "6698", "cbw"));
 
     // ========================================================
     // cdq family: SignExtendRaxRdx
-    insns.push((Inst::sign_extend_data(2), "6699", "cwd"));
-    insns.push((Inst::sign_extend_data(4), "99", "cdq"));
-    insns.push((Inst::sign_extend_data(8), "4899", "cqo"));
+    insns.push((Inst::sign_extend_data(OperandSize::Size16), "6699", "cwd"));
+    insns.push((Inst::sign_extend_data(OperandSize::Size32), "99", "cdq"));
+    insns.push((Inst::sign_extend_data(OperandSize::Size64), "4899", "cqo"));
 
     // ========================================================
     // Imm_R
@@ -1980,325 +2022,325 @@ fn test_x64_emit() {
     // ========================================================
     // Mov_R_M.  Byte stores are tricky.  Check everything carefully.
     insns.push((
-        Inst::mov_r_m(8, rax, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size64, rax, Amode::imm_reg(99, rdi)),
         "48894763",
         "movq    %rax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rbx, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size64, rbx, Amode::imm_reg(99, r8)),
         "49895863",
         "movq    %rbx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rcx, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size64, rcx, Amode::imm_reg(99, rsi)),
         "48894E63",
         "movq    %rcx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rdx, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size64, rdx, Amode::imm_reg(99, r9)),
         "49895163",
         "movq    %rdx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rsi, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size64, rsi, Amode::imm_reg(99, rax)),
         "48897063",
         "movq    %rsi, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rdi, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size64, rdi, Amode::imm_reg(99, r15)),
         "49897F63",
         "movq    %rdi, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rsp, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size64, rsp, Amode::imm_reg(99, rcx)),
         "48896163",
         "movq    %rsp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(8, rbp, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size64, rbp, Amode::imm_reg(99, r14)),
         "49896E63",
         "movq    %rbp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r8, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size64, r8, Amode::imm_reg(99, rdi)),
         "4C894763",
         "movq    %r8, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r9, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size64, r9, Amode::imm_reg(99, r8)),
         "4D894863",
         "movq    %r9, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r10, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size64, r10, Amode::imm_reg(99, rsi)),
         "4C895663",
         "movq    %r10, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r11, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size64, r11, Amode::imm_reg(99, r9)),
         "4D895963",
         "movq    %r11, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r12, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size64, r12, Amode::imm_reg(99, rax)),
         "4C896063",
         "movq    %r12, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r13, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size64, r13, Amode::imm_reg(99, r15)),
         "4D896F63",
         "movq    %r13, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r14, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size64, r14, Amode::imm_reg(99, rcx)),
         "4C897163",
         "movq    %r14, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(8, r15, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size64, r15, Amode::imm_reg(99, r14)),
         "4D897E63",
         "movq    %r15, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(4, rax, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size32, rax, Amode::imm_reg(99, rdi)),
         "894763",
         "movl    %eax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rbx, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size32, rbx, Amode::imm_reg(99, r8)),
         "41895863",
         "movl    %ebx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rcx, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size32, rcx, Amode::imm_reg(99, rsi)),
         "894E63",
         "movl    %ecx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rdx, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size32, rdx, Amode::imm_reg(99, r9)),
         "41895163",
         "movl    %edx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rsi, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size32, rsi, Amode::imm_reg(99, rax)),
         "897063",
         "movl    %esi, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rdi, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size32, rdi, Amode::imm_reg(99, r15)),
         "41897F63",
         "movl    %edi, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rsp, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size32, rsp, Amode::imm_reg(99, rcx)),
         "896163",
         "movl    %esp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(4, rbp, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size32, rbp, Amode::imm_reg(99, r14)),
         "41896E63",
         "movl    %ebp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r8, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size32, r8, Amode::imm_reg(99, rdi)),
         "44894763",
         "movl    %r8d, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r9, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size32, r9, Amode::imm_reg(99, r8)),
         "45894863",
         "movl    %r9d, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r10, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size32, r10, Amode::imm_reg(99, rsi)),
         "44895663",
         "movl    %r10d, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r11, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size32, r11, Amode::imm_reg(99, r9)),
         "45895963",
         "movl    %r11d, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r12, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size32, r12, Amode::imm_reg(99, rax)),
         "44896063",
         "movl    %r12d, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r13, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size32, r13, Amode::imm_reg(99, r15)),
         "45896F63",
         "movl    %r13d, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r14, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size32, r14, Amode::imm_reg(99, rcx)),
         "44897163",
         "movl    %r14d, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(4, r15, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size32, r15, Amode::imm_reg(99, r14)),
         "45897E63",
         "movl    %r15d, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(2, rax, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size16, rax, Amode::imm_reg(99, rdi)),
         "66894763",
         "movw    %ax, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rbx, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size16, rbx, Amode::imm_reg(99, r8)),
         "6641895863",
         "movw    %bx, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rcx, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size16, rcx, Amode::imm_reg(99, rsi)),
         "66894E63",
         "movw    %cx, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rdx, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size16, rdx, Amode::imm_reg(99, r9)),
         "6641895163",
         "movw    %dx, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rsi, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size16, rsi, Amode::imm_reg(99, rax)),
         "66897063",
         "movw    %si, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rdi, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size16, rdi, Amode::imm_reg(99, r15)),
         "6641897F63",
         "movw    %di, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rsp, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size16, rsp, Amode::imm_reg(99, rcx)),
         "66896163",
         "movw    %sp, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(2, rbp, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size16, rbp, Amode::imm_reg(99, r14)),
         "6641896E63",
         "movw    %bp, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r8, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size16, r8, Amode::imm_reg(99, rdi)),
         "6644894763",
         "movw    %r8w, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r9, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size16, r9, Amode::imm_reg(99, r8)),
         "6645894863",
         "movw    %r9w, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r10, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size16, r10, Amode::imm_reg(99, rsi)),
         "6644895663",
         "movw    %r10w, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r11, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size16, r11, Amode::imm_reg(99, r9)),
         "6645895963",
         "movw    %r11w, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r12, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size16, r12, Amode::imm_reg(99, rax)),
         "6644896063",
         "movw    %r12w, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r13, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size16, r13, Amode::imm_reg(99, r15)),
         "6645896F63",
         "movw    %r13w, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r14, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size16, r14, Amode::imm_reg(99, rcx)),
         "6644897163",
         "movw    %r14w, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(2, r15, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size16, r15, Amode::imm_reg(99, r14)),
         "6645897E63",
         "movw    %r15w, 99(%r14)",
     ));
     //
     insns.push((
-        Inst::mov_r_m(1, rax, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size8, rax, Amode::imm_reg(99, rdi)),
         "884763",
         "movb    %al, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rbx, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size8, rbx, Amode::imm_reg(99, r8)),
         "41885863",
         "movb    %bl, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rcx, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size8, rcx, Amode::imm_reg(99, rsi)),
         "884E63",
         "movb    %cl, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rdx, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size8, rdx, Amode::imm_reg(99, r9)),
         "41885163",
         "movb    %dl, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rsi, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size8, rsi, Amode::imm_reg(99, rax)),
         "40887063",
         "movb    %sil, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rdi, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size8, rdi, Amode::imm_reg(99, r15)),
         "41887F63",
         "movb    %dil, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rsp, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size8, rsp, Amode::imm_reg(99, rcx)),
         "40886163",
         "movb    %spl, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(1, rbp, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size8, rbp, Amode::imm_reg(99, r14)),
         "41886E63",
         "movb    %bpl, 99(%r14)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r8, Amode::imm_reg(99, rdi)),
+        Inst::mov_r_m(OperandSize::Size8, r8, Amode::imm_reg(99, rdi)),
         "44884763",
         "movb    %r8b, 99(%rdi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r9, Amode::imm_reg(99, r8)),
+        Inst::mov_r_m(OperandSize::Size8, r9, Amode::imm_reg(99, r8)),
         "45884863",
         "movb    %r9b, 99(%r8)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r10, Amode::imm_reg(99, rsi)),
+        Inst::mov_r_m(OperandSize::Size8, r10, Amode::imm_reg(99, rsi)),
         "44885663",
         "movb    %r10b, 99(%rsi)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r11, Amode::imm_reg(99, r9)),
+        Inst::mov_r_m(OperandSize::Size8, r11, Amode::imm_reg(99, r9)),
         "45885963",
         "movb    %r11b, 99(%r9)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r12, Amode::imm_reg(99, rax)),
+        Inst::mov_r_m(OperandSize::Size8, r12, Amode::imm_reg(99, rax)),
         "44886063",
         "movb    %r12b, 99(%rax)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r13, Amode::imm_reg(99, r15)),
+        Inst::mov_r_m(OperandSize::Size8, r13, Amode::imm_reg(99, r15)),
         "45886F63",
         "movb    %r13b, 99(%r15)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r14, Amode::imm_reg(99, rcx)),
+        Inst::mov_r_m(OperandSize::Size8, r14, Amode::imm_reg(99, rcx)),
         "44887163",
         "movb    %r14b, 99(%rcx)",
     ));
     insns.push((
-        Inst::mov_r_m(1, r15, Amode::imm_reg(99, r14)),
+        Inst::mov_r_m(OperandSize::Size8, r15, Amode::imm_reg(99, r14)),
         "45887E63",
         "movb    %r15b, 99(%r14)",
     ));
@@ -2306,152 +2348,212 @@ fn test_x64_emit() {
     // ========================================================
     // Shift_R
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftLeft, None, w_rdi),
+        Inst::shift_r(OperandSize::Size32, ShiftKind::ShiftLeft, None, w_rdi),
         "D3E7",
         "shll    %cl, %edi",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftLeft, None, w_r12),
+        Inst::shift_r(OperandSize::Size32, ShiftKind::ShiftLeft, None, w_r12),
         "41D3E4",
         "shll    %cl, %r12d",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftLeft, Some(2), w_r8),
+        Inst::shift_r(OperandSize::Size32, ShiftKind::ShiftLeft, Some(2), w_r8),
         "41C1E002",
         "shll    $2, %r8d",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftLeft, Some(31), w_r13),
+        Inst::shift_r(OperandSize::Size32, ShiftKind::ShiftLeft, Some(31), w_r13),
         "41C1E51F",
         "shll    $31, %r13d",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftLeft, None, w_r13),
+        Inst::shift_r(OperandSize::Size64, ShiftKind::ShiftLeft, None, w_r13),
         "49D3E5",
         "shlq    %cl, %r13",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftLeft, None, w_rdi),
+        Inst::shift_r(OperandSize::Size64, ShiftKind::ShiftLeft, None, w_rdi),
         "48D3E7",
         "shlq    %cl, %rdi",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftLeft, Some(2), w_r8),
+        Inst::shift_r(OperandSize::Size64, ShiftKind::ShiftLeft, Some(2), w_r8),
         "49C1E002",
         "shlq    $2, %r8",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftLeft, Some(3), w_rbx),
+        Inst::shift_r(OperandSize::Size64, ShiftKind::ShiftLeft, Some(3), w_rbx),
         "48C1E303",
         "shlq    $3, %rbx",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftLeft, Some(63), w_r13),
+        Inst::shift_r(OperandSize::Size64, ShiftKind::ShiftLeft, Some(63), w_r13),
         "49C1E53F",
         "shlq    $63, %r13",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftRightLogical, None, w_rdi),
+        Inst::shift_r(
+            OperandSize::Size32,
+            ShiftKind::ShiftRightLogical,
+            None,
+            w_rdi,
+        ),
         "D3EF",
         "shrl    %cl, %edi",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftRightLogical, Some(2), w_r8),
+        Inst::shift_r(
+            OperandSize::Size32,
+            ShiftKind::ShiftRightLogical,
+            Some(2),
+            w_r8,
+        ),
         "41C1E802",
         "shrl    $2, %r8d",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftRightLogical, Some(31), w_r13),
+        Inst::shift_r(
+            OperandSize::Size32,
+            ShiftKind::ShiftRightLogical,
+            Some(31),
+            w_r13,
+        ),
         "41C1ED1F",
         "shrl    $31, %r13d",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftRightLogical, None, w_rdi),
+        Inst::shift_r(
+            OperandSize::Size64,
+            ShiftKind::ShiftRightLogical,
+            None,
+            w_rdi,
+        ),
         "48D3EF",
         "shrq    %cl, %rdi",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftRightLogical, Some(2), w_r8),
+        Inst::shift_r(
+            OperandSize::Size64,
+            ShiftKind::ShiftRightLogical,
+            Some(2),
+            w_r8,
+        ),
         "49C1E802",
         "shrq    $2, %r8",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftRightLogical, Some(63), w_r13),
+        Inst::shift_r(
+            OperandSize::Size64,
+            ShiftKind::ShiftRightLogical,
+            Some(63),
+            w_r13,
+        ),
         "49C1ED3F",
         "shrq    $63, %r13",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftRightArithmetic, None, w_rdi),
+        Inst::shift_r(
+            OperandSize::Size32,
+            ShiftKind::ShiftRightArithmetic,
+            None,
+            w_rdi,
+        ),
         "D3FF",
         "sarl    %cl, %edi",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftRightArithmetic, Some(2), w_r8),
+        Inst::shift_r(
+            OperandSize::Size32,
+            ShiftKind::ShiftRightArithmetic,
+            Some(2),
+            w_r8,
+        ),
         "41C1F802",
         "sarl    $2, %r8d",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::ShiftRightArithmetic, Some(31), w_r13),
+        Inst::shift_r(
+            OperandSize::Size32,
+            ShiftKind::ShiftRightArithmetic,
+            Some(31),
+            w_r13,
+        ),
         "41C1FD1F",
         "sarl    $31, %r13d",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftRightArithmetic, None, w_rdi),
+        Inst::shift_r(
+            OperandSize::Size64,
+            ShiftKind::ShiftRightArithmetic,
+            None,
+            w_rdi,
+        ),
         "48D3FF",
         "sarq    %cl, %rdi",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftRightArithmetic, Some(2), w_r8),
+        Inst::shift_r(
+            OperandSize::Size64,
+            ShiftKind::ShiftRightArithmetic,
+            Some(2),
+            w_r8,
+        ),
         "49C1F802",
         "sarq    $2, %r8",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::ShiftRightArithmetic, Some(63), w_r13),
+        Inst::shift_r(
+            OperandSize::Size64,
+            ShiftKind::ShiftRightArithmetic,
+            Some(63),
+            w_r13,
+        ),
         "49C1FD3F",
         "sarq    $63, %r13",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::RotateLeft, None, w_r8),
+        Inst::shift_r(OperandSize::Size64, ShiftKind::RotateLeft, None, w_r8),
         "49D3C0",
         "rolq    %cl, %r8",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::RotateLeft, Some(3), w_r9),
+        Inst::shift_r(OperandSize::Size32, ShiftKind::RotateLeft, Some(3), w_r9),
         "41C1C103",
         "roll    $3, %r9d",
     ));
     insns.push((
-        Inst::shift_r(4, ShiftKind::RotateRight, None, w_rsi),
+        Inst::shift_r(OperandSize::Size32, ShiftKind::RotateRight, None, w_rsi),
         "D3CE",
         "rorl    %cl, %esi",
     ));
     insns.push((
-        Inst::shift_r(8, ShiftKind::RotateRight, Some(5), w_r15),
+        Inst::shift_r(OperandSize::Size64, ShiftKind::RotateRight, Some(5), w_r15),
         "49C1CF05",
         "rorq    $5, %r15",
     ));
     insns.push((
-        Inst::shift_r(1, ShiftKind::RotateRight, None, w_rsi),
+        Inst::shift_r(OperandSize::Size8, ShiftKind::RotateRight, None, w_rsi),
         "40D2CE",
         "rorb    %cl, %sil",
     ));
     insns.push((
-        Inst::shift_r(1, ShiftKind::RotateRight, None, w_rax),
+        Inst::shift_r(OperandSize::Size8, ShiftKind::RotateRight, None, w_rax),
         "D2C8",
         "rorb    %cl, %al",
     ));
     insns.push((
-        Inst::shift_r(1, ShiftKind::RotateRight, Some(5), w_r15),
+        Inst::shift_r(OperandSize::Size8, ShiftKind::RotateRight, Some(5), w_r15),
         "41C0CF05",
         "rorb    $5, %r15b",
     ));
     insns.push((
-        Inst::shift_r(2, ShiftKind::RotateRight, None, w_rsi),
+        Inst::shift_r(OperandSize::Size16, ShiftKind::RotateRight, None, w_rsi),
         "66D3CE",
         "rorw    %cl, %si",
     ));
     insns.push((
-        Inst::shift_r(2, ShiftKind::RotateRight, Some(5), w_r15),
+        Inst::shift_r(OperandSize::Size16, ShiftKind::RotateRight, Some(5), w_r15),
         "6641C1CF05",
         "rorw    $5, %r15w",
     ));
@@ -2459,276 +2561,324 @@ fn test_x64_emit() {
     // ========================================================
     // CmpRMIR
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::reg(r15), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size64, RegMemImm::reg(r15), rdx),
         "4C39FA",
         "cmpq    %r15, %rdx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::reg(rcx), r8),
+        Inst::cmp_rmi_r(OperandSize::Size64, RegMemImm::reg(rcx), r8),
         "4939C8",
         "cmpq    %rcx, %r8",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::reg(rcx), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size64, RegMemImm::reg(rcx), rsi),
         "4839CE",
         "cmpq    %rcx, %rsi",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(
+            OperandSize::Size64,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "483B5763",
         "cmpq    99(%rdi), %rdx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(
+            OperandSize::Size64,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            r8,
+        ),
         "4C3B4763",
         "cmpq    99(%rdi), %r8",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(
+            OperandSize::Size64,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rsi,
+        ),
         "483B7763",
         "cmpq    99(%rdi), %rsi",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::imm(76543210), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size64, RegMemImm::imm(76543210), rdx),
         "4881FAEAF48F04",
         "cmpq    $76543210, %rdx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::imm(-76543210i32 as u32), r8),
+        Inst::cmp_rmi_r(OperandSize::Size64, RegMemImm::imm(-76543210i32 as u32), r8),
         "4981F8160B70FB",
         "cmpq    $-76543210, %r8",
     ));
     insns.push((
-        Inst::cmp_rmi_r(8, RegMemImm::imm(76543210), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size64, RegMemImm::imm(76543210), rsi),
         "4881FEEAF48F04",
         "cmpq    $76543210, %rsi",
     ));
     //
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::reg(r15), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size32, RegMemImm::reg(r15), rdx),
         "4439FA",
         "cmpl    %r15d, %edx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::reg(rcx), r8),
+        Inst::cmp_rmi_r(OperandSize::Size32, RegMemImm::reg(rcx), r8),
         "4139C8",
         "cmpl    %ecx, %r8d",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::reg(rcx), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size32, RegMemImm::reg(rcx), rsi),
         "39CE",
         "cmpl    %ecx, %esi",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(
+            OperandSize::Size32,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "3B5763",
         "cmpl    99(%rdi), %edx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(
+            OperandSize::Size32,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            r8,
+        ),
         "443B4763",
         "cmpl    99(%rdi), %r8d",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(
+            OperandSize::Size32,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rsi,
+        ),
         "3B7763",
         "cmpl    99(%rdi), %esi",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::imm(76543210), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size32, RegMemImm::imm(76543210), rdx),
         "81FAEAF48F04",
         "cmpl    $76543210, %edx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::imm(-76543210i32 as u32), r8),
+        Inst::cmp_rmi_r(OperandSize::Size32, RegMemImm::imm(-76543210i32 as u32), r8),
         "4181F8160B70FB",
         "cmpl    $-76543210, %r8d",
     ));
     insns.push((
-        Inst::cmp_rmi_r(4, RegMemImm::imm(76543210), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size32, RegMemImm::imm(76543210), rsi),
         "81FEEAF48F04",
         "cmpl    $76543210, %esi",
     ));
     //
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::reg(r15), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size16, RegMemImm::reg(r15), rdx),
         "664439FA",
         "cmpw    %r15w, %dx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::reg(rcx), r8),
+        Inst::cmp_rmi_r(OperandSize::Size16, RegMemImm::reg(rcx), r8),
         "664139C8",
         "cmpw    %cx, %r8w",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::reg(rcx), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size16, RegMemImm::reg(rcx), rsi),
         "6639CE",
         "cmpw    %cx, %si",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(
+            OperandSize::Size16,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "663B5763",
         "cmpw    99(%rdi), %dx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(
+            OperandSize::Size16,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            r8,
+        ),
         "66443B4763",
         "cmpw    99(%rdi), %r8w",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(
+            OperandSize::Size16,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rsi,
+        ),
         "663B7763",
         "cmpw    99(%rdi), %si",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::imm(23210), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size16, RegMemImm::imm(23210), rdx),
         "6681FAAA5A",
         "cmpw    $23210, %dx",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::imm(-7654i32 as u32), r8),
+        Inst::cmp_rmi_r(OperandSize::Size16, RegMemImm::imm(-7654i32 as u32), r8),
         "664181F81AE2",
         "cmpw    $-7654, %r8w",
     ));
     insns.push((
-        Inst::cmp_rmi_r(2, RegMemImm::imm(7654), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size16, RegMemImm::imm(7654), rsi),
         "6681FEE61D",
         "cmpw    $7654, %si",
     ));
     //
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r15), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r15), rdx),
         "4438FA",
         "cmpb    %r15b, %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rcx), r8),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), r8),
         "4138C8",
         "cmpb    %cl, %r8b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rcx), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), rsi),
         "4038CE",
         "cmpb    %cl, %sil",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::cmp_rmi_r(
+            OperandSize::Size8,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "3A5763",
         "cmpb    99(%rdi), %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::mem(Amode::imm_reg(99, rdi)), r8),
+        Inst::cmp_rmi_r(
+            OperandSize::Size8,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            r8,
+        ),
         "443A4763",
         "cmpb    99(%rdi), %r8b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::mem(Amode::imm_reg(99, rdi)), rsi),
+        Inst::cmp_rmi_r(
+            OperandSize::Size8,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rsi,
+        ),
         "403A7763",
         "cmpb    99(%rdi), %sil",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::imm(70), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::imm(70), rdx),
         "80FA46",
         "cmpb    $70, %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::imm(-76i32 as u32), r8),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::imm(-76i32 as u32), r8),
         "4180F8B4",
         "cmpb    $-76, %r8b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::imm(76), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::imm(76), rsi),
         "4080FE4C",
         "cmpb    $76, %sil",
     ));
     // Extra byte-cases (paranoia!) for cmp_rmi_r for first operand = R
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rax), rbx),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rax), rbx),
         "38C3",
         "cmpb    %al, %bl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rbx), rax),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rbx), rax),
         "38D8",
         "cmpb    %bl, %al",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rcx), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), rdx),
         "38CA",
         "cmpb    %cl, %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rcx), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), rsi),
         "4038CE",
         "cmpb    %cl, %sil",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rcx), r10),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), r10),
         "4138CA",
         "cmpb    %cl, %r10b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rcx), r14),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), r14),
         "4138CE",
         "cmpb    %cl, %r14b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rbp), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rbp), rdx),
         "4038EA",
         "cmpb    %bpl, %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rbp), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rbp), rsi),
         "4038EE",
         "cmpb    %bpl, %sil",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rbp), r10),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rbp), r10),
         "4138EA",
         "cmpb    %bpl, %r10b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(rbp), r14),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(rbp), r14),
         "4138EE",
         "cmpb    %bpl, %r14b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r9), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r9), rdx),
         "4438CA",
         "cmpb    %r9b, %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r9), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r9), rsi),
         "4438CE",
         "cmpb    %r9b, %sil",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r9), r10),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r9), r10),
         "4538CA",
         "cmpb    %r9b, %r10b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r9), r14),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r9), r14),
         "4538CE",
         "cmpb    %r9b, %r14b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r13), rdx),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r13), rdx),
         "4438EA",
         "cmpb    %r13b, %dl",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r13), rsi),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r13), rsi),
         "4438EE",
         "cmpb    %r13b, %sil",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r13), r10),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r13), r10),
         "4538EA",
         "cmpb    %r13b, %r10b",
     ));
     insns.push((
-        Inst::cmp_rmi_r(1, RegMemImm::reg(r13), r14),
+        Inst::cmp_rmi_r(OperandSize::Size8, RegMemImm::reg(r13), r14),
         "4538EE",
         "cmpb    %r13b, %r14b",
     ));
@@ -2736,81 +2886,97 @@ fn test_x64_emit() {
     // ========================================================
     // TestRmiR
     insns.push((
-        Inst::test_rmi_r(8, RegMemImm::reg(r15), rdx),
+        Inst::test_rmi_r(OperandSize::Size64, RegMemImm::reg(r15), rdx),
         "4C85FA",
         "testq   %r15, %rdx",
     ));
     insns.push((
-        Inst::test_rmi_r(8, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::test_rmi_r(
+            OperandSize::Size64,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "48855763",
         "testq   99(%rdi), %rdx",
     ));
     insns.push((
-        Inst::test_rmi_r(8, RegMemImm::imm(76543210), rdx),
+        Inst::test_rmi_r(OperandSize::Size64, RegMemImm::imm(76543210), rdx),
         "48F7C2EAF48F04",
         "testq   $76543210, %rdx",
     ));
     //
     insns.push((
-        Inst::test_rmi_r(4, RegMemImm::reg(r15), rdx),
+        Inst::test_rmi_r(OperandSize::Size32, RegMemImm::reg(r15), rdx),
         "4485FA",
         "testl   %r15d, %edx",
     ));
     insns.push((
-        Inst::test_rmi_r(4, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::test_rmi_r(
+            OperandSize::Size32,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "855763",
         "testl   99(%rdi), %edx",
     ));
     insns.push((
-        Inst::test_rmi_r(4, RegMemImm::imm(76543210), rdx),
+        Inst::test_rmi_r(OperandSize::Size32, RegMemImm::imm(76543210), rdx),
         "F7C2EAF48F04",
         "testl   $76543210, %edx",
     ));
     //
     insns.push((
-        Inst::test_rmi_r(2, RegMemImm::reg(r15), rdx),
+        Inst::test_rmi_r(OperandSize::Size16, RegMemImm::reg(r15), rdx),
         "664485FA",
         "testw   %r15w, %dx",
     ));
     insns.push((
-        Inst::test_rmi_r(2, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::test_rmi_r(
+            OperandSize::Size16,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "66855763",
         "testw   99(%rdi), %dx",
     ));
     insns.push((
-        Inst::test_rmi_r(2, RegMemImm::imm(23210), rdx),
+        Inst::test_rmi_r(OperandSize::Size16, RegMemImm::imm(23210), rdx),
         "66F7C2AA5A",
         "testw   $23210, %dx",
     ));
     //
     insns.push((
-        Inst::test_rmi_r(1, RegMemImm::reg(r15), rdx),
+        Inst::test_rmi_r(OperandSize::Size8, RegMemImm::reg(r15), rdx),
         "4484FA",
         "testb   %r15b, %dl",
     ));
     insns.push((
-        Inst::test_rmi_r(1, RegMemImm::mem(Amode::imm_reg(99, rdi)), rdx),
+        Inst::test_rmi_r(
+            OperandSize::Size8,
+            RegMemImm::mem(Amode::imm_reg(99, rdi)),
+            rdx,
+        ),
         "845763",
         "testb   99(%rdi), %dl",
     ));
     insns.push((
-        Inst::test_rmi_r(1, RegMemImm::imm(70), rdx),
+        Inst::test_rmi_r(OperandSize::Size8, RegMemImm::imm(70), rdx),
         "F6C246",
         "testb   $70, %dl",
     ));
     // Extra byte-cases (paranoia!) for test_rmi_r for first operand = R
     insns.push((
-        Inst::test_rmi_r(1, RegMemImm::reg(rax), rbx),
+        Inst::test_rmi_r(OperandSize::Size8, RegMemImm::reg(rax), rbx),
         "84C3",
         "testb   %al, %bl",
     ));
     insns.push((
-        Inst::test_rmi_r(1, RegMemImm::reg(rcx), rsi),
+        Inst::test_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), rsi),
         "4084CE",
         "testb   %cl, %sil",
     ));
     insns.push((
-        Inst::test_rmi_r(1, RegMemImm::reg(rcx), r10),
+        Inst::test_rmi_r(OperandSize::Size8, RegMemImm::reg(rcx), r10),
         "4184CA",
         "testb   %cl, %r10b",
     ));
@@ -2826,13 +2992,13 @@ fn test_x64_emit() {
     // ========================================================
     // Cmove
     insns.push((
-        Inst::cmove(2, CC::O, RegMem::reg(rdi), w_rsi),
+        Inst::cmove(OperandSize::Size16, CC::O, RegMem::reg(rdi), w_rsi),
         "660F40F7",
         "cmovow  %di, %si",
     ));
     insns.push((
         Inst::cmove(
-            2,
+            OperandSize::Size16,
             CC::NO,
             RegMem::mem(Amode::imm_reg_reg_shift(37, rdi, rsi, 2)),
             w_r15,
@@ -2841,22 +3007,32 @@ fn test_x64_emit() {
         "cmovnow 37(%rdi,%rsi,4), %r15w",
     ));
     insns.push((
-        Inst::cmove(4, CC::LE, RegMem::reg(rdi), w_rsi),
+        Inst::cmove(OperandSize::Size32, CC::LE, RegMem::reg(rdi), w_rsi),
         "0F4EF7",
         "cmovlel %edi, %esi",
     ));
     insns.push((
-        Inst::cmove(4, CC::NLE, RegMem::mem(Amode::imm_reg(0, r15)), w_rsi),
+        Inst::cmove(
+            OperandSize::Size32,
+            CC::NLE,
+            RegMem::mem(Amode::imm_reg(0, r15)),
+            w_rsi,
+        ),
         "410F4F37",
         "cmovnlel 0(%r15), %esi",
     ));
     insns.push((
-        Inst::cmove(8, CC::Z, RegMem::reg(rdi), w_r14),
+        Inst::cmove(OperandSize::Size64, CC::Z, RegMem::reg(rdi), w_r14),
         "4C0F44F7",
         "cmovzq  %rdi, %r14",
     ));
     insns.push((
-        Inst::cmove(8, CC::NZ, RegMem::mem(Amode::imm_reg(13, rdi)), w_r14),
+        Inst::cmove(
+            OperandSize::Size64,
+            CC::NZ,
+            RegMem::mem(Amode::imm_reg(13, rdi)),
+            w_r14,
+        ),
         "4C0F45770D",
         "cmovnzq 13(%rdi), %r14",
     ));

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -885,23 +885,38 @@ fn test_x64_emit() {
     //
     // Alu_RMI_R
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::Add, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::Add,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "4C01FA",
         "addq    %r15, %rdx",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Add, RegMemImm::reg(rcx), w_r8),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Add,
+            RegMemImm::reg(rcx),
+            w_r8,
+        ),
         "4101C8",
         "addl    %ecx, %r8d",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Add, RegMemImm::reg(rcx), w_rsi),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Add,
+            RegMemImm::reg(rcx),
+            w_rsi,
+        ),
         "01CE",
         "addl    %ecx, %esi",
     ));
     insns.push((
         Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             AluRmiROpcode::Add,
             RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rdx,
@@ -911,7 +926,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Add,
             RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_r8,
@@ -921,7 +936,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Add,
             RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rsi,
@@ -931,7 +946,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             AluRmiROpcode::Add,
             RegMemImm::imm(-127i32 as u32),
             w_rdx,
@@ -941,7 +956,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             AluRmiROpcode::Add,
             RegMemImm::imm(-129i32 as u32),
             w_rdx,
@@ -950,13 +965,18 @@ fn test_x64_emit() {
         "addq    $-129, %rdx",
     ));
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::Add, RegMemImm::imm(76543210), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::Add,
+            RegMemImm::imm(76543210),
+            w_rdx,
+        ),
         "4881C2EAF48F04",
         "addq    $76543210, %rdx",
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Add,
             RegMemImm::imm(-127i32 as u32),
             w_r8,
@@ -966,7 +986,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Add,
             RegMemImm::imm(-129i32 as u32),
             w_r8,
@@ -976,7 +996,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Add,
             RegMemImm::imm(-76543210i32 as u32),
             w_r8,
@@ -986,7 +1006,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Add,
             RegMemImm::imm(-127i32 as u32),
             w_rsi,
@@ -996,7 +1016,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Add,
             RegMemImm::imm(-129i32 as u32),
             w_rsi,
@@ -1005,44 +1025,79 @@ fn test_x64_emit() {
         "addl    $-129, %esi",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Add, RegMemImm::imm(76543210), w_rsi),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Add,
+            RegMemImm::imm(76543210),
+            w_rsi,
+        ),
         "81C6EAF48F04",
         "addl    $76543210, %esi",
     ));
     // This is pretty feeble
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::Sub, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::Sub,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "4C29FA",
         "subq    %r15, %rdx",
     ));
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::And, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::And,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "4C21FA",
         "andq    %r15, %rdx",
     ));
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::Or, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::Or,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "4C09FA",
         "orq     %r15, %rdx",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::And8, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::And8,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "4420FA",
         "andb    %r15b, %dl",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::And8, RegMemImm::reg(rax), w_rsi),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::And8,
+            RegMemImm::reg(rax),
+            w_rsi,
+        ),
         "4020C6",
         "andb    %al, %sil",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::And8, RegMemImm::reg(rax), w_rbx),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::And8,
+            RegMemImm::reg(rax),
+            w_rbx,
+        ),
         "20C3",
         "andb    %al, %bl",
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::And8,
             RegMemImm::mem(Amode::imm_reg(0, rax)),
             w_rbx,
@@ -1051,23 +1106,38 @@ fn test_x64_emit() {
         "andb    0(%rax), %bl",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Or8, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Or8,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "4408FA",
         "orb     %r15b, %dl",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Or8, RegMemImm::reg(rax), w_rsi),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Or8,
+            RegMemImm::reg(rax),
+            w_rsi,
+        ),
         "4008C6",
         "orb     %al, %sil",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Or8, RegMemImm::reg(rax), w_rbx),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Or8,
+            RegMemImm::reg(rax),
+            w_rbx,
+        ),
         "08C3",
         "orb     %al, %bl",
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Or8,
             RegMemImm::mem(Amode::imm_reg(0, rax)),
             w_rbx,
@@ -1076,29 +1146,49 @@ fn test_x64_emit() {
         "orb     0(%rax), %bl",
     ));
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::Xor, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::Xor,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "4C31FA",
         "xorq    %r15, %rdx",
     ));
     // Test all mul cases, though
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::Mul, RegMemImm::reg(r15), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::Mul,
+            RegMemImm::reg(r15),
+            w_rdx,
+        ),
         "490FAFD7",
         "imulq   %r15, %rdx",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Mul, RegMemImm::reg(rcx), w_r8),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Mul,
+            RegMemImm::reg(rcx),
+            w_r8,
+        ),
         "440FAFC1",
         "imull   %ecx, %r8d",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Mul, RegMemImm::reg(rcx), w_rsi),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Mul,
+            RegMemImm::reg(rcx),
+            w_rsi,
+        ),
         "0FAFF1",
         "imull   %ecx, %esi",
     ));
     insns.push((
         Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             AluRmiROpcode::Mul,
             RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rdx,
@@ -1108,7 +1198,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Mul,
             RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_r8,
@@ -1118,7 +1208,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Mul,
             RegMemImm::mem(Amode::imm_reg(99, rdi)),
             w_rsi,
@@ -1128,7 +1218,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             AluRmiROpcode::Mul,
             RegMemImm::imm(-127i32 as u32),
             w_rdx,
@@ -1138,7 +1228,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            true,
+            OperandSize::Size64,
             AluRmiROpcode::Mul,
             RegMemImm::imm(-129i32 as u32),
             w_rdx,
@@ -1147,13 +1237,18 @@ fn test_x64_emit() {
         "imulq   $-129, %rdx",
     ));
     insns.push((
-        Inst::alu_rmi_r(true, AluRmiROpcode::Mul, RegMemImm::imm(76543210), w_rdx),
+        Inst::alu_rmi_r(
+            OperandSize::Size64,
+            AluRmiROpcode::Mul,
+            RegMemImm::imm(76543210),
+            w_rdx,
+        ),
         "4869D2EAF48F04",
         "imulq   $76543210, %rdx",
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Mul,
             RegMemImm::imm(-127i32 as u32),
             w_r8,
@@ -1163,7 +1258,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Mul,
             RegMemImm::imm(-129i32 as u32),
             w_r8,
@@ -1173,7 +1268,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Mul,
             RegMemImm::imm(-76543210i32 as u32),
             w_r8,
@@ -1183,7 +1278,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Mul,
             RegMemImm::imm(-127i32 as u32),
             w_rsi,
@@ -1193,7 +1288,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::alu_rmi_r(
-            false,
+            OperandSize::Size32,
             AluRmiROpcode::Mul,
             RegMemImm::imm(-129i32 as u32),
             w_rsi,
@@ -1202,7 +1297,12 @@ fn test_x64_emit() {
         "imull   $-129, %esi",
     ));
     insns.push((
-        Inst::alu_rmi_r(false, AluRmiROpcode::Mul, RegMemImm::imm(76543210), w_rsi),
+        Inst::alu_rmi_r(
+            OperandSize::Size32,
+            AluRmiROpcode::Mul,
+            RegMemImm::imm(76543210),
+            w_rsi,
+        ),
         "69F6EAF48F04",
         "imull   $76543210, %esi",
     ));
@@ -1442,42 +1542,42 @@ fn test_x64_emit() {
     // ========================================================
     // Mov_R_R
     insns.push((
-        Inst::mov_r_r(false, rbx, w_rsi),
+        Inst::mov_r_r(OperandSize::Size32, rbx, w_rsi),
         "89DE",
         "movl    %ebx, %esi",
     ));
     insns.push((
-        Inst::mov_r_r(false, rbx, w_r9),
+        Inst::mov_r_r(OperandSize::Size32, rbx, w_r9),
         "4189D9",
         "movl    %ebx, %r9d",
     ));
     insns.push((
-        Inst::mov_r_r(false, r11, w_rsi),
+        Inst::mov_r_r(OperandSize::Size32, r11, w_rsi),
         "4489DE",
         "movl    %r11d, %esi",
     ));
     insns.push((
-        Inst::mov_r_r(false, r12, w_r9),
+        Inst::mov_r_r(OperandSize::Size32, r12, w_r9),
         "4589E1",
         "movl    %r12d, %r9d",
     ));
     insns.push((
-        Inst::mov_r_r(true, rbx, w_rsi),
+        Inst::mov_r_r(OperandSize::Size64, rbx, w_rsi),
         "4889DE",
         "movq    %rbx, %rsi",
     ));
     insns.push((
-        Inst::mov_r_r(true, rbx, w_r9),
+        Inst::mov_r_r(OperandSize::Size64, rbx, w_r9),
         "4989D9",
         "movq    %rbx, %r9",
     ));
     insns.push((
-        Inst::mov_r_r(true, r11, w_rsi),
+        Inst::mov_r_r(OperandSize::Size64, r11, w_rsi),
         "4C89DE",
         "movq    %r11, %rsi",
     ));
     insns.push((
-        Inst::mov_r_r(true, r12, w_r9),
+        Inst::mov_r_r(OperandSize::Size64, r12, w_r9),
         "4D89E1",
         "movq    %r12, %r9",
     ));
@@ -3879,38 +3979,80 @@ fn test_x64_emit() {
     // ========================================================
     // XmmRmRImm
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Cmppd, RegMem::reg(xmm5), w_xmm1, 2, false),
+        Inst::xmm_rm_r_imm(
+            SseOpcode::Cmppd,
+            RegMem::reg(xmm5),
+            w_xmm1,
+            2,
+            OperandSize::Size32,
+        ),
         "660FC2CD02",
         "cmppd   $2, %xmm5, %xmm1",
     ));
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Cmpps, RegMem::reg(xmm15), w_xmm7, 0, false),
+        Inst::xmm_rm_r_imm(
+            SseOpcode::Cmpps,
+            RegMem::reg(xmm15),
+            w_xmm7,
+            0,
+            OperandSize::Size32,
+        ),
         "410FC2FF00",
         "cmpps   $0, %xmm15, %xmm7",
     ));
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Palignr, RegMem::reg(xmm1), w_xmm9, 3, false),
+        Inst::xmm_rm_r_imm(
+            SseOpcode::Palignr,
+            RegMem::reg(xmm1),
+            w_xmm9,
+            3,
+            OperandSize::Size32,
+        ),
         "66440F3A0FC903",
         "palignr $3, %xmm1, %xmm9",
     ));
 
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Roundps, RegMem::reg(xmm7), w_xmm8, 3, false),
+        Inst::xmm_rm_r_imm(
+            SseOpcode::Roundps,
+            RegMem::reg(xmm7),
+            w_xmm8,
+            3,
+            OperandSize::Size32,
+        ),
         "66440F3A08C703",
         "roundps $3, %xmm7, %xmm8",
     ));
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Roundpd, RegMem::reg(xmm10), w_xmm7, 2, false),
+        Inst::xmm_rm_r_imm(
+            SseOpcode::Roundpd,
+            RegMem::reg(xmm10),
+            w_xmm7,
+            2,
+            OperandSize::Size32,
+        ),
         "66410F3A09FA02",
         "roundpd $2, %xmm10, %xmm7",
     ));
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Roundps, RegMem::reg(xmm4), w_xmm8, 1, false),
+        Inst::xmm_rm_r_imm(
+            SseOpcode::Roundps,
+            RegMem::reg(xmm4),
+            w_xmm8,
+            1,
+            OperandSize::Size32,
+        ),
         "66440F3A08C401",
         "roundps $1, %xmm4, %xmm8",
     ));
     insns.push((
-        Inst::xmm_rm_r_imm(SseOpcode::Roundpd, RegMem::reg(xmm15), w_xmm15, 0, false),
+        Inst::xmm_rm_r_imm(
+            SseOpcode::Roundpd,
+            RegMem::reg(xmm15),
+            w_xmm15,
+            0,
+            OperandSize::Size32,
+        ),
         "66450F3A09FF00",
         "roundpd $0, %xmm15, %xmm15",
     ));

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -717,6 +717,7 @@ impl Inst {
     ) -> Inst {
         debug_assert!(src.get_class() == RegClass::V128);
         debug_assert!(dst.to_reg().get_class() == RegClass::I64);
+        debug_assert!(dst_size.is_size(&[OperandSize::Size32, OperandSize::Size64]));
         Inst::XmmToGpr {
             op,
             src,
@@ -732,6 +733,7 @@ impl Inst {
         dst: Writable<Reg>,
     ) -> Inst {
         src.assert_regclass_is(RegClass::I64);
+        debug_assert!(src_size.is_size(&[OperandSize::Size32, OperandSize::Size64]));
         debug_assert!(dst.to_reg().get_class() == RegClass::V128);
         Inst::GprToXmm {
             op,
@@ -776,6 +778,8 @@ impl Inst {
         tmp_gpr: Writable<Reg>,
         tmp_xmm: Writable<Reg>,
     ) -> Inst {
+        debug_assert!(src_size.is_size(&[OperandSize::Size32, OperandSize::Size64]));
+        debug_assert!(dst_size.is_size(&[OperandSize::Size32, OperandSize::Size64]));
         debug_assert!(src.to_reg().get_class() == RegClass::V128);
         debug_assert!(tmp_xmm.to_reg().get_class() == RegClass::V128);
         debug_assert!(tmp_gpr.to_reg().get_class() == RegClass::I64);
@@ -800,6 +804,8 @@ impl Inst {
         tmp_gpr: Writable<Reg>,
         tmp_xmm: Writable<Reg>,
     ) -> Inst {
+        debug_assert!(src_size.is_size(&[OperandSize::Size32, OperandSize::Size64]));
+        debug_assert!(dst_size.is_size(&[OperandSize::Size32, OperandSize::Size64]));
         debug_assert!(src.to_reg().get_class() == RegClass::V128);
         debug_assert!(tmp_xmm.to_reg().get_class() == RegClass::V128);
         debug_assert!(tmp_gpr.to_reg().get_class() == RegClass::I64);
@@ -821,6 +827,7 @@ impl Inst {
         lhs: Reg,
         rhs_dst: Writable<Reg>,
     ) -> Inst {
+        debug_assert!(size.is_size(&[OperandSize::Size32, OperandSize::Size64]));
         debug_assert_eq!(lhs.get_class(), RegClass::V128);
         debug_assert_eq!(rhs_dst.to_reg().get_class(), RegClass::V128);
         Inst::XmmMinMaxSeq {
@@ -1416,11 +1423,7 @@ impl PrettyPrint for Inst {
                     } else {
                         "xmm max seq ".to_string()
                     },
-                    match size {
-                        OperandSize::Size32 => "f32",
-                        OperandSize::Size64 => "f64",
-                    }
-                    .into()
+                    format!("f{}", size.to_bits())
                 ),
                 show_ireg_sized(*lhs, mb_rru, 8),
                 show_ireg_sized(rhs_dst.to_reg(), mb_rru, 8),
@@ -1459,10 +1462,7 @@ impl PrettyPrint for Inst {
                 dst,
                 dst_size,
             } => {
-                let dst_size = match dst_size {
-                    OperandSize::Size32 => 4,
-                    OperandSize::Size64 => 8,
-                };
+                let dst_size = dst_size.to_bytes();
                 format!(
                     "{} {}, {}",
                     ljustify(op.to_string()),
@@ -1512,16 +1512,8 @@ impl PrettyPrint for Inst {
                 "{} {}, {}",
                 ljustify(format!(
                     "cvt_float{}_to_sint{}_seq",
-                    if *src_size == OperandSize::Size64 {
-                        "64"
-                    } else {
-                        "32"
-                    },
-                    if *dst_size == OperandSize::Size64 {
-                        "64"
-                    } else {
-                        "32"
-                    }
+                    src_size.to_bits(),
+                    dst_size.to_bits()
                 )),
                 show_ireg_sized(src.to_reg(), mb_rru, 8),
                 show_ireg_sized(dst.to_reg(), mb_rru, dst_size.to_bytes()),
@@ -1537,16 +1529,8 @@ impl PrettyPrint for Inst {
                 "{} {}, {}",
                 ljustify(format!(
                     "cvt_float{}_to_uint{}_seq",
-                    if *src_size == OperandSize::Size64 {
-                        "64"
-                    } else {
-                        "32"
-                    },
-                    if *dst_size == OperandSize::Size64 {
-                        "64"
-                    } else {
-                        "32"
-                    }
+                    src_size.to_bits(),
+                    dst_size.to_bits()
                 )),
                 show_ireg_sized(src.to_reg(), mb_rru, 8),
                 show_ireg_sized(dst.to_reg(), mb_rru, dst_size.to_bytes()),

--- a/cranelift/codegen/src/isa/x64/inst/unwind.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind.rs
@@ -1,6 +1,6 @@
 use crate::isa::unwind::input::UnwindInfo;
 use crate::isa::x64::inst::{
-    args::{AluRmiROpcode, Amode, RegMemImm, SyntheticAmode},
+    args::{AluRmiROpcode, Amode, OperandSize, RegMemImm, SyntheticAmode},
     regs, Inst,
 };
 use crate::machinst::{UnwindInfoContext, UnwindInfoGenerator};
@@ -50,7 +50,7 @@ impl UnwindInfoGenerator<Inst> for X64UnwindInfo {
                     }
                 }
                 Inst::AluRmiR {
-                    is_64: true,
+                    size: OperandSize::Size64,
                     op: AluRmiROpcode::Sub,
                     src: RegMemImm::Imm { simm32 },
                     dst,
@@ -75,7 +75,7 @@ impl UnwindInfoGenerator<Inst> for X64UnwindInfo {
                     ));
                 }
                 Inst::AluRmiR {
-                    is_64: true,
+                    size: OperandSize::Size64,
                     op: AluRmiROpcode::Add,
                     src: RegMemImm::Imm { simm32 },
                     dst,


### PR DESCRIPTION
This is in preparation for refactoring all x64::Inst arms to use OperandSize.

Current uses of OperandSize fall into two categories:
  1. XMM operations which require 32/64 bit operands
  2. Immediates which only care about 64-bit or not.

Adds assertions to existing Inst constructors to check that they are passed valid sizes.
This change also removes the implicit widening of 1 and 2 byte values to 4 bytes. from_bytes() is only used by category 2, so removing this behavior will not change any visible behavior.

Overall this change should be a no-op.

Partially addresses #2586.