### PR TITLE
Don't verify publishing peepmatic crates

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -332,6 +332,7 @@ fn verify(crates: &[Crate]) {
         if krate.name.contains("lightbeam")
             || krate.name == "witx"
             || krate.name.contains("wasi-nn")
+            || krate.name.contains("peepmatic")
         {
             cmd.arg("--no-verify");
         }


### PR DESCRIPTION
Using `--no-verify` avoids building z3 which should shave at least 10
minutes off CI where the `verify-publish` builder currently takes ~30
minutes.
