### PR TITLE
Add fuel related functions to c-api

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -153,6 +153,15 @@ WASMTIME_CONFIG_PROP(void, debug_info, bool)
 WASMTIME_CONFIG_PROP(void, interruptable, bool)
 
 /**
+ * \brief Whether or not fuel is enabled for generated code.
+ *
+ * This setting is `false` by default. When enabled it will enable fuel counting
+ * meaning that fuel will be consumed every time a wasm instruction is executed,
+ * and trap when reaching zero.
+ */
+WASMTIME_CONFIG_PROP(void, consume_fuel, bool)
+
+/**
  * \brief Configures the maximum stack size, in bytes, that JIT code can use.
  *
  * This setting is 2MB by default. Configuring this setting will limit the
@@ -634,6 +643,29 @@ WASMTIME_DECLARE_OWN(interrupt_handle)
  * interrupts enabled. See #wasmtime_config_interruptable_set.
  */
 WASM_API_EXTERN own wasmtime_interrupt_handle_t *wasmtime_interrupt_handle_new(wasm_store_t *store);
+
+/**
+ * \brief Adds fuel to this Store for wasm to consume while executing.
+ *
+ * For this method to work fuel consumption must be enabled via
+ * #wasmtime_config_consume_fuel_set. By default a Store starts with 0 fuel
+ * for wasm to execute with (meaning it will immediately trap).
+ * This function must be called for the store to have
+ * some fuel to allow WebAssembly to execute.
+ *
+ * Note that at this time when fuel is entirely consumed it will cause
+ * wasm to trap. More usages of fuel are planned for the future.
+ */
+WASM_API_EXTERN void wasmtime_add_fuel(wasm_store_t *store, uint64_t fuel);
+
+/**
+ * \brief Returns the amount of fuel consumed by this store's execution so far.
+ *
+ * If fuel consumption is not enabled via #wasmtime_config_consume_fuel_set
+ * then this function will return 0. Also note that fuel, if enabled, must be
+ * originally configured via #wasmtime_add_fuel.
+ */
+WASM_API_EXTERN uint64_t wasmtime_fuel_consumed(wasm_store_t *store);
 
 /**
  * \brief Requests that WebAssembly code running in the store attached to this

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -56,6 +56,11 @@ pub extern "C" fn wasmtime_config_interruptable_set(c: &mut wasm_config_t, enabl
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_config_consume_fuel_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.consume_fuel(enable);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_max_wasm_stack_set(c: &mut wasm_config_t, size: usize) {
     c.config.max_wasm_stack(size);
 }

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -42,3 +42,13 @@ pub extern "C" fn wasmtime_interrupt_handle_new(
 pub extern "C" fn wasmtime_interrupt_handle_interrupt(handle: &wasmtime_interrupt_handle_t) {
     handle.handle.interrupt();
 }
+
+#[no_mangle]
+pub extern "C" fn wasmtime_add_fuel(store: &wasm_store_t, fuel: u64) {
+    store.store.add_fuel(fuel);
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_fuel_consumed(store: &wasm_store_t) -> u64 {
+    store.store.fuel_consumed().unwrap_or(0)
+}


### PR DESCRIPTION
This PR adds C api binding for the 3 methods of fuel counting #2611.
It directly exposes @alexcrichton work to C/C++ users.