### PR TITLE
Fix srem.{i8,i16}

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -489,7 +489,7 @@ pub(crate) fn emit(
                     // x % -1 = 0; put the result into the destination, $rdx.
                     let done_label = sink.get_label();
 
-                    let inst = Inst::imm(*size, 0, Writable::from_reg(regs::rdx()));
+                    let inst = Inst::imm(OperandSize::Size64, 0, Writable::from_reg(regs::rdx()));
                     inst.emit(sink, info, state);
 
                     let inst = Inst::jmp_known(done_label);
@@ -528,11 +528,6 @@ pub(crate) fn emit(
             if let Some(do_op) = do_op {
                 sink.bind_label(do_op);
             }
-
-            assert!(
-                *size != OperandSize::Size8,
-                "CheckedDivOrRemSeq for i8 is not yet implemented"
-            );
 
             // Fill in the high parts:
             if kind.is_signed() {

--- a/cranelift/filetests/filetests/isa/x64/div-checks-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks-run.clif
@@ -2,10 +2,31 @@ test run
 set avoid_div_traps=false
 target x86_64 machinst
 
-function %f0(i32, i32) -> i32 {
+function %i8(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+  v2 = srem.i8 v0, v1
+  return v2
+}
+; run: %i8(0x80, 0xff) == 0
+; run: %i8(0x2, 0x7) == 0x2
+
+function %i16(i16, i16) -> i16 {
+block0(v0: i16, v1: i16):
+  v2 = srem.i16 v0, v1
+  return v2
+}
+; run: %i16(0x8000, 0xffff) == 0
+
+function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
   v2 = srem.i32 v0, v1
   return v2
 }
+; run: %i32(0x80000000, 0xffffffff) == 0
 
-; run: %f0(0x80000000, 0xffffffff) == 0
+function %i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = srem.i64 v0, v1
+  return v2
+}
+; run: %i32(0x800000000000000, 0xffffffffffffffff) == 0

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -6,7 +6,41 @@ target x86_64 machinst
 ;; when `avoid_div_traps` above is false (i.e. even when the host is normally
 ;; willing to accept SIGFPEs as Wasm traps). The machine will SIGFPE in some
 ;; cases when `srem` is valid (specifically -INT_MIN % -1).
-function %f0(i64, i64) -> i64 {
+
+function %i8(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+  v2 = srem.i8 v0, v1
+; check:  movq    %rdi, %rax
+; nextln: movl    $$0, %edx
+; nextln: srem $$rax:$$rdx, %sil
+; nextln: shrq    $$8, %rax
+
+  return v2
+}
+
+function %i16(i16, i16) -> i16 {
+block0(v0: i16, v1: i16):
+  v2 = srem.i16 v0, v1
+; check:  movq    %rdi, %rax
+; nextln: movl    $$0, %edx
+; nextln: srem $$rax:$$rdx, %si
+; nextln: movq    %rdx, %rax
+
+  return v2
+}
+
+function %i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+  v2 = srem.i32 v0, v1
+; check:  movq    %rdi, %rax
+; nextln: movl    $$0, %edx
+; nextln: srem $$rax:$$rdx, %esi
+; nextln: movq    %rdx, %rax
+
+  return v2
+}
+
+function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
   v2 = srem.i64 v0, v1
 ; check:  movq    %rdi, %rax


### PR DESCRIPTION
Fixes one half of #2826.