### PR TITLE
Add some more `#[inline]` annotations for trivial functions

### DIFF
--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -70,21 +70,25 @@ macro_rules! entity_impl {
     // Basic traits.
     ($entity:ident) => {
         impl $crate::EntityRef for $entity {
+            #[inline]
             fn new(index: usize) -> Self {
                 debug_assert!(index < ($crate::__core::u32::MAX as usize));
                 $entity(index as u32)
             }
 
+            #[inline]
             fn index(self) -> usize {
                 self.0 as usize
             }
         }
 
         impl $crate::packed_option::ReservedValue for $entity {
+            #[inline]
             fn reserved_value() -> $entity {
                 $entity($crate::__core::u32::MAX)
             }
 
+            #[inline]
             fn is_reserved_value(&self) -> bool {
                 self.0 == $crate::__core::u32::MAX
             }
@@ -93,6 +97,7 @@ macro_rules! entity_impl {
         impl $entity {
             /// Create a new instance from a `u32`.
             #[allow(dead_code)]
+            #[inline]
             pub fn from_u32(x: u32) -> Self {
                 debug_assert!(x < $crate::__core::u32::MAX);
                 $entity(x)
@@ -100,6 +105,7 @@ macro_rules! entity_impl {
 
             /// Return the underlying index value as a `u32`.
             #[allow(dead_code)]
+            #[inline]
             pub fn as_u32(self) -> u32 {
                 self.0
             }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -448,12 +448,14 @@ impl Module {
     }
 
     /// Convert a `DefinedFuncIndex` into a `FuncIndex`.
+    #[inline]
     pub fn func_index(&self, defined_func: DefinedFuncIndex) -> FuncIndex {
         FuncIndex::new(self.num_imported_funcs + defined_func.index())
     }
 
     /// Convert a `FuncIndex` into a `DefinedFuncIndex`. Returns None if the
     /// index is an imported function.
+    #[inline]
     pub fn defined_func_index(&self, func: FuncIndex) -> Option<DefinedFuncIndex> {
         if func.index() < self.num_imported_funcs {
             None
@@ -465,17 +467,20 @@ impl Module {
     }
 
     /// Test whether the given function index is for an imported function.
+    #[inline]
     pub fn is_imported_function(&self, index: FuncIndex) -> bool {
         index.index() < self.num_imported_funcs
     }
 
     /// Convert a `DefinedTableIndex` into a `TableIndex`.
+    #[inline]
     pub fn table_index(&self, defined_table: DefinedTableIndex) -> TableIndex {
         TableIndex::new(self.num_imported_tables + defined_table.index())
     }
 
     /// Convert a `TableIndex` into a `DefinedTableIndex`. Returns None if the
     /// index is an imported table.
+    #[inline]
     pub fn defined_table_index(&self, table: TableIndex) -> Option<DefinedTableIndex> {
         if table.index() < self.num_imported_tables {
             None
@@ -487,17 +492,20 @@ impl Module {
     }
 
     /// Test whether the given table index is for an imported table.
+    #[inline]
     pub fn is_imported_table(&self, index: TableIndex) -> bool {
         index.index() < self.num_imported_tables
     }
 
     /// Convert a `DefinedMemoryIndex` into a `MemoryIndex`.
+    #[inline]
     pub fn memory_index(&self, defined_memory: DefinedMemoryIndex) -> MemoryIndex {
         MemoryIndex::new(self.num_imported_memories + defined_memory.index())
     }
 
     /// Convert a `MemoryIndex` into a `DefinedMemoryIndex`. Returns None if the
     /// index is an imported memory.
+    #[inline]
     pub fn defined_memory_index(&self, memory: MemoryIndex) -> Option<DefinedMemoryIndex> {
         if memory.index() < self.num_imported_memories {
             None
@@ -509,17 +517,20 @@ impl Module {
     }
 
     /// Test whether the given memory index is for an imported memory.
+    #[inline]
     pub fn is_imported_memory(&self, index: MemoryIndex) -> bool {
         index.index() < self.num_imported_memories
     }
 
     /// Convert a `DefinedGlobalIndex` into a `GlobalIndex`.
+    #[inline]
     pub fn global_index(&self, defined_global: DefinedGlobalIndex) -> GlobalIndex {
         GlobalIndex::new(self.num_imported_globals + defined_global.index())
     }
 
     /// Convert a `GlobalIndex` into a `DefinedGlobalIndex`. Returns None if the
     /// index is an imported global.
+    #[inline]
     pub fn defined_global_index(&self, global: GlobalIndex) -> Option<DefinedGlobalIndex> {
         if global.index() < self.num_imported_globals {
             None
@@ -531,6 +542,7 @@ impl Module {
     }
 
     /// Test whether the given global index is for an imported global.
+    #[inline]
     pub fn is_imported_global(&self, index: GlobalIndex) -> bool {
         index.index() < self.num_imported_globals
     }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -44,6 +44,7 @@ fn cast_to_u32(sz: usize) -> u32 {
 }
 
 /// Align an offset used in this module to a specific byte-width by rounding up
+#[inline]
 fn align(offset: u32, width: u32) -> u32 {
     (offset + (width - 1)) / width * width
 }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -970,6 +970,7 @@ impl InstanceHandle {
     /// of the internals, there's no lifetime tracking around its validity.
     /// You'll need to ensure that the returned handles all go out of scope at
     /// the same time.
+    #[inline]
     pub unsafe fn clone(&self) -> InstanceHandle {
         InstanceHandle {
             instance: self.instance,

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -490,17 +490,20 @@ mod test_vmshared_signature_index {
 
 impl VMSharedSignatureIndex {
     /// Create a new `VMSharedSignatureIndex`.
+    #[inline]
     pub fn new(value: u32) -> Self {
         Self(value)
     }
 
     /// Returns the underlying bits of the index.
+    #[inline]
     pub fn bits(&self) -> u32 {
         self.0
     }
 }
 
 impl Default for VMSharedSignatureIndex {
+    #[inline]
     fn default() -> Self {
         Self::new(u32::MAX)
     }


### PR DESCRIPTION
Looking at some profiles these or their related functions were all
showing up, so this commit adds `#[inline]` to allow cross-crate
inlining by default.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
