### PR TITLE
x64: fix Inst::store to understand all scalar types

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1126,16 +1126,7 @@ impl Inst {
     pub(crate) fn store(ty: Type, from_reg: Reg, to_addr: impl Into<SyntheticAmode>) -> Inst {
         let rc = from_reg.get_class();
         match rc {
-            RegClass::I64 => Inst::mov_r_m(
-                match ty {
-                    types::B1 => OperandSize::Size8,
-                    types::I32 | types::R32 => OperandSize::Size32,
-                    types::I64 | types::R64 => OperandSize::Size64,
-                    _ => unimplemented!("integer store of type: {}", ty),
-                },
-                from_reg,
-                to_addr,
-            ),
+            RegClass::I64 => Inst::mov_r_m(OperandSize::from_ty(ty), from_reg, to_addr),
             RegClass::V128 => {
                 let opcode = match ty {
                     types::F32 => SseOpcode::Movss,


### PR DESCRIPTION
In #2826, @bjorn3 found an issue relating to `Inst::store`--not all types, e.g. `I16`, were supported. There is no reason `Inst::store` shouldn't have this functionality: the [emission of `MovRM`](https://github.com/bytecodealliance/wasmtime/blob/8387bc0d76896bd724a0db85a28437c5465540b0/cranelift/codegen/src/isa/x64/inst/emit.rs#L786-L790) already supports this. @bjorn3, can you provide a CLIF test to trigger the error you found?

Also, to make troubleshooting easier in the future, I re-factored `lower.rs` to use `Inst::store` in all the places it previously used `Inst::mov_r_m`. This should make things easier to troubleshoot: only one function, `Inst::store`, now understands what move instruction is needed for each different CLIF type.

