### PR TITLE
Support "sleep" forms of `poll_oneoff`.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff.rs
@@ -195,6 +195,7 @@ unsafe fn test_fd_readwrite_invalid_fd() {
 
 unsafe fn test_poll_oneoff(dir_fd: wasi::Fd) {
     test_timeout();
+    test_sleep();
     test_empty_poll();
     test_fd_readwrite_valid_fd(dir_fd);
     test_fd_readwrite_invalid_fd();

--- a/crates/wasi-common/cap-std-sync/src/sched/unix.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/unix.rs
@@ -108,6 +108,9 @@ impl WasiSched for SyncSched {
         std::thread::yield_now();
         Ok(())
     }
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration)
+    }
 }
 
 fn wasi_file_raw_fd(f: &dyn WasiFile) -> Option<RawFd> {

--- a/crates/wasi-common/cap-std-sync/src/sched/windows.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/windows.rs
@@ -128,6 +128,9 @@ impl WasiSched for SyncSched {
         thread::yield_now();
         Ok(())
     }
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration)
+    }
 }
 
 fn wasi_file_raw_handle(f: &dyn WasiFile) -> Option<RawHandle> {

--- a/crates/wasi-common/src/sched.rs
+++ b/crates/wasi-common/src/sched.rs
@@ -10,6 +10,7 @@ use subscription::{MonotonicClockSubscription, RwSubscription, Subscription, Sub
 pub trait WasiSched {
     fn poll_oneoff(&self, poll: &Poll) -> Result<(), Error>;
     fn sched_yield(&self) -> Result<(), Error>;
+    fn sleep(&self, duration: Duration);
 }
 
 pub struct Userdata(u64);

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -738,6 +738,30 @@ impl<'a> wasi_unstable::WasiUnstable for WasiCtx {
             return Err(Error::invalid_argument().context("nsubscriptions must be nonzero"));
         }
 
+        // Special-case a `poll_oneoff` which is just sleeping on a single
+        // relative timer event, such as what WASI libc uses to implement sleep
+        // functions. This supports all clock IDs, because POSIX says that
+        // `clock_settime` doesn't effect relative sleeps.
+        if nsubscriptions == 1 {
+            let sub = subs.read()?;
+            if let types::SubscriptionU::Clock(clocksub) = sub.u {
+                if !clocksub
+                    .flags
+                    .contains(types::Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME)
+                {
+                    self.sched.sleep(Duration::from_nanos(clocksub.timeout));
+
+                    events.write(types::Event {
+                        userdata: sub.userdata,
+                        error: types::Errno::Success,
+                        type_: types::Eventtype::Clock,
+                        fd_readwrite: fd_readwrite_empty(),
+                    })?;
+                    return Ok(1);
+                }
+            }
+        }
+
         let table = self.table();
         let mut poll = Poll::new();
 

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -16,7 +16,6 @@ use std::cell::{Ref, RefMut};
 use std::convert::{TryFrom, TryInto};
 use std::io::{IoSlice, IoSliceMut};
 use std::ops::{Deref, DerefMut};
-use std::thread;
 use tracing::debug;
 use wiggle::GuestPtr;
 
@@ -921,7 +920,7 @@ impl<'a> wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
                     .flags
                     .contains(types::Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME)
                 {
-                    thread::sleep(Duration::from_nanos(clocksub.timeout));
+                    self.sched.sleep(Duration::from_nanos(clocksub.timeout));
 
                     events.write(types::Event {
                         userdata: sub.userdata,


### PR DESCRIPTION
Add support for `poll_oneoff` calls which just sleep on a relative
timeout. This fixes a bug handling code compiled with WASI libc's `sleep`
family of functions, which call `poll_oneoff` with a `CLOCK_REALTIME`
timer, which wasn't previously implemented.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
