### PR TITLE
Switch default to new x86_64 backend.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -286,7 +286,7 @@ jobs:
     # Test debug (DWARF) related functionality on new backend.
     - run: |
         sudo apt-get update && sudo apt-get install -y gdb lldb
-        cargo test --features experimental_x64 test_debug_dwarf -- --ignored --test-threads 1 --test debug::
+        cargo test test_debug_dwarf -- --ignored --test-threads 1 --test debug::
       if: matrix.os == 'ubuntu-latest'
       env:
         RUST_BACKTRACE: 1
@@ -309,10 +309,9 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-  # Perform all tests (debug mode) for `wasmtime` with the experimental x64
-  # backend.
+  # Perform all tests (debug mode) for `wasmtime` with the old x86 backend.
   test_x64:
-    name: Test x64 new backend
+    name: Test old x86 backend
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -328,38 +327,8 @@ jobs:
     - run: rustup target add wasm32-wasi
     - run: rustup target add wasm32-unknown-unknown
 
-    # Run the x64 CI script.
-    - run: ./ci/run-experimental-x64-ci.sh
-      env:
-        RUST_BACKTRACE: 1
-
-  # Perform tests on the new x64 backend on Windows as well.
-  test_x64_win:
-    name: Test x64 new backend on Windows
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-    - uses: ./.github/actions/define-llvm-env
-
-    - name: Install libclang
-      # Note: libclang is pre-installed on the macOS and linux images.
-      if: matrix.os == 'windows-latest'
-      run: |
-        curl https://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe -o llvm-installer.exe
-        7z x llvm-installer.exe -oC:/llvm-binary
-        echo LIBCLANG_PATH=C:/llvm-binary/bin/libclang.dll >> $GITHUB_ENV
-        echo C:/llvm-binary/bin >> $GITHUB_PATH
-
-    # Install wasm32 targets in order to build various tests throughout the
-    # repo.
-    - run: rustup target add wasm32-wasi
-    - run: rustup target add wasm32-unknown-unknown
-
-    # Run the x64 CI script.
-    - run: ./ci/run-experimental-x64-ci.sh
+    # Run the old x86 backend CI (we will eventually remove this).
+    - run: ./ci/run-old-x86-ci.sh
       env:
         RUST_BACKTRACE: 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,9 +93,12 @@ wasi-nn = ["wasmtime-wasi-nn"]
 uffd = ["wasmtime/uffd"]
 all-arch = ["wasmtime/all-arch"]
 
-# Try the experimental, work-in-progress new x86_64 backend. This is not stable
-# as of June 2020.
-experimental_x64 = ["wasmtime-jit/experimental_x64"]
+# Stub feature that does nothing, for Cargo-features compatibility: the new
+# backend is the default now.
+experimental_x64 = []
+
+# Use the old x86 backend.
+old-x86-backend = ["wasmtime-jit/old-x86-backend"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/build.rs
+++ b/build.rs
@@ -155,11 +155,8 @@ fn write_testsuite_tests(
     let testname = extract_name(path);
 
     writeln!(out, "#[test]")?;
-    if experimental_x64_should_panic(testsuite, &testname, strategy) {
-        writeln!(
-            out,
-            r#"#[cfg_attr(feature = "experimental_x64", should_panic)]"#
-        )?;
+    if x64_should_panic(testsuite, &testname, strategy) {
+        writeln!(out, r#"#[should_panic]"#)?;
     } else if ignore(testsuite, &testname, strategy) {
         writeln!(out, "#[ignore]")?;
     } else if pooling {
@@ -186,10 +183,10 @@ fn write_testsuite_tests(
     Ok(())
 }
 
-/// For experimental_x64 backend features that are not supported yet, mark tests as panicking, so
+/// For x64 backend features that are not supported yet, mark tests as panicking, so
 /// they stop "passing" once the features are properly implemented.
-fn experimental_x64_should_panic(testsuite: &str, testname: &str, strategy: &str) -> bool {
-    if !cfg!(feature = "experimental_x64") || strategy != "Cranelift" {
+fn x64_should_panic(testsuite: &str, testname: &str, strategy: &str) -> bool {
+    if !platform_is_x64() || strategy != "Cranelift" {
         return false;
     }
 
@@ -222,12 +219,11 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             _ => (),
         },
         "Cranelift" => match (testsuite, testname) {
-            // TODO(#1886): Ignore reference types tests if this isn't x64,
-            // because Cranelift only supports reference types on x64.
-            ("reference_types", _) => {
-                return env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64";
+            ("simd", _) if cfg!(feature = "old-x86-backend") => return true, // skip all SIMD tests on old backend.
+            // These are only implemented on x64.
+            ("simd", "simd_i64x2_arith2") | ("simd", "simd_boolean") => {
+                return !platform_is_x64() || cfg!(feature = "old-x86-backend")
             }
-
             // These are new instructions that are not really implemented in any backend.
             ("simd", "simd_i8x16_arith2")
             | ("simd", "simd_conversions")
@@ -240,26 +236,14 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             | ("simd", "simd_i64x2_extmul_i32x4")
             | ("simd", "simd_int_to_int_extend") => return true,
 
-            // These are only implemented on x64.
-            ("simd", "simd_i64x2_arith2") | ("simd", "simd_boolean") => {
-                return !cfg!(feature = "experimental_x64")
-            }
-
-            // These are only implemented on aarch64 and x64.
-            ("simd", "simd_i64x2_cmp")
-            | ("simd", "simd_f32x4_pmin_pmax")
-            | ("simd", "simd_f64x2_pmin_pmax")
-            | ("simd", "simd_f32x4_rounding")
-            | ("simd", "simd_f64x2_rounding")
-            | ("simd", "simd_i32x4_dot_i16x8") => {
-                return !(cfg!(feature = "experimental_x64")
-                    || env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "aarch64")
-            }
-
             _ => {}
         },
         _ => panic!("unrecognized strategy"),
     }
 
     false
+}
+
+fn platform_is_x64() -> bool {
+    env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64"
 }

--- a/ci/run-old-x86-ci.sh
+++ b/ci/run-old-x86-ci.sh
@@ -3,7 +3,7 @@
 cargo test \
             --locked \
             --features test-programs/test_programs \
-            --features experimental_x64 \
+            --features old-x86-backend \
             --all \
             --exclude wasmtime-lightbeam \
             --exclude wasmtime-wasi-nn \

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -50,7 +50,6 @@ default = ["disas", "wasm", "cranelift-codegen/all-arch", "peepmatic-souper", "s
 disas = ["capstone"]
 enable-peepmatic = ["cranelift-codegen/enable-peepmatic", "cranelift-filetests/enable-peepmatic"]
 wasm = ["wat", "cranelift-wasm"]
-experimental_x64 = ["cranelift-codegen/x64", "cranelift-filetests/experimental_x64", "cranelift-reader/experimental_x64"]
 experimental_arm32 = ["cranelift-codegen/arm32", "cranelift-filetests/experimental_arm32"]
 souper-harvest = ["cranelift-codegen/souper-harvest", "rayon"]
 all-arch = ["cranelift-codegen/all-arch"]

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -63,8 +63,14 @@ unwind = ["gimli"]
 x86 = []
 arm64 = []
 riscv = []
-x64 = [] # New work-in-progress codegen backend for x86_64 based on the new isel.
 arm32 = [] # Work-in-progress codegen backend for ARM.
+
+# Stub feature that does nothing, for Cargo-features compatibility: the new
+# backend is the default now.
+experimental_x64 = []
+
+# Make the old x86 backend the default.
+old-x86-backend = []
 
 # Option to enable all architectures.
 all-arch = [

--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -8,9 +8,7 @@ use log::warn;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "x64")]
 use crate::binemit::CodeOffset;
-#[cfg(feature = "x64")]
 use crate::isa::unwind::UnwindInst;
 
 /// Maximum (inclusive) size of a "small" stack allocation
@@ -334,10 +332,8 @@ impl UnwindInfo {
     }
 }
 
-#[cfg(feature = "x64")]
 const UNWIND_RBP_REG: u8 = 5;
 
-#[cfg(feature = "x64")]
 pub(crate) fn create_unwind_info_from_insts<MR: RegisterMapper<regalloc::Reg>>(
     insts: &[(CodeOffset, UnwindInst)],
 ) -> CodegenResult<UnwindInfo> {

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -109,6 +109,7 @@ mod tests {
     use target_lexicon::triple;
 
     #[test]
+    #[cfg_attr(feature = "old-x86-backend", ignore)]
     fn test_simple_func() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")
@@ -151,6 +152,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "old-x86-backend", ignore)]
     fn test_multi_return_func() {
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86 ISA")

--- a/cranelift/codegen/src/machinst/adapter.rs
+++ b/cranelift/codegen/src/machinst/adapter.rs
@@ -2,7 +2,9 @@
 
 use crate::binemit;
 use crate::ir;
-use crate::isa::{EncInfo, Encoding, Encodings, Legalize, RegClass, RegInfo, TargetIsa};
+use crate::isa::{
+    BackendVariant, EncInfo, Encoding, Encodings, Legalize, RegClass, RegInfo, TargetIsa,
+};
 use crate::machinst::*;
 use crate::regalloc::RegisterSet;
 use crate::settings::{self, Flags};
@@ -60,6 +62,10 @@ impl TargetIsa for TargetIsaAdapter {
 
     fn isa_flags(&self) -> Vec<settings::Value> {
         self.backend.isa_flags()
+    }
+
+    fn variant(&self) -> BackendVariant {
+        BackendVariant::MachInst
     }
 
     fn hash_all_flags(&self, hasher: &mut dyn Hasher) {

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -30,4 +30,3 @@ anyhow = "1.0.32"
 [features]
 enable-peepmatic = []
 experimental_arm32 = []
-experimental_x64 = []

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %amode_add(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/x64/b1.clif
+++ b/cranelift/filetests/filetests/isa/x64/b1.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(b1, i32, i32) -> i32 {
 ; check:  pushq   %rbp

--- a/cranelift/filetests/filetests/isa/x64/basic.clif
+++ b/cranelift/filetests/filetests/isa/x64/basic.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/isa/x64/bitops-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitops-i128-run.clif
@@ -1,6 +1,5 @@
 test run
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %ctz(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/x64/bitrev-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitrev-i128-run.clif
@@ -1,6 +1,5 @@
 test run
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %reverse_bits_zero() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64 has_lzcnt
-feature "experimental_x64"
+target x86_64 machinst has_lzcnt
 
 function %clz(i64) -> i64 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(i64, i64) -> i64, i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64 has_bmi1
-feature "experimental_x64"
+target x86_64 machinst has_bmi1
 
 function %ctz(i64) -> i64 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/div-checks-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks-run.clif
@@ -1,7 +1,6 @@
 test run
 set avoid_div_traps=false
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -1,7 +1,6 @@
 test compile
 set avoid_div_traps=false
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 ;; We should get the checked-div/rem sequence (`srem` pseudoinst below) even
 ;; when `avoid_div_traps` above is false (i.e. even when the host is normally

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -1,8 +1,7 @@
 test compile
 set enable_llvm_abi_extensions=true
 set unwind_info=true
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(i64, i64, i64, i64) -> i64 windows_fastcall {
 block0(v0: i64, v1: i64, v2: i64, v3: i64):

--- a/cranelift/filetests/filetests/isa/x64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/x64/floating-point.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f(f64) -> f64 {
 block0(v0: f64):

--- a/cranelift/filetests/filetests/isa/x64/heap.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f(i32, i64 vmctx) -> i64 {
     gv0 = vmctx

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_llvm_abi_extensions=true
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(i128, i128) -> i128 {
 ; check:   pushq   %rbp

--- a/cranelift/filetests/filetests/isa/x64/icmp-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/icmp-i128-run.clif
@@ -1,6 +1,5 @@
 test run
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %test_icmp_eq_i128() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %add_from_mem_u32_1(i64, i32) -> i32 {
 block0(v0: i64, v1: i32):

--- a/cranelift/filetests/filetests/isa/x64/move-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/move-elision.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_simd
-target x86_64 skylake
-feature "experimental_x64"
+target x86_64 machinst skylake
 
 function %move_registers(i32x4) -> b8x16 {
 block0(v0: i32x4):

--- a/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64 has_popcnt has_sse42
-feature "experimental_x64"
+target x86_64 machinst has_popcnt has_sse42
 
 function %popcnt(i64) -> i64 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %popcnt64(i64) -> i64 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/probestack.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_probestack=true
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f1() -> i64 {
 ss0 = explicit_slot 100000

--- a/cranelift/filetests/filetests/isa/x64/run-const.clif
+++ b/cranelift/filetests/filetests/isa/x64/run-const.clif
@@ -1,6 +1,5 @@
 test run
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %test_compare_i32() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_llvm_abi_extensions=true
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(i32, i128, i128) -> i128 {
 ; check:   pushq   %rbp

--- a/cranelift/filetests/filetests/isa/x64/shift-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/shift-i128-run.clif
@@ -1,6 +1,5 @@
 test run
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %ishl(i64, i64, i8) -> i64, i64 {
 block0(v0: i64, v1: i64, v2: i8):

--- a/cranelift/filetests/filetests/isa/x64/simd-arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arithmetic-run.clif
@@ -1,7 +1,6 @@
 test run
 set enable_simd
-target x86_64 skylake
-feature "experimental_x64"
+target x86_64 machinst skylake
 
 function %iadd_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0:i32x4, v1:i32x4):

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_simd
-target x86_64 skylake
-feature "experimental_x64"
+target x86_64 machinst skylake
 
 function %bitselect_i16x8() -> i16x8 {
 block0:

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-run.clif
@@ -1,7 +1,6 @@
 test run
 set enable_simd
-target x86_64 skylake
-feature "experimental_x64"
+target x86_64 machinst skylake
 
 function %bitselect_i8x16(i8x16, i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16, v2: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_simd
-target x86_64 skylake
-feature "experimental_x64"
+target x86_64 machinst skylake
 
 function %icmp_ne_32x4(i32x4, i32x4) -> b32x4 {
 block0(v0: i32x4, v1: i32x4):

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-run.clif
@@ -1,7 +1,6 @@
 test run
 set enable_simd
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %icmp_eq_i8x16() -> b8 {
 block0:

--- a/cranelift/filetests/filetests/isa/x64/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-conversion-run.clif
@@ -1,7 +1,6 @@
 test run
 set enable_simd
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %fcvt_from_sint() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_simd
-target x86_64 has_ssse3 has_sse41
-feature "experimental_x64"
+target x86_64 machinst has_ssse3 has_sse41
 
 ;; shuffle
 

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-run.clif
@@ -1,7 +1,6 @@
 test run
 set enable_simd
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 ;; shuffle
 

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -1,7 +1,6 @@
 test compile
 set enable_simd
-target x86_64 skylake
-feature "experimental_x64"
+target x86_64 machinst skylake
 
 function %bnot_b32x4(b32x4) -> b32x4 {
 block0(v0: b32x4):

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-run.clif
@@ -1,7 +1,6 @@
 test run
 set enable_simd
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %bnot() -> b32 {
 block0:

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function u0:0(i64 sarg(64)) -> i8 system_v {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %f0(i64 sret) {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_elf.clif
@@ -1,7 +1,6 @@
 test compile
 set tls_model=elf_gd
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function u0:0(i32) -> i64 {
 gv0 = symbol colocated tls u1:0

--- a/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 function %elide_uextend_add(i32, i32) -> i64 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/isa/x64/unused_jt_unreachable_block.clif
+++ b/cranelift/filetests/filetests/isa/x64/unused_jt_unreachable_block.clif
@@ -1,6 +1,5 @@
 test compile
-target x86_64
-feature "experimental_x64"
+target x86_64 machinst
 
 ;; From: https://github.com/bytecodealliance/wasmtime/issues/2670
 

--- a/cranelift/filetests/filetests/isa/x86/abcd.clif
+++ b/cranelift/filetests/filetests/isa/x86/abcd.clif
@@ -1,5 +1,5 @@
 test regalloc
-target i686
+target i686 legacy
 
 ; %rdi can't be used in a movsbl instruction, so test that the register
 ; allocator can move it to a register that can be.

--- a/cranelift/filetests/filetests/isa/x86/abi-bool.clif
+++ b/cranelift/filetests/filetests/isa/x86/abi-bool.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %foo(i64, i64, i64, i32) -> b1 system_v {
 block3(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/cranelift/filetests/filetests/isa/x86/abi32.clif
+++ b/cranelift/filetests/filetests/isa/x86/abi32.clif
@@ -1,6 +1,6 @@
 ; Test the legalization of function signatures.
 test legalizer
-target i686
+target i686 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/abi64.clif
+++ b/cranelift/filetests/filetests/isa/x86/abi64.clif
@@ -1,6 +1,6 @@
 ; Test the legalization of function signatures.
 test legalizer
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/allones_funcaddrs32.clif
+++ b/cranelift/filetests/filetests/isa/x86/allones_funcaddrs32.clif
@@ -2,7 +2,7 @@
 test binemit
 set opt_level=speed_and_size
 set emit_all_ones_funcaddrs
-target i686 haswell
+target i686 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/allones_funcaddrs64.clif
+++ b/cranelift/filetests/filetests/isa/x86/allones_funcaddrs64.clif
@@ -2,7 +2,7 @@
 test binemit
 set opt_level=speed_and_size
 set emit_all_ones_funcaddrs
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/baldrdash-table-sig-reg.clif
+++ b/cranelift/filetests/filetests/isa/x86/baldrdash-table-sig-reg.clif
@@ -1,6 +1,6 @@
 test compile
 set enable_probestack=false
-target i686
+target i686 legacy
 
 function u0:0(i32 vmctx) baldrdash_system_v {
     sig0 = (i32 vmctx, i32 sigid) baldrdash_system_v

--- a/cranelift/filetests/filetests/isa/x86/baseline_clz_ctz_popcount.clif
+++ b/cranelift/filetests/filetests/isa/x86/baseline_clz_ctz_popcount.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64 baseline
+target x86_64 legacy baseline
 
 
 ; clz/ctz on 64 bit operands

--- a/cranelift/filetests/filetests/isa/x86/baseline_clz_ctz_popcount_encoding.clif
+++ b/cranelift/filetests/filetests/isa/x86/baseline_clz_ctz_popcount_encoding.clif
@@ -1,6 +1,6 @@
 test binemit
 set opt_level=speed_and_size
-target x86_64 baseline
+target x86_64 legacy baseline
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/binary32-float.clif
+++ b/cranelift/filetests/filetests/isa/x86/binary32-float.clif
@@ -1,6 +1,6 @@
 ; Binary emission of 32-bit floating point code.
 test binemit
-target i686 haswell
+target i686 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/binary32.clif
+++ b/cranelift/filetests/filetests/isa/x86/binary32.clif
@@ -1,7 +1,7 @@
 ; binary emission of x86-32 code.
 test binemit
 set opt_level=speed_and_size
-target i686 haswell
+target i686 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/binary64-float.clif
+++ b/cranelift/filetests/filetests/isa/x86/binary64-float.clif
@@ -1,7 +1,7 @@
 ; Binary emission of 64-bit floating point code.
 test binemit
 set opt_level=speed_and_size
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/binary64-pic.clif
+++ b/cranelift/filetests/filetests/isa/x86/binary64-pic.clif
@@ -2,7 +2,7 @@
 test binemit
 set opt_level=speed_and_size
 set is_pic
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/binary64-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/binary64-run.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64
+target x86_64 legacy
 
 ; this verifies that returning b64 immediates does not result in a segmentation fault, see https://github.com/bytecodealliance/cranelift/issues/911
 function %test_b64() -> b64 {

--- a/cranelift/filetests/filetests/isa/x86/binary64.clif
+++ b/cranelift/filetests/filetests/isa/x86/binary64.clif
@@ -1,7 +1,7 @@
 ; binary emission of x86-64 code.
 test binemit
 set opt_level=speed_and_size
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/bitrev-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/bitrev-i128-run.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64
+target x86_64 legacy
 
 function %reverse_bits_zero() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/bnot-b1.clif
+++ b/cranelift/filetests/filetests/isa/x86/bnot-b1.clif
@@ -1,7 +1,7 @@
 test binemit
 test run
 
-target x86_64
+target x86_64 legacy
 
 function u0:323() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/br-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/br-i128-run.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64
+target x86_64 legacy
 
 function %br_false() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/br-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/br-i128.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i128) -> i8 fast {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/isa/x86/brz-i8-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/brz-i8-run.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/brz-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/brz-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/brz-x86_32-i64.clif
+++ b/cranelift/filetests/filetests/isa/x86/brz-x86_32-i64.clif
@@ -1,5 +1,5 @@
 test compile
-target i686
+target i686 legacy
 
 function u0:0(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/isa/x86/extend-i128-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/extend-i128-run.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/extend-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/extend-i128.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/extend-i64-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/extend-i64-run.clif
@@ -1,5 +1,5 @@
 test run
-target i686
+target i686 legacy
 
 function u0:0() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/extend-i64.clif
+++ b/cranelift/filetests/filetests/isa/x86/extend-i64.clif
@@ -1,5 +1,5 @@
 test compile
-target i686
+target i686 legacy
 
 function u0:0() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/floating-point-zero-constants-32bit.clif
+++ b/cranelift/filetests/filetests/isa/x86/floating-point-zero-constants-32bit.clif
@@ -1,6 +1,6 @@
 ; Check that floating-point and integer constants equal to zero are optimized correctly.
 test binemit
-target i686
+target i686 legacy
 
 function %foo() -> f32 fast {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/floating-point-zero-constants.clif
+++ b/cranelift/filetests/filetests/isa/x86/floating-point-zero-constants.clif
@@ -1,6 +1,6 @@
 ; Check that floating-point constants equal to zero are optimized correctly.
 test binemit
-target x86_64
+target x86_64 legacy
 
 function %zero_const_32bit_no_rex() -> f32 fast {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/i128-isplit-forward-jump.clif
+++ b/cranelift/filetests/filetests/isa/x86/i128-isplit-forward-jump.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> i128 system_v {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/i128.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64, i64) -> i128 fast {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/x86/icmp-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/icmp-i128.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %test_icmp_eq_i128() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/imul-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/imul-i128.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %test_imul_i128() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/ireduce-i16-to-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/ireduce-i16-to-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i16) -> i8 fast {
 block0(v0: i16):

--- a/cranelift/filetests/filetests/isa/x86/isplit-not-legalized-twice.clif
+++ b/cranelift/filetests/filetests/isa/x86/isplit-not-legalized-twice.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64, i64) -> i128 system_v {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/x86/isub_imm-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/isub_imm-i8.clif
@@ -1,6 +1,6 @@
 test compile
 set opt_level=speed_and_size
-target x86_64
+target x86_64 legacy
 
 function u0:0(i8) -> i8 fast {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/x86/jump_i128_param_unused.clif
+++ b/cranelift/filetests/filetests/isa/x86/jump_i128_param_unused.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i128) system_v {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/isa/x86/legalize-bint-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-bint-i8.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> i8 fast {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/legalize-bnot.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-bnot.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function u0:51(i64, i64) system_v {
     ss0 = explicit_slot 0

--- a/cranelift/filetests/filetests/isa/x86/legalize-br-icmp.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-br-icmp.clif
@@ -1,6 +1,6 @@
 test legalizer
 
-target x86_64
+target x86_64 legacy
 
 function %br_icmp(i64) fast {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x86/legalize-br-table.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-br-table.clif
@@ -1,6 +1,6 @@
 test compile
 set opt_level=speed_and_size
-target x86_64
+target x86_64 legacy
 ; regex: V=v\d+
 ; regex: BB=block\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-byte-ops-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-byte-ops-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-call.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-call.clif
@@ -1,7 +1,7 @@
 ; Test legalization of a non-colocated call in 64-bit non-PIC mode.
 test legalizer
 set opt_level=speed_and_size
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %call() {
     fn0 = %foo()

--- a/cranelift/filetests/filetests/isa/x86/legalize-clz-ctz-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-clz-ctz-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-custom.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-custom.clif
@@ -1,7 +1,7 @@
 ; Test the custom legalizations.
 test legalizer
-target i686
-target x86_64
+target i686 legacy
+target x86_64 legacy
 
 ; regex: V=v\d+
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/isa/x86/legalize-div-traps.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-div-traps.clif
@@ -2,7 +2,7 @@
 test legalizer
 ; See also legalize-div.clif.
 set avoid_div_traps=1
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/isa/x86/legalize-div.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-div.clif
@@ -2,7 +2,7 @@
 test legalizer
 ; See also legalize-div-traps.clif.
 set avoid_div_traps=0
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/isa/x86/legalize-f64const-x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-f64const-x64.clif
@@ -1,6 +1,6 @@
 ; Test the legalization of f64const.
 test legalizer
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-fcvt_from_usint-i16.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-fcvt_from_usint-i16.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i16) -> f64 fast {
 block0(v0: i16):

--- a/cranelift/filetests/filetests/isa/x86/legalize-heaps.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-heaps.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_heap_access_spectre_mitigation=false
-target x86_64
+target x86_64 legacy
 
 ; Test legalization for various forms of heap addresses.
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/isa/x86/legalize-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-i128.clif
@@ -1,6 +1,6 @@
 ; Test the legalization of i128 instructions on x86_64.
 test legalizer
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-i64.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-i64.clif
@@ -1,6 +1,6 @@
 ; Test the legalization of i64 instructions on x86_32.
 test legalizer
-target i686 haswell
+target i686 legacy haswell
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-icmp-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-icmp-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-iconst-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-iconst-i8.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64) system_v {
     ss0 = explicit_slot 0

--- a/cranelift/filetests/filetests/isa/x86/legalize-imul-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-imul-i8.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64, i8, i8) system_v {
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-imul-imm-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-imul-imm-i8.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64, i8) system_v {
     ss0 = explicit_slot 1

--- a/cranelift/filetests/filetests/isa/x86/legalize-ineg-x86_64.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-ineg-x86_64.clif
@@ -1,6 +1,6 @@
 ; Test the custom legalization of ineg.i64 on x86_64.
 test legalizer
-target x86_64
+target x86_64 legacy
 
 function %ineg_legalized_i64() {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i128.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i128.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i64.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-ireduce-i64.clif
@@ -1,5 +1,5 @@
 test compile
-target i686
+target i686 legacy
 
 function u0:0(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/isa/x86/legalize-isplit-backwards.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-isplit-backwards.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i128) -> i64, i64 fast {
 ; check: block0(v4: i64 [%rdi], v5: i64 [%rsi], v8: i64 [%rbp]):

--- a/cranelift/filetests/filetests/isa/x86/legalize-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-libcall.clif
@@ -2,7 +2,7 @@ test legalizer
 
 ; Pre-SSE 4.1, we need to use runtime library calls for floating point rounding operations.
 set is_pic
-target x86_64
+target x86_64 legacy
 
 function %floor(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x86/legalize-load-store-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-load-store-i8.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64, i8, i8) system_v {
     ss0 = explicit_slot 0

--- a/cranelift/filetests/filetests/isa/x86/legalize-memory.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-memory.clif
@@ -1,7 +1,7 @@
 ; Test the legalization of memory objects.
 test legalizer
 set enable_heap_access_spectre_mitigation=false
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/isa/x86/legalize-mulhi.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-mulhi.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64 baseline
+target x86_64 legacy baseline
 
 ; umulhi/smulhi on 64 bit operands
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-popcnt-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-popcnt-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i8) -> i8 fast {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/x86/legalize-regmove-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-regmove-i8.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64, i64, i64) system_v {
     ss0 = explicit_slot 0

--- a/cranelift/filetests/filetests/isa/x86/legalize-rotate.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-rotate.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 ; regex: R=%[a-z0-9]+

--- a/cranelift/filetests/filetests/isa/x86/legalize-shlr-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-shlr-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-tables.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-tables.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64
+target x86_64 legacy
 
 ; Test legalization for various forms of table addresses.
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/isa/x86/legalize-urem-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-urem-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/legalize-x86_32-shifts.clif
+++ b/cranelift/filetests/filetests/isa/x86/legalize-x86_32-shifts.clif
@@ -1,6 +1,6 @@
 test compile
 set enable_simd
-target i686 haswell
+target i686 legacy haswell
 
 function u0:1(i32) -> i64 system_v {
     block1(v0: i32):

--- a/cranelift/filetests/filetests/isa/x86/load-store-narrow.clif
+++ b/cranelift/filetests/filetests/isa/x86/load-store-narrow.clif
@@ -1,5 +1,5 @@
 test compile
-target i686
+target i686 legacy
 
 function u0:0(i64, i32) system_v {
 block0(v0: i64, v1: i32):

--- a/cranelift/filetests/filetests/isa/x86/nop.clif
+++ b/cranelift/filetests/filetests/isa/x86/nop.clif
@@ -1,6 +1,6 @@
 test compile
 
-target x86_64
+target x86_64 legacy
 
 function %test(i32) -> i32 system_v {
 block0(v0: i32):

--- a/cranelift/filetests/filetests/isa/x86/optimized-zero-constants-32bit.clif
+++ b/cranelift/filetests/filetests/isa/x86/optimized-zero-constants-32bit.clif
@@ -1,7 +1,7 @@
 ; Check that floating-point and integer constants equal to zero are optimized correctly.
 test binemit
 set opt_level=speed_and_size
-target i686
+target i686 legacy
 
 function %foo() -> f32 fast {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/optimized-zero-constants.clif
+++ b/cranelift/filetests/filetests/isa/x86/optimized-zero-constants.clif
@@ -1,7 +1,7 @@
 ; Check that floating-point constants equal to zero are optimized correctly.
 test binemit
 set opt_level=speed_and_size
-target x86_64
+target x86_64 legacy
 
 function %zero_const_32bit_no_rex() -> f32 fast {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x86/pinned-reg.clif
@@ -4,7 +4,7 @@ set enable_pinned_reg=true
 set use_pinned_reg_as_heap_base=true
 set opt_level=speed_and_size
 
-target x86_64
+target x86_64 legacy
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/isa/x86/probestack-adjusts-sp.clif
+++ b/cranelift/filetests/filetests/isa/x86/probestack-adjusts-sp.clif
@@ -1,7 +1,7 @@
 test compile
 set use_colocated_libcalls=1
 set probestack_func_adjusts_sp=1
-target x86_64
+target x86_64 legacy
 
 ; Like %big in probestack.clif, but with the probestack function adjusting
 ; the stack pointer itself.

--- a/cranelift/filetests/filetests/isa/x86/probestack-disabled.clif
+++ b/cranelift/filetests/filetests/isa/x86/probestack-disabled.clif
@@ -1,7 +1,7 @@
 test compile
 set use_colocated_libcalls=1
 set enable_probestack=0
-target x86_64
+target x86_64 legacy
 
 ; Like %big in probestack.clif, but with probes disabled.
 

--- a/cranelift/filetests/filetests/isa/x86/probestack-noncolocated.clif
+++ b/cranelift/filetests/filetests/isa/x86/probestack-noncolocated.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; Like %big in probestack.clif, but without a colocated libcall.
 

--- a/cranelift/filetests/filetests/isa/x86/probestack-size.clif
+++ b/cranelift/filetests/filetests/isa/x86/probestack-size.clif
@@ -1,7 +1,7 @@
 test compile
 set use_colocated_libcalls=1
 set probestack_size_log2=13
-target x86_64
+target x86_64 legacy
 
 ; Like %big in probestack.clif, but now the probestack size is bigger
 ; and it no longer needs a probe.

--- a/cranelift/filetests/filetests/isa/x86/probestack.clif
+++ b/cranelift/filetests/filetests/isa/x86/probestack.clif
@@ -1,6 +1,6 @@
 test compile
 set use_colocated_libcalls=1
-target x86_64
+target x86_64 legacy
 
 ; A function with a big stack frame. This should have a stack probe.
 

--- a/cranelift/filetests/filetests/isa/x86/prologue-epilogue.clif
+++ b/cranelift/filetests/filetests/isa/x86/prologue-epilogue.clif
@@ -2,7 +2,7 @@ test compile
 set opt_level=speed_and_size
 set is_pic
 set enable_probestack=false
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; An empty function.
 

--- a/cranelift/filetests/filetests/isa/x86/relax_branch.clif
+++ b/cranelift/filetests/filetests/isa/x86/relax_branch.clif
@@ -4,7 +4,7 @@ set avoid_div_traps
 set baldrdash_prologue_words=3
 set emit_all_ones_funcaddrs
 set enable_probestack=false
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; This checks that a branch that is too far away is getting relaxed. In
 ; particular, the first block has to be non-empty but its encoding size must be

--- a/cranelift/filetests/filetests/isa/x86/run-const.clif
+++ b/cranelift/filetests/filetests/isa/x86/run-const.clif
@@ -1,5 +1,5 @@
 test run
-target x86_64
+target x86_64 legacy
 
 function %test_compare_i32() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/run-i64.clif
+++ b/cranelift/filetests/filetests/isa/x86/run-i64.clif
@@ -1,6 +1,6 @@
 ; Test i64 instructions on x86_32.
 test compile
-target i686 haswell
+target i686 legacy haswell
 
 function %iadd(i64, i64) -> i64 {
 block0(v1: i64, v2: i64):

--- a/cranelift/filetests/filetests/isa/x86/saturating-float-cast.clif
+++ b/cranelift/filetests/filetests/isa/x86/saturating-float-cast.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> f32 system_v {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/select-i8.clif
+++ b/cranelift/filetests/filetests/isa/x86/select-i8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(b1, i8, i8) -> i8 {
 block0(v0: b1, v1: i8, v2: i8):

--- a/cranelift/filetests/filetests/isa/x86/shrink-multiple-uses.clif
+++ b/cranelift/filetests/filetests/isa/x86/shrink-multiple-uses.clif
@@ -1,6 +1,6 @@
 test shrink
 set opt_level=speed_and_size
-target x86_64
+target x86_64 legacy
 
 function %test_multiple_uses(i32 [%rdi]) -> i32 {
 block0(v0: i32 [%rdi]):

--- a/cranelift/filetests/filetests/isa/x86/shrink.clif
+++ b/cranelift/filetests/filetests/isa/x86/shrink.clif
@@ -1,6 +1,6 @@
 test binemit
 set opt_level=speed_and_size
-target x86_64
+target x86_64 legacy
 
 ; Test that instruction shrinking eliminates REX prefixes when possible.
 

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %arithmetic_i8x16(i8x16, i8x16) {
 block0(v0: i8x16 [%xmm6], v1: i8x16 [%xmm2]):

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %ineg_i32x4() -> b1 {
 ; check:  const0 = 0x00000001000000010000000100000001

--- a/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-arithmetic-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %iadd_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0:i32x4, v1:i32x4):

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 skylake has_avx512dq=true
+target x86_64 legacy skylake has_avx512dq=true
 
 function %imul_i64x2() {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-arithmetic-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake has_avx512dq=true
+target x86_64 legacy skylake has_avx512dq=true
 
 function %imul_i64x2(i64x2, i64x2) {
 block0(v0:i64x2, v1:i64x2):

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 has_avx512vl=true
+target x86_64 legacy has_avx512vl=true
 
 function %fcvt_from_uint(i32x4) {
 block0(v0: i32x4 [%xmm2]):

--- a/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-avx512-conversion-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake has_avx512f=true
+target x86_64 legacy skylake has_avx512f=true
 
 function %fcvt_from_uint(i32x4) -> f32x4 {
 block0(v0:i32x4):

--- a/cranelift/filetests/filetests/isa/x86/simd-bitselect-to-vselect-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitselect-to-vselect-run.clif
@@ -1,7 +1,7 @@
 test run
 set opt_level=speed_and_size
 set enable_simd
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ;; Test if bitselect->vselect optimization works properly
 

--- a/cranelift/filetests/filetests/isa/x86/simd-bitwise-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitwise-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %ishl_i16x8(i16x8, i64x2) -> i16x8 {
 block0(v0: i16x8 [%xmm2], v1: i64x2 [%xmm1]):

--- a/cranelift/filetests/filetests/isa/x86/simd-bitwise-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitwise-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %ushr_i8x16() -> i8x16 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-bitwise-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-bitwise-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 ; TODO: once available, replace all lane extraction with `icmp + all_ones`
 

--- a/cranelift/filetests/filetests/isa/x86/simd-comparison-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-comparison-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %icmp_i8x16() {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-comparison-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %icmp_ne_32x4(i32x4, i32x4) -> b32x4 {
 ; check: const0 = 0xffffffffffffffffffffffffffffffff

--- a/cranelift/filetests/filetests/isa/x86/simd-comparison-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-comparison-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 function %icmp_eq_i8x16() -> b8 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-construction-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-construction-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %splat_i64x2() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 nehalem
+target x86_64 legacy nehalem
 
 ; Ensure raw_bitcast emits no instructions.
 function %raw_bitcast_i16x8_to_b32x4() {

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %fcvt_from_uint(i32x4) -> f32x4 {
 block0(v0:i32x4):

--- a/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-conversion-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 function %fcvt_from_sint() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit-for-size.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit-for-size.clif
@@ -1,7 +1,7 @@
 test binemit
 set opt_level=speed_and_size
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 ;; These scalar_to_vector tests avoid the use of REX prefixes with the speed_and_size optimization flag.
 

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; for insertlane, floats are legalized differently than integers and booleans; integers and
 ; booleans use x86_pinsr which is manually placed in the IR so that it can be binemit-tested

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-compile.clif
@@ -2,7 +2,7 @@ test compile
 set opt_level=speed_and_size
 set enable_probestack=false
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 ; Ensure that scalar_to_vector emits no instructions for floats (already exist in an XMM register)
 function %scalar_to_vector_f32() -> f32x4 baldrdash_system_v {

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 ;; shuffle
 

--- a/cranelift/filetests/filetests/isa/x86/simd-lane-access-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-lane-access-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 function %shuffle_different_ssa_values() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-logical-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-logical-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %bor_b16x8(b16x8, b16x8) -> b16x8 {
 block0(v0: b16x8 [%xmm2], v1: b16x8 [%xmm1]):

--- a/cranelift/filetests/filetests/isa/x86/simd-logical-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-logical-legalize.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %bnot_b32x4(b32x4) -> b32x4 {
 ; check: const0 = 0xffffffffffffffffffffffffffffffff

--- a/cranelift/filetests/filetests/isa/x86/simd-logical-rodata.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-logical-rodata.clif
@@ -1,6 +1,6 @@
 test rodata
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %bnot_b32x4(b32x4) -> b32x4 {
 block0(v0: b32x4):

--- a/cranelift/filetests/filetests/isa/x86/simd-logical-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-logical-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %bnot() -> b32 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-memory-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 skylake
+target x86_64 legacy skylake
 
 function %load_store_simple(i64) {
 block0(v0: i64 [%rax]):

--- a/cranelift/filetests/filetests/isa/x86/simd-pextr-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-pextr-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function u0:0(i64 fp [%rbp]) -> i32 [%rax], i64 fp [%rbp] system_v {
     ss0 = explicit_slot 32, offset -48

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-binemit.clif
@@ -1,7 +1,7 @@
 test binemit
 set opt_level=speed_and_size
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 function %vconst_b8() {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-compile.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-compile.clif
@@ -1,7 +1,7 @@
 test compile
 set enable_simd=true
 set enable_probestack=false
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; use baldrdash calling convention here for simplicity (avoids prologue, epilogue)
 function %vconst_i32() -> i32x4 baldrdash_system_v {

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-optimized-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-optimized-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 function %vconst_optimizations() {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-optimized-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-optimized-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 function %vconst_zeroes() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-rodata.clif
@@ -1,6 +1,6 @@
 test rodata
 set enable_simd=true
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %vconst_i32() -> i32x4 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-vconst-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vconst-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 function %vconst_syntax() -> b1 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/simd-vselect-binemit.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vselect-binemit.clif
@@ -1,6 +1,6 @@
 test binemit
 set enable_simd
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %vselect_i8x16(b8x16, i8x16, i8x16) {
 block0(v0: b8x16 [%xmm0], v1: i8x16 [%xmm3], v2: i8x16 [%xmm5]):

--- a/cranelift/filetests/filetests/isa/x86/simd-vselect-legalize-to-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vselect-legalize-to-bitselect.clif
@@ -1,6 +1,6 @@
 test legalizer
 set enable_simd
-target x86_64
+target x86_64 legacy
 
 ;; Test if vselect gets legalized if BLEND* instructions are not available
 

--- a/cranelift/filetests/filetests/isa/x86/simd-vselect-run.clif
+++ b/cranelift/filetests/filetests/isa/x86/simd-vselect-run.clif
@@ -1,6 +1,6 @@
 test run
 set enable_simd
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %vselect_i8x16() -> i8x16 {
 block0:

--- a/cranelift/filetests/filetests/isa/x86/stack-addr32.clif
+++ b/cranelift/filetests/filetests/isa/x86/stack-addr32.clif
@@ -1,7 +1,7 @@
 ; binary emission of stack address instructions on i686.
 test binemit
 set opt_level=none
-target i686 haswell
+target i686 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/stack-addr64.clif
+++ b/cranelift/filetests/filetests/isa/x86/stack-addr64.clif
@@ -1,7 +1,7 @@
 ; binary emission of stack address instructions on x86-64.
 test binemit
 set opt_level=none
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; The binary encodings can be verified with the command:
 ;

--- a/cranelift/filetests/filetests/isa/x86/stack-load-store64.clif
+++ b/cranelift/filetests/filetests/isa/x86/stack-load-store64.clif
@@ -1,7 +1,7 @@
 ; legalization of stack load and store instructions on x86-64.
 test legalizer
 set opt_level=none
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %stack_load_and_store() {
            ss0 = explicit_slot 8, offset 0

--- a/cranelift/filetests/filetests/isa/x86/stack-load-store8.clif
+++ b/cranelift/filetests/filetests/isa/x86/stack-load-store8.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i8) -> i8 {
     ss0 = explicit_slot 1

--- a/cranelift/filetests/filetests/isa/x86/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x86/struct-arg.clif
@@ -1,6 +1,6 @@
 test compile
 set is_pic
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64 sarg(64)) -> i8 system_v {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x86/systemv_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/systemv_x64_unwind.clif
@@ -1,7 +1,7 @@
 test unwind
 set opt_level=speed_and_size
 set is_pic
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; check the unwind information with a function with no args
 function %no_args() system_v {

--- a/cranelift/filetests/filetests/isa/x86/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x86/tls_elf.clif
@@ -1,6 +1,6 @@
 test regalloc
 set tls_model=elf_gd
-target x86_64
+target x86_64 legacy
 
 function u0:0(i32) -> i32, i64 {
 gv0 = symbol colocated tls u1:0

--- a/cranelift/filetests/filetests/isa/x86/tls_enc.clif
+++ b/cranelift/filetests/filetests/isa/x86/tls_enc.clif
@@ -1,5 +1,5 @@
 test binemit
-target x86_64
+target x86_64 legacy
 
 function u0:0() -> i64, i64 {
 gv0 = symbol colocated tls u1:0

--- a/cranelift/filetests/filetests/isa/x86/tls_macho.clif
+++ b/cranelift/filetests/filetests/isa/x86/tls_macho.clif
@@ -1,6 +1,6 @@
 test regalloc
 set tls_model=macho
-target x86_64
+target x86_64 legacy
 
 function u0:0(i32) -> i32, i64 {
 gv0 = symbol colocated tls u1:0

--- a/cranelift/filetests/filetests/isa/x86/uextend-i8-to-i16.clif
+++ b/cranelift/filetests/filetests/isa/x86/uextend-i8-to-i16.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 function u0:0(i8) -> i16 fast {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64.clif
@@ -1,7 +1,7 @@
 test compile
 set opt_level=speed_and_size
 set is_pic
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; check if for one arg we use the right register
 function %one_arg(i64) windows_fastcall {

--- a/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/cranelift/filetests/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -1,7 +1,7 @@
 test unwind
 set opt_level=speed_and_size
 set is_pic
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; check the unwind information with a leaf function with no args
 function %no_args_leaf() windows_fastcall {

--- a/cranelift/filetests/filetests/legalizer/bitrev-i128.clif
+++ b/cranelift/filetests/filetests/legalizer/bitrev-i128.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64
+target x86_64 legacy
 
 function %reverse_bits(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/legalizer/bitrev.clif
+++ b/cranelift/filetests/filetests/legalizer/bitrev.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64
+target x86_64 legacy
 
 function %reverse_bits_8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/legalizer/br_table_cond.clif
+++ b/cranelift/filetests/filetests/legalizer/br_table_cond.clif
@@ -1,7 +1,7 @@
 test legalizer
 set enable_probestack=false
 set enable_jump_tables=false
-target x86_64
+target x86_64 legacy
 
 ; Test that when jump_tables_enables is false, all jump tables are eliminated.
 ; regex: V=v\d+

--- a/cranelift/filetests/filetests/legalizer/empty_br_table.clif
+++ b/cranelift/filetests/filetests/legalizer/empty_br_table.clif
@@ -1,7 +1,7 @@
 test legalizer
 set enable_probestack=false
 set enable_jump_tables=false
-target x86_64
+target x86_64 legacy
 
 function u0:0(i64) {
     jt0 = jump_table []

--- a/cranelift/filetests/filetests/legalizer/icmp_imm_i128.clif
+++ b/cranelift/filetests/filetests/legalizer/icmp_imm_i128.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64
+target x86_64 legacy
 
 function %icmp_imm_i128(i128) -> i8 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/legalizer/pass_by_ref.clif
+++ b/cranelift/filetests/filetests/legalizer/pass_by_ref.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64
+target x86_64 legacy
 
 function %legalize_entry(i128) -> i64 windows_fastcall {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/legalizer/popcnt-i128.clif
+++ b/cranelift/filetests/filetests/legalizer/popcnt-i128.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %foo() -> i128 {
 block0:

--- a/cranelift/filetests/filetests/postopt/basic.clif
+++ b/cranelift/filetests/filetests/postopt/basic.clif
@@ -1,5 +1,5 @@
 test postopt
-target i686
+target i686 legacy
 
 ; Test that compare+branch sequences are folded effectively on x86.
 

--- a/cranelift/filetests/filetests/postopt/complex_memory_ops.clif
+++ b/cranelift/filetests/filetests/postopt/complex_memory_ops.clif
@@ -1,5 +1,5 @@
 test postopt
-target x86_64
+target x86_64 legacy
 
 function %dual_loads(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/postopt/fold_offset_into_address.clif
+++ b/cranelift/filetests/filetests/postopt/fold_offset_into_address.clif
@@ -1,5 +1,5 @@
 test postopt
-target x86_64
+target x86_64 legacy
 
 ; Fold the immediate of an iadd_imm into an address offset.
 

--- a/cranelift/filetests/filetests/regalloc/aliases.clif
+++ b/cranelift/filetests/filetests/regalloc/aliases.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %value_aliases(i32, f32, i64 vmctx) baldrdash_system_v {
     gv0 = vmctx

--- a/cranelift/filetests/filetests/regalloc/coalescing-207.clif
+++ b/cranelift/filetests/filetests/regalloc/coalescing-207.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; Reported as https://github.com/bytecodealliance/cranelift/issues/207
 ;

--- a/cranelift/filetests/filetests/regalloc/coalescing-216.clif
+++ b/cranelift/filetests/filetests/regalloc/coalescing-216.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; Reported as https://github.com/bytecodealliance/cranelift/issues/216 from the Binaryen fuzzer.
 ;

--- a/cranelift/filetests/filetests/regalloc/coloring-227.clif
+++ b/cranelift/filetests/filetests/regalloc/coloring-227.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8]) system_v {
     gv0 = vmctx

--- a/cranelift/filetests/filetests/regalloc/fallthrough-return.clif
+++ b/cranelift/filetests/filetests/regalloc/fallthrough-return.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64
+target x86_64 legacy
 
 ; Test that fallthrough returns are visited by reload and coloring.
 

--- a/cranelift/filetests/filetests/regalloc/ghost-param.clif
+++ b/cranelift/filetests/filetests/regalloc/ghost-param.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; This test case would create a block parameter that was a ghost value.
 ; The coalescer would insert a copy of the ghost value, leading to verifier errors.

--- a/cranelift/filetests/filetests/regalloc/global-constraints.clif
+++ b/cranelift/filetests/filetests/regalloc/global-constraints.clif
@@ -1,5 +1,5 @@
 test regalloc
-target i686
+target i686 legacy
 
 ; This test covers the troubles when values with global live ranges are defined
 ; by instructions with constrained register classes.

--- a/cranelift/filetests/filetests/regalloc/global-fixed.clif
+++ b/cranelift/filetests/filetests/regalloc/global-fixed.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %foo() system_v {
 block4:

--- a/cranelift/filetests/filetests/regalloc/gpr-deref-safe-335.clif
+++ b/cranelift/filetests/filetests/regalloc/gpr-deref-safe-335.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64
+target x86_64 legacy
 
 function u0:587() fast {
 block0:

--- a/cranelift/filetests/filetests/regalloc/iterate.clif
+++ b/cranelift/filetests/filetests/regalloc/iterate.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function u0:9(i64 [%rdi], f32 [%xmm0], f64 [%xmm1], i32 [%rsi], i32 [%rdx], i64 vmctx [%r14]) -> i64 [%rax] baldrdash_system_v {
 block0(v0: i64, v1: f32, v2: f64, v3: i32, v4: i32, v5: i64):

--- a/cranelift/filetests/filetests/regalloc/multi-constraints.clif
+++ b/cranelift/filetests/filetests/regalloc/multi-constraints.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; Test combinations of constraints.
 ;

--- a/cranelift/filetests/filetests/regalloc/multiple-returns.clif
+++ b/cranelift/filetests/filetests/regalloc/multiple-returns.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64
+target x86_64 legacy
 
 ; Return the same value twice. This needs a copy so that each value can be
 ; allocated its own register.

--- a/cranelift/filetests/filetests/regalloc/output-interference.clif
+++ b/cranelift/filetests/filetests/regalloc/output-interference.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function %test(i64) -> i64 system_v {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/regalloc/reload-208.clif
+++ b/cranelift/filetests/filetests/regalloc/reload-208.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; regex: V=v\d+
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/regalloc/reload-779.clif
+++ b/cranelift/filetests/filetests/regalloc/reload-779.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; Filed as https://github.com/bytecodealliance/cranelift/issues/779
 ;

--- a/cranelift/filetests/filetests/regalloc/reload.clif
+++ b/cranelift/filetests/filetests/regalloc/reload.clif
@@ -1,5 +1,5 @@
 test regalloc
-target riscv32 enable_e
+target riscv32 legacy enable_e
 
 ; regex: V=v\d+
 

--- a/cranelift/filetests/filetests/regalloc/schedule-moves.clif
+++ b/cranelift/filetests/filetests/regalloc/schedule-moves.clif
@@ -1,5 +1,5 @@
 test regalloc
-target i686 haswell
+target i686 legacy haswell
 
 function %pr165() system_v {
 block0:

--- a/cranelift/filetests/filetests/regalloc/solver-fixedconflict-var-2.clif
+++ b/cranelift/filetests/filetests/regalloc/solver-fixedconflict-var-2.clif
@@ -1,7 +1,7 @@
 test compile
 set opt_level=speed
 set enable_pinned_reg=true
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function u0:0(i32, i32, i32, i64 vmctx) -> i64 uext system_v {
 block0(v0: i32, v1: i32, v2: i32, v3: i64):

--- a/cranelift/filetests/filetests/regalloc/solver-fixedconflict-var-3.clif
+++ b/cranelift/filetests/filetests/regalloc/solver-fixedconflict-var-3.clif
@@ -1,7 +1,7 @@
 test compile
 set opt_level=speed
 set enable_pinned_reg=true
-target x86_64 haswell
+target x86_64 legacy haswell
 
 function u0:0(i32, i32, i32, i64 vmctx) -> i64 uext system_v {
 block0(v0: i32, v1: i32, v2: i32, v3: i64):

--- a/cranelift/filetests/filetests/regalloc/solver-fixedconflict-var.clif
+++ b/cranelift/filetests/filetests/regalloc/solver-fixedconflict-var.clif
@@ -1,7 +1,7 @@
 test compile
 set opt_level=speed
 set enable_pinned_reg=true
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ;; Test for the issue #1123; https://github.com/bytecodealliance/cranelift/issues/1123
 

--- a/cranelift/filetests/filetests/regalloc/spill-noregs.clif
+++ b/cranelift/filetests/filetests/regalloc/spill-noregs.clif
@@ -1,5 +1,5 @@
 test regalloc
-target x86_64
+target x86_64 legacy
 
 ; Test case found by the Binaryen fuzzer.
 ;

--- a/cranelift/filetests/filetests/regalloc/spill.clif
+++ b/cranelift/filetests/filetests/regalloc/spill.clif
@@ -12,7 +12,7 @@ test regalloc
 ; regex: V=v\d+
 ; regex: WS=\s+
 
-target riscv32 enable_e
+target riscv32 legacy enable_e
 
 ; In straight-line code, the first value defined is spilled.
 ; That is in order:

--- a/cranelift/filetests/filetests/regalloc/unreachable_code.clif
+++ b/cranelift/filetests/filetests/regalloc/unreachable_code.clif
@@ -2,7 +2,7 @@
 test compile
 
 set enable_probestack=0
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ; This function contains unreachable blocks which trip up the register
 ; allocator if they don't get cleared out.

--- a/cranelift/filetests/filetests/regalloc/x86-regres.clif
+++ b/cranelift/filetests/filetests/regalloc/x86-regres.clif
@@ -1,5 +1,5 @@
 test regalloc
-target i686
+target i686 legacy
 
 ; regex: V=v\d+
 ; regex: BB=block\d+

--- a/cranelift/filetests/filetests/regress/allow-relaxation-shrink.clif
+++ b/cranelift/filetests/filetests/regress/allow-relaxation-shrink.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64
+target x86_64 legacy
 
 ; This checks that code shrink is allowed while relaxing code, when code shrink
 ; has not run.

--- a/cranelift/filetests/filetests/safepoint/basic.clif
+++ b/cranelift/filetests/filetests/safepoint/basic.clif
@@ -1,6 +1,6 @@
 test safepoint
 set enable_safepoints=true
-target x86_64
+target x86_64 legacy
 
 function %test(i32, r64, r64) -> r64 {
     block0(v0: i32, v1:r64, v2:r64):

--- a/cranelift/filetests/filetests/safepoint/call.clif
+++ b/cranelift/filetests/filetests/safepoint/call.clif
@@ -1,6 +1,6 @@
 test safepoint
 set enable_safepoints=true
-target x86_64
+target x86_64 legacy
 
 function %direct() -> r64 {
     fn0 = %none()

--- a/cranelift/filetests/filetests/stack_maps/call.clif
+++ b/cranelift/filetests/filetests/stack_maps/call.clif
@@ -1,6 +1,6 @@
 test stack_maps
 set enable_safepoints=true
-target x86_64
+target x86_64 legacy
 
 function %icall_fast(r64) -> r64 fast {
 ; check:  function %icall_fast

--- a/cranelift/filetests/filetests/stack_maps/incoming_args.clif
+++ b/cranelift/filetests/filetests/stack_maps/incoming_args.clif
@@ -1,6 +1,6 @@
 test stack_maps
 set enable_safepoints=true
-target x86_64
+target x86_64 legacy
 
 ;; Incoming args get included in stack maps.
 

--- a/cranelift/filetests/filetests/wasm/multi-val-b1.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-b1.clif
@@ -1,5 +1,5 @@
 test compile
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ;; `b1` return values need to be legalized into bytes so that they can be stored
 ;; in memory.

--- a/cranelift/filetests/filetests/wasm/multi-val-call-indirect.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-call-indirect.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ;; Indirect calls with many returns.
 

--- a/cranelift/filetests/filetests/wasm/multi-val-call-legalize-args.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-call-legalize-args.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ;; Test if arguments are legalized if function uses sret
 

--- a/cranelift/filetests/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-reuse-ret-ptr-stack-slot.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ;; Test that we don't reuse `sret` stack slots for multiple calls. We could do
 ;; this one day, but it would require some care to ensure that we don't have

--- a/cranelift/filetests/filetests/wasm/multi-val-sret-slot-alignment.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-sret-slot-alignment.clif
@@ -1,5 +1,5 @@
 test legalizer
-target x86_64 haswell
+target x86_64 legacy haswell
 
 ;; Need to insert padding after the `i8`s so that the `i32` and `i64` are
 ;; aligned.

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -4,10 +4,10 @@ use cranelift_codegen::binemit::{NullRelocSink, NullStackMapSink, NullTrapSink};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::immediates::{Ieee32, Ieee64};
 use cranelift_codegen::ir::{condcodes::IntCC, Function, InstBuilder, Signature, Type};
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{BackendVariant, TargetIsa};
 use cranelift_codegen::{ir, settings, CodegenError, Context};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-use cranelift_native::builder as host_isa_builder;
+use cranelift_native::builder_with_options;
 use log::trace;
 use memmap2::{Mmap, MmapMut};
 use std::cmp::max;
@@ -48,8 +48,9 @@ impl SingleFunctionCompiler {
     }
 
     /// Build a [SingleFunctionCompiler] using the host machine's ISA and the passed flags.
-    pub fn with_host_isa(flags: settings::Flags) -> Self {
-        let builder = host_isa_builder().expect("Unable to build a TargetIsa for the current host");
+    pub fn with_host_isa(flags: settings::Flags, variant: BackendVariant) -> Self {
+        let builder = builder_with_options(variant, true)
+            .expect("Unable to build a TargetIsa for the current host");
         let isa = builder.finish(flags);
         Self::new(isa)
     }
@@ -58,7 +59,7 @@ impl SingleFunctionCompiler {
     /// ISA.
     pub fn with_default_host_isa() -> Self {
         let flags = settings::Flags::new(settings::builder());
-        Self::with_host_isa(flags)
+        Self::with_host_isa(flags, BackendVariant::Any)
     }
 
     /// Compile the passed [Function] to a `CompiledFunction`. This function will:

--- a/cranelift/filetests/src/runone.rs
+++ b/cranelift/filetests/src/runone.rs
@@ -21,32 +21,15 @@ use std::time;
 /// When a test must be skipped, returns an Option with a string containing an explanation why;
 /// otherwise, return None.
 fn skip_feature_mismatches(testfile: &TestFile) -> Option<&'static str> {
-    let mut has_experimental_x64 = false;
     let mut has_experimental_arm32 = false;
 
     for feature in &testfile.features {
         if let Feature::With(name) = feature {
             match *name {
-                "experimental_x64" => has_experimental_x64 = true,
                 "experimental_arm32" => has_experimental_arm32 = true,
                 _ => {}
             }
         }
-    }
-
-    // On the experimental x64 backend, skip tests which are not marked with the feature and
-    // that want to run on the x86_64 target isa.
-    #[cfg(feature = "experimental_x64")]
-    if let IsaSpec::Some(ref isas) = testfile.isa_spec {
-        if isas.iter().any(|isa| isa.name() == "x64") && !has_experimental_x64 {
-            return Some("test requiring x86_64 not marked with experimental_x64");
-        }
-    }
-
-    // On other targets, ignore tests marked as experimental_x64 only.
-    #[cfg(not(feature = "experimental_x64"))]
-    if has_experimental_x64 {
-        return Some("missing support for experimental_x64");
     }
 
     // Don't run tests if the experimental support for arm32 is disabled.

--- a/cranelift/filetests/src/test_run.rs
+++ b/cranelift/filetests/src/test_run.rs
@@ -46,8 +46,9 @@ impl SubTest for TestRun {
             );
             return Ok(());
         }
+        let variant = context.isa.unwrap().variant();
 
-        let mut compiler = SingleFunctionCompiler::with_host_isa(context.flags.clone());
+        let mut compiler = SingleFunctionCompiler::with_host_isa(context.flags.clone(), variant);
         for comment in context.details.comments.iter() {
             if let Some(command) = parse_run_command(comment.text, &func.signature)? {
                 trace!("Parsed run command: {}", command);

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -23,6 +23,3 @@ wasmi = "0.7.0"
 
 [dev-dependencies]
 wat = "1.0.37"
-
-[features]
-experimental_x64 = ["wasmtime/experimental_x64"]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -48,9 +48,8 @@ vtune = ["wasmtime-profiling/vtune"]
 parallel-compilation = ["rayon"]
 all-arch = ["cranelift-codegen/all-arch"]
 
-# Try the experimental, work-in-progress new x86_64 backend. This is not stable
-# as of June 2020.
-experimental_x64 = ["cranelift-codegen/x64"]
+# Use the old x86 backend.
+old-x86-backend = ["cranelift-codegen/old-x86-backend"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -70,8 +70,8 @@ parallel-compilation = ["wasmtime-jit/parallel-compilation"]
 # Enables support for automatic cache configuration to be enabled in `Config`.
 cache = ["wasmtime-cache"]
 
-# Enables support for new x64 backend.
-experimental_x64 = ["wasmtime-jit/experimental_x64"]
+# Use the old x86 backend.
+old-x86-backend = ["wasmtime-jit/old-x86-backend"]
 
 # Enables support for "async stores" as well as defining host functions as
 # `async fn` and calling functions asynchronously.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,10 @@ wasmtime-fuzzing = { path = "../crates/fuzzing" }
 wasm-smith = "0.4.0"
 
 [features]
-experimental_x64 = ["wasmtime-fuzzing/experimental_x64"]
+# Leave a stub feature with no side-effects in place for now: the OSS-Fuzz
+# config builds fuzz targets with this feature enabled and we don't want to
+# break the build.
+experimental_x64 = []
 
 [[bin]]
 name = "compile"

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -141,7 +141,7 @@ check: exited with status
     // Ignore test on new backend. The value this is looking for is
     // not available at the point that the breakpoint is set when
     // compiled by the new backend.
-    not(feature = "experimental_x64"),
+    feature = "old-x86-backend",
 ))]
 pub fn test_debug_dwarf_ptr() -> Result<()> {
     let output = lldb_with_script(

--- a/tests/all/debug/translate.rs
+++ b/tests/all/debug/translate.rs
@@ -118,7 +118,7 @@ check:        DW_AT_decl_line	(10)
     // Ignore test on new backend. This is a specific test with hardcoded
     // offsets and the new backend compiles the return basic-block at a different
     // offset, causing mismatches.
-    not(feature = "experimental_x64"),
+    feature = "old-x86-backend",
 ))]
 fn test_debug_dwarf5_translate_lines() -> Result<()> {
     check_line_program(

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -27,8 +27,6 @@ fn test_trap_return() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn test_trap_trace() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -66,8 +64,6 @@ fn test_trap_trace() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn test_trap_trace_cb() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -99,8 +95,6 @@ fn test_trap_trace_cb() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn test_trap_stack_overflow() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -128,8 +122,6 @@ fn test_trap_stack_overflow() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn trap_display_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -161,8 +153,6 @@ wasm backtrace:
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn trap_display_multi_module() -> Result<()> {
     let store = Store::default();
     let wat = r#"
@@ -207,8 +197,6 @@ wasm backtrace:
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn trap_start_function_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -235,8 +223,6 @@ fn trap_start_function_import() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn rust_panic_import() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -278,8 +264,6 @@ fn rust_panic_import() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn rust_panic_start_function() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -313,8 +297,6 @@ fn rust_panic_start_function() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn mismatched_arguments() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -346,8 +328,6 @@ fn mismatched_arguments() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn call_signature_mismatch() -> Result<()> {
     let store = Store::default();
     let binary = wat::parse_str(
@@ -378,8 +358,6 @@ fn call_signature_mismatch() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(all(target_os = "windows", target_arch = "aarch64"), ignore)] // FIXME(#1642)
-#[cfg_attr(all(target_os = "windows", feature = "experimental_x64"), ignore)] // FIXME(#2079)
 fn start_trap_pretty() -> Result<()> {
     let store = Store::default();
     let wat = r#"


### PR DESCRIPTION
This PR switches the default backend on x86, for both the
`cranelift-codegen` crate and for Wasmtime, to the new
(`MachInst`-style, `VCode`-based) backend that has been under
 development and testing for some time now.
    
The old backend is still available by default in builds with the
`old-x86-backend` feature, or by requesting `BackendVariant::Legacy`
from the appropriate APIs.
    
As part of that switch, it adds some more runtime-configurable plumbing
to the testing infrastructure so that tests can be run using the
appropriate backend. `clif-util test` is now capable of parsing a
backend selector option from filetests and instantiating the correct
backend.
    
I has been updated so that the old x86 backend continues to run its
tests, just as we used to run the new x64 backend separately.
    
At some point, we will remove the old x86 backend entirely, once we are
satisfied that the new backend has not caused any unforeseen issues and
we do not need to revert.

This implements the switch described in bytecodealliance/rfcs#10; we should
not merge this until we reach consensus on the process described therein
and merge the RFC.