### PR TITLE
Fix build_value_labels_ranges for newBE when there are no labels

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -81,7 +81,7 @@ impl MachBackend for AArch64Backend {
             frame_size,
             disasm,
             unwind_info,
-            value_labels_ranges: None,
+            value_labels_ranges: Default::default(),
             stackslot_offsets,
         })
     }

--- a/cranelift/codegen/src/isa/arm32/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/mod.rs
@@ -76,7 +76,7 @@ impl MachBackend for Arm32Backend {
             frame_size,
             disasm,
             unwind_info: None,
-            value_labels_ranges: None,
+            value_labels_ranges: Default::default(),
             stackslot_offsets,
         })
     }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -343,7 +343,7 @@ pub struct MachCompileResult {
     /// Unwind info.
     pub unwind_info: Option<unwind_input::UnwindInfo<Reg>>,
     /// Debug info: value labels to registers/stackslots at code offsets.
-    pub value_labels_ranges: Option<ValueLabelsRanges>,
+    pub value_labels_ranges: ValueLabelsRanges,
     /// Debug info: stackslots to stack pointer offsets.
     pub stackslot_offsets: PrimaryMap<StackSlot, u32>,
 }

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -617,13 +617,13 @@ impl<I: VCodeInst> VCode<I> {
     }
 
     /// Generates value-label ranges.
-    pub fn value_labels_ranges(&self) -> Option<ValueLabelsRanges> {
+    pub fn value_labels_ranges(&self) -> ValueLabelsRanges {
         if !self.has_value_labels {
-            return None;
+            return ValueLabelsRanges::default();
         }
 
         let layout = &self.insts_layout.borrow();
-        Some(debug::compute(&self.insts, &layout.0[..], &layout.1[..]))
+        debug::compute(&self.insts, &layout.0[..], &layout.1[..])
     }
 
     /// Get the offsets of stackslots.

--- a/cranelift/codegen/src/value_label.rs
+++ b/cranelift/codegen/src/value_label.rs
@@ -113,12 +113,8 @@ pub fn build_value_labels_ranges<T>(
 where
     T: From<SourceLoc> + Deref<Target = SourceLoc> + Ord + Copy,
 {
-    if mach_compile_result.is_some() && mach_compile_result.unwrap().value_labels_ranges.is_some() {
-        return mach_compile_result
-            .unwrap()
-            .value_labels_ranges
-            .clone()
-            .unwrap();
+    if let Some(mach_compile_result) = mach_compile_result {
+        return mach_compile_result.value_labels_ranges.clone();
     }
 
     let values_labels = build_value_labels_index::<T>(func);


### PR DESCRIPTION
Fixes #2630