### PR TITLE
Disable wasmtime default-features in wasi crate

### DIFF
--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -16,5 +16,5 @@ build = "build.rs"
 wasi-common = { path = "../wasi-common", version = "0.23.0" }
 wiggle = { path = "../wiggle", default-features = false, version = "0.23.0" }
 wasmtime-wiggle = { path = "../wiggle/wasmtime", default-features = false, version = "0.23.0" }
-wasmtime = { path = "../wasmtime", version = "0.23.0" }
+wasmtime = { path = "../wasmtime", default-features = false, version = "0.23.0" }
 anyhow = "1.0"


### PR DESCRIPTION
Disabling `wasmtime`'s default features in the `wasi` crate has been removed in the transition from `0.22.0` to `0.23.0`. This brings in a whole lot of unnecessary features and dependencies that the `wasi` crate doesn't need. 

Not sure if there was a specific reason for the removal or just a small accident. Anyways, here is a small change to disable `wasmtime`'s default features again. :) 
