### PR TITLE
Fix nondeterministic failures in poll_oneoff_stdio.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
@@ -46,22 +46,23 @@ unsafe fn test_stdin_read() {
     let out = poll_oneoff_impl(&r#in).unwrap();
     // The result should be either a timeout, or that stdin is ready for reading.
     // Both are valid behaviors that depend on the test environment.
-    assert_eq!(out.len(), 1, "should return 1 event");
-    let event = &out[0];
-    if event.r#type == wasi::EVENTTYPE_CLOCK {
-        assert_errno!(event.error, wasi::ERRNO_SUCCESS);
-        assert_eq!(
-            event.userdata, CLOCK_ID,
-            "the event.userdata should contain CLOCK_ID",
-        );
-    } else if event.r#type == wasi::EVENTTYPE_FD_READ {
-        assert_errno!(event.error, wasi::ERRNO_SUCCESS);
-        assert_eq!(
-            event.userdata, STDIN_ID,
-            "the event.userdata should contain STDIN_ID",
-        );
-    } else {
-        panic!("unexpected event type {}", event.r#type);
+    assert!(out.len() >= 1, "should return at least 1 event");
+    for event in out {
+        if event.r#type == wasi::EVENTTYPE_CLOCK {
+            assert_errno!(event.error, wasi::ERRNO_SUCCESS);
+            assert_eq!(
+                event.userdata, CLOCK_ID,
+                "the event.userdata should contain CLOCK_ID",
+            );
+        } else if event.r#type == wasi::EVENTTYPE_FD_READ {
+            assert_errno!(event.error, wasi::ERRNO_SUCCESS);
+            assert_eq!(
+                event.userdata, STDIN_ID,
+                "the event.userdata should contain STDIN_ID",
+            );
+        } else {
+            panic!("unexpected event type {}", event.r#type);
+        }
     }
 }
 


### PR DESCRIPTION
Adjust this test so that it tolerates poll_oneoff returning that both a
timeout occurred and an input is ready for reading, at the same time.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
