### PR TITLE
WasiCtx: default to empty/sink stdio files rather than throw

### DIFF
--- a/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use std::path::Path;
 use wasi_cap_std_sync::WasiCtxBuilder;
-use wasi_common::pipe::{ReadPipe, WritePipe};
+use wasi_common::pipe::WritePipe;
 use wasmtime::{Linker, Module, Store};
 
 pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> anyhow::Result<()> {
@@ -18,7 +18,6 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         builder = builder
             .arg(bin_name)?
             .arg(".")?
-            .stdin(Box::new(ReadPipe::from(Vec::new())))
             .stdout(Box::new(stdout.clone()))
             .stderr(Box::new(stderr.clone()));
 


### PR DESCRIPTION
the test harness now uses the empty stdin file. I tested manually that
the sink stdout & stderr files work, but theres no test in tree at the
moment

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
