### PR TITLE
wasi-common: Timestamps should be in nanoseconds

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -749,8 +749,8 @@ impl<'a> wasi_unstable::WasiUnstable for WasiCtx {
                 types::SubscriptionU::Clock(clocksub) => match clocksub.id {
                     types::Clockid::Monotonic => {
                         let clock = self.clocks.monotonic.deref();
-                        let precision = Duration::from_micros(clocksub.precision);
-                        let duration = Duration::from_micros(clocksub.timeout);
+                        let precision = Duration::from_nanos(clocksub.precision);
+                        let duration = Duration::from_nanos(clocksub.timeout);
                         let deadline = if clocksub
                             .flags
                             .contains(types::Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME)

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -920,8 +920,8 @@ impl<'a> wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
                 types::SubscriptionU::Clock(clocksub) => match clocksub.id {
                     types::Clockid::Monotonic => {
                         let clock = self.clocks.monotonic.deref();
-                        let precision = Duration::from_micros(clocksub.precision);
-                        let duration = Duration::from_micros(clocksub.timeout);
+                        let precision = Duration::from_nanos(clocksub.precision);
+                        let duration = Duration::from_nanos(clocksub.timeout);
                         let deadline = if clocksub
                             .flags
                             .contains(types::Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME)


### PR DESCRIPTION
Sleeping takes 1000x longer than it should because the timestamps are interpreted as microseconds by accident.

This has not been discussed before, we just stumbled over this bug. I can possibly add some test cases if needed.
