### PR TITLE
Fix offsets_static_dynamic_oh_my failure on s390x

### DIFF
--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -19,6 +19,7 @@ fn module(engine: &Engine) -> Result<Module> {
             (2, &["i32.load16_s"]),
             (4, &["i32.load" /*, "f32.load"*/]),
             (8, &["i64.load" /*, "f64.load"*/]),
+            #[cfg(not(target_arch = "s390x"))]
             (16, &["v128.load"]),
         ]
         .iter()


### PR DESCRIPTION
The test unconditionally emits a SIMD load, which fails on s390x
as we do not yet support SIMD.  Disable this particular part of
the test on s390x.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
