### PR TITLE
cranelift: introduce a new WasmtimeAppleAarch64 calling convention

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -183,7 +183,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         args_or_rets: ArgsOrRets,
         add_ret_area_ptr: bool,
     ) -> CodegenResult<(Vec<ABIArg>, i64, Option<usize>)> {
-        let is_apple_cc = call_conv == isa::CallConv::AppleAarch64;
+        let is_apple_cc = call_conv.extends_apple_aarch64();
         let is_baldrdash = call_conv.extends_baldrdash();
         let has_baldrdash_tls = call_conv == isa::CallConv::Baldrdash2020;
 

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -18,7 +18,7 @@ pub enum CallConv {
     SystemV,
     /// Windows "fastcall" convention, also used for x64 and ARM.
     WindowsFastcall,
-    /// Mac aarch64 calling convention, which is a tweak aarch64 ABI.
+    /// Mac aarch64 calling convention, which is a tweaked aarch64 ABI.
     AppleAarch64,
     /// SpiderMonkey WebAssembly convention on systems using natively SystemV.
     BaldrdashSystemV,
@@ -39,6 +39,10 @@ pub enum CallConv {
     ///
     /// Differs from fastcall in the same way as `WasmtimeSystemV`.
     WasmtimeFastcall,
+    /// Wasmtime equivalent of AppleAarch64, not ABI-stable.
+    ///
+    /// Differs from apple-aarch64 in the same way as `WasmtimeSystemV`.
+    WasmtimeAppleAarch64,
 }
 
 impl CallConv {
@@ -78,6 +82,14 @@ impl CallConv {
         }
     }
 
+    /// Is the calling convention extending the Apple aarch64 ABI?
+    pub fn extends_apple_aarch64(self) -> bool {
+        match self {
+            Self::AppleAarch64 | Self::WasmtimeAppleAarch64 => true,
+            _ => false,
+        }
+    }
+
     /// Is the calling convention extending the Baldrdash ABI?
     pub fn extends_baldrdash(self) -> bool {
         match self {
@@ -89,7 +101,7 @@ impl CallConv {
     /// Is the calling convention extending the Wasmtime ABI?
     pub fn extends_wasmtime(self) -> bool {
         match self {
-            Self::WasmtimeSystemV | Self::WasmtimeFastcall => true,
+            Self::WasmtimeSystemV | Self::WasmtimeFastcall | Self::WasmtimeAppleAarch64 => true,
             _ => false,
         }
     }
@@ -109,6 +121,7 @@ impl fmt::Display for CallConv {
             Self::Probestack => "probestack",
             Self::WasmtimeSystemV => "wasmtime_system_v",
             Self::WasmtimeFastcall => "wasmtime_fastcall",
+            Self::WasmtimeAppleAarch64 => "wasmtime_apple_aarch64",
         })
     }
 }
@@ -128,6 +141,7 @@ impl str::FromStr for CallConv {
             "probestack" => Ok(Self::Probestack),
             "wasmtime_system_v" => Ok(Self::WasmtimeSystemV),
             "wasmtime_fastcall" => Ok(Self::WasmtimeFastcall),
+            "wasmtime_apple_aarch64" => Ok(Self::WasmtimeAppleAarch64),
             _ => Err(()),
         }
     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -906,7 +906,7 @@ fn get_intreg_for_retval(
             _ => None,
         },
         CallConv::BaldrdashWindows | CallConv::Probestack => todo!(),
-        CallConv::AppleAarch64 => unreachable!(),
+        CallConv::AppleAarch64 | CallConv::WasmtimeAppleAarch64 => unreachable!(),
     }
 }
 
@@ -936,7 +936,7 @@ fn get_fltreg_for_retval(
             _ => None,
         },
         CallConv::BaldrdashWindows | CallConv::Probestack => todo!(),
-        CallConv::AppleAarch64 => unreachable!(),
+        CallConv::AppleAarch64 | CallConv::WasmtimeAppleAarch64 => unreachable!(),
     }
 }
 
@@ -1005,7 +1005,7 @@ fn get_callee_saves(call_conv: &CallConv, regs: &Set<Writable<RealReg>>) -> Vec<
             .filter(|r| is_callee_save_fastcall(r.to_reg()))
             .collect(),
         CallConv::Probestack => todo!("probestack?"),
-        CallConv::AppleAarch64 => unreachable!(),
+        CallConv::AppleAarch64 | CallConv::WasmtimeAppleAarch64 => unreachable!(),
     };
     // Sort registers for deterministic code output. We can do an unstable sort because the
     // registers will be unique (there are no dups).

--- a/cranelift/codegen/src/isa/x86/abi.rs
+++ b/cranelift/codegen/src/isa/x86/abi.rs
@@ -514,7 +514,7 @@ pub fn prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> Codege
         }
         CallConv::Probestack => unimplemented!("probestack calling convention"),
         CallConv::Baldrdash2020 => unimplemented!("Baldrdash ABI 2020"),
-        CallConv::AppleAarch64 => unreachable!(),
+        CallConv::AppleAarch64 | CallConv::WasmtimeAppleAarch64 => unreachable!(),
     }
 }
 

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -652,7 +652,8 @@ impl<M: ABIMachineSpec> ABICalleeImpl<M> {
                 || call_conv.extends_baldrdash()
                 || call_conv.extends_windows_fastcall()
                 || call_conv == isa::CallConv::AppleAarch64
-                || call_conv == isa::CallConv::WasmtimeSystemV,
+                || call_conv == isa::CallConv::WasmtimeSystemV
+                || call_conv == isa::CallConv::WasmtimeAppleAarch64,
             "Unsupported calling convention: {:?}",
             call_conv
         );

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -468,9 +468,8 @@ pub fn blank_sig(isa: &dyn TargetIsa, call_conv: CallConv) -> ir::Signature {
 
 pub fn wasmtime_call_conv(isa: &dyn TargetIsa) -> CallConv {
     match isa.triple().default_calling_convention() {
-        Ok(CallingConvention::SystemV) | Ok(CallingConvention::AppleAarch64) | Err(()) => {
-            CallConv::WasmtimeSystemV
-        }
+        Ok(CallingConvention::AppleAarch64) => CallConv::WasmtimeAppleAarch64,
+        Ok(CallingConvention::SystemV) | Err(()) => CallConv::WasmtimeSystemV,
         Ok(CallingConvention::WindowsFastcall) => CallConv::WasmtimeFastcall,
         Ok(unimp) => unimplemented!("calling convention: {:?}", unimp),
     }


### PR DESCRIPTION
The previous choice to use the WasmtimeSystemV calling convention for
apple-aarch64 devices was incorrect: padding of arguments was
incorrectly computed. So we have to use some flavor of the apple-aarch64
ABI there.

Since we want to support the wasmtime custom convention for multiple
returns on apple-aarch64 too, a new custom Wasmtime calling convention
was introduced to support this.

---

As a matter of fact, the wasmtime tests using many arguments were broken on trunk, when being run on my M1 machine. I'll look into ways to automate testing on our side, and share the results with a broader audience.