### PR TITLE
Revert "wiggle: generate a span that is present at all levels"

### DIFF
--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -69,9 +69,8 @@ pub fn define_func(
         ) -> Result<#abi_ret, #rt::Trap> {
             use std::convert::TryFrom as _;
 
-            // This span is present at all levels (ERROR and below)
             let _span = #rt::tracing::span!(
-                #rt::tracing::Level::ERROR,
+                #rt::tracing::Level::TRACE,
                 "wiggle abi",
                 module = #mod_name,
                 function = #func_name


### PR DESCRIPTION
This reverts commit 0466f47cb4f48400745470d9d5c08d688e2227df. (#2782)

I got this wrong and now everyone is flooded with ERROR messages from wasi-common. Sorry! This backs out PR #2782.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
