### PR TITLE
Replace the wasmtime crate README with the main one

### DIFF
--- a/crates/wasmtime/README.md
+++ b/crates/wasmtime/README.md
@@ -1,8 +1,1 @@
-## Wasmtime Embedding API
-
-The `wasmtime` crate is an embedding API of the `wasmtime` WebAssembly runtime.
-This is intended to be used in Rust projects and provides a high-level API of
-working with WebAssembly modules.
-
-If you're interested in embedding `wasmtime` in other languages, you may wish to
-take a look a the [C embedding API](../c-api) instead!
+../../README.md


### PR DESCRIPTION
Use a small symlink to point to the main README. Currently our
[crates.io page](https://crates.io/crates/wasmtime) is pretty drab
because the README in the package is pretty small. This should hopefully
spice it up a bit with a more well-formed README.
