### PR TITLE
build: add musl target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -420,6 +420,11 @@ jobs:
         include:
         - build: x86_64-linux
           os: ubuntu-latest
+        - build: x86_64-linux-musl
+          os: ubuntu-latest
+          target: x86_64-unknown-linux-musl
+          gcc_package: musl-tools
+          gcc: musl-gcc
         - build: x86_64-macos
           os: macos-latest
         - build: x86_64-windows
@@ -459,7 +464,7 @@ jobs:
     # Build `libwasmtime.so`
     - run: $CENTOS cargo build --release --manifest-path crates/c-api/Cargo.toml
 
-    # Assemble release artifats appropriate for this platform, then upload them
+    # Assemble release artifacts appropriate for this platform, then upload them
     # unconditionally to this workflow's files so we have a copy of them.
     - run: ./ci/build-tarballs.sh "${{ matrix.build }}" "${{ matrix.target }}"
     - uses: actions/upload-artifact@v1

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -59,6 +59,9 @@ elif [ "$platform" = "x86_64-macos" ]; then
   install_name_tool -id "@rpath/libwasmtime.dylib" target/release/libwasmtime.dylib
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
+elif [ "$platform" = "x86_64-linux-musl" ]; then
+  cp target/$target/release/wasmtime tmp/$bin_pkgname
+  cp target/$target/release/libwasmtime.a tmp/$api_pkgname/lib # no libwasmtime.so for musl
 elif [ "$target" = "" ]; then
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib


### PR DESCRIPTION
This is the first step for fixing https://github.com/bytecodealliance/wasmtime-go/issues/21.

I had added it to the test job, too, but [ran into some problems there](https://github.com/srenatus/wasmtime/runs/2693186002?check_suite_focus=true#step:12:280):

```
   Compiling wasmtime-bench-api v0.19.0 (/home/runner/work/wasmtime/wasmtime/crates/bench-api)
warning: dropping unsupported crate type `cdylib` for target `x86_64-unknown-linux-musl`

warning: 1 warning emitted

    Finished test [optimized + debuginfo] target(s) in 17m 13s
     Running unittests (target/x86_64-unknown-linux-musl/debug/deps/cranelift-6e913790f68d2aa3)
error: test failed, to rerun pass '-p cranelift --lib'

Caused by:
  could not execute process `/opt/hostedtoolcache/qemu/bin/ /home/runner/work/wasmtime/wasmtime/target/x86_64-unknown-linux-musl/debug/deps/cranelift-6e913790f68d2aa3` (never executed)
```

I can't tell if it's worth figuring this out, or if we're OK with having musl as a build target only. What do you think? 😃 