### PR TITLE
Enable more tests on AArch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -157,11 +157,9 @@ fn write_testsuite_tests(
     writeln!(out, "#[test]")?;
     if x64_should_panic(testsuite, &testname, strategy) {
         writeln!(out, r#"#[should_panic]"#)?;
-    } else if ignore(testsuite, &testname, strategy) {
+    // Ignore when using QEMU for running tests (limited memory).
+    } else if ignore(testsuite, &testname, strategy) || (pooling && platform_is_emulated()) {
         writeln!(out, "#[ignore]")?;
-    } else if pooling {
-        // Ignore on aarch64 due to using QEMU for running tests (limited memory)
-        writeln!(out, r#"#[cfg_attr(target_arch = "aarch64", ignore)]"#)?;
     }
 
     writeln!(
@@ -254,4 +252,8 @@ fn platform_is_x64() -> bool {
 
 fn platform_is_s390x() -> bool {
     env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "s390x"
+}
+
+fn platform_is_emulated() -> bool {
+    env::var("WASMTIME_TEST_NO_HOG_MEMORY").unwrap_or_default() == "1"
 }

--- a/crates/debug/src/lib.rs
+++ b/crates/debug/src/lib.rs
@@ -116,6 +116,7 @@ fn ensure_supported_elf_format(bytes: &[u8]) -> Result<Endianness, Error> {
     let e = header.endian().unwrap();
 
     match header.e_machine.get(e) {
+        EM_AARCH64 => (),
         EM_X86_64 => (),
         EM_S390 => (),
         machine => {

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -1666,10 +1666,14 @@ mod test {
         );
     }
 
-    #[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
     #[cfg(all(unix, target_pointer_width = "64", feature = "async"))]
     #[test]
     fn test_stack_zeroed() -> Result<()> {
+        // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
+        if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
+            return Ok(());
+        }
+
         let allocator = PoolingInstanceAllocator::new(
             PoolingAllocationStrategy::NextAvailable,
             ModuleLimits {

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -673,7 +673,6 @@ mod test {
         Ok(())
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_isa_flags_mismatch() -> Result<()> {
         let engine = Engine::default();

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -455,9 +455,6 @@ fn func_write_nothing() -> anyhow::Result<()> {
 }
 
 #[test]
-// Note: Cranelift only supports refrerence types (used in the wasm in this
-// test) on x64.
-#[cfg(target_arch = "x86_64")]
 fn return_cross_store_value() -> anyhow::Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -490,9 +487,6 @@ fn return_cross_store_value() -> anyhow::Result<()> {
 }
 
 #[test]
-// Note: Cranelift only supports refrerence types (used in the wasm in this
-// test) on x64.
-#[cfg(target_arch = "x86_64")]
 fn pass_cross_store_arg() -> anyhow::Result<()> {
     let mut config = Config::new();
     config.wasm_reference_types(true);

--- a/tests/all/fuzzing.rs
+++ b/tests/all/fuzzing.rs
@@ -21,7 +21,6 @@ fn instantiate_empty_module_with_memory() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // FIXME(#1523)
 fn instantiate_module_that_compiled_to_x64_has_register_32() {
     let mut config = Config::new();
     config.debug_info(true);

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1,4 +1,5 @@
 use super::ref_types_module;
+use super::skip_pooling_allocator_tests;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
 use wasmtime::*;
@@ -237,9 +238,12 @@ fn drop_externref_via_table_set() -> anyhow::Result<()> {
 #[test]
 fn global_drops_externref() -> anyhow::Result<()> {
     test_engine(&Engine::default())?;
-    test_engine(&Engine::new(
-        Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()),
-    )?)?;
+
+    if !skip_pooling_allocator_tests() {
+        test_engine(&Engine::new(
+            Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()),
+        )?)?;
+    }
 
     return Ok(());
 
@@ -284,9 +288,12 @@ fn global_drops_externref() -> anyhow::Result<()> {
 #[cfg(not(feature = "old-x86-backend"))] // uses atomic instrs not implemented here
 fn table_drops_externref() -> anyhow::Result<()> {
     test_engine(&Engine::default())?;
-    test_engine(&Engine::new(
-        Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()),
-    )?)?;
+
+    if !skip_pooling_allocator_tests() {
+        test_engine(&Engine::new(
+            Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()),
+        )?)?;
+    }
 
     return Ok(());
 

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -5,7 +5,9 @@ mod debug;
 mod externals;
 mod fuel;
 mod func;
+mod funcref;
 mod fuzzing;
+mod gc;
 mod globals;
 mod host_funcs;
 mod iloop;
@@ -29,14 +31,7 @@ mod table;
 mod traps;
 mod wast;
 
-// TODO(#1886): Cranelift only supports reference types on x64.
-#[cfg(target_arch = "x86_64")]
-mod funcref;
-#[cfg(target_arch = "x86_64")]
-mod gc;
-
 /// A helper to compile a module in a new store with reference types enabled.
-#[cfg(target_arch = "x86_64")]
 pub(crate) fn ref_types_module(
     source: &str,
 ) -> anyhow::Result<(wasmtime::Store<()>, wasmtime::Module)> {
@@ -53,4 +48,12 @@ pub(crate) fn ref_types_module(
     let module = Module::new(&engine, source)?;
 
     Ok((store, module))
+}
+
+/// A helper determining whether the pooling allocator tests should be skipped.
+pub(crate) fn skip_pooling_allocator_tests() -> bool {
+    // There are a couple of issues when running the pooling allocator tests under QEMU:
+    // - high memory usage that may exceed the limits imposed by the environment (e.g. CI)
+    // - https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
+    std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok()
 }

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -1,3 +1,4 @@
+use super::skip_pooling_allocator_tests;
 use anyhow::Result;
 use wasmtime::*;
 
@@ -187,8 +188,11 @@ fn memory_guard_page_trap() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
 fn memory_zeroed() -> Result<()> {
+    if skip_pooling_allocator_tests() {
+        return Ok(());
+    }
+
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,
@@ -357,8 +361,11 @@ fn table_init() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)] // https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
 fn table_zeroed() -> Result<()> {
+    if skip_pooling_allocator_tests() {
+        return Ok(());
+    }
+
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: PoolingAllocationStrategy::NextAvailable,


### PR DESCRIPTION
These changes are partially in support of #2960. With them the tests run on AArch64 should be the same as those executing on x86-64, except for a couple that are specific to the latter platform, 3 that [fail under QEMU](https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133), and some CLIF tests missing the `target aarch64` directive.