### PR TITLE
Update to cap-std 0.13.10 and system-interface 0.6.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a7f9bdd49f3979c659811723041929803c986b3ed5381af726a4082e806c27"
+checksum = "ff3a1e32332db9ad29d6da34693ce9a7ac26a9edf96abb5c1788d193410031ab"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e206e688244a8f8158f91d77d3d8ed5891eb27aef2542bb26ceb98b970d5597"
+checksum = "2d253b74de50b097594462618e7dd17b93b3e3bef19f32d2e512996f9095661f"
 dependencies = [
  "errno",
  "fs-set-times",
@@ -303,18 +303,18 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0842ea6c9a2e078ab901b3b805608af65e11fcbfb87024d37fb129b2b74cb1ac"
+checksum = "458e98ed00e4276d0ac60da888d80957a177dfa7efa8dbb3be59f1e2b0e02ae5"
 dependencies = [
  "rand 0.8.3",
 ]
 
 [[package]]
 name = "cap-std"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d8cb4b761a2fb1ccf0e92d795c717bba9dcb1e54636ee0579fca628abfa305"
+checksum = "7019d48ea53c5f378e0fdab0fe5f627fc00e76d65e75dffd6fb1cbc0c9b382ee"
 dependencies = [
  "cap-primitives",
  "posish",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5c279d213dfe8f71c02c4cd740bd130d1dce39f45fdcdb745ae3de8a777fbd"
+checksum = "90585adeada7f804e6dcf71b8ff74217ad8742188fc870b9da5deab4722baa04"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -2719,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd411f50bd848d1efefd5957d494eddc80979380e3c4f80b4ba2ebd26d1b673"
+checksum = "ff09d1260270c02199b44e68140aab5225c27b365a38684e0d7b6155f0c37ffb"
 dependencies = [
  "atty",
  "bitflags",
@@ -3792,9 +3792,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a316462681accd062e32c37f9d78128691a4690764917d13bd8ea041baf2913e"
+checksum = "2bdb79e12a5ac98f09e863b99c38c72f942a41f643ae0bb05d4d6d2633481341"
 dependencies = [
  "bitflags",
  "winapi",

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,13 +15,13 @@ include = ["src/**/*", "LICENSE" ]
 wasi-common = { path = "../", version = "0.26.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.13.9"
-cap-fs-ext = "0.13.9"
-cap-time-ext = "0.13.9"
-cap-rand = "0.13.9"
+cap-std = "0.13.10"
+cap-fs-ext = "0.13.10"
+cap-time-ext = "0.13.10"
+cap-rand = "0.13.10"
 fs-set-times = "0.3.1"
 unsafe-io = "0.6.5"
-system-interface = { version = "0.6.3", features = ["cap_std_impls"] }
+system-interface = { version = "0.6.4", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -21,7 +21,7 @@ cap-fs-ext = "0.13.7"
 cap-time-ext = "0.13.7"
 fs-set-times = "0.3.1"
 unsafe-io = "0.6.5"
-system-interface = { version = "0.6.3", features = ["cap_std_impls"] }
+system-interface = { version = "0.6.4", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 anyhow = "1"


### PR DESCRIPTION
This includes fixes for bytecodealliance/cap-std#169,
bytecodealliance/system-interface#15, and bytecodealliance/system-interface#16.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
