### PR TITLE
Allow unwind support to work without a frame pointer

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -56,8 +56,8 @@ impl crate::isa::unwind::systemv::RegisterMapper<Reg> for RegisterMapper {
     fn sp(&self) -> u16 {
         regs::stack_reg().get_hw_encoding().into()
     }
-    fn fp(&self) -> u16 {
-        regs::fp_reg().get_hw_encoding().into()
+    fn fp(&self) -> Option<u16> {
+        Some(regs::fp_reg().get_hw_encoding().into())
     }
     fn lr(&self) -> Option<u16> {
         Some(regs::link_reg().get_hw_encoding().into())

--- a/cranelift/codegen/src/isa/unwind.rs
+++ b/cranelift/codegen/src/isa/unwind.rs
@@ -225,6 +225,11 @@ pub enum UnwindInst {
         /// the clobber area.
         offset_downward_to_clobbers: u32,
     },
+    /// The stack pointer was adjusted to allocate the stack.
+    StackAlloc {
+        /// Size to allocate.
+        size: u32,
+    },
     /// The stack slot at the given offset from the clobber-area base has been
     /// used to save the given register.
     ///

--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -356,6 +356,12 @@ pub(crate) fn create_unwind_info_from_insts<MR: RegisterMapper<regalloc::Reg>>(
                 frame_register_offset = ensure_unwind_offset(offset_downward_to_clobbers)?;
                 unwind_codes.push(UnwindCode::SetFPReg { instruction_offset });
             }
+            &UnwindInst::StackAlloc { size } => {
+                unwind_codes.push(UnwindCode::StackAlloc {
+                    instruction_offset,
+                    size,
+                });
+            }
             &UnwindInst::SaveReg {
                 clobber_offset,
                 reg,

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -89,8 +89,8 @@ impl crate::isa::unwind::systemv::RegisterMapper<Reg> for RegisterMapper {
     fn sp(&self) -> u16 {
         X86_64::RSP.0
     }
-    fn fp(&self) -> u16 {
-        X86_64::RBP.0
+    fn fp(&self) -> Option<u16> {
+        Some(X86_64::RBP.0)
     }
 }
 

--- a/cranelift/codegen/src/isa/x86/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x86/unwind/systemv.rs
@@ -121,8 +121,8 @@ pub(crate) fn create_unwind_info(
         fn sp(&self) -> u16 {
             X86_64::RSP.0
         }
-        fn fp(&self) -> u16 {
-            X86_64::RBP.0
+        fn fp(&self) -> Option<u16> {
+            Some(X86_64::RBP.0)
         }
     }
     let map = RegisterMapper(isa);


### PR DESCRIPTION
The patch extends the unwinder to support targets that do not need
to use a dedicated frame pointer register.  Specifically, the
changes include:

- Change the "fp" routine in the RegisterMapper to return an
  *optional* frame pointer regsiter via Option<Register>.

- On targets that choose to not define a FP register via the above
  routine, the UnwindInst::DefineNewFrame operation no longer switches
  the CFA to be defined in terms of the FP.  (The operation still can
  be used to define the location of the clobber area.)

- In addition, on targets that choose not to define a FP register, the
  UnwindInst::PushFrameRegs operation is not supported.

- There is a new operation UnwindInst::StackAlloc that needs to be
  called on targets without FP whenever the stack pointer is updated.
  This caused the CFA offset to be adjusted accordingly.  (On
  targets with FP this operation is a no-op.)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
