### PR TITLE
wasi stdio tests: increase timeout

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::mem::MaybeUninit;
 use wasi_tests::{assert_errno, STDERR_FD, STDIN_FD, STDOUT_FD};
 
+const TIMEOUT: u64 = 20_000_000u64; // 20 milliseconds, required to satisfy slow execution in CI
 const CLOCK_ID: wasi::Userdata = 0x0123_45678;
 const STDIN_ID: wasi::Userdata = 0x8765_43210;
 
@@ -18,7 +19,7 @@ unsafe fn poll_oneoff_impl(r#in: &[wasi::Subscription]) -> Result<Vec<wasi::Even
 unsafe fn test_stdin_read() {
     let clock = wasi::SubscriptionClock {
         id: wasi::CLOCKID_MONOTONIC,
-        timeout: 5_000_000u64, // 5 milliseconds
+        timeout: TIMEOUT,
         precision: 0,
         flags: 0,
     };
@@ -95,7 +96,7 @@ unsafe fn test_stdout_stderr_write() {
             u: wasi::SubscriptionUU {
                 clock: wasi::SubscriptionClock {
                     id: wasi::CLOCKID_MONOTONIC,
-                    timeout: 10_000_000u64, // 10 milliseconds
+                    timeout: TIMEOUT,
                     precision: 0,
                     flags: 0,
                 },

--- a/crates/wasi-common/tokio/tests/poll_oneoff.rs
+++ b/crates/wasi-common/tokio/tests/poll_oneoff.rs
@@ -8,6 +8,8 @@ use wasi_common::{
 };
 use wasi_tokio::{clocks_ctx, sched::poll_oneoff, Dir};
 
+const TIMEOUT: Duration = Duration::from_millis(20); // Required for slow execution in CI
+
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_file_readable() -> Result<(), Error> {
     let clocks = clocks_ctx();
@@ -40,7 +42,7 @@ async fn empty_file_readable() -> Result<(), Error> {
         clocks
             .monotonic
             .now(clocks.monotonic.resolution())
-            .checked_add(Duration::from_millis(10))
+            .checked_add(TIMEOUT)
             .unwrap(),
         clocks.monotonic.resolution(),
         Userdata::from(0),
@@ -82,7 +84,7 @@ async fn empty_file_writable() -> Result<(), Error> {
         clocks
             .monotonic
             .now(clocks.monotonic.resolution())
-            .checked_add(Duration::from_millis(10))
+            .checked_add(TIMEOUT)
             .unwrap(),
         clocks.monotonic.resolution(),
         Userdata::from(0),
@@ -109,7 +111,7 @@ async fn stdio_readable() -> Result<(), Error> {
     let deadline = clocks
         .monotonic
         .now(clocks.monotonic.resolution())
-        .checked_add(Duration::from_millis(10))
+        .checked_add(TIMEOUT)
         .unwrap();
 
     let mut waiting_on: HashMap<u64, Box<dyn WasiFile>> = vec![


### PR DESCRIPTION
Testing for the readiness of file descriptors for reading/writing is racy in wasi-tokio because the multithreaded runtime checks using `epoll` on a worker thread. Tests which expect multiple file descriptors to be ready simultaneously have to bound that expectation with a timeout.

On CI, these tests execute very slowly compared to local development, so this timeout needs to be increased until we don't see CI failures anymore. It has been doubled from the timeouts observed in https://github.com/bytecodealliance/wasmtime/pull/2893

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
