### PR TITLE
Object file support for s390x

### DIFF
--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -60,6 +60,8 @@ pub enum Reloc {
     Arm64Call,
     /// RISC-V call target
     RiscvCall,
+    /// s390x PC-relative 4-byte offset
+    S390xPCRel32Dbl,
 
     /// Elf x86_64 32 bit signed PC relative offset to two GOT entries for GD symbol.
     ElfX86_64TlsGd,
@@ -75,6 +77,7 @@ impl fmt::Display for Reloc {
         match *self {
             Self::Abs4 => write!(f, "Abs4"),
             Self::Abs8 => write!(f, "Abs8"),
+            Self::S390xPCRel32Dbl => write!(f, "PCRel32Dbl"),
             Self::X86PCRel4 => write!(f, "PCRel4"),
             Self::X86PCRelRodata4 => write!(f, "PCRelRodata4"),
             Self::X86CallPCRel4 => write!(f, "CallPCRel4"),

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -72,6 +72,15 @@ impl CompiledBlob {
                         write_unaligned(at as *mut i32, pcrel)
                     };
                 }
+                Reloc::S390xPCRel32Dbl => {
+                    let base = get_address(name);
+                    let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
+                    let pcrel = i32::try_from(((what as isize) - (at as isize)) >> 1).unwrap();
+                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+                    unsafe {
+                        write_unaligned(at as *mut i32, pcrel)
+                    };
+                }
                 _ => unimplemented!(),
             }
         }

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -153,6 +153,11 @@ cfg_if! {
                     cs.set_skipdata(true).map_err(map_caperr)?;
                     cs
                 }
+                Architecture::S390x {..} => Capstone::new()
+                    .sysz()
+                    .mode(arch::sysz::ArchMode::Default)
+                    .build()
+                    .map_err(map_caperr)?,
                 _ => anyhow::bail!("Unknown ISA"),
             };
 

--- a/crates/debug/src/lib.rs
+++ b/crates/debug/src/lib.rs
@@ -120,6 +120,7 @@ fn ensure_supported_elf_format(bytes: &mut Vec<u8>) -> Result<Endianness, Error>
 
     match header.e_machine.get(e) {
         EM_X86_64 => (),
+        EM_S390 => (),
         machine => {
             bail!("Unsupported ELF target machine: {:x}", machine);
         }

--- a/crates/obj/src/builder.rs
+++ b/crates/obj/src/builder.rs
@@ -80,6 +80,7 @@ fn to_object_relocations<'a>(
                 RelocationEncoding::Generic,
                 32,
             ),
+            Reloc::S390xPCRel32Dbl => (RelocationKind::Relative, RelocationEncoding::S390xDbl, 32),
             other => unimplemented!("Unimplemented relocation {:?}", other),
         };
         Some(ObjectRelocation {
@@ -102,6 +103,7 @@ fn to_object_architecture(
         X86_64 => Architecture::X86_64,
         Arm(_) => Architecture::Arm,
         Aarch64(_) => Architecture::Aarch64,
+        S390x => Architecture::S390x,
         architecture => {
             anyhow::bail!("target architecture {:?} is unsupported", architecture,);
         }

--- a/crates/profiling/src/jitdump_linux.rs
+++ b/crates/profiling/src/jitdump_linux.rs
@@ -241,6 +241,7 @@ impl State {
             Architecture::X86_32(_) => elf::EM_386 as u32,
             Architecture::Arm(_) => elf::EM_ARM as u32,
             Architecture::Aarch64(_) => elf::EM_AARCH64 as u32,
+            Architecture::S390x => elf::EM_S390 as u32,
             _ => unimplemented!("unrecognized architecture"),
         }
     }


### PR DESCRIPTION
Add support for s390x binary format object files.  In particular,
add support for s390x ELF relocation types (currently only
S390xPCRel32Dbl).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
