### PR TITLE
CI: pin nightly Rust version to limit breakages to explicit pinning updates.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2021-04-11
     - run: |
         cargo doc --no-deps --workspace \
           --exclude wasmtime-cli \
@@ -169,7 +169,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly
+        toolchain: nightly-2021-04-11
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz
@@ -219,7 +219,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2021-04-11
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
We seem to be seeing some CI failures in various PRs today due to new warnings added to nightly Rust.

It seems reasonable to me to pin the nightly version we use on CI, and periodically update this, so that if breakages are going to happen then they happen in a single place when we update the pinned version. This also insulates us somewhat from occasional bugs that slip into nightlies. (We had a similar strategy for the new-x64-backend tests for a bit, pinning to a particular nightly version.)

In particular, for the [latest failures](https://github.com/bytecodealliance/wasmtime/pull/2823/checks?check_run_id=2332455218), it looks like a nightly bug: the compiler is interpreting `_`-args as patterns rather than ignored args and then issuing warnings-as-errors to use underscores instead (!). The only immediate fix is to use a different nightly, I think.

I can see the argument for the other approach, though, that we want to guarantee as best we can that we work with the *latest* nightly and fix issues immediately as they arise (this is analogous to the usual rolling release vs fixed release debate I guess). Happy to discuss!

(I chose a one-day-old nightly for this PR -- let's s see if this works on CI...)