### PR TITLE
wiggle::async_trait is defined as async_trait::async_trait(?Send)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,6 +3651,7 @@ dependencies = [
 name = "wiggle-macro"
 version = "0.25.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
  "wiggle",

--- a/crates/wiggle/generate/src/module_trait.rs
+++ b/crates/wiggle/generate/src/module_trait.rs
@@ -89,8 +89,7 @@ pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings
     });
 
     quote! {
-        use #rt::async_trait;
-        #[async_trait(?Send)]
+        #[#rt::async_trait]
         pub trait #traitname {
             #(#traitmethods)*
         }

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -25,6 +25,7 @@ wiggle-generate = { path = "../generate", version = "0.25.0" }
 witx = { version = "0.9.0", path = "../../wasi-common/WASI/tools/witx" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 wiggle = { path = ".." }

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -83,11 +83,12 @@ use syn::parse_macro_input;
 ///
 /// /// The above witx text contains one module called `$example`. So, we must
 /// /// implement this one method trait for our ctx type.
-/// #[wiggle::async_trait(?Send)]
+/// #[wiggle::async_trait]
 /// /// We specified in the `async_` field that `example::double_int_return_float`
 /// /// is an asynchronous method. Therefore, we use the `async_trait` proc macro
-/// /// (re-exported by wiggle from the crate of the same name) to define this
-/// /// trait, so that `double_int_return_float` can be an `async fn`.
+/// /// to define this trait, so that `double_int_return_float` can be an `async fn`.
+/// /// `wiggle::async_trait` is defined as `#[async_trait::async_trait(?Send)]` -
+/// /// in wiggle, async methods do not have the Send constaint.
 /// impl example::Example for YourCtxType {
 ///     /// The arrays module has two methods, shown here.
 ///     /// Note that the `GuestPtr` type comes from `wiggle`,
@@ -155,4 +156,14 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(quote! { #code #metadata })
+}
+
+#[proc_macro_attribute]
+pub fn async_trait(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let _ = parse_macro_input!(attr as syn::parse::Nothing);
+    let item = proc_macro2::TokenStream::from(item);
+    TokenStream::from(quote! {
+        #[wiggle::async_trait_crate::async_trait(?Send)]
+        #item
+    })
 }

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -6,9 +6,8 @@ use std::slice;
 use std::str;
 use std::sync::Arc;
 
-pub use wiggle_macro::from_witx;
-// re-exports so users of wiggle don't need to track the dependency:
-pub use async_trait::async_trait;
+pub use wiggle_macro::{async_trait, from_witx};
+
 pub use bitflags;
 
 #[cfg(feature = "wiggle_metadata")]
@@ -23,6 +22,10 @@ pub extern crate tracing;
 pub use error::GuestError;
 pub use guest_type::{GuestErrorType, GuestType, GuestTypeTransparent};
 pub use region::Region;
+
+pub mod async_trait_crate {
+    pub use async_trait::*;
+}
 
 /// A trait which abstracts how to get at the region of host memory taht
 /// contains guest memory.

--- a/crates/wiggle/tests/atoms_async.rs
+++ b/crates/wiggle/tests/atoms_async.rs
@@ -14,7 +14,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-#[wiggle::async_trait(?Send)]
+#[wiggle::async_trait]
 impl<'a> atoms::Atoms for WasiCtx<'a> {
     async fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
         println!("INT FLOAT ARGS: {} {}", an_int, an_float);

--- a/crates/wiggle/wasmtime/tests/atoms_async.rs
+++ b/crates/wiggle/wasmtime/tests/atoms_async.rs
@@ -28,7 +28,7 @@ impl wiggle::GuestErrorType for types::Errno {
     }
 }
 
-#[wasmtime_wiggle::async_trait(?Send)]
+#[wasmtime_wiggle::async_trait]
 impl atoms::Atoms for Ctx {
     fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
         println!("INT FLOAT ARGS: {} {}", an_int, an_float);


### PR DESCRIPTION
async methods used by wiggle currently need to Not have the Send
constraint, so rather than make all use sites pass the argument
to the re-exported async_trait macro, define a new macro that
applies the argument.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
