### PR TITLE
cranelift: Fix spillslot regression on big-endian platforms

### DIFF
--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -1209,6 +1209,15 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         let spill_off = islot * M::word_bytes() as i64;
         let sp_off = self.stackslots_size as i64 + spill_off;
         trace!("load_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
+
+        // Integer types smaller than word size have been spilled as words below,
+        // and therefore must be reloaded in the same type.
+        let ty = if ty.is_int() && ty.bytes() < M::word_bytes() {
+            M::word_type()
+        } else {
+            ty
+        };
+
         gen_load_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), into_regs, ty)
     }
 

--- a/cranelift/filetests/filetests/isa/x64/store-stack-full-width-i32.clif
+++ b/cranelift/filetests/filetests/isa/x64/store-stack-full-width-i32.clif
@@ -51,7 +51,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;; This should be movq below, not movl.
 ; nextln:  movq    %rsi, rsp(0 + virtual offset)
 
-; nextln:  movslq  rsp(0 + virtual offset), %rsi
+; nextln:  movq    rsp(0 + virtual offset), %rsi
 ; nextln:  addl    %edi, %esi
 
     ;; Put an effectful instruction so that the live-ranges of the adds and


### PR DESCRIPTION
PR 2840 changed the store_spillslot routine to always store
integer registers in full word size to a spill slot.  However,
the load_spillslot routine was not updated, which may causes
the contents to be reloaded in a different type.  On big-endian
systems this will fetch wrong data.

Fixed by using the same type override in load_spillslot.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
