### PR TITLE
Use `min_by` instead of `sort_by` when we only want the minimum element.

### DIFF
--- a/crates/wasi-common/src/sched.rs
+++ b/crates/wasi-common/src/sched.rs
@@ -67,16 +67,13 @@ impl<'a> Poll<'a> {
         self.subs.is_empty()
     }
     pub fn earliest_clock_deadline(&'a self) -> Option<&MonotonicClockSubscription<'a>> {
-        let mut subs = self
-            .subs
+        self.subs
             .iter()
             .filter_map(|(s, _ud)| match s {
                 Subscription::MonotonicClock(t) => Some(t),
                 _ => None,
             })
-            .collect::<Vec<&MonotonicClockSubscription<'a>>>();
-        subs.sort_by(|a, b| a.deadline.cmp(&b.deadline));
-        subs.into_iter().next() // First element is earliest
+            .min_by(|a, b| a.deadline.cmp(&b.deadline))
     }
     pub fn rw_subscriptions(&'a self) -> impl Iterator<Item = &Subscription<'a>> {
         self.subs.iter().filter_map(|(s, _ud)| match s {


### PR DESCRIPTION
This is just a minor code simplification I happened to notice while
doing unrelated work on `poll_oneoff`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
