### PR TITLE
s390x: Basic support for IaddIfcout

### DIFF
--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -121,7 +121,12 @@ impl MachBackend for S390xBackend {
     }
 
     fn unsigned_add_overflow_condition(&self) -> IntCC {
-        unimplemented!()
+        // The ADD LOGICAL family of instructions set the condition code
+        // differently from normal comparisons, in a way that cannot be
+        // represented by any of the standard IntCC values.  So we use a
+        // dummy value here, which gets remapped to the correct condition
+        // code mask during lowering.
+        IntCC::UnsignedGreaterThan
     }
 
     fn unsigned_sub_overflow_condition(&self) -> IntCC {


### PR DESCRIPTION
This adds enough support for the IaddIfcout opcode to make the
code emitted by dynamic_addr work on s390x.

Note: On s390x, the condition code mask that has to be used to
implement unsigned_add_overflow_condition does not match any of
the masks for the "normal" condition codes, so this design is
not really a good match for s390x ...

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
