### PR TITLE
wasi-nn CI: use the same nightly as rest of file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,7 +345,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/install-rust
         with:
-          toolchain: nightly-2020-08-25
+          toolchain: nightly-2020-11-29
       - run: rustup target add wasm32-wasi
       - uses: ./.github/actions/install-openvino
       - run: ./ci/run-wasi-nn-example.sh


### PR DESCRIPTION
in particular, this 2020-08-25 fails to build `posish 0.5.9` which is
a dep in PR #2487. But there's no reason for this to be lagging
behind...

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
