### PR TITLE
make Module::deserialize's version check optional via Config

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -291,7 +291,7 @@ pub struct Config {
     #[cfg(feature = "async")]
     pub(crate) async_stack_size: usize,
     pub(crate) async_support: bool,
-    pub(crate) validate_module_version: bool,
+    pub(crate) deserialize_check_wasmtime_version: bool,
 }
 
 impl Config {
@@ -327,7 +327,7 @@ impl Config {
             #[cfg(feature = "async")]
             async_stack_size: 2 << 20,
             async_support: false,
-            validate_module_version: true,
+            deserialize_check_wasmtime_version: true,
         };
         ret.cranelift_debug_verifier(false);
         ret.cranelift_opt_level(OptLevel::Speed);
@@ -1103,8 +1103,8 @@ impl Config {
     /// produced by [`Module::serialize`] or [`Engine::precompile_module`].
     ///
     /// This value defaults to true.
-    pub fn validate_module_version(&mut self, check: bool) -> &mut Self {
-        self.validate_module_version = check;
+    pub fn deserialize_check_wasmtime_version(&mut self, check: bool) -> &mut Self {
+        self.deserialize_check_wasmtime_version = check;
         self
     }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -291,6 +291,7 @@ pub struct Config {
     #[cfg(feature = "async")]
     pub(crate) async_stack_size: usize,
     pub(crate) async_support: bool,
+    pub(crate) validate_module_version: bool,
 }
 
 impl Config {
@@ -326,6 +327,7 @@ impl Config {
             #[cfg(feature = "async")]
             async_stack_size: 2 << 20,
             async_support: false,
+            validate_module_version: true,
         };
         ret.cranelift_debug_verifier(false);
         ret.cranelift_opt_level(OptLevel::Speed);
@@ -1090,6 +1092,19 @@ impl Config {
         self.tunables.dynamic_memory_offset_guard_size = guard_size;
         self.tunables.static_memory_offset_guard_size =
             cmp::max(guard_size, self.tunables.static_memory_offset_guard_size);
+        self
+    }
+
+    /// Configure whether deserialized modules should validate version
+    /// information. This only effects [`Module::from_bytes`], which is used to
+    /// load compiled code from trusted sources.  When true,
+    /// [`Module::from_bytes`] verifies that the wasmtime crate's
+    /// `CARGO_PKG_VERSION` matches with the version in the binary, which was
+    /// produced by [`Module::serialize`] or [`Engine::precompile_module`].
+    ///
+    /// This value defaults to true.
+    pub fn validate_module_version(&mut self, check: bool) -> &mut Self {
+        self.validate_module_version = check;
         self
     }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1096,9 +1096,9 @@ impl Config {
     }
 
     /// Configure whether deserialized modules should validate version
-    /// information. This only effects [`crate::Module::from_bytes`], which is
+    /// information. This only effects [`crate::Module::deserialize()`], which is
     /// used to load compiled code from trusted sources.  When true,
-    /// [`crate::Module::from_bytes`] verifies that the wasmtime crate's
+    /// [`crate::Module::deserialize()`] verifies that the wasmtime crate's
     /// `CARGO_PKG_VERSION` matches with the version in the binary, which was
     /// produced by [`crate::Module::serialize`] or
     /// [`crate::Engine::precompile_module`].

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1096,11 +1096,12 @@ impl Config {
     }
 
     /// Configure whether deserialized modules should validate version
-    /// information. This only effects [`Module::from_bytes`], which is used to
-    /// load compiled code from trusted sources.  When true,
-    /// [`Module::from_bytes`] verifies that the wasmtime crate's
+    /// information. This only effects [`crate::Module::from_bytes`], which is
+    /// used to load compiled code from trusted sources.  When true,
+    /// [`crate::Module::from_bytes`] verifies that the wasmtime crate's
     /// `CARGO_PKG_VERSION` matches with the version in the binary, which was
-    /// produced by [`Module::serialize`] or [`Engine::precompile_module`].
+    /// produced by [`crate::Module::serialize`] or
+    /// [`crate::Engine::precompile_module`].
     ///
     /// This value defaults to true.
     pub fn deserialize_check_wasmtime_version(&mut self, check: bool) -> &mut Self {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -356,8 +356,10 @@ impl Module {
     /// blobs across versions of wasmtime you can be safely guaranteed that
     /// future versions of wasmtime will reject old cache entries).
     pub unsafe fn deserialize(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Module> {
-        let module =
-            SerializedModule::from_bytes(bytes.as_ref(), engine.config().validate_module_version)?;
+        let module = SerializedModule::from_bytes(
+            bytes.as_ref(),
+            engine.config().deserialize_check_wasmtime_version,
+        )?;
         module.into_module(engine)
     }
 

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -356,7 +356,8 @@ impl Module {
     /// blobs across versions of wasmtime you can be safely guaranteed that
     /// future versions of wasmtime will reject old cache entries).
     pub unsafe fn deserialize(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Module> {
-        let module = SerializedModule::from_bytes(bytes.as_ref())?;
+        let module =
+            SerializedModule::from_bytes(bytes.as_ref(), engine.config().validate_module_version)?;
         module.into_module(engine)
     }
 

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -329,7 +329,7 @@ impl<'a> SerializedModule<'a> {
         Ok(bytes)
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+    pub fn from_bytes(bytes: &[u8], check_version: bool) -> Result<Self> {
         if !bytes.starts_with(HEADER) {
             bail!("bytes are not a compatible serialized wasmtime module");
         }
@@ -345,12 +345,14 @@ impl<'a> SerializedModule<'a> {
             bail!("serialized data is malformed");
         }
 
-        let version = std::str::from_utf8(&bytes[1..1 + version_len])?;
-        if version != env!("CARGO_PKG_VERSION") {
-            bail!(
-                "Module was compiled with incompatible Wasmtime version '{}'",
-                version
-            );
+        if check_version {
+            let version = std::str::from_utf8(&bytes[1..1 + version_len])?;
+            if version != env!("CARGO_PKG_VERSION") {
+                bail!(
+                    "Module was compiled with incompatible Wasmtime version '{}'",
+                    version
+                );
+            }
         }
 
         Ok(bincode_options()

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -24,6 +24,13 @@ fn test_version_mismatch() -> Result<()> {
             .starts_with("Module was compiled with incompatible Wasmtime version")),
     }
 
+    // Test deserialize_check_wasmtime_version, which disables the logic which rejects the above.
+    let mut config = Config::new();
+    config.deserialize_check_wasmtime_version(false);
+    let engine = Engine::new(&config);
+    unsafe { Module::deserialize(&engine, &buffer) }
+        .expect("module with corrupt version should deserialize when check is disabled");
+
     Ok(())
 }
 

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -27,7 +27,7 @@ fn test_version_mismatch() -> Result<()> {
     // Test deserialize_check_wasmtime_version, which disables the logic which rejects the above.
     let mut config = Config::new();
     config.deserialize_check_wasmtime_version(false);
-    let engine = Engine::new(&config);
+    let engine = Engine::new(&config).unwrap();
     unsafe { Module::deserialize(&engine, &buffer) }
         .expect("module with corrupt version should deserialize when check is disabled");
 


### PR DESCRIPTION
Based on #2897  - draft until that PR lands.

A SerializedModule contains the CARGO_PKG_VERSION string, which is
checked for equality when loading. This is a great guard-rail but
some users may want to disable this check (e.g. so they can implement
their own versioning scheme)


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
