### PR TITLE
[simd] Implement load*_lane and store*_lane

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -192,14 +192,6 @@ fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str
         ("simd", "simd_i32x4_trunc_sat_f64x2") => return true,
         ("simd", "simd_i64x2_extmul_i32x4") => return true,
         ("simd", "simd_int_to_int_extend") => return true,
-        ("simd", "simd_load16_lane") => return true,
-        ("simd", "simd_load32_lane") => return true,
-        ("simd", "simd_load64_lane") => return true,
-        ("simd", "simd_load8_lane") => return true,
-        ("simd", "simd_store16_lane") => return true,
-        ("simd", "simd_store32_lane") => return true,
-        ("simd", "simd_store64_lane") => return true,
-        ("simd", "simd_store8_lane") => return true,
         ("simd", _) => return false,
         _ => {}
     }
@@ -234,15 +226,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             | ("simd", "simd_i32x4_extmul_i16x8")
             | ("simd", "simd_i32x4_trunc_sat_f64x2")
             | ("simd", "simd_i64x2_extmul_i32x4")
-            | ("simd", "simd_int_to_int_extend")
-            | ("simd", "simd_load16_lane")
-            | ("simd", "simd_load32_lane")
-            | ("simd", "simd_load64_lane")
-            | ("simd", "simd_load8_lane")
-            | ("simd", "simd_store16_lane")
-            | ("simd", "simd_store32_lane")
-            | ("simd", "simd_store64_lane")
-            | ("simd", "simd_store8_lane") => return true,
+            | ("simd", "simd_int_to_int_extend") => return true,
 
             // These are only implemented on x64.
             ("simd", "simd_i64x2_arith2") | ("simd", "simd_boolean") => {


### PR DESCRIPTION
The Wasm SIMD specification has added new instructions that allow inserting to the lane of a vector from a memory location, and conversely, extracting from a lane of a vector to a memory location. The simplest implementation lowers these instructions, `load[8|16|32|64]_lane` and `store[8|16|32|64]_lane`, to a sequence of either `load + insertlane` or `extractlane + store` (in CLIF). With the new backend's pattern matching, we expect these CLIF sequences to compile as a single machine instruction (at least in x64).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
