### PR TITLE
x64: improve multiplication lowering

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -462,6 +462,7 @@ pub(crate) enum InstructionSet {
     BMI2,
     AVX512F,
     AVX512VL,
+    AVX512DQ,
 }
 
 /// Some SSE operations requiring 2 operands r/m and r.
@@ -994,6 +995,7 @@ impl fmt::Display for SseOpcode {
 #[derive(Clone)]
 pub enum Avx512Opcode {
     Vpabsq,
+    Vpmullq,
 }
 
 impl Avx512Opcode {
@@ -1001,6 +1003,7 @@ impl Avx512Opcode {
     pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
         match self {
             Avx512Opcode::Vpabsq => smallvec![InstructionSet::AVX512F, InstructionSet::AVX512VL],
+            Avx512Opcode::Vpmullq => smallvec![InstructionSet::AVX512VL, InstructionSet::AVX512DQ],
         }
     }
 }
@@ -1009,6 +1012,7 @@ impl fmt::Debug for Avx512Opcode {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let name = match self {
             Avx512Opcode::Vpabsq => "vpabsq",
+            Avx512Opcode::Vpmullq => "vpmullq",
         };
         write!(fmt, "{}", name)
     }

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3556,6 +3556,12 @@ fn test_x64_emit() {
     ));
 
     insns.push((
+        Inst::xmm_rm_r_evex(Avx512Opcode::Vpmullq, RegMem::reg(xmm14), xmm10, w_xmm1),
+        "62D2AD0840CE",
+        "vpmullq %xmm14, %xmm10, %xmm1",
+    ));
+
+    insns.push((
         Inst::xmm_rm_r(SseOpcode::Pmuludq, RegMem::reg(xmm8), w_xmm9),
         "66450FF4C8",
         "pmuludq %xmm8, %xmm9",
@@ -4283,6 +4289,7 @@ fn test_x64_emit() {
     isa_flag_builder.enable("has_ssse3").unwrap();
     isa_flag_builder.enable("has_sse41").unwrap();
     isa_flag_builder.enable("has_avx512f").unwrap();
+    isa_flag_builder.enable("has_avx512dq").unwrap();
     let isa_flags = x64::settings::Flags::new(&flags, isa_flag_builder);
 
     let rru = regs::create_reg_universe_systemv(&flags);

--- a/cranelift/filetests/filetests/isa/x64/simd-arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arithmetic-run.clif
@@ -18,36 +18,19 @@ block0:
 }
 ; run: %iadd_i8x16_with_overflow() == [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
 
-function %isub_i32x4_rex() -> b1 {
-block0:
-    v0 = vconst.i32x4 [1 1 1 1]
-    v1 = vconst.i32x4 [1 2 3 4]
+function %isub_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
     v2 = isub v0, v1
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0
-
-    v5 = extractlane v2, 1
-    v6 = icmp_imm eq v5, 0xffffffff
-    ; TODO replace extractlanes with vector comparison
-
-    v7 = band v4, v6
-    return v7
+    return v2
 }
-; run
+; run: %isub_i32x4([1 1 1 1], [1 2 3 4]) == [0 -1 -2 -3]
 
-
-function %ineg_i32x4() -> b1 {
-block0:
-    v0 = vconst.i32x4 [1 1 1 1]
-    v2 = ineg v0
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, -1
-
-    return v4
+function %ineg_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = ineg v0
+    return v1
 }
-; run
+; run: %ineg_i32x4([1 1 1 1]) == [-1 -1 -1 -1]
 
 function %imul_i64x2(i64x2, i64x2) -> i64x2 {
 block0(v0: i64x2, v1: i64x2):
@@ -56,141 +39,93 @@ block0(v0: i64x2, v1: i64x2):
 }
 ; run: %imul_i64x2([0 2], [0 2]) == [0 4]
 
-function %imul_i32x4() -> b1 {
-block0:
-    v0 = vconst.i32x4 [-1 0 1 0x80_00_00_01]
-    v1 = vconst.i32x4 [2 2 2 2]
+function %imul_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
     v2 = imul v0, v1
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, -2
-
-    v5 = extractlane v2, 1
-    v6 = icmp_imm eq v5, 0
-
-    v7 = extractlane v2, 3
-    v8 = icmp_imm eq v7, 2 ; 0x80_00_00_01 * 2 == 0x1_00_00_00_02 (and the 1 is dropped)
-
-    v9 = band v4, v6
-    v10 = band v8, v9
-    return v10
+    return v2
 }
-; run
+; run: %imul_i32x4([-1 0 1 0x80_00_00_01], [2 2 2 2]) == [-2 0 2 2]
+; Note above how bits are truncated: 0x80_00_00_01 * 2 == 0x1_00_00_00_02, but
+; the leading 1 is dropped.
 
-function %imul_i16x8() -> b1 {
-block0:
-    v0 = vconst.i16x8 [-1 0 1 0x7f_ff 0 0 0 0]
-    v1 = vconst.i16x8 [2 2 2 2 0 0 0 0]
+function %imul_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
     v2 = imul v0, v1
-
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0xfffe ; 0xfffe == -2; -2 will not work here and below because v3 is
-    ; being uextend-ed, not sextend-ed
-
-    v5 = extractlane v2, 1
-    v6 = icmp_imm eq v5, 0
-
-    v7 = extractlane v2, 3
-    v8 = icmp_imm eq v7, 0xfffe ; 0x7f_ff * 2 == 0xff_fe
-
-    v9 = band v4, v6
-    v10 = band v8, v9
-
-    return v4
+    return v2
 }
-; run
+; run: %imul_i16x8([-1 0 1 0x7f_ff 0 0 0 0], [2 2 2 2 0 0 0 0]) == [-2 0 2 0xff_fe 0 0 0 0]
 
-function %sadd_sat_i8x16() -> b1 {
-block0:
-    v0 = vconst.i8x16 [127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
-    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
-
+function %sadd_sat_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
     v2 = sadd_sat v0, v1
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 127
-
-    return v4
+    return v2
 }
-; run
+; run: %sadd_sat_i8x16([0x7f 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]) == [0x7f 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
 
-function %uadd_sat_i16x8() -> b1 {
-block0:
-    v0 = vconst.i16x8 [-1 0 0 0 0 0 0 0]
-    v1 = vconst.i16x8 [-1 1 1 1 1 1 1 1]
-
+function %uadd_sat_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
     v2 = uadd_sat v0, v1
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 65535
-
-    return v4
+    return v2
 }
-; run
+; run: %uadd_sat_i16x8([-1 0 0 0 0 0 0 0], [-1 1 1 1 1 1 1 1]) == [65535 1 1 1 1 1 1 1]
 
-function %sub_sat_i8x16() -> b1 {
-block0:
-    v0 = vconst.i8x16 [128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] ; 128 == 0x80 == -128
-    v1 = vconst.i8x16 [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
-
+function %ssub_sat_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
     v2 = ssub_sat v0, v1
-    v3 = extractlane v2, 0
-    v4 = icmp_imm eq v3, 0x80 ; 0x80 == -128
+    return v2
+}
+; run: %ssub_sat_i8x16([0x80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]) == [0x80 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff]
+; Note that 0x80 == -128 and subtracting 1 from that should saturate.
 
-    ; now re-use 0x80 as an unsigned 128
-    v5 = usub_sat v0, v2
-    v6 = extractlane v5, 0
-    v7 = icmp_imm eq v6, 0
+function %usub_sat_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = usub_sat v0, v1
+    return v2
+}
+; run: %usub_sat_i8x16([0x80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]) == [0x7f 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
+
+function %add_sub_f32x4() -> b1 {
+block0:
+    v0 = vconst.f32x4 [0x4.2 0.0 0.0 0.0]
+    v1 = vconst.f32x4 [0x1.0 0x1.0 0x1.0 0x1.0]
+    v2 = vconst.f32x4 [0x5.2 0x1.0 0x1.0 0x1.0]
+
+    v3 = fadd v0, v1
+    v4 = fcmp eq v3, v2
+
+    v6 = fsub v2, v1
+    v7 = fcmp eq v6, v0
 
     v8 = band v4, v7
-    return v8
+    v9 = vall_true v8
+    return v9
 }
 ; run
 
-;function %add_sub_f32x4() -> b1 {
-;block0:
-;    v0 = vconst.f32x4 [0x4.2 0.0 0.0 0.0]
-;    v1 = vconst.f32x4 [0x1.0 0x1.0 0x1.0 0x1.0]
-;    v2 = vconst.f32x4 [0x5.2 0x1.0 0x1.0 0x1.0]
-;
-;    v3 = fadd v0, v1
-;    v4 = fcmp eq v3, v2
-;
-;    v6 = fsub v2, v1
-;    v7 = fcmp eq v6, v0
-;
-;    v8 = band v4, v7
-;    v9 = vall_true v8
-;    return v9
-;}
-; _run
+function %mul_div_f32x4() -> b1 {
+block0:
+    v0 = vconst.f32x4 [0x4.2 -0x2.1 0x2.0 0.0]
+    v1 = vconst.f32x4 [0x3.4 0x6.7 0x8.9 0xa.b]
+    v2 = vconst.f32x4 [0xd.68 -0xd.47 0x11.2 0x0.0]
 
-;function %mul_div_f32x4() -> b1 {
-;block0:
-;    v0 = vconst.f32x4 [0x4.2 -0x2.1 0x2.0 0.0]
-;    v1 = vconst.f32x4 [0x3.4 0x6.7 0x8.9 0xa.b]
-;    v2 = vconst.f32x4 [0xd.68 -0xd.47 0x11.2 0x0.0]
-;
-;    v3 = fmul v0, v1
-;    v4 = fcmp eq v3, v2
-;
-;    v6 = fdiv v2, v1
-;    v7 = fcmp eq v6, v0
-;
-;    v8 = band v4, v7
-;    v9 = vall_true v8
-;    return v9
-;}
-; _run
+    v3 = fmul v0, v1
+    v4 = fcmp eq v3, v2
 
-;function %sqrt_f64x2() -> b1 {
-;block0:
-;    v0 = vconst.f64x2 [0x9.0 0x1.0]
-;    v1 = sqrt v0
-;    v2 = vconst.f64x2 [0x3.0 0x1.0]
-;    v3 = fcmp eq v2, v1
-;    v4 = vall_true v3
-;    return v4
-;}
-; _run
+    v6 = fdiv v2, v1
+    v7 = fcmp eq v6, v0
+
+    v8 = band v4, v7
+    v9 = vall_true v8
+    return v9
+}
+; run
+
+function %sqrt_f64x2(f64x2) -> f64x2 {
+block0(v0: f64x2): 
+    v1 = sqrt v0
+    return v1
+}
+; run: %sqrt_f64x2([0x9.0 0x1.0]) == [0x3.0 0x1.0]
 
 function %fmax_f64x2(f64x2, f64x2) -> f64x2 {
 block0(v0: f64x2, v1: f64x2):
@@ -218,58 +153,33 @@ block0(v0: f64x2, v1: f64x2):
 ; run: %fmin_f64x2([-NaN 0.0], [0x1.0 0.0]) == [-NaN 0.0]
 ; run: %fmin_f64x2([NaN:0x42 0.0], [0x1.0 0.0]) == [-NaN 0.0]
 
-;function %fneg_f64x2() -> b1 {
-;block0:
-;    v0 = vconst.f64x2 [0x1.0 -0x1.0]
-;    v1 = fneg v0
-;
-;    v2 = vconst.f64x2 [-0x1.0 0x1.0]
-;    v3 = fcmp eq v1, v2
-;    v4 = vall_true v3
-;
-;    return v4
-;}
-; _run
+function %fneg_f64x2(f64x2) -> f64x2 {
+block0(v0: f64x2):
+    v1 = fneg v0
+    return v1
+}
+; run: %fneg_f64x2([0x1.0 -0x1.0]) == [-0x1.0 0x1.0]
 
-;function %fneg_f32x4() -> b1 {
-;block0:
-;    v0 = vconst.f32x4 [0x0.0 -0x0.0 -Inf Inf]
-;    v1 = fneg v0
-;
-;    v2 = vconst.f32x4 [-0x0.0 0x0.0 Inf -Inf]
-;    v3 = fcmp eq v1, v2
-;    v4 = vall_true v3
-;
-;    return v4
-;}
-; _run
+function %fneg_f32x4(f32x4) -> f32x4 {
+block0(v0: f32x4):
+    v1 = fneg v0
+    return v1
+}
+; run: %fneg_f32x4([0x0.0 -0x0.0 -Inf Inf]) == [-0x0.0 0x0.0 Inf -Inf]
 
-;function %fabs_f32x4() -> b1 {
-;block0:
-;    v0 = vconst.f32x4 [0x0.0 -0x1.0 0x2.0 -0x3.0]
-;    v1 = fabs v0
-;
-;    v2 = vconst.f32x4 [0x0.0 0x1.0 0x2.0 0x3.0]
-;    v3 = fcmp eq v1, v2
-;    v4 = vall_true v3
-;
-;    return v4
-;}
-; _run
+function %fabs_f32x4(f32x4) -> f32x4 {
+block0(v0: f32x4):
+    v1 = fabs v0
+    return v1
+}
+; run: %fabs_f32x4([0x0.0 -0x1.0 0x2.0 -0x3.0]) == [0x0.0 0x1.0 0x2.0 0x3.0]
 
-;function %average_rounding_i16x8() -> b1 {
-;block0:
-;    v0 = vconst.i16x8 [0 0 0 1 42 19 -1 0xffff]
-;    v1 = vconst.i16x8 [0 1 2 4 42 18 -1 0]
-;    v2 = vconst.i16x8 [0 1 1 3 42 19 -1 0x8000]
-;
-;    v3 = avg_round v0, v1
-;    v4 = icmp eq v2, v3
-;    v5 = vall_true v4
-;
-;    return v5
-;}
-; _run
+function %average_rounding_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = avg_round v0, v1
+    return v2
+}
+; run: %average_rounding_i16x8([0 0 0 1 42 19 -1 0xffff], [0 1 2 4 42 18 -1 0]) == [0 1 1 3 42 19 -1 0x8000]
 
 function %iabs(i32x4) -> i32x4 {
 block0(v0: i32x4):


### PR DESCRIPTION
Since the lowering of `imul` complicated the other ALU operations it was
matched with and since future commits will alter the multiplication
lowering further, this change moves the `imul` lowering to its own match
block. Then, it improves the filetests and uses `VPMULLQ` as a lowering
for `imul.i64x2` when the instruction is available.