### PR TITLE
Don't hash for the cache if it's disabled

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -48,16 +48,16 @@ impl<'config> ModuleCacheEntry<'config> {
         T: Hash,
         U: Serialize + for<'a> Deserialize<'a>,
     {
+        let inner = match &self.0 {
+            Some(inner) => inner,
+            None => return compute(state),
+        };
+
         let mut hasher = Sha256Hasher(Sha256::new());
         state.hash(&mut hasher);
         let hash: [u8; 32] = hasher.0.finalize().into();
         // standard encoding uses '/' which can't be used for filename
         let hash = base64::encode_config(&hash, base64::URL_SAFE_NO_PAD);
-
-        let inner = match &self.0 {
-            Some(inner) => inner,
-            None => return compute(state),
-        };
 
         if let Some(cached_val) = inner.get_data(&hash) {
             let mod_cache_path = inner.root_path.join(&hash);


### PR DESCRIPTION
This fixes an issue where even if the wasmtime cache was disabled we're
still calculating the sha256 of modules for the hash key. This hash
was then simply discarded if the cache was disabled!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
