### PR TITLE
Expose new `JITModule::read_got_entry` function

### DIFF
--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -285,6 +285,13 @@ impl JITModule {
         }
     }
 
+    /// Returns the given function's entry in the Global Offset Table.
+    ///
+    /// Panics if there's no entry in the table for the given function.
+    pub fn read_got_entry(&self, func_id: FuncId) -> *const u8 {
+        unsafe { *self.function_got_entries[func_id].unwrap().as_ptr() }
+    }
+
     fn get_got_address(&self, name: &ir::ExternalName) -> *const u8 {
         match *name {
             ir::ExternalName::User { .. } => {


### PR DESCRIPTION
This hasn't been discussed in a wasmtime issue, but (together with #2786) it's needed it for bjorn3/rustc_codegen_cranelift#1166.

It exposes ~`JITModule::get_got_address`~ a new `JITModule::read_got_entry` function so that, when jitting lazily, cranelift users can inspect the GOT to determine whether a given function's entry is still their shim trampoline or not (and therefore whether the function has already been jitted).  This prevents the function from being jitted differently from simultaneous requests arising from different threads.

No test cases added, ~because exposing a function obviously doesn't change any behaviour~.

Sorry, I don't know who would be an appropriate reviewer for this.
