### PR TITLE
wiggle: generate a span that is present at all levels

### DIFF
--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -69,8 +69,9 @@ pub fn define_func(
         ) -> Result<#abi_ret, #rt::Trap> {
             use std::convert::TryFrom as _;
 
+            // This span is present at all levels (ERROR and below)
             let _span = #rt::tracing::span!(
-                #rt::tracing::Level::TRACE,
+                #rt::tracing::Level::ERROR,
                 "wiggle abi",
                 module = #mod_name,
                 function = #func_name


### PR DESCRIPTION
The code I wrote here prior was incorrect: a span is present at the
level specified and below; previously I thought it was present at the
level specified and above. So, previously, a TRACE-level event inside
this span would be associated with the module and function name provided
here. Now all events inside this span should be associated with it.

Thank you @iximeow for teaching me this!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
