### PR TITLE
wasi-tokio: up test timeouts from 20ms to 50ms

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::mem::MaybeUninit;
 use wasi_tests::{assert_errno, STDERR_FD, STDIN_FD, STDOUT_FD};
 
-const TIMEOUT: u64 = 20_000_000u64; // 20 milliseconds, required to satisfy slow execution in CI
+const TIMEOUT: u64 = 50_000_000u64; // 50 milliseconds, required to satisfy slow execution in CI
 const CLOCK_ID: wasi::Userdata = 0x0123_45678;
 const STDIN_ID: wasi::Userdata = 0x8765_43210;
 

--- a/crates/wasi-common/tokio/tests/poll_oneoff.rs
+++ b/crates/wasi-common/tokio/tests/poll_oneoff.rs
@@ -8,7 +8,7 @@ use wasi_common::{
 };
 use wasi_tokio::{clocks_ctx, sched::poll_oneoff, Dir};
 
-const TIMEOUT: Duration = Duration::from_millis(20); // Required for slow execution in CI
+const TIMEOUT: Duration = Duration::from_millis(50); // Required for slow execution in CI
 
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_file_readable() -> Result<(), Error> {


### PR DESCRIPTION
Follow-up to #2896. Apparently we are still failing macos CI sometimes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
