### PR TITLE
Improve wasm2obj for AOT use case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,6 +3397,7 @@ version = "0.25.0"
 dependencies = [
  "addr2line",
  "anyhow",
+ "bincode",
  "cfg-if 1.0.0",
  "cranelift-codegen",
  "cranelift-entity",

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -37,6 +37,7 @@ gimli = { version = "0.23.0", default-features = false, features = ["write"] }
 object = { version = "0.23.0", default-features = false, features = ["write"] }
 serde = { version = "1.0.94", features = ["derive"] }
 addr2line = { version = "0.14", default-features = false }
+bincode = "1.2.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -1,7 +1,7 @@
 //! JIT compilation.
 
 use crate::instantiate::SetupError;
-use crate::object::{build_object, ObjectUnwindInfo};
+use crate::object::{build_object, ObjectMetadataFormat, ObjectUnwindInfo};
 use object::write::Object;
 #[cfg(feature = "parallel-compilation")]
 use rayon::prelude::*;
@@ -134,6 +134,7 @@ impl Compiler {
         &self,
         translation: &mut ModuleTranslation,
         types: &TypeTables,
+        artifact_format: ObjectMetadataFormat,
     ) -> Result<Compilation, SetupError> {
         let functions = mem::take(&mut translation.function_body_inputs);
         let functions = functions.into_iter().collect::<Vec<_>>();
@@ -163,8 +164,14 @@ impl Compiler {
             vec![]
         };
 
-        let (obj, unwind_info) =
-            build_object(&*self.isa, &translation, types, &funcs, dwarf_sections)?;
+        let (obj, unwind_info) = build_object(
+            &*self.isa,
+            &translation,
+            types,
+            &funcs,
+            dwarf_sections,
+            artifact_format,
+        )?;
 
         Ok(Compilation {
             obj,

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -6,7 +6,7 @@
 use crate::code_memory::CodeMemory;
 use crate::compiler::{Compilation, Compiler};
 use crate::link::link_module;
-use crate::object::ObjectUnwindInfo;
+use crate::object::{ObjectMetadataFormat, ObjectUnwindInfo};
 use object::File as ObjectFile;
 #[cfg(feature = "parallel-compilation")]
 use rayon::prelude::*;
@@ -117,7 +117,7 @@ impl CompilationArtifacts {
                     obj,
                     unwind_info,
                     funcs,
-                } = compiler.compile(&mut translation, &types)?;
+                } = compiler.compile(&mut translation, &types, ObjectMetadataFormat::JIT)?;
 
                 let ModuleTranslation {
                     mut module,

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -50,6 +50,7 @@ pub use crate::instantiate::{
     CompilationArtifacts, CompiledModule, ModuleCode, SetupError, SymbolizeContext, TypeTables,
 };
 pub use crate::link::link_module;
+pub use crate::object::ObjectMetadataFormat;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/commands/wasm2obj.rs
+++ b/src/commands/wasm2obj.rs
@@ -46,6 +46,10 @@ pub struct WasmToObjCommand {
     /// The target triple; default is the host triple
     #[structopt(long, value_name = "TARGET", parse(try_from_str = parse_target))]
     target: Option<Triple>,
+
+    /// The symbol prefix.
+    #[structopt(long, value_name = "SYMBOL_PREFIX")]
+    symbol_prefix: Option<String>,
 }
 
 impl WasmToObjCommand {
@@ -64,6 +68,7 @@ impl WasmToObjCommand {
             self.common.enable_simd,
             self.common.opt_level(),
             self.common.debug_info,
+            self.symbol_prefix.as_ref().unwrap_or(&"".to_string()),
         )?;
 
         let mut file =

--- a/tests/all/debug/obj.rs
+++ b/tests/all/debug/obj.rs
@@ -18,6 +18,7 @@ pub fn compile_cranelift(
         false,
         wasmtime::OptLevel::None,
         true,
+        "",
     )?;
 
     let mut file = File::create(output).context("failed to create object file")?;


### PR DESCRIPTION
This patch improves wasm2obj tool functionality:

- Use native (not only ELF) format, e.g. COFF for Windows
- Allows to save additional metadata (`Module`, as well as table of function and trampolines table) in a result object file
- Use Wasm debug names, export or name section, as symbol names
- Use a specified prefix in symbol names

All the above improvements are useful for AOT users. More extensive example can be found at https://github.com/yurydelendik/wasmtime/tree/aot-ftw-1

cc @shravanrn

