### PR TITLE
Remove the type-driven ability for duplicates in a `Linker`

### DIFF
--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -27,46 +27,45 @@ fn link_twice_bad() -> Result<()> {
     let mut linker = Linker::new(&store);
 
     // functions
-    linker.func("", "", || {})?;
-    assert!(linker.func("", "", || {}).is_err());
+    linker.func("f", "", || {})?;
+    assert!(linker.func("f", "", || {}).is_err());
     assert!(linker
-        .func("", "", || -> Result<(), Trap> { loop {} })
+        .func("f", "", || -> Result<(), Trap> { loop {} })
         .is_err());
-    linker.func("", "", |_: i32| {})?;
 
     // globals
     let ty = GlobalType::new(ValType::I32, Mutability::Const);
     let global = Global::new(&store, ty, Val::I32(0))?;
-    linker.define("", "", global.clone())?;
-    assert!(linker.define("", "", global.clone()).is_err());
+    linker.define("g", "1", global.clone())?;
+    assert!(linker.define("g", "1", global.clone()).is_err());
 
     let ty = GlobalType::new(ValType::I32, Mutability::Var);
     let global = Global::new(&store, ty, Val::I32(0))?;
-    linker.define("", "", global.clone())?;
-    assert!(linker.define("", "", global.clone()).is_err());
+    linker.define("g", "2", global.clone())?;
+    assert!(linker.define("g", "2", global.clone()).is_err());
 
     let ty = GlobalType::new(ValType::I64, Mutability::Const);
     let global = Global::new(&store, ty, Val::I64(0))?;
-    linker.define("", "", global.clone())?;
-    assert!(linker.define("", "", global.clone()).is_err());
+    linker.define("g", "3", global.clone())?;
+    assert!(linker.define("g", "3", global.clone()).is_err());
 
     // memories
     let ty = MemoryType::new(Limits::new(1, None));
     let memory = Memory::new(&store, ty);
-    linker.define("", "", memory.clone())?;
-    assert!(linker.define("", "", memory.clone()).is_err());
+    linker.define("m", "", memory.clone())?;
+    assert!(linker.define("m", "", memory.clone()).is_err());
     let ty = MemoryType::new(Limits::new(2, None));
     let memory = Memory::new(&store, ty);
-    assert!(linker.define("", "", memory.clone()).is_err());
+    assert!(linker.define("m", "", memory.clone()).is_err());
 
     // tables
     let ty = TableType::new(ValType::FuncRef, Limits::new(1, None));
     let table = Table::new(&store, ty, Val::FuncRef(None))?;
-    linker.define("", "", table.clone())?;
-    assert!(linker.define("", "", table.clone()).is_err());
+    linker.define("t", "", table.clone())?;
+    assert!(linker.define("t", "", table.clone()).is_err());
     let ty = TableType::new(ValType::FuncRef, Limits::new(2, None));
     let table = Table::new(&store, ty, Val::FuncRef(None))?;
-    assert!(linker.define("", "", table.clone()).is_err());
+    assert!(linker.define("t", "", table.clone()).is_err());
     Ok(())
 }
 


### PR DESCRIPTION
When `Linker` was first created it was attempted to be created with the
ability to instantiate any wasm modules, including those with duplicate
import strings of different types. In an effort to support this a
`Linker` supports defining the same names twice so long as they're
defined with differently-typed values.

This ended up causing wast testsuite failures module linking is enabled,
however, because the wrong error message is returned. While it would be
possible to fix this there's already the possibility for confusing error
messages today due to the `Linker` trying to take on this type-level
complexity. In a way this is yet-another type checker for wasm imports,
but sort of a bad one because it only supports things like
globals/functions, and otherwise you can only define one `Memory`, for
example, with a particular name.

This commit completely removes this feature from `Linker` to simplify
the implementation and make error messages more straightforward. This
means that any error message coming from a `Linker` is purely "this
thing wasn't defined" rather than a hybrid of "maybe the types didn't
match?". I think this also better aligns with the direction that we see
conventional wasm modules going which is that duplicate imports are not
ever present.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
