### PR TITLE
Explicitly install LLDB in CI to fix intermittent failure on Ubuntu 20.04 image.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -287,19 +287,21 @@ jobs:
 
     # Test debug (DWARF) related functionality.
     - run: |
-        sudo apt-get update && sudo apt-get install -y gdb
+        sudo apt-get update && sudo apt-get install -y gdb lldb
         cargo test test_debug_dwarf -- --ignored --test-threads 1
       if: matrix.os == 'ubuntu-latest'
       env:
         RUST_BACKTRACE: 1
+        LLDB: /usr/bin/lldb
 
     # Test debug (DWARF) related functionality on new backend.
     - run: |
-        sudo apt-get update && sudo apt-get install -y gdb
+        sudo apt-get update && sudo apt-get install -y gdb lldb
         cargo test --features experimental_x64 test_debug_dwarf -- --ignored --test-threads 1 --test debug::
       if: matrix.os == 'ubuntu-latest'
       env:
         RUST_BACKTRACE: 1
+        LLDB: /usr/bin/lldb
 
     # Test uffd functionality on Linux
     - run: |


### PR DESCRIPTION
There seems to be an intermittent CI issue, as uncovered by @peterhuene in [this comment](https://github.com/bytecodealliance/wasmtime/pull/2736#issuecomment-801552884), affecting a few open PRs right now. This attempts to fix the issue by adding `lldb` to the setup steps for the debugger tests (alongside our already-existing `apt-get install gdb`).