### PR TITLE
wasi-nn: turn it on by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,30 +191,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.55.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
-dependencies = [
- "bitflags",
- "cexpr",
- "cfg-if 0.1.10",
- "clang-sys",
- "clap",
- "env_logger 0.7.1",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
@@ -1730,22 +1706,30 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openvino"
-version = "0.1.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43eeb44285b7ce8e2012b92bec32968622e1dad452e812e6edea9e001e5e9410"
+checksum = "0cb74b3d8c653f7a9928bda494d329e6363ea0b428d3a3e5805b45ebb74ace76"
 dependencies = [
  "openvino-sys",
  "thiserror",
 ]
 
 [[package]]
-name = "openvino-sys"
-version = "0.1.8"
+name = "openvino-finder"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb64bef270a1ff665b0b2e28ebfa213e6205a007ce88223d020730225d6008f"
+checksum = "426587a131841eb1e1111b0fea96cbd4fd0fd5d7b6526fb9c41400587d1c525c"
+
+[[package]]
+name = "openvino-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d5e5d5e913f4e9aa42b2a7ae9c8719aedb4bc0eb443bf92f07d9ee9a05e7b1"
 dependencies = [
- "bindgen 0.55.1",
  "cmake",
+ "lazy_static",
+ "libloading",
+ "openvino-finder",
 ]
 
 [[package]]
@@ -2984,7 +2968,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ada4f4ae167325015f52cc65f9fb6c251b868d8fb3b6dd0ce2d60e497c4870a"
 dependencies = [
- "bindgen 0.57.0",
+ "bindgen",
  "cc",
  "cfg-if 0.1.10",
 ]
@@ -3602,15 +3586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec280a739b69173e0ffd12c1658507996836ba4e992ed9bc1e5385a0bd72a02"
 dependencies = [
  "wast 35.0.2",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ members = [
 ]
 
 [features]
-default = ["jitdump", "wasmtime/wat", "wasmtime/parallel-compilation"]
+default = ["jitdump", "wasmtime/wat", "wasmtime/parallel-compilation", "wasi-nn"]
 lightbeam = ["wasmtime/lightbeam"]
 jitdump = ["wasmtime/jitdump"]
 vtune = ["wasmtime/vtune"]

--- a/ci/run-wasi-crypto-example.sh
+++ b/ci/run-wasi-crypto-example.sh
@@ -7,4 +7,4 @@ pushd "$RUST_BINDINGS"
 cargo build --release --target=wasm32-wasi
 popd
 
-cargo run --features wasi-crypto -- run "$RUST_BINDINGS/target/wasm32-wasi/release/wasi-crypto-guest.wasm"
+cargo run --features wasi-crypto -- run "$RUST_BINDINGS/target/wasm32-wasi/release/wasi-crypto-guest.wasm" --wasi-modules=experimental-wasi-crypto

--- a/ci/run-wasi-nn-example.sh
+++ b/ci/run-wasi-nn-example.sh
@@ -37,7 +37,7 @@ cp target/wasm32-wasi/release/wasi-nn-example.wasm $TMP_DIR
 popd
 
 # Run the example in Wasmtime (note that the example uses `fixture` as the expected location of the model/tensor files).
-cargo run -- run --mapdir fixture::$TMP_DIR $TMP_DIR/wasi-nn-example.wasm
+cargo run -- run --mapdir fixture::$TMP_DIR $TMP_DIR/wasi-nn-example.wasm --wasi-modules=experimental-wasi-nn
 
 # Clean up the temporary directory only if it was not specified (users may want to keep the directory around).
 if [[ $REMOVE_TMP_DIR -eq 1 ]]; then

--- a/ci/run-wasi-nn-example.sh
+++ b/ci/run-wasi-nn-example.sh
@@ -37,7 +37,7 @@ cp target/wasm32-wasi/release/wasi-nn-example.wasm $TMP_DIR
 popd
 
 # Run the example in Wasmtime (note that the example uses `fixture` as the expected location of the model/tensor files).
-OPENVINO_INSTALL_DIR=/opt/intel/openvino cargo run --features wasi-nn -- run --mapdir fixture::$TMP_DIR $TMP_DIR/wasi-nn-example.wasm
+cargo run -- run --mapdir fixture::$TMP_DIR $TMP_DIR/wasi-nn-example.wasm
 
 # Clean up the temporary directory only if it was not specified (users may want to keep the directory around).
 if [[ $REMOVE_TMP_DIR -eq 1 ]]; then

--- a/crates/wasi-crypto/src/wiggle_interfaces/error.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/error.rs
@@ -1,4 +1,4 @@
-use super::{guest_types, WasiCryptoCtx};
+use super::guest_types;
 
 use std::num::TryFromIntError;
 use wasi_crypto::CryptoError;

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi", version = "0.26.0" }
 wiggle = { path = "../wiggle", version = "0.26.0" }
 
 # These dependencies are necessary for the wasi-nn implementation:
-openvino = "0.1.5"
+openvino = { version = "0.3.1", features = ["runtime-linking"] }
 thiserror = "1.0"
 
 [build-dependencies]

--- a/crates/wasi-nn/build.rs
+++ b/crates/wasi-nn/build.rs
@@ -1,11 +1,9 @@
 //! This build script:
 //!  - has the configuration necessary for the wiggle and witx macros.
-
-use std::path::PathBuf;
-
 fn main() {
     // This is necessary for Wiggle/Witx macros.
-    let wasi_root = PathBuf::from("./spec").canonicalize().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let wasi_root = cwd.join("spec");
     println!("cargo:rustc-env=WASI_ROOT={}", wasi_root.display());
 
     // Also automatically rebuild if the Witx files change

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -14,7 +14,8 @@ impl<'a> types::UserErrorConversion for WasiNnCtx {
     fn nn_errno_from_wasi_nn_error(&self, e: WasiNnError) -> Result<NnErrno, wiggle::Trap> {
         eprintln!("Host error: {:?}", e);
         match e {
-            WasiNnError::OpenvinoError(_) => unimplemented!(),
+            WasiNnError::OpenvinoSetupError(_) => unimplemented!(),
+            WasiNnError::OpenvinoInferenceError(_) => unimplemented!(),
             WasiNnError::GuestError(_) => unimplemented!(),
             WasiNnError::UsageError(_) => unimplemented!(),
         }

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "CC0-1.0",
+    "ISC",
     "MIT",
     "MPL-2.0",
     "Zlib",

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -28,7 +28,7 @@ lazy_static::lazy_static! {
             Compiling for a specific platform (Linux) and CPU preset (Skylake):\n\
             \n  \
             wasmtime compile --target x86_64-unknown-linux --cranelift-enable skylake foo.wasm\n",
-            crate::WASM_FEATURES.as_str()
+            crate::FLAG_EXPLANATIONS.as_str()
         )
     };
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,6 @@
 //! The module that implements the `wasmtime run` command.
 
-use crate::CommonOptions;
+use crate::{CommonOptions, WasiModules};
 use anyhow::{bail, Context as _, Result};
 use std::thread;
 use std::time::Duration;
@@ -70,7 +70,7 @@ fn parse_preloads(s: &str) -> Result<(String, PathBuf)> {
 
 lazy_static::lazy_static! {
     static ref AFTER_HELP: String = {
-        crate::WASM_FEATURES.to_string()
+        crate::FLAG_EXPLANATIONS.to_string()
     };
 }
 
@@ -146,7 +146,13 @@ impl RunCommand {
         let argv = self.compute_argv();
 
         let mut linker = Linker::new(&store);
-        populate_with_wasi(&mut linker, preopen_dirs, &argv, &self.vars)?;
+        populate_with_wasi(
+            &mut linker,
+            preopen_dirs,
+            &argv,
+            &self.vars,
+            &self.common.wasi_modules.unwrap_or(WasiModules::default()),
+        )?;
 
         // Load the preload wasm modules.
         for (name, path) in self.preloads.iter() {
@@ -351,6 +357,7 @@ fn populate_with_wasi(
     preopen_dirs: Vec<(String, Dir)>,
     argv: &[String],
     vars: &[(String, String)],
+    wasi_modules: &WasiModules,
 ) -> Result<()> {
     // Add the current snapshot to the linker.
     let mut builder = WasiCtxBuilder::new();
@@ -360,25 +367,40 @@ fn populate_with_wasi(
         builder = builder.preopened_dir(dir, name)?;
     }
 
-    Wasi::new(linker.store(), builder.build()?).add_to_linker(linker)?;
-
-    #[cfg(feature = "wasi-nn")]
-    {
-        use std::cell::RefCell;
-        use std::rc::Rc;
-        let wasi_nn = WasiNn::new(linker.store(), Rc::new(RefCell::new(WasiNnCtx::new()?)));
-        wasi_nn.add_to_linker(linker)?;
+    if wasi_modules.wasi_common {
+        Wasi::new(linker.store(), builder.build()?).add_to_linker(linker)?;
     }
 
-    #[cfg(feature = "wasi-crypto")]
-    {
-        use std::cell::RefCell;
-        use std::rc::Rc;
-        let cx_crypto = Rc::new(RefCell::new(WasiCryptoCtx::new()));
-        WasiCryptoCommon::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
-        WasiCryptoAsymmetricCommon::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
-        WasiCryptoSignatures::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
-        WasiCryptoSymmetric::new(linker.store(), cx_crypto).add_to_linker(linker)?;
+    if wasi_modules.wasi_nn {
+        #[cfg(not(feature = "wasi-nn"))]
+        {
+            bail!("Cannot enable wasi-nn when the binary is not compiled with this feature.");
+        }
+        #[cfg(feature = "wasi-nn")]
+        {
+            use std::cell::RefCell;
+            use std::rc::Rc;
+            let wasi_nn = WasiNn::new(linker.store(), Rc::new(RefCell::new(WasiNnCtx::new()?)));
+            wasi_nn.add_to_linker(linker)?;
+        }
+    }
+
+    if wasi_modules.wasi_crypto {
+        #[cfg(not(feature = "wasi-crypto"))]
+        {
+            bail!("Cannot enable wasi-crypto when the binary is not compiled with this feature.");
+        }
+        #[cfg(feature = "wasi-crypto")]
+        {
+            use std::cell::RefCell;
+            use std::rc::Rc;
+            let cx_crypto = Rc::new(RefCell::new(WasiCryptoCtx::new()));
+            WasiCryptoCommon::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+            WasiCryptoAsymmetricCommon::new(linker.store(), cx_crypto.clone())
+                .add_to_linker(linker)?;
+            WasiCryptoSignatures::new(linker.store(), cx_crypto.clone()).add_to_linker(linker)?;
+            WasiCryptoSymmetric::new(linker.store(), cx_crypto).add_to_linker(linker)?;
+        }
     }
 
     Ok(())

--- a/src/commands/wasm2obj.rs
+++ b/src/commands/wasm2obj.rs
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
             The default is a dummy environment that produces placeholder values.\n\
             \n\
             {}",
-            crate::WASM_FEATURES.as_str()
+            crate::FLAG_EXPLANATIONS.as_str()
         )
     };
 }

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -9,7 +9,7 @@ use wasmtime_wast::WastContext;
 
 lazy_static::lazy_static! {
     static ref AFTER_HELP: String = {
-        crate::WASM_FEATURES.to_string()
+        crate::FLAG_EXPLANATIONS.to_string()
     };
 }
 


### PR DESCRIPTION
This change makes the wasi-nn Cargo feature a default feature. Previously, a wasi-nn user would have to build a separate Wasmtime binary (e.g. `cargo build --features wasi-nn ...`) to use wasi-nn and the resulting binary would require OpenVINO shared libraries to be present in the environment in order to run (otherwise it would fail immediately with linking errors). With recent changes to the `openvino` crate, the wasi-nn implementation can defer the loading of the OpenVINO shared libraries until runtime (i.e., when the user Wasm program calls `wasi_ephemeral_nn::load`) and display a user-level error if anything goes wrong (e.g., the OpenVINO libraries are not present on the system). This runtime-linking addition allows the wasi-nn feature to be turned on by default and shipped with upcoming releases of Wasmtime. This change should be transparent for users who do not use wasi-nn: the `openvino` crate is small and the newly-available wasi-nn imports only affect programs in which they are used.

For those interested in reviewing the runtime linking approach added to the `openvino` crate, see https://github.com/intel/openvino-rs/pull/19.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
