### PR TITLE
wasmtime-cache: Update zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,18 +4055,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.6.1+zstd.1.4.9"
+version = "0.9.0+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de55e77f798f205d8561b8fe2ef57abfb6e0ff2abe7fd3c089e119cdb5631a3"
+checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.0.1+zstd.1.4.9"
+version = "4.1.1+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1387cabcd938127b30ce78c4bf00b30387dddf704e3f0881dbc4ff62b5566f8c"
+checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4074,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.20+zstd.1.4.9"
+version = "1.6.1+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
+checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
 dependencies = [
  "cc",
  "libc",

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -18,7 +18,7 @@ log = { version = "0.4.8", default-features = false }
 serde = { version = "1.0.94", features = ["derive"] }
 sha2 = "0.9.0"
 toml = "0.5.5"
-zstd = { version = "0.6", default-features = false }
+zstd = { version = "0.9", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"

--- a/deny.toml
+++ b/deny.toml
@@ -37,10 +37,9 @@ deny = []
 # Skip some multiple-versions checks, until they can be fixed.
 skip = [
     { name = "ansi_term" }, # transitive dependencies only
-    { name = "cfg-if" }, # transitive dependencies use 0.1
     { name = "env_logger" }, # pretty_env_logger and file-per-thread-logger depend on 0.7
     { name = "humantime" }, # caused by env_logger
     { name = "wast" }, # old one pulled in by witx
-    { name = "itertools" }, # 0.9 pulled in by zstd-sys
+    { name = "itertools" }, # 0.9 pulled in by criterion-plot
     { name = "quick-error" }, # transitive dependencies
 ]


### PR DESCRIPTION
[Update](https://github.com/gyscos/zstd-rs/compare/0.6.1...0.9.0) zstd dependency

Also update exceptions in deny.toml bans
