### PR TITLE
cargo deny: ignore RUSTSEC-2021-0064

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 ignore = [
+    "RUSTSEC-2021-0064"
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html


### PR DESCRIPTION
Transient dependencies depend on two different versions of `cpuid-bool`.

This advisory does not appear to be urgent. We should review this ignore
after a few weeks to see if our deps have switched over.

text of the advisory:

```
Issued
May 6, 2021
Package
cpuid-bool (crates.io)
Type
Unmaintained
Details
https://github.com/RustCrypto/utils/pull/381
Patched
no patched versions
Description
Please use the `cpufeatures`` crate going forward:

https://github.com/RustCrypto/utils/tree/master/cpufeatures

There will be no further releases of cpuid-bool.
```
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
