### PR TITLE
Cranelift: remove logging of vcode when the log level isn't debug or more

### DIFF
--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -5,7 +5,7 @@ use crate::machinst::*;
 use crate::settings;
 use crate::timing;
 
-use log::debug;
+use log::{debug, log_enabled, Level};
 use regalloc::{allocate_registers_with_opts, Algorithm, Options, PrettyPrint};
 
 /// Compile the given function down to VCode with allocated registers, ready
@@ -29,10 +29,15 @@ where
         lower.lower(b)?
     };
 
-    debug!(
-        "vcode from lowering: \n{}",
-        vcode.show_rru(Some(b.reg_universe()))
-    );
+    // Creating the vcode string representation may be costly for large functions, so don't do it
+    // if the Debug level hasn't been statically (through features) or dyanmically (through
+    // RUST_LOG) enabled.
+    if log_enabled!(Level::Debug) {
+        debug!(
+            "vcode from lowering: \n{}",
+            vcode.show_rru(Some(b.reg_universe()))
+        );
+    }
 
     // Perform register allocation.
     let (run_checker, algorithm) = match vcode.flags().regalloc() {
@@ -101,10 +106,12 @@ where
         vcode.replace_insns_from_regalloc(result);
     }
 
-    debug!(
-        "vcode after regalloc: final version:\n{}",
-        vcode.show_rru(Some(b.reg_universe()))
-    );
+    if log_enabled!(Level::Debug) {
+        debug!(
+            "vcode after regalloc: final version:\n{}",
+            vcode.show_rru(Some(b.reg_universe()))
+        );
+    }
 
     Ok(vcode)
 }

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -30,7 +30,7 @@ where
     };
 
     // Creating the vcode string representation may be costly for large functions, so don't do it
-    // if the Debug level hasn't been statically (through features) or dyanmically (through
+    // if the Debug level hasn't been statically (through features) or dynamically (through
     // RUST_LOG) enabled.
     if log_enabled!(Level::Debug) {
         debug!(


### PR DESCRIPTION
This logging step may be quite expensive, since rendering the VCode into strings has never been
optimized at all and is using pretty naive string concatenation. Removing it is a clear compile times win for a large wasm module I'm looking at. These are the results with parallel compilation enabled, so there could be an overall speedup due to less malloc lock contention too.

- x64 (AMD Ryzen 9 3950X): from 5.2 seconds to 1.8 seconds, i.e. 65% speedup
- aarch64 (Mac M1): from 17.6 seconds to 6.4 seconds, i.e. 63% speedup