### PR TITLE
Split out fiber stacks from fibers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,6 +3484,7 @@ dependencies = [
  "thiserror",
  "userfaultfd",
  "wasmtime-environ",
+ "wasmtime-fiber",
  "winapi",
 ]
 

--- a/crates/fiber/src/arch/x86_64.S
+++ b/crates/fiber/src/arch/x86_64.S
@@ -68,7 +68,7 @@ FUNCTION(wasmtime_fiber_init):
 
     // And then we specify the stack pointer resumption should begin at. Our
     // `wasmtime_fiber_switch` function consumes 6 registers plus a return
-    // pointer, and the top 16 bytes aree resereved, so that's:
+    // pointer, and the top 16 bytes are reserved, so that's:
     //
     //	(6 + 1) * 16 + 16 = 0x48
     lea -0x48(%rdi), %rax

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 wasmtime-environ = { path = "../environ", version = "0.25.0" }
+wasmtime-fiber = { path = "../fiber", version = "0.25.0", optional = true }
 region = "2.1.0"
 libc = { version = "0.2.82", default-features = false }
 log = "0.4.8"
@@ -44,6 +45,8 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = []
+
+async = ["wasmtime-fiber"]
 
 # Enables support for userfaultfd in the pooling allocator when building on Linux
 uffd = ["userfaultfd"]

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -536,19 +536,14 @@ unsafe fn initialize_vmcontext_globals(instance: &Instance) {
 #[derive(Clone)]
 pub struct OnDemandInstanceAllocator {
     mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
-    #[cfg(feature = "async")]
     stack_size: usize,
 }
 
 impl OnDemandInstanceAllocator {
     /// Creates a new on-demand instance allocator.
-    pub fn new(
-        mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
-        #[cfg(feature = "async")] stack_size: usize,
-    ) -> Self {
+    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
         Self {
             mem_creator,
-            #[cfg(feature = "async")]
             stack_size,
         }
     }
@@ -586,7 +581,6 @@ impl Default for OnDemandInstanceAllocator {
     fn default() -> Self {
         Self {
             mem_creator: None,
-            #[cfg(feature = "async")]
             stack_size: 0,
         }
     }

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -8,8 +8,8 @@
 //! when modules can be constrained based on configurable limits.
 
 use super::{
-    initialize_instance, initialize_vmcontext, FiberStackError, InstanceAllocationRequest,
-    InstanceAllocator, InstanceHandle, InstantiationError,
+    initialize_instance, initialize_vmcontext, InstanceAllocationRequest, InstanceAllocator,
+    InstanceHandle, InstantiationError,
 };
 use crate::{instance::Instance, Memory, Mmap, Table, VMContext};
 use anyhow::{anyhow, bail, Context, Result};
@@ -41,10 +41,13 @@ cfg_if::cfg_if! {
     }
 }
 
-use imp::{
-    commit_memory_pages, commit_stack_pages, commit_table_pages, decommit_memory_pages,
-    decommit_stack_pages, decommit_table_pages,
-};
+use imp::{commit_memory_pages, commit_table_pages, decommit_memory_pages, decommit_table_pages};
+
+#[cfg(all(feature = "async", unix))]
+use imp::{commit_stack_pages, decommit_stack_pages};
+
+#[cfg(feature = "async")]
+use super::FiberStackError;
 
 fn round_up_to_pow2(n: usize, to: usize) -> usize {
     debug_assert!(to > 0);
@@ -705,6 +708,7 @@ impl TablePool {
 ///
 /// The top of the stack (starting stack pointer) is returned when a stack is allocated
 /// from the pool.
+#[cfg(all(feature = "async", unix))]
 #[derive(Debug)]
 struct StackPool {
     mapping: Mmap,
@@ -714,13 +718,14 @@ struct StackPool {
     free_list: Mutex<Vec<usize>>,
 }
 
+#[cfg(all(feature = "async", unix))]
 impl StackPool {
     fn new(instance_limits: &InstanceLimits, stack_size: usize) -> Result<Self> {
         let page_size = region::page::size();
 
         // On Windows, don't allocate any fiber stacks as native fibers are always used
         // Add a page to the stack size for the guard page when using fiber stacks
-        let stack_size = if cfg!(windows) || stack_size == 0 {
+        let stack_size = if stack_size == 0 {
             0
         } else {
             round_up_to_pow2(stack_size, page_size)
@@ -758,8 +763,10 @@ impl StackPool {
         })
     }
 
-    fn allocate(&self, strategy: PoolingAllocationStrategy) -> Result<*mut u8, FiberStackError> {
-        // Stacks are not supported if nothing was allocated
+    fn allocate(
+        &self,
+        strategy: PoolingAllocationStrategy,
+    ) -> Result<wasmtime_fiber::FiberStack, FiberStackError> {
         if self.stack_size == 0 {
             return Err(FiberStackError::NotSupported);
         }
@@ -787,32 +794,28 @@ impl StackPool {
             commit_stack_pages(bottom_of_stack, size_without_guard)
                 .map_err(FiberStackError::Resource)?;
 
-            // The top of the stack should be returned
-            Ok(bottom_of_stack.add(size_without_guard))
+            wasmtime_fiber::FiberStack::from_top_ptr(bottom_of_stack.add(size_without_guard))
+                .map_err(|e| FiberStackError::Resource(e.into()))
         }
     }
 
-    fn deallocate(&self, top_of_stack: *mut u8) {
-        debug_assert!(!top_of_stack.is_null());
+    fn deallocate(&self, stack: &wasmtime_fiber::FiberStack) {
+        // Remove the guard page from the size
+        let stack_size = self.stack_size - self.page_size;
+        let bottom_of_stack = unsafe { stack.top().unwrap().sub(stack_size) };
 
-        unsafe {
-            // Remove the guard page from the size
-            let stack_size = self.stack_size - self.page_size;
-            let bottom_of_stack = top_of_stack.sub(stack_size);
+        let base = self.mapping.as_ptr() as usize;
+        let start_of_stack = (bottom_of_stack as usize) - self.page_size;
 
-            let base = self.mapping.as_ptr() as usize;
-            let start_of_stack = (bottom_of_stack as usize) - self.page_size;
+        debug_assert!(start_of_stack >= base && start_of_stack < (base + self.mapping.len()));
+        debug_assert!((start_of_stack - base) % self.stack_size == 0);
 
-            debug_assert!(start_of_stack >= base && start_of_stack < (base + self.mapping.len()));
-            debug_assert!((start_of_stack - base) % self.stack_size == 0);
+        let index = (start_of_stack - base) / self.stack_size;
+        debug_assert!(index < self.max_instances);
 
-            let index = (start_of_stack - base) / self.stack_size;
-            debug_assert!(index < self.max_instances);
+        decommit_stack_pages(bottom_of_stack, stack_size).unwrap();
 
-            decommit_stack_pages(bottom_of_stack, stack_size).unwrap();
-
-            self.free_list.lock().unwrap().push(index);
-        }
+        self.free_list.lock().unwrap().push(index);
     }
 }
 
@@ -828,7 +831,10 @@ pub struct PoolingInstanceAllocator {
     instance_limits: InstanceLimits,
     // This is manually drop so that the pools unmap their memory before the page fault handler drops.
     instances: mem::ManuallyDrop<InstancePool>,
+    #[cfg(all(feature = "async", unix))]
     stacks: StackPool,
+    #[cfg(all(feature = "async", windows))]
+    stack_size: usize,
     #[cfg(all(feature = "uffd", target_os = "linux"))]
     _fault_handler: imp::PageFaultHandler,
 }
@@ -839,7 +845,7 @@ impl PoolingInstanceAllocator {
         strategy: PoolingAllocationStrategy,
         module_limits: ModuleLimits,
         mut instance_limits: InstanceLimits,
-        stack_size: usize,
+        #[cfg(feature = "async")] stack_size: usize,
     ) -> Result<Self> {
         if instance_limits.count == 0 {
             bail!("the instance count limit cannot be zero");
@@ -857,7 +863,6 @@ impl PoolingInstanceAllocator {
             min(instance_limits.memory_reservation_size, 0x200000000);
 
         let instances = InstancePool::new(&module_limits, &instance_limits)?;
-        let stacks = StackPool::new(&instance_limits, stack_size)?;
 
         #[cfg(all(feature = "uffd", target_os = "linux"))]
         let _fault_handler = imp::PageFaultHandler::new(&instances)?;
@@ -867,7 +872,10 @@ impl PoolingInstanceAllocator {
             module_limits,
             instance_limits,
             instances: mem::ManuallyDrop::new(instances),
-            stacks,
+            #[cfg(all(feature = "async", unix))]
+            stacks: StackPool::new(&instance_limits, stack_size)?,
+            #[cfg(all(feature = "async", windows))]
+            stack_size,
             #[cfg(all(feature = "uffd", target_os = "linux"))]
             _fault_handler,
         })
@@ -956,12 +964,30 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
         self.instances.deallocate(handle);
     }
 
-    fn allocate_fiber_stack(&self) -> Result<*mut u8, FiberStackError> {
+    #[cfg(all(feature = "async", unix))]
+    fn allocate_fiber_stack(&self) -> Result<wasmtime_fiber::FiberStack, FiberStackError> {
         self.stacks.allocate(self.strategy)
     }
 
-    unsafe fn deallocate_fiber_stack(&self, stack: *mut u8) {
+    #[cfg(all(feature = "async", unix))]
+    unsafe fn deallocate_fiber_stack(&self, stack: &wasmtime_fiber::FiberStack) {
         self.stacks.deallocate(stack);
+    }
+
+    #[cfg(all(feature = "async", windows))]
+    fn allocate_fiber_stack(&self) -> Result<wasmtime_fiber::FiberStack, FiberStackError> {
+        if self.stack_size == 0 {
+            return Err(FiberStackError::NotSupported);
+        }
+
+        // On windows, we don't use a stack pool as we use the native fiber implementation
+        wasmtime_fiber::FiberStack::new(self.stack_size)
+            .map_err(|e| FiberStackError::Resource(e.into()))
+    }
+
+    #[cfg(all(feature = "async", windows))]
+    unsafe fn deallocate_fiber_stack(&self, _stack: &wasmtime_fiber::FiberStack) {
+        // A no-op as we don't own the fiber stack on Windows
     }
 }
 
@@ -1470,7 +1496,7 @@ mod test {
         Ok(())
     }
 
-    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[cfg(all(unix, target_pointer_width = "64", feature = "async"))]
     #[test]
     fn test_stack_pool() -> Result<()> {
         let pool = StackPool::new(
@@ -1497,7 +1523,10 @@ mod test {
             let stack = pool
                 .allocate(PoolingAllocationStrategy::NextAvailable)
                 .expect("allocation should succeed");
-            assert_eq!(((stack as usize - base) / pool.stack_size) - 1, i);
+            assert_eq!(
+                ((stack.top().unwrap() as usize - base) / pool.stack_size) - 1,
+                i
+            );
             stacks.push(stack);
         }
 
@@ -1512,7 +1541,7 @@ mod test {
         };
 
         for stack in stacks {
-            pool.deallocate(stack);
+            pool.deallocate(&stack);
         }
 
         assert_eq!(
@@ -1611,13 +1640,13 @@ mod test {
             for _ in 0..10 {
                 let stack = allocator.allocate_fiber_stack()?;
 
-                // The stack pointer is at the top, so decerement it first
-                let addr = stack.sub(1);
+                // The stack pointer is at the top, so decrement it first
+                let addr = stack.top().unwrap().sub(1);
 
                 assert_eq!(*addr, 0);
                 *addr = 1;
 
-                allocator.deallocate_fiber_stack(stack);
+                allocator.deallocate_fiber_stack(&stack);
             }
         }
 

--- a/crates/runtime/src/instance/allocator/pooling/linux.rs
+++ b/crates/runtime/src/instance/allocator/pooling/linux.rs
@@ -48,11 +48,13 @@ pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }
 
+#[cfg(feature = "async")]
 pub fn commit_stack_pages(_addr: *mut u8, _len: usize) -> Result<()> {
     // A no-op as stack pages remain READ|WRITE
     Ok(())
 }
 
+#[cfg(feature = "async")]
 pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -79,11 +79,13 @@ pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len)
 }
 
+#[cfg(feature = "async")]
 pub fn commit_stack_pages(_addr: *mut u8, _len: usize) -> Result<()> {
     // A no-op as stack pages remain READ|WRITE
     Ok(())
 }
 
+#[cfg(feature = "async")]
 pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len)
 }

--- a/crates/runtime/src/instance/allocator/pooling/unix.rs
+++ b/crates/runtime/src/instance/allocator/pooling/unix.rs
@@ -58,11 +58,13 @@ pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }
 
+#[cfg(feature = "async")]
 pub fn commit_stack_pages(_addr: *mut u8, _len: usize) -> Result<()> {
     // A no-op as stack pages remain READ|WRITE
     Ok(())
 }
 
+#[cfg(feature = "async")]
 pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }

--- a/crates/runtime/src/instance/allocator/pooling/windows.rs
+++ b/crates/runtime/src/instance/allocator/pooling/windows.rs
@@ -45,11 +45,3 @@ pub fn commit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
 pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len)
 }
-
-pub fn commit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
-    commit(addr, len)
-}
-
-pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
-    decommit(addr, len)
-}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
 pub use crate::instance::{
-    FiberStackError, InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstanceLimits,
+    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstanceLimits,
     InstantiationError, LinkError, ModuleLimits, OnDemandInstanceAllocator,
     PoolingAllocationStrategy, PoolingInstanceAllocator, RuntimeInstance,
 };

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -86,8 +86,7 @@ unsafe extern "C" fn trap_handler(
         // handling, and reset our trap handling flag. Then we figure
         // out what to do based on the result of the trap handling.
         let pc = get_pc(context);
-        let jmp_buf =
-            info.jmp_buf_if_trap(pc, |handler| handler(signum, siginfo, context));
+        let jmp_buf = info.jmp_buf_if_trap(pc, |handler| handler(signum, siginfo, context));
 
         // Figure out what to do based on the result of this handling of
         // the trap. Note that our sentinel value of 1 means that the

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -72,7 +72,7 @@ experimental_x64 = ["wasmtime-jit/experimental_x64"]
 
 # Enables support for "async stores" as well as defining host functions as
 # `async fn` and calling functions asynchronously.
-async = ["wasmtime-fiber"]
+async = ["wasmtime-fiber", "wasmtime-runtime/async"]
 
 # Enables userfaultfd support in the runtime's pooling allocator when building on Linux
 uffd = ["wasmtime-runtime/uffd"]

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1332,25 +1332,20 @@ impl Config {
         match self.allocation_strategy {
             InstanceAllocationStrategy::OnDemand => Ok(Box::new(OnDemandInstanceAllocator::new(
                 self.mem_creator.clone(),
+                #[cfg(feature = "async")]
+                self.async_stack_size,
             ))),
             InstanceAllocationStrategy::Pooling {
                 strategy,
                 module_limits,
                 instance_limits,
-            } => {
+            } => Ok(Box::new(PoolingInstanceAllocator::new(
+                strategy.into(),
+                module_limits.into(),
+                instance_limits.into(),
                 #[cfg(feature = "async")]
-                let stack_size = self.async_stack_size;
-
-                #[cfg(not(feature = "async"))]
-                let stack_size = 0;
-
-                Ok(Box::new(PoolingInstanceAllocator::new(
-                    strategy.into(),
-                    module_limits.into(),
-                    instance_limits.into(),
-                    stack_size,
-                )?))
-            }
+                self.async_stack_size,
+            )?)),
         }
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1329,11 +1329,16 @@ impl Config {
     }
 
     pub(crate) fn build_allocator(&self) -> Result<Box<dyn InstanceAllocator>> {
+        #[cfg(feature = "async")]
+        let stack_size = self.async_stack_size;
+
+        #[cfg(not(feature = "async"))]
+        let stack_size = 0;
+
         match self.allocation_strategy {
             InstanceAllocationStrategy::OnDemand => Ok(Box::new(OnDemandInstanceAllocator::new(
                 self.mem_creator.clone(),
-                #[cfg(feature = "async")]
-                self.async_stack_size,
+                stack_size,
             ))),
             InstanceAllocationStrategy::Pooling {
                 strategy,
@@ -1343,8 +1348,7 @@ impl Config {
                 strategy.into(),
                 module_limits.into(),
                 instance_limits.into(),
-                #[cfg(feature = "async")]
-                self.async_stack_size,
+                stack_size,
             )?)),
         }
     }

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -106,7 +106,7 @@ impl HostFunc {
 impl Drop for HostFunc {
     fn drop(&mut self) {
         // Host functions are always allocated with the default (on-demand) allocator
-        unsafe { OnDemandInstanceAllocator::new(None).deallocate(&self.instance) }
+        unsafe { OnDemandInstanceAllocator::default().deallocate(&self.instance) }
     }
 }
 

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -62,22 +62,27 @@ fn create_handle(
     imports.functions = func_imports;
 
     unsafe {
+        let config = store.engine().config();
         // Use the on-demand allocator when creating handles associated with host objects
         // The configured instance allocator should only be used when creating module instances
         // as we don't want host objects to count towards instance limits.
-        let handle = OnDemandInstanceAllocator::new(store.engine().config().mem_creator.clone())
-            .allocate(InstanceAllocationRequest {
-                module: Arc::new(module),
-                finished_functions: &finished_functions,
-                imports,
-                lookup_shared_signature: &|_| shared_signature_id.unwrap(),
-                host_state,
-                interrupts: store.interrupts(),
-                externref_activations_table: store.externref_activations_table()
-                    as *const VMExternRefActivationsTable
-                    as *mut _,
-                stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
-            })?;
+        let handle = OnDemandInstanceAllocator::new(
+            config.mem_creator.clone(),
+            #[cfg(feature = "async")]
+            config.async_stack_size,
+        )
+        .allocate(InstanceAllocationRequest {
+            module: Arc::new(module),
+            finished_functions: &finished_functions,
+            imports,
+            lookup_shared_signature: &|_| shared_signature_id.unwrap(),
+            host_state,
+            interrupts: store.interrupts(),
+            externref_activations_table: store.externref_activations_table()
+                as *const VMExternRefActivationsTable
+                as *mut _,
+            stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
+        })?;
 
         Ok(store.add_instance(handle, true))
     }

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -66,23 +66,20 @@ fn create_handle(
         // Use the on-demand allocator when creating handles associated with host objects
         // The configured instance allocator should only be used when creating module instances
         // as we don't want host objects to count towards instance limits.
-        let handle = OnDemandInstanceAllocator::new(
-            config.mem_creator.clone(),
-            #[cfg(feature = "async")]
-            config.async_stack_size,
-        )
-        .allocate(InstanceAllocationRequest {
-            module: Arc::new(module),
-            finished_functions: &finished_functions,
-            imports,
-            lookup_shared_signature: &|_| shared_signature_id.unwrap(),
-            host_state,
-            interrupts: store.interrupts(),
-            externref_activations_table: store.externref_activations_table()
-                as *const VMExternRefActivationsTable
-                as *mut _,
-            stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
-        })?;
+        let handle = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0).allocate(
+            InstanceAllocationRequest {
+                module: Arc::new(module),
+                finished_functions: &finished_functions,
+                imports,
+                lookup_shared_signature: &|_| shared_signature_id.unwrap(),
+                host_state,
+                interrupts: store.interrupts(),
+                externref_activations_table: store.externref_activations_table()
+                    as *const VMExternRefActivationsTable
+                    as *mut _,
+                stack_map_registry: store.stack_map_registry() as *const StackMapRegistry as *mut _,
+            },
+        )?;
 
         Ok(store.add_instance(handle, true))
     }

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -276,7 +276,7 @@ pub fn create_function(
 
     unsafe {
         Ok((
-            OnDemandInstanceAllocator::new(None).allocate(InstanceAllocationRequest {
+            OnDemandInstanceAllocator::default().allocate(InstanceAllocationRequest {
                 module: Arc::new(module),
                 finished_functions: &finished_functions,
                 imports: Imports::default(),
@@ -308,7 +308,7 @@ pub unsafe fn create_raw_function(
     finished_functions.push(func);
 
     Ok(
-        OnDemandInstanceAllocator::new(None).allocate(InstanceAllocationRequest {
+        OnDemandInstanceAllocator::default().allocate(InstanceAllocationRequest {
             module: Arc::new(module),
             finished_functions: &finished_functions,
             imports: Imports::default(),


### PR DESCRIPTION
This PR splits out a `FiberStack` from `Fiber`, allowing the instance
allocator trait to return `FiberStack` rather than raw stack pointers. This
keeps the stack creation mostly in `wasmtime_fiber`, but now the on-demand
instance allocator can make use of it.

The instance allocators no longer have to return a "not supported" error to
indicate that the store should allocate its own fiber stack.

This includes a bunch of cleanup in the instance allocator to scope stacks to
the new "async" feature in the runtime.

Closes #2708.