### PR TITLE
Implement std::fmt::Debug for InterruptHandle

### DIFF
--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -942,6 +942,7 @@ impl wasmtime_runtime::ModuleInfoLookup for StoreInner {
 /// particular `Store`.
 ///
 /// This structure is created by the [`Store::interrupt_handle`] method.
+#[derive(Debug)]
 pub struct InterruptHandle {
     interrupts: Arc<VMInterrupts>,
 }


### PR DESCRIPTION

Just a basic `fmt::Debug` implementation for InterrutpHandle.

Motiviation: it's annoying to manually implement Debug for types which hold
a handle.
