### PR TITLE
Wasmtime 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -504,14 +504,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -544,14 +544,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "serde",
 ]
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen",
  "hashbrown",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen",
  "target-lexicon",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-preopt"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen",
  "smallvec",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1446,7 +1446,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "lightbeam"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -1773,7 +1773,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "peepmatic"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "peepmatic-automata",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "peepmatic-automata"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "serde",
 ]
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "peepmatic-macro"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "peepmatic-runtime"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "bincode",
  "bumpalo",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "peepmatic-souper"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "log",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "peepmatic-test-operator"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "peepmatic-traits",
  "serde",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "peepmatic-traits"
-version = "0.70.0"
+version = "0.71.0"
 
 [[package]]
 name = "pem"
@@ -2964,7 +2964,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-lightbeam"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cranelift-codegen",
  "lightbeam",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "more-asserts",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rust-macro"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "wasi-common",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-crypto"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "wasi-crypto",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "log",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "wasmtime",
  "wasmtime-wiggle-macro",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle-macro"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bitflags",
  "proptest",
@@ -3542,14 +3542,14 @@ dependencies = [
 
 [[package]]
 name = "wiggle-borrow"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "wiggle",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "heck",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Command-line interface for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -22,18 +22,18 @@ doc = false
 
 [dependencies]
 # Enable all supported architectures by default.
-wasmtime = { path = "crates/wasmtime", version = "0.23.0", default-features = false, features = ['cache'] }
-wasmtime-cache = { path = "crates/cache", version = "0.23.0" }
-wasmtime-debug = { path = "crates/debug", version = "0.23.0" }
-wasmtime-environ = { path = "crates/environ", version = "0.23.0" }
-wasmtime-jit = { path = "crates/jit", version = "0.23.0" }
-wasmtime-obj = { path = "crates/obj", version = "0.23.0" }
-wasmtime-wast = { path = "crates/wast", version = "0.23.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "0.23.0" }
-wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "0.23.0", optional = true }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.23.0", optional = true }
-wasi-common = { path = "crates/wasi-common", version = "0.23.0" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "0.23.0" }
+wasmtime = { path = "crates/wasmtime", version = "0.24.0", default-features = false, features = ['cache'] }
+wasmtime-cache = { path = "crates/cache", version = "0.24.0" }
+wasmtime-debug = { path = "crates/debug", version = "0.24.0" }
+wasmtime-environ = { path = "crates/environ", version = "0.24.0" }
+wasmtime-jit = { path = "crates/jit", version = "0.24.0" }
+wasmtime-obj = { path = "crates/obj", version = "0.24.0" }
+wasmtime-wast = { path = "crates/wast", version = "0.24.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "0.24.0" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "0.24.0", optional = true }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.24.0", optional = true }
+wasi-common = { path = "crates/wasi-common", version = "0.24.0" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "0.24.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
 object = { version = "0.23.0", default-features = false, features = ["write"] }
 anyhow = "1.0.19"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,24 @@
 
 --------------------------------------------------------------------------------
 
+## 0.24.0
+
+### Added
+
+* Implement support for `async` functions in Wasmtime
+  [#2434](https://github.com/bytecodealliance/wasmtime/pull/2434)
+
+### Fixed
+
+* Fix preservation of the sigaltstack on macOS
+  [#2676](https://github.com/bytecodealliance/wasmtime/pull/2676)
+* Fix incorrect semver dependencies involving fs-set-times.
+  [#2705](https://github.com/bytecodealliance/wasmtime/pull/2705)
+* Fix some `i128` shift-related bugs in x64 backend.
+  [#2682](https://github.com/bytecodealliance/wasmtime/pull/2682)
+* Fix incomplete trap metadata due to multiple traps at one address
+  [#2685](https://github.com/bytecodealliance/wasmtime/pull/2685)
+
 ## 0.23.0
 
 Released 2021-02-16.

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -15,27 +15,27 @@ path = "src/clif-util.rs"
 
 [dependencies]
 cfg-if = "1.0"
-cranelift-codegen = { path = "codegen", version = "0.70.0" }
-cranelift-entity = { path = "entity", version = "0.70.0" }
-cranelift-interpreter = { path = "interpreter", version = "0.70.0" }
-cranelift-reader = { path = "reader", version = "0.70.0" }
-cranelift-frontend = { path = "frontend", version = "0.70.0" }
-cranelift-serde = { path = "serde", version = "0.70.0", optional = true }
-cranelift-wasm = { path = "wasm", version = "0.70.0", optional = true }
-cranelift-native = { path = "native", version = "0.70.0" }
+cranelift-codegen = { path = "codegen", version = "0.71.0" }
+cranelift-entity = { path = "entity", version = "0.71.0" }
+cranelift-interpreter = { path = "interpreter", version = "0.71.0" }
+cranelift-reader = { path = "reader", version = "0.71.0" }
+cranelift-frontend = { path = "frontend", version = "0.71.0" }
+cranelift-serde = { path = "serde", version = "0.71.0", optional = true }
+cranelift-wasm = { path = "wasm", version = "0.71.0", optional = true }
+cranelift-native = { path = "native", version = "0.71.0" }
 cranelift-filetests = { path = "filetests", version = "0.66.0" }
-cranelift-module = { path = "module", version = "0.70.0" }
-cranelift-object = { path = "object", version = "0.70.0" }
-cranelift-jit = { path = "jit", version = "0.70.0" }
-cranelift-preopt = { path = "preopt", version = "0.70.0" }
-cranelift = { path = "umbrella", version = "0.70.0" }
+cranelift-module = { path = "module", version = "0.71.0" }
+cranelift-object = { path = "object", version = "0.71.0" }
+cranelift-jit = { path = "jit", version = "0.71.0" }
+cranelift-preopt = { path = "preopt", version = "0.71.0" }
+cranelift = { path = "umbrella", version = "0.71.0" }
 filecheck = "0.5.0"
 log = "0.4.8"
 termcolor = "1.1.2"
 capstone = { version = "0.7.0", optional = true }
 wat = { version = "1.0.36", optional = true }
 target-lexicon = { version = "0.11", features = ["std"] }
-peepmatic-souper = { path = "./peepmatic/crates/souper", version = "0.70.0", optional = true }
+peepmatic-souper = { path = "./peepmatic/crates/souper", version = "0.71.0", optional = true }
 pretty_env_logger = "0.4.0"
 rayon = { version = "1", optional = true }
 file-per-thread-logger = "0.1.2"

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.70.0"
+version = "0.71.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"
@@ -12,7 +12,7 @@ keywords = ["btree", "forest", "set", "map"]
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../entity", version = "0.70.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.71.0", default-features = false }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.70.0"
+version = "0.71.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -13,9 +13,9 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen-shared = { path = "./shared", version = "0.70.0" }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
-cranelift-bforest = { path = "../bforest", version = "0.70.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.71.0" }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
+cranelift-bforest = { path = "../bforest", version = "0.71.0" }
 hashbrown = { version = "0.9.1", optional = true }
 target-lexicon = "0.11"
 log = { version = "0.4.6", default-features = false }
@@ -25,9 +25,9 @@ gimli = { version = "0.23.0", default-features = false, features = ["write"], op
 smallvec = { version = "1.6.1" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }
-peepmatic = { path = "../peepmatic", optional = true, version = "0.70.0" }
-peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, version = "0.70.0" }
-peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.70.0" }
+peepmatic = { path = "../peepmatic", optional = true, version = "0.71.0" }
+peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, version = "0.71.0" }
+peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.71.0" }
 regalloc = { version = "0.0.31" }
 souper-ir = { version = "2.1.0", optional = true }
 wast = { version = "35.0.0", optional = true }
@@ -37,7 +37,7 @@ wast = { version = "35.0.0", optional = true }
 # accomodated in `tests`.
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.70.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.71.0" }
 
 [features]
 default = ["std", "unwind"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.70.0"
+version = "0.71.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -12,8 +12,8 @@ edition = "2018"
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.70.0" }
-cranelift-entity = { path = "../../entity", version = "0.70.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.71.0" }
+cranelift-entity = { path = "../../entity", version = "0.71.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.70.0"
+version = "0.71.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.70.0"
+version = "0.71.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -10,12 +10,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0", features = ["testing_hooks"] }
-cranelift-frontend = { path = "../frontend", version = "0.70.0" }
-cranelift-interpreter = { path = "../interpreter", version = "0.70.0" }
-cranelift-native = { path = "../native", version = "0.70.0" }
-cranelift-reader = { path = "../reader", version = "0.70.0" }
-cranelift-preopt = { path = "../preopt", version = "0.70.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", features = ["testing_hooks"] }
+cranelift-frontend = { path = "../frontend", version = "0.71.0" }
+cranelift-interpreter = { path = "../interpreter", version = "0.71.0" }
+cranelift-native = { path = "../native", version = "0.71.0" }
+cranelift-reader = { path = "../reader", version = "0.71.0" }
+cranelift-preopt = { path = "../preopt", version = "0.71.0" }
 byteorder = { version = "1.3.2", default-features = false }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.70.0"
+version = "0.71.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false }
 target-lexicon = "0.11"
 log = { version = "0.4.6", default-features = false }
 hashbrown = { version = "0.9.1", optional = true }

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -11,15 +11,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0", features = ["all-arch"] }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
-cranelift-reader = { path = "../reader", version = "0.70.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", features = ["all-arch"] }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
+cranelift-reader = { path = "../reader", version = "0.71.0" }
 log = { version = "0.4.8", default-features = false }
 smallvec = "1.6.1"
 thiserror = "1.0.15"
 
 [dev-dependencies]
-cranelift-frontend = { path = "../frontend", version = "0.70.0" }
+cranelift-frontend = { path = "../frontend", version = "0.71.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -10,10 +10,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../module", version = "0.70.0" }
-cranelift-native = { path = "../native", version = "0.70.0" }
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false, features = ["std"] }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
+cranelift-module = { path = "../module", version = "0.71.0" }
+cranelift-native = { path = "../native", version = "0.71.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false, features = ["std"] }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
 anyhow = "1.0"
 region = "2.2.0"
 libc = { version = "0.2.42" }
@@ -30,9 +30,9 @@ selinux-fix = ['memmap2']
 default = []
 
 [dev-dependencies]
-cranelift = { path = "../umbrella", version = "0.70.0" }
-cranelift-frontend = { path = "../frontend", version = "0.70.0" }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
+cranelift = { path = "../umbrella", version = "0.71.0" }
+cranelift-frontend = { path = "../frontend", version = "0.71.0" }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
 hashbrown = { version = "0.9.1", optional = true }
 log = { version = "0.4.6", default-features = false }
 thiserror = "1.0.4"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false }
 target-lexicon = "0.11"
 
 [features]

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -10,16 +10,16 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-module = { path = "../module", version = "0.70.0" }
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false, features = ["std"] }
+cranelift-module = { path = "../module", version = "0.71.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false, features = ["std"] }
 object = { version = "0.23.0", default-features = false, features = ["write"] }
 target-lexicon = "0.11"
 anyhow = "1.0"
 log = { version = "0.4.6", default-features = false }
 
 [dev-dependencies]
-cranelift-frontend = { path = "../frontend", version = "0.70.0" }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
+cranelift-frontend = { path = "../frontend", version = "0.71.0" }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/peepmatic/Cargo.toml
+++ b/cranelift/peepmatic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peepmatic"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -10,13 +10,13 @@ description = "DSL and compiler for generating peephole optimizers"
 
 [dependencies]
 anyhow = "1.0.27"
-peepmatic-automata = { version = "0.70.0", path = "crates/automata", features = ["dot"] }
-peepmatic-macro = { version = "0.70.0", path = "crates/macro" }
-peepmatic-runtime = { version = "0.70.0", path = "crates/runtime", features = ["construct"] }
-peepmatic-traits = { version = "0.70.0", path = "crates/traits" }
+peepmatic-automata = { version = "0.71.0", path = "crates/automata", features = ["dot"] }
+peepmatic-macro = { version = "0.71.0", path = "crates/macro" }
+peepmatic-runtime = { version = "0.71.0", path = "crates/runtime", features = ["construct"] }
+peepmatic-traits = { version = "0.71.0", path = "crates/traits" }
 serde = { version = "1.0.105", features = ["derive"] }
 wast = "35.0.0"
 z3 = { version = "0.7.1", features = ["static-link-z3"] }
 
 [dev-dependencies]
-peepmatic-test-operator = { version = "0.70.0", path = "crates/test-operator" }
+peepmatic-test-operator = { version = "0.71.0", path = "crates/test-operator" }

--- a/cranelift/peepmatic/crates/automata/Cargo.toml
+++ b/cranelift/peepmatic/crates/automata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peepmatic-automata"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/peepmatic/crates/macro/Cargo.toml
+++ b/cranelift/peepmatic/crates/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peepmatic-macro"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/peepmatic/crates/runtime/Cargo.toml
+++ b/cranelift/peepmatic/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peepmatic-runtime"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,14 +12,14 @@ description = "Runtime support for peepmatic peephole optimizers"
 bincode = "1.2.1"
 bumpalo = "3.2.0"
 log = "0.4.8"
-peepmatic-automata = { version = "0.70.0", path = "../automata", features = ["serde"] }
-peepmatic-traits = { version = "0.70.0", path = "../traits" }
+peepmatic-automata = { version = "0.71.0", path = "../automata", features = ["serde"] }
+peepmatic-traits = { version = "0.71.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
 thiserror = "1.0.15"
 wast = { version = "35.0.0", optional = true }
 
 [dev-dependencies]
-peepmatic-test-operator = { version = "0.70.0", path = "../test-operator" }
+peepmatic-test-operator = { version = "0.71.0", path = "../test-operator" }
 serde_test = "1.0.114"
 
 [features]

--- a/cranelift/peepmatic/crates/souper/Cargo.toml
+++ b/cranelift/peepmatic/crates/souper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peepmatic-souper"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -14,6 +14,6 @@ souper-ir = { version = "2.1.0", features = ["parse"] }
 log = "0.4.8"
 
 [dev-dependencies]
-peepmatic = { path = "../..", version = "0.70.0" }
-peepmatic-test-operator = { version = "0.70.0", path = "../test-operator" }
+peepmatic = { path = "../..", version = "0.71.0" }
+peepmatic-test-operator = { version = "0.71.0", path = "../test-operator" }
 wast = "35.0.0"

--- a/cranelift/peepmatic/crates/test-operator/Cargo.toml
+++ b/cranelift/peepmatic/crates/test-operator/Cargo.toml
@@ -2,13 +2,13 @@
 name = "peepmatic-test-operator"
 description = "Operator for usage in peepmatic tests"
 license = "Apache-2.0 WITH LLVM-exception"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-peepmatic-traits = { version = "0.70.0", path = "../traits" }
+peepmatic-traits = { version = "0.71.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
 wast = "35.0.0"

--- a/cranelift/peepmatic/crates/traits/Cargo.toml
+++ b/cranelift/peepmatic/crates/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peepmatic-traits"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/preopt/Cargo.toml
+++ b/cranelift/preopt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-preopt"
-version = "0.70.0"
+version = "0.71.0"
 description = "Support for optimizations in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-preopt"
@@ -12,8 +12,8 @@ keywords = ["optimize", "compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
 # This is commented out because it doesn't build on Rust 1.25.0, which
 # cranelift currently supports.
 # rustc_apfloat = { version = "0.1.2", default-features = false }

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.70.0"
+version = "0.71.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0" }
 smallvec = "1.6.1"
 target-lexicon = "0.11"
 thiserror = "1.0.15"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -18,8 +18,8 @@ clap = "2.32.0"
 serde = "1.0.8"
 serde_derive = "1.0.75"
 serde_json = "1.0.26"
-cranelift-codegen = { path = "../codegen", version = "0.70.0", features = ["enable-serde"] }
-cranelift-reader = { path = "../reader", version = "0.70.0" }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", features = ["enable-serde"] }
+cranelift-reader = { path = "../reader", version = "0.71.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.70.0"
+version = "0.71.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"
@@ -12,8 +12,8 @@ keywords = ["compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false }
-cranelift-frontend = { path = "../frontend", version = "0.70.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false }
+cranelift-frontend = { path = "../frontend", version = "0.71.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.70.0"
+version = "0.71.0"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"
@@ -13,9 +13,9 @@ edition = "2018"
 
 [dependencies]
 wasmparser = { version = "0.76", default-features = false }
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.70.0" }
-cranelift-frontend = { path = "../frontend", version = "0.70.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.71.0" }
+cranelift-frontend = { path = "../frontend", version = "0.71.0", default-features = false }
 hashbrown = { version = "0.9.1", optional = true }
 itertools = "0.10.0"
 log = { version = "0.4.6", default-features = false }
@@ -27,7 +27,7 @@ thiserror = "1.0.4"
 wat = "1.0.36"
 target-lexicon = "0.11"
 # Enable the riscv feature for cranelift-codegen, as some tests require it
-cranelift-codegen = { path = "../codegen", version = "0.70.0", default-features = false, features = ["riscv"] }
+cranelift-codegen = { path = "../codegen", version = "0.71.0", default-features = false, features = ["riscv"] }
 
 [features]
 default = ["std"]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cache"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Support for automatic module caching with Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cranelift"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Integration between Cranelift and Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-environ = { path = "../environ", version = "0.23.0" }
-cranelift-wasm = { path = "../../cranelift/wasm", version = "0.70.0" }
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.70.0" }
-cranelift-frontend = { path = "../../cranelift/frontend", version = "0.70.0" }
-cranelift-entity = { path = "../../cranelift/entity", version = "0.70.0" }
+wasmtime-environ = { path = "../environ", version = "0.24.0" }
+cranelift-wasm = { path = "../../cranelift/wasm", version = "0.71.0" }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.71.0" }
+cranelift-frontend = { path = "../../cranelift/frontend", version = "0.71.0" }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.71.0" }
 wasmparser = "0.76.0"

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-debug"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Debug utils for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,7 +15,7 @@ edition = "2018"
 gimli = "0.23.0"
 wasmparser = "0.76"
 object = { version = "0.23.0", default-features = false, features = ["read_core", "elf", "write"] }
-wasmtime-environ = { path = "../environ", version = "0.23.0" }
+wasmtime-environ = { path = "../environ", version = "0.24.0" }
 target-lexicon = { version = "0.11.0", default-features = false }
 anyhow = "1.0"
 thiserror = "1.0.4"

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-environ"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Standalone environment support for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,9 +13,9 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.70.0", features = ["enable-serde"] }
-cranelift-entity = { path = "../../cranelift/entity", version = "0.70.0", features = ["enable-serde"] }
-cranelift-wasm = { path = "../../cranelift/wasm", version = "0.70.0", features = ["enable-serde"] }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.71.0", features = ["enable-serde"] }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.71.0", features = ["enable-serde"] }
+cranelift-wasm = { path = "../../cranelift/wasm", version = "0.71.0", features = ["enable-serde"] }
 wasmparser = "0.76"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-fiber"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Fiber support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT-style execution for WebAsssembly code in Cranelift"
 documentation = "https://docs.rs/wasmtime-jit"
@@ -12,18 +12,18 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.70.0", features = ["enable-serde"] }
-cranelift-entity = { path = "../../cranelift/entity", version = "0.70.0", features = ["enable-serde"] }
-cranelift-wasm = { path = "../../cranelift/wasm", version = "0.70.0", features = ["enable-serde"] }
-cranelift-native = { path = "../../cranelift/native", version = "0.70.0" }
-cranelift-frontend = { path = "../../cranelift/frontend", version = "0.70.0" }
-wasmtime-environ = { path = "../environ", version = "0.23.0" }
-wasmtime-runtime = { path = "../runtime", version = "0.23.0" }
-wasmtime-cranelift = { path = "../cranelift", version = "0.23.0" }
-wasmtime-lightbeam = { path = "../lightbeam/wasmtime", version = "0.23.0", optional = true }
-wasmtime-debug = { path = "../debug", version = "0.23.0" }
-wasmtime-profiling = { path = "../profiling", version = "0.23.0" }
-wasmtime-obj = { path = "../obj", version = "0.23.0" }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.71.0", features = ["enable-serde"] }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.71.0", features = ["enable-serde"] }
+cranelift-wasm = { path = "../../cranelift/wasm", version = "0.71.0", features = ["enable-serde"] }
+cranelift-native = { path = "../../cranelift/native", version = "0.71.0" }
+cranelift-frontend = { path = "../../cranelift/frontend", version = "0.71.0" }
+wasmtime-environ = { path = "../environ", version = "0.24.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.24.0" }
+wasmtime-cranelift = { path = "../cranelift", version = "0.24.0" }
+wasmtime-lightbeam = { path = "../lightbeam/wasmtime", version = "0.24.0", optional = true }
+wasmtime-debug = { path = "../debug", version = "0.24.0" }
+wasmtime-profiling = { path = "../profiling", version = "0.24.0" }
+wasmtime-obj = { path = "../obj", version = "0.24.0" }
 rayon = { version = "1.0", optional = true }
 region = "2.1.0"
 thiserror = "1.0.4"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightbeam"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Lightbeam Project Developers"]
 description = "An optimising one-pass streaming compiler for WebAssembly"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 arrayvec = "0.5"
 capstone = "0.7.0"
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.70.0" }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.71.0" }
 derive_more = "0.99"
 dynasm = "1.0.0"
 dynasmrt = "1.0.0"

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-lightbeam"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Integration between Lightbeam and Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-lightbeam = { path = "..", version = "0.23.0" }
+lightbeam = { path = "..", version = "0.24.0" }
 wasmparser = "0.76"
-cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.70.0" }
-wasmtime-environ = { path = "../../environ", version = "0.23.0" }
+cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.71.0" }
+wasmtime-environ = { path = "../../environ", version = "0.24.0" }

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Rust extension for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -15,9 +15,9 @@ test = false
 doctest = false
 
 [dependencies]
-wasmtime-rust-macro = { path = "./macro", version = "0.23.0" }
-wasmtime-wasi = { path = "../../wasi", version = "0.23.0" }
-wasmtime = { path = "../../wasmtime", version = "0.23.0" }
+wasmtime-rust-macro = { path = "./macro", version = "0.24.0" }
+wasmtime-wasi = { path = "../../wasi", version = "0.24.0" }
+wasmtime = { path = "../../wasmtime", version = "0.24.0" }
 anyhow = "1.0.19"
 
 [badges]

--- a/crates/misc/rust/macro/Cargo.toml
+++ b/crates/misc/rust/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-rust-macro"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Macro support crate for wasmtime-rust"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/obj/Cargo.toml
+++ b/crates/obj/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-obj"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Native object file output for WebAsssembly code in Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,11 +12,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmtime-environ = { path = "../environ", version = "0.23.0" }
+wasmtime-environ = { path = "../environ", version = "0.24.0" }
 object = { version = "0.23.0", default-features = false, features = ["write"] }
 more-asserts = "0.2.1"
 target-lexicon = { version = "0.11.0", default-features = false }
-wasmtime-debug = { path = "../debug", version = "0.23.0" }
+wasmtime-debug = { path = "../debug", version = "0.24.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-profiling"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -19,8 +19,8 @@ libc = { version = "0.2.60", default-features = false }
 scroll = { version = "0.10.1", features = ["derive"], optional = true }
 serde = { version = "1.0.99", features = ["derive"] }
 target-lexicon = "0.11.0"
-wasmtime-environ = { path = "../environ", version = "0.23.0" }
-wasmtime-runtime = { path = "../runtime", version = "0.23.0" }
+wasmtime-environ = { path = "../environ", version = "0.24.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.24.0" }
 ittapi-rs = { version = "0.1.5", optional = true }
 
 [dependencies.object]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-runtime"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 documentation = "https://docs.rs/wasmtime-runtime"
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmtime-environ = { path = "../environ", version = "0.23.0" }
+wasmtime-environ = { path = "../environ", version = "0.24.0" }
 region = "2.1.0"
 libc = { version = "0.2.82", default-features = false }
 log = "0.4.8"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -11,10 +11,10 @@ license = "Apache-2.0 WITH LLVM-exception"
 cfg-if = "1.0"
 
 [dev-dependencies]
-wasi-common = { path = "../wasi-common", version = "0.23.0" }
-wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "0.23.0" }
-wasmtime = { path = "../wasmtime", version = "0.23.0" }
-wasmtime-wasi = { path = "../wasi", version = "0.23.0" }
+wasi-common = { path = "../wasi-common", version = "0.24.0" }
+wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "0.24.0" }
+wasmtime = { path = "../wasmtime", version = "0.24.0" }
+wasmtime-wasi = { path = "../wasi", version = "0.24.0" }
 target-lexicon = "0.11.0"
 pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -20,7 +20,7 @@ links = "wasi-common-19"
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0"
-wiggle = { path = "../wiggle", default-features = false, version = "0.23.0" }
+wiggle = { path = "../wiggle", default-features = false, version = "0.24.0" }
 tracing = "0.1.19"
 cap-std = "0.13"
 cap-rand = "0.13"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-cap-std-sync"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2018"
 include = ["src/**/*", "LICENSE" ]
 
 [dependencies]
-wasi-common = { path = "../", version = "0.23.0" }
+wasi-common = { path = "../", version = "0.24.0" }
 anyhow = "1.0"
 cap-std = "0.13.7"
 cap-fs-ext = "0.13.7"

--- a/crates/wasi-crypto/Cargo.toml
+++ b/crates/wasi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-crypto"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Wasmtime implementation of the wasi-crypto API"
 documentation = "https://docs.rs/wasmtime-wasi-crypto"
@@ -14,9 +14,9 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 wasi-crypto = { path = "spec/implementations/hostcalls/rust", version = "0.1.4" }
-wasmtime = { path = "../wasmtime", version = "0.23.0", default-features = false }
-wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.23.0" }
-wiggle = { path = "../wiggle", version = "0.23.0" }
+wasmtime = { path = "../wasmtime", version = "0.24.0", default-features = false }
+wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.24.0" }
+wiggle = { path = "../wiggle", version = "0.24.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-nn"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Wasmtime implementation of the wasi-nn API"
 documentation = "https://docs.rs/wasmtime-wasi-nn"
@@ -15,11 +15,11 @@ edition = "2018"
 # These dependencies are necessary for the witx-generation macros to work:
 anyhow = "1.0"
 log = { version = "0.4", default-features = false }
-wasmtime = { path = "../wasmtime", version = "0.23.0", default-features = false }
-wasmtime-runtime = { path = "../runtime", version = "0.23.0" }
-wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.23.0" }
-wasmtime-wasi = { path = "../wasi", version = "0.23.0" }
-wiggle = { path = "../wiggle", version = "0.23.0" }
+wasmtime = { path = "../wasmtime", version = "0.24.0", default-features = false }
+wasmtime-runtime = { path = "../runtime", version = "0.24.0" }
+wasmtime-wiggle = { path = "../wiggle/wasmtime", version = "0.24.0" }
+wasmtime-wasi = { path = "../wasi", version = "0.24.0" }
+wiggle = { path = "../wiggle", version = "0.24.0" }
 
 # These dependencies are necessary for the wasi-nn implementation:
 openvino = "0.1.5"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,8 +13,8 @@ include = ["src/**/*", "LICENSE", "build.rs"]
 build = "build.rs"
 
 [dependencies]
-wasi-common = { path = "../wasi-common", version = "0.23.0" }
-wiggle = { path = "../wiggle", default-features = false, version = "0.23.0" }
-wasmtime-wiggle = { path = "../wiggle/wasmtime", default-features = false, version = "0.23.0" }
-wasmtime = { path = "../wasmtime", default-features = false, version = "0.23.0" }
+wasi-common = { path = "../wasi-common", version = "0.24.0" }
+wiggle = { path = "../wiggle", default-features = false, version = "0.24.0" }
+wasmtime-wiggle = { path = "../wiggle/wasmtime", default-features = false, version = "0.24.0" }
+wasmtime = { path = "../wasmtime", default-features = false, version = "0.24.0" }
 anyhow = "1.0"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "High-level API to expose the Wasmtime runtime"
 documentation = "https://docs.rs/wasmtime"
@@ -13,12 +13,12 @@ edition = "2018"
 rustdoc-args = ["--cfg", "nightlydoc"]
 
 [dependencies]
-wasmtime-runtime = { path = "../runtime", version = "0.23.0" }
-wasmtime-environ = { path = "../environ", version = "0.23.0" }
-wasmtime-jit = { path = "../jit", version = "0.23.0" }
-wasmtime-cache = { path = "../cache", version = "0.23.0", optional = true }
-wasmtime-profiling = { path = "../profiling", version = "0.23.0" }
-wasmtime-fiber = { path = "../fiber", version = "0.23.0", optional = true }
+wasmtime-runtime = { path = "../runtime", version = "0.24.0" }
+wasmtime-environ = { path = "../environ", version = "0.24.0" }
+wasmtime-jit = { path = "../jit", version = "0.24.0" }
+wasmtime-cache = { path = "../cache", version = "0.24.0", optional = true }
+wasmtime-profiling = { path = "../profiling", version = "0.24.0" }
+wasmtime-fiber = { path = "../fiber", version = "0.24.0", optional = true }
 target-lexicon = { version = "0.11.0", default-features = false }
 wasmparser = "0.76"
 anyhow = "1.0.19"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wast"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["The Wasmtime Project Developers"]
 description = "wast testing support for wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.19"
-wasmtime = { path = "../wasmtime", version = "0.23.0", default-features = false }
+wasmtime = { path = "../wasmtime", version = "0.24.0", default-features = false }
 wast = "35.0.0"
 
 [badges]

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,7 +13,7 @@ include = ["src/**/*", "LICENSE"]
 [dependencies]
 thiserror = "1"
 witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9", optional = true }
-wiggle-macro = { path = "macro", version = "0.23.0" }
+wiggle-macro = { path = "macro", version = "0.24.0" }
 tracing = "0.1.15"
 bitflags = "1.2"
 

--- a/crates/wiggle/borrow/Cargo.toml
+++ b/crates/wiggle/borrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-borrow"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,7 +11,7 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 include = ["src/**/*", "LICENSE"]
 
 [dependencies]
-wiggle = { path = "..", version = "0.23.0" }
+wiggle = { path = "..", version = "0.24.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-generate"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2018"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-macro"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -21,7 +21,7 @@ test = false
 doctest = false
 
 [dependencies]
-wiggle-generate = { path = "../generate", version = "0.23.0" }
+wiggle-generate = { path = "../generate", version = "0.24.0" }
 witx = { version = "0.9", path = "../../wasi-common/WASI/tools/witx" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/crates/wiggle/wasmtime/Cargo.toml
+++ b/crates/wiggle/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wiggle"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,11 +11,11 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 include = ["src/**/*", "LICENSE"]
 
 [dependencies]
-wasmtime = { path = "../../wasmtime", version = "0.23.0", default-features = false }
-wasmtime-wiggle-macro = { path = "./macro", version = "0.23.0" }
+wasmtime = { path = "../../wasmtime", version = "0.24.0", default-features = false }
+wasmtime-wiggle-macro = { path = "./macro", version = "0.24.0" }
 witx = { version = "0.9", path = "../../wasi-common/WASI/tools/witx", optional = true }
-wiggle = { path = "..", version = "0.23.0" }
-wiggle-borrow = { path = "../borrow", version = "0.23.0" }
+wiggle = { path = "..", version = "0.24.0" }
+wiggle-borrow = { path = "../borrow", version = "0.24.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wiggle/wasmtime/macro/Cargo.toml
+++ b/crates/wiggle/wasmtime/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wiggle-macro"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -16,7 +16,7 @@ test = false
 
 [dependencies]
 witx = { version = "0.9", path = "../../../wasi-common/WASI/tools/witx" }
-wiggle-generate = { path = "../../generate", version = "0.23.0" }
+wiggle-generate = { path = "../../generate", version = "0.24.0" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"]  }
 proc-macro2 = "1.0"


### PR DESCRIPTION
As reported in https://github.com/bytecodealliance/wasmtime/pull/2705, I made some semver-incompatible changes related to fs-set-times without properly bumping semver. This release is prompted by the need to update wasmtime past the problematic version. But this also happens to be a change to release the `async` functions support!