### PR TITLE
rename some wiggle tests to reflect new witx ast names

### DIFF
--- a/crates/wiggle/tests/lists.rs
+++ b/crates/wiggle/tests/lists.rs
@@ -3,13 +3,13 @@ use wiggle::{GuestMemory, GuestPtr, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/arrays.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/lists.witx"],
     ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);
 
-impl<'a> arrays::Arrays for WasiCtx<'a> {
+impl<'a> lists::Lists for WasiCtx<'a> {
     fn reduce_excuses(
         &self,
         excuses: &types::ConstExcuseArray,
@@ -97,7 +97,7 @@ impl ReduceExcusesExcercise {
             }
         }
 
-        let res = arrays::reduce_excuses(
+        let res = lists::reduce_excuses(
             &ctx,
             &host_memory,
             self.array_ptr_loc.ptr as i32,
@@ -177,7 +177,7 @@ impl PopulateExcusesExcercise {
                 .expect("failed to write value");
         }
 
-        let res = arrays::populate_excuses(
+        let res = lists::populate_excuses(
             &ctx,
             &host_memory,
             self.array_ptr_loc.ptr as i32,

--- a/crates/wiggle/tests/lists.witx
+++ b/crates/wiggle/tests/lists.witx
@@ -4,7 +4,7 @@
 (typename $const_excuse_array (list (@witx const_pointer $excuse)))
 (typename $excuse_array (list (@witx pointer $excuse)))
 
-(module $arrays
+(module $lists
   (@interface func (export "reduce_excuses")
     (param $excuses $const_excuse_array)
     (result $error (expected $excuse (error $errno)))

--- a/crates/wiggle/tests/records.witx
+++ b/crates/wiggle/tests/records.witx
@@ -18,14 +18,14 @@
 
 (typename $some_bytes (list u8))
 
-(typename $struct_of_array
+(typename $record_of_list
   (record
     (field $arr $some_bytes)))
 
 (typename $s64 s64)
 (typename $u16 u16)
 
-(module $structs
+(module $records
   (@interface func (export "sum_of_pair")
     (param $an_pair $pair_ints)
     (result $error (expected $s64 (error $errno))))
@@ -42,6 +42,6 @@
     (param $second (@witx const_pointer s32))
     (result $error (expected $pair_int_ptrs (error $errno))))
   (@interface func (export "sum_array")
-    (param $an_arr $struct_of_array)
+    (param $a_list $record_of_list)
     (result $error (expected $u16 (error $errno))))
 )

--- a/crates/wiggle/tests/variant.rs
+++ b/crates/wiggle/tests/variant.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/union.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/tests/variant.witx"],
     ctx: WasiCtx,
 });
 
@@ -31,7 +31,7 @@ fn mult_zero_nan(a: f32, b: u32) -> f32 {
     }
 }
 
-impl<'a> union_example::UnionExample for WasiCtx<'a> {
+impl<'a> variant_example::VariantExample for WasiCtx<'a> {
     fn get_tag(&self, u: &types::Reason) -> Result<types::Excuse, types::Errno> {
         println!("GET TAG: {:?}", u);
         match u {
@@ -126,7 +126,7 @@ impl GetTagExercise {
                 .expect("input contents ref_mut"),
             types::Reason::Sleeping => {} // Do nothing
         }
-        let e = union_example::get_tag(
+        let e = variant_example::get_tag(
             &ctx,
             &host_memory,
             self.input_loc.ptr as i32,
@@ -210,7 +210,7 @@ impl ReasonMultExercise {
             }
             types::Reason::Sleeping => {} // Do nothing
         }
-        let e = union_example::reason_mult(
+        let e = variant_example::reason_mult(
             &ctx,
             &host_memory,
             self.input_loc.ptr as i32,

--- a/crates/wiggle/tests/variant.witx
+++ b/crates/wiggle/tests/variant.witx
@@ -1,9 +1,6 @@
 (use "errno.witx")
 (use "excuse.witx")
 
-;; Every worker needs a union. Organize your workplace!
-;; Fight for the full product of your labor!
-
 (typename $reason
   (variant (@witx tag $excuse)
     (case $dog_ate f32)
@@ -16,7 +13,7 @@
     (case $traffic (@witx pointer s32))
     (case $sleeping)))
 
-(module $union_example
+(module $variant_example
   (@interface func (export "get_tag")
     (param $r $reason)
     (result $error (expected $excuse (error $errno)))


### PR DESCRIPTION
arrays are now lists
structs are now records
unions are now variants

Follow up to #2659
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
