### PR TITLE
Document the `-Wl,--stack-first` option to clang.

### DIFF
--- a/docs/wasm-c.md
+++ b/docs/wasm-c.md
@@ -12,4 +12,12 @@ that provide builds of Clang and sysroot libraries.
 WASI doesn't yet support `setjmp`/`longjmp` or C++ exceptions, as it is
 waiting for [unwinding support in WebAssembly].
 
+By default, the C/C++ toolchain orders linear memory to put the globals first,
+the stack second, and start the heap after that. This reduces code size,
+because references to globals can use small offsets. However, it also means
+that stack overflow will often lead to corrupted globals. The
+`-Wl,--stack-first` flag to clang instructs it to put the stack first, followed
+by the globals and the heap, which may produce slightly larger code, but will
+more reliably trap on stack overflow.
+
 [unwinding support in WebAssembly]: https://github.com/WebAssembly/exception-handling/

--- a/docs/wasm-c.md
+++ b/docs/wasm-c.md
@@ -20,4 +20,9 @@ that stack overflow will often lead to corrupted globals. The
 by the globals and the heap, which may produce slightly larger code, but will
 more reliably trap on stack overflow.
 
+See the [wasm-ld documentation] for more information and additional flags. Note
+flags related to dynamic linking, such `-shared` and `--export-dynamic` are
+not yet stable and are expected to change behavior in the future.
+
 [unwinding support in WebAssembly]: https://github.com/WebAssembly/exception-handling/
+[wasm-ld documentation]: https://lld.llvm.org/WebAssembly.html


### PR DESCRIPTION
As discussed in WebAssembly/wasi-libc#233, document the
`-Wl,--stack-first` option to help users diagnose stack overflow errors.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
