### PR TITLE
Redo the statically typed `Func` API

### DIFF
--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -301,9 +301,8 @@ impl BenchState {
             .as_ref()
             .expect("instantiate the module before executing it");
 
-        let start_func = instance.get_func("_start").expect("a _start function");
-        let runnable_func = start_func.typed::<(), ()>()?;
-        match runnable_func.call(()) {
+        let start_func = instance.get_typed_func::<(), ()>("_start")?;
+        match start_func.call(()) {
             Ok(_) => Ok(()),
             Err(trap) => {
                 // Since _start will likely return by using the system `exit` call, we must

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -302,8 +302,8 @@ impl BenchState {
             .expect("instantiate the module before executing it");
 
         let start_func = instance.get_func("_start").expect("a _start function");
-        let runnable_func = start_func.get0::<()>()?;
-        match runnable_func() {
+        let runnable_func = start_func.typed::<(), ()>()?;
+        match runnable_func.call(()) {
             Ok(_) => Ok(()),
             Err(trap) => {
                 // Since _start will likely return by using the system `exit` call, we must

--- a/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
@@ -58,8 +58,8 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         let module = Module::new(store.engine(), &data).context("failed to create wasm module")?;
         let instance = linker.instantiate(&module)?;
         let start = instance.get_func("_start").unwrap();
-        let with_type = start.get0::<()>()?;
-        with_type().map_err(anyhow::Error::from)
+        let with_type = start.typed::<(), ()>()?;
+        with_type.call(()).map_err(anyhow::Error::from)
     };
 
     match r {
@@ -113,8 +113,8 @@ pub fn instantiate_inherit_stdio(
         let module = Module::new(store.engine(), &data).context("failed to create wasm module")?;
         let instance = linker.instantiate(&module)?;
         let start = instance.get_func("_start").unwrap();
-        let with_type = start.get0::<()>()?;
-        with_type().map_err(anyhow::Error::from)
+        let with_type = start.typed::<(), ()>()?;
+        with_type.call(()).map_err(anyhow::Error::from)
     };
 
     match r {

--- a/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
@@ -57,9 +57,9 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
 
         let module = Module::new(store.engine(), &data).context("failed to create wasm module")?;
         let instance = linker.instantiate(&module)?;
-        let start = instance.get_func("_start").unwrap();
-        let with_type = start.typed::<(), ()>()?;
-        with_type.call(()).map_err(anyhow::Error::from)
+        let start = instance.get_typed_func::<(), ()>("_start")?;
+        start.call(())?;
+        Ok(())
     };
 
     match r {
@@ -112,9 +112,9 @@ pub fn instantiate_inherit_stdio(
 
         let module = Module::new(store.engine(), &data).context("failed to create wasm module")?;
         let instance = linker.instantiate(&module)?;
-        let start = instance.get_func("_start").unwrap();
-        let with_type = start.typed::<(), ()>()?;
-        with_type.call(()).map_err(anyhow::Error::from)
+        let start = instance.get_typed_func::<(), ()>("_start")?;
+        start.call(())?;
+        Ok(())
     };
 
     match r {

--- a/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
@@ -58,8 +58,7 @@ pub fn instantiate(data: &[u8], bin_name: &str, workspace: Option<&Path>) -> any
         let module = Module::new(store.engine(), &data).context("failed to create wasm module")?;
         let instance = linker.instantiate(&module)?;
         let start = instance.get_typed_func::<(), ()>("_start")?;
-        start.call(())?;
-        Ok(())
+        start.call(()).map_err(anyhow::Error::from)
     };
 
     match r {
@@ -113,8 +112,7 @@ pub fn instantiate_inherit_stdio(
         let module = Module::new(store.engine(), &data).context("failed to create wasm module")?;
         let instance = linker.instantiate(&module)?;
         let start = instance.get_typed_func::<(), ()>("_start")?;
-        start.call(())?;
-        Ok(())
+        start.call(()).map_err(anyhow::Error::from)
     };
 
     match r {

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -350,8 +350,8 @@ macro_rules! generate_wrap_async_host_func {
                     debug_assert!(store.async_support());
                     let mut future = Pin::from(func(caller, $($args),*));
                     match store.block_on(future.as_mut()) {
-                        Ok(ret) => ret.into_result(),
-                        Err(e) => Err(e),
+                        Ok(ret) => ret.into_fallible(),
+                        Err(e) => R::fallible_from_trap(e),
                     }
                 })
             );

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -255,8 +255,7 @@ unsafe impl Sync for HostFunc {}
 ///     "#,
 /// )?;
 /// let instance = Instance::new(&store, &module, &[add.into()])?;
-/// let call_add_twice = instance.get_func("call_add_twice").expect("export wasn't a function");
-/// let call_add_twice = call_add_twice.typed::<(), i32>()?;
+/// let call_add_twice = instance.get_typed_func::<(), i32>("call_add_twice")?;
 ///
 /// assert_eq!(call_add_twice.call(())?, 10);
 /// # Ok(())
@@ -604,7 +603,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[add.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().typed::<(i32, i32), i32>()?.clone();
+    /// let foo = instance.get_typed_func::<(i32, i32), i32>("foo")?;
     /// assert_eq!(foo.call((1, 2))?, 3);
     /// # Ok(())
     /// # }
@@ -635,7 +634,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[add.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().typed::<(i32, i32), i32>()?.clone();
+    /// let foo = instance.get_typed_func::<(i32, i32), i32>("foo")?;
     /// assert_eq!(foo.call((1, 2))?, 3);
     /// assert!(foo.call((i32::max_value(), 1)).is_err());
     /// # Ok(())
@@ -673,7 +672,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[debug.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
+    /// let foo = instance.get_typed_func::<(), ()>("foo")?;
     /// foo.call(())?;
     /// # Ok(())
     /// # }
@@ -729,7 +728,7 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[log_str.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
+    /// let foo = instance.get_typed_func::<(), ()>("foo")?;
     /// foo.call(())?;
     /// # Ok(())
     /// # }
@@ -1648,11 +1647,7 @@ fn wasm_ty_roundtrip() -> Result<(), anyhow::Error> {
          "#,
     )?;
     let instance = Instance::new(&store, &module, &[debug.into()])?;
-    let foo = instance
-        .get_func("foo")
-        .unwrap()
-        .typed::<(i32, u32, f32, i64, u64, f64), ()>()?
-        .clone();
+    let foo = instance.get_typed_func::<(i32, u32, f32, i64, u64, f64), ()>("foo")?;
     foo.call((-1, 1, 2.0, -3, 3, 4.0))?;
     Ok(())
 }

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1012,7 +1012,7 @@ impl Func {
     /// efficient when used to invoke WebAssembly functions. With the types
     /// statically known far less setup/teardown is required when invoking
     /// WebAssembly. If speed is desired then this function is recommended to be
-    /// used instead of [`Func::call`] (which is more general, hence it's
+    /// used instead of [`Func::call`] (which is more general, hence its
     /// slowdown).
     ///
     /// The `Params` type parameter is used to describe the parameters of the

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1027,7 +1027,6 @@ impl Func {
     ///
     /// Translation between Rust types and WebAssembly types looks like:
     ///
-    ///
     /// | WebAssembly | Rust                |
     /// |-------------|---------------------|
     /// | `i32`       | `i32` or `u32`      |
@@ -1044,6 +1043,11 @@ impl Func {
     /// [`TypedFunc::call`] or [`TypedFunc::call_async`] as necessary to actually invoke
     /// the function. This method does not invoke any WebAssembly code, it
     /// simply performs a typecheck before returning the [`TypedFunc`] value.
+    ///
+    /// This method also has a convenience wrapper as
+    /// [`Instance::get_typed_func`](crate::Instance::get_typed_func) to
+    /// directly get a typed function value from an
+    /// [`Instance`](crate::Instance).
     ///
     /// # Errors
     ///

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -156,7 +156,7 @@ unsafe impl Sync for HostFunc {}
 /// perspective of `Func` it's important to know that whether or not your
 /// [`Store`] is asynchronous will dictate whether you call functions through
 /// [`Func::call`] or [`Func::call_async`] (or the typed wrappers such as
-/// [`Typed::call`] vs [`Typed::call_async`]).
+/// [`TypedFunc::call`] vs [`TypedFunc::call_async`]).
 ///
 /// Note that asynchronous function APIs here are a bit trickier than their
 /// synchronous brethren. For example [`Func::new_async`] and
@@ -191,16 +191,16 @@ unsafe impl Sync for HostFunc {}
 ///
 /// * Statically typed - if you statically know the type signature of the wasm
 ///   function you're calling, then you'll want to use the [`Func::typed`]
-///   method to acquire an instance of [`Typed`]. This structure is static proof
+///   method to acquire an instance of [`TypedFunc`]. This structure is static proof
 ///   that the underlying wasm function has the ascripted type, and type
-///   validation is only done once up-front. The [`Typed::call`] and
-///   [`Typed::call_async`] methods are much more efficient than [`Func::call`]
+///   validation is only done once up-front. The [`TypedFunc::call`] and
+///   [`TypedFunc::call_async`] methods are much more efficient than [`Func::call`]
 ///   and [`Func::call_async`] because the type signature is statically known.
 ///   This eschews runtime checks as much as possible to get into wasm as fast
 ///   as possible.
 ///
 /// Unfortunately a limitation of the code generation backend right now means
-/// that [`Typed`] cannot be used with wasm funtions that have 2 or more return
+/// that [`TypedFunc`] cannot be used with wasm funtions that have 2 or more return
 /// values. We hope to fix this in the future, but for now wasm functions with
 /// 2 or more return values need to use the "dynamically typed" APIs.
 ///
@@ -1017,7 +1017,7 @@ impl Func {
     /// This function serves as an alternative to [`Func::call`] and
     /// [`Func::call_async`]. This method performs a static type check (using
     /// the `Params` and `Results` type parameters on the underlying wasm
-    /// function. If the type check passes then a `Typed` object is returned,
+    /// function. If the type check passes then a `TypedFunc` object is returned,
     /// otherwise an error is returned describing the typecheck failure.
     ///
     /// The purpose of this relative to [`Func::call`] is that it's much more
@@ -1053,10 +1053,10 @@ impl Func {
     ///
     /// (note that this mapping is the same as that of [`Func::wrap`]).
     ///
-    /// Note that once the [`Typed`] return value is acquired you'll use either
-    /// [`Typed::call`] or [`Typed::call_async`] as necessary to actually invoke
+    /// Note that once the [`TypedFunc`] return value is acquired you'll use either
+    /// [`TypedFunc::call`] or [`TypedFunc::call_async`] as necessary to actually invoke
     /// the function. This method does not invoke any WebAssembly code, it
-    /// simply performs a typecheck before returning the [`Typed`] value.
+    /// simply performs a typecheck before returning the [`TypedFunc`] value.
     ///
     /// # Errors
     ///
@@ -1098,7 +1098,7 @@ impl Func {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn typed<Params, Results>(&self) -> Result<&Typed<Params, Results>>
+    pub fn typed<Params, Results>(&self) -> Result<&TypedFunc<Params, Results>>
     where
         Params: WasmParams,
         Results: WasmResults,
@@ -1124,17 +1124,17 @@ impl Func {
     ///
     /// This function only safe to call if `typed` would otherwise return `Ok`
     /// for the same `Params` and `Results` specified. If `typed` would return
-    /// an error then the returned `Typed` is memory unsafe to invoke.
-    pub unsafe fn typed_unchecked<Params, Results>(&self) -> &Typed<Params, Results>
+    /// an error then the returned `TypedFunc` is memory unsafe to invoke.
+    pub unsafe fn typed_unchecked<Params, Results>(&self) -> &TypedFunc<Params, Results>
     where
         Params: WasmParams,
         Results: WasmResults,
     {
         assert_eq!(
-            mem::size_of::<Typed<Params, Results>>(),
+            mem::size_of::<TypedFunc<Params, Results>>(),
             mem::size_of_val(self)
         );
-        &*(self as *const Func as *const Typed<Params, Results>)
+        &*(self as *const Func as *const TypedFunc<Params, Results>)
     }
 }
 

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1657,7 +1657,8 @@ fn wasm_ty_roundtrip() -> Result<(), anyhow::Error> {
     let foo = instance
         .get_func("foo")
         .unwrap()
-        .typed::<(i32, u32, f32, i64, u64, f64), ()>()?;
+        .typed::<(i32, u32, f32, i64, u64, f64), ()>()?
+        .clone();
     foo.call((-1, 1, 2.0, -3, 3, 4.0))?;
     Ok(())
 }

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -944,7 +944,7 @@ impl Func {
         &self.export
     }
 
-    pub(crate) fn invoke(
+    fn invoke(
         store: &Store,
         ty: &FuncType,
         caller_vmctx: *mut VMContext,

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1,6 +1,10 @@
+use crate::store::StoreInner;
+use crate::trampoline::StoreInstanceHandle;
 use crate::{sig_registry::SignatureRegistry, trampoline::StoreInstanceHandle};
 use crate::{Config, Extern, ExternRef, FuncType, Store, Trap, Val, ValType};
+use crate::{Extern, FuncType, Store, Trap, Val, ValType};
 use anyhow::{bail, ensure, Context as _, Result};
+use anyhow::{bail, Context as _, Result};
 use smallvec::{smallvec, SmallVec};
 use std::any::Any;
 use std::cmp::max;
@@ -10,6 +14,7 @@ use std::mem;
 use std::panic::{self, AssertUnwindSafe};
 use std::pin::Pin;
 use std::ptr::{self, NonNull};
+use std::rc::Weak;
 use std::task::{Context, Poll};
 use wasmtime_environ::wasm::{EntityIndex, FuncIndex};
 use wasmtime_runtime::{
@@ -150,8 +155,8 @@ unsafe impl Sync for HostFunc {}
 /// information about [asynchronous configs](Config::async_support), but from the
 /// perspective of `Func` it's important to know that whether or not your
 /// [`Store`] is asynchronous will dictate whether you call functions through
-/// [`Func::call`] or [`Func::call_async`] (or the wrappers such as
-/// [`Func::get0`] vs [`Func::get0_async`]).
+/// [`Func::call`] or [`Func::call_async`] (or the typed wrappers such as
+/// [`Typed::call`] vs [`Typed::call_async`]).
 ///
 /// Note that asynchronous function APIs here are a bit trickier than their
 /// synchronous brethren. For example [`Func::new_async`] and
@@ -166,11 +171,13 @@ unsafe impl Sync for HostFunc {}
 /// etc). Be sure to consult the documentation for [`Func::wrap`] for how the
 /// wasm type signature is inferred from the Rust type signature.
 ///
-/// # To `Func::call` or to `Func::getN`
+/// # To `Func::call` or to `Func::typed().call()`
 ///
-/// There are four ways to call a `Func`. Half are asynchronous and half are
-/// synchronous, corresponding to the type of store you're using. Within each
-/// half you've got two choices:
+/// There's a 2x2 matrix of methods to call `Func`. Invocations can either be
+/// asynchronous or synchronous. They can also be statically typed or not.
+/// Whether or not an invocation is asynchronous is indicated via the method
+/// being `async` and `call_async` being the entry point. Otherwise for
+/// statically typed or not your options are:
 ///
 /// * Dynamically typed - if you don't statically know the signature of the
 ///   function that you're calling you'll be using [`Func::call`] or
@@ -183,18 +190,19 @@ unsafe impl Sync for HostFunc {}
 ///   looking for a speedier alternative you can also use...
 ///
 /// * Statically typed - if you statically know the type signature of the wasm
-///   function you're calling then you can use the [`Func::getN`](Func::get1)
-///   family of functions where `N` is the number of wasm arguments the function
-///   takes. Asynchronous users can use [`Func::getN_async`](Func::get1_async).
-///   These functions will perform type validation up-front and then return a
-///   specialized closure which can be used to invoke the wasm function. This
-///   route involves no dynamic allocation and does not type-checks during
-///   runtime, so it's recommended to use this where possible for maximal speed.
+///   function you're calling, then you'll want to use the [`Func::typed`]
+///   method to acquire an instance of [`Typed`]. This structure is static proof
+///   that the underlying wasm function has the ascripted type, and type
+///   validation is only done once up-front. The [`Typed::call`] and
+///   [`Typed::call_async`] methods are much more efficient than [`Func::call`]
+///   and [`Func::call_async`] because the type signature is statically known.
+///   This eschews runtime checks as much as possible to get into wasm as fast
+///   as possible.
 ///
 /// Unfortunately a limitation of the code generation backend right now means
-/// that the statically typed `getN` methods only work with wasm functions that
-/// return 0 or 1 value. If 2 or more values are returned you'll need to use the
-/// dynamic `call` API. We hope to fix this in the future, though!
+/// that [`Typed`] cannot be used with wasm funtions that have 2 or more return
+/// values. We hope to fix this in the future, but for now wasm functions with
+/// 2 or more return values need to use the "dynamically typed" APIs.
 ///
 /// # Examples
 ///
@@ -223,8 +231,8 @@ unsafe impl Sync for HostFunc {}
 /// // ... or we can make a static assertion about its signature and call it.
 /// // Our first call here can fail if the signatures don't match, and then the
 /// // second call can fail if the function traps (like the `match` above).
-/// let foo = foo.get0::<()>()?;
-/// foo()?;
+/// let foo = foo.typed::<(), ()>()?;
+/// foo.call(())?;
 /// # Ok(())
 /// # }
 /// ```
@@ -259,9 +267,9 @@ unsafe impl Sync for HostFunc {}
 /// )?;
 /// let instance = Instance::new(&store, &module, &[add.into()])?;
 /// let call_add_twice = instance.get_func("call_add_twice").expect("export wasn't a function");
-/// let call_add_twice = call_add_twice.get0::<i32>()?;
+/// let call_add_twice = call_add_twice.typed::<(), i32>()?;
 ///
-/// assert_eq!(call_add_twice()?, 10);
+/// assert_eq!(call_add_twice.call(())?, 10);
 /// # Ok(())
 /// # }
 /// ```
@@ -332,152 +340,8 @@ macro_rules! for_each_function_signature {
     };
 }
 
-macro_rules! generate_get_methods {
-    ($num:tt $($args:ident)*) => (paste::paste! {
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func`] structure for more documentation. Returns an error
-        /// if the type parameters and return parameter provided don't match the
-        /// actual function's type signature.
-        ///
-        /// # Panics
-        ///
-        /// Panics if this is called on a function in an asynchronous store.
-        #[allow(non_snake_case)]
-        pub fn [<get $num>]<$($args,)* R>(&self)
-            -> Result<impl Fn($($args,)*) -> Result<R, Trap>>
-        where
-            $($args: WasmTy,)*
-            R: WasmTy,
-        {
-            assert!(!self.store().async_support(), concat!("cannot use `get", $num, "` when async support is enabled on the config"));
-            self.[<_get $num>]::<$($args,)* R>()
-        }
-
-        /// Extracts a natively-callable object from this `Func`, if the
-        /// signature matches.
-        ///
-        /// See the [`Func`] structure for more documentation. Returns an error
-        /// if the type parameters and return parameter provided don't match the
-        /// actual function's type signature.
-        ///
-        /// # Panics
-        ///
-        /// Panics if this is called on a function in a synchronous store.
-        #[allow(non_snake_case, warnings)]
-        #[cfg(feature = "async")]
-        #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
-        pub fn [<get $num _async>]<$($args,)* R>(&self)
-            -> Result<impl Fn($($args,)*) -> WasmCall<R>>
-        where
-            $($args: WasmTy + 'static,)*
-            R: WasmTy + 'static,
-        {
-            assert!(self.store().async_support(), concat!("cannot use `get", $num, "_async` without enabling async support on the config"));
-
-            // TODO: ideally we wouldn't box up the future here but could
-            // instead name the future returned by `on_fiber`.  Unfortunately
-            // that would require a bunch of inter-future borrows which are safe
-            // but gnarly to implement by hand.
-            //
-            // Otherwise the implementation here is pretty similar to
-            // `call_async` where we're just calling the `on_fiber` method to
-            // run the blocking work. Most of the goop here is juggling
-            // lifetimes and making sure everything lives long enough and
-            // closures have the right signatures.
-            //
-            // This is... less readable than ideal.
-            let func = self.[<_get $num>]::<$($args,)* R>()?;
-            let store = self.store().clone();
-            Ok(move |$($args),*| {
-                let func = func.clone();
-                let store = store.clone();
-                WasmCall {
-                    inner: Pin::from(Box::new(async move {
-                        match store.on_fiber(|| func($($args,)*)).await {
-                            Ok(result) => result,
-                            Err(trap) => Err(trap),
-                        }
-                    }))
-                }
-            })
-        }
-
-        // Internal helper to share between `getN` and `getN_async`
-        #[allow(non_snake_case)]
-        fn [<_get $num>]<$($args,)* R>(&self)
-            -> Result<impl Fn($($args,)*) -> Result<R, Trap> + Clone>
-        where
-            $($args: WasmTy,)*
-            R: WasmTy,
-        {
-            // Verify all the paramers match the expected parameters, and that
-            // there are no extra parameters...
-            let ty = self.ty();
-            let mut params = ty.params();
-            let n = 0;
-            $(
-                let n = n + 1;
-                $args::matches(&mut params)
-                    .with_context(|| format!("Type mismatch in argument {}", n))?;
-            )*
-            ensure!(params.next().is_none(), "Type mismatch: too many arguments (expected {})", n);
-
-            // ... then do the same for the results...
-            let mut results = ty.results();
-            R::matches(&mut results)
-                .context("Type mismatch in return type")?;
-            ensure!(results.next().is_none(), "Type mismatch: too many return values (expected 1)");
-
-            // Pass the instance into the closure so that we keep it live for
-            // the lifetime of the closure. Pass the `anyfunc` in so that we can
-            // call it.
-            let instance = self.instance.clone();
-            let anyfunc = self.export.anyfunc;
-
-            // ... and then once we've passed the typechecks we can hand out our
-            // object since our `transmute` below should be safe!
-            Ok(move |$($args: $args),*| -> Result<R, Trap> {
-                unsafe {
-                    let fnptr = mem::transmute::<
-                        *const VMFunctionBody,
-                        unsafe extern "C" fn(
-                            *mut VMContext,
-                            *mut VMContext,
-                            $( $args::Abi, )*
-                        ) -> R::Abi,
-                    >(anyfunc.as_ref().func_ptr.as_ptr());
-
-                    let mut ret = None;
-
-                    $(
-                        // Because this returned closure is not marked `unsafe`,
-                        // we have to check that incoming values are compatible
-                        // with our store.
-                        if !$args.compatible_with_store(&instance.store) {
-                            return Err(Trap::new(
-                                "attempt to pass cross-`Store` value to Wasm as function argument"
-                            ));
-                        }
-
-                        let $args = $args.into_abi_for_arg(&instance.store);
-                    )*
-
-                    invoke_wasm_and_catch_traps(&instance.store, || {
-                        ret = Some(fnptr(
-                            anyfunc.as_ref().vmctx,
-                            ptr::null_mut(),
-                            $( $args, )*
-                        ));
-                    })?;
-
-                    Ok(R::from_abi(ret.unwrap(), &instance.store))
-                }
-            })
-        }
-    })
-}
+mod typed;
+pub use typed::*;
 
 macro_rules! generate_wrap_async_func {
     ($num:tt $($args:ident)*) => (paste::paste!{
@@ -505,8 +369,8 @@ macro_rules! generate_wrap_async_func {
                 let store = caller.store().clone();
                 let mut future = Pin::from(func(caller, &state, $($args),*));
                 match store.block_on(future.as_mut()) {
-                    Ok(ret) => ret.into_result(),
-                    Err(e) => Err(e),
+                    Ok(ret) => ret.into_fallible(),
+                    Err(e) => R::fallible_from_trap(e),
                 }
             })
         }
@@ -751,8 +615,8 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[add.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().get2::<i32, i32, i32>()?;
-    /// assert_eq!(foo(1, 2)?, 3);
+    /// let foo = instance.get_func("foo").unwrap().typed::<(i32, i32), i32>()?.clone();
+    /// assert_eq!(foo.call((1, 2))?, 3);
     /// # Ok(())
     /// # }
     /// ```
@@ -782,9 +646,9 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[add.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().get2::<i32, i32, i32>()?;
-    /// assert_eq!(foo(1, 2)?, 3);
-    /// assert!(foo(i32::max_value(), 1).is_err());
+    /// let foo = instance.get_func("foo").unwrap().typed::<(i32, i32), i32>()?.clone();
+    /// assert_eq!(foo.call((1, 2))?, 3);
+    /// assert!(foo.call((i32::max_value(), 1)).is_err());
     /// # Ok(())
     /// # }
     /// ```
@@ -820,8 +684,8 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[debug.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().get0::<()>()?;
-    /// foo()?;
+    /// let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
+    /// foo.call(())?;
     /// # Ok(())
     /// # }
     /// ```
@@ -876,8 +740,8 @@ impl Func {
     ///     "#,
     /// )?;
     /// let instance = Instance::new(&store, &module, &[log_str.into()])?;
-    /// let foo = instance.get_func("foo").unwrap().get0::<()>()?;
-    /// foo()?;
+    /// let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
+    /// foo.call(())?;
     /// # Ok(())
     /// # }
     /// ```
@@ -1073,8 +937,6 @@ impl Func {
         }
     }
 
-    for_each_function_signature!(generate_get_methods);
-
     /// Get a reference to this function's store.
     pub fn store(&self) -> &Store {
         &self.instance.store
@@ -1148,6 +1010,132 @@ impl Func {
 
         Ok(())
     }
+
+    /// Attempts to extract a typed object from this `Func` through which the
+    /// function can be called.
+    ///
+    /// This function serves as an alternative to [`Func::call`] and
+    /// [`Func::call_async`]. This method performs a static type check (using
+    /// the `Params` and `Results` type parameters on the underlying wasm
+    /// function. If the type check passes then a `Typed` object is returned,
+    /// otherwise an error is returned describing the typecheck failure.
+    ///
+    /// The purpose of this relative to [`Func::call`] is that it's much more
+    /// efficient when used to invoke WebAssembly functions. With the types
+    /// statically known far less setup/teardown is required when invoking
+    /// WebAssembly. If speed is desired then this function is recommended to be
+    /// used instead of [`Func::call`] (which is more general, hence it's
+    /// slowdown).
+    ///
+    /// The `Params` type parameter is used to describe the parameters of the
+    /// WebAssembly function. This can either be a single type (like `i32`), or
+    /// a tuple of types representing the list of parameters (like `(i32, f32,
+    /// f64)`). Additionally you can use `()` to represent that the function has
+    /// no parameters.
+    ///
+    /// The `Results` type parameter is used to describe the results of the
+    /// function. At this time multi-value functions are not supported, so
+    /// `Results` can only be a bare type (like `i32`) or `()` to signify no
+    /// types are returned.
+    ///
+    /// Translation between Rust types and WebAssembly types looks like:
+    ///
+    ///
+    /// | WebAssembly | Rust                |
+    /// |-------------|---------------------|
+    /// | `i32`       | `i32` or `u32`      |
+    /// | `i64`       | `i64` or `u64`      |
+    /// | `f32`       | `f32`               |
+    /// | `f64`       | `f64`               |
+    /// | `externref` | `Option<ExternRef>` |
+    /// | `funcref`   | `Option<Func>`      |
+    /// | `v128`      | not supported       |
+    ///
+    /// (note that this mapping is the same as that of [`Func::wrap`]).
+    ///
+    /// Note that once the [`Typed`] return value is acquired you'll use either
+    /// [`Typed::call`] or [`Typed::call_async`] as necessary to actually invoke
+    /// the function. This method does not invoke any WebAssembly code, it
+    /// simply performs a typecheck before returning the [`Typed`] value.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `Params` or `Results` does not
+    /// match the native type of this WebAssembly function.
+    ///
+    /// # Examples
+    ///
+    /// An end-to-end example of calling a function which takes no parameters
+    /// and has no results:
+    ///
+    /// ```
+    /// # use wasmtime::*;
+    /// # fn main() -> anyhow::Result<()> {
+    /// let engine = Engine::default();
+    /// let store = Store::new(&engine);
+    /// let module = Module::new(&engine, r#"(module (func (export "foo")))"#)?;
+    /// let instance = Instance::new(&store, &module, &[])?;
+    /// let foo = instance.get_func("foo").expect("export wasn't a function");
+    ///
+    /// // Note that this call can fail due to the typecheck not passing, but
+    /// // in our case we statically know the module so we know this should
+    /// // pass.
+    /// let typed = foo.typed::<(), ()>()?;
+    ///
+    /// // Note that this can fail if the wasm traps at runtime.
+    /// typed.call(())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// You can also pass in multiple parameters and get a result back
+    ///
+    /// ```
+    /// # use wasmtime::*;
+    /// # fn foo(add: &Func) -> anyhow::Result<()> {
+    /// let typed = add.typed::<(i32, i64), f32>()?;
+    /// assert_eq!(typed.call((1, 2))?, 3.0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn typed<Params, Results>(&self) -> Result<&Typed<Params, Results>>
+    where
+        Params: WasmParams,
+        Results: WasmResults,
+    {
+        // First type-check that the params/results are all valid...
+        let ty = self.ty();
+        Params::typecheck(ty.params()).context("type mismatch with parameters")?;
+        Results::typecheck(ty.results()).context("type mismatch with results")?;
+
+        // ... then we can construct the typed version of this function
+        // (unsafely), which should be safe since we just did the type check above.
+        unsafe { Ok(self.typed_unchecked::<Params, Results>()) }
+    }
+
+    /// An unchecked version of [`Func::typed`] which does not perform a
+    /// typecheck and simply assumes that the type declared here matches the
+    /// type of this function.
+    ///
+    /// The semantics of this function are the same as [`Func::typed`] except
+    /// that no error is returned because no typechecking is done.
+    ///
+    /// # Unsafety
+    ///
+    /// This function only safe to call if `typed` would otherwise return `Ok`
+    /// for the same `Params` and `Results` specified. If `typed` would return
+    /// an error then the returned `Typed` is memory unsafe to invoke.
+    pub unsafe fn typed_unchecked<Params, Results>(&self) -> &Typed<Params, Results>
+    where
+        Params: WasmParams,
+        Results: WasmResults,
+    {
+        assert_eq!(
+            mem::size_of::<Typed<Params, Results>>(),
+            mem::size_of_val(self)
+        );
+        &*(self as *const Func as *const Typed<Params, Results>)
+    }
 }
 
 impl fmt::Debug for Func {
@@ -1170,54 +1158,6 @@ pub(crate) fn invoke_wasm_and_catch_traps(
     }
 }
 
-/// A trait implemented for types which can be arguments to closures passed to
-/// [`Func::wrap`] and friends.
-///
-/// This trait should not be implemented by user types. This trait may change at
-/// any time internally. The types which implement this trait, however, are
-/// stable over time.
-///
-/// For more information see [`Func::wrap`]
-pub unsafe trait WasmTy {
-    // The raw ABI representation of this type inside Wasm.
-    #[doc(hidden)]
-    type Abi: Copy;
-
-    // Is this value compatible with the given store?
-    #[doc(hidden)]
-    fn compatible_with_store(&self, store: &Store) -> bool;
-
-    // Convert this value into its ABI representation, when passing a value into
-    // Wasm as an argument.
-    #[doc(hidden)]
-    fn into_abi_for_arg(self, store: &Store) -> Self::Abi;
-
-    // Convert from the raw ABI representation back into `Self`, when receiving
-    // a value from Wasm.
-    //
-    // Safety: The abi value *must* have be valid for this type (e.g. for
-    // `externref`, it must be a valid raw `VMExternRef` pointer, not some
-    // random, dangling pointer).
-    #[doc(hidden)]
-    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self;
-
-    // Add this type to the given vec of expected valtypes.
-    #[doc(hidden)]
-    fn valtype() -> Option<ValType>;
-
-    // Does the next valtype(s) match this type?
-    #[doc(hidden)]
-    fn matches(tys: impl Iterator<Item = ValType>) -> anyhow::Result<()>;
-
-    // Load this type's raw ABI representation from an args array.
-    #[doc(hidden)]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi;
-
-    // Store this type's raw ABI representation into an args array.
-    #[doc(hidden)]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128);
-}
-
 /// A trait implemented for types which can be returned from closures passed to
 /// [`Func::wrap`] and friends.
 ///
@@ -1230,11 +1170,6 @@ pub unsafe trait WasmRet {
     // Same as `WasmTy::Abi`.
     #[doc(hidden)]
     type Abi: Copy;
-
-    // The "ok" version of this, meaning that which is returned if there is no
-    // error.
-    #[doc(hidden)]
-    type Ok: WasmTy;
 
     // Same as `WasmTy::compatible_with_store`.
     #[doc(hidden)]
@@ -1249,33 +1184,24 @@ pub unsafe trait WasmRet {
     #[doc(hidden)]
     unsafe fn into_abi_for_ret(self, store: &Store) -> Self::Abi;
 
-    // Same as `WasmTy::from_abi`.
-    #[doc(hidden)]
-    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self;
-
     // Same as `WasmTy::push`.
     #[doc(hidden)]
     fn valtype() -> Option<ValType>;
 
-    // Same as `WasmTy::matches`.
+    // Utilities used to convert an instance of this type to a `Result`
+    // explicitly, used when wrapping async functions which always bottom-out
+    // in a function that returns a trap because futures can be cancelled.
     #[doc(hidden)]
-    fn matches(tys: impl Iterator<Item = ValType>) -> anyhow::Result<()>;
-
-    // Same as `WasmTy::load_from_args`.
+    type Fallible: WasmRet;
     #[doc(hidden)]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi;
-
-    // Same as `WasmTy::store_to_args`.
+    fn into_fallible(self) -> Self::Fallible;
     #[doc(hidden)]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128);
-
-    // Converts this result into an explicit `Result` to match on.
-    #[doc(hidden)]
-    fn into_result(self) -> Result<Self::Ok, Trap>;
+    fn fallible_from_trap(trap: Trap) -> Self::Fallible;
 }
 
-unsafe impl WasmTy for () {
-    type Abi = Self;
+unsafe impl WasmRet for () {
+    type Abi = ();
+    type Fallible = Result<(), Trap>;
 
     #[inline]
     fn compatible_with_store(&self, _store: &Store) -> bool {
@@ -1283,28 +1209,27 @@ unsafe impl WasmTy for () {
     }
 
     #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {}
+    unsafe fn into_abi_for_ret(self, _store: &Store) {}
 
     #[inline]
-    unsafe fn from_abi(_abi: Self::Abi, _store: &Store) -> Self {}
-
     fn valtype() -> Option<ValType> {
         None
     }
 
-    fn matches(_tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
+    #[inline]
+    fn into_fallible(self) -> Result<(), Trap> {
         Ok(())
     }
 
     #[inline]
-    unsafe fn load_from_args(_ptr: &mut *const u128) -> Self::Abi {}
-
-    #[inline]
-    unsafe fn store_to_args(_abi: Self::Abi, _ptr: *mut u128) {}
+    fn fallible_from_trap(trap: Trap) -> Result<(), Trap> {
+        Err(trap)
+    }
 }
 
-unsafe impl WasmTy for i32 {
-    type Abi = Self;
+unsafe impl WasmRet for Result<(), Trap> {
+    type Abi = ();
+    type Fallible = Self;
 
     #[inline]
     fn compatible_with_store(&self, _store: &Store) -> bool {
@@ -1312,358 +1237,26 @@ unsafe impl WasmTy for i32 {
     }
 
     #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
-        self
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
-        abi
-    }
-
-    fn valtype() -> Option<ValType> {
-        Some(ValType::I32)
-    }
-
-    fn matches(mut tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        let next = tys.next();
-        ensure!(
-            next == Some(ValType::I32),
-            "Type mismatch, expected i32, got {:?}",
-            next
-        );
-        Ok(())
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        let ret = *(*ptr).cast::<Self>();
-        *ptr = (*ptr).add(1);
-        return ret;
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        *ptr.cast::<Self>() = abi;
-    }
-}
-
-unsafe impl WasmTy for u32 {
-    type Abi = <i32 as WasmTy>::Abi;
-
-    #[inline]
-    fn compatible_with_store(&self, _store: &Store) -> bool {
-        true
-    }
-
-    #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
-        self as i32
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
-        abi as Self
-    }
-
-    fn valtype() -> Option<ValType> {
-        <i32 as WasmTy>::valtype()
-    }
-
-    fn matches(tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        <i32 as WasmTy>::matches(tys)
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        <i32 as WasmTy>::load_from_args(ptr)
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        <i32 as WasmTy>::store_to_args(abi, ptr)
-    }
-}
-
-unsafe impl WasmTy for i64 {
-    type Abi = Self;
-
-    #[inline]
-    fn compatible_with_store(&self, _store: &Store) -> bool {
-        true
-    }
-
-    #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
-        self
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
-        abi
-    }
-
-    fn valtype() -> Option<ValType> {
-        Some(ValType::I64)
-    }
-
-    fn matches(mut tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        let next = tys.next();
-        ensure!(
-            next == Some(ValType::I64),
-            "Type mismatch, expected i64, got {:?}",
-            next
-        );
-        Ok(())
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        let ret = *(*ptr).cast::<Self>();
-        *ptr = (*ptr).add(1);
-        return ret;
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        *ptr.cast::<Self>() = abi;
-    }
-}
-
-unsafe impl WasmTy for u64 {
-    type Abi = <i64 as WasmTy>::Abi;
-
-    #[inline]
-    fn compatible_with_store(&self, _store: &Store) -> bool {
-        true
-    }
-
-    #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
-        self as i64
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
-        abi as Self
-    }
-
-    fn valtype() -> Option<ValType> {
-        <i64 as WasmTy>::valtype()
-    }
-
-    fn matches(tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        <i64 as WasmTy>::matches(tys)
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        <i64 as WasmTy>::load_from_args(ptr)
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        <i64 as WasmTy>::store_to_args(abi, ptr)
-    }
-}
-
-unsafe impl WasmTy for f32 {
-    type Abi = Self;
-
-    #[inline]
-    fn compatible_with_store(&self, _store: &Store) -> bool {
-        true
-    }
-
-    #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
-        self
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
-        abi
-    }
-
-    fn valtype() -> Option<ValType> {
-        Some(ValType::F32)
-    }
-
-    fn matches(mut tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        let next = tys.next();
-        ensure!(
-            next == Some(ValType::F32),
-            "Type mismatch, expected f32, got {:?}",
-            next
-        );
-        Ok(())
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        let ret = f32::from_bits(*(*ptr).cast::<u32>());
-        *ptr = (*ptr).add(1);
-        return ret;
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        *ptr.cast::<u32>() = abi.to_bits();
-    }
-}
-
-unsafe impl WasmTy for f64 {
-    type Abi = Self;
-
-    #[inline]
-    fn compatible_with_store(&self, _store: &Store) -> bool {
-        true
-    }
-
-    #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
-        self
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
-        abi
-    }
-
-    fn valtype() -> Option<ValType> {
-        Some(ValType::F64)
-    }
-
-    fn matches(mut tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        let next = tys.next();
-        ensure!(
-            next == Some(ValType::F64),
-            "Type mismatch, expected f64, got {:?}",
-            next
-        );
-        Ok(())
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        let ret = f64::from_bits(*(*ptr).cast::<u64>());
-        *ptr = (*ptr).add(1);
-        return ret;
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        *ptr.cast::<u64>() = abi.to_bits();
-    }
-}
-
-unsafe impl WasmTy for Option<ExternRef> {
-    type Abi = *mut u8;
-
-    #[inline]
-    fn compatible_with_store(&self, _store: &Store) -> bool {
-        true
-    }
-
-    #[inline]
-    fn into_abi_for_arg(self, store: &Store) -> Self::Abi {
-        if let Some(x) = self {
-            let abi = x.inner.as_raw();
-            unsafe {
-                store
-                    .externref_activations_table()
-                    .insert_with_gc(x.inner, store.stack_map_registry());
-            }
-            abi
-        } else {
-            ptr::null_mut()
+    unsafe fn into_abi_for_ret<'a>(self, _store: WeakStore<'a>) {
+        match self {
+            Ok(()) => {}
+            Err(trap) => raise_user_trap(trap.into()),
         }
     }
 
     #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &Store) -> Self {
-        if abi.is_null() {
-            None
-        } else {
-            Some(ExternRef {
-                inner: VMExternRef::clone_from_raw(abi),
-            })
-        }
-    }
-
     fn valtype() -> Option<ValType> {
-        Some(ValType::ExternRef)
-    }
-
-    fn matches(mut tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        let next = tys.next();
-        ensure!(
-            next == Some(ValType::ExternRef),
-            "Type mismatch, expected externref, got {:?}",
-            next
-        );
-        Ok(())
-    }
-
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        let ret = *(*ptr).cast::<usize>() as *mut u8;
-        *ptr = (*ptr).add(1);
-        ret
-    }
-
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        ptr::write(ptr.cast::<usize>(), abi as usize);
-    }
-}
-
-unsafe impl WasmTy for Option<Func> {
-    type Abi = *mut VMCallerCheckedAnyfunc;
-
-    #[inline]
-    fn compatible_with_store(&self, store: &Store) -> bool {
-        if let Some(f) = self {
-            Store::same(store, f.store())
-        } else {
-            true
-        }
+        None
     }
 
     #[inline]
-    fn into_abi_for_arg(self, _store: &Store) -> Self::Abi {
-        if let Some(f) = self {
-            f.caller_checked_anyfunc().as_ptr()
-        } else {
-            ptr::null_mut()
-        }
+    fn into_fallible(self) -> Result<(), Trap> {
+        self
     }
 
     #[inline]
-    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self {
-        Func::from_caller_checked_anyfunc(store, abi)
-    }
-
-    fn valtype() -> Option<ValType> {
-        Some(ValType::FuncRef)
-    }
-
-    fn matches(mut tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        let next = tys.next();
-        ensure!(
-            next == Some(ValType::FuncRef),
-            "Type mismatch, expected funcref, got {:?}",
-            next
-        );
-        Ok(())
-    }
-
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        let ret = *(*ptr).cast::<usize>() as *mut VMCallerCheckedAnyfunc;
-        *ptr = (*ptr).add(1);
-        ret
-    }
-
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        ptr::write(ptr.cast::<usize>(), abi as usize);
+    fn fallible_from_trap(trap: Trap) -> Result<(), Trap> {
+        Err(trap)
     }
 }
 
@@ -1672,45 +1265,26 @@ where
     T: WasmTy,
 {
     type Abi = <T as WasmTy>::Abi;
-    type Ok = T;
+    type Fallible = Result<T, Trap>;
 
-    #[inline]
-    fn compatible_with_store(&self, store: &Store) -> bool {
+    fn compatible_with_store(&self, store: WeakStore<'_>) -> bool {
         <Self as WasmTy>::compatible_with_store(self, store)
     }
 
-    #[inline]
-    unsafe fn into_abi_for_ret(self, store: &Store) -> Self::Abi {
-        <Self as WasmTy>::into_abi_for_arg(self, store)
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self {
-        <Self as WasmTy>::from_abi(abi, store)
+    unsafe fn into_abi_for_ret(self, store: WeakStore<'_>) -> Self::Abi {
+        <Self as WasmTy>::into_abi(self, store)
     }
 
     fn valtype() -> Option<ValType> {
-        <Self as WasmTy>::valtype()
+        Some(<Self as WasmTy>::valtype())
     }
 
-    #[inline]
-    fn matches(tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        <Self as WasmTy>::matches(tys)
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        <Self as WasmTy>::load_from_args(ptr)
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        <Self as WasmTy>::store_to_args(abi, ptr)
-    }
-
-    #[inline]
-    fn into_result(self) -> Result<T, Trap> {
+    fn into_fallible(self) -> Result<T, Trap> {
         Ok(self)
+    }
+
+    fn fallible_from_trap(trap: Trap) -> Result<T, Trap> {
+        Err(trap)
     }
 }
 
@@ -1719,20 +1293,18 @@ where
     T: WasmTy,
 {
     type Abi = <T as WasmTy>::Abi;
-    type Ok = T;
+    type Fallible = Self;
 
-    #[inline]
-    fn compatible_with_store(&self, store: &Store) -> bool {
+    fn compatible_with_store(&self, store: WeakStore<'_>) -> bool {
         match self {
             Ok(x) => <T as WasmTy>::compatible_with_store(x, store),
             Err(_) => true,
         }
     }
 
-    #[inline]
-    unsafe fn into_abi_for_ret(self, store: &Store) -> Self::Abi {
+    unsafe fn into_abi_for_ret(self, store: WeakStore<'_>) -> Self::Abi {
         match self {
-            Ok(val) => return <T as WasmTy>::into_abi_for_arg(val, store),
+            Ok(val) => return <T as WasmTy>::into_abi(val, store),
             Err(trap) => handle_trap(trap),
         }
 
@@ -1741,32 +1313,16 @@ where
         }
     }
 
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, store: &Store) -> Self {
-        Ok(<T as WasmTy>::from_abi(abi, store))
-    }
-
     fn valtype() -> Option<ValType> {
-        <T as WasmTy>::valtype()
+        Some(<T as WasmTy>::valtype())
     }
 
-    fn matches(tys: impl Iterator<Item = ValType>) -> anyhow::Result<()> {
-        <T as WasmTy>::matches(tys)
-    }
-
-    #[inline]
-    unsafe fn load_from_args(ptr: &mut *const u128) -> Self::Abi {
-        <T as WasmTy>::load_from_args(ptr)
-    }
-
-    #[inline]
-    unsafe fn store_to_args(abi: Self::Abi, ptr: *mut u128) {
-        <T as WasmTy>::store_to_args(abi, ptr);
-    }
-
-    #[inline]
-    fn into_result(self) -> Result<T, Trap> {
+    fn into_fallible(self) -> Result<T, Trap> {
         self
+    }
+
+    fn fallible_from_trap(trap: Trap) -> Result<T, Trap> {
+        Err(trap)
     }
 }
 
@@ -1999,15 +1555,18 @@ macro_rules! impl_into_func {
                         ) -> R::Abi,
                     >(ptr);
 
-                    let mut _next = args as *const u128;
-                    $( let $args = $args::load_from_args(&mut _next); )*
+                    let mut _n = 0;
+                    $(
+                        let $args = *args.add(_n).cast::<$args::Abi>();
+                        _n += 1;
+                    )*
                     let ret = ptr(callee_vmctx, caller_vmctx, $( $args ),*);
-                    R::store_to_args(ret, args);
+                    *args.cast::<R::Abi>() = ret;
                 }
 
                 let ty = FuncType::new(
                     None::<ValType>.into_iter()
-                        $(.chain($args::valtype()))*
+                        $(.chain(Some($args::valtype())))*
                     ,
                     R::valtype(),
                 );
@@ -2039,20 +1598,6 @@ macro_rules! impl_into_func {
 }
 
 for_each_function_signature!(impl_into_func);
-
-/// Returned future from the [`Func::get1_async`] family of methods, used to
-/// represent an asynchronous call into WebAssembly.
-pub struct WasmCall<R> {
-    inner: Pin<Box<dyn Future<Output = Result<R, Trap>>>>,
-}
-
-impl<R> Future for WasmCall<R> {
-    type Output = Result<R, Trap>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.inner.as_mut().poll(cx)
-    }
-}
 
 #[test]
 fn wasm_ty_roundtrip() -> Result<(), anyhow::Error> {
@@ -2105,7 +1650,7 @@ fn wasm_ty_roundtrip() -> Result<(), anyhow::Error> {
     let foo = instance
         .get_func("foo")
         .unwrap()
-        .get6::<i32, u32, f32, i64, u64, f64, ()>()?;
-    foo(-1, 1, 2.0, -3, 3, 4.0)?;
+        .typed::<(i32, u32, f32, i64, u64, f64), ()>()?;
+    foo.call((-1, 1, 2.0, -3, 3, 4.0))?;
     Ok(())
 }

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -199,11 +199,6 @@ unsafe impl Sync for HostFunc {}
 ///   This eschews runtime checks as much as possible to get into wasm as fast
 ///   as possible.
 ///
-/// Unfortunately a limitation of the code generation backend right now means
-/// that [`TypedFunc`] cannot be used with wasm funtions that have 2 or more return
-/// values. We hope to fix this in the future, but for now wasm functions with
-/// 2 or more return values need to use the "dynamically typed" APIs.
-///
 /// # Examples
 ///
 /// One way to get a `Func` is from an [`Instance`] after you've instantiated
@@ -1034,9 +1029,8 @@ impl Func {
     /// no parameters.
     ///
     /// The `Results` type parameter is used to describe the results of the
-    /// function. At this time multi-value functions are not supported, so
-    /// `Results` can only be a bare type (like `i32`) or `()` to signify no
-    /// types are returned.
+    /// function. This behaves the same way as `Params`, but just for the
+    /// results of the function.
     ///
     /// Translation between Rust types and WebAssembly types looks like:
     ///
@@ -1095,6 +1089,19 @@ impl Func {
     /// # fn foo(add: &Func) -> anyhow::Result<()> {
     /// let typed = add.typed::<(i32, i64), f32>()?;
     /// assert_eq!(typed.call((1, 2))?, 3.0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// and similarly if a function has multiple results you can bind that too
+    ///
+    /// ```
+    /// # use wasmtime::*;
+    /// # fn foo(add_with_overflow: &Func) -> anyhow::Result<()> {
+    /// let typed = add_with_overflow.typed::<(u32, u32), (u32, i32)>()?;
+    /// let (result, overflow) = typed.call((u32::max_value(), 2))?;
+    /// assert_eq!(result, 1);
+    /// assert_eq!(overflow, 1);
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -1,0 +1,381 @@
+use super::{invoke_wasm_and_catch_traps, WeakStore};
+use crate::{ExternRef, Func, Store, Trap, ValType};
+use anyhow::{bail, Result};
+use std::marker;
+use std::mem::{self, MaybeUninit};
+use std::ptr;
+use wasmtime_runtime::{VMContext, VMFunctionBody};
+
+/// A statically typed WebAssembly function.
+///
+/// Values of this type represent statically type-checked WebAssembly functions.
+/// The function within a [`Typed`] is statically known to have `Params` as its
+/// parameters and `Results` as its results.
+///
+/// This structure is created via [`Func::typed`] or [`Func::typed_unchecked`].
+/// For more documentation about this see those methods.
+#[repr(transparent)]
+pub struct Typed<Params, Results> {
+    _a: marker::PhantomData<fn(Params) -> Results>,
+    func: Func,
+}
+
+impl<Params, Results> Clone for Typed<Params, Results> {
+    fn clone(&self) -> Typed<Params, Results> {
+        Typed {
+            _a: marker::PhantomData,
+            func: self.func.clone(),
+        }
+    }
+}
+
+impl<Params, Results> Typed<Params, Results>
+where
+    Params: WasmParams,
+    Results: WasmResults,
+{
+    /// Returns the underlying [`Func`] that this is wrapping, losing the static
+    /// type information in the process.
+    pub fn func(&self) -> &Func {
+        &self.func
+    }
+
+    /// Invokes this WebAssembly function with the specified parameters.
+    ///
+    /// Returns either the results of the call, or a [`Trap`] if one happened.
+    ///
+    /// For more information, see the [`Func::typed`] and [`Func::call`]
+    /// documentation.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it is called when the underlying [`Func`] is
+    /// connected to an asynchronous store.
+    pub fn call(&self, params: Params) -> Result<Results, Trap> {
+        assert!(
+            !self.func.store().is_async(),
+            "must use `call_async` with async stores"
+        );
+        unsafe { self._call(params) }
+    }
+
+    /// Invokes this WebAssembly function with the specified parameters.
+    ///
+    /// Returns either the results of the call, or a [`Trap`] if one happened.
+    ///
+    /// For more information, see the [`Func::typed`] and [`Func::call_async`]
+    /// documentation.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it is called when the underlying [`Func`] is
+    /// connected to a synchronous store.
+    #[cfg(feature = "async")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+    pub async fn call_async(&self, params: Params) -> Result<Results, Trap> {
+        assert!(
+            self.func.store().is_async(),
+            "must use `call` with non-async stores"
+        );
+        self.func
+            .store()
+            .on_fiber(|| unsafe { self._call(params) })
+            .await?
+    }
+
+    unsafe fn _call(&self, params: Params) -> Result<Results, Trap> {
+        let weak_store = self.func.instance.store.weak();
+        let weak_store = WeakStore(&weak_store);
+
+        // Validate that all runtime values flowing into this store indeed
+        // belong within this store, otherwise it would be unsafe for store
+        // values to cross each other.
+        if !params.compatible_with_store(weak_store) {
+            return Err(Trap::new(
+                "attempt to pass cross-`Store` value to Wasm as function argument",
+            ));
+        }
+
+        let anyfunc = self.func.export.anyfunc.as_ref();
+        let params = MaybeUninit::new(params);
+        let mut ret = MaybeUninit::uninit();
+        let mut called = false;
+        let mut returned = false;
+        let result = invoke_wasm_and_catch_traps(anyfunc.vmctx, &self.func.instance.store, || {
+            called = true;
+            let params = ptr::read(params.as_ptr());
+            let result = params.invoke::<Results>(
+                weak_store,
+                anyfunc.func_ptr.as_ptr(),
+                anyfunc.vmctx,
+                ptr::null_mut(),
+            );
+            ptr::write(ret.as_mut_ptr(), result);
+            returned = true
+        });
+
+        // This can happen if we early-trap due to interrupts or other
+        // pre-flight checks, so we need to be sure the parameters are at least
+        // dropped at some point.
+        if !called {
+            drop(params.assume_init());
+        }
+        debug_assert_eq!(result.is_ok(), returned);
+        result?;
+
+        Ok(ret.assume_init())
+    }
+}
+
+/// A trait implemented for types which can be arguments and results for
+/// closures passed to [`Func::wrap`] as well as parameters to [`Func::typed`].
+///
+/// This trait should not be implemented by user types. This trait may change at
+/// any time internally. The types which implement this trait, however, are
+/// stable over time.
+///
+/// For more information see [`Func::wrap`] and [`Func::typed`]
+pub unsafe trait WasmTy {
+    #[doc(hidden)]
+    type Abi: Copy;
+    #[doc(hidden)]
+    fn typecheck(ty: crate::ValType) -> Result<()> {
+        if ty == Self::valtype() {
+            Ok(())
+        } else {
+            bail!("expected {} found {}", Self::valtype(), ty)
+        }
+    }
+    #[doc(hidden)]
+    fn valtype() -> ValType;
+    #[doc(hidden)]
+    fn compatible_with_store(&self, store: WeakStore<'_>) -> bool;
+    #[doc(hidden)]
+    fn into_abi(self, store: WeakStore<'_>) -> Self::Abi;
+    #[doc(hidden)]
+    unsafe fn from_abi(abi: Self::Abi, store: WeakStore<'_>) -> Self;
+}
+
+macro_rules! primitives {
+    ($($primitive:ident => $ty:ident)*) => ($(
+        unsafe impl WasmTy for $primitive {
+            type Abi = $primitive;
+            #[inline]
+            fn valtype() -> ValType {
+                ValType::$ty
+            }
+            #[inline]
+            fn compatible_with_store(&self, _: WeakStore<'_>) -> bool {
+                true
+            }
+            #[inline]
+            fn into_abi(self, _store: WeakStore<'_>) -> Self::Abi {
+                self
+            }
+            #[inline]
+            unsafe fn from_abi(abi: Self::Abi, _store: WeakStore<'_>) -> Self {
+                abi
+            }
+        }
+    )*)
+}
+
+primitives! {
+    i32 => I32
+    u32 => I32
+    i64 => I64
+    u64 => I64
+    f32 => F32
+    f64 => F64
+}
+
+unsafe impl WasmTy for Option<ExternRef> {
+    type Abi = *mut u8;
+
+    #[inline]
+    fn valtype() -> ValType {
+        ValType::ExternRef
+    }
+
+    #[inline]
+    fn compatible_with_store<'a>(&self, _store: WeakStore<'a>) -> bool {
+        true
+    }
+
+    fn into_abi(self, store: WeakStore<'_>) -> Self::Abi {
+        if let Some(x) = self {
+            let store = Store::upgrade(store.0).unwrap();
+            let abi = x.inner.as_raw();
+            unsafe {
+                store
+                    .externref_activations_table()
+                    .insert_with_gc(x.inner, store.stack_map_registry());
+            }
+            abi
+        } else {
+            ptr::null_mut()
+        }
+    }
+
+    #[inline]
+    unsafe fn from_abi(abi: Self::Abi, _store: WeakStore<'_>) -> Self {
+        if abi.is_null() {
+            None
+        } else {
+            Some(ExternRef {
+                inner: wasmtime_runtime::VMExternRef::clone_from_raw(abi),
+            })
+        }
+    }
+}
+
+unsafe impl WasmTy for Option<Func> {
+    type Abi = *mut wasmtime_runtime::VMCallerCheckedAnyfunc;
+
+    #[inline]
+    fn valtype() -> ValType {
+        ValType::FuncRef
+    }
+
+    #[inline]
+    fn compatible_with_store<'a>(&self, store: WeakStore<'a>) -> bool {
+        if let Some(f) = self {
+            let store = Store::upgrade(store.0).unwrap();
+            Store::same(&store, f.store())
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn into_abi(self, _store: WeakStore<'_>) -> Self::Abi {
+        if let Some(f) = self {
+            f.caller_checked_anyfunc().as_ptr()
+        } else {
+            ptr::null_mut()
+        }
+    }
+
+    #[inline]
+    unsafe fn from_abi(abi: Self::Abi, store: WeakStore<'_>) -> Self {
+        let store = Store::upgrade(store.0).unwrap();
+        Func::from_caller_checked_anyfunc(&store, abi)
+    }
+}
+
+/// A trait used for [`Func::typed`] and with [`Typed`] to represent the set of
+/// parameters for wasm functions.
+///
+/// This is implemented for bare types that can be passed to wasm as well as
+/// tuples of those types.
+pub unsafe trait WasmParams {
+    #[doc(hidden)]
+    fn typecheck(params: impl ExactSizeIterator<Item = crate::ValType>) -> Result<()>;
+    #[doc(hidden)]
+    fn compatible_with_store(&self, store: WeakStore<'_>) -> bool;
+    #[doc(hidden)]
+    unsafe fn invoke<R: WasmResults>(
+        self,
+        store: WeakStore<'_>,
+        func: *const VMFunctionBody,
+        vmctx1: *mut VMContext,
+        vmctx2: *mut VMContext,
+    ) -> R;
+}
+
+// Forward an impl from `T` to `(T,)` for convenience if there's only one
+// parameter.
+unsafe impl<T> WasmParams for T
+where
+    T: WasmTy,
+{
+    fn typecheck(params: impl ExactSizeIterator<Item = crate::ValType>) -> Result<()> {
+        <(T,)>::typecheck(params)
+    }
+    fn compatible_with_store(&self, store: WeakStore<'_>) -> bool {
+        <T as WasmTy>::compatible_with_store(self, store)
+    }
+    unsafe fn invoke<R: WasmResults>(
+        self,
+        store: WeakStore<'_>,
+        func: *const VMFunctionBody,
+        vmctx1: *mut VMContext,
+        vmctx2: *mut VMContext,
+    ) -> R {
+        <(T,)>::invoke((self,), store, func, vmctx1, vmctx2)
+    }
+}
+
+macro_rules! impl_wasm_params {
+    ($n:tt $($t:ident)*) => {
+        #[allow(non_snake_case)]
+        unsafe impl<$($t: WasmTy,)*> WasmParams for ($($t,)*) {
+            fn typecheck(mut params: impl ExactSizeIterator<Item = crate::ValType>) -> Result<()> {
+                let mut _n = 0;
+                $(
+                    match params.next() {
+                        Some(t) => $t::typecheck(t)?,
+                        None => bail!("expected {} types, found {}", $n, _n),
+                    }
+                    _n += 1;
+                )*
+
+                match params.next() {
+                    None => Ok(()),
+                    Some(_) => bail!("expected {} types, found {}", $n, params.len() + _n),
+                }
+            }
+
+            fn compatible_with_store(&self, _store: WeakStore<'_>) -> bool {
+                let ($($t,)*) = self;
+                $($t.compatible_with_store(_store)&&)* true
+            }
+
+            unsafe fn invoke<R: WasmResults>(
+                self,
+                store: WeakStore<'_>,
+                func: *const VMFunctionBody,
+                vmctx1: *mut VMContext,
+                vmctx2: *mut VMContext,
+            ) -> R {
+                let fnptr = mem::transmute::<
+                    *const VMFunctionBody,
+                    unsafe extern "C" fn(
+                        *mut VMContext,
+                        *mut VMContext,
+                        $($t::Abi,)*
+                    ) -> R::Abi,
+                >(func);
+                let ($($t,)*) = self;
+                R::from_abi(fnptr(vmctx1, vmctx2, $($t.into_abi(store),)*), store)
+            }
+        }
+    };
+}
+
+for_each_function_signature!(impl_wasm_params);
+
+/// A trait used for [`Func::typed`] and with [`Typed`] to represent the set of
+/// results for wasm functions.
+///
+/// This is currently only implemented for `()` and for bare types that can be
+/// returned. This is not yet implemented for tuples because a multi-value
+/// `Typed` is not currently supported.
+pub trait WasmResults: WasmParams {
+    #[doc(hidden)]
+    type Abi;
+    #[doc(hidden)]
+    unsafe fn from_abi(abi: Self::Abi, store: WeakStore<'_>) -> Self;
+}
+
+impl WasmResults for () {
+    type Abi = ();
+    unsafe fn from_abi(_abi: (), _store: WeakStore<'_>) {}
+}
+
+impl<T: WasmTy> WasmResults for T {
+    type Abi = T::Abi;
+    unsafe fn from_abi(abi: Self::Abi, store: WeakStore<'_>) -> Self {
+        <T as WasmTy>::from_abi(abi, store)
+    }
+}

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -9,27 +9,27 @@ use wasmtime_runtime::{VMContext, VMFunctionBody};
 /// A statically typed WebAssembly function.
 ///
 /// Values of this type represent statically type-checked WebAssembly functions.
-/// The function within a [`Typed`] is statically known to have `Params` as its
+/// The function within a [`TypedFunc`] is statically known to have `Params` as its
 /// parameters and `Results` as its results.
 ///
 /// This structure is created via [`Func::typed`] or [`Func::typed_unchecked`].
 /// For more documentation about this see those methods.
 #[repr(transparent)]
-pub struct Typed<Params, Results> {
+pub struct TypedFunc<Params, Results> {
     _a: marker::PhantomData<fn(Params) -> Results>,
     func: Func,
 }
 
-impl<Params, Results> Clone for Typed<Params, Results> {
-    fn clone(&self) -> Typed<Params, Results> {
-        Typed {
+impl<Params, Results> Clone for TypedFunc<Params, Results> {
+    fn clone(&self) -> TypedFunc<Params, Results> {
+        TypedFunc {
             _a: marker::PhantomData,
             func: self.func.clone(),
         }
     }
 }
 
-impl<Params, Results> Typed<Params, Results>
+impl<Params, Results> TypedFunc<Params, Results>
 where
     Params: WasmParams,
     Results: WasmResults,
@@ -139,6 +139,7 @@ pub unsafe trait WasmTy {
     #[doc(hidden)]
     type Abi: Copy;
     #[doc(hidden)]
+    #[inline]
     fn typecheck(ty: crate::ValType) -> Result<()> {
         if ty == Self::valtype() {
             Ok(())
@@ -263,7 +264,7 @@ unsafe impl WasmTy for Option<Func> {
     }
 }
 
-/// A trait used for [`Func::typed`] and with [`Typed`] to represent the set of
+/// A trait used for [`Func::typed`] and with [`TypedFunc`] to represent the set of
 /// parameters for wasm functions.
 ///
 /// This is implemented for bare types that can be passed to wasm as well as
@@ -355,12 +356,12 @@ macro_rules! impl_wasm_params {
 
 for_each_function_signature!(impl_wasm_params);
 
-/// A trait used for [`Func::typed`] and with [`Typed`] to represent the set of
+/// A trait used for [`Func::typed`] and with [`TypedFunc`] to represent the set of
 /// results for wasm functions.
 ///
 /// This is currently only implemented for `()` and for bare types that can be
 /// returned. This is not yet implemented for tuples because a multi-value
-/// `Typed` is not currently supported.
+/// `TypedFunc` is not currently supported.
 pub trait WasmResults: WasmParams {
     #[doc(hidden)]
     type Abi;

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -202,6 +202,7 @@ unsafe impl WasmTy for Option<ExternRef> {
         true
     }
 
+    #[inline]
     fn into_abi(self, store: &Store) -> Self::Abi {
         if let Some(x) = self {
             let abi = x.inner.as_raw();

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -47,13 +47,9 @@
 //!
 //!     // Instantiation of a module requires specifying its imports and then
 //!     // afterwards we can fetch exports by name, as well as asserting the
-//!     // type signature of the function with `get0`.
+//!     // type signature of the function with `get_typed_func`.
 //!     let instance = Instance::new(&store, &module, &[host_hello.into()])?;
-//!     let hello = instance
-//!         .get_func("hello")
-//!         .ok_or(anyhow::format_err!("failed to find `hello` function export"))?
-//!         .typed::<(), ()>()?
-//!         .clone();
+//!     let hello = instance.get_typed_func::<(), ()>("hello")?;
 //!
 //!     // And finally we can call the wasm as if it were a Rust function!
 //!     hello.call(())?;
@@ -263,7 +259,7 @@
 //!     "#,
 //! )?;
 //! let instance = Instance::new(&store, &module, &[log_str.into()])?;
-//! let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
+//! let foo = instance.get_typed_func::<(), ()>("foo")?;
 //! foo.call(())?;
 //! # Ok(())
 //! # }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -52,10 +52,11 @@
 //!     let hello = instance
 //!         .get_func("hello")
 //!         .ok_or(anyhow::format_err!("failed to find `hello` function export"))?
-//!         .get0::<()>()?;
+//!         .typed::<(), ()>()?
+//!         .clone();
 //!
 //!     // And finally we can call the wasm as if it were a Rust function!
-//!     hello()?;
+//!     hello.call(())?;
 //!
 //!     Ok(())
 //! }
@@ -262,8 +263,8 @@
 //!     "#,
 //! )?;
 //! let instance = Instance::new(&store, &module, &[log_str.into()])?;
-//! let foo = instance.get_func("foo").unwrap().get0::<()>()?;
-//! foo()?;
+//! let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
+//! foo.call(())?;
 //! # Ok(())
 //! # }
 //! ```

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -355,10 +355,10 @@ impl Linker {
     /// "#;
     /// let module = Module::new(store.engine(), wat)?;
     /// linker.module("commander", &module)?;
-    /// let run = linker.get_default("")?.get0::<()>()?;
-    /// run()?;
-    /// run()?;
-    /// run()?;
+    /// let run = linker.get_default("")?.typed::<(), ()>()?.clone();
+    /// run.call(())?;
+    /// run.call(())?;
+    /// run.call(())?;
     ///
     /// let wat = r#"
     ///     (module
@@ -374,7 +374,8 @@ impl Linker {
     /// "#;
     /// let module = Module::new(store.engine(), wat)?;
     /// linker.module("", &module)?;
-    /// let count = linker.get_one_by_name("", Some("run"))?.into_func().unwrap().get0::<i32>()?()?;
+    /// let run = linker.get_one_by_name("", Some("run"))?.into_func().unwrap();
+    /// let count = run.typed::<(), i32>()?.call(())?;
     /// assert_eq!(count, 0, "a Command should get a fresh instance on each invocation");
     ///
     /// # Ok(())
@@ -388,8 +389,8 @@ impl Linker {
 
                 if let Some(export) = instance.get_export("_initialize") {
                     if let Extern::Func(func) = export {
-                        func.get0::<()>()
-                            .and_then(|f| f().map_err(Into::into))
+                        func.typed::<(), ()>()
+                            .and_then(|f| f.call(()).map_err(Into::into))
                             .context("calling the Reactor initialization function")?;
                     }
                 }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -482,7 +482,8 @@ impl Store {
     /// let run = instance
     ///     .get_func("run")
     ///     .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-    ///     .get0::<()>()?;
+    ///     .typed::<(), ()>()?
+    ///     .clone();
     ///
     /// // Spin up a thread to send us an interrupt in a second
     /// std::thread::spawn(move || {
@@ -490,7 +491,7 @@ impl Store {
     ///     interrupt_handle.interrupt();
     /// });
     ///
-    /// let trap = run().unwrap_err();
+    /// let trap = run.call(()).unwrap_err();
     /// assert!(trap.to_string().contains("wasm trap: interrupt"));
     /// # Ok(())
     /// # }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -479,11 +479,7 @@ impl Store {
     ///     (func (export "run") (loop br 0))
     /// "#)?;
     /// let instance = Instance::new(&store, &module, &[])?;
-    /// let run = instance
-    ///     .get_func("run")
-    ///     .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-    ///     .typed::<(), ()>()?
-    ///     .clone();
+    /// let run = instance.get_typed_func::<(), ()>("run")?;
     ///
     /// // Spin up a thread to send us an interrupt in a second
     /// std::thread::spawn(move || {

--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -79,13 +79,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("`answer` was not an exported function");
 
     // There's a few ways we can call the `answer` `Func` value. The easiest
-    // is to statically assert its signature with `get0` (in this case asserting
-    // it takes no arguments and returns one i32) and then call it.
-    let answer = answer.get0::<i32>()?;
+    // is to statically assert its signature with `typed` (in this case
+    // asserting it takes no arguments and returns one i32) and then call it.
+    let answer = answer.typed::<(), i32>()?;
 
     // And finally we can call our function! Note that the error propagation
     // with `?` is done to handle the case where the wasm function traps.
-    let result = answer()?;
+    let result = answer.call(())?;
     println!("Answer: {:?}", result);
     Ok(())
 }
@@ -168,9 +168,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .get_func("run")
         .expect("`run` was not an exported function");
 
-    let run = run.get0::<()>()?;
+    let run = run.typed::<(), ()>()?;
 
-    Ok(run()?)
+    Ok(run.call(())?)
 }
 ```
 

--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -164,12 +164,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // entry in the slice must line up with the imports in the module.
     let instance = Instance::new(&store, &module, &[log.into(), double.into()])?;
 
-    let run = instance
-        .get_func("run")
-        .expect("`run` was not an exported function");
-
-    let run = run.typed::<(), ()>()?;
-
+    let run = instance.get_typed_func::<(), ()>("run")?;
     Ok(run.call(())?)
 }
 ```

--- a/docs/wasm-wat.md
+++ b/docs/wasm-wat.md
@@ -48,8 +48,7 @@ let wat = r#"
 "#;
 let module = Module::new(&engine, wat)?;
 let instance = Instance::new(&store, &module, &[])?;
-let add = instance.get_func("add").unwrap();
-let add = add.typed::<(i32, i32), i32>()?;
+let add = instance.get_typed_func::<(i32, i32), i32>("add")?;
 println!("1 + 2 = {}", add.call((1, 2))?);
 # Ok(())
 # }

--- a/docs/wasm-wat.md
+++ b/docs/wasm-wat.md
@@ -49,8 +49,8 @@ let wat = r#"
 let module = Module::new(&engine, wat)?;
 let instance = Instance::new(&store, &module, &[])?;
 let add = instance.get_func("add").unwrap();
-let add = add.get2::<i32, i32, i32>()?;
-println!("1 + 2 = {}", add(1, 2)?);
+let add = add.typed::<(i32, i32), i32>()?;
+println!("1 + 2 = {}", add.call((1, 2))?);
 # Ok(())
 # }
 ```

--- a/examples/externref.rs
+++ b/examples/externref.rs
@@ -41,8 +41,8 @@ fn main() -> Result<()> {
 
     println!("Calling `externref` func...");
     let func = instance.get_func("func").unwrap();
-    let func = func.get1::<Option<ExternRef>, Option<ExternRef>>()?;
-    let ret = func(Some(externref.clone()))?;
+    let func = func.typed::<Option<ExternRef>, Option<ExternRef>>()?;
+    let ret = func.call(Some(externref.clone()))?;
     assert!(ret.is_some());
     assert!(ret.unwrap().ptr_eq(&externref));
 

--- a/examples/externref.rs
+++ b/examples/externref.rs
@@ -40,8 +40,7 @@ fn main() -> Result<()> {
     assert!(global_val.ptr_eq(&externref));
 
     println!("Calling `externref` func...");
-    let func = instance.get_func("func").unwrap();
-    let func = func.typed::<Option<ExternRef>, Option<ExternRef>>()?;
+    let func = instance.get_typed_func::<Option<ExternRef>, Option<ExternRef>>("func")?;
     let ret = func.call(Some(externref.clone()))?;
     assert!(ret.is_some());
     assert!(ret.unwrap().ptr_eq(&externref));

--- a/examples/fib-debug/main.rs
+++ b/examples/fib-debug/main.rs
@@ -21,11 +21,7 @@ fn main() -> Result<()> {
     let instance = Instance::new(&store, &module, &[])?;
 
     // Invoke `fib` export
-    let fib = instance
-        .get_func("fib")
-        .ok_or(anyhow::format_err!("failed to find `fib` function export"))?
-        .typed::<i32, i32>()?
-        .clone();
+    let fib = instance.get_typed_func::<i32, i32>("fib")?;
     println!("fib(6) = {}", fib.call(6)?);
     Ok(())
 }

--- a/examples/fib-debug/main.rs
+++ b/examples/fib-debug/main.rs
@@ -24,7 +24,8 @@ fn main() -> Result<()> {
     let fib = instance
         .get_func("fib")
         .ok_or(anyhow::format_err!("failed to find `fib` function export"))?
-        .get1::<i32, i32>()?;
-    println!("fib(6) = {}", fib(6)?);
+        .typed::<i32, i32>()?
+        .clone();
+    println!("fib(6) = {}", fib.call(6)?);
     Ok(())
 }

--- a/examples/gcd.rs
+++ b/examples/gcd.rs
@@ -15,11 +15,7 @@ fn main() -> Result<()> {
     let instance = Instance::new(&store, &module, &[])?;
 
     // Invoke `gcd` export
-    let gcd = instance
-        .get_func("gcd")
-        .ok_or(anyhow::format_err!("failed to find `gcd` function export"))?
-        .typed::<(i32, i32), i32>()?
-        .clone();
+    let gcd = instance.get_typed_func::<(i32, i32), i32>("gcd")?;
 
     println!("gcd(6, 27) = {}", gcd.call((6, 27))?);
     Ok(())

--- a/examples/gcd.rs
+++ b/examples/gcd.rs
@@ -18,8 +18,9 @@ fn main() -> Result<()> {
     let gcd = instance
         .get_func("gcd")
         .ok_or(anyhow::format_err!("failed to find `gcd` function export"))?
-        .get2::<i32, i32, i32>()?;
+        .typed::<(i32, i32), i32>()?
+        .clone();
 
-    println!("gcd(6, 27) = {}", gcd(6, 27)?);
+    println!("gcd(6, 27) = {}", gcd.call((6, 27))?);
     Ok(())
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -34,11 +34,7 @@ fn main() -> Result<()> {
 
     // Next we poke around a bit to extract the `run` function from the module.
     println!("Extracting export...");
-    let run = instance
-        .get_func("run")
-        .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .typed::<(), ()>()?
-        .clone();
+    let run = instance.get_typed_func::<(), ()>("run")?;
 
     // And last but not least we can call it!
     println!("Calling export...");

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -37,11 +37,12 @@ fn main() -> Result<()> {
     let run = instance
         .get_func("run")
         .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .get0::<()>()?;
+        .typed::<(), ()>()?
+        .clone();
 
     // And last but not least we can call it!
     println!("Calling export...");
-    run()?;
+    run.call(())?;
 
     println!("Done.");
     Ok(())

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -16,11 +16,7 @@ fn main() -> Result<()> {
     // Compile and instantiate a small example with an infinite loop.
     let module = Module::from_file(&engine, "examples/interrupt.wat")?;
     let instance = Instance::new(&store, &module, &[])?;
-    let run = instance
-        .get_func("run")
-        .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .typed::<(), ()>()?
-        .clone();
+    let run = instance.get_typed_func::<(), ()>("run")?;
 
     // Spin up a thread to send us an interrupt in a second
     std::thread::spawn(move || {

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -19,7 +19,8 @@ fn main() -> Result<()> {
     let run = instance
         .get_func("run")
         .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .get0::<()>()?;
+        .typed::<(), ()>()?
+        .clone();
 
     // Spin up a thread to send us an interrupt in a second
     std::thread::spawn(move || {
@@ -29,7 +30,7 @@ fn main() -> Result<()> {
     });
 
     println!("Entering infinite loop ...");
-    let trap = run().unwrap_err();
+    let trap = run.call(()).unwrap_err();
 
     println!("trap received...");
     assert!(trap.to_string().contains("wasm trap: interrupt"));

--- a/examples/linking.rs
+++ b/examples/linking.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
     // And with that we can perform the final link and the execute the module.
     let linking1 = linker.instantiate(&linking1)?;
     let run = linking1.get_func("run").unwrap();
-    let run = run.get0::<()>()?;
-    run()?;
+    let run = run.typed::<(), ()>()?;
+    run.call(())?;
     Ok(())
 }

--- a/examples/linking.rs
+++ b/examples/linking.rs
@@ -34,8 +34,7 @@ fn main() -> Result<()> {
 
     // And with that we can perform the final link and the execute the module.
     let linking1 = linker.instantiate(&linking1)?;
-    let run = linking1.get_func("run").unwrap();
-    let run = run.typed::<(), ()>()?;
+    let run = linking1.get_typed_func::<(), ()>("run")?;
     run.call(())?;
     Ok(())
 }

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -23,15 +23,18 @@ fn main() -> Result<()> {
     let size = instance
         .get_func("size")
         .ok_or(anyhow::format_err!("failed to find `size` export"))?
-        .get0::<i32>()?;
+        .typed::<(), i32>()?
+        .clone();
     let load = instance
         .get_func("load")
         .ok_or(anyhow::format_err!("failed to find `load` export"))?
-        .get1::<i32, i32>()?;
+        .typed::<i32, i32>()?
+        .clone();
     let store = instance
         .get_func("store")
         .ok_or(anyhow::format_err!("failed to find `store` export"))?
-        .get2::<i32, i32, ()>()?;
+        .typed::<(i32, i32), ()>()?
+        .clone();
 
     // Note that these memory reads are *unsafe* due to unknown knowledge about
     // aliasing with wasm memory. For more information about the safety
@@ -46,27 +49,27 @@ fn main() -> Result<()> {
         assert_eq!(memory.data_unchecked_mut()[0x1003], 4);
     }
 
-    assert_eq!(size()?, 2);
-    assert_eq!(load(0)?, 0);
-    assert_eq!(load(0x1000)?, 1);
-    assert_eq!(load(0x1003)?, 4);
-    assert_eq!(load(0x1ffff)?, 0);
-    assert!(load(0x20000).is_err()); // out of bounds trap
+    assert_eq!(size.call(())?, 2);
+    assert_eq!(load.call(0)?, 0);
+    assert_eq!(load.call(0x1000)?, 1);
+    assert_eq!(load.call(0x1003)?, 4);
+    assert_eq!(load.call(0x1ffff)?, 0);
+    assert!(load.call(0x20000).is_err()); // out of bounds trap
 
     println!("Mutating memory...");
     unsafe {
         memory.data_unchecked_mut()[0x1003] = 5;
     }
 
-    store(0x1002, 6)?;
-    assert!(store(0x20000, 0).is_err()); // out of bounds trap
+    store.call((0x1002, 6))?;
+    assert!(store.call((0x20000, 0)).is_err()); // out of bounds trap
 
     unsafe {
         assert_eq!(memory.data_unchecked_mut()[0x1002], 6);
         assert_eq!(memory.data_unchecked_mut()[0x1003], 5);
     }
-    assert_eq!(load(0x1002)?, 6);
-    assert_eq!(load(0x1003)?, 5);
+    assert_eq!(load.call(0x1002)?, 6);
+    assert_eq!(load.call(0x1003)?, 5);
 
     // Grow memory.
     println!("Growing memory...");
@@ -74,10 +77,10 @@ fn main() -> Result<()> {
     assert_eq!(memory.size(), 3);
     assert_eq!(memory.data_size(), 0x30000);
 
-    assert_eq!(load(0x20000)?, 0);
-    store(0x20000, 0)?;
-    assert!(load(0x30000).is_err());
-    assert!(store(0x30000, 0).is_err());
+    assert_eq!(load.call(0x20000)?, 0);
+    store.call((0x20000, 0))?;
+    assert!(load.call(0x30000).is_err());
+    assert!(store.call((0x30000, 0)).is_err());
 
     assert!(memory.grow(1).is_err());
     assert!(memory.grow(0).is_ok());

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -20,21 +20,9 @@ fn main() -> Result<()> {
     let memory = instance
         .get_memory("memory")
         .ok_or(anyhow::format_err!("failed to find `memory` export"))?;
-    let size = instance
-        .get_func("size")
-        .ok_or(anyhow::format_err!("failed to find `size` export"))?
-        .typed::<(), i32>()?
-        .clone();
-    let load = instance
-        .get_func("load")
-        .ok_or(anyhow::format_err!("failed to find `load` export"))?
-        .typed::<i32, i32>()?
-        .clone();
-    let store = instance
-        .get_func("store")
-        .ok_or(anyhow::format_err!("failed to find `store` export"))?
-        .typed::<(i32, i32), ()>()?
-        .clone();
+    let size = instance.get_typed_func::<(), i32>("size")?;
+    let load = instance.get_typed_func::<i32, i32>("load")?;
+    let store = instance.get_typed_func::<(i32, i32), ()>("store")?;
 
     // Note that these memory reads are *unsafe* due to unknown knowledge about
     // aliasing with wasm memory. For more information about the safety

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -7,7 +7,7 @@
 
 // You can execute this example with `cargo run --example multi`
 
-use anyhow::{format_err, Result};
+use anyhow::Result;
 use wasmtime::*;
 
 fn main() -> Result<()> {
@@ -40,51 +40,31 @@ fn main() -> Result<()> {
 
     // Extract exports.
     println!("Extracting export...");
-    let g = instance
-        .get_func("g")
-        .ok_or(format_err!("failed to find export `g`"))?;
+    let g = instance.get_typed_func::<(i32, i64), (i64, i32)>("g")?;
 
     // Call `$g`.
     println!("Calling export \"g\"...");
-    let results = g.call(&[Val::I32(1), Val::I64(3)])?;
+    let (a, b) = g.call((1, 3))?;
 
     println!("Printing result...");
-    println!("> {} {}", results[0].unwrap_i64(), results[1].unwrap_i32());
+    println!("> {} {}", a, b);
 
-    assert_eq!(results[0].unwrap_i64(), 4);
-    assert_eq!(results[1].unwrap_i32(), 2);
+    assert_eq!(a, 4);
+    assert_eq!(b, 2);
 
     // Call `$round_trip_many`.
     println!("Calling export \"round_trip_many\"...");
     let round_trip_many = instance
-        .get_func("round_trip_many")
-        .ok_or(format_err!("failed to find export `round_trip_many`"))?;
-    let args = vec![
-        Val::I64(0),
-        Val::I64(1),
-        Val::I64(2),
-        Val::I64(3),
-        Val::I64(4),
-        Val::I64(5),
-        Val::I64(6),
-        Val::I64(7),
-        Val::I64(8),
-        Val::I64(9),
-    ];
-    let results = round_trip_many.call(&args)?;
+        .get_typed_func::<
+        (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64),
+        (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64),
+        >
+        ("round_trip_many")?;
+    let results = round_trip_many.call((0, 1, 2, 3, 4, 5, 6, 7, 8, 9))?;
 
     println!("Printing result...");
-    print!(">");
-    for r in results.iter() {
-        print!(" {}", r.unwrap_i64());
-    }
-    println!();
-
-    assert_eq!(results.len(), 10);
-    assert!(args
-        .iter()
-        .zip(results.iter())
-        .all(|(a, r)| a.i64() == r.i64()));
+    println!("> {:?}", results);
+    assert_eq!(results, (0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
     Ok(())
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -50,11 +50,7 @@ fn deserialize(buffer: &[u8]) -> Result<()> {
 
     // Next we poke around a bit to extract the `run` function from the module.
     println!("Extracting export...");
-    let run = instance
-        .get_func("run")
-        .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .typed::<(), ()>()?
-        .clone();
+    let run = instance.get_typed_func::<(), ()>("run")?;
 
     // And last but not least we can call it!
     println!("Calling export...");

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -53,11 +53,12 @@ fn deserialize(buffer: &[u8]) -> Result<()> {
     let run = instance
         .get_func("run")
         .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .get0::<()>()?;
+        .typed::<(), ()>()?
+        .clone();
 
     // And last but not least we can call it!
     println!("Calling export...");
-    run()?;
+    run.call(())?;
 
     println!("Done.");
     Ok(())

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,6 +1,6 @@
 // You can execute this example with `cargo run --example threads`
 
-use anyhow::{format_err, Result};
+use anyhow::Result;
 use std::thread;
 use std::time;
 use wasmtime::*;
@@ -26,14 +26,12 @@ fn run(engine: &Engine, module: Module, id: i32) -> Result<()> {
 
     // Extract exports.
     println!("Extracting export...");
-    let g = instance
-        .get_func("run")
-        .ok_or(format_err!("failed to find export `run`"))?;
+    let g = instance.get_typed_func::<(), ()>("run")?;
 
     for _ in 0..N_REPS {
         thread::sleep(time::Duration::from_millis(100));
         // Call `$run`.
-        drop(g.call(&[])?);
+        drop(g.call(())?);
     }
 
     Ok(())

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
     // Instantiate our module with the imports we've created, and run it.
     let module = Module::from_file(store.engine(), "target/wasm32-wasi/debug/wasi.wasm")?;
     linker.module("", &module)?;
-    linker.get_default("")?.get0::<()>()?()?;
+    linker.get_default("")?.typed::<(), ()>()?.call(())?;
 
     Ok(())
 }

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -18,12 +18,12 @@ fn run_smoke_test(func: &Func) {
     run(future1).unwrap();
 }
 
-fn run_smoke_get0_test(func: &Func) {
-    let func = func.get0_async::<()>().unwrap();
-    run(func()).unwrap();
-    run(func()).unwrap();
-    let future1 = func();
-    let future2 = func();
+fn run_smoke_typed_test(func: &Func) {
+    let func = func.typed::<(), ()>().unwrap();
+    run(func.call_async(())).unwrap();
+    run(func.call_async(())).unwrap();
+    let future1 = func.call_async(());
+    let future2 = func.call_async(());
     run(future2).unwrap();
     run(future1).unwrap();
 }
@@ -38,13 +38,13 @@ fn smoke() {
         move |_caller, _state, _params, _results| Box::new(async { Ok(()) }),
     );
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 
     let func = Func::wrap0_async(&store, (), move |_caller: Caller<'_>, _state| {
         Box::new(async { Ok(()) })
     });
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 }
 
 #[test]
@@ -67,13 +67,13 @@ fn smoke_host_func() {
         .get_host_func("", "first")
         .expect("expected host function");
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 
     let func = store
         .get_host_func("", "second")
         .expect("expected host function");
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn smoke_with_suspension() {
         },
     );
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 
     let func = Func::wrap0_async(&store, (), move |_caller: Caller<'_>, _state| {
         Box::new(async {
@@ -100,7 +100,7 @@ fn smoke_with_suspension() {
         })
     });
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 }
 
 #[test]
@@ -131,13 +131,13 @@ fn smoke_host_func_with_suspension() {
         .get_host_func("", "first")
         .expect("expected host function");
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 
     let func = store
         .get_host_func("", "second")
         .expect("expected host function");
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 }
 
 #[test]
@@ -460,7 +460,7 @@ fn async_with_pooling_stacks() {
     );
 
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 }
 
 #[test]
@@ -491,5 +491,5 @@ fn async_host_func_with_pooling_stacks() {
     let func = store.get_host_func("", "").expect("expected host function");
 
     run_smoke_test(&func);
-    run_smoke_get0_test(&func);
+    run_smoke_typed_test(&func);
 }

--- a/tests/all/externals.rs
+++ b/tests/all/externals.rs
@@ -120,6 +120,16 @@ fn cross_store() -> anyhow::Result<()> {
     assert!(s2_f.call(&[Val::FuncRef(Some(s1_f.clone()))]).is_err());
     assert!(s2_f.call(&[Val::FuncRef(Some(s2_f.clone()))]).is_ok());
 
+    let s1_f_t = s1_f.typed::<Option<Func>, ()>()?;
+    let s2_f_t = s2_f.typed::<Option<Func>, ()>()?;
+
+    assert!(s1_f_t.call(None).is_ok());
+    assert!(s2_f_t.call(None).is_ok());
+    assert!(s1_f_t.call(Some(s1_f.clone())).is_ok());
+    assert!(s1_f_t.call(Some(s2_f.clone())).is_err());
+    assert!(s2_f_t.call(Some(s1_f.clone())).is_err());
+    assert!(s2_f_t.call(Some(s2_f.clone())).is_ok());
+
     Ok(())
 }
 

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -243,41 +243,40 @@ fn trap_import() -> Result<()> {
 fn get_from_wrapper() {
     let store = Store::default();
     let f = Func::wrap(&store, || {});
-    assert!(f.get0::<()>().is_ok());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<(), ()>().is_ok());
-    assert!(f.get1::<i32, ()>().is_err());
-    assert!(f.get1::<i32, i32>().is_err());
-    assert!(f.get2::<(), (), ()>().is_ok());
-    assert!(f.get2::<i32, i32, ()>().is_err());
-    assert!(f.get2::<i32, i32, i32>().is_err());
+    assert!(f.typed::<(), ()>().is_ok());
+    assert!(f.typed::<(), i32>().is_err());
+    assert!(f.typed::<(), ()>().is_ok());
+    assert!(f.typed::<i32, ()>().is_err());
+    assert!(f.typed::<i32, i32>().is_err());
+    assert!(f.typed::<(i32, i32), ()>().is_err());
+    assert!(f.typed::<(i32, i32), i32>().is_err());
 
     let f = Func::wrap(&store, || -> i32 { loop {} });
-    assert!(f.get0::<i32>().is_ok());
+    assert!(f.typed::<(), i32>().is_ok());
     let f = Func::wrap(&store, || -> f32 { loop {} });
-    assert!(f.get0::<f32>().is_ok());
+    assert!(f.typed::<(), f32>().is_ok());
     let f = Func::wrap(&store, || -> f64 { loop {} });
-    assert!(f.get0::<f64>().is_ok());
+    assert!(f.typed::<(), f64>().is_ok());
     let f = Func::wrap(&store, || -> Option<ExternRef> { loop {} });
-    assert!(f.get0::<Option<ExternRef>>().is_ok());
+    assert!(f.typed::<(), Option<ExternRef>>().is_ok());
     let f = Func::wrap(&store, || -> Option<Func> { loop {} });
-    assert!(f.get0::<Option<Func>>().is_ok());
+    assert!(f.typed::<(), Option<Func>>().is_ok());
 
     let f = Func::wrap(&store, |_: i32| {});
-    assert!(f.get1::<i32, ()>().is_ok());
-    assert!(f.get1::<i64, ()>().is_err());
-    assert!(f.get1::<f32, ()>().is_err());
-    assert!(f.get1::<f64, ()>().is_err());
+    assert!(f.typed::<i32, ()>().is_ok());
+    assert!(f.typed::<i64, ()>().is_err());
+    assert!(f.typed::<f32, ()>().is_err());
+    assert!(f.typed::<f64, ()>().is_err());
     let f = Func::wrap(&store, |_: i64| {});
-    assert!(f.get1::<i64, ()>().is_ok());
+    assert!(f.typed::<i64, ()>().is_ok());
     let f = Func::wrap(&store, |_: f32| {});
-    assert!(f.get1::<f32, ()>().is_ok());
+    assert!(f.typed::<f32, ()>().is_ok());
     let f = Func::wrap(&store, |_: f64| {});
-    assert!(f.get1::<f64, ()>().is_ok());
+    assert!(f.typed::<f64, ()>().is_ok());
     let f = Func::wrap(&store, |_: Option<ExternRef>| {});
-    assert!(f.get1::<Option<ExternRef>, ()>().is_ok());
+    assert!(f.typed::<Option<ExternRef>, ()>().is_ok());
     let f = Func::wrap(&store, |_: Option<Func>| {});
-    assert!(f.get1::<Option<Func>, ()>().is_ok());
+    assert!(f.typed::<Option<Func>, ()>().is_ok());
 }
 
 #[test]
@@ -285,16 +284,16 @@ fn get_from_signature() {
     let store = Store::default();
     let ty = FuncType::new(None, None);
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.get0::<()>().is_ok());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<i32, ()>().is_err());
+    assert!(f.typed::<(), ()>().is_ok());
+    assert!(f.typed::<(), i32>().is_err());
+    assert!(f.typed::<i32, ()>().is_err());
 
     let ty = FuncType::new(Some(ValType::I32), Some(ValType::F64));
     let f = Func::new(&store, ty, |_, _, _| panic!());
-    assert!(f.get0::<()>().is_err());
-    assert!(f.get0::<i32>().is_err());
-    assert!(f.get1::<i32, ()>().is_err());
-    assert!(f.get1::<i32, f64>().is_ok());
+    assert!(f.typed::<(), ()>().is_err());
+    assert!(f.typed::<(), i32>().is_err());
+    assert!(f.typed::<i32, ()>().is_err());
+    assert!(f.typed::<i32, f64>().is_ok());
 }
 
 #[test]
@@ -314,17 +313,17 @@ fn get_from_module() -> anyhow::Result<()> {
     )?;
     let instance = Instance::new(&store, &module, &[])?;
     let f0 = instance.get_func("f0").unwrap();
-    assert!(f0.get0::<()>().is_ok());
-    assert!(f0.get0::<i32>().is_err());
+    assert!(f0.typed::<(), ()>().is_ok());
+    assert!(f0.typed::<(), i32>().is_err());
     let f1 = instance.get_func("f1").unwrap();
-    assert!(f1.get0::<()>().is_err());
-    assert!(f1.get1::<i32, ()>().is_ok());
-    assert!(f1.get1::<i32, f32>().is_err());
+    assert!(f1.typed::<(), ()>().is_err());
+    assert!(f1.typed::<i32, ()>().is_ok());
+    assert!(f1.typed::<i32, f32>().is_err());
     let f2 = instance.get_func("f2").unwrap();
-    assert!(f2.get0::<()>().is_err());
-    assert!(f2.get0::<i32>().is_ok());
-    assert!(f2.get1::<i32, ()>().is_err());
-    assert!(f2.get1::<i32, f32>().is_err());
+    assert!(f2.typed::<(), ()>().is_err());
+    assert!(f2.typed::<(), i32>().is_ok());
+    assert!(f2.typed::<i32, ()>().is_err());
+    assert!(f2.typed::<i32, f32>().is_err());
     Ok(())
 }
 
@@ -338,31 +337,32 @@ fn call_wrapped_func() -> Result<()> {
         assert_eq!(d, 4.0);
     });
     f.call(&[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()])?;
-    f.get4::<i32, i64, f32, f64, ()>()?(1, 2, 3.0, 4.0)?;
+    f.typed::<(i32, i64, f32, f64), ()>()?
+        .call((1, 2, 3.0, 4.0))?;
 
     let f = Func::wrap(&store, || 1i32);
     let results = f.call(&[])?;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].unwrap_i32(), 1);
-    assert_eq!(f.get0::<i32>()?()?, 1);
+    assert_eq!(f.typed::<(), i32>()?.call(())?, 1);
 
     let f = Func::wrap(&store, || 2i64);
     let results = f.call(&[])?;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].unwrap_i64(), 2);
-    assert_eq!(f.get0::<i64>()?()?, 2);
+    assert_eq!(f.typed::<(), i64>()?.call(())?, 2);
 
     let f = Func::wrap(&store, || 3.0f32);
     let results = f.call(&[])?;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].unwrap_f32(), 3.0);
-    assert_eq!(f.get0::<f32>()?()?, 3.0);
+    assert_eq!(f.typed::<(), f32>()?.call(())?, 3.0);
 
     let f = Func::wrap(&store, || 4.0f64);
     let results = f.call(&[])?;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].unwrap_f64(), 4.0);
-    assert_eq!(f.get0::<f64>()?()?, 4.0);
+    assert_eq!(f.typed::<(), f64>()?.call(())?, 4.0);
     Ok(())
 }
 
@@ -500,8 +500,8 @@ fn pass_cross_store_arg() -> anyhow::Result<()> {
 
     // And using `.get` followed by a function call also fails with cross-Store
     // arguments.
-    let f = store1_func.get1::<Option<Func>, ()>()?;
-    let result = f(Some(store2_func));
+    let f = store1_func.typed::<Option<Func>, ()>()?;
+    let result = f.call(Some(store2_func));
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("cross-`Store`"));
 

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -27,9 +27,13 @@ fn loops_interruptable() -> anyhow::Result<()> {
     let store = interruptable_store();
     let module = Module::new(store.engine(), r#"(func (export "loop") (loop br 0))"#)?;
     let instance = Instance::new(&store, &module, &[])?;
-    let iloop = instance.get_func("loop").unwrap().get0::<()>()?;
+    let iloop = instance
+        .get_func("loop")
+        .unwrap()
+        .typed::<(), ()>()?
+        .clone();
     store.interrupt_handle()?.interrupt();
-    let trap = iloop().unwrap_err();
+    let trap = iloop.call(()).unwrap_err();
     assert!(trap.to_string().contains("wasm trap: interrupt"));
     Ok(())
 }
@@ -40,9 +44,13 @@ fn functions_interruptable() -> anyhow::Result<()> {
     let module = hugely_recursive_module(&store)?;
     let func = Func::wrap(&store, || {});
     let instance = Instance::new(&store, &module, &[func.into()])?;
-    let iloop = instance.get_func("loop").unwrap().get0::<()>()?;
+    let iloop = instance
+        .get_func("loop")
+        .unwrap()
+        .typed::<(), ()>()?
+        .clone();
     store.interrupt_handle()?.interrupt();
-    let trap = iloop().unwrap_err();
+    let trap = iloop.call(()).unwrap_err();
     assert!(
         trap.to_string().contains("wasm trap: interrupt"),
         "{}",
@@ -88,8 +96,12 @@ fn loop_interrupt_from_afar() -> anyhow::Result<()> {
 
     // Enter the infinitely looping function and assert that our interrupt
     // handle does indeed actually interrupt the function.
-    let iloop = instance.get_func("loop").unwrap().get0::<()>()?;
-    let trap = iloop().unwrap_err();
+    let iloop = instance
+        .get_func("loop")
+        .unwrap()
+        .typed::<(), ()>()?
+        .clone();
+    let trap = iloop.call(()).unwrap_err();
     thread.join().unwrap();
     assert!(
         trap.to_string().contains("wasm trap: interrupt"),
@@ -124,8 +136,12 @@ fn function_interrupt_from_afar() -> anyhow::Result<()> {
 
     // Enter the infinitely looping function and assert that our interrupt
     // handle does indeed actually interrupt the function.
-    let iloop = instance.get_func("loop").unwrap().get0::<()>()?;
-    let trap = iloop().unwrap_err();
+    let iloop = instance
+        .get_func("loop")
+        .unwrap()
+        .typed::<(), ()>()?
+        .clone();
+    let trap = iloop.call(()).unwrap_err();
     thread.join().unwrap();
     assert!(
         trap.to_string().contains("wasm trap: interrupt"),

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -27,11 +27,7 @@ fn loops_interruptable() -> anyhow::Result<()> {
     let store = interruptable_store();
     let module = Module::new(store.engine(), r#"(func (export "loop") (loop br 0))"#)?;
     let instance = Instance::new(&store, &module, &[])?;
-    let iloop = instance
-        .get_func("loop")
-        .unwrap()
-        .typed::<(), ()>()?
-        .clone();
+    let iloop = instance.get_typed_func::<(), ()>("loop")?;
     store.interrupt_handle()?.interrupt();
     let trap = iloop.call(()).unwrap_err();
     assert!(trap.to_string().contains("wasm trap: interrupt"));
@@ -44,11 +40,7 @@ fn functions_interruptable() -> anyhow::Result<()> {
     let module = hugely_recursive_module(&store)?;
     let func = Func::wrap(&store, || {});
     let instance = Instance::new(&store, &module, &[func.into()])?;
-    let iloop = instance
-        .get_func("loop")
-        .unwrap()
-        .typed::<(), ()>()?
-        .clone();
+    let iloop = instance.get_typed_func::<(), ()>("loop")?;
     store.interrupt_handle()?.interrupt();
     let trap = iloop.call(()).unwrap_err();
     assert!(
@@ -96,11 +88,7 @@ fn loop_interrupt_from_afar() -> anyhow::Result<()> {
 
     // Enter the infinitely looping function and assert that our interrupt
     // handle does indeed actually interrupt the function.
-    let iloop = instance
-        .get_func("loop")
-        .unwrap()
-        .typed::<(), ()>()?
-        .clone();
+    let iloop = instance.get_typed_func::<(), ()>("loop")?;
     let trap = iloop.call(()).unwrap_err();
     thread.join().unwrap();
     assert!(
@@ -136,11 +124,7 @@ fn function_interrupt_from_afar() -> anyhow::Result<()> {
 
     // Enter the infinitely looping function and assert that our interrupt
     // handle does indeed actually interrupt the function.
-    let iloop = instance
-        .get_func("loop")
-        .unwrap()
-        .typed::<(), ()>()?
-        .clone();
+    let iloop = instance.get_typed_func::<(), ()>("loop")?;
     let trap = iloop.call(()).unwrap_err();
     thread.join().unwrap();
     assert!(

--- a/tests/all/import_indexes.rs
+++ b/tests/all/import_indexes.rs
@@ -43,12 +43,8 @@ fn same_import_names_still_distinct() -> anyhow::Result<()> {
     ];
     let instance = Instance::new(&store, &module, &imports)?;
 
-    let func = instance.get_func("foo").unwrap();
-    let results = func.call(&[])?;
-    assert_eq!(results.len(), 1);
-    match results[0] {
-        Val::I32(n) => assert_eq!(n, 3),
-        _ => panic!("unexpected type of return"),
-    }
+    let func = instance.get_typed_func::<(), i32>("foo")?;
+    let result = func.call(())?;
+    assert_eq!(result, 3);
     Ok(())
 }

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -96,8 +96,8 @@ fn function_interposition() -> Result<()> {
     }
     let instance = linker.instantiate(&module)?;
     let func = instance.get_export("green").unwrap().into_func().unwrap();
-    let func = func.get0::<i32>()?;
-    assert_eq!(func()?, 112);
+    let func = func.typed::<(), i32>()?;
+    assert_eq!(func.call(())?, 112);
     Ok(())
 }
 
@@ -129,8 +129,8 @@ fn function_interposition_renamed() -> Result<()> {
     }
     let instance = linker.instantiate(&module)?;
     let func = instance.get_func("export").unwrap();
-    let func = func.get0::<i32>()?;
-    assert_eq!(func()?, 112);
+    let func = func.typed::<(), i32>()?;
+    assert_eq!(func.call(())?, 112);
     Ok(())
 }
 
@@ -158,8 +158,8 @@ fn module_interposition() -> Result<()> {
     }
     let instance = linker.instantiate(&module)?;
     let func = instance.get_export("export").unwrap().into_func().unwrap();
-    let func = func.get0::<i32>()?;
-    assert_eq!(func()?, 112);
+    let func = func.typed::<(), i32>()?;
+    assert_eq!(func.call(())?, 112);
     Ok(())
 }
 

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -20,11 +20,7 @@ fn test_module_serialize_simple() -> Result<()> {
 
     let store = Store::default();
     let instance = deserialize_and_instantiate(&store, &buffer)?;
-    let run = instance
-        .get_func("run")
-        .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .typed::<(), i32>()?
-        .clone();
+    let run = instance.get_typed_func::<(), i32>("run")?;
     let result = run.call(())?;
 
     assert_eq!(42, result);

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -23,8 +23,9 @@ fn test_module_serialize_simple() -> Result<()> {
     let run = instance
         .get_func("run")
         .ok_or(anyhow::format_err!("failed to find `run` function export"))?
-        .get0::<i32>()?;
-    let result = run()?;
+        .typed::<(), i32>()?
+        .clone();
+    let result = run.call(())?;
 
     assert_eq!(42, result);
     Ok(())

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -63,12 +63,7 @@ fn memory_limit() -> Result<()> {
     {
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
-        let f = instance
-            .get_func("f")
-            .unwrap()
-            .typed::<(), i32>()
-            .unwrap()
-            .clone();
+        let f = instance.get_typed_func::<(), i32>("f")?;
 
         assert_eq!(f.call(()).expect("function should not trap"), 0);
         assert_eq!(f.call(()).expect("function should not trap"), 1);
@@ -160,12 +155,7 @@ fn memory_guard_page_trap() -> Result<()> {
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
         let m = instance.get_memory("m").unwrap();
-        let f = instance
-            .get_func("f")
-            .unwrap()
-            .typed::<i32, ()>()
-            .unwrap()
-            .clone();
+        let f = instance.get_typed_func::<i32, ()>("f")?;
 
         let trap = f.call(0).expect_err("function should trap");
         assert!(trap.to_string().contains("out of bounds"));
@@ -271,12 +261,7 @@ fn table_limit() -> Result<()> {
     {
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
-        let f = instance
-            .get_func("f")
-            .unwrap()
-            .typed::<(), i32>()
-            .unwrap()
-            .clone();
+        let f = instance.get_typed_func::<(), i32>("f")?;
 
         for i in 0..TABLE_ELEMENTS {
             assert_eq!(f.call(()).expect("function should not trap"), i as i32);

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -63,13 +63,18 @@ fn memory_limit() -> Result<()> {
     {
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
-        let f = instance.get_func("f").unwrap().get0::<i32>().unwrap();
+        let f = instance
+            .get_func("f")
+            .unwrap()
+            .typed::<(), i32>()
+            .unwrap()
+            .clone();
 
-        assert_eq!(f().expect("function should not trap"), 0);
-        assert_eq!(f().expect("function should not trap"), 1);
-        assert_eq!(f().expect("function should not trap"), 2);
-        assert_eq!(f().expect("function should not trap"), -1);
-        assert_eq!(f().expect("function should not trap"), -1);
+        assert_eq!(f.call(()).expect("function should not trap"), 0);
+        assert_eq!(f.call(()).expect("function should not trap"), 1);
+        assert_eq!(f.call(()).expect("function should not trap"), 2);
+        assert_eq!(f.call(()).expect("function should not trap"), -1);
+        assert_eq!(f.call(()).expect("function should not trap"), -1);
     }
 
     // Instantiate the module and grow the memory via the Wasmtime API
@@ -155,25 +160,30 @@ fn memory_guard_page_trap() -> Result<()> {
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
         let m = instance.get_memory("m").unwrap();
-        let f = instance.get_func("f").unwrap().get1::<i32, ()>().unwrap();
+        let f = instance
+            .get_func("f")
+            .unwrap()
+            .typed::<i32, ()>()
+            .unwrap()
+            .clone();
 
-        let trap = f(0).expect_err("function should trap");
+        let trap = f.call(0).expect_err("function should trap");
         assert!(trap.to_string().contains("out of bounds"));
 
-        let trap = f(1).expect_err("function should trap");
-        assert!(trap.to_string().contains("out of bounds"));
-
-        m.grow(1).expect("memory should grow");
-        f(0).expect("function should not trap");
-
-        let trap = f(65536).expect_err("function should trap");
-        assert!(trap.to_string().contains("out of bounds"));
-
-        let trap = f(65537).expect_err("function should trap");
+        let trap = f.call(1).expect_err("function should trap");
         assert!(trap.to_string().contains("out of bounds"));
 
         m.grow(1).expect("memory should grow");
-        f(65536).expect("function should not trap");
+        f.call(0).expect("function should not trap");
+
+        let trap = f.call(65536).expect_err("function should trap");
+        assert!(trap.to_string().contains("out of bounds"));
+
+        let trap = f.call(65537).expect_err("function should trap");
+        assert!(trap.to_string().contains("out of bounds"));
+
+        m.grow(1).expect("memory should grow");
+        f.call(65536).expect("function should not trap");
 
         m.grow(1).expect_err("memory should be at the limit");
     }
@@ -261,14 +271,19 @@ fn table_limit() -> Result<()> {
     {
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
-        let f = instance.get_func("f").unwrap().get0::<i32>().unwrap();
+        let f = instance
+            .get_func("f")
+            .unwrap()
+            .typed::<(), i32>()
+            .unwrap()
+            .clone();
 
         for i in 0..TABLE_ELEMENTS {
-            assert_eq!(f().expect("function should not trap"), i as i32);
+            assert_eq!(f.call(()).expect("function should not trap"), i as i32);
         }
 
-        assert_eq!(f().expect("function should not trap"), -1);
-        assert_eq!(f().expect("function should not trap"), -1);
+        assert_eq!(f.call(()).expect("function should not trap"), -1);
+        assert_eq!(f.call(()).expect("function should not trap"), -1);
     }
 
     // Instantiate the module and grow the table via the Wasmtime API

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -24,7 +24,7 @@ fn host_always_has_some_stack() -> anyhow::Result<()> {
     )?;
     let func = Func::wrap(&store, test_host_stack);
     let instance = Instance::new(&store, &module, &[func.into()])?;
-    let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
+    let foo = instance.get_typed_func::<(), ()>("foo")?;
 
     // Make sure that our function traps and the trap says that the call stack
     // has been exhausted.

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -24,11 +24,11 @@ fn host_always_has_some_stack() -> anyhow::Result<()> {
     )?;
     let func = Func::wrap(&store, test_host_stack);
     let instance = Instance::new(&store, &module, &[func.into()])?;
-    let foo = instance.get_func("foo").unwrap().get0::<()>()?;
+    let foo = instance.get_func("foo").unwrap().typed::<(), ()>()?.clone();
 
     // Make sure that our function traps and the trap says that the call stack
     // has been exhausted.
-    let trap = foo().unwrap_err();
+    let trap = foo.call(()).unwrap_err();
     assert!(
         trap.to_string().contains("call stack exhausted"),
         "{}",

--- a/tests/all/use_after_drop.rs
+++ b/tests/all/use_after_drop.rs
@@ -15,7 +15,7 @@ fn use_func_after_drop() -> Result<()> {
         table.set(0, func.into())?;
     }
     let func = table.get(0).unwrap().funcref().unwrap().unwrap().clone();
-    let func = func.get0::<()>()?;
-    func()?;
+    let func = func.typed::<(), ()>()?;
+    func.call(())?;
     Ok(())
 }


### PR DESCRIPTION
This commit reimplements the `Func` API with respect to statically typed
dispatch. Previously `Func` had a `getN` and `getN_async` family of
methods which were implemented for 0 to 16 parameters. The return value
of these functions was an `impl Fn(..)` closure with the appropriate
parameters and return values.

There are a number of downsides with this approach that have become
apparent over time:

* The addition of `*_async` doubled the API surface area (which is quite
  large here due to one-method-per-number-of-parameters).
* The [documentation of `Func`][old-docs] are quite verbose and feel
  "polluted" with all these getters, making it harder to understand the
  other methods that can be used to interact with a `Func`.
* These methods unconditionally pay the cost of returning an owned `impl
  Fn` with a `'static` lifetime. While cheap, this is still paying the
  cost for cloning the `Store` effectively and moving data into the
  closed-over environment.
* Storage of the return value into a struct, for example, always
  requires `Box`-ing the returned closure since it otherwise cannot be
  named.
* Recently I had the desire to implement an "unchecked" path for
  invoking wasm where you unsafely assert the type signature of a wasm
  function. Doing this with today's scheme would require doubling
  (again) the API surface area for both async and synchronous calls,
  further polluting the documentation.

The main benefit of the previous scheme is that by returning a `impl Fn`
it was quite easy and ergonomic to actually invoke the function. In
practice, though, examples would often have something akin to
`.get0::<()>()?()?` which is a lot of things to interpret all at once.
Note that `get0` means "0 parameters" yet a type parameter is passed.
There's also a double function invocation which looks like a lot of
characters all lined up in a row.

Overall, I think that the previous design is starting to show too many
cracks and deserves a rewrite. This commit is that rewrite.

The new design in this commit is to delete the `getN{,_async}` family of
functions and instead have a new API:

    impl Func {
        fn typed<P, R>(&self) -> Result<&TypedFunc<P, R>>;
    }

    impl TypedFunc<P, R> {
        fn call(&self, params: P) -> Result<R, Trap>;
        async fn call_async(&self, params: P) -> Result<R, Trap>;
    }

This should entirely replace the current scheme, albeit by slightly
losing ergonomics use cases. The idea behind the API is that the
existence of `TypedFunc<P, R>` is a "proof" that the underlying function
takes `P` and returns `R`. The `Func::typed` method peforms a runtime
type-check to ensure that types all match up, and if successful you get
a `TypedFunc` value. Otherwise an error is returned.

Once you have a `TypedFunc` then, like `Func`, you can either `call` or
`call_async`. The difference with a `Typed`, however, is that the
params/results are statically known and hence these calls can be much
more efficient.

This is a much smaller API surface area from before and should greatly
simplify the `Func` documentation. There's still a problem where
`Func::wrapN_async` produces a lot of functions to document, but that's
now the sole offender. It's a nice benefit that the
statically-typed-async verisons are now expressed with an `async`
function rather than a function-returning-a-future which makes it both
more efficient and easier to understand.

The type `P` and `R` are intended to either be bare types (e.g. `i32`)
or tuples of any length (including 0). At this time `R` is only allowed
to be `()` or a bare `i32`-style type because multi-value is not
supported with a native ABI (yet). The `P`, however, can be any size of
tuples of parameters. This is also where some ergonomics are lost
because instead of `f(1, 2)` you now have to write `f.call((1, 2))`
(note the double-parens). Similarly `f()` becomes `f.call(())`.

Overall I feel that this is a better tradeoff than before. While not
universally better due to the loss in ergonomics I feel that this design
is much more flexible in terms of what you can do with the return value
and also understanding the API surface area (just less to take in).

[old-docs]: https://docs.rs/wasmtime/0.24.0/wasmtime/struct.Func.html#method.get0

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
