### PR TITLE
Correct the value of size_of_vmmemory_definition_current_length.

### DIFF
--- a/crates/runtime/src/export.rs
+++ b/crates/runtime/src/export.rs
@@ -89,7 +89,8 @@ impl From<ExportMemory> for Export {
 pub struct ExportGlobal {
     /// The address of the global storage.
     pub definition: *mut VMGlobalDefinition,
-    /// Pointer to the containing `VMContext`.
+    /// Pointer to a `VMContext` which has a lifetime at least as long as the
+    /// global. This may not be the `VMContext` which defines the global.
     pub vmctx: *mut VMContext,
     /// The global declaration, used for compatibilty checking.
     pub global: Global,

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -159,6 +159,10 @@ mod test_vmmemory_import {
 
 /// The fields compiled code needs to access to utilize a WebAssembly global
 /// variable imported from another instance.
+///
+/// Note that unlike with functions, tables, and memories, `VMGlobalImport`
+/// doesn't include a `vmctx` pointer. Globals are never resized, and don't
+/// require a `vmctx` pointer to access.
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct VMGlobalImport {
@@ -744,8 +748,6 @@ mod test_vminterrupts {
 /// The struct here is empty, as the sizes of these fields are dynamic, and
 /// we can't describe them in Rust's type system. Sufficient memory is
 /// allocated at runtime.
-///
-/// TODO: We could move the globals into the `vmctx` allocation too.
 #[derive(Debug)]
 #[repr(C, align(16))] // align 16 since globals are aligned to that and contained inside
 pub struct VMContext {


### PR DESCRIPTION
Also, update various comments and asserts. This forward-ports the relevant
parts of #1396.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
