### PR TITLE
wiggle: support for Rust async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,6 +3484,8 @@ dependencies = [
 name = "wasmtime-wiggle"
 version = "0.23.0"
 dependencies = [
+ "anyhow",
+ "proptest",
  "wasmtime",
  "wasmtime-wiggle-macro",
  "wiggle",
@@ -3531,6 +3544,7 @@ dependencies = [
 name = "wiggle"
 version = "0.23.0"
 dependencies = [
+ "async-trait",
  "bitflags",
  "proptest",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ members = [
   "crates/misc/run-examples",
   "crates/misc/rust",
   "crates/wiggle",
+  "crates/wiggle/generate",
+  "crates/wiggle/macro",
   "crates/wiggle/wasmtime",
   "crates/wasi-common",
   "crates/wasi-common/cap-std-sync",

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -15,7 +15,6 @@ use wiggle::GuestPtr;
 
 wiggle::from_witx!({
     witx: ["$WASI_ROOT/phases/old/snapshot_0/witx/wasi_unstable.witx"],
-    ctx: WasiCtx,
     errors: { errno => Error },
 });
 

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -21,7 +21,6 @@ use wiggle::GuestPtr;
 
 wiggle::from_witx!({
     witx: ["$WASI_ROOT/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
-    ctx: WasiCtx,
     errors: { errno => Error },
 });
 

--- a/crates/wasi-crypto/src/wiggle_interfaces/mod.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/mod.rs
@@ -2,7 +2,6 @@ pub use wasi_crypto::CryptoCtx as WasiCryptoCtx;
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/spec/witx/wasi_ephemeral_crypto.witx"],
-    ctx: WasiCryptoCtx
 });
 
 pub mod wasi_modules {

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -5,7 +5,6 @@ use crate::ctx::WasiNnError;
 // Generate the traits and types of wasi-nn in several Rust modules (e.g. `types`).
 wiggle::from_witx!({
     witx: ["$WASI_ROOT/phases/ephemeral/witx/wasi_ephemeral_nn.witx"],
-    ctx: WasiNnCtx,
     errors: { nn_errno => WasiNnError }
 });
 

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -601,6 +601,16 @@ impl Linker {
         Instance::new(&self.store, module, &imports)
     }
 
+    /// Attempts to instantiate the `module` provided. This is the same as [`Linker::instantiate`],
+    /// except for async `Store`s.
+    #[cfg(feature = "async")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+    pub async fn instantiate_async(&self, module: &Module) -> Result<Instance> {
+        let imports = self.compute_imports(module)?;
+
+        Instance::new_async(&self.store, module, &imports).await
+    }
+
     fn compute_imports(&self, module: &Module) -> Result<Vec<Extern>> {
         module
             .imports()

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -16,6 +16,7 @@ witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9", optional = tr
 wiggle-macro = { path = "macro", version = "0.23.0" }
 tracing = "0.1.15"
 bitflags = "1.2"
+async-trait = "0.1.42"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wiggle/generate/src/codegen_settings.rs
+++ b/crates/wiggle/generate/src/codegen_settings.rs
@@ -1,10 +1,28 @@
-use crate::config::ErrorConf;
+use crate::config::{AsyncConf, ErrorConf};
 use anyhow::{anyhow, Error};
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::HashMap;
 use std::rc::Rc;
-use witx::{Document, Id, NamedType, TypeRef};
+use witx::{Document, Id, InterfaceFunc, Module, NamedType, TypeRef};
+
+pub struct CodegenSettings {
+    pub errors: ErrorTransform,
+    async_: AsyncConf,
+}
+impl CodegenSettings {
+    pub fn new(error_conf: &ErrorConf, async_: &AsyncConf, doc: &Document) -> Result<Self, Error> {
+        let errors = ErrorTransform::new(error_conf, doc)?;
+        Ok(Self {
+            errors,
+            async_: async_.clone(),
+        })
+    }
+    pub fn is_async(&self, module: &Module, func: &InterfaceFunc) -> bool {
+        self.async_
+            .is_async(module.name.as_str(), func.name.as_str())
+    }
+}
 
 pub struct ErrorTransform {
     m: Vec<UserErrorType>,

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -27,7 +27,6 @@ mod kw {
     syn::custom_keyword!(witx);
     syn::custom_keyword!(witx_literal);
     syn::custom_keyword!(errors);
-    syn::custom_keyword!(async_);
 }
 
 impl Parse for ConfigField {
@@ -45,8 +44,8 @@ impl Parse for ConfigField {
             input.parse::<kw::errors>()?;
             input.parse::<Token![:]>()?;
             Ok(ConfigField::Error(input.parse()?))
-        } else if lookahead.peek(kw::async_) {
-            input.parse::<kw::async_>()?;
+        } else if lookahead.peek(Token![async]) {
+            input.parse::<Token![async]>()?;
             input.parse::<Token![:]>()?;
             Ok(ConfigField::Async(input.parse()?))
         } else {

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -12,22 +12,22 @@ use {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub witx: WitxConf,
-    pub ctx: CtxConf,
     pub errors: ErrorConf,
+    pub async_: AsyncConf,
 }
 
 #[derive(Debug, Clone)]
 pub enum ConfigField {
     Witx(WitxConf),
-    Ctx(CtxConf),
     Error(ErrorConf),
+    Async(AsyncConf),
 }
 
 mod kw {
     syn::custom_keyword!(witx);
     syn::custom_keyword!(witx_literal);
-    syn::custom_keyword!(ctx);
     syn::custom_keyword!(errors);
+    syn::custom_keyword!(async_);
 }
 
 impl Parse for ConfigField {
@@ -41,14 +41,14 @@ impl Parse for ConfigField {
             input.parse::<kw::witx_literal>()?;
             input.parse::<Token![:]>()?;
             Ok(ConfigField::Witx(WitxConf::Literal(input.parse()?)))
-        } else if lookahead.peek(kw::ctx) {
-            input.parse::<kw::ctx>()?;
-            input.parse::<Token![:]>()?;
-            Ok(ConfigField::Ctx(input.parse()?))
         } else if lookahead.peek(kw::errors) {
             input.parse::<kw::errors>()?;
             input.parse::<Token![:]>()?;
             Ok(ConfigField::Error(input.parse()?))
+        } else if lookahead.peek(kw::async_) {
+            input.parse::<kw::async_>()?;
+            input.parse::<Token![:]>()?;
+            Ok(ConfigField::Async(input.parse()?))
         } else {
             Err(lookahead.error())
         }
@@ -58,8 +58,8 @@ impl Parse for ConfigField {
 impl Config {
     pub fn build(fields: impl Iterator<Item = ConfigField>, err_loc: Span) -> Result<Self> {
         let mut witx = None;
-        let mut ctx = None;
         let mut errors = None;
+        let mut async_ = None;
         for f in fields {
             match f {
                 ConfigField::Witx(c) => {
@@ -68,17 +68,17 @@ impl Config {
                     }
                     witx = Some(c);
                 }
-                ConfigField::Ctx(c) => {
-                    if ctx.is_some() {
-                        return Err(Error::new(err_loc, "duplicate `ctx` field"));
-                    }
-                    ctx = Some(c);
-                }
                 ConfigField::Error(c) => {
                     if errors.is_some() {
                         return Err(Error::new(err_loc, "duplicate `errors` field"));
                     }
                     errors = Some(c);
+                }
+                ConfigField::Async(c) => {
+                    if async_.is_some() {
+                        return Err(Error::new(err_loc, "duplicate `async` field"));
+                    }
+                    async_ = Some(c);
                 }
             }
         }
@@ -86,10 +86,8 @@ impl Config {
             witx: witx
                 .take()
                 .ok_or_else(|| Error::new(err_loc, "`witx` field required"))?,
-            ctx: ctx
-                .take()
-                .ok_or_else(|| Error::new(err_loc, "`ctx` field required"))?,
             errors: errors.take().unwrap_or_default(),
+            async_: async_.take().unwrap_or_default(),
         })
     }
 
@@ -216,19 +214,6 @@ impl Parse for Literal {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct CtxConf {
-    pub name: Ident,
-}
-
-impl Parse for CtxConf {
-    fn parse(input: ParseStream) -> Result<Self> {
-        Ok(CtxConf {
-            name: input.parse()?,
-        })
-    }
-}
-
 #[derive(Clone, Default, Debug)]
 /// Map from abi error type to rich error type
 pub struct ErrorConf(HashMap<Ident, ErrorConfField>);
@@ -292,5 +277,79 @@ impl Parse for ErrorConfField {
             rich_error,
             err_loc,
         })
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+/// Modules and funcs that should be async
+pub struct AsyncConf(HashMap<String, Vec<String>>);
+
+impl AsyncConf {
+    pub fn is_async(&self, module: &str, function: &str) -> bool {
+        self.0
+            .get(module)
+            .and_then(|fs| fs.iter().find(|f| *f == function))
+            .is_some()
+    }
+}
+
+impl Parse for AsyncConf {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        let _ = braced!(content in input);
+        let items: Punctuated<AsyncConfField, Token![,]> =
+            content.parse_terminated(Parse::parse)?;
+        let mut m: HashMap<String, Vec<String>> = HashMap::new();
+        use std::collections::hash_map::Entry;
+        for i in items {
+            let function_names = i
+                .function_names
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<String>>();
+            match m.entry(i.module_name.to_string()) {
+                Entry::Occupied(o) => o.into_mut().extend(function_names),
+                Entry::Vacant(v) => {
+                    v.insert(function_names);
+                }
+            }
+        }
+        Ok(AsyncConf(m))
+    }
+}
+
+#[derive(Clone)]
+pub struct AsyncConfField {
+    pub module_name: Ident,
+    pub function_names: Vec<Ident>,
+    pub err_loc: Span,
+}
+
+impl Parse for AsyncConfField {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let err_loc = input.span();
+        let module_name = input.parse::<Ident>()?;
+        let _doublecolon: Token![::] = input.parse()?;
+        let lookahead = input.lookahead1();
+        if lookahead.peek(syn::token::Brace) {
+            let content;
+            let _ = braced!(content in input);
+            let function_names: Punctuated<Ident, Token![,]> =
+                content.parse_terminated(Parse::parse)?;
+            Ok(AsyncConfField {
+                module_name,
+                function_names: function_names.iter().cloned().collect(),
+                err_loc,
+            })
+        } else if lookahead.peek(Ident) {
+            let name = input.parse()?;
+            Ok(AsyncConfField {
+                module_name,
+                function_names: vec![name],
+                err_loc,
+            })
+        } else {
+            Err(lookahead.error())
+        }
     }
 }

--- a/crates/wiggle/generate/src/names.rs
+++ b/crates/wiggle/generate/src/names.rs
@@ -7,20 +7,12 @@ use witx::{BuiltinType, Id, Type, TypeRef, WasmType};
 use crate::{lifetimes::LifetimeExt, UserErrorType};
 
 pub struct Names {
-    ctx_type: Ident,
     runtime_mod: TokenStream,
 }
 
 impl Names {
-    pub fn new(ctx_type: &Ident, runtime_mod: TokenStream) -> Names {
-        Names {
-            ctx_type: ctx_type.clone(),
-            runtime_mod,
-        }
-    }
-
-    pub fn ctx_type(&self) -> Ident {
-        self.ctx_type.clone()
+    pub fn new(runtime_mod: TokenStream) -> Names {
+        Names { runtime_mod }
     }
 
     pub fn runtime_mod(&self) -> TokenStream {

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -15,9 +15,11 @@ use syn::parse_macro_input;
 ///   Rust-idiomatic snake\_case.
 ///
 ///     * For each `@interface func` defined in a witx module, an abi-level
-///       function is generated which takes ABI-level arguments, along with a
-///       "context" struct (whose type is given by the `ctx` field in the
-///       macro invocation) and a `GuestMemory` implementation.
+///       function is generated which takes ABI-level arguments, along with
+///       a ref that impls the module trait, and a `GuestMemory` implementation.
+///       Users typically won't use these abi-level functions: The `wasmtime-wiggle`
+///       and `lucet-wiggle` crates adapt these to work with a particular WebAssembly
+///       engine.
 ///
 ///     * A public "module trait" is defined (called the module name, in
 ///       SnakeCase) which has a `&self` method for each function in the
@@ -27,61 +29,118 @@ use syn::parse_macro_input;
 /// Arguments are provided using Rust struct value syntax.
 ///
 /// * `witx` takes a list of string literal paths. Paths are relative to the
-///   CARGO_MANIFEST_DIR of the crate where the macro is invoked.
-/// * `ctx` takes a type name. This type must implement all of the module
-///    traits
+///   CARGO_MANIFEST_DIR of the crate where the macro is invoked. Alternatively,
+///   `witx_literal` takes a string containing a complete witx document.
+/// * Optional: `errors` takes a mapping of witx identifiers to types, e.g
+///   `{ errno => YourErrnoType }`. This allows you to use the `UserErrorConversion`
+///   trait to map these rich errors into the flat witx type, or to terminate
+///   WebAssembly execution by trapping.
+/// * Optional: `async_` takes a set of witx modules and functions which are
+///   made Rust `async` functions in the module trait.
 ///
 /// ## Example
 ///
 /// ```
-/// use wiggle::{GuestPtr, GuestErrorType};
-///
-/// /// The test witx file `arrays.witx` lives in the test directory. For a
-/// /// full-fledged example with runtime tests, see `tests/arrays.rs` and
-/// /// the rest of the files in that directory.
+/// use wiggle::GuestPtr;
 /// wiggle::from_witx!({
-///     witx: ["../tests/arrays.witx"],
-///     ctx: YourCtxType,
+///     witx_literal: "
+///         (typename $errno
+///           (enum (@witx tag u32)
+///             $ok
+///             $invalid_arg
+///             $io
+///             $overflow))
+///          (typename $alias_to_float f32)
+///          (module $example
+///            (@interface func (export \"int_float_args\")
+///              (param $an_int u32)
+///              (param $some_floats (list f32))
+///              (result $r (expected (error $errno))))
+///            (@interface func (export \"double_int_return_float\")
+///              (param $an_int u32)
+///              (result $r (expected $alias_to_float (error $errno)))))
+///     ",
+///     errors: { errno => YourRichError },
+///     async_: { example::double_int_return_float },
 /// });
 ///
-/// /// The `ctx` type for this wiggle invocation.
+/// /// Witx generates a set of traits, which the user must impl on a
+/// /// type they define. We call this the ctx type. It stores any context
+/// /// these functions need to execute.
 /// pub struct YourCtxType {}
 ///
-/// /// `arrays.witx` contains one module called `arrays`. So, we must
-/// /// implement this one method trait for our ctx type:
-/// impl arrays::Arrays for YourCtxType {
+/// /// Witx provides a hook to translate "rich" (arbitrary Rust type) errors
+/// /// into the flat error enums used at the WebAssembly interface. You will
+/// /// need to impl the `types::UserErrorConversion` trait to provide a translation
+/// /// from this rich type.
+/// #[derive(Debug)]
+/// pub enum YourRichError {
+///     InvalidArg(String),
+///     Io(std::io::Error),
+///     Overflow,
+///     Trap(String),
+/// }
+///
+/// /// The above witx text contains one module called `$example`. So, we must
+/// /// implement this one method trait for our ctx type.
+/// #[wiggle::async_trait(?Send)]
+/// /// We specified in the `async_` field that `example::double_int_return_float`
+/// /// is an asynchronous method. Therefore, we use the `async_trait` proc macro
+/// /// (re-exported by wiggle from the crate of the same name) to define this
+/// /// trait, so that `double_int_return_float` can be an `async fn`.
+/// impl example::Example for YourCtxType {
 ///     /// The arrays module has two methods, shown here.
 ///     /// Note that the `GuestPtr` type comes from `wiggle`,
 ///     /// whereas the witx-defined types like `Excuse` and `Errno` come
 ///     /// from the `pub mod types` emitted by the `wiggle::from_witx!`
 ///     /// invocation above.
-///     fn reduce_excuses(&self, _a: &GuestPtr<[GuestPtr<types::Excuse>]>)
-///         -> Result<types::Excuse, types::Errno> {
+///     fn int_float_args(&self, _int: u32, _floats: &GuestPtr<[f32]>)
+///         -> Result<(), YourRichError> {
 ///         unimplemented!()
 ///     }
-///     fn populate_excuses(&self, _a: &GuestPtr<[GuestPtr<types::Excuse>]>)
-///         -> Result<(), types::Errno> {
-///         unimplemented!()
+///     async fn double_int_return_float(&self, int: u32)
+///         -> Result<f32, YourRichError> {
+///         Ok(int.checked_mul(2).ok_or(YourRichError::Overflow)? as f32)
 ///     }
 /// }
 ///
-/// /// For all types used in the `Error` position of a `Result` in the module
-/// /// traits, you must implement `GuestErrorType` which tells wiggle-generated
+/// /// For all types used in the `error` an `expected` in the witx document,
+/// /// you must implement `GuestErrorType` which tells wiggle-generated
 /// /// code what value to return when the method returns Ok(...).
-/// impl GuestErrorType for types::Errno {
+/// impl wiggle::GuestErrorType for types::Errno {
 ///     fn success() -> Self {
 ///         unimplemented!()
 ///     }
 /// }
 ///
 /// /// The `types::GuestErrorConversion` trait is also generated with a method for
-/// /// each type used in the `Error` position. This trait allows wiggle-generated
+/// /// each type used in the `error` position. This trait allows wiggle-generated
 /// /// code to convert a `wiggle::GuestError` into the right error type. The trait
-/// /// must be implemented for the user's `ctx` type.
+/// /// must be implemented for the user's ctx type.
 ///
 /// impl types::GuestErrorConversion for YourCtxType {
 ///     fn into_errno(&self, _e: wiggle::GuestError) -> types::Errno {
 ///         unimplemented!()
+///     }
+/// }
+///
+/// /// If you specify a `error` mapping to the macro, you must implement the
+/// /// `types::UserErrorConversion` for your ctx type as well. This trait gives
+/// /// you an opportunity to store or log your rich error type, while returning
+/// /// a basic witx enum to the WebAssembly caller. It also gives you the ability
+/// /// to terminate WebAssembly execution by trapping.
+///
+/// impl types::UserErrorConversion for YourCtxType {
+///     fn errno_from_your_rich_error(&self, e: YourRichError)
+///         -> Result<types::Errno, wiggle::Trap>
+///     {
+///         println!("Rich error: {:?}", e);
+///         match e {
+///             YourRichError::InvalidArg{..} => Ok(types::Errno::InvalidArg),
+///             YourRichError::Io{..} => Ok(types::Errno::Io),
+///             YourRichError::Overflow => Ok(types::Errno::Overflow),
+///             YourRichError::Trap(s) => Err(wiggle::Trap::String(s)),
+///         }
 ///     }
 /// }
 ///
@@ -93,10 +152,11 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
     let config = parse_macro_input!(args as wiggle_generate::Config);
 
     let doc = config.load_document();
-    let names = wiggle_generate::Names::new(&config.ctx.name, quote!(wiggle));
+    let names = wiggle_generate::Names::new(quote!(wiggle));
 
-    let error_transform = wiggle_generate::ErrorTransform::new(&config.errors, &doc)
-        .expect("validating error transform");
+    let error_transform =
+        wiggle_generate::CodegenSettings::new(&config.errors, &config.async_, &doc)
+            .expect("validating codegen settings");
 
     let code = wiggle_generate::generate(&doc, &names, &error_transform);
     let metadata = if cfg!(feature = "wiggle_metadata") {

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -35,7 +35,7 @@ use syn::parse_macro_input;
 ///   `{ errno => YourErrnoType }`. This allows you to use the `UserErrorConversion`
 ///   trait to map these rich errors into the flat witx type, or to terminate
 ///   WebAssembly execution by trapping.
-/// * Optional: `async_` takes a set of witx modules and functions which are
+/// * Optional: `async` takes a set of witx modules and functions which are
 ///   made Rust `async` functions in the module trait.
 ///
 /// ## Example
@@ -61,7 +61,7 @@ use syn::parse_macro_input;
 ///              (result $r (expected $alias_to_float (error $errno)))))
 ///     ",
 ///     errors: { errno => YourRichError },
-///     async_: { example::double_int_return_float },
+///     async: { example::double_int_return_float },
 /// });
 ///
 /// /// Witx generates a set of traits, which the user must impl on a

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -6,8 +6,10 @@ use std::slice;
 use std::str;
 use std::sync::Arc;
 
-pub use bitflags;
 pub use wiggle_macro::from_witx;
+// re-exports so users of wiggle don't need to track the dependency:
+pub use async_trait::async_trait;
+pub use bitflags;
 
 #[cfg(feature = "wiggle_metadata")]
 pub use witx;

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -24,7 +24,6 @@ witx_literal: "
      (param $s $s)
      (result $err (expected $t (error $errno)))))
     ",
-    ctx: WasiCtx,
     errors: { errno => RichError },
 });
 

--- a/crates/wiggle/tests/atoms_async.rs
+++ b/crates/wiggle/tests/atoms_async.rs
@@ -1,19 +1,29 @@
 use proptest::prelude::*;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use wiggle::GuestMemory;
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    async_: {
+        atoms::{int_float_args, double_int_return_float}
+    }
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);
 
+#[wiggle::async_trait(?Send)]
 impl<'a> atoms::Atoms for WasiCtx<'a> {
-    fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
+    async fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
         println!("INT FLOAT ARGS: {} {}", an_int, an_float);
         Ok(())
     }
-    fn double_int_return_float(&self, an_int: u32) -> Result<types::AliasToFloat, types::Errno> {
+    async fn double_int_return_float(
+        &self,
+        an_int: u32,
+    ) -> Result<types::AliasToFloat, types::Errno> {
         Ok((an_int as f32) * 2.0)
     }
 }
@@ -31,7 +41,12 @@ impl IntFloatExercise {
         let ctx = WasiCtx::new();
         let host_memory = HostMemory::new();
 
-        let e = atoms::int_float_args(&ctx, &host_memory, self.an_int as i32, self.an_float);
+        let e = run(atoms::int_float_args(
+            &ctx,
+            &host_memory,
+            self.an_int as i32,
+            self.an_float,
+        ));
 
         assert_eq!(e, Ok(types::Errno::Ok as i32), "int_float_args error");
     }
@@ -60,12 +75,12 @@ impl DoubleIntExercise {
         let ctx = WasiCtx::new();
         let host_memory = HostMemory::new();
 
-        let e = atoms::double_int_return_float(
+        let e = run(atoms::double_int_return_float(
             &ctx,
             &host_memory,
             self.input as i32,
             self.return_loc.ptr as i32,
-        );
+        ));
 
         let return_val = host_memory
             .ptr::<types::AliasToFloat>(self.return_loc.ptr)
@@ -86,5 +101,39 @@ proptest! {
     #[test]
     fn double_int_return_float(e in DoubleIntExercise::strat()) {
         e.test()
+    }
+}
+
+fn run<F: Future>(future: F) -> F::Output {
+    let mut f = Pin::from(Box::new(future));
+    let waker = dummy_waker();
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match f.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => break val,
+            Poll::Pending => {}
+        }
+    }
+}
+
+fn dummy_waker() -> Waker {
+    return unsafe { Waker::from_raw(clone(5 as *const _)) };
+
+    unsafe fn clone(ptr: *const ()) -> RawWaker {
+        assert_eq!(ptr as usize, 5);
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+        RawWaker::new(ptr, &VTABLE)
+    }
+
+    unsafe fn wake(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn wake_by_ref(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn drop(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
     }
 }

--- a/crates/wiggle/tests/atoms_async.rs
+++ b/crates/wiggle/tests/atoms_async.rs
@@ -7,7 +7,7 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
-    async_: {
+    async: {
         atoms::{int_float_args, double_int_return_float}
     }
 });

--- a/crates/wiggle/tests/errors.rs
+++ b/crates/wiggle/tests/errors.rs
@@ -23,7 +23,6 @@ mod convert_just_errno {
      (param $strike u32)
      (result $err (expected (error $errno)))))
     ",
-        ctx: WasiCtx,
         errors: { errno => RichError },
     });
 
@@ -133,7 +132,6 @@ mod convert_multiple_error_types {
      (param $drink u32)
      (@witx noreturn)))
     ",
-        ctx: WasiCtx,
         errors: { errno => RichError, errno2 => AnotherRichError },
     });
 

--- a/crates/wiggle/tests/flags.rs
+++ b/crates/wiggle/tests/flags.rs
@@ -5,7 +5,6 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/flags.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/handles.rs
+++ b/crates/wiggle/tests/handles.rs
@@ -6,7 +6,6 @@ const FD_VAL: u32 = 123;
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/handles.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/ints.rs
+++ b/crates/wiggle/tests/ints.rs
@@ -5,7 +5,6 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/ints.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/keywords.rs
+++ b/crates/wiggle/tests/keywords.rs
@@ -13,7 +13,6 @@ mod enum_test {
                      $2big
                  )
              )",
-        ctx: DummyCtx,
     });
 }
 
@@ -31,7 +30,6 @@ mod module_trait_fn_and_arg_test {
                      (param $virtual u32)
                  )
              )",
-        ctx: WasiCtx,
     });
     impl<'a> self_::Self_ for WasiCtx<'a> {
         #[allow(unused_variables)]
@@ -51,7 +49,6 @@ mod struct_test {
                      (field $mut s32)
                  )
              )",
-        ctx: DummyCtx,
     });
 }
 
@@ -59,6 +56,5 @@ mod struct_test {
 mod union_test {
     wiggle::from_witx!({
         witx: ["$CARGO_MANIFEST_DIR/tests/keywords_union.witx"],
-        ctx: DummyCtx,
     });
 }

--- a/crates/wiggle/tests/lists.rs
+++ b/crates/wiggle/tests/lists.rs
@@ -4,7 +4,6 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/lists.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/pointers.rs
+++ b/crates/wiggle/tests/pointers.rs
@@ -4,7 +4,6 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/pointers.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/records.rs
+++ b/crates/wiggle/tests/records.rs
@@ -4,7 +4,6 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/records.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/strings.rs
+++ b/crates/wiggle/tests/strings.rs
@@ -4,7 +4,6 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/strings.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/variant.rs
+++ b/crates/wiggle/tests/variant.rs
@@ -4,7 +4,6 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/variant.witx"],
-    ctx: WasiCtx,
 });
 
 impl_errno!(types::Errno, types::GuestErrorConversion);

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -8,7 +8,6 @@ use wiggle_test::WasiCtx;
 
 wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/wasi.witx"],
-    ctx: WasiCtx,
 });
 
 // The only test in this file is to verify that the witx document provided by the

--- a/crates/wiggle/wasmtime/Cargo.toml
+++ b/crates/wiggle/wasmtime/Cargo.toml
@@ -17,10 +17,22 @@ witx = { version = "0.9", path = "../../wasi-common/WASI/tools/witx", optional =
 wiggle = { path = "..", version = "0.23.0" }
 wiggle-borrow = { path = "../borrow", version = "0.23.0" }
 
+[dev-dependencies]
+anyhow = "1"
+proptest = "0.10"
+
+[[test]]
+name = "atoms_async"
+path = "tests/atoms_async.rs"
+required-features = ["async", "wasmtime/wat"]
+
 [badges]
 maintenance = { status = "actively-developed" }
 
 [features]
+# Async support for wasmtime
+async = [ 'wasmtime/async', 'wasmtime-wiggle-macro/async' ]
+
 # The wiggle proc-macro emits some code (inside `pub mod metadata`) guarded
 # by the `wiggle_metadata` feature flag. We use this feature flag so that
 # users of wiggle are not forced to take a direct dependency on the `witx`
@@ -33,4 +45,4 @@ wiggle_metadata = ['witx', "wiggle/wiggle_metadata"]
 # the logs out of wiggle-generated libraries.
 tracing_log = [ "wiggle/tracing_log" ]
 
-default = ["wiggle_metadata" ]
+default = ["wiggle_metadata", "async"]

--- a/crates/wiggle/wasmtime/macro/Cargo.toml
+++ b/crates/wiggle/wasmtime/macro/Cargo.toml
@@ -24,3 +24,6 @@ proc-macro2 = "1.0"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+async = []
+default = []

--- a/crates/wiggle/wasmtime/macro/src/config.rs
+++ b/crates/wiggle/wasmtime/macro/src/config.rs
@@ -39,7 +39,6 @@ mod kw {
     syn::custom_keyword!(name);
     syn::custom_keyword!(docs);
     syn::custom_keyword!(function_override);
-    syn::custom_keyword!(async_);
 }
 
 impl Parse for ConfigField {
@@ -65,8 +64,8 @@ impl Parse for ConfigField {
             input.parse::<kw::modules>()?;
             input.parse::<Token![:]>()?;
             Ok(ConfigField::Modules(input.parse()?))
-        } else if lookahead.peek(kw::async_) {
-            input.parse::<kw::async_>()?;
+        } else if lookahead.peek(Token![async]) {
+            input.parse::<Token![async]>()?;
             input.parse::<Token![:]>()?;
             #[cfg(feature = "async")]
             {
@@ -76,7 +75,7 @@ impl Parse for ConfigField {
             {
                 Err(syn::Error::new(
                     input.span(),
-                    "async_ not supported, enable cargo feature \"async\"",
+                    "async not supported, enable cargo feature \"async\"",
                 ))
             }
         } else {
@@ -122,7 +121,7 @@ impl Config {
                 #[cfg(feature = "async")]
                 ConfigField::Async(c) => {
                     if async_.is_some() {
-                        return Err(Error::new(err_loc, "duplicate `async_` field"));
+                        return Err(Error::new(err_loc, "duplicate `async` field"));
                     }
                     async_ = Some(c);
                 }

--- a/crates/wiggle/wasmtime/tests/atoms.witx
+++ b/crates/wiggle/wasmtime/tests/atoms.witx
@@ -1,0 +1,25 @@
+
+(typename $errno
+    (enum (@witx tag u32)
+        ;;; Success
+        $ok
+        ;;; Invalid argument
+        $invalid_arg
+        ;;; I really don't want to
+        $dont_want_to
+        ;;; I am physically unable to
+        $physically_unable
+        ;;; Well, that's a picket line alright!
+        $picket_line))
+
+(typename $alias_to_float f32)
+
+(module $atoms
+  (@interface func (export "int_float_args")
+    (param $an_int u32)
+    (param $an_float f32)
+    (result $error (expected (error $errno))))
+  (@interface func (export "double_int_return_float")
+    (param $an_int u32)
+    (result $error (expected $alias_to_float (error $errno))))
+)

--- a/crates/wiggle/wasmtime/tests/atoms_async.rs
+++ b/crates/wiggle/wasmtime/tests/atoms_async.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 wasmtime_wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
-    async_: {
+    async: {
         atoms::{double_int_return_float}
     }
 });
@@ -16,7 +16,7 @@ wasmtime_wiggle::wasmtime_integration!({
     witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
     ctx: Ctx,
     modules: { atoms => { name: Atoms } },
-    async_: {
+    async: {
         atoms::double_int_return_float
     }
 });

--- a/crates/wiggle/wasmtime/tests/atoms_async.rs
+++ b/crates/wiggle/wasmtime/tests/atoms_async.rs
@@ -1,0 +1,175 @@
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+wasmtime_wiggle::from_witx!({
+    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    async_: {
+        atoms::{double_int_return_float}
+    }
+});
+
+wasmtime_wiggle::wasmtime_integration!({
+    target: crate,
+    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    ctx: Ctx,
+    modules: { atoms => { name: Atoms } },
+    async_: {
+        atoms::double_int_return_float
+    }
+});
+
+pub struct Ctx;
+impl wiggle::GuestErrorType for types::Errno {
+    fn success() -> Self {
+        types::Errno::Ok
+    }
+}
+
+#[wasmtime_wiggle::async_trait(?Send)]
+impl atoms::Atoms for Ctx {
+    fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
+        println!("INT FLOAT ARGS: {} {}", an_int, an_float);
+        Ok(())
+    }
+    async fn double_int_return_float(
+        &self,
+        an_int: u32,
+    ) -> Result<types::AliasToFloat, types::Errno> {
+        Ok((an_int as f32) * 2.0)
+    }
+}
+
+#[test]
+fn test_sync_host_func() {
+    let store = async_store();
+
+    let ctx = Rc::new(RefCell::new(Ctx));
+    let atoms = Atoms::new(&store, ctx.clone());
+
+    let shim_mod = shim_module(&store);
+    let mut linker = wasmtime::Linker::new(&store);
+    atoms.add_to_linker(&mut linker).unwrap();
+    let shim_inst = run(linker.instantiate_async(&shim_mod)).unwrap();
+
+    let results = run(shim_inst
+        .get_func("int_float_args_shim")
+        .unwrap()
+        .call_async(&[0i32.into(), 123.45f32.into()]))
+    .unwrap();
+
+    assert_eq!(results.len(), 1, "one return value");
+    assert_eq!(
+        results[0].unwrap_i32(),
+        types::Errno::Ok as i32,
+        "int_float_args errno"
+    );
+}
+
+#[test]
+fn test_async_host_func() {
+    let store = async_store();
+
+    let ctx = Rc::new(RefCell::new(Ctx));
+    let atoms = Atoms::new(&store, ctx.clone());
+
+    let shim_mod = shim_module(&store);
+    let mut linker = wasmtime::Linker::new(&store);
+    atoms.add_to_linker(&mut linker).unwrap();
+    let shim_inst = run(linker.instantiate_async(&shim_mod)).unwrap();
+
+    let input: i32 = 123;
+    let result_location: i32 = 0;
+
+    let results = run(shim_inst
+        .get_func("double_int_return_float_shim")
+        .unwrap()
+        .call_async(&[input.into(), result_location.into()]))
+    .unwrap();
+
+    assert_eq!(results.len(), 1, "one return value");
+    assert_eq!(
+        results[0].unwrap_i32(),
+        types::Errno::Ok as i32,
+        "double_int_return_float errno"
+    );
+
+    // The actual result is in memory:
+    let mem = shim_inst.get_memory("memory").unwrap();
+    let mut result_bytes: [u8; 4] = [0, 0, 0, 0];
+    mem.read(result_location as usize, &mut result_bytes)
+        .unwrap();
+    let result = f32::from_le_bytes(result_bytes);
+    assert_eq!((input * 2) as f32, result);
+}
+
+fn run<F: Future>(future: F) -> F::Output {
+    let mut f = Pin::from(Box::new(future));
+    let waker = dummy_waker();
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match f.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => break val,
+            Poll::Pending => {}
+        }
+    }
+}
+
+fn dummy_waker() -> Waker {
+    return unsafe { Waker::from_raw(clone(5 as *const _)) };
+
+    unsafe fn clone(ptr: *const ()) -> RawWaker {
+        assert_eq!(ptr as usize, 5);
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+        RawWaker::new(ptr, &VTABLE)
+    }
+
+    unsafe fn wake(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn wake_by_ref(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn drop(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+}
+fn async_store() -> wasmtime::Store {
+    let engine = wasmtime::Engine::default();
+    wasmtime::Store::new_async(&engine)
+}
+
+// Wiggle expects the caller to have an exported memory. Wasmtime can only
+// provide this if the caller is a WebAssembly module, so we need to write
+// a shim module:
+fn shim_module(store: &wasmtime::Store) -> wasmtime::Module {
+    wasmtime::Module::new(
+        store.engine(),
+        r#"
+        (module
+            (memory 1)
+            (export "memory" (memory 0))
+            (import "atoms" "int_float_args" (func $int_float_args (param i32 f32) (result i32)))
+            (import "atoms" "double_int_return_float" (func $double_int_return_float (param i32 i32) (result i32)))
+
+            (func $int_float_args_shim (param i32 f32) (result i32)
+                local.get 0
+                local.get 1
+                call $int_float_args
+            )
+            (func $double_int_return_float_shim (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                call $double_int_return_float
+            )
+            (export "int_float_args_shim" (func $int_float_args_shim))
+            (export "double_int_return_float_shim" (func $double_int_return_float_shim))
+        )
+    "#,
+    )
+    .unwrap()
+}


### PR DESCRIPTION
Following #2434, wiggle now supports async functions. Users of the wiggle macro can specify which functions should be async with a new `async_` section of the settings.

The new integration test of wasmtime-wiggle shows async support working end-to-end: https://github.com/bytecodealliance/wasmtime/pull/2701/files#diff-9b1eee5f3bd355b0c43aa2ec5d647ddcc085d50f81324540cdbbce39ca6de21b

I rewrote a bunch of the doc test to document the new functionality, plus other earlier changes that had been left out: https://github.com/bytecodealliance/wasmtime/blob/1e4cde62ab510f6c5b551ab73203b48bff707635/crates/wiggle/macro/src/lib.rs

During this work I realized that the wiggle::from_witx macro did not need to take the user's so-called `ctx` type as an argument to the macro. Instead, all code generated by `wiggle` is generic - it will accept any type which implements the required traits. (Async lifetime issues meant it was easier to make this particular type generic rather than concrete, because lifetime parameters can't be elided in some async fn contexts.) The `wasmtime-wiggle` integration does still require the user to specify a concrete ctx type. 

Over in `crates/wasmtime`, I added a missing function `Linker::instantiate_async`, for use with async stores.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
