### PR TITLE
Optionally compile wasmtime-bench-api with wasi-nn and wasi-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3148,6 +3148,8 @@ dependencies = [
  "wasi-cap-std-sync",
  "wasmtime",
  "wasmtime-wasi",
+ "wasmtime-wasi-crypto",
+ "wasmtime-wasi-nn",
  "wat",
 ]
 

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -19,6 +19,8 @@ anyhow = "1.0"
 shuffling-allocator = { version = "1.1.1", optional = true }
 wasmtime = { path = "../wasmtime", default-features = false }
 wasmtime-wasi = { path = "../wasi" }
+wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
+wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
 cap-std = "0.13"
 
@@ -27,3 +29,6 @@ wat = "1.0"
 
 [features]
 default = ["shuffling-allocator"]
+wasi-crypto = ["wasmtime-wasi-crypto"]
+wasi-nn = ["wasmtime-wasi-nn"]
+


### PR DESCRIPTION
This adds the ability to add feature flags (e.g. `--features wasi-nn`) when compiling `wasmtime-bench-api` to allow benchmarking Wasmtime with WASI proposals included. Note that due to https://github.com/rust-lang/cargo/issues/5364, these features are only available:
 - in the `crates/bench-api` directory, e.g. `pushd crates/bench-api; cargo build --features wasi-crypto`
 - or from the top-level project directory using `-Zpackage-features`, e.g. `OPENVINO_INSTALL_DIR=/opt/intel/openvino cargo +nightly build -p wasmtime-bench-api -Zpackage-features --features wasi-nn`

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
