### PR TITLE
Compile fewer trampolines with module linking

### DIFF
--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -320,10 +320,11 @@ impl Store {
     }
 
     fn register_signatures(&self, module: &Module) {
-        let trampolines = module.compiled_module().trampolines();
         let mut signatures = self.signatures().borrow_mut();
-        for (index, wasm) in module.types().wasm_signatures.iter() {
-            signatures.register(wasm, trampolines[index]);
+        let types = module.types();
+        for (index, trampoline) in module.compiled_module().trampolines() {
+            let wasm = &types.wasm_signatures[*index];
+            signatures.register(wasm, *trampoline);
         }
     }
 


### PR DESCRIPTION
Previously each module in a module-linking-using-module would compile
all the trampolines for all signatures for all modules. In forest-like
situations with lots of modules this would cause quite a few trampolines
to get compiled. The original intention was to have one global list of
trampolines for all modules in the module-linking graph that they could
all share. With the current design of module linking, however, the
intention is for modules to be relatively isolated from one another
which would make achieving this difficult.

In lieu of total sharing (which would be good for the global scope
anyway but we also don't do that right now) this commit implements an
alternative strategy where each module simply compiles its own
trampolines that it itself can reach. This should mean that
module-linking modules behave more similarly to standalone modules in
terms of trampoline duplication. If we ever do global trampoline
deduplication we can likely batch this all together into one, but for
now this should fix the performance issues seen in fuzzing.

Closes #2525
