### PR TITLE
Simplify the list of builtin intrinsics Wasmtime needs

### DIFF
--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -5,12 +5,6 @@ macro_rules! foreach_builtin_function {
         $mac! {
             /// Returns an index for wasm's `memory.grow` builtin function.
             memory32_grow(vmctx, i32, i32) -> (i32);
-            /// Returns an index for wasm's imported `memory.grow` builtin function.
-            imported_memory32_grow(vmctx, i32, i32) -> (i32);
-            /// Returns an index for wasm's `memory.size` builtin function.
-            memory32_size(vmctx, i32) -> (i32);
-            /// Returns an index for wasm's imported `memory.size` builtin function.
-            imported_memory32_size(vmctx, i32) -> (i32);
             /// Returns an index for wasm's `table.copy` when both tables are locally
             /// defined.
             table_copy(vmctx, i32, i32, i32, i32, i32) -> ();
@@ -20,10 +14,8 @@ macro_rules! foreach_builtin_function {
             elem_drop(vmctx, i32) -> ();
             /// Returns an index for wasm's `memory.copy`
             memory_copy(vmctx, i32, i32, i32, i32, i32) -> ();
-            /// Returns an index for wasm's `memory.fill` for locally defined memories.
+            /// Returns an index for wasm's `memory.fill` instruction.
             memory_fill(vmctx, i32, i32, i32, i32) -> ();
-            /// Returns an index for wasm's `memory.fill` for imported memories.
-            imported_memory_fill(vmctx, i32, i32, i32, i32) -> ();
             /// Returns an index for wasm's `memory.init` instruction.
             memory_init(vmctx, i32, i32, i32, i32, i32) -> ();
             /// Returns an index for wasm's `data.drop` instruction.
@@ -45,18 +37,12 @@ macro_rules! foreach_builtin_function {
             externref_global_get(vmctx, i32) -> (reference);
             /// Returns an index for Wasm's `global.get` instruction for `externref`s.
             externref_global_set(vmctx, i32, reference) -> ();
-            /// Returns an index for wasm's `memory.atomic.notify` for locally defined memories.
+            /// Returns an index for wasm's `memory.atomic.notify` instruction.
             memory_atomic_notify(vmctx, i32, i32, i32) -> (i32);
-            /// Returns an index for wasm's `memory.atomic.notify` for imported memories.
-            imported_memory_atomic_notify(vmctx, i32, i32, i32) -> (i32);
-            /// Returns an index for wasm's `memory.atomic.wait32` for locally defined memories.
+            /// Returns an index for wasm's `memory.atomic.wait32` instruction.
             memory_atomic_wait32(vmctx, i32, i32, i32, i64) -> (i32);
-            /// Returns an index for wasm's `memory.atomic.wait32` for imported memories.
-            imported_memory_atomic_wait32(vmctx, i32, i32, i32, i64) -> (i32);
-            /// Returns an index for wasm's `memory.atomic.wait64` for locally defined memories.
+            /// Returns an index for wasm's `memory.atomic.wait64` instruction.
             memory_atomic_wait64(vmctx, i32, i32, i64, i64) -> (i32);
-            /// Returns an index for wasm's `memory.atomic.wait64` for imported memories.
-            imported_memory_atomic_wait64(vmctx, i32, i32, i64, i64) -> (i32);
             /// Invoked when fuel has run out while executing a function.
             out_of_gas(vmctx) -> ();
         }

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -63,8 +63,7 @@ use crate::vmcontext::{VMCallerCheckedAnyfunc, VMContext};
 use std::mem;
 use std::ptr::{self, NonNull};
 use wasmtime_environ::wasm::{
-    DataIndex, DefinedMemoryIndex, ElemIndex, GlobalIndex, MemoryIndex, TableElementType,
-    TableIndex,
+    DataIndex, ElemIndex, GlobalIndex, MemoryIndex, TableElementType, TableIndex,
 };
 
 const TOINT_32: f32 = 1.0 / f32::EPSILON;
@@ -192,44 +191,10 @@ pub unsafe extern "C" fn wasmtime_memory32_grow(
     memory_index: u32,
 ) -> u32 {
     let instance = (*vmctx).instance_mut();
-    let memory_index = DefinedMemoryIndex::from_u32(memory_index);
-
+    let memory_index = MemoryIndex::from_u32(memory_index);
     instance
         .memory_grow(memory_index, delta)
         .unwrap_or(u32::max_value())
-}
-
-/// Implementation of memory.grow for imported 32-bit memories.
-pub unsafe extern "C" fn wasmtime_imported_memory32_grow(
-    vmctx: *mut VMContext,
-    delta: u32,
-    memory_index: u32,
-) -> u32 {
-    let instance = (*vmctx).instance_mut();
-    let memory_index = MemoryIndex::from_u32(memory_index);
-
-    instance
-        .imported_memory_grow(memory_index, delta)
-        .unwrap_or(u32::max_value())
-}
-
-/// Implementation of memory.size for locally-defined 32-bit memories.
-pub unsafe extern "C" fn wasmtime_memory32_size(vmctx: *mut VMContext, memory_index: u32) -> u32 {
-    let instance = (*vmctx).instance();
-    let memory_index = DefinedMemoryIndex::from_u32(memory_index);
-
-    instance.memory_size(memory_index)
-}
-
-/// Implementation of memory.size for imported 32-bit memories.
-pub unsafe extern "C" fn wasmtime_imported_memory32_size(
-    vmctx: *mut VMContext,
-    memory_index: u32,
-) -> u32 {
-    let instance = (*vmctx).instance();
-    let memory_index = MemoryIndex::from_u32(memory_index);
-
-    instance.imported_memory_size(memory_index)
 }
 
 /// Implementation of `table.grow`.
@@ -243,13 +208,8 @@ pub unsafe extern "C" fn wasmtime_table_grow(
 ) -> u32 {
     let instance = (*vmctx).instance_mut();
     let table_index = TableIndex::from_u32(table_index);
-    match instance.table_element_type(table_index) {
-        TableElementType::Func => {
-            let func = init_value as *mut VMCallerCheckedAnyfunc;
-            instance
-                .table_grow(table_index, delta, func.into())
-                .unwrap_or(-1_i32 as u32)
-        }
+    let element = match instance.table_element_type(table_index) {
+        TableElementType::Func => (init_value as *mut VMCallerCheckedAnyfunc).into(),
         TableElementType::Val(ty) => {
             debug_assert_eq!(ty, crate::ref_type());
 
@@ -258,12 +218,12 @@ pub unsafe extern "C" fn wasmtime_table_grow(
             } else {
                 Some(VMExternRef::clone_from_raw(init_value))
             };
-
-            instance
-                .table_grow(table_index, delta, init_value.into())
-                .unwrap_or(-1_i32 as u32)
+            init_value.into()
         }
-    }
+    };
+    instance
+        .table_grow(table_index, delta, element)
+        .unwrap_or(-1_i32 as u32)
 }
 
 /// Implementation of `table.fill`.
@@ -379,27 +339,9 @@ pub unsafe extern "C" fn wasmtime_memory_fill(
     len: u32,
 ) {
     let result = {
-        let memory_index = DefinedMemoryIndex::from_u32(memory_index);
-        let instance = (*vmctx).instance();
-        instance.defined_memory_fill(memory_index, dst, val, len)
-    };
-    if let Err(trap) = result {
-        raise_lib_trap(trap);
-    }
-}
-
-/// Implementation of `memory.fill` for imported memories.
-pub unsafe extern "C" fn wasmtime_imported_memory_fill(
-    vmctx: *mut VMContext,
-    memory_index: u32,
-    dst: u32,
-    val: u32,
-    len: u32,
-) {
-    let result = {
         let memory_index = MemoryIndex::from_u32(memory_index);
         let instance = (*vmctx).instance_mut();
-        instance.imported_memory_fill(memory_index, dst, val, len)
+        instance.memory_fill(memory_index, dst, val, len)
     };
     if let Err(trap) = result {
         raise_lib_trap(trap);
@@ -517,18 +459,6 @@ pub unsafe extern "C" fn wasmtime_memory_atomic_notify(
     ))));
 }
 
-/// Implementation of `memory.atomic.notify` for imported memories.
-pub unsafe extern "C" fn wasmtime_imported_memory_atomic_notify(
-    _vmctx: *mut VMContext,
-    _memory_index: u32,
-    _addr: u32,
-    _count: u32,
-) -> u32 {
-    raise_lib_trap(Trap::User(Box::new(Unimplemented(
-        "wasm atomics (fn wasmtime_imported_memory_atomic_notify) unsupported",
-    ))));
-}
-
 /// Implementation of `memory.atomic.wait32` for locally defined memories.
 pub unsafe extern "C" fn wasmtime_memory_atomic_wait32(
     _vmctx: *mut VMContext,
@@ -542,19 +472,6 @@ pub unsafe extern "C" fn wasmtime_memory_atomic_wait32(
     ))));
 }
 
-/// Implementation of `memory.atomic.wait32` for imported memories.
-pub unsafe extern "C" fn wasmtime_imported_memory_atomic_wait32(
-    _vmctx: *mut VMContext,
-    _memory_index: u32,
-    _addr: u32,
-    _expected: u32,
-    _timeout: u64,
-) -> u32 {
-    raise_lib_trap(Trap::User(Box::new(Unimplemented(
-        "wasm atomics (fn wasmtime_imported_memory_atomic_wait32) unsupported",
-    ))));
-}
-
 /// Implementation of `memory.atomic.wait64` for locally defined memories.
 pub unsafe extern "C" fn wasmtime_memory_atomic_wait64(
     _vmctx: *mut VMContext,
@@ -565,19 +482,6 @@ pub unsafe extern "C" fn wasmtime_memory_atomic_wait64(
 ) -> u32 {
     raise_lib_trap(Trap::User(Box::new(Unimplemented(
         "wasm atomics (fn wasmtime_memory_atomic_wait32) unsupported",
-    ))));
-}
-
-/// Implementation of `memory.atomic.wait32` for imported memories.
-pub unsafe extern "C" fn wasmtime_imported_memory_atomic_wait64(
-    _vmctx: *mut VMContext,
-    _memory_index: u32,
-    _addr: u32,
-    _expected: u64,
-    _timeout: u64,
-) -> u32 {
-    raise_lib_trap(Trap::User(Box::new(Unimplemented(
-        "wasm atomics (fn wasmtime_imported_memory_atomic_wait64) unsupported",
     ))));
 }
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -597,12 +597,6 @@ impl VMBuiltinFunctionsArray {
 
         ptrs[BuiltinFunctionIndex::memory32_grow().index() as usize] =
             wasmtime_memory32_grow as usize;
-        ptrs[BuiltinFunctionIndex::imported_memory32_grow().index() as usize] =
-            wasmtime_imported_memory32_grow as usize;
-        ptrs[BuiltinFunctionIndex::memory32_size().index() as usize] =
-            wasmtime_memory32_size as usize;
-        ptrs[BuiltinFunctionIndex::imported_memory32_size().index() as usize] =
-            wasmtime_imported_memory32_size as usize;
         ptrs[BuiltinFunctionIndex::table_copy().index() as usize] = wasmtime_table_copy as usize;
         ptrs[BuiltinFunctionIndex::table_grow_funcref().index() as usize] =
             wasmtime_table_grow as usize;
@@ -612,8 +606,6 @@ impl VMBuiltinFunctionsArray {
         ptrs[BuiltinFunctionIndex::elem_drop().index() as usize] = wasmtime_elem_drop as usize;
         ptrs[BuiltinFunctionIndex::memory_copy().index() as usize] = wasmtime_memory_copy as usize;
         ptrs[BuiltinFunctionIndex::memory_fill().index() as usize] = wasmtime_memory_fill as usize;
-        ptrs[BuiltinFunctionIndex::imported_memory_fill().index() as usize] =
-            wasmtime_imported_memory_fill as usize;
         ptrs[BuiltinFunctionIndex::memory_init().index() as usize] = wasmtime_memory_init as usize;
         ptrs[BuiltinFunctionIndex::data_drop().index() as usize] = wasmtime_data_drop as usize;
         ptrs[BuiltinFunctionIndex::drop_externref().index() as usize] =
@@ -630,16 +622,10 @@ impl VMBuiltinFunctionsArray {
             wasmtime_table_fill as usize;
         ptrs[BuiltinFunctionIndex::memory_atomic_notify().index() as usize] =
             wasmtime_memory_atomic_notify as usize;
-        ptrs[BuiltinFunctionIndex::imported_memory_atomic_notify().index() as usize] =
-            wasmtime_imported_memory_atomic_notify as usize;
         ptrs[BuiltinFunctionIndex::memory_atomic_wait32().index() as usize] =
             wasmtime_memory_atomic_wait32 as usize;
-        ptrs[BuiltinFunctionIndex::imported_memory_atomic_wait32().index() as usize] =
-            wasmtime_imported_memory_atomic_wait32 as usize;
         ptrs[BuiltinFunctionIndex::memory_atomic_wait64().index() as usize] =
             wasmtime_memory_atomic_wait64 as usize;
-        ptrs[BuiltinFunctionIndex::imported_memory_atomic_wait64().index() as usize] =
-            wasmtime_imported_memory_atomic_wait64 as usize;
         ptrs[BuiltinFunctionIndex::out_of_gas().index() as usize] = wasmtime_out_of_gas as usize;
 
         if cfg!(debug_assertions) {


### PR DESCRIPTION
This commit slims down the list of builtin intrinsics. It removes the
duplicated intrinsics for imported and locally defined items, instead
always using one intrinsic for both. This was previously inconsistently
applied where some intrinsics got two copies (one for imported one for
local) and other intrinsics got only one copy. This does add an extra
branch in intrinsics since they need to determine whether something is
local or not, but that's generally much lower cost than the intrinsics
themselves.

This also removes the `memory32_size` intrinsic, instead inlining the
codegen directly into the clif IR. This matches what the `table.size`
instruction does and removes the need for a few functions on a
`wasmtime_runtime::Instance`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
