### PR TITLE
fuzz: Remove peepmatic fuzz targets

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -65,41 +65,6 @@ test = false
 doc = false
 
 [[bin]]
-name = "peepmatic_simple_automata"
-path = "fuzz_targets/peepmatic_simple_automata.rs"
-test = false
-doc = false
-required-features = ["peepmatic-fuzzing"]
-
-[[bin]]
-name = "peepmatic_fst_differential"
-path = "fuzz_targets/peepmatic_fst_differential.rs"
-test = false
-doc = false
-required-features = ["peepmatic-fuzzing"]
-
-[[bin]]
-name = "peepmatic_parser"
-path = "fuzz_targets/peepmatic_parser.rs"
-test = false
-doc = false
-required-features = ["peepmatic-fuzzing"]
-
-[[bin]]
-name = "peepmatic_compile"
-path = "fuzz_targets/peepmatic_compile.rs"
-test = false
-doc = false
-required-features = ["peepmatic-fuzzing"]
-
-[[bin]]
-name = "peepmatic_interp"
-path = "fuzz_targets/peepmatic_interp.rs"
-test = false
-doc = false
-required-features = ["peepmatic-fuzzing"]
-
-[[bin]]
 name = "instantiate-wasm-smith"
 path = "fuzz_targets/instantiate-wasm-smith.rs"
 test = false

--- a/fuzz/fuzz_targets/peepmatic_compile.rs
+++ b/fuzz/fuzz_targets/peepmatic_compile.rs
@@ -1,8 +1,0 @@
-#![no_main]
-
-use libfuzzer_sys::fuzz_target;
-use peepmatic_fuzzing::compile::compile;
-
-fuzz_target!(|data: &[u8]| {
-    compile(data);
-});

--- a/fuzz/fuzz_targets/peepmatic_fst_differential.rs
+++ b/fuzz/fuzz_targets/peepmatic_fst_differential.rs
@@ -1,8 +1,0 @@
-#![no_main]
-use libfuzzer_sys::fuzz_target;
-use peepmatic_fuzzing::automata::fst_differential;
-use std::collections::HashMap;
-
-fuzz_target!(|map: HashMap<Vec<u8>, u64>| {
-    fst_differential(map);
-});

--- a/fuzz/fuzz_targets/peepmatic_interp.rs
+++ b/fuzz/fuzz_targets/peepmatic_interp.rs
@@ -1,8 +1,0 @@
-#![no_main]
-
-use libfuzzer_sys::fuzz_target;
-use peepmatic_fuzzing::interp::interp;
-
-fuzz_target!(|data: &[u8]| {
-    interp(data);
-});

--- a/fuzz/fuzz_targets/peepmatic_parser.rs
+++ b/fuzz/fuzz_targets/peepmatic_parser.rs
@@ -1,8 +1,0 @@
-#![no_main]
-
-use libfuzzer_sys::fuzz_target;
-use peepmatic_fuzzing::parser::parse;
-
-fuzz_target!(|data: &[u8]| {
-    parse(data);
-});

--- a/fuzz/fuzz_targets/peepmatic_simple_automata.rs
+++ b/fuzz/fuzz_targets/peepmatic_simple_automata.rs
@@ -1,7 +1,0 @@
-#![no_main]
-use libfuzzer_sys::fuzz_target;
-use peepmatic_fuzzing::automata::simple_automata;
-
-fuzz_target!(|input_output_pairs: Vec<Vec<(u8, Vec<u8>)>>| {
-    simple_automata(input_output_pairs);
-});


### PR DESCRIPTION
There are occasional timeouts in type checking where Z3 hangs. This is a known
issue[0] with the implementation of type checking in Peepmatic, and getting
these timeouts in the fuzzers is just annoying and adds noise to our fuzzing
results. When we fix [0] we can reintroduce these fuzz targets.

[0]: https://github.com/bytecodealliance/wasmtime/issues/2695

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
