### PR TITLE
wasi-common: fix fdstat of dirfd

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -1112,7 +1112,7 @@ impl From<&FdStat> for types::Fdstat {
 impl From<&DirFdStat> for types::Fdstat {
     fn from(dirstat: &DirFdStat) -> types::Fdstat {
         let fs_rights_base = types::Rights::from(&dirstat.dir_caps);
-        let fs_rights_inheriting = types::Rights::from(&dirstat.file_caps);
+        let fs_rights_inheriting = types::Rights::from(&dirstat.file_caps) | fs_rights_base;
         types::Fdstat {
             fs_filetype: types::Filetype::Directory,
             fs_rights_base,


### PR DESCRIPTION
the fdstat of a dirfd needs to include both the file and dir rights in
the inheriting field.

The wasi-libc path_open bases the base rights of child directories off
the inheriting rights of the parent, so if we only put file rights in
there, opening a child directory will not have any directory operations
permitted.

Fixes https://github.com/bytecodealliance/wasmtime/issues/2638

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
