### PR TITLE
Fix updating srclocs in truncate_last_branch

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -680,8 +680,12 @@ impl<I: VCodeInst> MachBuffer<I> {
         //    (end of buffer)
         self.data.truncate(b.start as usize);
         self.fixup_records.truncate(b.fixup);
-        while let Some(last_srcloc) = self.srclocs.last() {
+        while let Some(mut last_srcloc) = self.srclocs.last_mut() {
             if last_srcloc.end <= b.start {
+                break;
+            }
+            if last_srcloc.start < b.start {
+                last_srcloc.end = b.start;
                 break;
             }
             self.srclocs.pop();


### PR DESCRIPTION
The truncate_last_branch removes an instruction that had already
been added to the buffer, and must update various bookkeeping.

However, updating the "srclocs" field is incorrect: if there is
a srclocs entry that spans both the removed branch *and some
previous instruction*, that whole srclocs entry is removed,
which makes those previous instructions now uncovered by any
srclocs record.  This can cause subsequent problems e.g. if
one of those instructions traps.

Fixed by just truncating instead of fully removing the srclocs
record in this case.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
