### PR TITLE
Clean up our github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/clif-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/clif-bug-report.md
@@ -7,13 +7,37 @@ assignees: ''
 
 ---
 
-Thanks for opening a bug report! Please answer the questions below
-if they're relevant and delete this text before submitting.
+Thanks for filing an issue! Please fill out the TODOs below.
 
-- What are the steps to reproduce the issue? Can you include a CLIF test case,
-  ideally reduced with the `bugpoint` clif-util command?
-- What do you expect to happen? What does actually happen? Does it panic, and
-  if so, with which assertion?
-- Which Cranelift version / commit hash / branch are you using?
-- If relevant, can you include some extra information about your environment?
-  (Rust version, operating system, architecture...)
+### `.clif` Test Case
+
+```
+TODO: paste .clif test case here. Ideally, a test case that has been reduced via
+the `clif-util bugpoint` command.
+```
+
+### Steps to Reproduce
+
+* TODO: First, ...
+* TODO: Then, ...
+* Etc...
+
+### Expected Results
+
+TODO: What do you expect to happen?
+
+### Actual Results
+
+TODO: What actually happens? Panic? Segfault? Incorrect result?
+
+### Versions and Environment
+
+Cranelift version or commit: TODO
+
+Operating system: TODO
+
+Architecture: TODO
+
+### Extra Info
+
+Anything else you'd like to add?

--- a/.github/ISSUE_TEMPLATE/clif-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/clif-bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: Cranelift Bug report
+name: Cranelift Bug Report
 about: Report a bug or a crash in Cranelift.
 title: 'Cranelift: '
 labels: bug, cranelift

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -7,26 +7,25 @@ assignees: ''
 
 ---
 
-<!-- Please try to describe precisely what you would like to do in
-Cranelift/Wasmtime and/or expect from it. You can answer the questions below if
-they're relevant and delete this text before submitting. Thanks for opening an
-issue! -->
+Thanks for filing a feature request! Please fill out the TODOs below.
 
 #### Feature
 
-<!-- What is the feature or code improvement you would like to do in
-Cranelift/Wasmtime? -->
+TODO: Brief description of the feature/improvement you'd like to see in
+Cranelift/Wasmtime.
 
 #### Benefit
 
-<!-- What is the value of adding this in Cranelift/Wasmtime? -->
+TODO: What is the value of adding this in Cranelift/Wasmtime? What problems does
+it solve?
 
 #### Implementation
 
-<!-- Do you have an implementation plan, and/or ideas for data structures or
-algorithms to use? -->
+TODO: Do you have an implementation plan, and/or ideas for data structures or
+algorithms to use?
 
 #### Alternatives
 
-<!-- Have you considered alternative implementations? If so, how are they
-better or worse than your proposal? -->
+TODO: What are the alternative implementation approaches or alternative ways to
+solve the problem that this feature would solve? How do these alternatives
+compare to this proposal?

--- a/.github/ISSUE_TEMPLATE/wasmtime-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/wasmtime-bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: Wasmtime bug report
+name: Wasmtime Bug Report
 about: Report a bug or a crash in Wasmtime
 title: ''
 labels: bug
@@ -7,12 +7,34 @@ assignees: ''
 
 ---
 
-Thanks for opening a bug report! Please answer the questions below
-if they're relevant and delete this text before submitting.
+Thanks for filing a bug report! Please fill out the TODOs below.
 
-- What are the steps to reproduce the issue?
-- What do you expect to happen? What does actually happen? Does it panic, and
-  if so, with which assertion?
-- Which Wasmtime version / commit hash / branch are you using?
-- If relevant, can you include some extra information about your environment?
-  (Rust version, operating system, architecture...)
+### Test Case
+
+TODO: upload Wasm file here
+
+### Steps to Reproduce
+
+* TODO: first, ...
+* TODO: second, ...
+* Etc...
+
+### Expected Results
+
+TODO: What do you expect to happen?
+
+### Actual Results
+
+TODO: What actually happens? Panic? Segfault? Incorrect result?
+
+### Versions and Environment
+
+Wasmtime version or commit: TODO
+
+Operating system: TODO
+
+Architecture: TODO
+
+### Extra Info
+
+Anything else you'd like to add?


### PR DESCRIPTION
* Don't use HTML comments, as they are noisy, which makes the templates more
  intimidating.

* Use "TODO" to clearly demarcate everywhere the issue reporter should fill in
  some information.

* Use headers and white space abundantly, which makes it easier to visually
  process the template and its sections at a glance, and less of an intimidating
  wall of text.

Fixes #2661