### PR TITLE
[x64] Add i64x2.all_true and i64x2.bitmask

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -224,10 +224,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
                 return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
             }
 
-            // Waiting for an update to the spec testsuite to not use old
-            // instruction names.
-            ("simd", "simd_lane") => return true,
-
             // These are new instructions that are not really implemented in any backend.
             ("simd", "simd_i8x16_arith2")
             | ("simd", "simd_conversions")

--- a/build.rs
+++ b/build.rs
@@ -226,7 +226,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
 
             // Waiting for an update to the spec testsuite to not use old
             // instruction names.
-            ("simd", "simd_boolean") | ("simd", "simd_lane") => return true,
+            ("simd", "simd_lane") => return true,
 
             // These are new instructions that are not really implemented in any backend.
             ("simd", "simd_i8x16_arith2")
@@ -249,7 +249,9 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             | ("simd", "simd_store8_lane") => return true,
 
             // These are only implemented on x64.
-            ("simd", "simd_i64x2_arith2") => return !cfg!(feature = "experimental_x64"),
+            ("simd", "simd_i64x2_arith2") | ("simd", "simd_boolean") => {
+                return !cfg!(feature = "experimental_x64")
+            }
 
             // These are only implemented on aarch64 and x64.
             ("simd", "simd_i64x2_cmp")

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1633,12 +1633,18 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let bool_result = builder.ins().vany_true(a);
             state.push1(builder.ins().bint(I32, bool_result))
         }
-        Operator::I8x16AllTrue | Operator::I16x8AllTrue | Operator::I32x4AllTrue => {
+        Operator::I8x16AllTrue
+        | Operator::I16x8AllTrue
+        | Operator::I32x4AllTrue
+        | Operator::I64x2AllTrue => {
             let a = pop1_with_bitcast(state, type_of(op), builder);
             let bool_result = builder.ins().vall_true(a);
             state.push1(builder.ins().bint(I32, bool_result))
         }
-        Operator::I8x16Bitmask | Operator::I16x8Bitmask | Operator::I32x4Bitmask => {
+        Operator::I8x16Bitmask
+        | Operator::I16x8Bitmask
+        | Operator::I32x4Bitmask
+        | Operator::I64x2Bitmask => {
             let a = pop1_with_bitcast(state, type_of(op), builder);
             state.push1(builder.ins().vhigh_bits(I32, a));
         }
@@ -1826,8 +1832,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (a, b) = pop2_with_bitcast(state, I16X8, builder);
             state.push1(builder.ins().widening_pairwise_dot_product_s(a, b));
         }
-        Operator::I64x2Bitmask
-        | Operator::I64x2ExtendLowI32x4S
+
+        Operator::I64x2ExtendLowI32x4S
         | Operator::I64x2ExtendHighI32x4S
         | Operator::I64x2ExtendLowI32x4U
         | Operator::I64x2ExtendHighI32x4U
@@ -1852,7 +1858,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I64x2ExtMulHighI32x4S
         | Operator::I64x2ExtMulLowI32x4U
         | Operator::I64x2ExtMulHighI32x4U
-        | Operator::I64x2AllTrue
         | Operator::I16x8ExtAddPairwiseI8x16S
         | Operator::I16x8ExtAddPairwiseI8x16U
         | Operator::I32x4ExtAddPairwiseI16x8S
@@ -2647,12 +2652,14 @@ fn type_of(operator: &Operator) -> Type {
         | Operator::I64x2GeS
         | Operator::I64x2Neg
         | Operator::I64x2Abs
+        | Operator::I64x2AllTrue
         | Operator::I64x2Shl
         | Operator::I64x2ShrS
         | Operator::I64x2ShrU
         | Operator::I64x2Add
         | Operator::I64x2Sub
         | Operator::I64x2Mul
+        | Operator::I64x2Bitmask
         | Operator::V128Load64Zero { .. } => I64X2,
 
         Operator::F32x4Splat


### PR DESCRIPTION
These instructions already had CLIF implementations but were only recently approved in the Wasm SIMD working group. Additionally, this re-enables the `simd_lane.wast` spec tests (probably disabled waiting on wasm-tools?).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
