### PR TITLE
Allow Async Stores with Fuel to Run Forever

### DIFF
--- a/examples/tokio/main.rs
+++ b/examples/tokio/main.rs
@@ -137,7 +137,7 @@ async fn _run_wasm(inputs: Inputs) -> Result<(), Error> {
 
     // WebAssembly execution will be paused for an async yield every time it
     // consumes 10000 fuel. Fuel will be refilled u32::MAX times.
-    store.out_of_fuel_async_yield(u32::MAX, 10000);
+    store.out_of_fuel_async_yield(Some(u32::MAX), 10000);
 
     Wasi::set_context(
         &store,

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -375,7 +375,7 @@ fn dummy_waker() -> Waker {
 fn iloop_with_fuel() {
     let engine = Engine::new(Config::new().async_support(true).consume_fuel(true)).unwrap();
     let store = Store::new(&engine);
-    store.out_of_fuel_async_yield(1_000, 10);
+    store.out_of_fuel_async_yield(Some(1_000), 10);
     let module = Module::new(
         &engine,
         "
@@ -409,7 +409,7 @@ fn iloop_with_fuel() {
 fn fuel_eventually_finishes() {
     let engine = Engine::new(Config::new().async_support(true).consume_fuel(true)).unwrap();
     let store = Store::new(&engine);
-    store.out_of_fuel_async_yield(u32::max_value(), 10);
+    store.out_of_fuel_async_yield(Some(u32::max_value()), 10);
     let module = Module::new(
         &engine,
         "


### PR DESCRIPTION
Currently there is no way to configure an async store to run forever.

A fuel injection count has to be specified, which eventually reaches 0 and 
causes a trap.

This changes the OutOfGas::InjectFuel configuration to make the injection
count optional, which allows stores to run forever.

NOTE: this is obviously a breaking API change.

It would also be possible to add an additional config method.
