### PR TITLE
Update wasm-smith to generate more wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a982408719f704307ac7f45247350f06ce739d759362ef8293ed7b4d922adee8"
+checksum = "f7e95fdeed16adeffed44efdc7ccf27d4f57ff2e99de417c75bcee7dee09049b"
 dependencies = [
  "arbitrary",
  "indexmap",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -18,7 +18,7 @@ wasmprinter = "0.2.26"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 wasm-encoder = "0.4.1"
-wasm-smith = "0.4.4"
+wasm-smith = "0.4.5"
 wasmi = "0.7.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This brings in bytecodealliance/wasm-tools#277 which should improve the
wasm programs that wasm-smith generates.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
