### PR TITLE
Switch fuzzers to use new Cranelift backend.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,11 +16,8 @@ libfuzzer-sys = "0.4.0"
 target-lexicon = "0.12"
 peepmatic-fuzzing = { path = "../cranelift/peepmatic/crates/fuzzing", optional = true }
 wasmtime = { path = "../crates/wasmtime" }
-wasmtime-fuzzing = { path = "../crates/fuzzing" }
+wasmtime-fuzzing = { path = "../crates/fuzzing", features = ["experimental_x64"] }
 wasm-smith = "0.4.0"
-
-[features]
-experimental_x64 = ["wasmtime-fuzzing/experimental_x64"]
 
 [[bin]]
 name = "compile"


### PR DESCRIPTION
As per bytecodealliance/rfcs#10, the first step in our transition to the
new Cranelift x86-64 backend by default in Wasmtime is to switch our
fuzzers and monitor for any breakage.

This PR moves all Wasmtime fuzz targets over to use the new backend. The
differential old-vs-new-backend target still works by dynamically
selecting both backends (the build feature just changes the default,
which is what all the other fuzz targets use).

We should watch for ~a week or so, I think, on oss-fuzz, to make sure
this sticks without issue before moving further.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
