### PR TITLE
Specified type for V128AnyTrue

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2516,6 +2516,7 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::V128AndNot
         | Operator::V128Or
         | Operator::V128Xor
+        | Operator::V128AnyTrue
         | Operator::V128Bitselect => I8X16, // default type representing V128
 
         Operator::I8x16Shuffle { .. }


### PR DESCRIPTION
This was causing an issue in the stdarch WASM CI (https://github.com/rust-lang/stdarch/pull/1004#issuecomment-778929078). I'm assuming that V128AnyTrue was mistakenly not added in the `type_of` function, because all the other operators are there. If this was intentional, please let me know.