### PR TITLE
Use `_setjmp` instead of `setjmp`

### DIFF
--- a/crates/runtime/build.rs
+++ b/crates/runtime/build.rs
@@ -1,7 +1,13 @@
+use std::env;
+
 fn main() {
     println!("cargo:rerun-if-changed=src/helpers.c");
     cc::Build::new()
         .warnings(true)
+        .define(
+            &format!("CFG_TARGET_OS_{}", env::var("CARGO_CFG_TARGET_OS").unwrap()),
+            None,
+        )
         .file("src/helpers.c")
         .compile("helpers");
 }

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -1,11 +1,25 @@
 #include <setjmp.h>
 
+// Note that `sigsetjmp` and `siglongjmp` are used here where possible to
+// explicitly pass a 0 argument to `sigsetjmp` that we don't need to preserve
+// the process signal mask. This should make this call a bit faster b/c it
+// doesn't need to touch the kernel signal handling routines.
+#ifdef CFG_TARGET_OS_windows
+#define platform_setjmp(buf) setjmp(buf)
+#define platform_longjmp(buf, arg) longjmp(buf, arg)
+#define platform_jmp_buf jmp_buf
+#else
+#define platform_setjmp(buf) sigsetjmp(buf, 0)
+#define platform_longjmp(buf, arg) siglongjmp(buf, arg)
+#define platform_jmp_buf sigjmp_buf
+#endif
+
 int RegisterSetjmp(
     void **buf_storage,
     void (*body)(void*),
     void *payload) {
-  jmp_buf buf;
-  if (setjmp(buf) != 0) {
+  platform_jmp_buf buf;
+  if (platform_setjmp(buf) != 0) {
     return 0;
   }
   *buf_storage = &buf;
@@ -14,6 +28,6 @@ int RegisterSetjmp(
 }
 
 void Unwind(void *JmpBuf) {
-  jmp_buf *buf = (jmp_buf*) JmpBuf;
-  longjmp(*buf, 1);
+  platform_jmp_buf *buf = (platform_jmp_buf*) JmpBuf;
+  platform_longjmp(*buf, 1);
 }


### PR DESCRIPTION
Apparently on macOS `setjmp` manipulates the process-wide signal mask
which adds a good deal of overhead. We don't actually need this
functionality so this commit switches to using the underscore-prefixed
version of setjmp/longjmp which is defined to not maniuplate the signal
mask. This came out of poking around on #2644 and on macOS locally thi
sdropped the overhead from 721ns to 55ns.

I'll note that I'm not sure if the underscore-versions are present in other platforms, but I figure that CI can figure it out here.