### PR TITLE
Add a type parameter to `VMOffsets` for pointer size

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -120,7 +120,7 @@ pub struct FuncEnvironment<'module_environment> {
     builtin_function_signatures: BuiltinFunctionSignatures,
 
     /// Offsets to struct fields accessed by JIT code.
-    pub(crate) offsets: VMOffsets,
+    pub(crate) offsets: VMOffsets<u8>,
 
     tunables: &'module_environment Tunables,
 
@@ -288,7 +288,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
         // If this changes that's ok, the `atomic_rmw` below just needs to be
         // preceded with an add instruction of `externref` and the offset.
-        assert_eq!(VMOffsets::vm_extern_data_ref_count(), 0);
+        assert_eq!(self.offsets.vm_extern_data_ref_count(), 0);
         let delta = builder.ins().iconst(pointer_type, delta);
         builder.ins().atomic_rmw(
             pointer_type,

--- a/crates/lightbeam/wasmtime/src/lib.rs
+++ b/crates/lightbeam/wasmtime/src/lib.rs
@@ -175,7 +175,7 @@ struct FuncEnvironment<'module_environment> {
     module: &'module_environment Module,
 
     /// Offsets to struct fields accessed by JIT code.
-    offsets: VMOffsets,
+    offsets: VMOffsets<u8>,
 }
 
 impl<'module_environment> FuncEnvironment<'module_environment> {

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -965,8 +965,20 @@ mod tests {
 
         let actual_offset = (ref_count_ptr as usize) - (extern_data_ptr as usize);
 
+        let offsets = wasmtime_environ::VMOffsets::from(wasmtime_environ::VMOffsetsFields {
+            ptr: 8,
+            num_signature_ids: 0,
+            num_imported_functions: 0,
+            num_imported_tables: 0,
+            num_imported_memories: 0,
+            num_imported_globals: 0,
+            num_defined_functions: 0,
+            num_defined_tables: 0,
+            num_defined_memories: 0,
+            num_defined_globals: 0,
+        });
         assert_eq!(
-            wasmtime_environ::VMOffsets::vm_extern_data_ref_count(),
+            offsets.vm_extern_data_ref_count(),
             actual_offset.try_into().unwrap(),
         );
     }
@@ -981,7 +993,7 @@ mod tests {
         let actual_offset = (next_ptr as usize) - (table_ptr as usize);
 
         let offsets = wasmtime_environ::VMOffsets::from(wasmtime_environ::VMOffsetsFields {
-            pointer_size: 8,
+            ptr: 8,
             num_signature_ids: 0,
             num_imported_functions: 0,
             num_imported_tables: 0,
@@ -1008,7 +1020,7 @@ mod tests {
         let actual_offset = (end_ptr as usize) - (table_ptr as usize);
 
         let offsets = wasmtime_environ::VMOffsets::from(wasmtime_environ::VMOffsetsFields {
-            pointer_size: 8,
+            ptr: 8,
             num_signature_ids: 0,
             num_imported_functions: 0,
             num_imported_tables: 0,

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -27,7 +27,7 @@ use wasmtime_environ::wasm::{
     DataIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, ElemIndex, EntityIndex,
     FuncIndex, GlobalIndex, MemoryIndex, TableElementType, TableIndex, WasmType,
 };
-use wasmtime_environ::{ir, Module, VMOffsets};
+use wasmtime_environ::{ir, HostPtr, Module, VMOffsets};
 
 mod allocator;
 
@@ -119,7 +119,7 @@ pub(crate) struct Instance {
     module: Arc<Module>,
 
     /// Offsets in the `vmctx` region, precomputed from the `module` above.
-    offsets: VMOffsets,
+    offsets: VMOffsets<HostPtr>,
 
     /// WebAssembly linear memory data.
     ///

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -22,8 +22,8 @@ use wasmtime_environ::wasm::{
     DefinedFuncIndex, DefinedMemoryIndex, DefinedTableIndex, GlobalInit, SignatureIndex, WasmType,
 };
 use wasmtime_environ::{
-    ir, MemoryInitialization, MemoryInitializer, Module, ModuleType, TableInitializer, VMOffsets,
-    WASM_PAGE_SIZE,
+    ir, HostPtr, MemoryInitialization, MemoryInitializer, Module, ModuleType, TableInitializer,
+    VMOffsets, WASM_PAGE_SIZE,
 };
 
 mod pooling;
@@ -643,7 +643,7 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
         let mut handle = {
             let instance = Instance {
                 module: req.module.clone(),
-                offsets: VMOffsets::new(std::mem::size_of::<*const u8>() as u8, &req.module),
+                offsets: VMOffsets::new(HostPtr, &req.module),
                 memories,
                 tables,
                 dropped_elements: EntitySet::with_capacity(req.module.passive_elements.len()),


### PR DESCRIPTION
This commit adds a type parameter to `VMOffsets` representing the
pointer size to improve computations in `wasmtime-runtime` which always
use a constant value of the host's pointer size. The type parameter is
`u8` for `wasmtime-cranelift`'s use case where cross-compilation may be
involved.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
