### PR TITLE
Remove TLS lookup of the store on `Trap::new`

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1219,7 +1219,6 @@ fn enter_wasm_init<'a>(store: &'a Store) -> Result<impl Drop + 'a, Trap> {
             // considered interrupted.
             interrupts.stack_limit.store(usize::max_value(), Relaxed);
             return Err(Trap::new_wasm(
-                Some(store),
                 None,
                 wasmtime_environ::ir::TrapCode::Interrupt,
                 backtrace::Backtrace::new_unresolved(),

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -33,19 +33,6 @@ fn func_by_pc(module: &CompiledModule, pc: usize) -> Option<(DefinedFuncIndex, u
 pub struct ModuleRegistry(BTreeMap<usize, Arc<RegisteredModule>>);
 
 impl ModuleRegistry {
-    /// Fetches frame information about a program counter in a backtrace.
-    ///
-    /// Returns an object if this `pc` is known to some previously registered
-    /// module, or returns `None` if no information can be found. The boolean
-    /// returned indicates whether the original module has unparsed debug
-    /// information due to the compiler's configuration.
-    pub fn lookup_frame_info(&self, pc: usize) -> Option<(FrameInfo, bool)> {
-        let module = self.module(pc)?;
-        module
-            .lookup_frame_info(pc)
-            .map(|info| (info, module.has_unparsed_debuginfo()))
-    }
-
     /// Fetches trap information about a program counter in a backtrace.
     pub fn lookup_trap_info(&self, pc: usize) -> Option<&TrapInformation> {
         self.module(pc)?.lookup_trap_info(pc)
@@ -132,76 +119,6 @@ struct RegisteredModule {
 }
 
 impl RegisteredModule {
-    /// Determines if the related module has unparsed debug information.
-    pub fn has_unparsed_debuginfo(&self) -> bool {
-        self.module.has_unparsed_debuginfo()
-    }
-
-    /// Fetches frame information about a program counter in a backtrace.
-    ///
-    /// Returns an object if this `pc` is known to this module, or returns `None`
-    /// if no information can be found.
-    pub fn lookup_frame_info(&self, pc: usize) -> Option<FrameInfo> {
-        let (index, offset) = func_by_pc(&self.module, pc)?;
-        let info = self.module.func_info(index);
-        let pos = Self::instr_pos(offset, &info.address_map);
-
-        // In debug mode for now assert that we found a mapping for `pc` within
-        // the function, because otherwise something is buggy along the way and
-        // not accounting for all the instructions. This isn't super critical
-        // though so we can omit this check in release mode.
-        debug_assert!(pos.is_some(), "failed to find instruction for {:x}", pc);
-
-        let instr = match pos {
-            Some(pos) => info.address_map.instructions[pos].srcloc,
-            None => info.address_map.start_srcloc,
-        };
-
-        // Use our wasm-relative pc to symbolize this frame. If there's a
-        // symbolication context (dwarf debug info) available then we can try to
-        // look this up there.
-        //
-        // Note that dwarf pcs are code-section-relative, hence the subtraction
-        // from the location of `instr`. Also note that all errors are ignored
-        // here for now since technically wasm modules can always have any
-        // custom section contents.
-        let mut symbols = Vec::new();
-
-        if let Some(s) = &self.module.symbolize_context().ok().and_then(|c| c) {
-            let to_lookup = (instr.bits() as u64) - s.code_section_offset();
-            if let Ok(mut frames) = s.addr2line().find_frames(to_lookup) {
-                while let Ok(Some(frame)) = frames.next() {
-                    symbols.push(FrameSymbol {
-                        name: frame
-                            .function
-                            .as_ref()
-                            .and_then(|l| l.raw_name().ok())
-                            .map(|s| s.to_string()),
-                        file: frame
-                            .location
-                            .as_ref()
-                            .and_then(|l| l.file)
-                            .map(|s| s.to_string()),
-                        line: frame.location.as_ref().and_then(|l| l.line),
-                        column: frame.location.as_ref().and_then(|l| l.column),
-                    });
-                }
-            }
-        }
-
-        let module = self.module.module();
-        let index = module.func_index(index);
-
-        Some(FrameInfo {
-            module_name: module.name.clone(),
-            func_index: index.index() as u32,
-            func_name: module.func_names.get(&index).cloned(),
-            instr,
-            func_start: info.address_map.start_srcloc,
-            symbols,
-        })
-    }
-
     /// Fetches trap information about a program counter in a backtrace.
     pub fn lookup_trap_info(&self, pc: usize) -> Option<&TrapInformation> {
         let (index, offset) = func_by_pc(&self.module, pc)?;
@@ -306,6 +223,7 @@ impl ModuleInfo for RegisteredModule {
 struct GlobalRegisteredModule {
     start: usize,
     module: Arc<CompiledModule>,
+    wasm_backtrace_details_env_used: bool,
     /// Note that modules can be instantiated in many stores, so the purpose of
     /// this field is to keep track of how many stores have registered a
     /// module. Information is only removed from the global registry when this
@@ -335,22 +253,52 @@ impl GlobalModuleRegistry {
     pub(crate) fn is_wasm_pc(pc: usize) -> bool {
         let modules = GLOBAL_MODULES.lock().unwrap();
 
-        match modules.0.range(pc..).next() {
-            Some((end, entry)) => {
-                if pc < entry.start || *end < pc {
-                    return false;
+        match modules.module(pc) {
+            Some(entry) => match func_by_pc(&entry.module, pc) {
+                Some((index, offset)) => {
+                    let info = entry.module.func_info(index);
+                    RegisteredModule::instr_pos(offset, &info.address_map).is_some()
                 }
-
-                match func_by_pc(&entry.module, pc) {
-                    Some((index, offset)) => {
-                        let info = entry.module.func_info(index);
-                        RegisteredModule::instr_pos(offset, &info.address_map).is_some()
-                    }
-                    None => false,
-                }
-            }
+                None => false,
+            },
             None => false,
         }
+    }
+
+    fn module(&self, pc: usize) -> Option<&GlobalRegisteredModule> {
+        let (end, info) = self.0.range(pc..).next()?;
+        if pc < info.start || *end < pc {
+            return None;
+        }
+        Some(info)
+    }
+
+    // Work with the global instance of `GlobalModuleRegistry`. Note that only
+    // shared access is allowed, this isn't intended to mutate the contents.
+    //
+    // (right now we use a `Mutex` but if motivated we could one day use a
+    // `RwLock`)
+    pub(crate) fn with(f: impl FnOnce(&GlobalModuleRegistry)) {
+        f(&GLOBAL_MODULES.lock().unwrap())
+    }
+
+    /// Fetches frame information about a program counter in a backtrace.
+    ///
+    /// Returns an object if this `pc` is known to some previously registered
+    /// module, or returns `None` if no information can be found. The first
+    /// boolean returned indicates whether the original module has unparsed
+    /// debug information due to the compiler's configuration. The second
+    /// boolean indicates whether the engine used to compile this module is
+    /// using environment variables to control debuginfo parsing.
+    pub(crate) fn lookup_frame_info(&self, pc: usize) -> Option<(FrameInfo, bool, bool)> {
+        let module = self.module(pc)?;
+        module.lookup_frame_info(pc).map(|info| {
+            (
+                info,
+                module.has_unparsed_debuginfo(),
+                module.wasm_backtrace_details_env_used,
+            )
+        })
     }
 
     /// Registers a new region of code, described by `(start, end)` and with
@@ -359,6 +307,10 @@ impl GlobalModuleRegistry {
         let info = self.0.entry(end).or_insert_with(|| GlobalRegisteredModule {
             start,
             module: module.compiled_module().clone(),
+            wasm_backtrace_details_env_used: module
+                .engine()
+                .config()
+                .wasm_backtrace_details_env_used,
             references: 0,
         });
 
@@ -377,6 +329,78 @@ impl GlobalModuleRegistry {
         if info.references == 0 {
             self.0.remove(&end);
         }
+    }
+}
+
+impl GlobalRegisteredModule {
+    /// Determines if the related module has unparsed debug information.
+    pub fn has_unparsed_debuginfo(&self) -> bool {
+        self.module.has_unparsed_debuginfo()
+    }
+
+    /// Fetches frame information about a program counter in a backtrace.
+    ///
+    /// Returns an object if this `pc` is known to this module, or returns `None`
+    /// if no information can be found.
+    pub fn lookup_frame_info(&self, pc: usize) -> Option<FrameInfo> {
+        let (index, offset) = func_by_pc(&self.module, pc)?;
+        let info = self.module.func_info(index);
+        let pos = RegisteredModule::instr_pos(offset, &info.address_map);
+
+        // In debug mode for now assert that we found a mapping for `pc` within
+        // the function, because otherwise something is buggy along the way and
+        // not accounting for all the instructions. This isn't super critical
+        // though so we can omit this check in release mode.
+        debug_assert!(pos.is_some(), "failed to find instruction for {:x}", pc);
+
+        let instr = match pos {
+            Some(pos) => info.address_map.instructions[pos].srcloc,
+            None => info.address_map.start_srcloc,
+        };
+
+        // Use our wasm-relative pc to symbolize this frame. If there's a
+        // symbolication context (dwarf debug info) available then we can try to
+        // look this up there.
+        //
+        // Note that dwarf pcs are code-section-relative, hence the subtraction
+        // from the location of `instr`. Also note that all errors are ignored
+        // here for now since technically wasm modules can always have any
+        // custom section contents.
+        let mut symbols = Vec::new();
+
+        if let Some(s) = &self.module.symbolize_context().ok().and_then(|c| c) {
+            let to_lookup = (instr.bits() as u64) - s.code_section_offset();
+            if let Ok(mut frames) = s.addr2line().find_frames(to_lookup) {
+                while let Ok(Some(frame)) = frames.next() {
+                    symbols.push(FrameSymbol {
+                        name: frame
+                            .function
+                            .as_ref()
+                            .and_then(|l| l.raw_name().ok())
+                            .map(|s| s.to_string()),
+                        file: frame
+                            .location
+                            .as_ref()
+                            .and_then(|l| l.file)
+                            .map(|s| s.to_string()),
+                        line: frame.location.as_ref().and_then(|l| l.line),
+                        column: frame.location.as_ref().and_then(|l| l.column),
+                    });
+                }
+            }
+        }
+
+        let module = self.module.module();
+        let index = module.func_index(index);
+
+        Some(FrameInfo {
+            module_name: module.name.clone(),
+            func_index: index.index() as u32,
+            func_name: module.func_names.get(&index).cloned(),
+            instr,
+            func_start: info.address_map.start_srcloc,
+            symbols,
+        })
     }
 }
 

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -563,17 +563,18 @@ fn test_frame_info() -> Result<(), anyhow::Error> {
     )?;
     // Create an instance to ensure the frame information is registered.
     Instance::new(&store, &module, &[])?;
-    let modules = store.modules().borrow();
-    for (i, alloc) in module.compiled_module().finished_functions() {
-        let (start, end) = unsafe {
-            let ptr = (**alloc).as_ptr();
-            let len = (**alloc).len();
-            (ptr as usize, ptr as usize + len)
-        };
-        for pc in start..end {
-            let (frame, _) = modules.lookup_frame_info(pc).unwrap();
-            assert!(frame.func_index() == i.as_u32());
+    GlobalModuleRegistry::with(|modules| {
+        for (i, alloc) in module.compiled_module().finished_functions() {
+            let (start, end) = unsafe {
+                let ptr = (**alloc).as_ptr();
+                let len = (**alloc).len();
+                (ptr as usize, ptr as usize + len)
+            };
+            for pc in start..end {
+                let (frame, _, _) = modules.lookup_frame_info(pc).unwrap();
+                assert!(frame.func_index() == i.as_u32());
+            }
         }
-    }
+    });
     Ok(())
 }

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -1,3 +1,4 @@
+use crate::module::GlobalModuleRegistry;
 use crate::{FrameInfo, Store};
 use backtrace::Backtrace;
 use std::fmt;
@@ -138,14 +139,13 @@ impl Trap {
     /// ```
     pub fn new<I: Into<String>>(message: I) -> Self {
         let reason = TrapReason::Message(message.into());
-        Trap::new_with_trace(None, None, reason, Backtrace::new_unresolved())
+        Trap::new_with_trace(None, reason, Backtrace::new_unresolved())
     }
 
     /// Creates a new `Trap` representing an explicit program exit with a classic `i32`
     /// exit status value.
     pub fn i32_exit(status: i32) -> Self {
         Trap::new_with_trace(
-            None,
             None,
             TrapReason::I32Exit(status),
             Backtrace::new_unresolved(),
@@ -169,34 +169,29 @@ impl Trap {
                 if maybe_interrupted && code == ir::TrapCode::StackOverflow {
                     code = ir::TrapCode::Interrupt;
                 }
-                Trap::new_wasm(Some(store), Some(pc), code, backtrace)
+                Trap::new_wasm(Some(pc), code, backtrace)
             }
             wasmtime_runtime::Trap::Wasm {
                 trap_code,
                 backtrace,
-            } => Trap::new_wasm(Some(store), None, trap_code, backtrace),
+            } => Trap::new_wasm(None, trap_code, backtrace),
             wasmtime_runtime::Trap::OOM { backtrace } => {
                 let reason = TrapReason::Message("out of memory".to_string());
-                Trap::new_with_trace(Some(store), None, reason, backtrace)
+                Trap::new_with_trace(None, reason, backtrace)
             }
         }
     }
 
     pub(crate) fn new_wasm(
-        store: Option<&Store>,
         trap_pc: Option<usize>,
         code: ir::TrapCode,
         backtrace: Backtrace,
     ) -> Self {
         let code = TrapCode::from_non_user(code);
-        Trap::new_with_trace(store, trap_pc, TrapReason::InstructionTrap(code), backtrace)
+        Trap::new_with_trace(trap_pc, TrapReason::InstructionTrap(code), backtrace)
     }
 
     /// Creates a new `Trap`.
-    ///
-    /// * `store` - this is optionally provided, if available. If `None` we'll
-    ///   look up the last store, if available, used to call wasm code on the
-    ///   stack.
     ///
     /// * `trap_pc` - this is the precise program counter, if available, that
     ///   wasm trapped at. This is used when learning about the wasm stack trace
@@ -208,52 +203,40 @@ impl Trap {
     /// * `native_trace` - this is a captured backtrace from when the trap
     ///   occurred, and this will iterate over the frames to find frames that
     ///   lie in wasm jit code.
-    fn new_with_trace(
-        store: Option<&Store>,
-        trap_pc: Option<usize>,
-        reason: TrapReason,
-        native_trace: Backtrace,
-    ) -> Self {
+    fn new_with_trace(trap_pc: Option<usize>, reason: TrapReason, native_trace: Backtrace) -> Self {
         let mut wasm_trace = Vec::new();
         let mut hint_wasm_backtrace_details_env = false;
-        wasmtime_runtime::with_last_info(|last| {
-            // If the `store` passed in is `None` then we look at the `last`
-            // store configured to call wasm, and if that's a `Store` we use
-            // that. If that all fails then we just don't generate any
-            // `wasm_trace` information.
-            if let Some(store) = store.or_else(|| last?.downcast_ref()) {
-                for frame in native_trace.frames() {
-                    let pc = frame.ip() as usize;
-                    if pc == 0 {
-                        continue;
-                    }
-                    // Note that we need to be careful about the pc we pass in
-                    // here to lookup frame information. This program counter is
-                    // used to translate back to an original source location in
-                    // the origin wasm module. If this pc is the exact pc that
-                    // the trap happened at, then we look up that pc precisely.
-                    // Otherwise backtrace information typically points at the
-                    // pc *after* the call instruction (because otherwise it's
-                    // likely a call instruction on the stack). In that case we
-                    // want to lookup information for the previous instruction
-                    // (the call instruction) so we subtract one as the lookup.
-                    let pc_to_lookup = if Some(pc) == trap_pc { pc } else { pc - 1 };
-                    if let Some((info, has_unparsed_debuginfo)) =
-                        store.modules().borrow().lookup_frame_info(pc_to_lookup)
-                    {
-                        wasm_trace.push(info);
 
-                        // If this frame has unparsed debug information and the
-                        // store's configuration indicates that we were
-                        // respecting the environment variable of whether to
-                        // do this then we will print out a helpful note in
-                        // `Display` to indicate that more detailed information
-                        // in a trap may be available.
-                        if has_unparsed_debuginfo
-                            && store.engine().config().wasm_backtrace_details_env_used
-                        {
-                            hint_wasm_backtrace_details_env = true;
-                        }
+        GlobalModuleRegistry::with(|registry| {
+            for frame in native_trace.frames() {
+                let pc = frame.ip() as usize;
+                if pc == 0 {
+                    continue;
+                }
+                // Note that we need to be careful about the pc we pass in
+                // here to lookup frame information. This program counter is
+                // used to translate back to an original source location in
+                // the origin wasm module. If this pc is the exact pc that
+                // the trap happened at, then we look up that pc precisely.
+                // Otherwise backtrace information typically points at the
+                // pc *after* the call instruction (because otherwise it's
+                // likely a call instruction on the stack). In that case we
+                // want to lookup information for the previous instruction
+                // (the call instruction) so we subtract one as the lookup.
+                let pc_to_lookup = if Some(pc) == trap_pc { pc } else { pc - 1 };
+                if let Some((info, has_unparsed_debuginfo, wasm_backtrace_details_env_used)) =
+                    registry.lookup_frame_info(pc_to_lookup)
+                {
+                    wasm_trace.push(info);
+
+                    // If this frame has unparsed debug information and the
+                    // store's configuration indicates that we were
+                    // respecting the environment variable of whether to
+                    // do this then we will print out a helpful note in
+                    // `Display` to indicate that more detailed information
+                    // in a trap may be available.
+                    if has_unparsed_debuginfo && wasm_backtrace_details_env_used {
+                        hint_wasm_backtrace_details_env = true;
                     }
                 }
             }
@@ -388,7 +371,7 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for Trap {
             trap.clone()
         } else {
             let reason = TrapReason::Error(e.into());
-            Trap::new_with_trace(None, None, reason, Backtrace::new_unresolved())
+            Trap::new_with_trace(None, reason, Backtrace::new_unresolved())
         }
     }
 }


### PR DESCRIPTION
This commit removes a TLS lookup of the store information whenever a
trap is created. This was previously done to lookup information in the
module registry, but nowadays there's a global registry which has all
the equivalent information as well. This commit moves around some code
in the module registry and then uses this global map when creating
traps.

This is not motivated by performance, and likely regresses performance
slightly since it involves taking a global lock now. That being said the
perf of creating a `Trap` is generally not super consequential, so this
is seen as ok.

The goal of this commit is to lessen Wasmtime's reliance on TLS for
store-based information. I'm hoping to lessen this even more with the
changes for bytecodealliance/rfcs#11, where acquiring a store via TLS is
going to be much more difficult if not possible any more.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
