### PR TITLE
Add a safe method for accessing memory and `T`

### DIFF
--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -118,25 +118,9 @@ fn generate_func(
                 return Err(#rt::wasmtime_crate::Trap::new("missing required memory export"));
             }
         };
-        // Note the unsafety here. Our goal is to simultaneously borrow the
-        // memory and custom data from `caller`, and the store it's connected
-        // to. Rust will not let us do that, however, because we must call two
-        // separate methods (both of which borrow the whole `caller`) and one of
-        // our borrows is mutable (the custom data).
-        //
-        // This operation, however, is safe because these borrows do not overlap
-        // and in the process of borrowing them mutability doesn't actually
-        // touch anything. This is akin to mutably borrowing two indices in an
-        // array, which is safe so long as the indices are separate.
-        //
-        // TODO: depending on how common this is for other users to run into we
-        // may wish to consider adding a dedicated method for this. For now the
-        // future of `GuestPtr` may be a bit hazy, so let's just get this
-        // working from the previous iteration for now.
-        let (ctx, mem) = unsafe {
-            let mem = &mut *(mem.data_mut(&mut caller) as *mut [u8]);
-            (get_cx(caller.data_mut()), #rt::wasmtime::WasmtimeGuestMemory::new(mem))
-        };
+        let (mem , ctx) = mem.data_and_store_mut(&mut caller);
+        let ctx = get_cx(ctx);
+        let mem = #rt::wasmtime::WasmtimeGuestMemory::new(mem);
         match #abi_func(ctx, &mem #(, #arg_names)*) #await_ {
             Ok(r) => Ok(<#ret_ty>::from(r)),
             Err(#rt::Trap::String(err)) => Err(#rt::wasmtime_crate::Trap::new(err)),


### PR DESCRIPTION
This is currently a very common operation in host bindings where if wasm
gives a host function a relative pointer you'll want to simulataneously
work with the host state and the wasm memory. These two regions are
distinct and safe to borrow mutably simulataneously but it's not obvious
in the Rust type system that this is so, so add a helper method here to
assist in doing so.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
