### PR TITLE
Improve usability of constants

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -18,10 +18,12 @@ pub enum DataValue {
     I16(i16),
     I32(i32),
     I64(i64),
+    I128(i128),
     U8(u8),
     U16(u16),
     U32(u32),
     U64(u64),
+    U128(u128),
     F32(Ieee32),
     F64(Ieee64),
     V128([u8; 16]),
@@ -48,6 +50,7 @@ impl DataValue {
             DataValue::I16(_) | DataValue::U16(_) => types::I16,
             DataValue::I32(_) | DataValue::U32(_) => types::I32,
             DataValue::I64(_) | DataValue::U64(_) => types::I64,
+            DataValue::I128(_) | DataValue::U128(_) => types::I128,
             DataValue::F32(_) => types::F32,
             DataValue::F64(_) => types::F64,
             DataValue::V128(_) => types::I8X16, // A default type.
@@ -157,10 +160,12 @@ build_conversion_impl!(i8, I8, I8);
 build_conversion_impl!(i16, I16, I16);
 build_conversion_impl!(i32, I32, I32);
 build_conversion_impl!(i64, I64, I64);
+build_conversion_impl!(i128, I128, I128);
 build_conversion_impl!(u8, U8, I8);
 build_conversion_impl!(u16, U16, I16);
 build_conversion_impl!(u32, U32, I32);
 build_conversion_impl!(u64, U64, I64);
+build_conversion_impl!(u128, U128, I128);
 build_conversion_impl!(Ieee32, F32, F32);
 build_conversion_impl!(Ieee64, F64, F64);
 build_conversion_impl!([u8; 16], V128, I8X16);
@@ -178,10 +183,12 @@ impl Display for DataValue {
             DataValue::I16(dv) => write!(f, "{}", dv),
             DataValue::I32(dv) => write!(f, "{}", dv),
             DataValue::I64(dv) => write!(f, "{}", dv),
+            DataValue::I128(dv) => write!(f, "{}", dv),
             DataValue::U8(dv) => write!(f, "{}", dv),
             DataValue::U16(dv) => write!(f, "{}", dv),
             DataValue::U32(dv) => write!(f, "{}", dv),
             DataValue::U64(dv) => write!(f, "{}", dv),
+            DataValue::U128(dv) => write!(f, "{}", dv),
             // The Ieee* wrappers here print the expected syntax.
             DataValue::F32(dv) => write!(f, "{}", dv),
             DataValue::F64(dv) => write!(f, "{}", dv),

--- a/cranelift/codegen/src/ir/constant.rs
+++ b/cranelift/codegen/src/ir/constant.rs
@@ -174,8 +174,10 @@ pub type ConstantOffset = u32;
 /// because it must be set relative to the function code size (i.e. constants are emitted after the
 /// function body); because the function is not yet compiled when constants are inserted,
 /// [`set_offset`](crate::ir::ConstantPool::set_offset) must be called once a constant's offset
-/// from the beginning of the function is known (see
-/// `relaxation` in `relaxation.rs`).
+/// from the beginning of the function is known (see `relaxation` in `relaxation.rs`).
+///
+/// TODO: The offset part of this can be removed with the x86 backend
+/// See: https://github.com/bytecodealliance/wasmtime/issues/1936
 #[derive(Clone)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct ConstantPoolEntry {
@@ -268,6 +270,9 @@ impl ConstantPool {
 
     /// Assign an offset to a given constant, where the offset is the number of bytes from the
     /// beginning of the function to the beginning of the constant data inside the pool.
+    ///
+    /// TODO: This method should be removed with the x86 backend.
+    /// See: https://github.com/bytecodealliance/wasmtime/issues/1936
     pub fn set_offset(&mut self, constant_handle: Constant, constant_offset: ConstantOffset) {
         assert!(
             self.handles_to_values.contains_key(&constant_handle),
@@ -281,6 +286,9 @@ impl ConstantPool {
 
     /// Retrieve the offset of a given constant, where the offset is the number of bytes from the
     /// beginning of the function to the beginning of the constant data inside the pool.
+    ///
+    /// TODO: This method should be removed with the x86 backend.
+    /// See: https://github.com/bytecodealliance/wasmtime/issues/1936
     pub fn get_offset(&self, constant_handle: Constant) -> ConstantOffset {
         self.handles_to_values
             .get(&constant_handle)

--- a/cranelift/codegen/src/isa/arm32/lower.rs
+++ b/cranelift/codegen/src/isa/arm32/lower.rs
@@ -13,6 +13,7 @@ use crate::isa::arm32::Arm32Backend;
 
 use super::lower_inst;
 
+use crate::data_value::DataValue;
 use regalloc::{Reg, Writable};
 
 //============================================================================
@@ -71,13 +72,7 @@ pub(crate) fn input_to_reg<C: LowerCtx<I = Inst>>(
     let inputs = ctx.get_input_as_source_or_const(input.insn, input.input);
     let in_reg = if let Some(c) = inputs.constant {
         let to_reg = ctx.alloc_tmp(ty).only_reg().unwrap();
-        for inst in Inst::gen_constant(ValueRegs::one(to_reg), c as u128, ty, |ty| {
-            ctx.alloc_tmp(ty).only_reg().unwrap()
-        })
-        .into_iter()
-        {
-            ctx.emit(inst);
-        }
+        ctx.emit_constant(DataValue::U64(c), ValueRegs::one(to_reg));
         to_reg.to_reg()
     } else {
         ctx.put_input_in_regs(input.insn, input.input)

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -694,15 +694,14 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         let memcpy_addr = get_intreg_for_arg(&call_conv, 3, 3).unwrap();
         insts.push(Inst::gen_move(Writable::from_reg(arg0), dst, I64));
         insts.push(Inst::gen_move(Writable::from_reg(arg1), src, I64));
-        insts.extend(
-            Inst::gen_constant(
-                ValueRegs::one(Writable::from_reg(arg2)),
-                size as u128,
-                I64,
-                |_| panic!("tmp should not be needed"),
-            )
-            .into_iter(),
-        );
+
+        // TODO: We should use `gen_constant` here, but it requires a `LowerCtx` which we don't have
+        insts.push(Inst::imm(
+            OperandSize::Size64,
+            size as u64,
+            Writable::from_reg(arg2),
+        ));
+
         // We use an indirect call and a full LoadExtName because we do not have
         // information about the libcall `RelocDistance` here, so we
         // conservatively use the more flexible calling sequence.

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -18,7 +18,7 @@ pub fn compile<B: LowerBackend + MachBackend>(
     emit_info: <B::MInst as MachInstEmit>::Info,
 ) -> CodegenResult<VCode<B::MInst>>
 where
-    B::MInst: PrettyPrint,
+    B::MInst: PrettyPrint + ConstantGenerator,
 {
     // Compute lowered block order.
     let block_order = BlockLoweringOrder::new(f);

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -151,7 +151,7 @@ impl Value for DataValue {
 
     fn int(n: i64, ty: Type) -> ValueResult<Self> {
         if ty.is_int() && !ty.is_vector() {
-            DataValue::from_integer(n, ty).map_err(|_| ValueError::InvalidValue(ty))
+            DataValue::from_value(n as u128, ty).map_err(|_| ValueError::InvalidValue(ty))
         } else {
             Err(ValueError::InvalidType(ValueTypeClass::Integer, ty))
         }


### PR DESCRIPTION
Hey,

This is a update on @abrown 's PR https://github.com/bytecodealliance/wasmtime/pull/2468.

The main changes are:
* The introduction of i128's into `DataValue`
* The Trait based `ConstantGenerator` and `PooledConstantGenerator`

This was also discussed as potential fix to https://github.com/bytecodealliance/wasmtime/issues/2906. But I haven't checked if it fixes it yet.

Closes #2468 