### PR TITLE
Fix access to VMMemoryDefinition::current_length on big-endian

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -703,10 +703,10 @@ impl Instance {
 
         if src
             .checked_add(len)
-            .map_or(true, |n| n as usize > src_mem.current_length)
+            .map_or(true, |n| n > src_mem.current_length)
             || dst
                 .checked_add(len)
-                .map_or(true, |m| m as usize > dst_mem.current_length)
+                .map_or(true, |m| m > dst_mem.current_length)
         {
             return Err(Trap::wasm(ir::TrapCode::HeapOutOfBounds));
         }
@@ -741,7 +741,7 @@ impl Instance {
 
         if dst
             .checked_add(len)
-            .map_or(true, |m| m as usize > memory.current_length)
+            .map_or(true, |m| m > memory.current_length)
         {
             return Err(Trap::wasm(ir::TrapCode::HeapOutOfBounds));
         }
@@ -825,7 +825,7 @@ impl Instance {
             .map_or(true, |n| n as usize > data.len())
             || dst
                 .checked_add(len)
-                .map_or(true, |m| m as usize > memory.current_length)
+                .map_or(true, |m| m > memory.current_length)
         {
             return Err(Trap::wasm(ir::TrapCode::HeapOutOfBounds));
         }

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -309,7 +309,7 @@ fn check_memory_init_bounds(
         let end = start.checked_add(init.data.len());
 
         match end {
-            Some(end) if end <= memory.current_length => {
+            Some(end) if end <= memory.current_length as usize => {
                 // Initializer is in bounds
             }
             _ => {
@@ -382,8 +382,9 @@ fn initialize_instance(
         MemoryInitialization::Paged { map, out_of_bounds } => {
             for (index, pages) in map {
                 let memory = instance.memory(index);
-                let slice =
-                    unsafe { slice::from_raw_parts_mut(memory.base, memory.current_length) };
+                let slice = unsafe {
+                    slice::from_raw_parts_mut(memory.base, memory.current_length as usize)
+                };
 
                 for (page_index, page) in pages.iter().enumerate() {
                     if let Some(data) = page {

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -155,6 +155,10 @@ impl RuntimeLinearMemory for MmapMemory {
             // Linear memory size would exceed the index range.
             return None;
         }
+        // FIXME: https://github.com/bytecodealliance/wasmtime/issues/3022
+        if new_pages == WASM_MAX_PAGES {
+            return None;
+        }
 
         let delta_bytes = usize::try_from(delta).unwrap() * WASM_PAGE_SIZE as usize;
         let prev_bytes = usize::try_from(prev_pages).unwrap() * WASM_PAGE_SIZE as usize;
@@ -194,7 +198,8 @@ impl RuntimeLinearMemory for MmapMemory {
     fn vmmemory(&self) -> VMMemoryDefinition {
         VMMemoryDefinition {
             base: unsafe { self.mmap.alloc.as_mut_ptr().add(self.pre_guard_size) },
-            current_length: self.mmap.size as usize * WASM_PAGE_SIZE as usize,
+            current_length: u32::try_from(self.mmap.size as usize * WASM_PAGE_SIZE as usize)
+                .unwrap(),
         }
     }
 }
@@ -271,6 +276,13 @@ impl Memory {
     }
 
     fn limit_new(plan: &MemoryPlan, limiter: Option<&mut dyn ResourceLimiter>) -> Result<()> {
+        // FIXME: https://github.com/bytecodealliance/wasmtime/issues/3022
+        if plan.memory.minimum == WASM_MAX_PAGES {
+            bail!(
+                "memory minimum size of {} pages exceeds memory limits",
+                plan.memory.minimum
+            );
+        }
         if let Some(limiter) = limiter {
             if !limiter.memory_growing(0, plan.memory.minimum, plan.memory.maximum) {
                 bail!(
@@ -362,6 +374,10 @@ impl Memory {
                 if new_size > maximum.unwrap_or(WASM_MAX_PAGES) {
                     return None;
                 }
+                // FIXME: https://github.com/bytecodealliance/wasmtime/issues/3022
+                if new_size == WASM_MAX_PAGES {
+                    return None;
+                }
 
                 let start = usize::try_from(old_size).unwrap() * WASM_PAGE_SIZE as usize;
                 let len = usize::try_from(delta).unwrap() * WASM_PAGE_SIZE as usize;
@@ -381,7 +397,7 @@ impl Memory {
         match self {
             Memory::Static { base, size, .. } => VMMemoryDefinition {
                 base: base.as_ptr() as *mut _,
-                current_length: *size as usize * WASM_PAGE_SIZE as usize,
+                current_length: u32::try_from(*size as usize * WASM_PAGE_SIZE as usize).unwrap(),
             },
             Memory::Dynamic(mem) => mem.vmmemory(),
         }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -203,7 +203,7 @@ pub struct VMMemoryDefinition {
     pub base: *mut u8,
 
     /// The current logical size of this linear memory in bytes.
-    pub current_length: usize,
+    pub current_length: u32,
 }
 
 #[cfg(test)]

--- a/crates/wasmtime/src/memory.rs
+++ b/crates/wasmtime/src/memory.rs
@@ -318,7 +318,7 @@ impl Memory {
         unsafe {
             let store = store.into();
             let definition = *store[self.0].definition;
-            slice::from_raw_parts(definition.base, definition.current_length)
+            slice::from_raw_parts(definition.base, definition.current_length as usize)
         }
     }
 
@@ -334,7 +334,7 @@ impl Memory {
         unsafe {
             let store = store.into();
             let definition = *store[self.0].definition;
-            slice::from_raw_parts_mut(definition.base, definition.current_length)
+            slice::from_raw_parts_mut(definition.base, definition.current_length as usize)
         }
     }
 
@@ -395,7 +395,7 @@ impl Memory {
     ///
     /// Panics if this memory doesn't belong to `store`.
     pub fn data_size(&self, store: impl AsContext) -> usize {
-        unsafe { (*store.as_context()[self.0].definition).current_length }
+        unsafe { (*store.as_context()[self.0].definition).current_length as usize }
     }
 
     /// Returns the size, in WebAssembly pages, of this wasm memory.

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -7,6 +7,7 @@ use wasmtime_environ::entity::PrimaryMap;
 use wasmtime_environ::{wasm, MemoryPlan, MemoryStyle, Module, WASM_PAGE_SIZE};
 use wasmtime_runtime::{RuntimeLinearMemory, RuntimeMemoryCreator, VMMemoryDefinition};
 
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 pub fn create_memory(store: &mut StoreOpaque<'_>, memory: &MemoryType) -> Result<InstanceId> {
@@ -48,7 +49,8 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
     fn vmmemory(&self) -> VMMemoryDefinition {
         VMMemoryDefinition {
             base: self.mem.as_ptr(),
-            current_length: self.mem.size() as usize * WASM_PAGE_SIZE as usize,
+            current_length: u32::try_from(self.mem.size() as usize * WASM_PAGE_SIZE as usize)
+                .unwrap(),
         }
     }
 }

--- a/tests/all/instance.rs
+++ b/tests/all/instance.rs
@@ -55,7 +55,7 @@ fn linear_memory_limits() -> Result<()> {
     fn test(engine: &Engine) -> Result<()> {
         let wat = r#"
         (module
-            (memory 65535)
+            (memory 65534)
 
             (func (export "foo")  (result i32)
                 i32.const 1
@@ -68,7 +68,7 @@ fn linear_memory_limits() -> Result<()> {
         let instance = Instance::new(&mut store, &module, &[])?;
         let foo = instance.get_typed_func::<(), i32, _>(&mut store, "foo")?;
 
-        assert_eq!(foo.call(&mut store, ())?, 65535);
+        assert_eq!(foo.call(&mut store, ())?, 65534);
         assert_eq!(foo.call(&mut store, ())?, -1);
         Ok(())
     }


### PR DESCRIPTION
The current_length member is defined as "usize" in Rust code,
but generated wasm code refers to it as if it were "u32".  Not
sure why this is case, and it happens to work on little-endian
machines (as long as the length is < 4GB), but it will always
fail on big-endian machines.

Add the minimal fixes to make it work on big-endian as well.
(Note: this patch does not attempt to fix the actual underlying
type mismatch ...)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
