### PR TITLE
Use stable Rust on CI to test the x64 backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,11 +73,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    # Note that we use nightly Rust for the doc_cfg feature (enabled via `nightlydoc` above)
-    # This version is an older nightly for the new x64 backend (see below)
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-12-26
+        toolchain: nightly
     - run: cargo doc --no-deps --all --exclude wasmtime-cli --exclude test-programs --exclude cranelift-codegen-meta
     - run: cargo doc --package cranelift-codegen-meta --document-private-items
     - uses: actions/upload-artifact@v1
@@ -321,10 +319,7 @@ jobs:
         RUST_BACKTRACE: 1
 
   # Perform all tests (debug mode) for `wasmtime` with the experimental x64
-  # backend. This runs on an older nightly of Rust (because of issues with
-  # unifying Cargo features on stable) on Ubuntu such that it's new enough
-  # to build Wasmtime, but old enough where the -Z options being used
-  # haven't been stabilized yet.
+  # backend.
   test_x64:
     name: Test x64 new backend
     runs-on: ubuntu-latest
@@ -334,7 +329,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-12-26
+        toolchain: stable
     - uses: ./.github/actions/define-llvm-env
 
     # Install wasm32 targets in order to build various tests throughout the
@@ -345,7 +340,6 @@ jobs:
     # Run the x64 CI script.
     - run: ./ci/run-experimental-x64-ci.sh
       env:
-        CARGO_VERSION: "+nightly-2020-12-26"
         RUST_BACKTRACE: 1
 
   # Perform tests on the new x64 backend on Windows as well.
@@ -357,8 +351,6 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-      with:
-        toolchain: nightly-2020-11-29
     - uses: ./.github/actions/define-llvm-env
 
     - name: Install libclang
@@ -378,7 +370,6 @@ jobs:
     # Run the x64 CI script.
     - run: ./ci/run-experimental-x64-ci.sh
       env:
-        CARGO_VERSION: "+nightly-2020-11-29"
         RUST_BACKTRACE: 1
 
   # Build and test the wasi-nn module.
@@ -390,8 +381,6 @@ jobs:
         with:
           submodules: true
       - uses: ./.github/actions/install-rust
-        with:
-          toolchain: nightly
       - run: rustup target add wasm32-wasi
       - uses: ./.github/actions/install-openvino
       - run: ./ci/run-wasi-nn-example.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,6 +177,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - run: rustup update stable && rustup default stable
     - name: Test `peepmatic`
       run: |
         cargo test \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - run: rustup update stable && rustup default stable
     - run: |
         set -e
         curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.4/mdbook-v0.4.4-x86_64-unknown-linux-gnu.tar.gz | tar xzf -

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ anyhow = "1.0.19"
 opt-level = 0
 
 [workspace]
+resolver = '2'
 members = [
   "cranelift",
   "crates/bench-api",

--- a/ci/run-experimental-x64-ci.sh
+++ b/ci/run-experimental-x64-ci.sh
@@ -1,24 +1,7 @@
 #!/bin/bash
 
-# Use the Nightly variant of the compiler to properly unify the
-# experimental_x64 feature across all crates.  Once the feature has stabilized
-# and become the default, we can remove this.
-CARGO_VERSION=${CARGO_VERSION:-"+nightly"}
-
-# Some WASI tests seem to have an issue on Windows with symlinks if we run them
-# with this particular invocation. It's unclear why (nightly toolchain?) but
-# we're moving to the new backend by default soon enough, and all tests seem to
-# work with the main test setup, so let's just work around this by skipping
-# the tests for now.
-MINGW_EXTRA=""
-if [ `uname -o` == "Msys" ]; then
-	MINGW_EXTRA="-- --skip wasi_cap_std_sync"
-fi
-
-cargo $CARGO_VERSION \
+cargo test \
             --locked \
-            -Zfeatures=all -Zpackage-features \
-            test \
             --features test-programs/test_programs \
             --features experimental_x64 \
             --all \
@@ -32,5 +15,4 @@ cargo $CARGO_VERSION \
             --exclude peepmatic-runtime \
             --exclude peepmatic-test \
             --exclude peepmatic-souper \
-            --exclude lightbeam \
-	    $MINGW_EXTRA
+            --exclude lightbeam

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -8,8 +8,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition = "2018"
 
-[package.metadata.docs.rs]
-rustdoc-args = [ "--document-private-items" ]
+# FIXME(rust-lang/cargo#9300): uncomment once that lands
+# [package.metadata.docs.rs]
+# rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
 cranelift-codegen-shared = { path = "../shared", version = "0.72.0" }

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -462,6 +462,7 @@ pub(crate) enum InstructionSet {
 
 /// Some SSE operations requiring 2 operands r/m and r.
 #[derive(Clone, Copy, PartialEq)]
+#[allow(dead_code)] // some variants here aren't used just yet
 pub enum SseOpcode {
     Addps,
     Addpd,

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -204,6 +204,7 @@ enum ExtSpec {
     ZeroExtendTo32,
     ZeroExtendTo64,
     SignExtendTo32,
+    #[allow(dead_code)] // not used just yet but may be used in the future!
     SignExtendTo64,
 }
 

--- a/cranelift/peepmatic/crates/automata/Cargo.toml
+++ b/cranelift/peepmatic/crates/automata/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Finite-state transducer automata"
 
-[package.metadata.docs.rs]
-all-features = true
+# FIXME(rust-lang/cargo#9300): uncomment once that lands
+# [package.metadata.docs.rs]
+# all-features = true
 
 [dependencies]
 serde = { version = "1.0.106", optional = true }

--- a/crates/jit/src/unwind/systemv.rs
+++ b/crates/jit/src/unwind/systemv.rs
@@ -90,7 +90,10 @@ impl UnwindRegistry {
         let mut eh_frame = EhFrame(EndianVec::new(RunTimeEndian::default()));
         table.write_eh_frame(&mut eh_frame).unwrap();
 
-        if cfg!(any(all(target_os = "linux", target_env = "gnu"), target_os = "freebsd")) {
+        if cfg!(any(
+            all(target_os = "linux", target_env = "gnu"),
+            target_os = "freebsd"
+        )) {
             // libgcc expects a terminating "empty" length, so write a 0 length at the end of the table.
             eh_frame.0.write_u32(0).unwrap();
         }
@@ -101,7 +104,10 @@ impl UnwindRegistry {
     }
 
     unsafe fn register_frames(&mut self) {
-        if cfg!(any(all(target_os = "linux", target_env = "gnu"), target_os = "freebsd")) {
+        if cfg!(any(
+            all(target_os = "linux", target_env = "gnu"),
+            target_os = "freebsd"
+        )) {
             // On gnu (libgcc), `__register_frame` will walk the FDEs until an entry of length 0
             let ptr = self.frame_table.as_ptr();
             __register_frame(ptr);

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -1618,7 +1618,7 @@ mod test {
     }
 
     #[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
-    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[cfg(all(unix, target_pointer_width = "64", feature = "async"))]
     #[test]
     fn test_stack_zeroed() -> Result<()> {
         let allocator = PoolingInstanceAllocator::new(

--- a/crates/wasi-nn/examples/classification-example/src/main.rs
+++ b/crates/wasi-nn/examples/classification-example/src/main.rs
@@ -49,7 +49,8 @@ pub fn main() {
             0,
             &mut output_buffer[..] as *mut [f32] as *mut u8,
             (output_buffer.len() * 4).try_into().unwrap(),
-        );
+        )
+        .unwrap();
     }
     println!(
         "Found results, sorted top 5: {:?}",

--- a/crates/wasi-nn/examples/wasi-nn-rust-bindings/src/generated.rs
+++ b/crates/wasi-nn/examples/wasi-nn-rust-bindings/src/generated.rs
@@ -152,6 +152,7 @@ pub unsafe fn compute(context: GraphExecutionContext) -> Result<()> {
     }
 }
 
+#[allow(improper_ctypes)]
 pub mod wasi_ephemeral_nn {
     use super::*;
     #[link(wasm_import_module = "wasi_ephemeral_nn")]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -9,8 +9,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition = "2018"
 
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "nightlydoc"]
+# FIXME(rust-lang/cargo#9300): uncomment once that lands
+# [package.metadata.docs.rs]
+# rustdoc-args = ["--cfg", "nightlydoc"]
 
 [dependencies]
 wasmtime-runtime = { path = "../runtime", version = "0.25.0" }


### PR DESCRIPTION
This commit leverages the newly-released 1.51.0 compiler to test the
new backend on Windows and Linux with a stable compiler instead of a
nightly compiler. This isolates the nightly build to just the nightly
documentation generation and fuzzing, both of which rely on nightly for
the best results right now.
