### PR TITLE
Sunfishcode/readmes

### DIFF
--- a/crates/wasi-common/cap-std-sync/README.md
+++ b/crates/wasi-common/cap-std-sync/README.md
@@ -1,0 +1,1 @@
+WASI implementation in Rust, using cap-std.

--- a/crates/wasi/README.md
+++ b/crates/wasi/README.md
@@ -1,0 +1,2 @@
+Crate defining the `Wasi` type for Wasmtime, which represents a WASI
+instance which may be added to a linker.


### PR DESCRIPTION
This PR adds README.md files for cap-std-sync and wasmtime-wasi. I added these when publishing 0.23.0 packages to satisfy the `readme = "README.md"` lines in their Cargo.toml files, but it seems I didn't add them to the release PR.