### PR TITLE
x64: lower fcvt_from_uint to VCVTUDQ2PS when possible

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1000,6 +1000,7 @@ impl fmt::Display for SseOpcode {
 
 #[derive(Clone)]
 pub enum Avx512Opcode {
+    Vcvtudq2ps,
     Vpabsq,
     Vpmullq,
 }
@@ -1008,6 +1009,9 @@ impl Avx512Opcode {
     /// Which `InstructionSet`s support the opcode?
     pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
         match self {
+            Avx512Opcode::Vcvtudq2ps => {
+                smallvec![InstructionSet::AVX512F, InstructionSet::AVX512VL]
+            }
             Avx512Opcode::Vpabsq => smallvec![InstructionSet::AVX512F, InstructionSet::AVX512VL],
             Avx512Opcode::Vpmullq => smallvec![InstructionSet::AVX512VL, InstructionSet::AVX512DQ],
         }
@@ -1017,6 +1021,7 @@ impl Avx512Opcode {
 impl fmt::Debug for Avx512Opcode {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let name = match self {
+            Avx512Opcode::Vcvtudq2ps => "vcvtudq2ps",
             Avx512Opcode::Vpabsq => "vpabsq",
             Avx512Opcode::Vpmullq => "vpmullq",
         };

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1408,16 +1408,17 @@ pub(crate) fn emit(
         }
 
         Inst::XmmUnaryRmREvex { op, src, dst } => {
-            let opcode = match op {
-                Avx512Opcode::Vpabsq => 0x1f,
+            let (prefix, map, w, opcode) = match op {
+                Avx512Opcode::Vpabsq => (LegacyPrefixes::_66, OpcodeMap::_0F38, true, 0x1f),
+                Avx512Opcode::Vcvtudq2ps => (LegacyPrefixes::_F2, OpcodeMap::_0F, false, 0x7a),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
             match src {
                 RegMem::Reg { reg: src } => EvexInstruction::new()
                     .length(EvexVectorLength::V128)
-                    .prefix(LegacyPrefixes::_66)
-                    .map(OpcodeMap::_0F38)
-                    .w(true)
+                    .prefix(prefix)
+                    .map(map)
+                    .w(w)
                     .opcode(opcode)
                     .reg(dst.to_reg().get_hw_encoding())
                     .rm(src.get_hw_encoding())

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3889,6 +3889,12 @@ fn test_x64_emit() {
         "vpabsq  %xmm2, %xmm8",
     ));
 
+    insns.push((
+        Inst::xmm_unary_rm_r_evex(Avx512Opcode::Vcvtudq2ps, RegMem::reg(xmm2), w_xmm8),
+        "62717F087AC2",
+        "vcvtudq2ps %xmm2, %xmm8",
+    ));
+
     // Xmm to int conversions, and conversely.
 
     insns.push((

--- a/cranelift/filetests/filetests/isa/x64/simd-conversion-run.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-conversion-run.clif
@@ -2,17 +2,21 @@ test run
 set enable_simd
 target x86_64 machinst
 
-function %fcvt_from_sint() -> b1 {
-block0:
-    v0 = vconst.i32x4 [-1 0 1 123456789]
+function %fcvt_from_sint(i32x4) -> f32x4 {
+block0(v0: i32x4):
     v1 = fcvt_from_sint.f32x4 v0
-
-    v2 = vconst.f32x4 [-0x1.0 0.0 0x1.0 0x75bcd18.0] ; 123456789 rounds to 123456792.0, an error of 3
-    v3 = fcmp eq v1, v2
-    v4 = vall_true v3
-    return v4
+    return v1
 }
-; run
+; run: %fcvt_from_sint([-1 0 1 123456789]) == [-0x1.0 0.0 0x1.0 0x75bcd18.0]
+; Note that 123456789 rounds to 123456792.0, an error of 3
+
+function %fcvt_from_uint(i32x4) -> f32x4 {
+block0(v0: i32x4):
+    v1 = fcvt_from_uint.f32x4 v0
+    return v1
+}
+; run: %fcvt_from_uint([0xFFFFFFFF 0 1 123456789]) == [0x100000000.0 0.0 0x1.0 0x75bcd18.0]
+; Note that 0xFFFFFFFF is decimal 4,294,967,295 and is rounded up 1 to 4,294,967,296 in f32x4.
 
 function %fcvt_to_sint_sat(f32x4) -> i32x4 {
 block0(v0:f32x4):


### PR DESCRIPTION
When AVX512VL and AVX512F are available, use a single instruction
(`VCVTUDQ2PS`) instead of a length 9-instruction sequence. This
optimization is a port from the legacy x86 backend.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
