### PR TITLE
Optimize `table.init` instruction and instantiation

### DIFF
--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -747,7 +747,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         &mut self,
         _table_index: TableIndex,
         _base: Option<GlobalIndex>,
-        _offset: usize,
+        _offset: u32,
         _elements: Box<[FuncIndex]>,
     ) -> WasmResult<()> {
         // We do nothing
@@ -792,7 +792,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         &mut self,
         _memory_index: MemoryIndex,
         _base: Option<GlobalIndex>,
-        _offset: usize,
+        _offset: u32,
         _data: &'data [u8],
     ) -> WasmResult<()> {
         // We do nothing

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -937,7 +937,7 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         &mut self,
         table_index: TableIndex,
         base: Option<GlobalIndex>,
-        offset: usize,
+        offset: u32,
         elements: Box<[FuncIndex]>,
     ) -> WasmResult<()>;
 
@@ -984,7 +984,7 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         &mut self,
         memory_index: MemoryIndex,
         base: Option<GlobalIndex>,
-        offset: usize,
+        offset: u32,
         data: &'data [u8],
     ) -> WasmResult<()>;
 

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -377,7 +377,7 @@ pub fn parse_element_section<'data>(
             } => {
                 let mut init_expr_reader = init_expr.get_binary_reader();
                 let (base, offset) = match init_expr_reader.read_operator()? {
-                    Operator::I32Const { value } => (None, value as u32 as usize),
+                    Operator::I32Const { value } => (None, value as u32),
                     Operator::GlobalGet { global_index } => {
                         (Some(GlobalIndex::from_u32(global_index)), 0)
                     }
@@ -388,12 +388,6 @@ pub fn parse_element_section<'data>(
                         ));
                     }
                 };
-                // Check for offset + len overflow
-                if offset.checked_add(segments.len()).is_none() {
-                    return Err(wasm_unsupported!(
-                        "element segment offset and length overflows"
-                    ));
-                }
                 environ.declare_table_elements(
                     TableIndex::from_u32(table_index),
                     base,
@@ -429,7 +423,7 @@ pub fn parse_data_section<'data>(
             } => {
                 let mut init_expr_reader = init_expr.get_binary_reader();
                 let (base, offset) = match init_expr_reader.read_operator()? {
-                    Operator::I32Const { value } => (None, value as u32 as usize),
+                    Operator::I32Const { value } => (None, value as u32),
                     Operator::GlobalGet { global_index } => {
                         (Some(GlobalIndex::from_u32(global_index)), 0)
                     }
@@ -440,12 +434,6 @@ pub fn parse_data_section<'data>(
                         ))
                     }
                 };
-                // Check for offset + len overflow
-                if offset.checked_add(data.len()).is_none() {
-                    return Err(wasm_unsupported!(
-                        "data segment offset and length overflows"
-                    ));
-                }
                 environ.declare_data_initialization(
                     MemoryIndex::from_u32(memory_index),
                     base,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -705,7 +705,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         &mut self,
         table_index: TableIndex,
         base: Option<GlobalIndex>,
-        offset: usize,
+        offset: u32,
         elements: Box<[FuncIndex]>,
     ) -> WasmResult<()> {
         for element in elements.iter() {
@@ -794,7 +794,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         &mut self,
         memory_index: MemoryIndex,
         base: Option<GlobalIndex>,
-        offset: usize,
+        offset: u32,
         data: &'data [u8],
     ) -> WasmResult<()> {
         match &mut self.result.module.memory_initialization {

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -220,8 +220,7 @@ impl Table {
         dst: u32,
         items: impl ExactSizeIterator<Item = *mut VMCallerCheckedAnyfunc>,
     ) -> Result<(), Trap> {
-        let ty = TableElementType::Func;
-        assert!(ty == TableElementType::Func);
+        assert!(self.element_type() == TableElementType::Func);
 
         self.with_elements_mut(|elements| {
             let elements = match elements
@@ -233,7 +232,7 @@ impl Table {
             };
 
             for (item, slot) in items.zip(elements) {
-                Self::set_raw(ty, slot, item.into())
+                *slot = item as *mut u8;
             }
             Ok(())
         })

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -7,7 +7,7 @@ use crate::{ResourceLimiter, Trap, VMExternRef};
 use anyhow::{bail, Result};
 use std::cell::{Cell, RefCell};
 use std::cmp::min;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::ops::Range;
 use std::ptr;
 use std::rc::Rc;
@@ -210,6 +210,33 @@ impl Table {
             TableStorage::Static { maximum, .. } => Some(*maximum),
             TableStorage::Dynamic { maximum, .. } => maximum.clone(),
         }
+    }
+
+    /// Fill `table[dst..]` with values from `items`
+    ///
+    /// Returns a trap error on out-of-bounds accesses.
+    pub fn init_funcs(
+        &self,
+        dst: u32,
+        items: impl ExactSizeIterator<Item = *mut VMCallerCheckedAnyfunc>,
+    ) -> Result<(), Trap> {
+        let ty = TableElementType::Func;
+        assert!(ty == TableElementType::Func);
+
+        self.with_elements_mut(|elements| {
+            let elements = match elements
+                .get_mut(usize::try_from(dst).unwrap()..)
+                .and_then(|s| s.get_mut(..items.len()))
+            {
+                Some(elements) => elements,
+                None => return Err(Trap::wasm(ir::TrapCode::TableOutOfBounds)),
+            };
+
+            for (item, slot) in items.zip(elements) {
+                Self::set_raw(ty, slot, item.into())
+            }
+            Ok(())
+        })
     }
 
     /// Fill `table[dst..dst + len]` with `val`.


### PR DESCRIPTION
This commit optimizes table initialization as part of instance
instantiation and also applies the same optimization to the `table.init`
instruction. One part of this commit is to remove some preexisting
duplication between instance instantiation and the `table.init`
instruction itself, after this the actual implementation of `table.init`
is optimized to effectively have fewer bounds checks in fewer places and
have a much tighter loop for instantiation.

A big fallout from this change is that memory/table initializer offsets
are now stored as `u32` instead of `usize` to remove a few casts in a
few places. This ended up requiring moving some overflow checks that
happened in parsing to later in code itself because otherwise the wrong
spec test errors are emitted during testing. I've tried to trace where
these can possibly overflow but I think that I managed to get
everything.

In a local synthetic test where an empty module with a single 80,000
element initializer this improves total instantiation time by 4x (562us
=> 141us)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
