### PR TITLE
wiggle: delete GuestErrorConversion, improve some error reporting

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -24,14 +24,6 @@ impl wiggle::GuestErrorType for types::Errno {
     }
 }
 
-impl types::GuestErrorConversion for WasiCtx {
-    fn into_errno(&self, e: wiggle::GuestError) -> types::Errno {
-        debug!("Guest error: {:?}", e);
-        let snapshot1_errno: snapshot1_types::Errno = e.into();
-        snapshot1_errno.into()
-    }
-}
-
 impl types::UserErrorConversion for WasiCtx {
     fn errno_from_error(&self, e: Error) -> Result<types::Errno, wiggle::Trap> {
         debug!("Error: {:?}", e);

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -30,13 +30,6 @@ impl wiggle::GuestErrorType for types::Errno {
     }
 }
 
-impl types::GuestErrorConversion for WasiCtx {
-    fn into_errno(&self, e: wiggle::GuestError) -> types::Errno {
-        debug!("Guest error: {:?}", e);
-        e.into()
-    }
-}
-
 impl types::UserErrorConversion for WasiCtx {
     fn errno_from_error(&self, e: Error) -> Result<types::Errno, wiggle::Trap> {
         debug!("Error: {:?}", e);

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -96,7 +96,6 @@ impl From<wiggle::GuestError> for types::Errno {
             InvalidUtf8 { .. } => Self::Ilseq,
             TryFromIntError { .. } => Self::Overflow,
             InFunc { err, .. } => types::Errno::from(*err),
-            InDataField { err, .. } => types::Errno::from(*err),
             SliceLengthsDiffer { .. } => Self::Fault,
             BorrowCheckerOutOfHandles { .. } => Self::Fault,
         }

--- a/crates/wasi-crypto/src/wiggle_interfaces/error.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/error.rs
@@ -52,13 +52,6 @@ impl<'a> wiggle::GuestErrorType for guest_types::CryptoErrno {
     }
 }
 
-impl guest_types::GuestErrorConversion for WasiCryptoCtx {
-    fn into_crypto_errno(&self, e: wiggle::GuestError) -> guest_types::CryptoErrno {
-        eprintln!("GuestError (witx) {:?}", e);
-        guest_types::CryptoErrno::GuestError
-    }
-}
-
 impl From<wiggle::GuestError> for guest_types::CryptoErrno {
     fn from(e: wiggle::GuestError) -> Self {
         eprintln!("GuestError (impl) {:?}", e);

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -10,16 +10,6 @@ wiggle::from_witx!({
 
 use types::NnErrno;
 
-/// Wiggle generates code that performs some input validation on the arguments passed in by users of
-/// wasi-nn. Here we convert the validation error into one (or more, eventually) of the error
-/// variants defined in the witx.
-impl types::GuestErrorConversion for WasiNnCtx {
-    fn into_nn_errno(&self, e: wiggle::GuestError) -> NnErrno {
-        eprintln!("Guest error: {:?}", e);
-        NnErrno::InvalidArgument
-    }
-}
-
 impl<'a> types::UserErrorConversion for WasiNnCtx {
     fn nn_errno_from_wasi_nn_error(&self, e: WasiNnError) -> Result<NnErrno, wiggle::Trap> {
         eprintln!("Host error: {:?}", e);

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -139,10 +139,12 @@ impl witx::Bindgen for Rust<'_> {
     ) {
         let rt = self.rt;
         let wrap_err = |location: &str| {
+            let modulename = self.module.name.as_str();
             let funcname = self.funcname;
             quote! {
                 |e| {
                     #rt::GuestError::InFunc {
+                        modulename: #modulename,
                         funcname: #funcname,
                         location: #location,
                         err: Box::new(#rt::GuestError::from(e)),

--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -38,17 +38,6 @@ pub fn generate(doc: &witx::Document, names: &Names, settings: &CodegenSettings)
         }
     });
 
-    let guest_error_methods = doc.error_types().map(|t| {
-        let typename = names.type_ref(&t, anon_lifetime());
-        let err_method = names.guest_error_conversion_method(&t);
-        quote!(fn #err_method(&self, e: #rt::GuestError) -> #typename;)
-    });
-    let guest_error_conversion = quote! {
-        pub trait GuestErrorConversion {
-            #(#guest_error_methods)*
-        }
-    };
-
     let user_error_methods = settings.errors.iter().map(|errtype| {
         let abi_typename = names.type_ref(&errtype.abi_type(), anon_lifetime());
         let user_typename = errtype.typename();
@@ -82,7 +71,6 @@ pub fn generate(doc: &witx::Document, names: &Names, settings: &CodegenSettings)
 
             #(#types)*
             #(#constants)*
-            #guest_error_conversion
             #user_error_conversion
         }
         #(#modules)*

--- a/crates/wiggle/generate/src/names.rs
+++ b/crates/wiggle/generate/src/names.rs
@@ -196,11 +196,6 @@ impl Names {
         }
     }
 
-    pub fn guest_error_conversion_method(&self, tref: &TypeRef) -> Ident {
-        let suffix = Self::snake_typename(tref);
-        format_ident!("into_{}", suffix)
-    }
-
     pub fn user_error_conversion_method(&self, user_type: &UserErrorType) -> Ident {
         let abi_type = Self::snake_typename(&user_type.abi_type());
         format_ident!(

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -113,17 +113,6 @@ use syn::parse_macro_input;
 ///     }
 /// }
 ///
-/// /// The `types::GuestErrorConversion` trait is also generated with a method for
-/// /// each type used in the `error` position. This trait allows wiggle-generated
-/// /// code to convert a `wiggle::GuestError` into the right error type. The trait
-/// /// must be implemented for the user's ctx type.
-///
-/// impl types::GuestErrorConversion for YourCtxType {
-///     fn into_errno(&self, _e: wiggle::GuestError) -> types::Errno {
-///         unimplemented!()
-///     }
-/// }
-///
 /// /// If you specify a `error` mapping to the macro, you must implement the
 /// /// `types::UserErrorConversion` for your ctx type as well. This trait gives
 /// /// you an opportunity to store or log your rich error type, while returning

--- a/crates/wiggle/src/error.rs
+++ b/crates/wiggle/src/error.rs
@@ -27,13 +27,6 @@ pub enum GuestError {
         #[source]
         err: Box<GuestError>,
     },
-    #[error("In data {typename}.{field}: {err}")]
-    InDataField {
-        typename: String,
-        field: String,
-        #[source]
-        err: Box<GuestError>,
-    },
     #[error("Invalid UTF-8 encountered: {0:?}")]
     InvalidUtf8(#[from] ::std::str::Utf8Error),
     #[error("Int conversion error: {0:?}")]

--- a/crates/wiggle/src/error.rs
+++ b/crates/wiggle/src/error.rs
@@ -19,14 +19,15 @@ pub enum GuestError {
     BorrowCheckerOutOfHandles,
     #[error("Slice length mismatch")]
     SliceLengthsDiffer,
-    #[error("In func {funcname}:{location}:")]
+    #[error("In func {modulename}::{funcname} at {location}: {err}")]
     InFunc {
+        modulename: &'static str,
         funcname: &'static str,
         location: &'static str,
         #[source]
         err: Box<GuestError>,
     },
-    #[error("In data {typename}.{field}:")]
+    #[error("In data {typename}.{field}: {err}")]
     InDataField {
         typename: String,
         field: String,

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -27,10 +27,6 @@ witx_literal: "
     errors: { errno => RichError },
 });
 
-// The impl of GuestErrorConversion works just like in every other test where
-// we have a single error type with witx `$errno` with the success called `$ok`
-impl_errno!(types::Errno, types::GuestErrorConversion);
-
 /// When the `errors` mapping in witx is non-empty, we need to impl the
 /// types::UserErrorConversion trait that wiggle generates from that mapping.
 impl<'a> types::UserErrorConversion for WasiCtx<'a> {

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -27,6 +27,8 @@ witx_literal: "
     errors: { errno => RichError },
 });
 
+impl_errno!(types::Errno);
+
 /// When the `errors` mapping in witx is non-empty, we need to impl the
 /// types::UserErrorConversion trait that wiggle generates from that mapping.
 impl<'a> types::UserErrorConversion for WasiCtx<'a> {

--- a/crates/wiggle/test-helpers/src/lib.rs
+++ b/crates/wiggle/test-helpers/src/lib.rs
@@ -347,17 +347,10 @@ impl<'a> WasiCtx<'a> {
 // with these errors. We just push them to vecs.
 #[macro_export]
 macro_rules! impl_errno {
-    ( $errno:ty, $convert:path ) => {
+    ( $errno:ty ) => {
         impl wiggle::GuestErrorType for $errno {
             fn success() -> $errno {
                 <$errno>::Ok
-            }
-        }
-        impl<'a> $convert for WasiCtx<'a> {
-            fn into_errno(&self, e: wiggle::GuestError) -> $errno {
-                eprintln!("GuestError: {:?}", e);
-                self.guest_errors.borrow_mut().push(e);
-                <$errno>::InvalidArg
             }
         }
     };

--- a/crates/wiggle/tests/atoms.rs
+++ b/crates/wiggle/tests/atoms.rs
@@ -6,7 +6,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> atoms::Atoms for WasiCtx<'a> {
     fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {

--- a/crates/wiggle/tests/atoms_async.rs
+++ b/crates/wiggle/tests/atoms_async.rs
@@ -12,7 +12,7 @@ wiggle::from_witx!({
     }
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 #[wiggle::async_trait(?Send)]
 impl<'a> atoms::Atoms for WasiCtx<'a> {

--- a/crates/wiggle/tests/errors.rs
+++ b/crates/wiggle/tests/errors.rs
@@ -26,9 +26,7 @@ mod convert_just_errno {
         errors: { errno => RichError },
     });
 
-    // The impl of GuestErrorConversion works just like in every other test where
-    // we have a single error type with witx `$errno` with the success called `$ok`
-    impl_errno!(types::Errno, types::GuestErrorConversion);
+    impl_errno!(types::Errno);
 
     /// When the `errors` mapping in witx is non-empty, we need to impl the
     /// types::UserErrorConversion trait that wiggle generates from that mapping.
@@ -104,7 +102,7 @@ mod convert_just_errno {
 /// we use two distinct error types.
 mod convert_multiple_error_types {
     pub use super::convert_just_errno::RichError;
-    use wiggle_test::WasiCtx;
+    use wiggle_test::{impl_errno, WasiCtx};
 
     /// Test that we can map multiple types of errors.
     #[derive(Debug, thiserror::Error)]
@@ -135,27 +133,8 @@ mod convert_multiple_error_types {
         errors: { errno => RichError, errno2 => AnotherRichError },
     });
 
-    // Can't use the impl_errno! macro as usual here because the conversion
-    // trait ends up having two methods.
-    // We aren't going to execute this code, so the bodies are elided.
-    impl<'a> types::GuestErrorConversion for WasiCtx<'a> {
-        fn into_errno(&self, _e: wiggle::GuestError) -> types::Errno {
-            unimplemented!()
-        }
-        fn into_errno2(&self, _e: wiggle::GuestError) -> types::Errno2 {
-            unimplemented!()
-        }
-    }
-    impl wiggle::GuestErrorType for types::Errno {
-        fn success() -> types::Errno {
-            <types::Errno>::Ok
-        }
-    }
-    impl wiggle::GuestErrorType for types::Errno2 {
-        fn success() -> types::Errno2 {
-            <types::Errno2>::Ok
-        }
-    }
+    impl_errno!(types::Errno);
+    impl_errno!(types::Errno2);
 
     // The UserErrorConversion trait will also have two methods for this test. They correspond to
     // each member of the `errors` mapping.

--- a/crates/wiggle/tests/flags.rs
+++ b/crates/wiggle/tests/flags.rs
@@ -7,7 +7,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/flags.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> flags::Flags for WasiCtx<'a> {
     fn configure_car(

--- a/crates/wiggle/tests/handles.rs
+++ b/crates/wiggle/tests/handles.rs
@@ -8,7 +8,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/handles.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> handle_examples::HandleExamples for WasiCtx<'a> {
     fn fd_create(&self) -> Result<types::Fd, types::Errno> {

--- a/crates/wiggle/tests/ints.rs
+++ b/crates/wiggle/tests/ints.rs
@@ -7,7 +7,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/ints.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> ints::Ints for WasiCtx<'a> {
     fn cookie_cutter(&self, init_cookie: types::Cookie) -> Result<types::Bool, types::Errno> {

--- a/crates/wiggle/tests/lists.rs
+++ b/crates/wiggle/tests/lists.rs
@@ -6,7 +6,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/lists.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> lists::Lists for WasiCtx<'a> {
     fn reduce_excuses(

--- a/crates/wiggle/tests/pointers.rs
+++ b/crates/wiggle/tests/pointers.rs
@@ -6,7 +6,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/pointers.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> pointers::Pointers for WasiCtx<'a> {
     fn pointers_and_enums<'b>(

--- a/crates/wiggle/tests/records.rs
+++ b/crates/wiggle/tests/records.rs
@@ -6,7 +6,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/records.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> records::Records for WasiCtx<'a> {
     fn sum_of_pair(&self, an_pair: &types::PairInts) -> Result<i64, types::Errno> {

--- a/crates/wiggle/tests/strings.rs
+++ b/crates/wiggle/tests/strings.rs
@@ -6,7 +6,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/strings.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 impl<'a> strings::Strings for WasiCtx<'a> {
     fn hello_string(&self, a_string: &GuestPtr<str>) -> Result<u32, types::Errno> {

--- a/crates/wiggle/tests/variant.rs
+++ b/crates/wiggle/tests/variant.rs
@@ -6,7 +6,7 @@ wiggle::from_witx!({
     witx: ["$CARGO_MANIFEST_DIR/tests/variant.witx"],
 });
 
-impl_errno!(types::Errno, types::GuestErrorConversion);
+impl_errno!(types::Errno);
 
 // Avoid panics on overflow
 fn mult_lose_overflow(a: i32, b: u32) -> i32 {

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -1,4 +1,4 @@
-use wiggle::{GuestError, GuestErrorType, GuestPtr, GuestSlice};
+use wiggle::{GuestErrorType, GuestPtr, GuestSlice};
 use wiggle_test::WasiCtx;
 
 // This test file exists to make sure that the entire `wasi.witx` file can be
@@ -28,13 +28,6 @@ type Result<T> = std::result::Result<T, types::Errno>;
 impl GuestErrorType for types::Errno {
     fn success() -> types::Errno {
         types::Errno::Success
-    }
-}
-
-impl<'a> types::GuestErrorConversion for WasiCtx<'a> {
-    fn into_errno(&self, e: GuestError) -> types::Errno {
-        eprintln!("GuestError {:?}", e);
-        types::Errno::Badf
     }
 }
 


### PR DESCRIPTION
With the latest renovation to witx, wiggle no longer generates code that calls the `GuestErrorConversion` trait to transform a `GuestError` into the function's error type. Instead, wiggle will trap execution if a `GuestError` is thrown in generated code.

This PR removes generation of the `GuestErrorConversion` trait. Users can delete their impls of it - they are dead code.

I also fixed up the Display impl of the `GuestError::InFunc` variant to be more useful, and deleted `GuestError::InDataField` because it was also dead code.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
