### PR TITLE
`wasmtime-wasi` usability: re-exports of common siblings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,8 +3285,6 @@ dependencies = [
  "tempfile",
  "test-programs",
  "tracing-subscriber",
- "wasi-cap-std-sync",
- "wasi-common",
  "wasmparser",
  "wasmtime",
  "wasmtime-cache",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,6 +3513,7 @@ name = "wasmtime-wasi"
 version = "0.25.0"
 dependencies = [
  "anyhow",
+ "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
  "wasmtime-wiggle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,7 +3269,6 @@ name = "wasmtime-cli"
 version = "0.25.0"
 dependencies = [
  "anyhow",
- "cap-std",
  "env_logger 0.8.3",
  "file-per-thread-logger",
  "filecheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ wasmtime-wast = { path = "crates/wast", version = "0.25.0" }
 wasmtime-wasi = { path = "crates/wasi", version = "0.25.0" }
 wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "0.25.0", optional = true }
 wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.25.0", optional = true }
-wasi-common = { path = "crates/wasi-common", version = "0.25.0" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "0.25.0" }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
 object = { version = "0.23.0", default-features = false, features = ["write"] }
 anyhow = "1.0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ log = "0.4.8"
 rayon = "1.2.1"
 humantime = "2.0.0"
 wasmparser = "0.77.0"
-cap-std = "0.13"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -11,11 +11,10 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::slice;
 use std::str;
-use wasi_cap_std_sync::WasiCtxBuilder;
-use wasi_common::WasiCtx;
 use wasmtime::{Extern, Linker, Trap};
 use wasmtime_wasi::{
     snapshots::preview_0::Wasi as WasiSnapshot0, snapshots::preview_1::Wasi as WasiPreview1,
+    sync::WasiCtxBuilder, WasiCtx,
 };
 
 unsafe fn cstr_to_path<'a>(path: *const c_char) -> Option<&'a Path> {
@@ -186,7 +185,7 @@ pub unsafe extern "C" fn wasi_config_preopen_dir(
     };
 
     let dir = match cstr_to_path(path) {
-        Some(p) => match cap_std::fs::Dir::open_ambient_dir(p) {
+        Some(p) => match Dir::open_ambient_dir(p) {
             Ok(d) => d,
             Err(_) => return false,
         },

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -1,7 +1,6 @@
 //! The WASI embedding API definitions for Wasmtime.
 use crate::{wasm_extern_t, wasm_importtype_t, wasm_store_t, wasm_trap_t};
 use anyhow::Result;
-use cap_std::fs::Dir;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::CStr;
@@ -13,8 +12,10 @@ use std::slice;
 use std::str;
 use wasmtime::{Extern, Linker, Trap};
 use wasmtime_wasi::{
-    snapshots::preview_0::Wasi as WasiSnapshot0, snapshots::preview_1::Wasi as WasiPreview1,
-    sync::WasiCtxBuilder, WasiCtx,
+    snapshots::preview_0::Wasi as WasiSnapshot0,
+    snapshots::preview_1::Wasi as WasiPreview1,
+    sync::{Dir, WasiCtxBuilder},
+    WasiCtx,
 };
 
 unsafe fn cstr_to_path<'a>(path: *const c_char) -> Option<&'a Path> {

--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -14,6 +14,10 @@
 //! `cap_std::fs::Dir`, and provides convenience methods for inheriting the
 //! parent process's stdio, args, and env.
 //!
+//! For the convenience of consumers, `cap_std::fs::Dir` is re-exported from
+//! this crate. This saves consumers tracking an additional dep on the exact
+//! version of cap_std used by this crate, if they want to avoid it.
+//!
 //! The only place we expect to run into long-term compatibility issues
 //! between `wasi-cap-std-sync` and the other impl crates that will come later
 //! is in the `Sched` abstraction. Once we can build an async scheduler based
@@ -33,6 +37,7 @@ pub mod file;
 pub mod sched;
 pub mod stdio;
 
+pub use cap_std::fs::Dir;
 pub use clocks::clocks_ctx;
 pub use sched::sched_ctx;
 
@@ -110,13 +115,9 @@ impl WasiCtxBuilder {
     pub fn inherit_stdio(self) -> Self {
         self.inherit_stdin().inherit_stdout().inherit_stderr()
     }
-    pub fn preopened_dir(
-        self,
-        dir: cap_std::fs::Dir,
-        path: impl AsRef<Path>,
-    ) -> Result<Self, Error> {
+    pub fn preopened_dir(self, dir: Dir, guest_path: impl AsRef<Path>) -> Result<Self, Error> {
         let dir = Box::new(crate::dir::Dir::from_cap_std(dir));
-        Ok(WasiCtxBuilder(self.0.preopened_dir(dir, path)?))
+        Ok(WasiCtxBuilder(self.0.preopened_dir(dir, guest_path)?))
     }
     pub fn build(self) -> Result<WasiCtx, Error> {
         self.0.build()

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -14,7 +14,12 @@ build = "build.rs"
 
 [dependencies]
 wasi-common = { path = "../wasi-common", version = "0.25.0" }
+wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "0.25.0", optional = true }
 wiggle = { path = "../wiggle", default-features = false, version = "0.25.0" }
 wasmtime-wiggle = { path = "../wiggle/wasmtime", default-features = false, version = "0.25.0" }
 wasmtime = { path = "../wasmtime", default-features = false, version = "0.25.0" }
 anyhow = "1.0"
+
+[features]
+default = ["sync"]
+sync = ["wasi-cap-std-sync"]

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -12,6 +12,14 @@ use std::rc::Rc;
 pub use wasi_common::{Error, WasiCtx, WasiCtxBuilder, WasiDir, WasiFile};
 use wasmtime::{Config, Linker, Store};
 
+/// Re-export the commonly used wasi-cap-std-sync crate here. This saves
+/// consumers of this library from having to keep additional dependencies
+/// in sync.
+#[cfg(feature = "sync")]
+pub mod sync {
+    pub use wasi_cap_std_sync::*;
+}
+
 /// An instantiated instance of all available wasi exports. Presently includes
 /// both the "preview1" snapshot and the "unstable" (preview0) snapshot.
 pub struct Wasi {

--- a/examples/linking.rs
+++ b/examples/linking.rs
@@ -3,9 +3,8 @@
 // You can execute this example with `cargo run --example linking`
 
 use anyhow::Result;
-use wasi_cap_std_sync::WasiCtxBuilder;
 use wasmtime::*;
-use wasmtime_wasi::Wasi;
+use wasmtime_wasi::{sync::WasiCtxBuilder, Wasi};
 
 fn main() -> Result<()> {
     let engine = Engine::default();

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -4,9 +4,8 @@
 // You can execute this example with `cargo run --example wasi`
 
 use anyhow::Result;
-use wasi_cap_std_sync::WasiCtxBuilder;
 use wasmtime::*;
-use wasmtime_wasi::Wasi;
+use wasmtime_wasi::{sync::WasiCtxBuilder, Wasi};
 
 fn main() -> Result<()> {
     tracing_subscriber::FmtSubscriber::builder()

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -11,9 +11,8 @@ use std::{
     process,
 };
 use structopt::{clap::AppSettings, StructOpt};
-use wasi_cap_std_sync::WasiCtxBuilder;
 use wasmtime::{Engine, Func, Linker, Module, Store, Trap, Val, ValType};
-use wasmtime_wasi::Wasi;
+use wasmtime_wasi::{sync::WasiCtxBuilder, Wasi};
 
 #[cfg(feature = "wasi-nn")]
 use wasmtime_wasi_nn::{WasiNn, WasiNnCtx};

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -2,7 +2,6 @@
 
 use crate::{init_file_per_thread_logger, CommonOptions};
 use anyhow::{bail, Context as _, Result};
-use cap_std::fs::Dir;
 use std::thread;
 use std::time::Duration;
 use std::{
@@ -12,7 +11,10 @@ use std::{
 };
 use structopt::{clap::AppSettings, StructOpt};
 use wasmtime::{Engine, Func, Linker, Module, Store, Trap, Val, ValType};
-use wasmtime_wasi::{sync::WasiCtxBuilder, Wasi};
+use wasmtime_wasi::{
+    sync::{Dir, WasiCtxBuilder},
+    Wasi,
+};
 
 #[cfg(feature = "wasi-nn")]
 use wasmtime_wasi_nn::{WasiNn, WasiNnCtx};

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
-use wasi_cap_std_sync::WasiCtxBuilder;
 use wasmtime::*;
-use wasmtime_wasi::Wasi;
+use wasmtime_wasi::{sync::WasiCtxBuilder, Wasi};
 
 #[test]
 fn async_required() {

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -512,7 +512,7 @@ fn parse_dwarf_info() -> Result<()> {
     let mut linker = Linker::new(&store);
     wasmtime_wasi::Wasi::new(
         &store,
-        wasi_cap_std_sync::WasiCtxBuilder::new()
+        wasmtime_wasi::sync::WasiCtxBuilder::new()
             .inherit_stdio()
             .build()?,
     )


### PR DESCRIPTION
Until more impls come along, every user of `wasmtime-wasi` is going to use `wasi-cap-std-sync` as their `WasiCtxBuilder`. Rather than make our users track a dependency on an additional crate, re-export it under the top-level `sync` module.

This re-export sits behind the `sync` Cargo feature, which is enabled by default. Users who want to opt out of these re-exports can disable default-features.

Additionally, `wasi-cap-std-sync` now re-exports the `cap_std::fs::Dir` type that it consumes in `WasiCtxBuilder::preopened_dir`. Again, just keeps the consumers of these crates from tracking another dep version.

And finally I cleaned up those extra deps for the wasmtime cli.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
