### PR TITLE
Fix printing float results from the CLI

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -333,10 +333,10 @@ impl RunCommand {
             match result {
                 Val::I32(i) => println!("{}", i),
                 Val::I64(i) => println!("{}", i),
-                Val::F32(f) => println!("{}", f),
-                Val::F64(f) => println!("{}", f),
+                Val::F32(f) => println!("{}", f32::from_bits(f)),
+                Val::F64(f) => println!("{}", f64::from_bits(f)),
                 Val::ExternRef(_) => println!("<externref>"),
-                Val::FuncRef(_) => println!("<externref>"),
+                Val::FuncRef(_) => println!("<funcref>"),
                 Val::V128(i) => println!("{}", i),
             }
         }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -97,6 +97,26 @@ fn run_wasmtime_simple_wat() -> Result<()> {
         "--disable-cache",
         "4",
     ])?;
+    assert_eq!(
+        run_wasmtime(&[
+            "run",
+            wasm.path().to_str().unwrap(),
+            "--invoke",
+            "get_f32",
+            "--disable-cache",
+        ])?,
+        "100\n"
+    );
+    assert_eq!(
+        run_wasmtime(&[
+            "run",
+            wasm.path().to_str().unwrap(),
+            "--invoke",
+            "get_f64",
+            "--disable-cache",
+        ])?,
+        "100\n"
+    );
     Ok(())
 }
 

--- a/tests/wasm/simple.wat
+++ b/tests/wasm/simple.wat
@@ -2,4 +2,6 @@
     (func (export "simple") (param i32) (result i32)
         local.get 0
     )
+    (func (export "get_f32") (result f32) f32.const 100)
+    (func (export "get_f64") (result f64) f64.const 100)
 )


### PR DESCRIPTION
Previously their bit patterns were printed interpreted as decimals, now
they're printed as floats.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
