### PR TITLE
Connect helper C symbols to their static library

### DIFF
--- a/crates/runtime/build.rs
+++ b/crates/runtime/build.rs
@@ -9,5 +9,5 @@ fn main() {
             None,
         )
         .file("src/helpers.c")
-        .compile("helpers");
+        .compile("wasmtime-helpers");
 }

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -14,7 +14,7 @@
 #define platform_jmp_buf sigjmp_buf
 #endif
 
-int RegisterSetjmp(
+int wasmtime_setjmp(
     void **buf_storage,
     void (*body)(void*, void*),
     void *payload,
@@ -28,7 +28,7 @@ int RegisterSetjmp(
   return 1;
 }
 
-void Unwind(void *JmpBuf) {
+void wasmtime_longjmp(void *JmpBuf) {
   platform_jmp_buf *buf = (platform_jmp_buf*) JmpBuf;
   platform_longjmp(*buf, 1);
 }

--- a/crates/runtime/src/traphandlers/macos.rs
+++ b/crates/runtime/src/traphandlers/macos.rs
@@ -33,7 +33,7 @@
 
 #![allow(non_snake_case)]
 
-use crate::traphandlers::{tls, Trap, Unwind};
+use crate::traphandlers::{tls, wasmtime_longjmp, Trap};
 use mach::exception_types::*;
 use mach::kern_return::*;
 use mach::mach_init::*;
@@ -389,7 +389,7 @@ unsafe extern "C" fn unwind(wasm_pc: *const u8) -> ! {
         state.jmp_buf.get()
     });
     debug_assert!(!jmp_buf.is_null());
-    Unwind(jmp_buf);
+    wasmtime_longjmp(jmp_buf);
 }
 
 thread_local! {

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -1,4 +1,4 @@
-use crate::traphandlers::{tls, Trap, Unwind};
+use crate::traphandlers::{tls, wasmtime_longjmp, Trap};
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::io;
@@ -99,7 +99,7 @@ unsafe extern "C" fn trap_handler(
             return true;
         }
         info.capture_backtrace(pc);
-        Unwind(jmp_buf)
+        wasmtime_longjmp(jmp_buf)
     });
 
     if handled {

--- a/crates/runtime/src/traphandlers/windows.rs
+++ b/crates/runtime/src/traphandlers/windows.rs
@@ -1,4 +1,4 @@
-use crate::traphandlers::{tls, Trap, Unwind};
+use crate::traphandlers::{tls, wasmtime_longjmp, Trap};
 use std::io;
 use winapi::um::errhandlingapi::*;
 use winapi::um::minwinbase::*;
@@ -69,7 +69,7 @@ unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS)
             EXCEPTION_CONTINUE_EXECUTION
         } else {
             info.capture_backtrace(ip);
-            Unwind(jmp_buf)
+            wasmtime_longjmp(jmp_buf)
         }
     })
 }


### PR DESCRIPTION
This commit adds a `#[link]` annotation to the block defining symbols
coming from a native static library that we build and link. This is
required by rustc to get symbols to get exported correctly when linking
wasmtime into a Rust dynamic library instead of always as an rlib.

While I was at it I went ahead and renamed the symbols now that they're
no longer in C++ and they're doing setjmp/longjmp and not much else.

Closes #3006

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
