### PR TITLE
Automatically add wasmtime-publish team while publishing

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -271,6 +271,17 @@ fn publish(krate: &Crate) {
     if !status.success() {
         println!("FAIL: failed to publish `{}`: {}", krate.name, status);
     }
+
+    // Note that the status is ignored here. This fails most of the time because
+    // the owner is already set and present, so we only want to add this to
+    // crates which haven't previously been published.
+    Command::new("cargo")
+        .arg("owner")
+        .arg("-a")
+        .arg("github:bytecodealliance:wasmtime-publish")
+        .arg(&krate.name)
+        .status()
+        .expect("failed to run cargo");
 }
 
 // Verify the current tree is publish-able to crates.io. The intention here is


### PR DESCRIPTION
This updates the publication script we have for crates to ensure that
the `wasmtime-publish` GitHub team is added to all crates published.
This will fail for most publications because the team is already listed,
but the hope is that whomever is publishing can see the logs and catch
anything that looks awry.

