### PR TITLE
Factor out byteorder in cranelift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,6 @@ name = "cranelift-codegen"
 version = "0.73.0"
 dependencies = [
  "bincode",
- "byteorder",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
@@ -591,7 +590,6 @@ name = "cranelift-filetests"
 version = "0.73.0"
 dependencies = [
  "anyhow",
- "byteorder",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-interpreter",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -24,7 +24,6 @@ bincode = { version = "1.2.1", optional = true }
 gimli = { version = "0.23.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.6.1" }
 thiserror = "1.0.4"
-byteorder = { version = "1.3.2", default-features = false }
 peepmatic = { path = "../peepmatic", optional = true, version = "0.73.0" }
 peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, version = "0.73.0" }
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.73.0" }

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -16,7 +16,6 @@ cranelift-interpreter = { path = "../interpreter", version = "0.73.0" }
 cranelift-native = { path = "../native", version = "0.73.0" }
 cranelift-reader = { path = "../reader", version = "0.73.0" }
 cranelift-preopt = { path = "../preopt", version = "0.73.0" }
-byteorder = { version = "1.3.2", default-features = false }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"
 gimli = { version = "0.23.0", default-features = false, features = ["read"] }

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -72,7 +72,6 @@ impl SubTest for TestUnwind {
 }
 
 mod windowsx64 {
-    use byteorder::{ByteOrder, LittleEndian};
     use std::fmt::Write;
 
     pub fn dump<W: Write>(text: &mut W, mem: &[u8]) {
@@ -165,23 +164,24 @@ mod windowsx64 {
             let op_and_info = mem[1];
             let op = UnwindOperation::from(op_and_info & 0xF);
             let info = (op_and_info & 0xF0) >> 4;
+            let unwind_le_bytes = |bytes| match (bytes, &mem[2..]) {
+                (2, &[b0, b1, ..]) => UnwindValue::U16(u16::from_le_bytes([b0, b1])),
+                (4, &[b0, b1, b2, b3, ..]) => {
+                    UnwindValue::U32(u32::from_le_bytes([b0, b1, b2, b3]))
+                }
+                (_, _) => panic!("not enough bytes to unwind value"),
+            };
 
-            let value = match op {
-                UnwindOperation::LargeStackAlloc => match info {
-                    0 => UnwindValue::U16(LittleEndian::read_u16(&mem[2..])),
-                    1 => UnwindValue::U32(LittleEndian::read_u32(&mem[2..])),
-                    _ => panic!("unexpected stack alloc info value"),
-                },
-                UnwindOperation::SaveNonvolatileRegister => {
-                    UnwindValue::U16(LittleEndian::read_u16(&mem[2..]))
+            let value = match (&op, info) {
+                (UnwindOperation::LargeStackAlloc, 0) => unwind_le_bytes(2),
+                (UnwindOperation::LargeStackAlloc, 1) => unwind_le_bytes(4),
+                (UnwindOperation::LargeStackAlloc, _) => {
+                    panic!("unexpected stack alloc info value")
                 }
-                UnwindOperation::SaveNonvolatileRegisterFar => {
-                    UnwindValue::U32(LittleEndian::read_u32(&mem[2..]))
-                }
-                UnwindOperation::SaveXmm128 => UnwindValue::U16(LittleEndian::read_u16(&mem[2..])),
-                UnwindOperation::SaveXmm128Far => {
-                    UnwindValue::U32(LittleEndian::read_u32(&mem[2..]))
-                }
+                (UnwindOperation::SaveNonvolatileRegister, _) => unwind_le_bytes(2),
+                (UnwindOperation::SaveNonvolatileRegisterFar, _) => unwind_le_bytes(4),
+                (UnwindOperation::SaveXmm128, _) => unwind_le_bytes(2),
+                (UnwindOperation::SaveXmm128Far, _) => unwind_le_bytes(4),
                 _ => UnwindValue::None,
             };
 


### PR DESCRIPTION
This removes an existing dependency on the byteorder crate in favor of
using std equivalents directly.

While not an issue for wasmtime per se, cranelift is now part of the
critical path of building and testing Rust, and minimizing dependencies,
even small ones, can help reduce the time and bandwidth required.
