### PR TITLE
Bring back `Module::deserialize`

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -992,9 +992,13 @@ WASM_API_EXTERN own wasmtime_error_t* wasmtime_module_serialize(
 
 /**
  * \brief Build a module from serialized data.
- * *
+ *
  * This function does not take ownership of any of its arguments, but the
  * returned error and module are owned by the caller.
+ *
+ * This function is not safe to receive arbitrary user input. See the Rust
+ * documentation for more information on what inputs are safe to pass in here
+ * (e.g. only that of #wasmtime_module_serialize)
  */
 WASM_API_EXTERN own wasmtime_error_t *wasmtime_module_deserialize(
     wasm_engine_t *engine,

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -186,7 +186,7 @@ pub extern "C" fn wasmtime_module_deserialize(
     ret: &mut *mut wasm_module_t,
 ) -> Option<Box<wasmtime_error_t>> {
     handle_result(
-        Module::deserialize(&engine.engine, binary.as_slice()),
+        unsafe { Module::deserialize(&engine.engine, binary.as_slice()) },
         |module| {
             let module = Box::new(wasm_module_t::new(module));
             *ret = Box::into_raw(module);

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -185,10 +185,13 @@ pub extern "C" fn wasmtime_module_deserialize(
     binary: &wasm_byte_vec_t,
     ret: &mut *mut wasm_module_t,
 ) -> Option<Box<wasmtime_error_t>> {
-    handle_result(Module::new(&engine.engine, binary.as_slice()), |module| {
-        let module = Box::new(wasm_module_t::new(module));
-        *ret = Box::into_raw(module);
-    })
+    handle_result(
+        Module::deserialize(&engine.engine, binary.as_slice()),
+        |module| {
+            let module = Box::new(wasm_module_t::new(module));
+            *ret = Box::into_raw(module);
+        },
+    )
 }
 
 #[no_mangle]

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -160,8 +160,9 @@ impl Engine {
     ///   Note that the `wat` feature is enabled by default.
     ///
     /// This method may be used to compile a module for use with a different target
-    /// host. The output of this method may be used with [`Module::new`](crate::Module::new)
-    /// on hosts compatible with the [`Config`] associated with this [`Engine`].
+    /// host. The output of this method may be used with
+    /// [`Module::deserialize`](crate::Module::deserialize) on hosts compatible
+    /// with the [`Config`] associated with this [`Engine`].
     ///
     /// The output of this method is safe to send to another host machine for later
     /// execution. As the output is already a compiled module, translation and code

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -322,18 +322,40 @@ impl Module {
     ///
     /// This function will deserialize the binary blobs emitted by
     /// [`Module::serialize`] and [`Engine::precompile_module`] back into an
-    /// in-memory [`Module`] that's ready to be instantiated. Note that this is
-    /// only compatible with bytes that were produced by the same version of the
-    /// wasmtime crate itself.
+    /// in-memory [`Module`] that's ready to be instantiated.
     ///
-    /// It's important to not that this is somewhat `unsafe` but is not marked
-    /// as `unsafe`. It is technically possible to feed in arbitrary bytes here
-    /// and have custom jit code which enables arbitrary code execution. The
-    /// `bytes` structure is validated to have the right "structure" of bytes
-    /// but the contents are not validated by `wasmtime`. It is safe to pass in
-    /// any wasmtime-compiled blob here (from future and past versions), but
-    /// this should not be exposed to arbitrary user-defined input.
-    pub fn deserialize(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Module> {
+    /// # Unsafety
+    ///
+    /// This function is marked as `unsafe` because if fed invalid input or used
+    /// improperly this could lead to memory safety vulnerabilities. This method
+    /// should not, for example, be exposed to arbitrary user input.
+    ///
+    /// The structure of the binary blob read here is only lightly validated
+    /// internally in `wasmtime`. This is intended to be an efficient
+    /// "rehydration" for a [`Module`] which has very few runtime checks beyond
+    /// deserialization. Arbitrary input could, for example, replace valid
+    /// compiled code with any other valid compiled code, meaning that this can
+    /// trivially be used to execute arbitrary code otherwise.
+    ///
+    /// For these reasons this function is `unsafe`. This function is only
+    /// designed to receive the previous input from [`Module::serialize`] and
+    /// [`Engine::precompile_module`]. If the exact output of those functions
+    /// (unmodified) is passed to this function then calls to this function can
+    /// be considered safe. It is the caller's responsibility to provide the
+    /// guarantee that only previously-serialized bytes are being passed in
+    /// here.
+    ///
+    /// Note that this function is designed to be safe receiving output from
+    /// *any* compiled version of `wasmtime` itself. This means that it is safe
+    /// to feed output from older versions of Wasmtime into this function, in
+    /// addition to newer versions of wasmtime (from the future!). These inputs
+    /// will deterministically and safely produce an `Err`. This function only
+    /// successfully accepts inputs from the same version of `wasmtime`, but the
+    /// safety guarantee only applies to externally-defined blobs of bytes, not
+    /// those defined by any version of wasmtime. (this means that if you cache
+    /// blobs across versions of wasmtime you can be safely guaranteed that
+    /// future versions of wasmtime will reject old cache entries).
+    pub unsafe fn deserialize(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Module> {
         let module = SerializedModule::from_bytes(bytes.as_ref())?;
         module.into_module(engine)
     }

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -329,9 +329,9 @@ impl<'a> SerializedModule<'a> {
         Ok(bytes)
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Option<Self>> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         if !bytes.starts_with(HEADER) {
-            return Ok(None);
+            bail!("bytes are not a compatible serialized wasmtime module");
         }
 
         let bytes = &bytes[HEADER.len()..];
@@ -353,11 +353,9 @@ impl<'a> SerializedModule<'a> {
             );
         }
 
-        Ok(Some(
-            bincode_options()
-                .deserialize::<SerializedModule<'_>>(&bytes[1 + version_len..])
-                .context("deserialize compilation artifacts")?,
-        ))
+        Ok(bincode_options()
+            .deserialize::<SerializedModule<'_>>(&bytes[1 + version_len..])
+            .context("deserialize compilation artifacts")?)
     }
 
     fn check_triple(&self, isa: &dyn TargetIsa) -> Result<()> {

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -29,9 +29,12 @@ fn deserialize(buffer: &[u8]) -> Result<()> {
     println!("Initializing...");
     let store = Store::default();
 
-    // Compile the wasm binary into an in-memory instance of a `Module`.
+    // Compile the wasm binary into an in-memory instance of a `Module`. Note
+    // that this is `unsafe` because it is our responsibility for guaranteeing
+    // that these bytes are valid precompiled module bytes. We know that from
+    // the structure of this example program.
     println!("Deserialize module...");
-    let module = Module::deserialize(store.engine(), buffer)?;
+    let module = unsafe { Module::deserialize(store.engine(), buffer)? };
 
     // Here we handle the imports of the module, which in this case is our
     // `HelloCallback` type and its associated implementation of `Callback.

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -31,7 +31,7 @@ fn deserialize(buffer: &[u8]) -> Result<()> {
 
     // Compile the wasm binary into an in-memory instance of a `Module`.
     println!("Deserialize module...");
-    let module = Module::new(store.engine(), buffer)?;
+    let module = Module::deserialize(store.engine(), buffer)?;
 
     // Here we handle the imports of the module, which in this case is our
     // `HelloCallback` type and its associated implementation of `Callback.

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -126,7 +126,8 @@ mod test {
         command.execute()?;
 
         let engine = Engine::default();
-        let module = Module::from_file(&engine, output_path)?;
+        let contents = std::fs::read(output_path)?;
+        let module = Module::deserialize(&engine, contents)?;
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
         let f = instance.get_typed_func::<i32, i32>("f")?;

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -127,7 +127,7 @@ mod test {
 
         let engine = Engine::default();
         let contents = std::fs::read(output_path)?;
-        let module = Module::deserialize(&engine, contents)?;
+        let module = unsafe { Module::deserialize(&engine, contents)? };
         let store = Store::new(&engine);
         let instance = Instance::new(&store, &module, &[])?;
         let f = instance.get_typed_func::<i32, i32>("f")?;

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -27,18 +27,18 @@ fn caches_across_engines() {
         .serialize()
         .unwrap();
 
-    let res = Module::new(&Engine::new(&Config::new()).unwrap(), &bytes);
+    let res = Module::deserialize(&Engine::new(&Config::new()).unwrap(), &bytes);
     assert!(res.is_ok());
 
     // differ in shared cranelift flags
-    let res = Module::new(
+    let res = Module::deserialize(
         &Engine::new(Config::new().cranelift_nan_canonicalization(true)).unwrap(),
         &bytes,
     );
     assert!(res.is_err());
 
     // differ in cranelift settings
-    let res = Module::new(
+    let res = Module::deserialize(
         &Engine::new(Config::new().cranelift_opt_level(OptLevel::None)).unwrap(),
         &bytes,
     );
@@ -46,7 +46,7 @@ fn caches_across_engines() {
 
     // Missing required cpu flags
     if cfg!(target_arch = "x86_64") {
-        let res = Module::new(
+        let res = Module::deserialize(
             &Engine::new(
                 Config::new()
                     .target(&target_lexicon::Triple::host().to_string())
@@ -66,7 +66,7 @@ fn aot_compiles() -> Result<()> {
         "(module (func (export \"f\") (param i32) (result i32) local.get 0))".as_bytes(),
     )?;
 
-    let module = Module::from_binary(&engine, &bytes)?;
+    let module = Module::deserialize(&engine, &bytes)?;
 
     let store = Store::new(&engine);
     let instance = Instance::new(&store, &module, &[])?;

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -27,35 +27,37 @@ fn caches_across_engines() {
         .serialize()
         .unwrap();
 
-    let res = Module::deserialize(&Engine::new(&Config::new()).unwrap(), &bytes);
-    assert!(res.is_ok());
+    unsafe {
+        let res = Module::deserialize(&Engine::new(&Config::new()).unwrap(), &bytes);
+        assert!(res.is_ok());
 
-    // differ in shared cranelift flags
-    let res = Module::deserialize(
-        &Engine::new(Config::new().cranelift_nan_canonicalization(true)).unwrap(),
-        &bytes,
-    );
-    assert!(res.is_err());
-
-    // differ in cranelift settings
-    let res = Module::deserialize(
-        &Engine::new(Config::new().cranelift_opt_level(OptLevel::None)).unwrap(),
-        &bytes,
-    );
-    assert!(res.is_err());
-
-    // Missing required cpu flags
-    if cfg!(target_arch = "x86_64") {
+        // differ in shared cranelift flags
         let res = Module::deserialize(
-            &Engine::new(
-                Config::new()
-                    .target(&target_lexicon::Triple::host().to_string())
-                    .unwrap(),
-            )
-            .unwrap(),
+            &Engine::new(Config::new().cranelift_nan_canonicalization(true)).unwrap(),
             &bytes,
         );
         assert!(res.is_err());
+
+        // differ in cranelift settings
+        let res = Module::deserialize(
+            &Engine::new(Config::new().cranelift_opt_level(OptLevel::None)).unwrap(),
+            &bytes,
+        );
+        assert!(res.is_err());
+
+        // Missing required cpu flags
+        if cfg!(target_arch = "x86_64") {
+            let res = Module::deserialize(
+                &Engine::new(
+                    Config::new()
+                        .target(&target_lexicon::Triple::host().to_string())
+                        .unwrap(),
+                )
+                .unwrap(),
+                &bytes,
+            );
+            assert!(res.is_err());
+        }
     }
 }
 
@@ -66,7 +68,7 @@ fn aot_compiles() -> Result<()> {
         "(module (func (export \"f\") (param i32) (result i32) local.get 0))".as_bytes(),
     )?;
 
-    let module = Module::deserialize(&engine, &bytes)?;
+    let module = unsafe { Module::deserialize(&engine, &bytes)? };
 
     let store = Store::new(&engine);
     let instance = Instance::new(&store, &module, &[])?;

--- a/tests/all/module_linking.rs
+++ b/tests/all/module_linking.rs
@@ -39,7 +39,9 @@ fn compile() -> Result<()> {
     assert_eq!(m.imports().len(), 0);
     assert_eq!(m.exports().len(), 0);
     let bytes = m.serialize()?;
-    Module::deserialize(&engine, &bytes)?;
+    unsafe {
+        Module::deserialize(&engine, &bytes)?;
+    }
     assert_eq!(m.imports().len(), 0);
     assert_eq!(m.exports().len(), 0);
     Ok(())

--- a/tests/all/module_linking.rs
+++ b/tests/all/module_linking.rs
@@ -39,7 +39,7 @@ fn compile() -> Result<()> {
     assert_eq!(m.imports().len(), 0);
     assert_eq!(m.exports().len(), 0);
     let bytes = m.serialize()?;
-    Module::new(&engine, &bytes)?;
+    Module::deserialize(&engine, &bytes)?;
     assert_eq!(m.imports().len(), 0);
     assert_eq!(m.exports().len(), 0);
     Ok(())

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -7,7 +7,7 @@ fn serialize(engine: &Engine, wat: &'static str) -> Result<Vec<u8>> {
 }
 
 fn deserialize_and_instantiate(store: &Store, buffer: &[u8]) -> Result<Instance> {
-    let module = Module::new(store.engine(), buffer)?;
+    let module = Module::deserialize(store.engine(), buffer)?;
     Ok(Instance::new(&store, &module, &[])?)
 }
 
@@ -17,7 +17,7 @@ fn test_version_mismatch() -> Result<()> {
     let mut buffer = serialize(&engine, "(module)")?;
     buffer[13 /* header length */ + 1 /* version length */] = 'x' as u8;
 
-    match Module::new(&engine, &buffer) {
+    match Module::deserialize(&engine, &buffer) {
         Ok(_) => bail!("expected deserialization to fail"),
         Err(e) => assert!(e
             .to_string()

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -6,7 +6,7 @@ fn serialize(engine: &Engine, wat: &'static str) -> Result<Vec<u8>> {
     Ok(module.serialize()?)
 }
 
-fn deserialize_and_instantiate(store: &Store, buffer: &[u8]) -> Result<Instance> {
+unsafe fn deserialize_and_instantiate(store: &Store, buffer: &[u8]) -> Result<Instance> {
     let module = Module::deserialize(store.engine(), buffer)?;
     Ok(Instance::new(&store, &module, &[])?)
 }
@@ -17,7 +17,7 @@ fn test_version_mismatch() -> Result<()> {
     let mut buffer = serialize(&engine, "(module)")?;
     buffer[13 /* header length */ + 1 /* version length */] = 'x' as u8;
 
-    match Module::deserialize(&engine, &buffer) {
+    match unsafe { Module::deserialize(&engine, &buffer) } {
         Ok(_) => bail!("expected deserialization to fail"),
         Err(e) => assert!(e
             .to_string()
@@ -35,7 +35,7 @@ fn test_module_serialize_simple() -> Result<()> {
     )?;
 
     let store = Store::default();
-    let instance = deserialize_and_instantiate(&store, &buffer)?;
+    let instance = unsafe { deserialize_and_instantiate(&store, &buffer)? };
     let run = instance.get_typed_func::<(), i32>("run")?;
     let result = run.call(())?;
 
@@ -53,7 +53,7 @@ fn test_module_serialize_fail() -> Result<()> {
     let mut config = Config::new();
     config.cranelift_opt_level(OptLevel::None);
     let store = Store::new(&Engine::new(&config)?);
-    match deserialize_and_instantiate(&store, &buffer) {
+    match unsafe { deserialize_and_instantiate(&store, &buffer) } {
         Ok(_) => bail!("expected failure at deserialization"),
         Err(_) => (),
     }


### PR DESCRIPTION
I thought I was being clever suggesting that `Module::deserialize` was
removed from #2791 by funneling all module constructors into
`Module::new`. As our studious fuzzers have found, though, this means
that `Module::new` is not safe currently to pass arbitrary user-defined
input into. Now one might pretty reasonable expect to be able to do
that, however, being a WebAssembly engine and all. This PR as a result
separates the `deserialize` part of `Module::new` back into
`Module::deserialize`.

This means that binary blobs created with `Module::serialize` and
`Engine::precompile_module` will need to be passed to
`Module::deserialize` to "rehydrate" them back into a `Module`. This
restores the property that it should be safe to pass arbitrary input to
`Module::new` since it's always expected to be a wasm module. This also
means that fuzzing will no longer attempt to fuzz `Module::deserialize`
which isn't something we want to do anyway.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
