### PR TITLE
debug: Fix frame base memory accesses

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -565,6 +565,7 @@ where
                         // Add frame base expressions.
                         flush_code_chunk!();
                         parts.extend_from_slice(&frame_base.unwrap().parts);
+                        need_deref = frame_base.unwrap().need_deref;
                     }
                     if let Some(CompiledExpressionPart::Local { trailing, .. }) = parts.last_mut() {
                         // Reset local trailing flag.
@@ -966,7 +967,7 @@ mod tests {
                     },
                     CompiledExpressionPart::Code(vec![35, 18])
                 ],
-                need_deref: true,
+                need_deref: false,
             }
         );
 


### PR DESCRIPTION
When translating a WebAssembly DWARF expression into a native
DWARF expression, care needs to be taken to translate WebAssembly
memory addresses into native memory addresses by adding the base
address.  However, some addresses are already native addresses,
so the two cases need to be distinguished.  Existing code uses
the "need_deref" flag to do so.

However, this flag seems to be calculated incorrectly in some
cases involving frame base register accesses.  For example,
in the test case file tests/all/debug/testsuite/fib-wasm.wasm,
the location of the local parameter "n" is described as:
  DW_OP_fbreg + 28
while the frame base register is described as:
  DW_OP_WASM_location 0x0 0x3, DW_OP_stack_value

Now, the result of evaluating the DW_OP_WASM_location is a
native memory address (retrieved from a native register or
a native stack slot), so we must not add the memory base.
And indeed, when evaluating the DW_AT_frame_base attribute,
the resulting expression does *not* have need_deref set.

However, when evaluating the DW_OP_fbreg operation, the
frame base expression is copied, the offset (28) is added,
but then also the need_deref flag is set, causing the
memory base to be added.  This seems incorrect.  If the
frame base is already a native address, then an offset
relative to the frame base is likewise a native address.

This patch fixes the problem by respecting the need_deref
flag of DW_AT_frame_base when evaluating DW_OP_fbreg.
This fixes the test failure I was seeing on s390x.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
