### PR TITLE
update WASI submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,12 +987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "33.0.0"
+version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d04fe175c7f78214971293e7d8875673804e736092206a3a4544dbc12811c1b"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
 dependencies = [
  "leb128",
 ]
@@ -3986,16 +3980,13 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
- "diff",
  "log",
- "pretty_env_logger",
  "rayon",
- "structopt",
  "thiserror",
- "wast 33.0.0",
+ "wast 35.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,19 +73,13 @@ members = [
   "cranelift",
   "crates/bench-api",
   "crates/c-api",
-  "crates/fuzzing",
   "crates/misc/run-examples",
-  "crates/wiggle",
-  "crates/wiggle/generate",
-  "crates/wiggle/macro",
-  "crates/wasi-common",
-  "crates/wasi-common/cap-std-sync",
-  "crates/wasi-common/tokio",
   "examples/fib-debug/wasm",
   "examples/wasi/wasm",
   "examples/tokio/wasm",
   "fuzz",
 ]
+exclude = ['crates/wasi-common/WASI/tools/witx-cli']
 
 [features]
 default = ["jitdump", "wasmtime/wat", "wasmtime/parallel-compilation", "wasi-nn"]

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*", "README.md", "LICENSE"]
 
 [dependencies]
 thiserror = "1"
-witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9.0", optional = true }
+witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9.1", optional = true }
 wiggle-macro = { path = "macro", version = "0.28.0" }
 tracing = "0.1.15"
 bitflags = "1.2"

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "README.md", "LICENSE"]
 [lib]
 
 [dependencies]
-witx = { version = "0.9.0", path = "../../wasi-common/WASI/tools/witx" }
+witx = { version = "0.9.1", path = "../../wasi-common/WASI/tools/witx" }
 quote = "1.0"
 proc-macro2 = "1.0"
 heck = "0.3"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [dependencies]
 wiggle-generate = { path = "../generate", version = "0.28.0" }
-witx = { version = "0.9.0", path = "../../wasi-common/WASI/tools/witx" }
+witx = { version = "0.9.1", path = "../../wasi-common/WASI/tools/witx" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -302,15 +302,13 @@ fn verify(crates: &[Crate]) {
     fs::create_dir_all(".cargo").unwrap();
     fs::write(".cargo/config.toml", vendor.stdout).unwrap();
 
-    // Vendor 'witx' and 'witx-cli'. These were not vendored because they are a path dependencies,
-    // but they will need to be in our directory registry for crates that depend on them.
-    for krate in crates
+    // Vendor witx which wasn't vendored because it's a path dependency, but
+    // it'll need to be in our directory registry for crates that depend on it.
+    let witx = crates
         .iter()
-        .filter(|Crate { name, .. }| (name == "witx" || name == "witx-cli"))
-        .filter(|c| c.manifest.iter().any(|p| p == "wasi-common"))
-    {
-        verify_and_vendor(&krate);
-    }
+        .find(|c| c.name == "witx" && c.manifest.iter().any(|p| p == "wasi-common"))
+        .unwrap();
+    verify_and_vendor(&witx);
 
     // Vendor wasi-crypto which is also a path dependency
     let wasi_crypto = crates.iter().find(|c| c.name == "wasi-crypto").unwrap();


### PR DESCRIPTION
This PR updates our assorted `witx` dependencies to 0.9.1, which includes an important bug fix. See WebAssembly/WASI#434 for more information.