### PR TITLE
Upgrade capstone to v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "capstone"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60e7f097987a09a9b678c6214b5a5eb326f9fc1e3eac88cce5d086c2b3b8dc9"
+checksum = "51e4890dad38e19668a2a9bce54242e6b0dece021b862ba25ae80b439c6d36b6"
 dependencies = [
  "capstone-sys",
  "libc",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "capstone-sys"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebe07897b48983847943662bfc3198aabfa51636c81313c1955d04d857ed739"
+checksum = "81c2624132869952c2db6f1d77e24da16b6db5f5a918270c5685a5ea8db822c4"
 dependencies = [
  "cc",
  "libc",

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -32,7 +32,7 @@ cranelift = { path = "umbrella", version = "0.74.0" }
 filecheck = "0.5.0"
 log = "0.4.8"
 termcolor = "1.1.2"
-capstone = { version = "0.7.0", optional = true }
+capstone = { version = "0.8.0", optional = true }
 wat = { version = "1.0.36", optional = true }
 target-lexicon = { version = "0.12", features = ["std"] }
 peepmatic-souper = { path = "./peepmatic/crates/souper", version = "0.74.0", optional = true }

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 arrayvec = "0.5"
-capstone = "0.7.0"
+capstone = "0.8.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.74.0" }
 derive_more = "0.99"
 dynasm = "1.0.0"


### PR DESCRIPTION
While debugging #2930, I realized that the current disassembly mechanism for Cranelift, `capstone` cannot handle some newer instructions, e.g., `VPERMI2B` in something like `cargo run -p cranelift-tools -- compile --target="x86_64 skylake has_avx512vl" --set enable_simd -dDp scratch.clif`. Upgrading the package solves this.