### PR TITLE
make ResourceLimiter operate on Store data; add hooks for entering and exiting native code

### DIFF
--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use wasmtime::*;
 
 /// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_linker<'module>(store: &mut Store<()>, module: &Module) -> Linker<()> {
+pub fn dummy_linker<'module, T>(store: &mut Store<T>, module: &Module) -> Linker<T> {
     let mut linker = Linker::new(store.engine());
     linker.allow_shadowing(true);
     for import in module.imports() {
@@ -34,7 +34,7 @@ pub fn dummy_linker<'module>(store: &mut Store<()>, module: &Module) -> Linker<(
 }
 
 /// Construct a dummy `Extern` from its type signature
-pub fn dummy_extern(store: &mut Store<()>, ty: ExternType) -> Extern {
+pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Extern {
     match ty {
         ExternType::Func(func_ty) => Extern::Func(dummy_func(store, func_ty)),
         ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)),
@@ -46,7 +46,7 @@ pub fn dummy_extern(store: &mut Store<()>, ty: ExternType) -> Extern {
 }
 
 /// Construct a dummy function for the given function type
-pub fn dummy_func(store: &mut Store<()>, ty: FuncType) -> Func {
+pub fn dummy_func<T>(store: &mut Store<T>, ty: FuncType) -> Func {
     Func::new(store, ty.clone(), move |_, _, results| {
         for (ret_ty, result) in ty.results().zip(results) {
             *result = dummy_value(ret_ty);
@@ -74,19 +74,19 @@ pub fn dummy_values(val_tys: impl IntoIterator<Item = ValType>) -> Vec<Val> {
 }
 
 /// Construct a dummy global for the given global type.
-pub fn dummy_global(store: &mut Store<()>, ty: GlobalType) -> Global {
+pub fn dummy_global<T>(store: &mut Store<T>, ty: GlobalType) -> Global {
     let val = dummy_value(ty.content().clone());
     Global::new(store, ty, val).unwrap()
 }
 
 /// Construct a dummy table for the given table type.
-pub fn dummy_table(store: &mut Store<()>, ty: TableType) -> Table {
+pub fn dummy_table<T>(store: &mut Store<T>, ty: TableType) -> Table {
     let init_val = dummy_value(ty.element().clone());
     Table::new(store, ty, init_val).unwrap()
 }
 
 /// Construct a dummy memory for the given memory type.
-pub fn dummy_memory(store: &mut Store<()>, ty: MemoryType) -> Memory {
+pub fn dummy_memory<T>(store: &mut Store<T>, ty: MemoryType) -> Memory {
     Memory::new(store, ty).unwrap()
 }
 
@@ -94,7 +94,7 @@ pub fn dummy_memory(store: &mut Store<()>, ty: MemoryType) -> Memory {
 ///
 /// This is done by using the expected type to generate a module on-the-fly
 /// which we the instantiate.
-pub fn dummy_instance(store: &mut Store<()>, ty: InstanceType) -> Instance {
+pub fn dummy_instance<T>(store: &mut Store<T>, ty: InstanceType) -> Instance {
     let mut wat = WatGenerator::new();
     for ty in ty.exports() {
         wat.export(&ty);

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -34,11 +34,18 @@ mod allocator;
 
 pub use allocator::*;
 
+/// Value returned by [`ResourceLimiter::instances`] default method
+pub const DEFAULT_INSTANCE_LIMIT: usize = 10000;
+/// Value returned by [`ResourceLimiter::tables`] default method
+pub const DEFAULT_TABLE_LIMIT: usize = 10000;
+/// Value returned by [`ResourceLimiter::memories`] default method
+pub const DEFAULT_MEMORY_LIMIT: usize = 10000;
+
 /// Used by hosts to limit resource consumption of instances.
 ///
 /// An instance can be created with a resource limiter so that hosts can take into account
 /// non-WebAssembly resource usage to determine if a linear memory or table should grow.
-pub trait ResourceLimiter: Send + Sync + 'static {
+pub trait ResourceLimiter {
     /// Notifies the resource limiter that an instance's linear memory has been requested to grow.
     ///
     /// * `current` is the current size of the linear memory in WebAssembly page units.
@@ -67,17 +74,29 @@ pub trait ResourceLimiter: Send + Sync + 'static {
     /// The maximum number of instances that can be created for a `Store`.
     ///
     /// Module instantiation will fail if this limit is exceeded.
-    fn instances(&self) -> usize;
+    ///
+    /// This value defaults to 10,000.
+    fn instances(&self) -> usize {
+        DEFAULT_INSTANCE_LIMIT
+    }
 
     /// The maximum number of tables that can be created for a `Store`.
     ///
     /// Module instantiation will fail if this limit is exceeded.
-    fn tables(&self) -> usize;
-
-    /// The maximum number of tables that can be created for a `Store`.
     ///
-    /// Module instantiation will fail if this limit is exceeded.
-    fn memories(&self) -> usize;
+    /// This value defaults to 10,000.
+    fn tables(&self) -> usize {
+        DEFAULT_TABLE_LIMIT
+    }
+
+    /// The maximum number of linear memories that can be created for a `Store`
+    ///
+    /// Instantiation will fail with an error if this limit is exceeded.
+    ///
+    /// This value defaults to 10,000.
+    fn memories(&self) -> usize {
+        DEFAULT_MEMORY_LIMIT
+    }
 }
 
 /// A WebAssembly instance.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -42,7 +42,8 @@ pub use crate::imports::Imports;
 pub use crate::instance::{
     InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstanceLimits,
     InstantiationError, LinkError, ModuleLimits, OnDemandInstanceAllocator,
-    PoolingAllocationStrategy, PoolingInstanceAllocator, ResourceLimiter,
+    PoolingAllocationStrategy, PoolingInstanceAllocator, ResourceLimiter, DEFAULT_INSTANCE_LIMIT,
+    DEFAULT_MEMORY_LIMIT, DEFAULT_TABLE_LIMIT,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -566,11 +566,11 @@ impl Table {
     /// Panics if `store` does not own this table.
     pub fn grow(&self, mut store: impl AsContextMut, delta: u32, init: Val) -> Result<u32> {
         let ty = self.ty(&store).element().clone();
-        let mut store = store.as_context_mut().opaque();
-        let init = init.into_table_element(&mut store, ty)?;
-        let table = self.wasmtime_table(&mut store);
+        let init = init.into_table_element(&mut store.as_context_mut().opaque(), ty)?;
+        let table = self.wasmtime_table(&mut store.as_context_mut().opaque());
+        let store = store.as_context_mut();
         unsafe {
-            match (*table).grow(delta, init, store.limiter()) {
+            match (*table).grow(delta, init, store.0.limiter()) {
                 Some(size) => {
                     let vm = (*table).vmtable();
                     *store[self.0].definition = vm;

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -719,8 +719,8 @@ impl Func {
     where
         T: Send,
     {
-        store.as_context_mut().0.exiting_native_hook()?;
         let my_ty = self.ty(&store);
+        store.as_context_mut().0.exiting_native_hook()?;
         let r = self
             ._call_async(store.as_context_mut().opaque_send(), my_ty, params)
             .await;

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -71,12 +71,15 @@ where
     /// This function will panic if it is called when the underlying [`Func`] is
     /// connected to an asynchronous store.
     pub fn call(&self, mut store: impl AsContextMut, params: Params) -> Result<Results, Trap> {
-        let mut store = store.as_context_mut().opaque();
+        store.as_context_mut().0.exiting_native_hook()?;
+        let mut store_opaque = store.as_context_mut().opaque();
         assert!(
-            !cfg!(feature = "async") || !store.async_support(),
+            !cfg!(feature = "async") || !store_opaque.async_support(),
             "must use `call_async` with async stores"
         );
-        unsafe { self._call(&mut store, params) }
+        let r = unsafe { self._call(&mut store_opaque, params) };
+        store.as_context_mut().0.entering_native_hook()?;
+        r
     }
 
     /// Invokes this WebAssembly function with the specified parameters.
@@ -100,14 +103,17 @@ where
     where
         T: Send,
     {
-        let mut store = store.as_context_mut().opaque_send();
+        store.as_context_mut().0.exiting_native_hook()?;
+        let mut store_opaque = store.as_context_mut().opaque_send();
         assert!(
-            store.async_support(),
+            store_opaque.async_support(),
             "must use `call` with non-async stores"
         );
-        store
+        let r = store_opaque
             .on_fiber(|store| unsafe { self._call(store, params) })
-            .await?
+            .await?;
+        store.as_context_mut().0.entering_native_hook()?;
+        r
     }
 
     unsafe fn _call(&self, store: &mut StoreOpaque<'_>, params: Params) -> Result<Results, Trap> {

--- a/crates/wasmtime/src/memory.rs
+++ b/crates/wasmtime/src/memory.rs
@@ -416,10 +416,10 @@ impl Memory {
     /// # }
     /// ```
     pub fn grow(&self, mut store: impl AsContextMut, delta: u32) -> Result<u32> {
-        let mut store = store.as_context_mut().opaque();
-        let mem = self.wasmtime_memory(&mut store);
+        let mem = self.wasmtime_memory(&mut store.as_context_mut().opaque());
+        let store = store.as_context_mut();
         unsafe {
-            match (*mem).grow(delta, store.limiter()) {
+            match (*mem).grow(delta, store.0.limiter()) {
                 Some(size) => {
                     let vm = (*mem).vmmemory();
                     *store[self.0].definition = vm;

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -258,11 +258,13 @@ impl<T> Store<T> {
     }
 
     /// Access the underlying data owned by this `Store`.
+    #[inline]
     pub fn data(&self) -> &T {
         self.inner.data()
     }
 
     /// Access the underlying data owned by this `Store`.
+    #[inline]
     pub fn data_mut(&mut self) -> &mut T {
         self.inner.data_mut()
     }
@@ -634,10 +636,12 @@ impl<'a, T> StoreContextMut<'a, T> {
 }
 
 impl<T> StoreInner<T> {
+    #[inline]
     fn data(&self) -> &T {
         &self.data
     }
 
+    #[inline]
     fn data_mut(&mut self) -> &mut T {
         &mut self.data
     }
@@ -694,10 +698,12 @@ impl StoreInnermost {
 
         Ok(())
     }
+    #[inline]
     pub fn async_support(&self) -> bool {
         self.engine().config().async_support
     }
 
+    #[inline]
     pub fn engine(&self) -> &Engine {
         &self.engine
     }
@@ -785,6 +791,7 @@ impl StoreInnermost {
     }
 
     #[cfg(feature = "async")]
+    #[inline]
     pub fn async_cx(&self) -> AsyncCx {
         debug_assert!(self.async_support());
         AsyncCx {
@@ -896,11 +903,13 @@ impl StoreInnermost {
         Ok(())
     }
 
+    #[inline]
     pub fn signal_handler(&self) -> Option<*const SignalHandler<'static>> {
         let handler = self.signal_handler.as_ref()?;
         Some(&**handler as *const _)
     }
 
+    #[inline]
     pub fn vminterrupts(&self) -> *mut VMInterrupts {
         &*self.interrupts as *const VMInterrupts as *mut VMInterrupts
     }
@@ -910,6 +919,7 @@ impl StoreInnermost {
             .insert_with_gc(r, &self.modules)
     }
 
+    #[inline]
     pub fn default_callee(&self) -> *mut VMContext {
         self.default_callee.vmctx_ptr()
     }

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -3,7 +3,7 @@ use wasmtime::*;
 
 /// Return an instance implementing the "spectest" interface used in the
 /// spec testsuite.
-pub fn link_spectest(linker: &mut Linker<()>, store: &mut Store<()>) -> Result<()> {
+pub fn link_spectest<T>(linker: &mut Linker<T>, store: &mut Store<T>) -> Result<()> {
     linker.func_wrap("spectest", "print", || {})?;
     linker.func_wrap("spectest", "print_i32", |val: i32| println!("{}: i32", val))?;
     linker.func_wrap("spectest", "print_i64", |val: i64| println!("{}: i64", val))?;

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -32,12 +32,12 @@ fn runtime_value(v: &wast::Expression<'_>) -> Result<Val> {
 
 /// The wast test script language allows modules to be defined and actions
 /// to be performed on them.
-pub struct WastContext {
+pub struct WastContext<T> {
     /// Wast files have a concept of a "current" module, which is the most
     /// recently defined.
     current: Option<Instance>,
-    linker: Linker<()>,
-    store: Store<()>,
+    linker: Linker<T>,
+    store: Store<T>,
 }
 
 enum Outcome<T = Vec<Val>> {
@@ -54,9 +54,9 @@ impl<T> Outcome<T> {
     }
 }
 
-impl WastContext {
+impl<T> WastContext<T> {
     /// Construct a new instance of `WastContext`.
-    pub fn new(store: Store<()>) -> Self {
+    pub fn new(store: Store<T>) -> Self {
         // Spec tests will redefine the same module/name sometimes, so we need
         // to allow shadowing in the linker which picks the most recent
         // definition as what to link when linking.

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -1,6 +1,4 @@
 use anyhow::Result;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
-use std::sync::Arc;
 use wasmtime::*;
 
 #[test]
@@ -11,13 +9,14 @@ fn test_limits() -> Result<()> {
         r#"(module (memory (export "m") 0) (table (export "t") 0 anyfunc))"#,
     )?;
 
-    let mut store = Store::new(&engine, ());
-    store.limiter(
+    let mut store = Store::new(
+        &engine,
         StoreLimitsBuilder::new()
             .memory_pages(10)
             .table_elements(5)
             .build(),
     );
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
 
     let instance = Instance::new(&mut store, &module, &[])?;
 
@@ -72,8 +71,8 @@ fn test_limits_memory_only() -> Result<()> {
         r#"(module (memory (export "m") 0) (table (export "t") 0 anyfunc))"#,
     )?;
 
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().memory_pages(10).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().memory_pages(10).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
 
     let instance = Instance::new(&mut store, &module, &[])?;
 
@@ -118,8 +117,8 @@ fn test_initial_memory_limits_exceeded() -> Result<()> {
     let engine = Engine::default();
     let module = Module::new(&engine, r#"(module (memory (export "m") 11))"#)?;
 
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().memory_pages(10).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().memory_pages(10).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
 
     match Instance::new(&mut store, &module, &[]) {
         Ok(_) => unreachable!(),
@@ -148,8 +147,8 @@ fn test_limits_table_only() -> Result<()> {
         r#"(module (memory (export "m") 0) (table (export "t") 0 anyfunc))"#,
     )?;
 
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().table_elements(5).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().table_elements(5).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
 
     let instance = Instance::new(&mut store, &module, &[])?;
 
@@ -194,8 +193,8 @@ fn test_initial_table_limits_exceeded() -> Result<()> {
     let engine = Engine::default();
     let module = Module::new(&engine, r#"(module (table (export "t") 23 anyfunc))"#)?;
 
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().table_elements(4).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().table_elements(4).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
 
     match Instance::new(&mut store, &module, &[]) {
         Ok(_) => unreachable!(),
@@ -242,8 +241,8 @@ fn test_pooling_allocator_initial_limits_exceeded() -> Result<()> {
         r#"(module (memory (export "m1") 2) (memory (export "m2") 5))"#,
     )?;
 
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().memory_pages(3).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().memory_pages(3).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
 
     match Instance::new(&mut store, &module, &[]) {
         Ok(_) => unreachable!(),
@@ -262,46 +261,34 @@ fn test_pooling_allocator_initial_limits_exceeded() -> Result<()> {
 }
 
 struct MemoryContext {
-    host_memory_used: AtomicUsize,
-    wasm_memory_used: AtomicUsize,
+    host_memory_used: usize,
+    wasm_memory_used: usize,
     memory_limit: usize,
-    limit_exceeded: AtomicBool,
-    limiter_dropped: AtomicBool,
+    limit_exceeded: bool,
 }
 
-struct HostMemoryLimiter(Arc<MemoryContext>);
-
-impl ResourceLimiter for HostMemoryLimiter {
+impl ResourceLimiter for MemoryContext {
     fn memory_growing(&mut self, current: u32, desired: u32, maximum: Option<u32>) -> bool {
         // Check if the desired exceeds a maximum (either from Wasm or from the host)
         if desired > maximum.unwrap_or(u32::MAX) {
-            self.0.limit_exceeded.store(true, SeqCst);
+            self.limit_exceeded = true;
             return false;
         }
 
-        assert_eq!(
-            current as usize * 0x10000,
-            self.0.wasm_memory_used.load(SeqCst)
-        );
+        assert_eq!(current as usize * 0x10000, self.wasm_memory_used,);
         let desired = desired as usize * 0x10000;
 
-        if desired + self.0.host_memory_used.load(SeqCst) > self.0.memory_limit {
-            self.0.limit_exceeded.store(true, SeqCst);
+        if desired + self.host_memory_used > self.memory_limit {
+            self.limit_exceeded = true;
             return false;
         }
 
-        self.0.wasm_memory_used.store(desired, SeqCst);
+        self.wasm_memory_used = desired;
         true
     }
 
     fn table_growing(&mut self, _current: u32, _desired: u32, _maximum: Option<u32>) -> bool {
         true
-    }
-}
-
-impl Drop for HostMemoryLimiter {
-    fn drop(&mut self) {
-        self.0.limiter_dropped.store(true, SeqCst);
     }
 }
 
@@ -315,18 +302,16 @@ fn test_custom_limiter() -> Result<()> {
     linker.func_wrap(
         "",
         "alloc",
-        |caller: Caller<'_, Arc<MemoryContext>>, size: u32| -> u32 {
-            let ctx = caller.data();
+        |mut caller: Caller<'_, MemoryContext>, size: u32| -> u32 {
+            let mut ctx = caller.data_mut();
             let size = size as usize;
 
-            if size + ctx.host_memory_used.load(SeqCst) + ctx.wasm_memory_used.load(SeqCst)
-                <= ctx.memory_limit
-            {
-                ctx.host_memory_used.fetch_add(size, SeqCst);
+            if size + ctx.host_memory_used + ctx.wasm_memory_used <= ctx.memory_limit {
+                ctx.host_memory_used += size;
                 return 1;
             }
 
-            ctx.limit_exceeded.store(true, SeqCst);
+            ctx.limit_exceeded = true;
 
             0
         },
@@ -337,16 +322,15 @@ fn test_custom_limiter() -> Result<()> {
         r#"(module (import "" "alloc" (func $alloc (param i32) (result i32))) (memory (export "m") 0) (func (export "f") (param i32) (result i32) local.get 0 call $alloc))"#,
     )?;
 
-    let context = Arc::new(MemoryContext {
-        host_memory_used: AtomicUsize::new(0),
-        wasm_memory_used: AtomicUsize::new(0),
+    let context = MemoryContext {
+        host_memory_used: 0,
+        wasm_memory_used: 0,
         memory_limit: 1 << 20, // 16 wasm pages is the limit for both wasm + host memory
-        limit_exceeded: AtomicBool::new(false),
-        limiter_dropped: AtomicBool::new(false),
-    });
+        limit_exceeded: false,
+    };
 
-    let mut store = Store::new(&engine, context.clone());
-    store.limiter(HostMemoryLimiter(context.clone()));
+    let mut store = Store::new(&engine, context);
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
     let instance = linker.instantiate(&mut store, &module)?;
     let memory = instance.get_memory(&mut store, "m").unwrap();
 
@@ -355,7 +339,7 @@ fn test_custom_limiter() -> Result<()> {
     memory.grow(&mut store, 5)?;
     memory.grow(&mut store, 2)?;
 
-    assert!(!context.limit_exceeded.load(SeqCst));
+    assert!(!store.data().limit_exceeded);
 
     // Grow the host "memory" by 384 KiB
     let f = instance.get_typed_func::<u32, u32, _>(&mut store, "f")?;
@@ -365,7 +349,7 @@ fn test_custom_limiter() -> Result<()> {
     assert_eq!(f.call(&mut store, 2 * 0x10000)?, 1);
 
     // Memory is at the maximum, but the limit hasn't been exceeded
-    assert!(!context.limit_exceeded.load(SeqCst));
+    assert!(!store.data().limit_exceeded);
 
     // Try to grow the memory again
     assert_eq!(
@@ -376,16 +360,14 @@ fn test_custom_limiter() -> Result<()> {
         "failed to grow memory by `1`"
     );
 
-    assert!(context.limit_exceeded.load(SeqCst));
+    assert!(store.data().limit_exceeded);
 
     // Try to grow the host "memory" again
     assert_eq!(f.call(&mut store, 1)?, 0);
 
-    assert!(context.limit_exceeded.load(SeqCst));
+    assert!(store.data().limit_exceeded);
 
     drop(store);
-
-    assert!(context.limiter_dropped.load(SeqCst));
 
     Ok(())
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -20,6 +20,7 @@ mod module;
 mod module_linking;
 mod module_serialize;
 mod name;
+mod native_hooks;
 mod pooling_allocator;
 mod stack_overflow;
 mod store;

--- a/tests/all/module_linking.rs
+++ b/tests/all/module_linking.rs
@@ -217,8 +217,8 @@ fn limit_instances() -> Result<()> {
             )
         "#,
     )?;
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().instances(10).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().instances(10).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
     let err = Instance::new(&mut store, &module, &[]).err().unwrap();
     assert!(
         err.to_string().contains("resource limit exceeded"),
@@ -253,8 +253,8 @@ fn limit_memories() -> Result<()> {
             )
         "#,
     )?;
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().memories(10).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().memories(10).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
     let err = Instance::new(&mut store, &module, &[]).err().unwrap();
     assert!(
         err.to_string().contains("resource limit exceeded"),
@@ -288,8 +288,8 @@ fn limit_tables() -> Result<()> {
             )
         "#,
     )?;
-    let mut store = Store::new(&engine, ());
-    store.limiter(StoreLimitsBuilder::new().tables(10).build());
+    let mut store = Store::new(&engine, StoreLimitsBuilder::new().tables(10).build());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
     let err = Instance::new(&mut store, &module, &[]).err().unwrap();
     assert!(
         err.to_string().contains("resource limit exceeded"),

--- a/tests/all/native_hooks.rs
+++ b/tests/all/native_hooks.rs
@@ -1,52 +1,244 @@
-use anyhow::Result;
+use anyhow::Error;
 use wasmtime::*;
 
-enum State {
-    Native,
-    Vm,
-}
-
-impl Default for State {
-    fn default() -> Self {
-        State::Native
-    }
-}
-
+// Crate a synchronous Func, call it directly:
 #[test]
-fn call_wrapped_func() -> Result<()> {
+fn call_wrapped_func() -> Result<(), Error> {
     let mut store = Store::<State>::default();
-    store.entering_native_code_hook(|s| match &s {
-        State::Vm => {
-            println!("entering native");
-            *s = State::Native;
-            Ok(())
-        }
-        State::Native => Err(Trap::new("illegal state: exiting vm when in native")),
-    });
-    store.exiting_native_code_hook(|s| match &s {
-        State::Native => {
-            println!("entering vm");
-            *s = State::Vm;
-            Ok(())
-        }
-        State::Vm => Err(Trap::new("illegal state: exiting native when in vm")),
-    });
-    let f = Func::wrap(&mut store, |a: i32, b: i64, c: f32, d: f64| {
-        assert_eq!(a, 1);
-        assert_eq!(b, 2);
-        assert_eq!(c, 3.0);
-        assert_eq!(d, 4.0);
-    });
+    store.entering_native_code_hook(State::entering_native);
+    store.exiting_native_code_hook(State::exiting_native);
+    let f = Func::wrap(
+        &mut store,
+        |caller: Caller<State>, a: i32, b: i64, c: f32, d: f64| {
+            assert_eq!(
+                caller.data().switches_into_native % 2,
+                1,
+                "odd number of switches into native while in a Func"
+            );
+            assert_eq!(a, 1);
+            assert_eq!(b, 2);
+            assert_eq!(c, 3.0);
+            assert_eq!(d, 4.0);
+        },
+    );
 
-    println!("untyped call");
     f.call(
         &mut store,
         &[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()],
     )?;
 
-    println!("typed call");
+    // One switch from vm to native to call f, another in return from f.
+    assert_eq!(store.data().switches_into_native, 2);
+
     f.typed::<(i32, i64, f32, f64), (), _>(&store)?
         .call(&mut store, (1, 2, 3.0, 4.0))?;
 
+    assert_eq!(store.data().switches_into_native, 4);
+
     Ok(())
+}
+
+// Create an async Func, call it directly:
+#[tokio::test]
+async fn call_wrapped_async_func() -> Result<(), Error> {
+    let mut config = Config::new();
+    config.async_support(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, State::default());
+    store.entering_native_code_hook(State::entering_native);
+    store.exiting_native_code_hook(State::exiting_native);
+    let f = Func::wrap4_async(
+        &mut store,
+        |caller: Caller<State>, a: i32, b: i64, c: f32, d: f64| {
+            Box::new(async move {
+                assert_eq!(
+                    caller.data().switches_into_native % 2,
+                    1,
+                    "odd number of switches into native while in a Func"
+                );
+                assert_eq!(a, 1);
+                assert_eq!(b, 2);
+                assert_eq!(c, 3.0);
+                assert_eq!(d, 4.0);
+            })
+        },
+    );
+
+    f.call_async(
+        &mut store,
+        &[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()],
+    )
+    .await?;
+
+    // One switch from vm to native to call f, another in return from f.
+    assert_eq!(store.data().switches_into_native, 2);
+
+    f.typed::<(i32, i64, f32, f64), (), _>(&store)?
+        .call_async(&mut store, (1, 2, 3.0, 4.0))
+        .await?;
+
+    assert_eq!(store.data().switches_into_native, 4);
+
+    Ok(())
+}
+
+// Use the Linker to define a sync func, call it through WebAssembly:
+#[test]
+fn call_linked_func() -> Result<(), Error> {
+    let engine = Engine::default();
+    let mut store = Store::new(&engine, State::default());
+    store.entering_native_code_hook(State::entering_native);
+    store.exiting_native_code_hook(State::exiting_native);
+    let mut linker = Linker::new(&engine);
+
+    linker.func_wrap(
+        "host",
+        "f",
+        |caller: Caller<State>, a: i32, b: i64, c: f32, d: f64| {
+            assert_eq!(
+                caller.data().switches_into_native % 2,
+                1,
+                "odd number of switches into native while in a Func"
+            );
+            assert_eq!(a, 1);
+            assert_eq!(b, 2);
+            assert_eq!(c, 3.0);
+            assert_eq!(d, 4.0);
+        },
+    )?;
+
+    let wat = r#"
+        (module
+            (import "host" "f"
+                (func $f (param i32) (param i64) (param f32) (param f64)))
+            (func (export "export")
+                (call $f (i32.const 1) (i64.const 2) (f32.const 3.0) (f64.const 4.0)))
+        )
+    "#;
+    let module = Module::new(&engine, wat)?;
+
+    let inst = linker.instantiate(&mut store, &module)?;
+    let export = inst
+        .get_export(&mut store, "export")
+        .expect("get export")
+        .into_func()
+        .expect("export is func");
+
+    export.call(&mut store, &[])?;
+
+    // One switch from vm to native to call f, another in return from f.
+    assert_eq!(store.data().switches_into_native, 2);
+
+    export.typed::<(), (), _>(&store)?.call(&mut store, ())?;
+
+    assert_eq!(store.data().switches_into_native, 4);
+
+    Ok(())
+}
+
+// Use the Linker to define an async func, call it through WebAssembly:
+#[tokio::test]
+async fn call_linked_func_async() -> Result<(), Error> {
+    let mut config = Config::new();
+    config.async_support(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, State::default());
+    store.entering_native_code_hook(State::entering_native);
+    store.exiting_native_code_hook(State::exiting_native);
+
+    let f = Func::wrap4_async(
+        &mut store,
+        |caller: Caller<State>, a: i32, b: i64, c: f32, d: f64| {
+            Box::new(async move {
+                assert_eq!(
+                    caller.data().switches_into_native % 2,
+                    1,
+                    "odd number of switches into native while in a Func"
+                );
+                assert_eq!(a, 1);
+                assert_eq!(b, 2);
+                assert_eq!(c, 3.0);
+                assert_eq!(d, 4.0);
+            })
+        },
+    );
+
+    let mut linker = Linker::new(&engine);
+
+    linker.define("host", "f", f)?;
+
+    let wat = r#"
+        (module
+            (import "host" "f"
+                (func $f (param i32) (param i64) (param f32) (param f64)))
+            (func (export "export")
+                (call $f (i32.const 1) (i64.const 2) (f32.const 3.0) (f64.const 4.0)))
+        )
+    "#;
+    let module = Module::new(&engine, wat)?;
+
+    let inst = linker.instantiate_async(&mut store, &module).await?;
+    let export = inst
+        .get_export(&mut store, "export")
+        .expect("get export")
+        .into_func()
+        .expect("export is func");
+
+    export.call_async(&mut store, &[]).await?;
+
+    // One switch from vm to native to call f, another in return from export.
+    assert_eq!(store.data().switches_into_native, 2);
+
+    export
+        .typed::<(), (), _>(&store)?
+        .call_async(&mut store, ())
+        .await?;
+
+    // 2 more switches.
+    assert_eq!(store.data().switches_into_native, 4);
+
+    Ok(())
+}
+
+enum Context {
+    Native,
+    Vm,
+}
+
+struct State {
+    context: Context,
+    switches_into_native: usize,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State {
+            context: Context::Native,
+            switches_into_native: 0,
+        }
+    }
+}
+
+impl State {
+    fn entering_native(&mut self) -> Result<(), Trap> {
+        match self.context {
+            Context::Vm => {
+                println!("entering native");
+                self.context = Context::Native;
+                self.switches_into_native += 1;
+                Ok(())
+            }
+            Context::Native => Err(Trap::new("illegal state: exiting vm when in native")),
+        }
+    }
+    fn exiting_native(&mut self) -> Result<(), Trap> {
+        match self.context {
+            Context::Native => {
+                println!("entering vm");
+                self.context = Context::Vm;
+                Ok(())
+            }
+            Context::Vm => Err(Trap::new("illegal state: exiting native when in vm")),
+        }
+    }
 }

--- a/tests/all/native_hooks.rs
+++ b/tests/all/native_hooks.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use wasmtime::*;
+
+enum State {
+    Native,
+    Vm,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Native
+    }
+}
+
+#[test]
+fn call_wrapped_func() -> Result<()> {
+    let mut store = Store::<State>::default();
+    store.entering_native_code_hook(|s| match &s {
+        State::Vm => {
+            println!("entering native");
+            *s = State::Native;
+            Ok(())
+        }
+        State::Native => Err(Trap::new("illegal state: exiting vm when in native")),
+    });
+    store.exiting_native_code_hook(|s| match &s {
+        State::Native => {
+            println!("entering vm");
+            *s = State::Vm;
+            Ok(())
+        }
+        State::Vm => Err(Trap::new("illegal state: exiting native when in vm")),
+    });
+    let f = Func::wrap(&mut store, |a: i32, b: i64, c: f32, d: f64| {
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+        assert_eq!(c, 3.0);
+        assert_eq!(d, 4.0);
+    });
+
+    println!("untyped call");
+    f.call(
+        &mut store,
+        &[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()],
+    )?;
+
+    println!("typed call");
+    f.typed::<(i32, i64, f32, f64), (), _>(&store)?
+        .call(&mut store, (1, 2, 3.0, 4.0))?;
+
+    Ok(())
+}


### PR DESCRIPTION
Based on #2897 - draft until that PR lands.

This PR does two things:

* The `ResourceLimiter` trait is now implemented on the data inside a `Store` rather than as a standalone owned type. This change required changing the structure of the Store internals a bunch. Additionally, the trait is now defined in `wasmtime_runtime` and re-exported by `wasmtime`.
* Two new functions, `entering_native_code_hook` and `exiting_native_code_hook`, are added to `Store`. These functions get to operate on the data inside a `Store` much like resource limiter's mut methods. These functions give embedding the opportunity to measure time (or other resources) and trap before entering any native code (i.e. a `Func`) linked into the `Store`, and again before returning from that native code.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
