### PR TITLE
Implement shared host functions.

### DIFF
--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -203,7 +203,7 @@ impl BenchState {
         config.wasm_simd(true);
         // NB: do not configure a code cache.
 
-        let engine = Engine::new(&config);
+        let engine = Engine::new(&config)?;
         let store = Store::new(&engine);
 
         let mut linker = Linker::new(&store);

--- a/crates/c-api/src/engine.rs
+++ b/crates/c-api/src/engine.rs
@@ -30,6 +30,6 @@ pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
 pub extern "C" fn wasm_engine_new_with_config(c: Box<wasm_config_t>) -> Box<wasm_engine_t> {
     let config = c.config;
     Box::new(wasm_engine_t {
-        engine: Engine::new(&config),
+        engine: Engine::new(&config).unwrap(),
     })
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -90,7 +90,7 @@ pub fn instantiate_with_config(
         Timeout::Fuel(_) => true,
         _ => false,
     });
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config).unwrap();
     let store = Store::new(&engine);
 
     let mut timeout_state = SignalOnDrop::default();
@@ -143,7 +143,7 @@ pub fn instantiate_with_config(
 pub fn compile(wasm: &[u8], strategy: Strategy) {
     crate::init_fuzzing();
 
-    let engine = Engine::new(&crate::fuzz_default_config(strategy).unwrap());
+    let engine = Engine::new(&crate::fuzz_default_config(strategy).unwrap()).unwrap();
     log_wasm(wasm);
     let _ = Module::new(&engine, wasm);
 }
@@ -180,7 +180,7 @@ pub fn differential_execution(
     log_wasm(&wasm);
 
     for config in &configs {
-        let engine = Engine::new(config);
+        let engine = Engine::new(config).unwrap();
         let store = Store::new(&engine);
 
         let module = Module::new(&engine, &wasm).unwrap();
@@ -320,7 +320,7 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
             ApiCall::EngineNew => {
                 log::trace!("creating engine");
                 assert!(engine.is_none());
-                engine = Some(Engine::new(config.as_ref().unwrap()));
+                engine = Some(Engine::new(config.as_ref().unwrap()).unwrap());
             }
 
             ApiCall::StoreNew => {
@@ -416,7 +416,7 @@ pub fn spectest(fuzz_config: crate::generators::Config, test: crate::generators:
     let mut config = fuzz_config.to_wasmtime();
     config.wasm_reference_types(false);
     config.wasm_bulk_memory(false);
-    let store = Store::new(&Engine::new(&config));
+    let store = Store::new(&Engine::new(&config).unwrap());
     if fuzz_config.consume_fuel {
         store.add_fuel(u64::max_value()).unwrap();
     }
@@ -439,7 +439,7 @@ pub fn table_ops(
     {
         let mut config = fuzz_config.to_wasmtime();
         config.wasm_reference_types(true);
-        let engine = Engine::new(&config);
+        let engine = Engine::new(&config).unwrap();
         let store = Store::new(&engine);
         if fuzz_config.consume_fuel {
             store.add_fuel(u64::max_value()).unwrap();
@@ -554,7 +554,7 @@ pub fn differential_wasmi_execution(wasm: &[u8], config: &crate::generators::Con
     // Instantiate wasmtime module and instance.
     let mut wasmtime_config = config.to_wasmtime();
     wasmtime_config.cranelift_nan_canonicalization(true);
-    let wasmtime_engine = Engine::new(&wasmtime_config);
+    let wasmtime_engine = Engine::new(&wasmtime_config).unwrap();
     let wasmtime_store = Store::new(&wasmtime_engine);
     if config.consume_fuel {
         wasmtime_store.add_fuel(u64::max_value()).unwrap();

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -359,7 +359,7 @@ mod tests {
         let mut config = Config::default();
         config.wasm_module_linking(true);
         config.wasm_multi_memory(true);
-        let engine = wasmtime::Engine::new(&config);
+        let engine = wasmtime::Engine::new(&config).unwrap();
         Store::new(&engine)
     }
 

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -581,9 +581,6 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
         &self,
         mut req: InstanceAllocationRequest,
     ) -> Result<InstanceHandle, InstantiationError> {
-        debug_assert!(!req.externref_activations_table.is_null());
-        debug_assert!(!req.stack_map_registry.is_null());
-
         let memories = self.create_memories(&req.module)?;
         let tables = Self::create_tables(&req.module);
 

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -10,7 +10,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 pub use wasi_common::{Error, WasiCtx, WasiCtxBuilder, WasiDir, WasiFile};
-use wasmtime::{Linker, Store};
+use wasmtime::{Config, Linker, Store};
 
 /// An instantiated instance of all available wasi exports. Presently includes
 /// both the "preview1" snapshot and the "unstable" (preview0) snapshot.
@@ -33,6 +33,15 @@ impl Wasi {
         self.preview_1.add_to_linker(linker)?;
         self.preview_0.add_to_linker(linker)?;
         Ok(())
+    }
+    pub fn add_to_config(config: &mut Config) {
+        snapshots::preview_1::Wasi::add_to_config(config);
+        snapshots::preview_0::Wasi::add_to_config(config);
+    }
+    pub fn set_context(store: &Store, context: WasiCtx) -> Result<(), WasiCtx> {
+        // It doesn't matter which underlying `Wasi` type this gets called on as the
+        // implementations are identical
+        snapshots::preview_1::Wasi::set_context(store, context)
     }
 }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1322,11 +1322,11 @@ impl Config {
         Compiler::new(isa, self.strategy, tunables, self.features)
     }
 
-    pub(crate) fn build_allocator(&self) -> Box<dyn InstanceAllocator> {
+    pub(crate) fn build_allocator(&self) -> Result<Box<dyn InstanceAllocator>> {
         match self.allocation_strategy {
-            InstanceAllocationStrategy::OnDemand => {
-                Box::new(OnDemandInstanceAllocator::new(self.mem_creator.clone()))
-            }
+            InstanceAllocationStrategy::OnDemand => Ok(Box::new(OnDemandInstanceAllocator::new(
+                self.mem_creator.clone(),
+            ))),
             InstanceAllocationStrategy::Pooling {
                 strategy,
                 module_limits,
@@ -1338,15 +1338,12 @@ impl Config {
                 #[cfg(not(feature = "async"))]
                 let stack_size = 0;
 
-                Box::new(
-                    PoolingInstanceAllocator::new(
-                        strategy.into(),
-                        module_limits.into(),
-                        instance_limits.into(),
-                        stack_size,
-                    )
-                    .expect("failed to create pooling instance allocator"),
-                )
+                Ok(Box::new(PoolingInstanceAllocator::new(
+                    strategy.into(),
+                    module_limits.into(),
+                    instance_limits.into(),
+                    stack_size,
+                )?))
             }
         }
     }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -325,7 +325,7 @@ macro_rules! generate_wrap_async_host_func {
         #[allow(non_snake_case)]
         #[cfg(feature = "async")]
         #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
-        pub fn [<wrap_host_func $num _async>]<$($args,)* R>(
+        pub fn [<wrap $num _host_func_async>]<$($args,)* R>(
             &mut self,
             module: &str,
             name: &str,
@@ -1280,7 +1280,7 @@ impl Config {
     ///
     /// Additionally note that this is quite a dynamic function since signatures
     /// are not statically known. For performance reasons, it's recommended
-    /// to use `Config::wrap_host_func$N_async` if you can because with statically known
+    /// to use `Config::wrap$N_host_func_async` if you can because with statically known
     /// signatures the engine can optimize the implementation much more.
     ///
     /// The callback must be `Send` and `Sync` as it is shared between all engines created

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -44,6 +44,7 @@ impl Engine {
     /// configuration settings.
     pub fn new(config: &Config) -> Result<Engine> {
         debug_builtins::ensure_exported();
+        config.validate()?;
         let allocator = config.build_allocator()?;
         Ok(Engine {
             inner: Arc::new(EngineInner {

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -150,14 +150,14 @@ unsafe impl Sync for HostFunc {}
 /// might have an `async` function in Rust, however, which you'd like to make
 /// available from WebAssembly. Wasmtime supports asynchronously calling
 /// WebAssembly through native stack switching. You can get some more
-/// information about [asynchronous stores](Store::new_async), but from the
+/// information about [asynchronous configs](Config::new_async), but from the
 /// perspective of `Func` it's important to know that whether or not your
 /// [`Store`] is asynchronous will dictate whether you call functions through
 /// [`Func::call`] or [`Func::call_async`] (or the wrappers such as
 /// [`Func::get0`] vs [`Func::get0_async`]).
 ///
 /// Note that asynchronous function APIs here are a bit trickier than their
-/// synchronous bretheren. For example [`Func::new_async`] and
+/// synchronous brethren. For example [`Func::new_async`] and
 /// [`Func::wrapN_async`](Func::wrap1_async) take explicit state parameters to
 /// allow you to close over the state in the returned future. It's recommended
 /// that you pass state via these parameters instead of through the closure's
@@ -171,7 +171,7 @@ unsafe impl Sync for HostFunc {}
 ///
 /// # To `Func::call` or to `Func::getN`
 ///
-/// There are four ways to call a `Func`. Half are asynchronus and half are
+/// There are four ways to call a `Func`. Half are asynchronous and half are
 /// synchronous, corresponding to the type of store you're using. Within each
 /// half you've got two choices:
 ///
@@ -609,8 +609,8 @@ impl Func {
     ///
     /// # Panics
     ///
-    /// This function will panic if `store` is not an [asynchronous
-    /// store](Store::new_async).
+    /// This function will panic if `store` is not associated with an [async
+    /// config](Config::new_async).
     ///
     /// # Examples
     ///
@@ -636,7 +636,7 @@ impl Func {
     ///
     /// // Using `new_async` we can hook up into calling our async
     /// // `get_row_count` function.
-    /// let store = Store::new_async(&Engine::default());
+    /// let store = Store::new(&Engine::new(&Config::new_async()));
     /// let get_row_count_type = wasmtime::FuncType::new(
     ///     None,
     ///     Some(wasmtime::ValType::I32),
@@ -965,8 +965,8 @@ impl Func {
     /// asynchronously.
     ///
     /// This function is the same as [`Func::call`] except that it is
-    /// asynchronous. This is only compatible with [asynchronous
-    /// stores](Store::new_async).
+    /// asynchronous. This is only compatible with stores associated with an
+    /// [asynchronous config](Config::new_async).
     ///
     /// It's important to note that the execution of WebAssembly will happen
     /// synchronously in the `poll` method of the future returned from this
@@ -976,7 +976,7 @@ impl Func {
     /// in a "blocking context".
     ///
     /// For more information see the documentation on [asynchronous
-    /// stores](Store::new_async).
+    /// configs](Config::new_async).
     ///
     /// # Panics
     ///

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -633,7 +633,7 @@ impl Func {
     ///
     /// // Using `new_async` we can hook up into calling our async
     /// // `get_row_count` function.
-    /// let store = Store::new(&Engine::new(&Config::new_async()));
+    /// let store = Store::new(&Engine::new(&Config::new_async())?);
     /// let get_row_count_type = wasmtime::FuncType::new(
     ///     None,
     ///     Some(wasmtime::ValType::I32),

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1,8 +1,8 @@
-use crate::store::StoreInner;
-use crate::trampoline::StoreInstanceHandle;
-use crate::{Extern, ExternRef, FuncType, Store, Trap, Val, ValType};
+use crate::{sig_registry::SignatureRegistry, trampoline::StoreInstanceHandle};
+use crate::{Config, Extern, ExternRef, FuncType, Store, Trap, Val, ValType};
 use anyhow::{bail, ensure, Context as _, Result};
 use smallvec::{smallvec, SmallVec};
+use std::any::Any;
 use std::cmp::max;
 use std::fmt;
 use std::future::Future;
@@ -10,13 +10,120 @@ use std::mem;
 use std::panic::{self, AssertUnwindSafe};
 use std::pin::Pin;
 use std::ptr::{self, NonNull};
-use std::rc::Weak;
 use std::task::{Context, Poll};
-use wasmtime_environ::wasm::EntityIndex;
+use wasmtime_environ::wasm::{EntityIndex, FuncIndex};
 use wasmtime_runtime::{
-    raise_user_trap, InstanceHandle, VMContext, VMFunctionBody, VMSharedSignatureIndex,
-    VMTrampoline,
+    raise_user_trap, ExportFunction, InstanceAllocator, InstanceHandle, OnDemandInstanceAllocator,
+    VMCallerCheckedAnyfunc, VMContext, VMExternRef, VMFunctionBody, VMFunctionImport,
+    VMSharedSignatureIndex, VMTrampoline,
 };
+
+/// Represents a host function.
+///
+/// This differs from `Func` in that it is not associated with a `Store`.
+/// Host functions are associated with a `Config`.
+pub(crate) struct HostFunc {
+    ty: FuncType,
+    instance: InstanceHandle,
+    trampoline: VMTrampoline,
+}
+
+impl HostFunc {
+    /// Creates a new host function from a callback.
+    ///
+    /// This is analogous to [`Func::new`].
+    pub fn new(
+        config: &Config,
+        ty: FuncType,
+        func: impl Fn(Caller<'_>, &[Val], &mut [Val]) -> Result<(), Trap> + Send + Sync + 'static,
+    ) -> Self {
+        let ty_clone = ty.clone();
+
+        // Create a trampoline that converts raw u128 values to `Val`
+        let func = Box::new(move |caller_vmctx, values_vec: *mut u128| {
+            // Lookup the last registered store as host functions have no associated store
+            let store = wasmtime_runtime::with_last_info(|last| {
+                last.and_then(Any::downcast_ref::<Store>)
+                    .cloned()
+                    .expect("Host function called without thread state")
+            });
+
+            Func::invoke(&store, &ty_clone, caller_vmctx, values_vec, &func)
+        });
+
+        let (instance, trampoline) = crate::trampoline::create_function(&ty, func, config, None)
+            .expect("failed to create host function");
+
+        Self {
+            ty,
+            instance,
+            trampoline,
+        }
+    }
+
+    /// Creates a new host function from wrapping a closure.
+    ///
+    /// This is analogous to [`Func::wrap`].
+    pub fn wrap<Params, Results>(
+        allocator: &dyn InstanceAllocator,
+        func: impl IntoFunc<Params, Results> + Send + Sync,
+    ) -> Self {
+        let (ty, instance, trampoline) = func.into_func(allocator, None);
+
+        Self {
+            ty,
+            instance,
+            trampoline,
+        }
+    }
+
+    /// Converts a `HostFunc` to a `Func`.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe as the caller must ensure that the store's config defines this `HostFunc`.
+    pub unsafe fn to_func(&self, store: &Store) -> Func {
+        let instance = StoreInstanceHandle {
+            store: store.clone(),
+            // This clone of the instance handle should be safe because it should not be deallocated
+            // until all configs that reference it are dropped.
+            // A config will not drop until all stores referencing the config are dropped.
+            handle: self.instance.clone(),
+        };
+
+        let export = ExportFunction {
+            anyfunc: std::ptr::NonNull::new_unchecked(store.get_host_anyfunc(
+                &self.instance,
+                &self.ty,
+                self.trampoline,
+            )),
+        };
+
+        Func {
+            instance,
+            trampoline: self.trampoline,
+            export,
+        }
+    }
+}
+
+impl Drop for HostFunc {
+    fn drop(&mut self) {
+        // Host functions are always allocated with the default (on-demand) allocator
+        unsafe { OnDemandInstanceAllocator::new(None).deallocate(&self.instance) }
+    }
+}
+
+// A note about thread safety of host function instance handles:
+// Host functions must be `Send+Sync` because `Module` must be `Send+Sync`.
+// However, the underlying runtime `Instance` is not `Send` or `Sync`.
+// For this to be safe, we must ensure that the runtime instance's state is not mutated for host functions.
+// Additionally, we add the `Send+Sync` bounds to `define_host_func` and `wrap_host_func` so
+// that the underlying closure stored in the instance's host state is safe to call from any thread.
+// Therefore, these impls should be safe because the underlying instance is not mutated and
+// the closures backing the host functions are required to be `Send+Sync`.
+unsafe impl Send for HostFunc {}
+unsafe impl Sync for HostFunc {}
 
 /// A WebAssembly function which can be called.
 ///
@@ -203,7 +310,7 @@ use wasmtime_runtime::{
 pub struct Func {
     instance: StoreInstanceHandle,
     trampoline: VMTrampoline,
-    export: wasmtime_runtime::ExportFunction,
+    export: ExportFunction,
 }
 
 macro_rules! for_each_function_signature {
@@ -347,23 +454,20 @@ macro_rules! generate_get_methods {
 
                     let mut ret = None;
 
-                    let weak_store = instance.store.weak();
-                    let weak_store = WeakStore(&weak_store);
-
                     $(
                         // Because this returned closure is not marked `unsafe`,
                         // we have to check that incoming values are compatible
                         // with our store.
-                        if !$args.compatible_with_store(weak_store) {
+                        if !$args.compatible_with_store(&instance.store) {
                             return Err(Trap::new(
                                 "attempt to pass cross-`Store` value to Wasm as function argument"
                             ));
                         }
 
-                        let $args = $args.into_abi_for_arg(weak_store);
+                        let $args = $args.into_abi_for_arg(&instance.store);
                     )*
 
-                    invoke_wasm_and_catch_traps(anyfunc.as_ref().vmctx, &instance.store, || {
+                    invoke_wasm_and_catch_traps(&instance.store, || {
                         ret = Some(fnptr(
                             anyfunc.as_ref().vmctx,
                             ptr::null_mut(),
@@ -371,7 +475,7 @@ macro_rules! generate_get_methods {
                         ));
                     })?;
 
-                    Ok(R::from_abi(ret.unwrap(), weak_store))
+                    Ok(R::from_abi(ret.unwrap(), &instance.store))
                 }
             })
         }
@@ -401,7 +505,7 @@ macro_rules! generate_wrap_async_func {
         {
             assert!(store.is_async());
             Func::wrap(store, move |caller: Caller<'_>, $($args: $args),*| {
-                let store = caller.store();
+                let store = caller.store().clone();
                 let mut future = Pin::from(func(caller, &state, $($args),*));
                 match store.block_on(future.as_mut()) {
                     Ok(ret) => ret.into_result(),
@@ -441,63 +545,36 @@ impl Func {
         ty: FuncType,
         func: impl Fn(Caller<'_>, &[Val], &mut [Val]) -> Result<(), Trap> + 'static,
     ) -> Self {
-        let store_weak = store.weak();
         let ty_clone = ty.clone();
 
-        // Create our actual trampoline function which translates from a bunch
-        // of bit patterns on the stack to actual instances of `Val` being
-        // passed to the given function.
+        // Create a trampoline that converts raw u128 values to `Val`
         let func = Box::new(move |caller_vmctx, values_vec: *mut u128| {
-            // We have a dynamic guarantee that `values_vec` has the right
-            // number of arguments and the right types of arguments. As a result
-            // we should be able to safely run through them all and read them.
-            const STACK_ARGS: usize = 4;
-            const STACK_RETURNS: usize = 2;
-            let mut args: SmallVec<[Val; STACK_ARGS]> =
-                SmallVec::with_capacity(ty_clone.params().len());
-            let store = Store::upgrade(&store_weak).unwrap();
-            for (i, ty) in ty_clone.params().enumerate() {
-                unsafe {
-                    let val = Val::read_value_from(&store, values_vec.add(i), ty);
-                    args.push(val);
-                }
-            }
+            // Lookup the last registered store as host functions have no associated store
+            let store = wasmtime_runtime::with_last_info(|last| {
+                last.and_then(Any::downcast_ref::<Store>)
+                    .cloned()
+                    .expect("function called without thread state")
+            });
 
-            let mut returns: SmallVec<[Val; STACK_RETURNS]> =
-                smallvec![Val::null(); ty_clone.results().len()];
-
-            func(
-                Caller {
-                    store: &store_weak,
-                    caller_vmctx,
-                },
-                &args,
-                &mut returns,
-            )?;
-
-            // Unlike our arguments we need to dynamically check that the return
-            // values produced are correct. There could be a bug in `func` that
-            // produces the wrong number, wrong types, or wrong stores of
-            // values, and we need to catch that here.
-            for (i, (ret, ty)) in returns.into_iter().zip(ty_clone.results()).enumerate() {
-                if ret.ty() != ty {
-                    return Err(Trap::new(
-                        "function attempted to return an incompatible value",
-                    ));
-                }
-                if !ret.comes_from_same_store(&store) {
-                    return Err(Trap::new(
-                        "cross-`Store` values are not currently supported",
-                    ));
-                }
-                unsafe {
-                    ret.write_value_to(&store, values_vec.add(i));
-                }
-            }
-            Ok(())
+            Func::invoke(&store, &ty_clone, caller_vmctx, values_vec, &func)
         });
-        let (instance, export, trampoline) =
-            crate::trampoline::generate_func_export(&ty, func, store).expect("generated func");
+
+        let (instance, trampoline) = crate::trampoline::create_function(
+            &ty,
+            func,
+            store.engine().config(),
+            Some(&mut store.signatures().borrow_mut()),
+        )
+        .expect("failed to create function");
+
+        let idx = EntityIndex::Function(FuncIndex::from_u32(0));
+        let (instance, export) = match instance.lookup_by_declaration(&idx) {
+            wasmtime_runtime::Export::Function(f) => {
+                (unsafe { store.add_instance(instance, true) }, f)
+            }
+            _ => unreachable!(),
+        };
+
         Func {
             instance,
             trampoline,
@@ -590,7 +667,7 @@ impl Func {
     {
         assert!(store.is_async());
         Func::new(store, ty, move |caller, params, results| {
-            let store = caller.store();
+            let store = caller.store().clone();
             let mut future = Pin::from(func(caller, &state, params, results));
             match store.block_on(future.as_mut()) {
                 Ok(Ok(())) => Ok(()),
@@ -601,13 +678,11 @@ impl Func {
 
     pub(crate) unsafe fn from_caller_checked_anyfunc(
         store: &Store,
-        anyfunc: *mut wasmtime_runtime::VMCallerCheckedAnyfunc,
+        anyfunc: *mut VMCallerCheckedAnyfunc,
     ) -> Option<Self> {
         let anyfunc = NonNull::new(anyfunc)?;
-        debug_assert!(
-            anyfunc.as_ref().type_index != wasmtime_runtime::VMSharedSignatureIndex::default()
-        );
-        let export = wasmtime_runtime::ExportFunction { anyfunc };
+        debug_assert!(anyfunc.as_ref().type_index != VMSharedSignatureIndex::default());
+        let export = ExportFunction { anyfunc };
         let f = Func::from_wasmtime_function(&export, store);
         Some(f)
     }
@@ -807,7 +882,24 @@ impl Func {
     /// # }
     /// ```
     pub fn wrap<Params, Results>(store: &Store, func: impl IntoFunc<Params, Results>) -> Func {
-        func.into_func(store)
+        let (_, instance, trampoline) = func.into_func(
+            &store.engine().config().default_instance_allocator,
+            Some(&mut store.signatures().borrow_mut()),
+        );
+
+        let (instance, export) = unsafe {
+            let idx = EntityIndex::Function(FuncIndex::from_u32(0));
+            match instance.lookup_by_declaration(&idx) {
+                wasmtime_runtime::Export::Function(f) => (store.add_instance(instance, true), f),
+                _ => unreachable!(),
+            }
+        };
+
+        Func {
+            instance,
+            export,
+            trampoline,
+        }
     }
 
     for_each_function_signature!(generate_wrap_async_func);
@@ -939,7 +1031,7 @@ impl Func {
         // Call the trampoline.
         unsafe {
             let anyfunc = self.export.anyfunc.as_ref();
-            invoke_wasm_and_catch_traps(anyfunc.vmctx, &self.instance.store, || {
+            invoke_wasm_and_catch_traps(&self.instance.store, || {
                 (self.trampoline)(
                     anyfunc.vmctx,
                     ptr::null_mut(),
@@ -961,16 +1053,11 @@ impl Func {
         Ok(results.into())
     }
 
-    pub(crate) fn caller_checked_anyfunc(
-        &self,
-    ) -> NonNull<wasmtime_runtime::VMCallerCheckedAnyfunc> {
+    pub(crate) fn caller_checked_anyfunc(&self) -> NonNull<VMCallerCheckedAnyfunc> {
         self.export.anyfunc
     }
 
-    pub(crate) unsafe fn from_wasmtime_function(
-        export: &wasmtime_runtime::ExportFunction,
-        store: &Store,
-    ) -> Self {
+    pub(crate) unsafe fn from_wasmtime_function(export: &ExportFunction, store: &Store) -> Self {
         // Each function signature in a module should have a trampoline stored
         // on that module as well, so unwrap the result here since otherwise
         // it's a bug in wasmtime.
@@ -996,18 +1083,73 @@ impl Func {
         &self.instance.store
     }
 
-    pub(crate) fn vmimport(&self) -> wasmtime_runtime::VMFunctionImport {
+    pub(crate) fn vmimport(&self) -> VMFunctionImport {
         unsafe {
             let f = self.caller_checked_anyfunc();
-            wasmtime_runtime::VMFunctionImport {
+            VMFunctionImport {
                 body: f.as_ref().func_ptr,
                 vmctx: f.as_ref().vmctx,
             }
         }
     }
 
-    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::ExportFunction {
+    pub(crate) fn wasmtime_export(&self) -> &ExportFunction {
         &self.export
+    }
+
+    pub(crate) fn invoke(
+        store: &Store,
+        ty: &FuncType,
+        caller_vmctx: *mut VMContext,
+        values_vec: *mut u128,
+        func: &dyn Fn(Caller<'_>, &[Val], &mut [Val]) -> Result<(), Trap>,
+    ) -> Result<(), Trap> {
+        // We have a dynamic guarantee that `values_vec` has the right
+        // number of arguments and the right types of arguments. As a result
+        // we should be able to safely run through them all and read them.
+        const STACK_ARGS: usize = 4;
+        const STACK_RETURNS: usize = 2;
+        let mut args: SmallVec<[Val; STACK_ARGS]> = SmallVec::with_capacity(ty.params().len());
+        for (i, ty) in ty.params().enumerate() {
+            unsafe {
+                let val = Val::read_value_from(store, values_vec.add(i), ty);
+                args.push(val);
+            }
+        }
+
+        let mut returns: SmallVec<[Val; STACK_RETURNS]> =
+            smallvec![Val::null(); ty.results().len()];
+
+        func(
+            Caller {
+                store,
+                caller_vmctx,
+            },
+            &args,
+            &mut returns,
+        )?;
+
+        // Unlike our arguments we need to dynamically check that the return
+        // values produced are correct. There could be a bug in `func` that
+        // produces the wrong number, wrong types, or wrong stores of
+        // values, and we need to catch that here.
+        for (i, (ret, ty)) in returns.into_iter().zip(ty.results()).enumerate() {
+            if ret.ty() != ty {
+                return Err(Trap::new(
+                    "function attempted to return an incompatible value",
+                ));
+            }
+            if !ret.comes_from_same_store(store) {
+                return Err(Trap::new(
+                    "cross-`Store` values are not currently supported",
+                ));
+            }
+            unsafe {
+                ret.write_value_to(store, values_vec.add(i));
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -1018,7 +1160,6 @@ impl fmt::Debug for Func {
 }
 
 pub(crate) fn invoke_wasm_and_catch_traps(
-    vmctx: *mut VMContext,
     store: &Store,
     closure: impl FnMut(),
 ) -> Result<(), Trap> {
@@ -1028,16 +1169,9 @@ pub(crate) fn invoke_wasm_and_catch_traps(
             .externref_activations_table()
             .set_stack_canary(&canary);
 
-        wasmtime_runtime::catch_traps(vmctx, store, closure)
-            .map_err(|e| Trap::from_runtime(store, e))
+        wasmtime_runtime::catch_traps(store, closure).map_err(|e| Trap::from_runtime(store, e))
     }
 }
-
-// Public (but hidden) wrapper around a `Weak<StoreInner>` so that we can use it
-// in public (but hidden) trait methods.
-#[doc(hidden)]
-#[derive(Clone, Copy)]
-pub struct WeakStore<'a>(&'a Weak<StoreInner>);
 
 /// A trait implemented for types which can be arguments to closures passed to
 /// [`Func::wrap`] and friends.
@@ -1054,12 +1188,12 @@ pub unsafe trait WasmTy {
 
     // Is this value compatible with the given store?
     #[doc(hidden)]
-    fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool;
+    fn compatible_with_store(&self, store: &Store) -> bool;
 
     // Convert this value into its ABI representation, when passing a value into
     // Wasm as an argument.
     #[doc(hidden)]
-    fn into_abi_for_arg<'a>(self, store: WeakStore<'a>) -> Self::Abi;
+    fn into_abi_for_arg(self, store: &Store) -> Self::Abi;
 
     // Convert from the raw ABI representation back into `Self`, when receiving
     // a value from Wasm.
@@ -1068,7 +1202,7 @@ pub unsafe trait WasmTy {
     // `externref`, it must be a valid raw `VMExternRef` pointer, not some
     // random, dangling pointer).
     #[doc(hidden)]
-    unsafe fn from_abi<'a>(abi: Self::Abi, store: WeakStore<'a>) -> Self;
+    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self;
 
     // Add this type to the given vec of expected valtypes.
     #[doc(hidden)]
@@ -1107,7 +1241,7 @@ pub unsafe trait WasmRet {
 
     // Same as `WasmTy::compatible_with_store`.
     #[doc(hidden)]
-    fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool;
+    fn compatible_with_store(&self, store: &Store) -> bool;
 
     // Similar to `WasmTy::into_abi_for_arg` but used when host code is
     // returning a value into Wasm, rather than host code passing an argument to
@@ -1116,11 +1250,11 @@ pub unsafe trait WasmRet {
     // `invoke_wasm_and_catch_traps` is on the stack, and therefore this method
     // is unsafe.
     #[doc(hidden)]
-    unsafe fn into_abi_for_ret<'a>(self, store: WeakStore<'a>) -> Self::Abi;
+    unsafe fn into_abi_for_ret(self, store: &Store) -> Self::Abi;
 
     // Same as `WasmTy::from_abi`.
     #[doc(hidden)]
-    unsafe fn from_abi<'a>(abi: Self::Abi, store: WeakStore<'a>) -> Self;
+    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self;
 
     // Same as `WasmTy::push`.
     #[doc(hidden)]
@@ -1147,15 +1281,15 @@ unsafe impl WasmTy for () {
     type Abi = Self;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {}
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {}
 
     #[inline]
-    unsafe fn from_abi<'a>(_abi: Self::Abi, _store: WeakStore<'a>) -> Self {}
+    unsafe fn from_abi(_abi: Self::Abi, _store: &Store) -> Self {}
 
     fn valtype() -> Option<ValType> {
         None
@@ -1176,17 +1310,17 @@ unsafe impl WasmTy for i32 {
     type Abi = Self;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, _store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
         abi
     }
 
@@ -1221,17 +1355,17 @@ unsafe impl WasmTy for u32 {
     type Abi = <i32 as WasmTy>::Abi;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
         self as i32
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, _store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
         abi as Self
     }
 
@@ -1258,17 +1392,17 @@ unsafe impl WasmTy for i64 {
     type Abi = Self;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, _store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
         abi
     }
 
@@ -1303,17 +1437,17 @@ unsafe impl WasmTy for u64 {
     type Abi = <i64 as WasmTy>::Abi;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
         self as i64
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, _store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
         abi as Self
     }
 
@@ -1340,17 +1474,17 @@ unsafe impl WasmTy for f32 {
     type Abi = Self;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, _store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
         abi
     }
 
@@ -1385,17 +1519,17 @@ unsafe impl WasmTy for f64 {
     type Abi = Self;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, _store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
         abi
     }
 
@@ -1430,14 +1564,13 @@ unsafe impl WasmTy for Option<ExternRef> {
     type Abi = *mut u8;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, _store: &Store) -> bool {
         true
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, store: &Store) -> Self::Abi {
         if let Some(x) = self {
-            let store = Store::upgrade(store.0).unwrap();
             let abi = x.inner.as_raw();
             unsafe {
                 store
@@ -1451,12 +1584,12 @@ unsafe impl WasmTy for Option<ExternRef> {
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, _store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
         if abi.is_null() {
             None
         } else {
             Some(ExternRef {
-                inner: wasmtime_runtime::VMExternRef::clone_from_raw(abi),
+                inner: VMExternRef::clone_from_raw(abi),
             })
         }
     }
@@ -1487,20 +1620,19 @@ unsafe impl WasmTy for Option<ExternRef> {
 }
 
 unsafe impl WasmTy for Option<Func> {
-    type Abi = *mut wasmtime_runtime::VMCallerCheckedAnyfunc;
+    type Abi = *mut VMCallerCheckedAnyfunc;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, store: &Store) -> bool {
         if let Some(f) = self {
-            let store = Store::upgrade(store.0).unwrap();
-            Store::same(&store, f.store())
+            Store::same(store, f.store())
         } else {
             true
         }
     }
 
     #[inline]
-    fn into_abi_for_arg<'a>(self, _store: WeakStore<'a>) -> Self::Abi {
+    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
         if let Some(f) = self {
             f.caller_checked_anyfunc().as_ptr()
         } else {
@@ -1509,9 +1641,8 @@ unsafe impl WasmTy for Option<Func> {
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, store: WeakStore<'a>) -> Self {
-        let store = Store::upgrade(store.0).unwrap();
-        Func::from_caller_checked_anyfunc(&store, abi)
+    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self {
+        Func::from_caller_checked_anyfunc(store, abi)
     }
 
     fn valtype() -> Option<ValType> {
@@ -1529,7 +1660,7 @@ unsafe impl WasmTy for Option<Func> {
     }
 
     unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        let ret = *(*ptr).cast::<usize>() as *mut wasmtime_runtime::VMCallerCheckedAnyfunc;
+        let ret = *(*ptr).cast::<usize>() as *mut VMCallerCheckedAnyfunc;
         *ptr = (*ptr).add(1);
         ret
     }
@@ -1547,17 +1678,17 @@ where
     type Ok = T;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, store: &Store) -> bool {
         <Self as WasmTy>::compatible_with_store(self, store)
     }
 
     #[inline]
-    unsafe fn into_abi_for_ret<'a>(self, store: WeakStore<'a>) -> Self::Abi {
+    unsafe fn into_abi_for_ret(self, store: &Store) -> Self::Abi {
         <Self as WasmTy>::into_abi_for_arg(self, store)
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self {
         <Self as WasmTy>::from_abi(abi, store)
     }
 
@@ -1594,7 +1725,7 @@ where
     type Ok = T;
 
     #[inline]
-    fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool {
+    fn compatible_with_store(&self, store: &Store) -> bool {
         match self {
             Ok(x) => <T as WasmTy>::compatible_with_store(x, store),
             Err(_) => true,
@@ -1602,7 +1733,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_abi_for_ret<'a>(self, store: WeakStore<'a>) -> Self::Abi {
+    unsafe fn into_abi_for_ret(self, store: &Store) -> Self::Abi {
         match self {
             Ok(val) => return <T as WasmTy>::into_abi_for_arg(val, store),
             Err(trap) => handle_trap(trap),
@@ -1614,7 +1745,7 @@ where
     }
 
     #[inline]
-    unsafe fn from_abi<'a>(abi: Self::Abi, store: WeakStore<'a>) -> Self {
+    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self {
         Ok(<T as WasmTy>::from_abi(abi, store))
     }
 
@@ -1643,13 +1774,17 @@ where
 }
 
 /// Internal trait implemented for all arguments that can be passed to
-/// [`Func::wrap`].
+/// [`Func::wrap`] and [`Config::wrap_host_func`](crate::Config::wrap_host_func).
 ///
 /// This trait should not be implemented by external users, it's only intended
 /// as an implementation detail of this crate.
 pub trait IntoFunc<Params, Results> {
     #[doc(hidden)]
-    fn into_func(self, store: &Store) -> Func;
+    fn into_func(
+        self,
+        allocator: &dyn InstanceAllocator,
+        registry: Option<&mut SignatureRegistry>,
+    ) -> (FuncType, InstanceHandle, VMTrampoline);
 }
 
 /// A structure representing the *caller's* context when creating a function
@@ -1672,23 +1807,7 @@ pub trait IntoFunc<Params, Results> {
 /// you're relying on this Caller type it's recommended to become familiar with
 /// interface types to ensure that your use case is covered by the proposal.
 pub struct Caller<'a> {
-    // Note that this is a `Weak` pointer instead of a `&'a Store`,
-    // intentionally so. This allows us to break an `Rc` cycle which would
-    // otherwise look like this:
-    //
-    // * A `Store` object ...
-    // * ... owns all `InstanceHandle` objects ...
-    // * ... which are created in `Func::wrap` with custom host data ...
-    // * ... where the custom host data needs to point to `Store` to be stored
-    //   here
-    //
-    // This `Rc` cycle means that we would never actually reclaim any memory or
-    // deallocate any instances. To break this cycle we use a weak pointer here
-    // which points back to `Store`. A `Caller` should only ever be usable
-    // when the original `Store` is alive, however, so this should always be an
-    // upgrade-able pointer. Alternative solutions or other ideas to break this
-    // cycle would be most welcome!
-    store: &'a Weak<StoreInner>,
+    store: &'a Store,
     caller_vmctx: *mut VMContext,
 }
 
@@ -1701,7 +1820,7 @@ impl Caller<'_> {
     /// in the future!
     ///
     /// Note that when accessing and calling exported functions, one should adhere
-    /// to the guidlines of the interface types proposal.
+    /// to the guidelines of the interface types proposal.
     ///
     /// # Return
     ///
@@ -1722,13 +1841,7 @@ impl Caller<'_> {
                 return None;
             }
             let instance = InstanceHandle::from_vmctx(self.caller_vmctx);
-            // Our `Weak` pointer is used only to break a cycle where `Store`
-            // stores instance handles which have this weak pointer as their
-            // custom host data. This function should only be invoke-able while
-            // the `Store` is active, so this upgrade should always succeed.
-            debug_assert!(self.store.upgrade().is_some());
-            let handle =
-                Store::from_inner(self.store.upgrade()?).existing_instance_handle(instance);
+            let handle = self.store.existing_instance_handle(instance);
             let index = handle.module().exports.get(name)?;
             match index {
                 // Only allow memory/functions for now to emulate what interface
@@ -1744,10 +1857,9 @@ impl Caller<'_> {
         }
     }
 
-    /// Get a handle to this caller's store.
-    pub fn store(&self) -> Store {
-        // See comment above the `store` member for why this unwrap is OK.
-        Store::upgrade(&self.store).unwrap()
+    /// Get a reference to the caller's store.
+    pub fn store(&self) -> &Store {
+        self.store
     }
 }
 
@@ -1777,17 +1889,19 @@ macro_rules! impl_into_func {
         // Implement for functions without a leading `&Caller` parameter,
         // delegating to the implementation below which does have the leading
         // `Caller` parameter.
+        #[allow(non_snake_case)]
         impl<F, $($args,)* R> IntoFunc<($($args,)*), R> for F
         where
             F: Fn($($args),*) -> R + 'static,
             $($args: WasmTy,)*
             R: WasmRet,
         {
-            #[allow(non_snake_case)]
-            fn into_func(self, store: &Store) -> Func {
-                Func::wrap(store, move |_: Caller<'_>, $($args:$args),*| {
+            fn into_func(self, allocator: &dyn InstanceAllocator, registry: Option<&mut SignatureRegistry>) -> (FuncType, InstanceHandle, VMTrampoline) {
+                let f = move |_: Caller<'_>, $($args:$args),*| {
                     self($($args),*)
-                })
+                };
+
+                f.into_func(allocator, registry)
             }
         }
 
@@ -1798,7 +1912,7 @@ macro_rules! impl_into_func {
             $($args: WasmTy,)*
             R: WasmRet,
         {
-            fn into_func(self, store: &Store) -> Func {
+            fn into_func(self, allocator: &dyn InstanceAllocator, registry: Option<&mut SignatureRegistry>) -> (FuncType, InstanceHandle, VMTrampoline) {
                 /// This shim is called by Wasm code, constructs a `Caller`,
                 /// calls the wrapped host function, and returns the translated
                 /// result back to Wasm.
@@ -1820,15 +1934,20 @@ macro_rules! impl_into_func {
                     // Double-check ourselves in debug mode, but we control
                     // the `Any` here so an unsafe downcast should also
                     // work.
-                    debug_assert!(state.is::<(F, Weak<StoreInner>)>());
-                    let (func, store) = &*(state as *const _ as *const (F, Weak<StoreInner>));
-                    let weak_store = WeakStore(store);
+                    debug_assert!(state.is::<F>());
+                    let func = &*(state as *const _ as *const F);
+
+                    let store = wasmtime_runtime::with_last_info(|last| {
+                        last.and_then(Any::downcast_ref::<Store>)
+                            .cloned()
+                            .expect("function called without thread state")
+                    });
 
                     let ret = {
                         panic::catch_unwind(AssertUnwindSafe(|| {
                             func(
-                                Caller { store, caller_vmctx },
-                                $( $args::from_abi($args, weak_store), )*
+                                Caller { store: &store, caller_vmctx },
+                                $( $args::from_abi($args, &store), )*
                             )
                         }))
                     };
@@ -1846,12 +1965,14 @@ macro_rules! impl_into_func {
                             // Because the wrapped function is not `unsafe`, we
                             // can't assume it returned a value that is
                             // compatible with this store.
-                            if !ret.compatible_with_store(weak_store) {
+                            if !ret.compatible_with_store(&store) {
+                                // Explicitly drop all locals with destructors prior to raising the trap
+                                drop(store);
                                 drop(ret);
                                 raise_cross_store_trap();
                             }
 
-                            ret.into_abi_for_ret(weak_store)
+                            ret.into_abi_for_ret(&store)
                         }
                     }
                 }
@@ -1895,27 +2016,28 @@ macro_rules! impl_into_func {
                     R::valtype(),
                 );
 
-                let store_weak = store.weak();
                 let trampoline = host_trampoline::<$($args,)* R>;
-                let (instance, export) = unsafe {
-                    crate::trampoline::generate_raw_func_export(
-                        &ty,
+
+                // If not given a registry, use a default signature index that is guaranteed to trap
+                // if the function is called indirectly without first being associated with a store (a bug condition).
+                let shared_signature_id = registry
+                    .map(|r| r.register(ty.as_wasm_func_type(), trampoline))
+                    .unwrap_or(VMSharedSignatureIndex::default());
+
+                let instance = unsafe {
+                    crate::trampoline::create_raw_function(
+                        allocator,
                         std::slice::from_raw_parts_mut(
                             wasm_to_host_shim::<F, $($args,)* R> as *mut _,
                             0,
                         ),
-                        trampoline,
-                        store,
-                        Box::new((self, store_weak)),
+                        Box::new(self),
+                        shared_signature_id
                     )
-                    .expect("failed to generate export")
+                    .expect("failed to create raw function")
                 };
 
-                Func {
-                    instance,
-                    export,
-                    trampoline,
-                }
+                (ty, instance, trampoline)
             }
         }
     }

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -551,7 +551,7 @@ impl<'a> Instantiator<'a> {
             };
             let vmctx_ptr = instance.handle.vmctx_ptr();
             unsafe {
-                super::func::invoke_wasm_and_catch_traps(vmctx_ptr, &instance.store, || {
+                super::func::invoke_wasm_and_catch_traps(&instance.store, || {
                     mem::transmute::<
                         *const VMFunctionBody,
                         unsafe extern "C" fn(*mut VMContext, *mut VMContext),

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -491,9 +491,8 @@ impl<'a> Instantiator<'a> {
         self.store.register_module(&self.cur.module);
 
         unsafe {
-            let config = self.store.engine().config();
-
-            let allocator = config.instance_allocator();
+            let engine = self.store.engine();
+            let allocator = engine.allocator();
 
             let instance = allocator.allocate(InstanceAllocationRequest {
                 module: compiled_module.module().clone(),
@@ -520,7 +519,7 @@ impl<'a> Instantiator<'a> {
             // initialization is successful, we need to keep the instance alive.
             let instance = self.store.add_instance(instance, false);
             allocator
-                .initialize(&instance.handle, config.features.bulk_memory)
+                .initialize(&instance.handle, engine.config().features.bulk_memory)
                 .map_err(|e| -> Error {
                     match e {
                         InstantiationError::Trap(trap) => {

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -92,8 +92,8 @@ impl Instance {
     ///
     /// # Panics
     ///
-    /// This function will panic if called within an asynchronous store
-    /// (created with [`Store::new_async`]).
+    /// This function will panic if called with a store associated with a
+    /// [`asynchronous config`](crate::Config::new_async).
     ///
     /// [inst]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
     /// [issue]: https://github.com/bytecodealliance/wasmtime/issues/727
@@ -127,11 +127,9 @@ impl Instance {
     ///
     /// # Panics
     ///
-    /// This function will panic if called within a non-asynchronous store
-    /// (created with [`Store::new`]). This is only compatible with asynchronous
-    /// stores created with [`Store::new_async`].
-    ///
-    /// [asynchronous stores]: Store::new_async
+    /// This function will panic if called with a store associated with a [`synchronous
+    /// config`](crate::Config::new). This is only compatible with stores associated with
+    /// an [`asynchronous config`](crate::Config::new_async).
     #[cfg(feature = "async")]
     #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
     pub async fn new_async(

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -93,15 +93,15 @@ impl Instance {
     /// # Panics
     ///
     /// This function will panic if called with a store associated with a
-    /// [`asynchronous config`](crate::Config::new_async).
+    /// [`asynchronous config`](crate::Config::async_support).
     ///
     /// [inst]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
     /// [issue]: https://github.com/bytecodealliance/wasmtime/issues/727
     /// [`ExternType`]: crate::ExternType
     pub fn new(store: &Store, module: &Module, imports: &[Extern]) -> Result<Instance, Error> {
         assert!(
-            !store.is_async(),
-            "cannot instantiate synchronously within an asynchronous store"
+            !store.async_support(),
+            "cannot use `new` when async support is enabled on the config"
         );
 
         // NB: this is the same code as `Instance::new_async`. It's intentionally
@@ -129,7 +129,7 @@ impl Instance {
     ///
     /// This function will panic if called with a store associated with a [`synchronous
     /// config`](crate::Config::new). This is only compatible with stores associated with
-    /// an [`asynchronous config`](crate::Config::new_async).
+    /// an [`asynchronous config`](crate::Config::async_support).
     #[cfg(feature = "async")]
     #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
     pub async fn new_async(
@@ -138,8 +138,8 @@ impl Instance {
         imports: &[Extern],
     ) -> Result<Instance, Error> {
         assert!(
-            store.is_async(),
-            "cannot instantiate asynchronously within a synchronous store"
+            store.async_support(),
+            "cannot use `new_async` without enabling async support on the config"
         );
 
         // NB: this is the same code as `Instance::new`. It's intentionally

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -275,11 +275,13 @@
 #![cfg_attr(nightlydoc, feature(doc_cfg))]
 #![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
 
+#[macro_use]
+mod func;
+
 mod config;
 mod engine;
 mod externals;
 mod frame_info;
-mod func;
 mod instance;
 mod linker;
 mod memory;

--- a/crates/wasmtime/src/memory.rs
+++ b/crates/wasmtime/src/memory.rs
@@ -566,7 +566,7 @@ mod tests {
         let mut cfg = Config::new();
         cfg.static_memory_maximum_size(0)
             .dynamic_memory_guard_size(0);
-        let store = Store::new(&Engine::new(&cfg));
+        let store = Store::new(&Engine::new(&cfg).unwrap());
         let ty = MemoryType::new(Limits::new(1, None));
         let mem = Memory::new(&store, ty);
         assert_eq!(mem.wasmtime_export.memory.offset_guard_size, 0);

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -332,10 +332,7 @@ impl Module {
         let module = modules.remove(main_module);
 
         // Validate the module can be used with the current allocator
-        engine
-            .config()
-            .instance_allocator()
-            .validate(module.module())?;
+        engine.allocator().validate(module.module())?;
 
         Ok(Module {
             inner: Arc::new(ModuleInner {

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -470,7 +470,7 @@ impl Store {
     /// # fn main() -> Result<()> {
     /// // Enable interruptable code via `Config` and then create an interrupt
     /// // handle which we'll use later to interrupt running code.
-    /// let engine = Engine::new(Config::new().interruptable(true));
+    /// let engine = Engine::new(Config::new().interruptable(true))?;
     /// let store = Store::new(&engine);
     /// let interrupt_handle = store.interrupt_handle()?;
     ///

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -1,6 +1,5 @@
 //! Utility module to create trampolines in/out WebAssembly module.
 
-mod create_handle;
 mod func;
 mod global;
 mod memory;
@@ -8,16 +7,20 @@ mod table;
 
 pub(crate) use memory::MemoryCreatorProxy;
 
-use self::func::create_handle_with_function;
+pub use self::func::{create_function, create_raw_function};
 use self::global::create_global;
-use self::memory::create_handle_with_memory;
-use self::table::create_handle_with_table;
-use crate::{FuncType, GlobalType, MemoryType, Store, TableType, Trap, Val};
+use self::memory::create_memory;
+use self::table::create_table;
+use crate::{GlobalType, MemoryType, Store, TableType, Val};
 use anyhow::Result;
 use std::any::Any;
 use std::ops::Deref;
-use wasmtime_environ::wasm;
-use wasmtime_runtime::{InstanceHandle, VMContext, VMFunctionBody, VMTrampoline};
+use std::sync::Arc;
+use wasmtime_environ::{entity::PrimaryMap, wasm, Module};
+use wasmtime_runtime::{
+    Imports, InstanceAllocationRequest, InstanceAllocator, InstanceHandle, StackMapRegistry,
+    VMExternRefActivationsTable, VMFunctionBody, VMFunctionImport, VMSharedSignatureIndex,
+};
 
 /// A wrapper around `wasmtime_runtime::InstanceHandle` which pairs it with the
 /// `Store` that it's rooted within. The instance is deallocated when `Store` is
@@ -46,38 +49,39 @@ impl Deref for StoreInstanceHandle {
     }
 }
 
-pub fn generate_func_export(
-    ft: &FuncType,
-    func: Box<dyn Fn(*mut VMContext, *mut u128) -> Result<(), Trap>>,
+fn create_handle(
+    module: Module,
     store: &Store,
-) -> Result<(
-    StoreInstanceHandle,
-    wasmtime_runtime::ExportFunction,
-    VMTrampoline,
-)> {
-    let (instance, trampoline) = create_handle_with_function(ft, func, store)?;
-    let idx = wasm::EntityIndex::Function(wasm::FuncIndex::from_u32(0));
-    match instance.lookup_by_declaration(&idx) {
-        wasmtime_runtime::Export::Function(f) => Ok((instance, f, trampoline)),
-        _ => unreachable!(),
-    }
-}
+    finished_functions: PrimaryMap<wasm::DefinedFuncIndex, *mut [VMFunctionBody]>,
+    host_state: Box<dyn Any>,
+    func_imports: &[VMFunctionImport],
+    shared_signature_id: Option<VMSharedSignatureIndex>,
+) -> Result<StoreInstanceHandle> {
+    let mut imports = Imports::default();
+    imports.functions = func_imports;
 
-/// Note that this is `unsafe` since `func` must be a valid function pointer and
-/// have a signature which matches `ft`, otherwise the returned
-/// instance/export/etc may exhibit undefined behavior.
-pub unsafe fn generate_raw_func_export(
-    ft: &FuncType,
-    func: *mut [VMFunctionBody],
-    trampoline: VMTrampoline,
-    store: &Store,
-    state: Box<dyn Any>,
-) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportFunction)> {
-    let instance = func::create_handle_with_raw_function(ft, func, trampoline, store, state)?;
-    let idx = wasm::EntityIndex::Function(wasm::FuncIndex::from_u32(0));
-    match instance.lookup_by_declaration(&idx) {
-        wasmtime_runtime::Export::Function(f) => Ok((instance, f)),
-        _ => unreachable!(),
+    unsafe {
+        // Use the default allocator when creating handles associated with host objects
+        // The configured instance allocator should only be used when creating module instances
+        // as we don't want host objects to count towards instance limits.
+        let handle = store
+            .engine()
+            .config()
+            .default_instance_allocator
+            .allocate(InstanceAllocationRequest {
+                module: Arc::new(module),
+                finished_functions: &finished_functions,
+                imports,
+                lookup_shared_signature: &|_| shared_signature_id.unwrap(),
+                host_state,
+                interrupts: store.interrupts(),
+                externref_activations_table: store.externref_activations_table()
+                    as *const VMExternRefActivationsTable
+                    as *mut _,
+                stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
+            })?;
+
+        Ok(store.add_instance(handle, true))
     }
 }
 
@@ -98,7 +102,7 @@ pub fn generate_memory_export(
     store: &Store,
     m: &MemoryType,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportMemory)> {
-    let instance = create_handle_with_memory(store, m)?;
+    let instance = create_memory(store, m)?;
     let idx = wasm::EntityIndex::Memory(wasm::MemoryIndex::from_u32(0));
     match instance.lookup_by_declaration(&idx) {
         wasmtime_runtime::Export::Memory(m) => Ok((instance, m)),
@@ -110,7 +114,7 @@ pub fn generate_table_export(
     store: &Store,
     t: &TableType,
 ) -> Result<(StoreInstanceHandle, wasmtime_runtime::ExportTable)> {
-    let instance = create_handle_with_table(store, t)?;
+    let instance = create_table(store, t)?;
     let idx = wasm::EntityIndex::Table(wasm::TableIndex::from_u32(0));
     match instance.lookup_by_declaration(&idx) {
         wasmtime_runtime::Export::Table(t) => Ok((instance, t)),

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -1,16 +1,15 @@
 //! Support for a calling of an imported function.
 
-use super::create_handle::create_handle;
-use crate::trampoline::StoreInstanceHandle;
-use crate::{FuncType, Store, Trap};
+use crate::{sig_registry::SignatureRegistry, Config, FuncType, Trap};
 use anyhow::Result;
 use std::any::Any;
 use std::cmp;
 use std::mem;
 use std::panic::{self, AssertUnwindSafe};
+use std::sync::Arc;
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::isa::TargetIsa;
-use wasmtime_environ::wasm::SignatureIndex;
+use wasmtime_environ::wasm::{DefinedFuncIndex, SignatureIndex};
 use wasmtime_environ::{ir, wasm, CompiledFunction, Module, ModuleType};
 use wasmtime_jit::trampoline::ir::{
     ExternalName, Function, InstBuilder, MemFlags, StackSlotData, StackSlotKind,
@@ -19,7 +18,10 @@ use wasmtime_jit::trampoline::{
     self, binemit, pretty_error, Context, FunctionBuilder, FunctionBuilderContext,
 };
 use wasmtime_jit::CodeMemory;
-use wasmtime_runtime::{InstanceHandle, VMContext, VMFunctionBody, VMTrampoline};
+use wasmtime_runtime::{
+    Imports, InstanceAllocationRequest, InstanceAllocator, InstanceHandle, VMContext,
+    VMFunctionBody, VMSharedSignatureIndex, VMTrampoline,
+};
 
 struct TrampolineState {
     func: Box<dyn Fn(*mut VMContext, *mut u128) -> Result<(), Trap>>,
@@ -203,19 +205,23 @@ fn make_trampoline(
         .expect("allocate_for_function")
 }
 
-pub fn create_handle_with_function(
+fn create_function_trampoline(
+    config: &Config,
     ft: &FuncType,
     func: Box<dyn Fn(*mut VMContext, *mut u128) -> Result<(), Trap>>,
-    store: &Store,
-) -> Result<(StoreInstanceHandle, VMTrampoline)> {
+) -> Result<(
+    Module,
+    PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
+    VMTrampoline,
+    TrampolineState,
+)> {
     // Note that we specifically enable reference types here in our ISA because
     // `Func::new` is intended to be infallible, but our signature may use
     // reference types which requires safepoints.
-    let isa = store.engine().config().target_isa_with_reference_types();
+    let isa = config.target_isa_with_reference_types();
 
     let pointer_type = isa.pointer_type();
     let sig = ft.get_wasmtime_signature(pointer_type);
-    let wft = ft.as_wasm_func_type();
 
     let mut fn_builder_ctx = FunctionBuilderContext::new();
     let mut module = Module::new();
@@ -226,10 +232,12 @@ pub fn create_handle_with_function(
     // and calls into `stub_fn`...
     let sig_id = SignatureIndex::from_u32(u32::max_value() - 1);
     module.types.push(ModuleType::Function(sig_id));
+
     let func_id = module.functions.push(sig_id);
     module
         .exports
         .insert(String::new(), wasm::EntityIndex::Function(func_id));
+
     let trampoline = make_trampoline(isa.as_ref(), &mut code_memory, &mut fn_builder_ctx, &sig);
     finished_functions.push(trampoline);
 
@@ -243,33 +251,54 @@ pub fn create_handle_with_function(
         &sig,
         mem::size_of::<u128>(),
     )?;
-    let shared_signature_id = store.signatures().borrow_mut().register(wft, trampoline);
 
-    // Next up we wrap everything up into an `InstanceHandle` by publishing our
-    // code memory (makes it executable) and ensuring all our various bits of
-    // state make it into the instance constructors.
     code_memory.publish(isa.as_ref());
+
     let trampoline_state = TrampolineState { func, code_memory };
-    create_handle(
-        module,
-        store,
-        finished_functions,
-        Box::new(trampoline_state),
-        &[],
-        Some(shared_signature_id),
-    )
-    .map(|instance| (instance, trampoline))
+
+    Ok((module, finished_functions, trampoline, trampoline_state))
 }
 
-pub unsafe fn create_handle_with_raw_function(
+pub fn create_function(
     ft: &FuncType,
-    func: *mut [VMFunctionBody],
-    trampoline: VMTrampoline,
-    store: &Store,
-    state: Box<dyn Any>,
-) -> Result<StoreInstanceHandle> {
-    let wft = ft.as_wasm_func_type();
+    func: Box<dyn Fn(*mut VMContext, *mut u128) -> Result<(), Trap>>,
+    config: &Config,
+    registry: Option<&mut SignatureRegistry>,
+) -> Result<(InstanceHandle, VMTrampoline)> {
+    let (module, finished_functions, trampoline, trampoline_state) =
+        create_function_trampoline(config, ft, func)?;
 
+    // If there is no signature registry, use the default signature index which is
+    // guaranteed to trap if there is ever an indirect call on the function (should not happen)
+    let shared_signature_id = registry
+        .map(|r| r.register(ft.as_wasm_func_type(), trampoline))
+        .unwrap_or(VMSharedSignatureIndex::default());
+
+    unsafe {
+        Ok((
+            config
+                .default_instance_allocator
+                .allocate(InstanceAllocationRequest {
+                    module: Arc::new(module),
+                    finished_functions: &finished_functions,
+                    imports: Imports::default(),
+                    lookup_shared_signature: &|_| shared_signature_id,
+                    host_state: Box::new(trampoline_state),
+                    interrupts: std::ptr::null(),
+                    externref_activations_table: std::ptr::null_mut(),
+                    stack_map_registry: std::ptr::null_mut(),
+                })?,
+            trampoline,
+        ))
+    }
+}
+
+pub unsafe fn create_raw_function(
+    allocator: &dyn InstanceAllocator,
+    func: *mut [VMFunctionBody],
+    host_state: Box<dyn Any>,
+    shared_signature_id: VMSharedSignatureIndex,
+) -> Result<InstanceHandle> {
     let mut module = Module::new();
     let mut finished_functions = PrimaryMap::new();
 
@@ -280,14 +309,15 @@ pub unsafe fn create_handle_with_raw_function(
         .exports
         .insert(String::new(), wasm::EntityIndex::Function(func_id));
     finished_functions.push(func);
-    let shared_signature_id = store.signatures().borrow_mut().register(wft, trampoline);
 
-    create_handle(
-        module,
-        store,
-        finished_functions,
-        state,
-        &[],
-        Some(shared_signature_id),
-    )
+    Ok(allocator.allocate(InstanceAllocationRequest {
+        module: Arc::new(module),
+        finished_functions: &finished_functions,
+        imports: Imports::default(),
+        lookup_shared_signature: &|_| shared_signature_id,
+        host_state,
+        interrupts: std::ptr::null(),
+        externref_activations_table: std::ptr::null_mut(),
+        stack_map_registry: std::ptr::null_mut(),
+    })?)
 }

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -1,5 +1,4 @@
-use super::create_handle::create_handle;
-use crate::trampoline::StoreInstanceHandle;
+use crate::trampoline::{create_handle, StoreInstanceHandle};
 use crate::{GlobalType, Mutability, Store, Val};
 use anyhow::Result;
 use wasmtime_environ::entity::PrimaryMap;

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -1,6 +1,5 @@
-use super::create_handle::create_handle;
 use crate::memory::{LinearMemory, MemoryCreator};
-use crate::trampoline::StoreInstanceHandle;
+use crate::trampoline::{create_handle, StoreInstanceHandle};
 use crate::Store;
 use crate::{Limits, MemoryType};
 use anyhow::{anyhow, Result};
@@ -10,10 +9,7 @@ use wasmtime_runtime::{RuntimeLinearMemory, RuntimeMemoryCreator, VMMemoryDefini
 
 use std::sync::Arc;
 
-pub fn create_handle_with_memory(
-    store: &Store,
-    memory: &MemoryType,
-) -> Result<StoreInstanceHandle> {
+pub fn create_memory(store: &Store, memory: &MemoryType) -> Result<StoreInstanceHandle> {
     let mut module = Module::new();
 
     let memory = wasm::Memory {

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -1,12 +1,11 @@
-use super::create_handle::create_handle;
-use crate::trampoline::StoreInstanceHandle;
+use crate::trampoline::{create_handle, StoreInstanceHandle};
 use crate::Store;
 use crate::{TableType, ValType};
 use anyhow::{bail, Result};
 use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::{wasm, Module};
 
-pub fn create_handle_with_table(store: &Store, table: &TableType) -> Result<StoreInstanceHandle> {
+pub fn create_table(store: &Store, table: &TableType) -> Result<StoreInstanceHandle> {
     let mut module = Module::new();
 
     let table = wasm::Table {

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -282,7 +282,7 @@ fn generate_func(
     }
 
     if is_async {
-        let wrapper = format_ident!("wrap_host_func{}_async", params.len());
+        let wrapper = format_ident!("wrap{}_host_func_async", params.len());
         host_funcs.push(quote! {
             config.#wrapper(
                 stringify!(#module_ident),

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::parse_macro_input;
 use wiggle_generate::Names;
 
@@ -102,14 +102,23 @@ fn generate_module(
     let module_id = names.module(&module.name);
     let target_module = quote! { #target_path::#module_id };
 
-    let ctor_externs = module.funcs().map(|f| {
+    let mut fns = Vec::new();
+    let mut ctor_externs = Vec::new();
+    let mut host_funcs = Vec::new();
+
+    for f in module.funcs() {
         generate_func(
+            &module_id,
             &f,
             names,
             &target_module,
+            ctx_type,
             async_conf.is_async(module.name.as_str(), f.name.as_str()),
-        )
-    });
+            &mut fns,
+            &mut ctor_externs,
+            &mut host_funcs,
+        );
+    }
 
     let type_name = module_conf.name.clone();
     let type_docs = module_conf
@@ -121,7 +130,7 @@ fn generate_module(
         "Creates a new [`{}`] instance.
 
 External values are allocated into the `store` provided and
-configuration of the wasi instance itself should be all
+configuration of the instance itself should be all
 contained in the `cx` parameter.",
         module_conf.name.to_string()
     );
@@ -134,7 +143,7 @@ contained in the `cx` parameter.",
 
         impl #type_name {
             #[doc = #constructor_docs]
-            pub fn new(store: &wasmtime::Store, cx: std::rc::Rc<std::cell::RefCell<#ctx_type>>) -> Self {
+            pub fn new(store: &wasmtime::Store, ctx: std::rc::Rc<std::cell::RefCell<#ctx_type>>) -> Self {
                 #(#ctor_externs)*
 
                 Self {
@@ -159,16 +168,47 @@ contained in the `cx` parameter.",
                 #(#linker_add)*
                 Ok(())
             }
+
+            /// Adds the host functions to the given [`wasmtime::Config`].
+            ///
+            /// Host functions added to the config expect [`set_context`] to be called.
+            ///
+            /// Host functions will trap if the context is not set in the calling [`wasmtime::Store`].
+            pub fn add_to_config(config: &mut wasmtime::Config) {
+                #(#host_funcs)*
+            }
+
+            /// Sets the context in the given store.
+            ///
+            /// Context must be set in the store when using [`add_to_config`] and prior to any
+            /// host function being called.
+            ///
+            /// If the context is already set in the store, the given context is returned as an error.
+            pub fn set_context(store: &wasmtime::Store, ctx: #ctx_type) -> Result<(), #ctx_type> {
+                store.set(std::rc::Rc::new(std::cell::RefCell::new(ctx))).map_err(|ctx| {
+                    match std::rc::Rc::try_unwrap(ctx) {
+                        Ok(ctx) => ctx.into_inner(),
+                        Err(_) => unreachable!(),
+                    }
+                })
+            }
+
+            #(#fns)*
         }
     }
 }
 
 fn generate_func(
+    module_ident: &Ident,
     func: &witx::InterfaceFunc,
     names: &Names,
     target_module: &TokenStream2,
+    ctx_type: &syn::Type,
     is_async: bool,
-) -> TokenStream2 {
+    fns: &mut Vec<TokenStream2>,
+    ctors: &mut Vec<TokenStream2>,
+    host_funcs: &mut Vec<TokenStream2>,
+) {
     let name_ident = names.func(&func.name);
 
     let (params, results) = func.wasm_signature();
@@ -176,11 +216,15 @@ fn generate_func(
     let arg_names = (0..params.len())
         .map(|i| Ident::new(&format!("arg{}", i), Span::call_site()))
         .collect::<Vec<_>>();
-    let arg_decls = params.iter().enumerate().map(|(i, ty)| {
-        let name = &arg_names[i];
-        let wasm = names.wasm_type(*ty);
-        quote! { #name: #wasm }
-    });
+    let arg_decls = params
+        .iter()
+        .enumerate()
+        .map(|(i, ty)| {
+            let name = &arg_names[i];
+            let wasm = names.wasm_type(*ty);
+            quote! { #name: #wasm }
+        })
+        .collect::<Vec<_>>();
 
     let ret_ty = match results.len() {
         0 => quote!(()),
@@ -188,54 +232,87 @@ fn generate_func(
         _ => unimplemented!(),
     };
 
-    let runtime = names.runtime_mod();
-
+    let async_ = if is_async { quote!(async) } else { quote!() };
     let await_ = if is_async { quote!(.await) } else { quote!() };
 
-    let closure_body = quote! {
-        unsafe {
-            let mem = match caller.get_export("memory") {
-                Some(wasmtime::Extern::Memory(m)) => m,
-                _ => {
-                    return Err(wasmtime::Trap::new("missing required memory export"));
-                }
-            };
-            let mem = #runtime::WasmtimeGuestMemory::new(mem);
-            let result = #target_module::#name_ident(
-                &mut *my_cx.borrow_mut(),
-                &mem,
-                #(#arg_names),*
-            ) #await_;
-            match result {
-                Ok(r) => Ok(r.into()),
-                Err(wasmtime_wiggle::Trap::String(err)) => Err(wasmtime::Trap::new(err)),
-                Err(wasmtime_wiggle::Trap::I32Exit(err)) => Err(wasmtime::Trap::i32_exit(err)),
-            }
-        }
+    let runtime = names.runtime_mod();
+    let fn_ident = format_ident!("{}_{}", module_ident, name_ident);
 
-    };
-    if is_async {
-        let wrapper = quote::format_ident!("wrap{}_async", params.len());
-        quote! {
-        let #name_ident = wasmtime::Func::#wrapper(
-            store,
-            cx.clone(),
-            move |caller: wasmtime::Caller<'_>, my_cx: &Rc<RefCell<_>> #(,#arg_decls)*|
-              -> Box<dyn std::future::Future<Output = Result<#ret_ty, wasmtime::Trap>>>
-            {
-                Box::new(async move { #closure_body })
+    fns.push(quote! {
+        #async_ fn #fn_ident(caller: &wasmtime::Caller<'_>, ctx: &mut #ctx_type #(, #arg_decls)*) -> Result<#ret_ty, wasmtime::Trap> {
+            unsafe {
+                let mem = match caller.get_export("memory") {
+                    Some(wasmtime::Extern::Memory(m)) => m,
+                    _ => {
+                        return Err(wasmtime::Trap::new("missing required memory export"));
+                    }
+                };
+                let mem = #runtime::WasmtimeGuestMemory::new(mem);
+                match #target_module::#name_ident(ctx, &mem #(, #arg_names)*) #await_ {
+                    Ok(r) => Ok(r.into()),
+                    Err(wasmtime_wiggle::Trap::String(err)) => Err(wasmtime::Trap::new(err)),
+                    Err(wasmtime_wiggle::Trap::I32Exit(err)) => Err(wasmtime::Trap::i32_exit(err)),
+                }
             }
-        );
         }
-    } else {
-        quote! {
-            let my_cx = cx.clone();
-            let #name_ident = wasmtime::Func::wrap(
+    });
+
+    if is_async {
+        let wrapper = format_ident!("wrap{}_async", params.len());
+        ctors.push(quote! {
+            let #name_ident = wasmtime::Func::#wrapper(
                 store,
-                move |caller: wasmtime::Caller<'_> #(,#arg_decls)*| -> Result<#ret_ty, wasmtime::Trap> {
-                    #closure_body
+                ctx.clone(),
+                move |caller: wasmtime::Caller<'_>, my_ctx: &Rc<RefCell<_>> #(,#arg_decls)*|
+                    -> Box<dyn std::future::Future<Output = Result<#ret_ty, wasmtime::Trap>>> {
+                    Box::new(async move { Self::#fn_ident(&caller, &mut my_ctx.borrow_mut() #(, #arg_names)*).await })
                 }
             );
-        }
+        });
+    } else {
+        ctors.push(quote! {
+            let my_ctx = ctx.clone();
+            let #name_ident = wasmtime::Func::wrap(
+                store,
+                move |caller: wasmtime::Caller #(, #arg_decls)*| -> Result<#ret_ty, wasmtime::Trap> {
+                    Self::#fn_ident(&caller, &mut my_ctx.borrow_mut() #(, #arg_names)*)
+                }
+            );
+        });
+    }
+
+    if is_async {
+        let wrapper = format_ident!("wrap_host_func{}_async", params.len());
+        host_funcs.push(quote! {
+            config.#wrapper(
+                stringify!(#module_ident),
+                stringify!(#name_ident),
+                move |caller #(,#arg_decls)*|
+                    -> Box<dyn std::future::Future<Output = Result<#ret_ty, wasmtime::Trap>>> {
+                    Box::new(async move {
+                        let ctx = caller.store()
+                            .get::<std::rc::Rc<std::cell::RefCell<#ctx_type>>>()
+                            .ok_or_else(|| wasmtime::Trap::new("context is missing in the store"))?;
+                        let result = Self::#fn_ident(&caller, &mut ctx.borrow_mut() #(, #arg_names)*).await;
+                        result
+                    })
+                }
+            );
+        });
+    } else {
+        host_funcs.push(quote! {
+            config.wrap_host_func(
+                stringify!(#module_ident),
+                stringify!(#name_ident),
+                move |caller: wasmtime::Caller #(, #arg_decls)*| -> Result<#ret_ty, wasmtime::Trap> {
+                    let ctx = caller
+                        .store()
+                        .get::<std::rc::Rc<std::cell::RefCell<#ctx_type>>>()
+                        .ok_or_else(|| wasmtime::Trap::new("context is missing in the store"))?;
+                    let result = Self::#fn_ident(&caller, &mut ctx.borrow_mut()  #(, #arg_names)*);
+                    result
+                },
+            );
+        });
     }
 }

--- a/crates/wiggle/wasmtime/tests/atoms_async.rs
+++ b/crates/wiggle/wasmtime/tests/atoms_async.rs
@@ -117,11 +117,11 @@ fn test_async_host_func() {
 
 #[test]
 fn test_sync_config_host_func() {
-    let mut config = wasmtime::Config::new();
+    let mut config = wasmtime::Config::new_async();
     Atoms::add_to_config(&mut config);
 
     let engine = wasmtime::Engine::new(&config);
-    let store = wasmtime::Store::new_async(&engine);
+    let store = wasmtime::Store::new(&engine);
 
     assert!(Atoms::set_context(&store, Ctx).is_ok());
 
@@ -131,11 +131,11 @@ fn test_sync_config_host_func() {
 
 #[test]
 fn test_async_config_host_func() {
-    let mut config = wasmtime::Config::new();
+    let mut config = wasmtime::Config::new_async();
     Atoms::add_to_config(&mut config);
 
     let engine = wasmtime::Engine::new(&config);
-    let store = wasmtime::Store::new_async(&engine);
+    let store = wasmtime::Store::new(&engine);
 
     assert!(Atoms::set_context(&store, Ctx).is_ok());
 
@@ -178,8 +178,7 @@ fn dummy_waker() -> Waker {
 }
 
 fn async_store() -> wasmtime::Store {
-    let engine = wasmtime::Engine::default();
-    wasmtime::Store::new_async(&engine)
+    wasmtime::Store::new(&wasmtime::Engine::new(&wasmtime::Config::new_async()))
 }
 
 // Wiggle expects the caller to have an exported memory. Wasmtime can only

--- a/crates/wiggle/wasmtime/tests/atoms_async.rs
+++ b/crates/wiggle/wasmtime/tests/atoms_async.rs
@@ -120,7 +120,7 @@ fn test_sync_config_host_func() {
     let mut config = wasmtime::Config::new_async();
     Atoms::add_to_config(&mut config);
 
-    let engine = wasmtime::Engine::new(&config);
+    let engine = wasmtime::Engine::new(&config).unwrap();
     let store = wasmtime::Store::new(&engine);
 
     assert!(Atoms::set_context(&store, Ctx).is_ok());
@@ -134,7 +134,7 @@ fn test_async_config_host_func() {
     let mut config = wasmtime::Config::new_async();
     Atoms::add_to_config(&mut config);
 
-    let engine = wasmtime::Engine::new(&config);
+    let engine = wasmtime::Engine::new(&config).unwrap();
     let store = wasmtime::Store::new(&engine);
 
     assert!(Atoms::set_context(&store, Ctx).is_ok());
@@ -178,7 +178,7 @@ fn dummy_waker() -> Waker {
 }
 
 fn async_store() -> wasmtime::Store {
-    wasmtime::Store::new(&wasmtime::Engine::new(&wasmtime::Config::new_async()))
+    wasmtime::Store::new(&wasmtime::Engine::new(&wasmtime::Config::new_async()).unwrap())
 }
 
 // Wiggle expects the caller to have an exported memory. Wasmtime can only

--- a/crates/wiggle/wasmtime/tests/atoms_async.rs
+++ b/crates/wiggle/wasmtime/tests/atoms_async.rs
@@ -117,7 +117,8 @@ fn test_async_host_func() {
 
 #[test]
 fn test_sync_config_host_func() {
-    let mut config = wasmtime::Config::new_async();
+    let mut config = wasmtime::Config::new();
+    config.async_support(true);
     Atoms::add_to_config(&mut config);
 
     let engine = wasmtime::Engine::new(&config).unwrap();
@@ -131,7 +132,8 @@ fn test_sync_config_host_func() {
 
 #[test]
 fn test_async_config_host_func() {
-    let mut config = wasmtime::Config::new_async();
+    let mut config = wasmtime::Config::new();
+    config.async_support(true);
     Atoms::add_to_config(&mut config);
 
     let engine = wasmtime::Engine::new(&config).unwrap();
@@ -178,7 +180,9 @@ fn dummy_waker() -> Waker {
 }
 
 fn async_store() -> wasmtime::Store {
-    wasmtime::Store::new(&wasmtime::Engine::new(&wasmtime::Config::new_async()).unwrap())
+    wasmtime::Store::new(
+        &wasmtime::Engine::new(wasmtime::Config::new().async_support(true)).unwrap(),
+    )
 }
 
 // Wiggle expects the caller to have an exported memory. Wasmtime can only

--- a/crates/wiggle/wasmtime/tests/atoms_async.rs
+++ b/crates/wiggle/wasmtime/tests/atoms_async.rs
@@ -42,16 +42,8 @@ impl atoms::Atoms for Ctx {
     }
 }
 
-#[test]
-fn test_sync_host_func() {
-    let store = async_store();
-
-    let ctx = Rc::new(RefCell::new(Ctx));
-    let atoms = Atoms::new(&store, ctx.clone());
-
-    let shim_mod = shim_module(&store);
-    let mut linker = wasmtime::Linker::new(&store);
-    atoms.add_to_linker(&mut linker).unwrap();
+fn run_sync_func(linker: &wasmtime::Linker) {
+    let shim_mod = shim_module(linker.store());
     let shim_inst = run(linker.instantiate_async(&shim_mod)).unwrap();
 
     let results = run(shim_inst
@@ -68,16 +60,8 @@ fn test_sync_host_func() {
     );
 }
 
-#[test]
-fn test_async_host_func() {
-    let store = async_store();
-
-    let ctx = Rc::new(RefCell::new(Ctx));
-    let atoms = Atoms::new(&store, ctx.clone());
-
-    let shim_mod = shim_module(&store);
-    let mut linker = wasmtime::Linker::new(&store);
-    atoms.add_to_linker(&mut linker).unwrap();
+fn run_async_func(linker: &wasmtime::Linker) {
+    let shim_mod = shim_module(linker.store());
     let shim_inst = run(linker.instantiate_async(&shim_mod)).unwrap();
 
     let input: i32 = 123;
@@ -103,6 +87,60 @@ fn test_async_host_func() {
         .unwrap();
     let result = f32::from_le_bytes(result_bytes);
     assert_eq!((input * 2) as f32, result);
+}
+
+#[test]
+fn test_sync_host_func() {
+    let store = async_store();
+
+    let ctx = Rc::new(RefCell::new(Ctx));
+    let atoms = Atoms::new(&store, ctx.clone());
+
+    let mut linker = wasmtime::Linker::new(&store);
+    atoms.add_to_linker(&mut linker).unwrap();
+
+    run_sync_func(&linker);
+}
+
+#[test]
+fn test_async_host_func() {
+    let store = async_store();
+
+    let ctx = Rc::new(RefCell::new(Ctx));
+    let atoms = Atoms::new(&store, ctx.clone());
+
+    let mut linker = wasmtime::Linker::new(&store);
+    atoms.add_to_linker(&mut linker).unwrap();
+
+    run_async_func(&linker);
+}
+
+#[test]
+fn test_sync_config_host_func() {
+    let mut config = wasmtime::Config::new();
+    Atoms::add_to_config(&mut config);
+
+    let engine = wasmtime::Engine::new(&config);
+    let store = wasmtime::Store::new_async(&engine);
+
+    assert!(Atoms::set_context(&store, Ctx).is_ok());
+
+    let linker = wasmtime::Linker::new(&store);
+    run_sync_func(&linker);
+}
+
+#[test]
+fn test_async_config_host_func() {
+    let mut config = wasmtime::Config::new();
+    Atoms::add_to_config(&mut config);
+
+    let engine = wasmtime::Engine::new(&config);
+    let store = wasmtime::Store::new_async(&engine);
+
+    assert!(Atoms::set_context(&store, Ctx).is_ok());
+
+    let linker = wasmtime::Linker::new(&store);
+    run_async_func(&linker);
 }
 
 fn run<F: Future>(future: F) -> F::Output {
@@ -138,6 +176,7 @@ fn dummy_waker() -> Waker {
         assert_eq!(ptr as usize, 5);
     }
 }
+
 fn async_store() -> wasmtime::Store {
     let engine = wasmtime::Engine::default();
     wasmtime::Store::new_async(&engine)

--- a/examples/externref.rs
+++ b/examples/externref.rs
@@ -9,7 +9,7 @@ fn main() -> Result<()> {
     println!("Initializing...");
     let mut config = Config::new();
     config.wasm_reference_types(true);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
 
     println!("Compiling module...");

--- a/examples/fib-debug/main.rs
+++ b/examples/fib-debug/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
     // Load our previously compiled wasm file (built previously with Cargo) and
     // also ensure that we generate debuginfo so this executable can be
     // debugged in GDB.
-    let engine = Engine::new(Config::new().debug_info(true));
+    let engine = Engine::new(Config::new().debug_info(true))?;
     let store = Store::new(&engine);
     let module = Module::from_file(&engine, "target/wasm32-unknown-unknown/debug/fib.wasm")?;
     let instance = Instance::new(&store, &module, &[])?;

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -9,7 +9,7 @@ use wasmtime::*;
 fn main() -> Result<()> {
     // Enable interruptable code via `Config` and then create an interrupt
     // handle which we'll use later to interrupt running code.
-    let engine = Engine::new(Config::new().interruptable(true));
+    let engine = Engine::new(Config::new().interruptable(true))?;
     let store = Store::new(&engine);
     let interrupt_handle = store.interrupt_handle()?;
 

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -14,20 +14,25 @@ fn main() -> Result<()> {
         .with_ansi(true)
         .init();
 
-    let store = Store::default();
-    let mut linker = Linker::new(&store);
+    // Define the WASI functions globally on the `Config`.
+    let mut config = Config::default();
+    Wasi::add_to_config(&mut config);
 
-    // Create an instance of `Wasi` which contains a `WasiCtx`. Note that
-    // `WasiCtx` provides a number of ways to configure what the target program
+    let store = Store::new(&Engine::new(&config)?);
+
+    // Set the WASI context in the store; all instances in the store share this context.
+    // `WasiCtxBuilder` provides a number of ways to configure what the target program
     // will have access to.
-    let wasi = Wasi::new(
+    assert!(Wasi::set_context(
         &store,
         WasiCtxBuilder::new()
             .inherit_stdio()
             .inherit_args()?
-            .build()?,
-    );
-    wasi.add_to_linker(&mut linker)?;
+            .build()?
+    )
+    .is_ok());
+
+    let mut linker = Linker::new(&store);
 
     // Instantiate our module with the imports we've created, and run it.
     let module = Module::from_file(store.engine(), "target/wasm32-wasi/debug/wasi.wasm")?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -137,7 +137,7 @@ impl RunCommand {
         if self.wasm_timeout.is_some() {
             config.interruptable(true);
         }
-        let engine = Engine::new(&config);
+        let engine = Engine::new(&config)?;
         let store = Store::new(&engine);
 
         // Make wasi available by default.

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -34,7 +34,7 @@ impl WastCommand {
         }
 
         let config = self.common.config()?;
-        let store = Store::new(&Engine::new(&config));
+        let store = Store::new(&Engine::new(&config)?);
         let mut wast_context = WastContext::new(store);
 
         wast_context

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use wasmtime::*;
 
 fn async_store() -> Store {
-    Store::new(&Engine::new(&Config::new_async()))
+    Store::new(&Engine::new(&Config::new_async()).unwrap())
 }
 
 fn run_smoke_test(func: &Func) {
@@ -60,7 +60,7 @@ fn smoke_host_func() {
         Box::new(async { Ok(()) })
     });
 
-    let store = Store::new(&Engine::new(&config));
+    let store = Store::new(&Engine::new(&config).unwrap());
 
     let func = store
         .get_host_func("", "first")
@@ -123,7 +123,7 @@ fn smoke_host_func_with_suspension() {
         })
     });
 
-    let store = Store::new(&Engine::new(&config));
+    let store = Store::new(&Engine::new(&config).unwrap());
 
     let func = store
         .get_host_func("", "first")
@@ -370,7 +370,7 @@ fn dummy_waker() -> Waker {
 
 #[test]
 fn iloop_with_fuel() {
-    let engine = Engine::new(Config::new_async().consume_fuel(true));
+    let engine = Engine::new(Config::new_async().consume_fuel(true)).unwrap();
     let store = Store::new(&engine);
     store.out_of_fuel_async_yield(1_000, 10);
     let module = Module::new(
@@ -404,7 +404,7 @@ fn iloop_with_fuel() {
 
 #[test]
 fn fuel_eventually_finishes() {
-    let engine = Engine::new(Config::new_async().consume_fuel(true));
+    let engine = Engine::new(Config::new_async().consume_fuel(true)).unwrap();
     let store = Store::new(&engine);
     store.out_of_fuel_async_yield(u32::max_value(), 10);
     let module = Module::new(
@@ -447,7 +447,7 @@ fn async_with_pooling_stacks() {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config).unwrap();
     let store = Store::new(&engine);
     let func = Func::new_async(
         &store,
@@ -483,7 +483,7 @@ fn async_host_func_with_pooling_stacks() {
         move |_caller, _params, _results| Box::new(async { Ok(()) }),
     );
 
-    let store = Store::new(&Engine::new(&config));
+    let store = Store::new(&Engine::new(&config).unwrap());
     let func = store.get_host_func("", "").expect("expected host function");
 
     run_smoke_test(&func);

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -434,20 +434,18 @@ fn fuel_eventually_finishes() {
 #[test]
 fn async_with_pooling_stacks() {
     let mut config = Config::new_async();
-    config
-        .with_allocation_strategy(InstanceAllocationStrategy::Pooling {
-            strategy: PoolingAllocationStrategy::NextAvailable,
-            module_limits: ModuleLimits {
-                memory_pages: 1,
-                table_elements: 0,
-                ..Default::default()
-            },
-            instance_limits: InstanceLimits {
-                count: 1,
-                memory_reservation_size: 1,
-            },
-        })
-        .expect("pooling allocator created");
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 1,
+            table_elements: 0,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            memory_reservation_size: 1,
+        },
+    });
 
     let engine = Engine::new(&config);
     let store = Store::new(&engine);
@@ -465,20 +463,18 @@ fn async_with_pooling_stacks() {
 #[test]
 fn async_host_func_with_pooling_stacks() {
     let mut config = Config::new_async();
-    config
-        .with_allocation_strategy(InstanceAllocationStrategy::Pooling {
-            strategy: PoolingAllocationStrategy::NextAvailable,
-            module_limits: ModuleLimits {
-                memory_pages: 1,
-                table_elements: 0,
-                ..Default::default()
-            },
-            instance_limits: InstanceLimits {
-                count: 1,
-                memory_reservation_size: 1,
-            },
-        })
-        .expect("pooling allocator created");
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: PoolingAllocationStrategy::NextAvailable,
+        module_limits: ModuleLimits {
+            memory_pages: 1,
+            table_elements: 0,
+            ..Default::default()
+        },
+        instance_limits: InstanceLimits {
+            count: 1,
+            memory_reservation_size: 1,
+        },
+    });
 
     config.define_host_func_async(
         "",

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -6,8 +6,7 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use wasmtime::*;
 
 fn async_store() -> Store {
-    let engine = Engine::default();
-    Store::new_async(&engine)
+    Store::new(&Engine::new(&Config::new_async()))
 }
 
 #[test]
@@ -304,8 +303,8 @@ fn dummy_waker() -> Waker {
 
 #[test]
 fn iloop_with_fuel() {
-    let engine = Engine::new(Config::new().consume_fuel(true));
-    let store = Store::new_async(&engine);
+    let engine = Engine::new(Config::new_async().consume_fuel(true));
+    let store = Store::new(&engine);
     store.out_of_fuel_async_yield(1_000, 10);
     let module = Module::new(
         &engine,
@@ -338,8 +337,8 @@ fn iloop_with_fuel() {
 
 #[test]
 fn fuel_eventually_finishes() {
-    let engine = Engine::new(Config::new().consume_fuel(true));
-    let store = Store::new_async(&engine);
+    let engine = Engine::new(Config::new_async().consume_fuel(true));
+    let store = Store::new(&engine);
     store.out_of_fuel_async_yield(u32::max_value(), 10);
     let module = Module::new(
         &engine,
@@ -367,7 +366,7 @@ fn fuel_eventually_finishes() {
 
 #[test]
 fn async_with_pooling_stacks() {
-    let mut config = Config::new();
+    let mut config = Config::new_async();
     config
         .with_allocation_strategy(InstanceAllocationStrategy::Pooling {
             strategy: PoolingAllocationStrategy::NextAvailable,
@@ -384,7 +383,7 @@ fn async_with_pooling_stacks() {
         .expect("pooling allocator created");
 
     let engine = Engine::new(&config);
-    let store = Store::new_async(&engine);
+    let store = Store::new(&engine);
     let func = Func::new_async(
         &store,
         FuncType::new(None, None),

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use wasmtime::*;
 
 fn async_store() -> Store {
-    Store::new(&Engine::new(&Config::new_async()).unwrap())
+    Store::new(&Engine::new(Config::new().async_support(true)).unwrap())
 }
 
 fn run_smoke_test(func: &Func) {
@@ -49,7 +49,8 @@ fn smoke() {
 
 #[test]
 fn smoke_host_func() {
-    let mut config = Config::new_async();
+    let mut config = Config::new();
+    config.async_support(true);
     config.define_host_func_async(
         "",
         "first",
@@ -104,7 +105,8 @@ fn smoke_with_suspension() {
 
 #[test]
 fn smoke_host_func_with_suspension() {
-    let mut config = Config::new_async();
+    let mut config = Config::new();
+    config.async_support(true);
     config.define_host_func_async(
         "",
         "first",
@@ -370,7 +372,7 @@ fn dummy_waker() -> Waker {
 
 #[test]
 fn iloop_with_fuel() {
-    let engine = Engine::new(Config::new_async().consume_fuel(true)).unwrap();
+    let engine = Engine::new(Config::new().async_support(true).consume_fuel(true)).unwrap();
     let store = Store::new(&engine);
     store.out_of_fuel_async_yield(1_000, 10);
     let module = Module::new(
@@ -404,7 +406,7 @@ fn iloop_with_fuel() {
 
 #[test]
 fn fuel_eventually_finishes() {
-    let engine = Engine::new(Config::new_async().consume_fuel(true)).unwrap();
+    let engine = Engine::new(Config::new().async_support(true).consume_fuel(true)).unwrap();
     let store = Store::new(&engine);
     store.out_of_fuel_async_yield(u32::max_value(), 10);
     let module = Module::new(
@@ -433,7 +435,8 @@ fn fuel_eventually_finishes() {
 
 #[test]
 fn async_with_pooling_stacks() {
-    let mut config = Config::new_async();
+    let mut config = Config::new();
+    config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
@@ -462,7 +465,8 @@ fn async_with_pooling_stacks() {
 
 #[test]
 fn async_host_func_with_pooling_stacks() {
-    let mut config = Config::new_async();
+    let mut config = Config::new();
+    config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -112,7 +112,7 @@ mod tests {
     // hostcall can be handled.
     #[test]
     fn test_custom_signal_handler_single_instance_hostcall() -> Result<()> {
-        let engine = Engine::new(&Config::default());
+        let engine = Engine::new(&Config::default())?;
         let store = Store::new(&engine);
         let module = Module::new(&engine, WAT1)?;
 
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_custom_signal_handler_single_instance() -> Result<()> {
-        let engine = Engine::new(&Config::default());
+        let engine = Engine::new(&Config::default())?;
         let store = Store::new(&engine);
         let module = Module::new(&engine, WAT1)?;
 
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_custom_signal_handler_multiple_instances() -> Result<()> {
-        let engine = Engine::new(&Config::default());
+        let engine = Engine::new(&Config::default())?;
         let store = Store::new(&engine);
         let module = Module::new(&engine, WAT1)?;
 
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn test_custom_signal_handler_instance_calling_another_instance() -> Result<()> {
-        let engine = Engine::new(&Config::default());
+        let engine = Engine::new(&Config::default())?;
         let store = Store::new(&engine);
 
         // instance1 which defines 'read'

--- a/tests/all/externals.rs
+++ b/tests/all/externals.rs
@@ -57,7 +57,7 @@ fn bad_tables() {
 fn cross_store() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store1 = Store::new(&engine);
     let store2 = Store::new(&engine);
 
@@ -127,7 +127,7 @@ fn cross_store() -> anyhow::Result<()> {
 fn get_set_externref_globals_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     // Initialize with a null externref.
@@ -162,7 +162,7 @@ fn get_set_externref_globals_via_api() -> anyhow::Result<()> {
 fn get_set_funcref_globals_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     let f = Func::wrap(&store, || {});
@@ -197,7 +197,7 @@ fn get_set_funcref_globals_via_api() -> anyhow::Result<()> {
 fn create_get_set_funcref_tables_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     let table_ty = TableType::new(ValType::FuncRef, Limits::at_least(10));
@@ -218,7 +218,7 @@ fn create_get_set_funcref_tables_via_api() -> anyhow::Result<()> {
 fn fill_funcref_tables_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     let table_ty = TableType::new(ValType::FuncRef, Limits::at_least(10));
@@ -244,7 +244,7 @@ fn fill_funcref_tables_via_api() -> anyhow::Result<()> {
 fn grow_funcref_tables_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     let table_ty = TableType::new(ValType::FuncRef, Limits::at_least(10));
@@ -261,7 +261,7 @@ fn grow_funcref_tables_via_api() -> anyhow::Result<()> {
 fn create_get_set_externref_tables_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     let table_ty = TableType::new(ValType::ExternRef, Limits::at_least(10));
@@ -292,7 +292,7 @@ fn create_get_set_externref_tables_via_api() -> anyhow::Result<()> {
 fn fill_externref_tables_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     let table_ty = TableType::new(ValType::ExternRef, Limits::at_least(10));
@@ -328,7 +328,7 @@ fn fill_externref_tables_via_api() -> anyhow::Result<()> {
 fn grow_externref_tables_via_api() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);
-    let engine = Engine::new(&cfg);
+    let engine = Engine::new(&cfg)?;
     let store = Store::new(&engine);
 
     let table_ty = TableType::new(ValType::ExternRef, Limits::at_least(10));
@@ -344,7 +344,7 @@ fn grow_externref_tables_via_api() -> anyhow::Result<()> {
 #[test]
 fn read_write_memory_via_api() {
     let cfg = Config::new();
-    let store = Store::new(&Engine::new(&cfg));
+    let store = Store::new(&Engine::new(&cfg).unwrap());
     let ty = MemoryType::new(Limits::new(1, None));
     let mem = Memory::new(&store, ty);
     mem.grow(1).unwrap();

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -48,7 +48,7 @@ fn run() -> Result<()> {
 fn fuel_consumed(wasm: &[u8]) -> u64 {
     let mut config = Config::new();
     config.consume_fuel(true);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config).unwrap();
     let module = Module::new(&engine, wasm).unwrap();
     let store = Store::new(&engine);
     store.add_fuel(u64::max_value()).unwrap();
@@ -110,7 +110,7 @@ fn iloop() {
     fn iloop_aborts(wat: &str) {
         let mut config = Config::new();
         config.consume_fuel(true);
-        let engine = Engine::new(&config);
+        let engine = Engine::new(&config).unwrap();
         let module = Module::new(&engine, wat).unwrap();
         let store = Store::new(&engine);
         store.add_fuel(10_000).unwrap();

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -156,7 +156,7 @@ fn import_works() -> Result<()> {
     )?;
     let mut config = Config::new();
     config.wasm_reference_types(true);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
     let module = Module::new(&engine, &wasm)?;
     let instance = Instance::new(
@@ -459,7 +459,7 @@ fn return_cross_store_value() -> anyhow::Result<()> {
     )?;
     let mut config = Config::new();
     config.wasm_reference_types(true);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, &wasm)?;
 
     let store1 = Store::new(&engine);
@@ -485,7 +485,7 @@ fn return_cross_store_value() -> anyhow::Result<()> {
 fn pass_cross_store_arg() -> anyhow::Result<()> {
     let mut config = Config::new();
     config.wasm_reference_types(true);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     let store1 = Store::new(&engine);
     let store2 = Store::new(&engine);

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -5,6 +5,25 @@ use wasmtime::*;
 use wasmtime_wasi::Wasi;
 
 #[test]
+fn async_required() {
+    let mut config = Config::default();
+    config.define_host_func_async(
+        "",
+        "",
+        FuncType::new(None, None),
+        move |_caller, _params, _results| Box::new(async { Ok(()) }),
+    );
+
+    assert_eq!(
+        Engine::new(&config)
+            .map_err(|e| e.to_string())
+            .err()
+            .unwrap(),
+        "an async host function cannot be defined without async support enabled in the config"
+    );
+}
+
+#[test]
 fn wrap_func() {
     let mut config = Config::default();
 

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -83,7 +83,7 @@ fn drop_delayed() -> Result<()> {
 
     assert_eq!(HITS.load(SeqCst), 0);
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, &wat::parse_str(r#"(import "" "" (func))"#)?)?;
 
     let store = Store::new(&engine);
@@ -138,7 +138,7 @@ fn signatures_match() -> Result<()> {
         },
     );
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
 
     let f = store
@@ -271,7 +271,7 @@ fn import_works() -> Result<()> {
         },
     );
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, &wasm)?;
 
     let store = Store::new(&engine);
@@ -314,7 +314,7 @@ fn trap_smoke() -> Result<()> {
     let mut config = Config::default();
     config.wrap_host_func("", "", || -> Result<(), Trap> { Err(Trap::new("test")) });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
 
     let f = store.get_host_func("", "").expect("should be defined");
@@ -339,7 +339,7 @@ fn trap_import() -> Result<()> {
     let mut config = Config::default();
     config.wrap_host_func("", "", || -> Result<(), Trap> { Err(Trap::new("foo")) });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, &wasm)?;
     let store = Store::new(&engine);
 
@@ -367,7 +367,7 @@ fn new_from_signature() -> Result<()> {
     let ty = FuncType::new(Some(ValType::I32), Some(ValType::F64));
     config.define_host_func("", "f2", ty, |_, _, _| panic!());
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
 
     let f = store.get_host_func("", "f1").expect("func defined");
@@ -403,7 +403,7 @@ fn call_wrapped_func() -> Result<()> {
 
     config.wrap_host_func("", "f5", || 4.0f64);
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
 
     let f = store.get_host_func("", "f1").expect("func defined");
@@ -444,7 +444,7 @@ fn func_return_nothing() -> Result<()> {
 
     config.define_host_func("", "", ty, |_, _, _| Ok(()));
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
     let f = store.get_host_func("", "").expect("func defined");
     let err = f.call(&[]).unwrap_err().downcast::<Trap>()?;
@@ -485,7 +485,7 @@ fn call_via_funcref() -> Result<()> {
         x + y
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, &wasm)?;
     let store = Store::new(&engine);
     let instance = Instance::new(&store, &module, &[])?;
@@ -534,7 +534,7 @@ fn store_with_context() -> Result<()> {
         ctx.called.set(true);
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
     assert!(store.get::<Ctx>().is_none());
     assert!(store
@@ -572,7 +572,7 @@ fn wasi_imports_missing_context() -> Result<()> {
         "#,
     )?;
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, wasm)?;
     let store = Store::new(&engine);
     let linker = Linker::new(&store);
@@ -603,7 +603,7 @@ fn wasi_imports() -> Result<()> {
         "#,
     )?;
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, wasm)?;
     let store = Store::new(&engine);
     assert!(Wasi::set_context(&store, WasiCtxBuilder::new().build()?).is_ok());

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -1,0 +1,619 @@
+use anyhow::Result;
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use wasi_cap_std_sync::WasiCtxBuilder;
+use wasmtime::*;
+use wasmtime_wasi::Wasi;
+
+#[test]
+fn wrap_func() {
+    let mut config = Config::default();
+
+    config.wrap_host_func("", "", || {});
+    config.wrap_host_func("m", "f", |_: i32| {});
+    config.wrap_host_func("m", "f2", |_: i32, _: i64| {});
+    config.wrap_host_func("m2", "f", |_: f32, _: f64| {});
+    config.wrap_host_func("m2", "f2", || -> i32 { 0 });
+    config.wrap_host_func("", "", || -> i64 { 0 });
+    config.wrap_host_func("m", "f", || -> f32 { 0.0 });
+    config.wrap_host_func("m2", "f", || -> f64 { 0.0 });
+    config.wrap_host_func("m3", "", || -> Option<ExternRef> { None });
+    config.wrap_host_func("m3", "f", || -> Option<Func> { None });
+
+    config.wrap_host_func("", "f1", || -> Result<(), Trap> { loop {} });
+    config.wrap_host_func("", "f2", || -> Result<i32, Trap> { loop {} });
+    config.wrap_host_func("", "f3", || -> Result<i64, Trap> { loop {} });
+    config.wrap_host_func("", "f4", || -> Result<f32, Trap> { loop {} });
+    config.wrap_host_func("", "f5", || -> Result<f64, Trap> { loop {} });
+    config.wrap_host_func("", "f6", || -> Result<Option<ExternRef>, Trap> { loop {} });
+    config.wrap_host_func("", "f7", || -> Result<Option<Func>, Trap> { loop {} });
+}
+
+#[test]
+fn drop_func() -> Result<()> {
+    static HITS: AtomicUsize = AtomicUsize::new(0);
+    struct A;
+
+    impl Drop for A {
+        fn drop(&mut self) {
+            HITS.fetch_add(1, SeqCst);
+        }
+    }
+
+    let mut config = Config::default();
+
+    let a = A;
+    config.wrap_host_func("", "", move || {
+        drop(&a);
+    });
+
+    assert_eq!(HITS.load(SeqCst), 0);
+
+    // Define the function again to ensure redefined functions are dropped
+
+    let a = A;
+    config.wrap_host_func("", "", move || {
+        drop(&a);
+    });
+
+    assert_eq!(HITS.load(SeqCst), 1);
+
+    drop(config);
+
+    assert_eq!(HITS.load(SeqCst), 2);
+
+    Ok(())
+}
+
+#[test]
+fn drop_delayed() -> Result<()> {
+    static HITS: AtomicUsize = AtomicUsize::new(0);
+
+    struct A;
+
+    impl Drop for A {
+        fn drop(&mut self) {
+            HITS.fetch_add(1, SeqCst);
+        }
+    }
+
+    let mut config = Config::default();
+
+    let a = A;
+    config.wrap_host_func("", "", move || drop(&a));
+
+    assert_eq!(HITS.load(SeqCst), 0);
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, &wat::parse_str(r#"(import "" "" (func))"#)?)?;
+
+    let store = Store::new(&engine);
+    let instance = Instance::new(
+        &store,
+        &module,
+        &[store
+            .get_host_func("", "")
+            .expect("function should be defined")
+            .into()],
+    )?;
+
+    drop((instance, store));
+
+    assert_eq!(HITS.load(SeqCst), 0);
+
+    let store = Store::new(&engine);
+    let instance = Instance::new(
+        &store,
+        &module,
+        &[store
+            .get_host_func("", "")
+            .expect("function should be defined")
+            .into()],
+    )?;
+
+    drop((instance, store, engine, module));
+
+    assert_eq!(HITS.load(SeqCst), 0);
+
+    drop(config);
+
+    assert_eq!(HITS.load(SeqCst), 1);
+
+    Ok(())
+}
+
+#[test]
+fn signatures_match() -> Result<()> {
+    let mut config = Config::default();
+
+    config.wrap_host_func("", "f1", || {});
+    config.wrap_host_func("", "f2", || -> i32 { loop {} });
+    config.wrap_host_func("", "f3", || -> i64 { loop {} });
+    config.wrap_host_func("", "f4", || -> f32 { loop {} });
+    config.wrap_host_func("", "f5", || -> f64 { loop {} });
+    config.wrap_host_func(
+        "",
+        "f6",
+        |_: f32, _: f64, _: i32, _: i64, _: i32, _: Option<ExternRef>, _: Option<Func>| -> f64 {
+            loop {}
+        },
+    );
+
+    let engine = Engine::new(&config);
+    let store = Store::new(&engine);
+
+    let f = store
+        .get_host_func("", "f1")
+        .expect("func should be defined");
+
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.param_arity(), 0);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.result_arity(), 0);
+
+    let f = store
+        .get_host_func("", "f2")
+        .expect("func should be defined");
+
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::I32]);
+
+    let f = store
+        .get_host_func("", "f3")
+        .expect("func should be defined");
+
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::I64]);
+
+    let f = store
+        .get_host_func("", "f4")
+        .expect("func should be defined");
+
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::F32]);
+
+    let f = store
+        .get_host_func("", "f5")
+        .expect("func should be defined");
+
+    assert_eq!(f.ty().params().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::F64]);
+
+    let f = store
+        .get_host_func("", "f6")
+        .expect("func should be defined");
+
+    assert_eq!(
+        f.ty().params().collect::<Vec<_>>(),
+        &[
+            ValType::F32,
+            ValType::F64,
+            ValType::I32,
+            ValType::I64,
+            ValType::I32,
+            ValType::ExternRef,
+            ValType::FuncRef,
+        ]
+    );
+    assert_eq!(f.ty().results().collect::<Vec<_>>(), &[ValType::F64]);
+
+    Ok(())
+}
+
+#[test]
+// Note: Cranelift only supports refrerence types (used in the wasm in this
+// test) on x64.
+#[cfg(target_arch = "x86_64")]
+fn import_works() -> Result<()> {
+    static HITS: AtomicUsize = AtomicUsize::new(0);
+
+    let wasm = wat::parse_str(
+        r#"
+            (import "" "f1" (func))
+            (import "" "f2" (func (param i32) (result i32)))
+            (import "" "f3" (func (param i32) (param i64)))
+            (import "" "f4" (func (param i32 i64 i32 f32 f64 externref funcref)))
+
+            (func (export "run") (param externref funcref)
+                call 0
+                i32.const 0
+                call 1
+                i32.const 1
+                i32.add
+                i64.const 3
+                call 2
+
+                i32.const 100
+                i64.const 200
+                i32.const 300
+                f32.const 400
+                f64.const 500
+                local.get 0
+                local.get 1
+                call 3
+            )
+        "#,
+    )?;
+
+    let mut config = Config::new();
+    config.wasm_reference_types(true);
+
+    config.wrap_host_func("", "f1", || {
+        assert_eq!(HITS.fetch_add(1, SeqCst), 0);
+    });
+
+    config.wrap_host_func("", "f2", |x: i32| -> i32 {
+        assert_eq!(x, 0);
+        assert_eq!(HITS.fetch_add(1, SeqCst), 1);
+        1
+    });
+
+    config.wrap_host_func("", "f3", |x: i32, y: i64| {
+        assert_eq!(x, 2);
+        assert_eq!(y, 3);
+        assert_eq!(HITS.fetch_add(1, SeqCst), 2);
+    });
+
+    config.wrap_host_func(
+        "",
+        "f4",
+        |a: i32, b: i64, c: i32, d: f32, e: f64, f: Option<ExternRef>, g: Option<Func>| {
+            assert_eq!(a, 100);
+            assert_eq!(b, 200);
+            assert_eq!(c, 300);
+            assert_eq!(d, 400.0);
+            assert_eq!(e, 500.0);
+            assert_eq!(
+                f.as_ref().unwrap().data().downcast_ref::<String>().unwrap(),
+                "hello"
+            );
+            assert_eq!(g.as_ref().unwrap().call(&[]).unwrap()[0].unwrap_i32(), 42);
+            assert_eq!(HITS.fetch_add(1, SeqCst), 3);
+        },
+    );
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, &wasm)?;
+
+    let store = Store::new(&engine);
+    let instance = Instance::new(
+        &store,
+        &module,
+        &[
+            store
+                .get_host_func("", "f1")
+                .expect("should be defined")
+                .into(),
+            store
+                .get_host_func("", "f2")
+                .expect("should be defined")
+                .into(),
+            store
+                .get_host_func("", "f3")
+                .expect("should be defined")
+                .into(),
+            store
+                .get_host_func("", "f4")
+                .expect("should be defined")
+                .into(),
+        ],
+    )?;
+
+    let run = instance.get_func("run").unwrap();
+    run.call(&[
+        Val::ExternRef(Some(ExternRef::new("hello".to_string()))),
+        Val::FuncRef(Some(Func::wrap(&store, || -> i32 { 42 }))),
+    ])?;
+
+    assert_eq!(HITS.load(SeqCst), 4);
+
+    Ok(())
+}
+
+#[test]
+fn trap_smoke() -> Result<()> {
+    let mut config = Config::default();
+    config.wrap_host_func("", "", || -> Result<(), Trap> { Err(Trap::new("test")) });
+
+    let engine = Engine::new(&config);
+    let store = Store::new(&engine);
+
+    let f = store.get_host_func("", "").expect("should be defined");
+
+    let err = f.call(&[]).unwrap_err().downcast::<Trap>()?;
+
+    assert!(err.to_string().contains("test"));
+    assert!(err.i32_exit_status().is_none());
+
+    Ok(())
+}
+
+#[test]
+fn trap_import() -> Result<()> {
+    let wasm = wat::parse_str(
+        r#"
+            (import "" "" (func))
+            (start 0)
+        "#,
+    )?;
+
+    let mut config = Config::default();
+    config.wrap_host_func("", "", || -> Result<(), Trap> { Err(Trap::new("foo")) });
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, &wasm)?;
+    let store = Store::new(&engine);
+
+    let trap = Instance::new(
+        &store,
+        &module,
+        &[store.get_host_func("", "").expect("defined").into()],
+    )
+    .err()
+    .unwrap()
+    .downcast::<Trap>()?;
+
+    assert!(trap.to_string().contains("foo"));
+
+    Ok(())
+}
+
+#[test]
+fn new_from_signature() -> Result<()> {
+    let mut config = Config::default();
+
+    let ty = FuncType::new(None, None);
+    config.define_host_func("", "f1", ty, |_, _, _| panic!());
+
+    let ty = FuncType::new(Some(ValType::I32), Some(ValType::F64));
+    config.define_host_func("", "f2", ty, |_, _, _| panic!());
+
+    let engine = Engine::new(&config);
+    let store = Store::new(&engine);
+
+    let f = store.get_host_func("", "f1").expect("func defined");
+    assert!(f.get0::<()>().is_ok());
+    assert!(f.get0::<i32>().is_err());
+    assert!(f.get1::<i32, ()>().is_err());
+
+    let f = store.get_host_func("", "f2").expect("func defined");
+    assert!(f.get0::<()>().is_err());
+    assert!(f.get0::<i32>().is_err());
+    assert!(f.get1::<i32, ()>().is_err());
+    assert!(f.get1::<i32, f64>().is_ok());
+
+    Ok(())
+}
+
+#[test]
+fn call_wrapped_func() -> Result<()> {
+    let mut config = Config::default();
+
+    config.wrap_host_func("", "f1", |a: i32, b: i64, c: f32, d: f64| {
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+        assert_eq!(c, 3.0);
+        assert_eq!(d, 4.0);
+    });
+
+    config.wrap_host_func("", "f2", || 1i32);
+
+    config.wrap_host_func("", "f3", || 2i64);
+
+    config.wrap_host_func("", "f4", || 3.0f32);
+
+    config.wrap_host_func("", "f5", || 4.0f64);
+
+    let engine = Engine::new(&config);
+    let store = Store::new(&engine);
+
+    let f = store.get_host_func("", "f1").expect("func defined");
+    f.call(&[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()])?;
+    f.get4::<i32, i64, f32, f64, ()>()?(1, 2, 3.0, 4.0)?;
+
+    let f = store.get_host_func("", "f2").expect("func defined");
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_i32(), 1);
+    assert_eq!(f.get0::<i32>()?()?, 1);
+
+    let f = store.get_host_func("", "f3").expect("func defined");
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_i64(), 2);
+    assert_eq!(f.get0::<i64>()?()?, 2);
+
+    let f = store.get_host_func("", "f4").expect("func defined");
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_f32(), 3.0);
+    assert_eq!(f.get0::<f32>()?()?, 3.0);
+
+    let f = store.get_host_func("", "f5").expect("func defined");
+    let results = f.call(&[])?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].unwrap_f64(), 4.0);
+    assert_eq!(f.get0::<f64>()?()?, 4.0);
+
+    Ok(())
+}
+
+#[test]
+fn func_return_nothing() -> Result<()> {
+    let mut config = Config::default();
+    let ty = FuncType::new(None, Some(ValType::I32));
+
+    config.define_host_func("", "", ty, |_, _, _| Ok(()));
+
+    let engine = Engine::new(&config);
+    let store = Store::new(&engine);
+    let f = store.get_host_func("", "").expect("func defined");
+    let err = f.call(&[]).unwrap_err().downcast::<Trap>()?;
+    assert!(err
+        .to_string()
+        .contains("function attempted to return an incompatible value"));
+    Ok(())
+}
+
+#[test]
+fn call_via_funcref() -> Result<()> {
+    static HITS: AtomicUsize = AtomicUsize::new(0);
+
+    struct A;
+
+    impl Drop for A {
+        fn drop(&mut self) {
+            HITS.fetch_add(1, SeqCst);
+        }
+    }
+
+    let wasm = wat::parse_str(
+        r#"
+            (table $t 1 funcref)
+            (type $add (func (param i32 i32) (result i32)))
+            (func (export "call") (param funcref) (result i32 funcref)
+                (table.set $t (i32.const 0) (local.get 0))
+                (call_indirect (type $add) (i32.const 3) (i32.const 4) (i32.const 0))
+                (local.get 0)
+            )
+        "#,
+    )?;
+
+    let mut config = Config::default();
+    let a = A;
+    config.wrap_host_func("", "", move |x: i32, y: i32| {
+        drop(&a);
+        x + y
+    });
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, &wasm)?;
+    let store = Store::new(&engine);
+    let instance = Instance::new(&store, &module, &[])?;
+
+    let results = instance
+        .get_func("call")
+        .unwrap()
+        .call(&[store.get_host_func("", "").expect("func defined").into()])?;
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].unwrap_i32(), 7);
+
+    {
+        let f = results[1].unwrap_funcref().unwrap();
+        let results = f.call(&[1.into(), 2.into()])?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].unwrap_i32(), 3);
+    }
+
+    assert_eq!(HITS.load(SeqCst), 0);
+
+    drop((results, instance, store, module, engine));
+
+    assert_eq!(HITS.load(SeqCst), 0);
+
+    drop(config);
+
+    assert_eq!(HITS.load(SeqCst), 1);
+
+    Ok(())
+}
+
+#[test]
+fn store_with_context() -> Result<()> {
+    struct Ctx {
+        called: std::cell::Cell<bool>,
+    }
+
+    let mut config = Config::default();
+
+    config.wrap_host_func("", "", |caller: Caller| {
+        let ctx = caller
+            .store()
+            .get::<Ctx>()
+            .expect("store should have context");
+        ctx.called.set(true);
+    });
+
+    let engine = Engine::new(&config);
+    let store = Store::new(&engine);
+    assert!(store.get::<Ctx>().is_none());
+    assert!(store
+        .set(Ctx {
+            called: std::cell::Cell::new(false)
+        })
+        .is_ok());
+    assert!(store
+        .set(Ctx {
+            called: std::cell::Cell::new(false)
+        })
+        .is_err());
+    assert!(!store.get::<Ctx>().unwrap().called.get());
+
+    let f = store.get_host_func("", "").expect("func defined");
+    f.call(&[])?;
+
+    assert!(store.get::<Ctx>().unwrap().called.get());
+
+    Ok(())
+}
+
+#[test]
+fn wasi_imports_missing_context() -> Result<()> {
+    let mut config = Config::default();
+    Wasi::add_to_config(&mut config);
+
+    let wasm = wat::parse_str(
+        r#"
+        (import "wasi_snapshot_preview1" "proc_exit" (func $__wasi_proc_exit (param i32)))
+        (memory (export "memory") 0)
+        (func (export "_start")
+            (call $__wasi_proc_exit (i32.const 123))
+        )
+        "#,
+    )?;
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, wasm)?;
+    let store = Store::new(&engine);
+    let linker = Linker::new(&store);
+    let instance = linker.instantiate(&module)?;
+
+    let start = instance.get_func("_start").unwrap().get0::<()>()?;
+
+    let trap = start().unwrap_err();
+
+    assert!(trap.to_string().contains("context is missing in the store"));
+    assert!(trap.i32_exit_status().is_none());
+
+    Ok(())
+}
+
+#[test]
+fn wasi_imports() -> Result<()> {
+    let mut config = Config::default();
+    Wasi::add_to_config(&mut config);
+
+    let wasm = wat::parse_str(
+        r#"
+        (import "wasi_snapshot_preview1" "proc_exit" (func $__wasi_proc_exit (param i32)))
+        (memory (export "memory") 0)
+        (func (export "_start")
+            (call $__wasi_proc_exit (i32.const 123))
+        )
+        "#,
+    )?;
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, wasm)?;
+    let store = Store::new(&engine);
+    assert!(Wasi::set_context(&store, WasiCtxBuilder::new().build()?).is_ok());
+    let linker = Linker::new(&store);
+    let instance = linker.instantiate(&module)?;
+
+    let start = instance.get_func("_start").unwrap().get0::<()>()?;
+
+    let trap = start().unwrap_err();
+    assert_eq!(trap.i32_exit_status(), Some(123));
+
+    Ok(())
+}

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;
 
 fn interruptable_store() -> Store {
-    let engine = Engine::new(Config::new().interruptable(true));
+    let engine = Engine::new(Config::new().interruptable(true)).unwrap();
     Store::new(&engine)
 }
 

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -223,3 +223,40 @@ fn no_leak_with_imports() -> Result<()> {
     assert!(flag.get(), "store was leaked");
     Ok(())
 }
+
+#[test]
+fn get_host_function() -> Result<()> {
+    let mut config = Config::default();
+    config.wrap_host_func("mod", "f1", || {});
+
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, r#"(module (import "mod" "f1" (func)))"#)?;
+    let store = Store::new(&engine);
+
+    let linker = Linker::new(&store);
+    assert!(linker.get(&module.imports().nth(0).unwrap()).is_some());
+
+    Ok(())
+}
+
+#[test]
+fn shadowing_host_function() -> Result<()> {
+    let mut config = Config::default();
+    config.wrap_host_func("mod", "f1", || {});
+
+    let engine = Engine::new(&config);
+    let store = Store::new(&engine);
+
+    let mut linker = Linker::new(&store);
+    assert!(linker
+        .define("mod", "f1", Func::wrap(&store, || {}))
+        .is_err());
+    linker.define("mod", "f2", Func::wrap(&store, || {}))?;
+
+    let mut linker = Linker::new(&store);
+    linker.allow_shadowing(true);
+    linker.define("mod", "f1", Func::wrap(&store, || {}))?;
+    linker.define("mod", "f2", Func::wrap(&store, || {}))?;
+
+    Ok(())
+}

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -229,7 +229,7 @@ fn get_host_function() -> Result<()> {
     let mut config = Config::default();
     config.wrap_host_func("mod", "f1", || {});
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, r#"(module (import "mod" "f1" (func)))"#)?;
     let store = Store::new(&engine);
 
@@ -244,7 +244,7 @@ fn shadowing_host_function() -> Result<()> {
     let mut config = Config::default();
     config.wrap_host_func("mod", "f1", || {});
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
 
     let mut linker = Linker::new(&store);

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -7,6 +7,7 @@ mod fuel;
 mod func;
 mod fuzzing;
 mod globals;
+mod host_funcs;
 mod iloop;
 mod import_calling_export;
 mod import_indexes;

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -44,7 +44,7 @@ pub(crate) fn ref_types_module(
     let mut config = Config::new();
     config.wasm_reference_types(true);
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
 
     let module = Module::new(&engine, source)?;

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -136,7 +136,7 @@ mod not_for_windows {
             .with_host_memory(mem_creator.clone())
             .static_memory_maximum_size(0)
             .dynamic_memory_guard_size(0);
-        (Store::new(&Engine::new(&config)), mem_creator)
+        (Store::new(&Engine::new(&config).unwrap()), mem_creator)
     }
 
     #[test]

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -5,13 +5,13 @@ fn caches_across_engines() {
     let mut c = Config::new();
     c.cranelift_clear_cpu_flags();
 
-    let bytes = Module::new(&Engine::new(&c), "(module)")
+    let bytes = Module::new(&Engine::new(&c).unwrap(), "(module)")
         .unwrap()
         .serialize()
         .unwrap();
 
     let res = Module::deserialize(
-        &Engine::new(&Config::new().cranelift_clear_cpu_flags()),
+        &Engine::new(&Config::new().cranelift_clear_cpu_flags()).unwrap(),
         &bytes,
     );
     assert!(res.is_ok());
@@ -22,7 +22,8 @@ fn caches_across_engines() {
             &Config::new()
                 .cranelift_clear_cpu_flags()
                 .cranelift_nan_canonicalization(true),
-        ),
+        )
+        .unwrap(),
         &bytes,
     );
     assert!(res.is_err());
@@ -33,7 +34,8 @@ fn caches_across_engines() {
             &Config::new()
                 .cranelift_clear_cpu_flags()
                 .cranelift_opt_level(OptLevel::None),
-        ),
+        )
+        .unwrap(),
         &bytes,
     );
     assert!(res.is_err());
@@ -46,7 +48,8 @@ fn caches_across_engines() {
                     .cranelift_clear_cpu_flags()
                     .cranelift_other_flag("has_sse3", "true")
                     .unwrap()
-            }),
+            })
+            .unwrap(),
             &bytes,
         );
         assert!(res.is_err());

--- a/tests/all/module_linking.rs
+++ b/tests/all/module_linking.rs
@@ -4,7 +4,7 @@ use wasmtime::*;
 fn engine() -> Engine {
     let mut config = Config::new();
     config.wasm_module_linking(true);
-    Engine::new(&config)
+    Engine::new(&config).unwrap()
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn limit_instances() -> Result<()> {
     let mut config = Config::new();
     config.wasm_module_linking(true);
     config.max_instances(10);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(
         &engine,
         r#"
@@ -232,7 +232,7 @@ fn limit_memories() -> Result<()> {
     config.wasm_module_linking(true);
     config.wasm_multi_memory(true);
     config.max_memories(10);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(
         &engine,
         r#"
@@ -267,7 +267,7 @@ fn limit_tables() -> Result<()> {
     let mut config = Config::new();
     config.wasm_module_linking(true);
     config.max_tables(10);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(
         &engine,
         r#"

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -39,7 +39,7 @@ fn test_module_serialize_fail() -> Result<()> {
 
     let mut config = Config::new();
     config.cranelift_opt_level(OptLevel::None);
-    let store = Store::new(&Engine::new(&config));
+    let store = Store::new(&Engine::new(&config)?);
     match deserialize_and_instantiate(&store, &buffer) {
         Ok(_) => bail!("expected failure at deserialization"),
         Err(_) => (),

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -4,7 +4,7 @@ use wasmtime::*;
 #[test]
 fn successful_instantiation() -> Result<()> {
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 1,
@@ -15,7 +15,7 @@ fn successful_instantiation() -> Result<()> {
             count: 1,
             memory_reservation_size: 1,
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
     let module = Module::new(&engine, r#"(module (memory 1) (table 10 funcref))"#)?;
@@ -30,7 +30,7 @@ fn successful_instantiation() -> Result<()> {
 #[test]
 fn memory_limit() -> Result<()> {
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 3,
@@ -41,7 +41,7 @@ fn memory_limit() -> Result<()> {
             count: 1,
             memory_reservation_size: 196608,
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
 
@@ -92,7 +92,7 @@ fn memory_limit() -> Result<()> {
 #[test]
 fn memory_init() -> Result<()> {
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 2,
@@ -103,7 +103,7 @@ fn memory_init() -> Result<()> {
             count: 1,
             ..Default::default()
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
 
@@ -130,7 +130,7 @@ fn memory_init() -> Result<()> {
 #[test]
 fn memory_guard_page_trap() -> Result<()> {
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 2,
@@ -141,7 +141,7 @@ fn memory_guard_page_trap() -> Result<()> {
             count: 1,
             ..Default::default()
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
 
@@ -185,7 +185,7 @@ fn memory_guard_page_trap() -> Result<()> {
 #[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
 fn memory_zeroed() -> Result<()> {
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 1,
@@ -196,7 +196,7 @@ fn memory_zeroed() -> Result<()> {
             count: 1,
             memory_reservation_size: 1,
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
 
@@ -228,7 +228,7 @@ fn memory_zeroed() -> Result<()> {
 fn table_limit() -> Result<()> {
     const TABLE_ELEMENTS: u32 = 10;
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 1,
@@ -239,7 +239,7 @@ fn table_limit() -> Result<()> {
             count: 1,
             memory_reservation_size: 1,
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
 
@@ -296,7 +296,7 @@ fn table_limit() -> Result<()> {
 #[test]
 fn table_init() -> Result<()> {
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 0,
@@ -307,7 +307,7 @@ fn table_init() -> Result<()> {
             count: 1,
             ..Default::default()
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
 
@@ -346,7 +346,7 @@ fn table_init() -> Result<()> {
 #[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
 fn table_zeroed() -> Result<()> {
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 1,
@@ -357,7 +357,7 @@ fn table_zeroed() -> Result<()> {
             count: 1,
             memory_reservation_size: 1,
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
 
@@ -388,7 +388,7 @@ fn table_zeroed() -> Result<()> {
 fn instantiation_limit() -> Result<()> {
     const INSTANCE_LIMIT: u32 = 10;
     let mut config = Config::new();
-    config.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
         module_limits: ModuleLimits {
             memory_pages: 1,
@@ -399,7 +399,7 @@ fn instantiation_limit() -> Result<()> {
             count: INSTANCE_LIMIT,
             memory_reservation_size: 1,
         },
-    })?;
+    });
 
     let engine = Engine::new(&config);
     let module = Module::new(&engine, r#"(module)"#)?;

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -17,7 +17,7 @@ fn successful_instantiation() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, r#"(module (memory 1) (table 10 funcref))"#)?;
 
     // Module should instantiate
@@ -43,7 +43,7 @@ fn memory_limit() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     // Module should fail to validate because the minimum is greater than the configured limit
     match Module::new(&engine, r#"(module (memory 4))"#) {
@@ -105,7 +105,7 @@ fn memory_init() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(
         &engine,
@@ -143,7 +143,7 @@ fn memory_guard_page_trap() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(
         &engine,
@@ -198,7 +198,7 @@ fn memory_zeroed() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(&engine, r#"(module (memory (export "m") 1))"#)?;
 
@@ -241,7 +241,7 @@ fn table_limit() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     // Module should fail to validate because the minimum is greater than the configured limit
     match Module::new(&engine, r#"(module (table 31 funcref))"#) {
@@ -309,7 +309,7 @@ fn table_init() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(
         &engine,
@@ -359,7 +359,7 @@ fn table_zeroed() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(&engine, r#"(module (table (export "t") 10 funcref))"#)?;
 
@@ -401,7 +401,7 @@ fn instantiation_limit() -> Result<()> {
         },
     });
 
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let module = Module::new(&engine, r#"(module)"#)?;
 
     // Instantiate to the limit

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -526,7 +526,7 @@ fn parse_dwarf_info() -> Result<()> {
     );
     let mut config = Config::new();
     config.wasm_backtrace_details(WasmBacktraceDetails::Enable);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
     let module = Module::new(&engine, &wasm)?;
     let mut linker = Linker::new(&store);
@@ -561,7 +561,7 @@ fn parse_dwarf_info() -> Result<()> {
 fn no_hint_even_with_dwarf_info() -> Result<()> {
     let mut config = Config::new();
     config.wasm_backtrace_details(WasmBacktraceDetails::Disable);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config)?;
     let store = Store::new(&engine);
     let module = Module::new(
         &engine,

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -52,7 +52,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
         // However, these limits may become insufficient in the future as the wast tests change.
         // If a wast test fails because of a limit being "exceeded" or if memory/table
         // fails to grow, the values here will need to be adjusted.
-        cfg.with_allocation_strategy(InstanceAllocationStrategy::Pooling {
+        cfg.allocation_strategy(InstanceAllocationStrategy::Pooling {
             strategy: PoolingAllocationStrategy::NextAvailable,
             module_limits: ModuleLimits {
                 imported_memories: 2,
@@ -68,7 +68,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
                 count: 450,
                 ..Default::default()
             },
-        })?;
+        });
     }
 
     let store = Store::new(&Engine::new(&cfg));

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -71,7 +71,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
         });
     }
 
-    let store = Store::new(&Engine::new(&cfg));
+    let store = Store::new(&Engine::new(&cfg)?);
     let mut wast_context = WastContext::new(store);
     wast_context.register_spectest()?;
     wast_context.run_file(wast)?;


### PR DESCRIPTION
This PR introduces defining host functions at the `Config` rather than with
`Func` tied to a `Store`.

The intention here is to enable a host to define all of the functions once at
with a `Config` and then use a `Linker` (or directly with
`Store::get_host_func`) to use the functions when instantiating a module.

This should help improve the performance of use cases where a `Store` is
short-lived and redefining the functions at every module instantiation a
noticeable performance hit.

See bytecodealliance/rfcs#9 regarding these changes.