### PR TITLE
Bump dependencies to get a single version of rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -2069,18 +2069,18 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "quick-error 2.0.0",
+ "rand 0.8.3",
+ "rand_chacha 0.3.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2101,6 +2101,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quickcheck"
@@ -2211,11 +2217,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -2399,7 +2405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -3472,7 +3478,7 @@ dependencies = [
  "memoffset",
  "more-asserts",
  "psm",
- "rand 0.7.3",
+ "rand 0.8.3",
  "region",
  "thiserror",
  "userfaultfd",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -24,7 +24,7 @@ cfg-if = "1.0"
 backtrace = "0.3.55"
 lazy_static = "1.3.0"
 psm = "0.1.11"
-rand = "0.7.3"
+rand = "0.8.3"
 anyhow = "1.0.38"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -263,7 +263,7 @@ impl PoolingAllocationStrategy {
 
         match self {
             Self::NextAvailable => free_count - 1,
-            Self::Random => rand::thread_rng().gen_range(0, free_count),
+            Self::Random => rand::thread_rng().gen_range(0..free_count),
         }
     }
 }

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "actively-developed" }
 
 [dev-dependencies]
 wiggle-test = { path = "test-helpers" }
-proptest = "0.10"
+proptest = "1.0.0"
 
 [features]
 # The wiggle proc-macro emits some code (inside `pub mod metadata`) guarded

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*", "LICENSE"]
 publish = false
 
 [dependencies]
-proptest = "0.10"
+proptest = "1.0.0"
 wiggle = { path = "..", features = ["tracing_log"] }
 wiggle-borrow = { path = "../borrow" }
 

--- a/crates/wiggle/wasmtime/Cargo.toml
+++ b/crates/wiggle/wasmtime/Cargo.toml
@@ -19,7 +19,7 @@ wiggle-borrow = { path = "../borrow", version = "0.25.0" }
 
 [dev-dependencies]
 anyhow = "1"
-proptest = "0.10"
+proptest = "1.0.0"
 
 [[test]]
 name = "atoms_async"

--- a/deny.toml
+++ b/deny.toml
@@ -40,10 +40,7 @@ skip = [
     { name = "cfg-if" }, # transitive dependencies use 0.1
     { name = "env_logger" }, # pretty_env_logger and file-per-thread-logger depend on 0.7
     { name = "humantime" }, # caused by env_logger
-    { name = "getrandom" }, # rand not updates to 0.2 yet
     { name = "wast" }, # old one pulled in by witx
-    { name = "rand" }, # 0.7 pulled in by transitive deps
-    { name = "rand_core" }, # 0.7 pulled in by transitive deps
-    { name = "rand_chacha" }, # 0.7 pulled in by transitive deps
     { name = "itertools" }, # 0.9 pulled in by zstd-sys
+    { name = "quick-error" }, # transitive dependencies
 ]


### PR DESCRIPTION
This removes a few duplicate crates in the dependencies, and a few exceptions (at
the price of a new one) in the cargo-deny configuration.