### PR TITLE
Enable simd_i64x2_cmp.wast for aarch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -250,11 +250,9 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             | ("simd", "simd_store64_lane")
             | ("simd", "simd_store8_lane") => return true,
 
-            // These are only implemented on x64.
-            ("simd", "simd_i64x2_cmp") => return !cfg!(feature = "experimental_x64"),
-
             // These are only implemented on aarch64 and x64.
-            ("simd", "simd_f32x4_pmin_pmax")
+            ("simd", "simd_i64x2_cmp")
+            | ("simd", "simd_f32x4_pmin_pmax")
             | ("simd", "simd_f64x2_pmin_pmax")
             | ("simd", "simd_f32x4_rounding")
             | ("simd", "simd_f64x2_rounding")


### PR DESCRIPTION
As mentioned in https://github.com/bytecodealliance/wasmtime/pull/2697#discussion_r585168434, this commit enables the simd_i64x2_cmp.wast spec test on aarch64; I had mistakenly classified the test as only working on x64.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
