### PR TITLE
Use unpacked debuginfo on macOS CI

### DIFF
--- a/.github/actions/install-rust/main.js
+++ b/.github/actions/install-rust/main.js
@@ -30,3 +30,8 @@ set_env("CARGO_INCREMENTAL", "0");
 // Turn down debuginfo from 2 to 1 to help save disk space
 set_env("CARGO_PROFILE_DEV_DEBUG", "1");
 set_env("CARGO_PROFILE_TEST_DEBUG", "1");
+
+if (process.platform === 'darwin') {
+  set_env("CARGO_PROFILE_DEV_SPLIT_DEBUGINFO", "unpacked");
+  set_env("CARGO_PROFILE_TEST_SPLIT_DEBUGINFO", "unpacked");
+}


### PR DESCRIPTION
This shaves ~10 minutes off the testing builder since `dsymutil` is
never run and the linker isn't exactly speedy moving around so much debuginfo.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
