### PR TITLE
Lower Arm64Call relocations in cranelift-object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,9 +1847,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.25.1"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9023c1c0973b327f073c7f2fceb9bcc049862f93a7d14c6feb46c8a56460a0d5"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
  "crc32fast",
  "indexmap",

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 cranelift-module = { path = "../module", version = "0.75.0" }
 cranelift-codegen = { path = "../codegen", version = "0.75.0", default-features = false, features = ["std"] }
-object = { version = "0.25.0", default-features = false, features = ["write"] }
+object = { version = "0.25.3", default-features = false, features = ["write"] }
 target-lexicon = "0.12"
 anyhow = "1.0"
 log = { version = "0.4.6", default-features = false }

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -585,6 +585,11 @@ impl ObjectModule {
                 32,
             ),
             Reloc::X86GOTPCRel4 => (RelocationKind::GotRelative, RelocationEncoding::Generic, 32),
+            Reloc::Arm64Call => (
+                RelocationKind::Relative,
+                RelocationEncoding::AArch64Call,
+                26,
+            ),
             Reloc::ElfX86_64TlsGd => {
                 assert_eq!(
                     self.object.format(),
@@ -614,7 +619,7 @@ impl ObjectModule {
                 )
             }
             // FIXME
-            _ => unimplemented!(),
+            reloc => unimplemented!("{:?}", reloc),
         };
         ObjectRelocRecord {
             offset: record.offset,


### PR DESCRIPTION
At least TLS support and better 128bit int support will also be necessary for cg_clif to work on AArch64.

Depends on https://github.com/gimli-rs/object/pull/322