### PR TITLE
ci: Use something else for zip files on Windows

### DIFF
--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -76,9 +76,8 @@ mktarball() {
     tar -cvf - -C tmp $dir | xz -9 -T0 > dist/$dir.tar.xz
   else
     # Note that this runs on Windows, and it looks like GitHub Actions doesn't
-    # have a `zip` tool there, so we use powershell
-    (cd tmp && powershell Compress-Archive $dir $dir.zip)
-    mv tmp/$dir.zip dist
+    # have a `zip` tool there, so we use something else
+    (cd tmp && 7z a ../dist/$dir.zip $dir/)
   fi
 }
 


### PR DESCRIPTION
Apparently `powershell Compress-Archive` produces zip files with
backslashes in filesnames which makes them unable to be extracted with
some Unix variants of extraction. For example [this failure][build] and
using macOS's built-in unzip feature it creates filenames with
backslashes in them rather than subdirectories.

[build]: https://github.com/bytecodealliance/wasmtime-go/runs/2680596219?check_suite_focus=true

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
