### PR TITLE
wasi: make WasiSched::sleep fallible

### DIFF
--- a/crates/wasi-common/cap-std-sync/src/sched/unix.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/unix.rs
@@ -108,8 +108,9 @@ impl WasiSched for SyncSched {
         std::thread::yield_now();
         Ok(())
     }
-    fn sleep(&self, duration: Duration) {
-        std::thread::sleep(duration)
+    fn sleep(&self, duration: Duration) -> Result<(), Error> {
+        std::thread::sleep(duration);
+        Ok(())
     }
 }
 

--- a/crates/wasi-common/cap-std-sync/src/sched/windows.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/windows.rs
@@ -128,8 +128,9 @@ impl WasiSched for SyncSched {
         thread::yield_now();
         Ok(())
     }
-    fn sleep(&self, duration: Duration) {
-        std::thread::sleep(duration)
+    fn sleep(&self, duration: Duration) -> Result<(), Error> {
+        std::thread::sleep(duration);
+        Ok(())
     }
 }
 

--- a/crates/wasi-common/src/sched.rs
+++ b/crates/wasi-common/src/sched.rs
@@ -10,7 +10,7 @@ use subscription::{MonotonicClockSubscription, RwSubscription, Subscription, Sub
 pub trait WasiSched {
     fn poll_oneoff(&self, poll: &Poll) -> Result<(), Error>;
     fn sched_yield(&self) -> Result<(), Error>;
-    fn sleep(&self, duration: Duration);
+    fn sleep(&self, duration: Duration) -> Result<(), Error>;
 }
 
 pub struct Userdata(u64);

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -749,8 +749,7 @@ impl<'a> wasi_unstable::WasiUnstable for WasiCtx {
                     .flags
                     .contains(types::Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME)
                 {
-                    self.sched.sleep(Duration::from_nanos(clocksub.timeout));
-
+                    self.sched.sleep(Duration::from_nanos(clocksub.timeout))?;
                     events.write(types::Event {
                         userdata: sub.userdata,
                         error: types::Errno::Success,

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -920,8 +920,7 @@ impl<'a> wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
                     .flags
                     .contains(types::Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME)
                 {
-                    self.sched.sleep(Duration::from_nanos(clocksub.timeout));
-
+                    self.sched.sleep(Duration::from_nanos(clocksub.timeout))?;
                     events.write(types::Event {
                         userdata: sub.userdata,
                         error: types::Errno::Success,


### PR DESCRIPTION
some systems do not support sleeping and may want to return EINVAL here.

I forgot about this when reviewing https://github.com/bytecodealliance/wasmtime/pull/2753

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
