### PR TITLE
Implement iadd,isub,imul for i128 in AArch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -601,6 +601,8 @@ impl MachInstEmit for Inst {
                     ALUOp::Adc64 => 0b10011010_000,
                     ALUOp::Sub32 => 0b01001011_000,
                     ALUOp::Sub64 => 0b11001011_000,
+                    ALUOp::Sbc32 => 0b01011010_000,
+                    ALUOp::Sbc64 => 0b11011010_000,
                     ALUOp::Orr32 => 0b00101010_000,
                     ALUOp::Orr64 => 0b10101010_000,
                     ALUOp::And32 => 0b00001010_000,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -597,6 +597,8 @@ impl MachInstEmit for Inst {
                 let top11 = match alu_op {
                     ALUOp::Add32 => 0b00001011_000,
                     ALUOp::Add64 => 0b10001011_000,
+                    ALUOp::Adc32 => 0b00011010_000,
+                    ALUOp::Adc64 => 0b10011010_000,
                     ALUOp::Sub32 => 0b01001011_000,
                     ALUOp::Sub64 => 0b11001011_000,
                     ALUOp::Orr32 => 0b00101010_000,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -52,6 +52,26 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AluRRR {
+            alu_op: ALUOp::Adc32,
+            rd: writable_xreg(1),
+            rn: xreg(2),
+            rm: xreg(3),
+        },
+        "4100031A",
+        "adc w1, w2, w3",
+    ));
+    insns.push((
+        Inst::AluRRR {
+            alu_op: ALUOp::Adc64,
+            rd: writable_xreg(4),
+            rn: xreg(5),
+            rm: xreg(6),
+        },
+        "A400069A",
+        "adc x4, x5, x6",
+    ));
+    insns.push((
+        Inst::AluRRR {
             alu_op: ALUOp::Sub32,
             rd: writable_xreg(1),
             rn: xreg(2),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -92,6 +92,27 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AluRRR {
+            alu_op: ALUOp::Sbc32,
+            rd: writable_xreg(1),
+            rn: xreg(2),
+            rm: xreg(3),
+        },
+        "4100035A",
+        "sbc w1, w2, w3",
+    ));
+    insns.push((
+        Inst::AluRRR {
+            alu_op: ALUOp::Sbc64,
+            rd: writable_xreg(4),
+            rn: xreg(5),
+            rm: xreg(6),
+        },
+        "A40006DA",
+        "sbc x4, x5, x6",
+    ));
+
+    insns.push((
+        Inst::AluRRR {
             alu_op: ALUOp::Orr32,
             rd: writable_xreg(1),
             rn: xreg(2),

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -87,6 +87,9 @@ pub enum ALUOp {
     /// Add with carry
     Adc32,
     Adc64,
+    /// Subtract with carry
+    Sbc32,
+    Sbc64,
 }
 
 /// An ALU operation with three arguments.
@@ -3209,6 +3212,8 @@ impl Inst {
                 ALUOp::Lsl64 => ("lsl", OperandSize::Size64),
                 ALUOp::Adc32 => ("adc", OperandSize::Size32),
                 ALUOp::Adc64 => ("adc", OperandSize::Size64),
+                ALUOp::Sbc32 => ("sbc", OperandSize::Size32),
+                ALUOp::Sbc64 => ("sbc", OperandSize::Size64),
             }
         }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -84,6 +84,9 @@ pub enum ALUOp {
     Asr64,
     Lsl32,
     Lsl64,
+    /// Add with carry
+    Adc32,
+    Adc64,
 }
 
 /// An ALU operation with three arguments.
@@ -1363,6 +1366,23 @@ impl Inst {
 
             insts
         }
+    }
+
+    /// Create instructions that load a 128-bit constant.
+    pub fn load_constant128(to_regs: ValueRegs<Writable<Reg>>, value: u128) -> SmallVec<[Inst; 4]> {
+        assert_eq!(to_regs.len(), 2, "Expected to load i128 into two registers");
+
+        let lower = value as u64;
+        let upper = (value >> 64) as u64;
+
+        let lower_reg = to_regs.regs()[0];
+        let upper_reg = to_regs.regs()[1];
+
+        let mut load_ins = Inst::load_constant(lower_reg, lower);
+        let load_upper = Inst::load_constant(upper_reg, upper);
+
+        load_ins.extend(load_upper.into_iter());
+        load_ins
     }
 
     /// Create instructions that load a 32-bit floating-point constant.
@@ -3033,30 +3053,15 @@ impl MachInst for Inst {
         ty: Type,
         alloc_tmp: F,
     ) -> SmallVec<[Inst; 4]> {
-        let to_reg = to_regs
-            .only_reg()
-            .expect("multi-reg values not supported yet");
-        let value = value as u64;
-        if ty == F64 {
-            Inst::load_fp_constant64(to_reg, value, alloc_tmp)
-        } else if ty == F32 {
-            Inst::load_fp_constant32(to_reg, value as u32, alloc_tmp)
-        } else {
-            // Must be an integer type.
-            debug_assert!(
-                ty == B1
-                    || ty == I8
-                    || ty == B8
-                    || ty == I16
-                    || ty == B16
-                    || ty == I32
-                    || ty == B32
-                    || ty == I64
-                    || ty == B64
-                    || ty == R32
-                    || ty == R64
-            );
-            Inst::load_constant(to_reg, value)
+        let to_reg = to_regs.only_reg();
+        match ty {
+            F64 => Inst::load_fp_constant64(to_reg.unwrap(), value as u64, alloc_tmp),
+            F32 => Inst::load_fp_constant32(to_reg.unwrap(), value as u32, alloc_tmp),
+            B1 | B8 | B16 | B32 | B64 | I8 | I16 | I32 | I64 | R32 | R64 => {
+                Inst::load_constant(to_reg.unwrap(), value as u64)
+            }
+            I128 => Inst::load_constant128(to_regs, value),
+            _ => panic!("Cannot generate constant for type: {}", ty),
         }
     }
 
@@ -3202,6 +3207,8 @@ impl Inst {
                 ALUOp::Asr64 => ("asr", OperandSize::Size64),
                 ALUOp::Lsl32 => ("lsl", OperandSize::Size32),
                 ALUOp::Lsl64 => ("lsl", OperandSize::Size64),
+                ALUOp::Adc32 => ("adc", OperandSize::Size32),
+                ALUOp::Adc64 => ("adc", OperandSize::Size64),
             }
         }
 

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic-run.clif
@@ -11,16 +11,6 @@ block0:
 }
 ; run: %i128_const_0() == [0, 0]
 
-; TODO: Blocked by https://github.com/bytecodealliance/wasmtime/issues/2906
-;function %i128_const_neg_1() -> i64, i64 {
-;block0:
-;    v1 = iconst.i128 -1
-;    v2, v3 = isplit v1
-;    return v2, v3
-;}
-; r-un: %i128_const_neg_1() == [0xffffffff_ffffffff, 0xffffffff_ffffffff]
-
-
 function %add_i128(i64, i64, i64, i64) -> i64, i64 {
 block0(v0: i64,v1: i64,v2: i64,v3: i64):
     v4 = iconcat v0, v1
@@ -38,6 +28,9 @@ block0(v0: i64,v1: i64,v2: i64,v3: i64):
 ; run: %add_i128(1, 0, -1, -1) == [0, 0]
 ; run: %add_i128(-1, 0, 1, 0) == [0, 1]
 
+; run: %add_i128(0x01234567_89ABCDEF, 0x01234567_89ABCDEF, 0xFEDCBA98_76543210, 0xFEDCBA98_76543210) == [-1, -1]
+; run: %add_i128(0x06060606_06060606, 0xA00A00A0_0A00A00A, 0x30303030_30303030, 0x0BB0BB0B_B0BB0BB0) == [0x36363636_36363636, 0xABBABBAB_BABBABBA]
+; run: %add_i128(0xC0FFEEEE_C0FFEEEE, 0xC0FFEEEE_C0FFEEEE, 0x1DCB1111_1DCB1111, 0x1DCB1111_1DCB1111) == [0xDECAFFFF_DECAFFFF, 0xDECAFFFF_DECAFFFF]
 
 function %sub_i128(i64, i64, i64, i64) -> i64, i64 {
 block0(v0: i64,v1: i64,v2: i64,v3: i64):
@@ -54,3 +47,32 @@ block0(v0: i64,v1: i64,v2: i64,v3: i64):
 ; run: %sub_i128(1, 0, 0, 0) == [1, 0]
 ; run: %sub_i128(0, 0, 1, 0) == [-1, -1]
 ; run: %sub_i128(0, 0, -1, -1) == [1, 0]
+
+; run: %sub_i128(-1, -1, 0xFEDCBA98_76543210, 0xFEDCBA98_76543210) == [0x01234567_89ABCDEF, 0x01234567_89ABCDEF]
+; run: %sub_i128(0x36363636_36363636, 0xABBABBAB_BABBABBA, 0x30303030_30303030, 0x0BB0BB0B_B0BB0BB0) == [0x06060606_06060606, 0xA00A00A0_0A00A00A]
+; run: %sub_i128(0xDECAFFFF_DECAFFFF, 0xDECAFFFF_DECAFFFF, 0x1DCB1111_1DCB1111, 0x1DCB1111_1DCB1111) == [0xC0FFEEEE_C0FFEEEE, 0xC0FFEEEE_C0FFEEEE]
+
+
+function %mul_i128(i64, i64, i64, i64) -> i64, i64 {
+block0(v0: i64,v1: i64,v2: i64,v3: i64):
+    v4 = iconcat v0, v1
+    v5 = iconcat v2, v3
+
+    v6 = imul v4, v5
+
+    v7, v8 = isplit v6
+    return v7, v8
+}
+; run: %mul_i128(0, 0, 0, 0) == [0, 0]
+; run: %mul_i128(1, 0, 1, 0) == [1, 0]
+; run: %mul_i128(1, 0, 0, 0) == [0, 0]
+; run: %mul_i128(0, 0, 1, 0) == [0, 0]
+; run: %mul_i128(2, 0, 1, 0) == [2, 0]
+; run: %mul_i128(2, 0, 2, 0) == [4, 0]
+; run: %mul_i128(1, 0, -1, -1) == [-1, -1]
+; run: %mul_i128(2, 0, -1, -1) == [-2, -1]
+
+; run: %mul_i128(0x01010101_01010101, 0x01010101_01010101, 13, 0) == [0x0D0D0D0D_0D0D0D0D, 0x0D0D0D0D_0D0D0D0D]
+; run: %mul_i128(13, 0, 0x01010101_01010101, 0x01010101_01010101) == [0x0D0D0D0D_0D0D0D0D, 0x0D0D0D0D_0D0D0D0D]
+; run: %mul_i128(0x00000000_01234567, 0x89ABCDEF_00000000, 0x00000000_FEDCBA98, 0x76543210_00000000) == [0x0121FA00_23E20B28, 0xE2946058_00000000]
+; run: %mul_i128(0xC0FFEEEE_C0FFEEEE, 0xC0FFEEEE_C0FFEEEE, 0xDECAFFFF_DECAFFFF, 0xDECAFFFF_DECAFFFF) == [0xDB6B1E48_19BA1112, 0x5ECD38B5_9D1C2B7E]

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic-run.clif
@@ -2,7 +2,7 @@ test run
 target aarch64
 
 ; i128 tests
-; TODO: It would be nice if we had native support for i128 immediates in CLIF's parser
+; TODO: Cleanup these tests when we have native support for i128 immediates in CLIF's parser
 function %i128_const_0() -> i64, i64 {
 block0:
     v1 = iconst.i128 0
@@ -37,3 +37,20 @@ block0(v0: i64,v1: i64,v2: i64,v3: i64):
 ; run: %add_i128(1, 0, 1, 0) == [2, 0]
 ; run: %add_i128(1, 0, -1, -1) == [0, 0]
 ; run: %add_i128(-1, 0, 1, 0) == [0, 1]
+
+
+function %sub_i128(i64, i64, i64, i64) -> i64, i64 {
+block0(v0: i64,v1: i64,v2: i64,v3: i64):
+    v4 = iconcat v0, v1
+    v5 = iconcat v2, v3
+
+    v6 = isub v4, v5
+
+    v7, v8 = isplit v6
+    return v7, v8
+}
+; run: %sub_i128(0, 0, 0, 0) == [0, 0]
+; run: %sub_i128(1, 0, 1, 0) == [0, 0]
+; run: %sub_i128(1, 0, 0, 0) == [1, 0]
+; run: %sub_i128(0, 0, 1, 0) == [-1, -1]
+; run: %sub_i128(0, 0, -1, -1) == [1, 0]

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic-run.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic-run.clif
@@ -1,0 +1,39 @@
+test run
+target aarch64
+
+; i128 tests
+; TODO: It would be nice if we had native support for i128 immediates in CLIF's parser
+function %i128_const_0() -> i64, i64 {
+block0:
+    v1 = iconst.i128 0
+    v2, v3 = isplit v1
+    return v2, v3
+}
+; run: %i128_const_0() == [0, 0]
+
+; TODO: Blocked by https://github.com/bytecodealliance/wasmtime/issues/2906
+;function %i128_const_neg_1() -> i64, i64 {
+;block0:
+;    v1 = iconst.i128 -1
+;    v2, v3 = isplit v1
+;    return v2, v3
+;}
+; r-un: %i128_const_neg_1() == [0xffffffff_ffffffff, 0xffffffff_ffffffff]
+
+
+function %add_i128(i64, i64, i64, i64) -> i64, i64 {
+block0(v0: i64,v1: i64,v2: i64,v3: i64):
+    v4 = iconcat v0, v1
+    v5 = iconcat v2, v3
+
+    v6 = iadd v4, v5
+
+    v7, v8 = isplit v6
+    return v7, v8
+}
+; run: %add_i128(0, 0, 0, 0) == [0, 0]
+; run: %add_i128(0, -1, -1, 0) == [-1, -1]
+; run: %add_i128(1, 0, 0, 0) == [1, 0]
+; run: %add_i128(1, 0, 1, 0) == [2, 0]
+; run: %add_i128(1, 0, -1, -1) == [0, 0]
+; run: %add_i128(-1, 0, 1, 0) == [0, 1]

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -425,3 +425,18 @@ block0(v0: i8x16):
 ; nextln: ushl v0.16b, v0.16b, v1.16b
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
+
+
+function %add_i128(i128, i128) -> i128 {
+block0(v0: i128, v1: i128):
+    v2 = iadd v0, v1
+    return v2
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: adds x0, x0, x2
+; nextln: adc x1, x1, x3
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -453,3 +453,18 @@ block0(v0: i128, v1: i128):
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
 
+function %mul_i128(i128, i128) -> i128 {
+block0(v0: i128, v1: i128):
+    v2 = imul v0, v1
+    return v2
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: umulh x4, x0, x2
+; nextln: madd x3, x0, x3, x4
+; nextln: madd x1, x1, x2, x3
+; nextln: madd x0, x0, x2, xzr
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -440,3 +440,16 @@ block0(v0: i128, v1: i128):
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
 
+function %sub_i128(i128, i128) -> i128 {
+block0(v0: i128, v1: i128):
+    v2 = isub v0, v1
+    return v2
+}
+
+; check:  stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: subs x0, x0, x2
+; nextln: sbc x1, x1, x3
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+


### PR DESCRIPTION
This PR implements some basic operations (add, sub, mul) for i128 types on AArch64