### PR TITLE
wasmtime-wiggle: make it possible to add host funcs to a config under an alias

### DIFF
--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -309,7 +309,6 @@ fn generate_func(
     let host_wrapper = if is_async {
         let wrapper = format_ident!("wrap{}_host_func_async", params.len());
         quote! {
-            println!("Adding {}::{} to config as {}::{}", stringify!(#module_ident), stringify!(#name_ident), module, field);
             config.#wrapper(
                 module,
                 field,
@@ -327,7 +326,6 @@ fn generate_func(
         }
     } else {
         quote! {
-            println!("Adding {}::{} to config as {}::{}", stringify!(#module_ident), stringify!(#name_ident), module, field);
             config.wrap_host_func(
                 module,
                 field,

--- a/crates/wiggle/wasmtime/macro/src/lib.rs
+++ b/crates/wiggle/wasmtime/macro/src/lib.rs
@@ -135,6 +135,28 @@ contained in the `cx` parameter.",
         module_conf.name.to_string()
     );
 
+    let config_adder_definitions = host_funcs.iter().map(|(func_name, body)| {
+        let adder_func = format_ident!("add_{}_to_config", names.func(&func_name));
+        let docs = format!(
+            "Add the host function for `{}` to a config under a given module and field name.",
+            func_name.as_str()
+        );
+        quote! {
+            #[doc = #docs]
+            pub fn #adder_func(config: &mut wasmtime::Config, module: &str, field: &str) {
+                #body
+            }
+        }
+    });
+    let config_adder_invocations = host_funcs.iter().map(|(func_name, _body)| {
+        let adder_func = format_ident!("add_{}_to_config", names.func(&func_name));
+        let module = module.name.as_str();
+        let field = func_name.as_str();
+        quote! {
+            Self::#adder_func(config, #module, #field);
+        }
+    });
+
     quote! {
         #type_docs
         pub struct #type_name {
@@ -150,6 +172,7 @@ contained in the `cx` parameter.",
                     #(#ctor_fields,)*
                 }
             }
+
 
             /// Looks up a field called `name` in this structure, returning it
             /// if found.
@@ -175,8 +198,10 @@ contained in the `cx` parameter.",
             ///
             /// Host functions will trap if the context is not set in the calling [`wasmtime::Store`].
             pub fn add_to_config(config: &mut wasmtime::Config) {
-                #(#host_funcs)*
+                #(#config_adder_invocations)*
             }
+
+            #(#config_adder_definitions)*
 
             /// Sets the context in the given store.
             ///
@@ -207,7 +232,7 @@ fn generate_func(
     is_async: bool,
     fns: &mut Vec<TokenStream2>,
     ctors: &mut Vec<TokenStream2>,
-    host_funcs: &mut Vec<TokenStream2>,
+    host_funcs: &mut Vec<(witx::Id, TokenStream2)>,
 ) {
     let name_ident = names.func(&func.name);
 
@@ -281,12 +306,13 @@ fn generate_func(
         });
     }
 
-    if is_async {
+    let host_wrapper = if is_async {
         let wrapper = format_ident!("wrap{}_host_func_async", params.len());
-        host_funcs.push(quote! {
+        quote! {
+            println!("Adding {}::{} to config as {}::{}", stringify!(#module_ident), stringify!(#name_ident), module, field);
             config.#wrapper(
-                stringify!(#module_ident),
-                stringify!(#name_ident),
+                module,
+                field,
                 move |caller #(,#arg_decls)*|
                     -> Box<dyn std::future::Future<Output = Result<#ret_ty, wasmtime::Trap>>> {
                     Box::new(async move {
@@ -298,12 +324,13 @@ fn generate_func(
                     })
                 }
             );
-        });
+        }
     } else {
-        host_funcs.push(quote! {
+        quote! {
+            println!("Adding {}::{} to config as {}::{}", stringify!(#module_ident), stringify!(#name_ident), module, field);
             config.wrap_host_func(
-                stringify!(#module_ident),
-                stringify!(#name_ident),
+                module,
+                field,
                 move |caller: wasmtime::Caller #(, #arg_decls)*| -> Result<#ret_ty, wasmtime::Trap> {
                     let ctx = caller
                         .store()
@@ -313,6 +340,7 @@ fn generate_func(
                     result
                 },
             );
-        });
-    }
+        }
+    };
+    host_funcs.push((func.name.clone(), host_wrapper));
 }


### PR DESCRIPTION
This addition to wasmtime-wiggle makes it possible to add a function to a `Config` under an arbitrary name.

Embeddings that allow Wasm functions defined by wiggle to be imported under additional names (for example, for legacy compatibility) can do so by writing their own `Linker` invocation, but functions were added to a `Config` under only the name specified by the witx file. Now, in addition to the default `add_to_config` behavior, you can `add_<functionname>_to_config(&mut config, module: &str, field: &str)` as well.


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
