### PR TITLE
Refer to BA security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/wasmtime-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/wasmtime-bug-report.md
@@ -9,6 +9,8 @@ assignees: ''
 
 Thanks for filing a bug report! Please fill out the TODOs below.
 
+**Note: if you want to report a security issue, please read our [security policy](https://bytecodealliance.org/security)!**
+
 ### Test Case
 
 TODO: upload Wasm file here

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,29 +1,3 @@
 # Security Policy
 
-Building secure foundations for software development is at the core of what we do in the Bytecode Alliance. Contributions of external security researchers are a vital part of that.
-
-## Scope
-
-If you believe you've found a security issue in any website, service, or software owned or operated by the Bytecode Alliance, we encourage you to notify us.
-
-## How to Submit a Report
-
-To submit a vulnerability report to the Bytecode Alliance, please contact us at [security@bytecodealliance.org](mailto:security@bytecodealliance.org). Your submission will be reviewed and validated by a member of our security team.
-
-## Safe Harbor
-
-The Bytecode Alliance supports safe harbor for security researchers who:
-
-*   Make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of our services.
-*   Only interact with accounts you own or with explicit permission of the account holder. If you do encounter Personally Identifiable Information (PII) contact us immediately, do not proceed with access, and immediately purge any local information.
-*   Provide us with a reasonable amount of time to resolve vulnerabilities prior to any disclosure to the public or a third-party.
-
-We will consider activities conducted consistent with this policy to constitute "authorized" conduct and will not pursue civil action or initiate a complaint to law enforcement. We will help to the extent we can if legal action is initiated by a third party against you.
-
-Please submit a report to us before engaging in conduct that may be inconsistent with or unaddressed by this policy.
-
-## Preferences
-
-*   Please provide detailed reports with reproducible steps and a clearly defined impact.
-*   Submit one vulnerability per report.
-*   Social engineering (e.g. phishing, vishing, smishing) is prohibited.
+Please refer to the [Bytecode Alliance security policy](https://bytecodealliance.org/security) for details on how to report security issues in Wasmtime, our disclosure policy, and how to receive notifications about security issues.

--- a/crates/cranelift/SECURITY.md
+++ b/crates/cranelift/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+Please refer to the [Bytecode Alliance security policy](https://bytecodealliance.org/security) for details on how to report security issues in Cranelift, our disclosure policy, and how to receive notifications about security issues.

--- a/docs/security-disclosure.md
+++ b/docs/security-disclosure.md
@@ -1,3 +1,3 @@
 # Disclosure Policy
 
-... more coming soon
+The disclosure policy for security issues in Wasmtime is [documented on the Bytecode Alliance website](https://bytecodealliance.org/security#disclosure-policy).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,3 @@
 # Security
 
-... more coming soon
+Please refer to the [Bytecode Alliance security policy](https://bytecodealliance.org/security) for details on how to report security issues in Wasmtime, our disclosure policy, and how to receive notifications about security issues.


### PR DESCRIPTION
At a meeting last week, the Bytecode Alliance board resolved to introduce a [BA security policy](https://bytecodealliance.org/security), and apply it to some core projects to begin with.

This PR applies it to both Wasmtime and Cranelift explicitly, but other crates contained in this repository should be considered to be covered, too.