### PR TITLE
aarch64: Implement TLS ELF GD Relocations

### DIFF
--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -68,6 +68,16 @@ pub enum Reloc {
 
     /// Mach-O x86_64 32 bit signed PC relative offset to a `__thread_vars` entry.
     MachOX86_64Tlv,
+
+    /// AArch64 TLS GD
+    /// Set an ADRP immediate field to the top 21 bits of the final address. Checks for overflow.
+    /// This is equivalent to `R_AARCH64_TLSGD_ADR_PAGE21` in the [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#relocations-for-thread-local-storage)
+    Aarch64TlsGdAdrPage21,
+
+    /// AArch64 TLS GD
+    /// Set the add immediate field to the low 12 bits of the final address. Does not check for overflow.
+    /// This is equivalent to `R_AARCH64_TLSGD_ADD_LO12_NC` in the [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#relocations-for-thread-local-storage)
+    Aarch64TlsGdAddLo12Nc,
 }
 
 impl fmt::Display for Reloc {
@@ -87,6 +97,8 @@ impl fmt::Display for Reloc {
 
             Self::ElfX86_64TlsGd => write!(f, "ElfX86_64TlsGd"),
             Self::MachOX86_64Tlv => write!(f, "MachOX86_64Tlv"),
+            Self::Aarch64TlsGdAdrPage21 => write!(f, "Aarch64TlsGdAdrPage21"),
+            Self::Aarch64TlsGdAddLo12Nc => write!(f, "Aarch64TlsGdAddLo12Nc"),
         }
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -8,7 +8,7 @@ use crate::ir::{InstructionData, Opcode, TrapCode};
 use crate::isa::aarch64::settings as aarch64_settings;
 use crate::machinst::lower::*;
 use crate::machinst::*;
-use crate::settings::Flags;
+use crate::settings::{Flags, TlsModel};
 use crate::{CodegenError, CodegenResult};
 
 use crate::isa::aarch64::abi::*;
@@ -3489,7 +3489,24 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             });
         }
 
-        Opcode::TlsValue => unimplemented!("tls_value"),
+        Opcode::TlsValue => match flags.tls_model() {
+            TlsModel::ElfGd => {
+                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                let (name, _, _) = ctx.symbol_value(insn).unwrap();
+                let symbol = name.clone();
+                ctx.emit(Inst::ElfTlsGetAddr { symbol });
+
+                let x0 = xreg(0);
+                ctx.emit(Inst::gen_move(dst, x0, I64));
+            }
+            _ => {
+                todo!(
+                    "Unimplemented TLS model in AArch64 backend: {:?}",
+                    flags.tls_model()
+                );
+            }
+        },
+
         Opcode::FcvtLowFromSint => unimplemented!("FcvtLowFromSint"),
         Opcode::FvpromoteLow => unimplemented!("FvpromoteLow"),
         Opcode::Fvdemote => unimplemented!("Fvdemote"),

--- a/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
@@ -1,0 +1,29 @@
+test compile
+set tls_model=elf_gd
+target aarch64
+
+function u0:0(i32) -> i32, i64 {
+gv0 = symbol colocated tls u1:0
+
+block0(v0: i32):
+    v1 = global_value.i64 gv0
+    return v0, v1
+}
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: str x19, [sp, #-16]!
+; nextln: stp d14, d15, [sp, #-16]!
+; nextln: stp d12, d13, [sp, #-16]!
+; nextln: stp d10, d11, [sp, #-16]!
+; nextln: stp d8, d9, [sp, #-16]!
+; nextln: mov x19, x0
+; nextln: elf_tls_get_addr u1:0
+; nextln: mov x1, x0
+; nextln: mov x0, x19
+; nextln: ldp d8, d9, [sp], #16
+; nextln: ldp d10, d11, [sp], #16
+; nextln: ldp d12, d13, [sp], #16
+; nextln: ldp d14, d15, [sp], #16
+; nextln: ldr x19, [sp], #16
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -618,6 +618,30 @@ impl ObjectModule {
                     32,
                 )
             }
+            Reloc::Aarch64TlsGdAdrPage21 => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "Aarch64TlsGdAdrPrel21 is not supported for this file format"
+                );
+                (
+                    RelocationKind::Elf(object::elf::R_AARCH64_TLSGD_ADR_PAGE21),
+                    RelocationEncoding::Generic,
+                    21,
+                )
+            }
+            Reloc::Aarch64TlsGdAddLo12Nc => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "Aarch64TlsGdAddLo12Nc is not supported for this file format"
+                );
+                (
+                    RelocationKind::Elf(object::elf::R_AARCH64_TLSGD_ADD_LO12_NC),
+                    RelocationEncoding::Generic,
+                    12,
+                )
+            }
             // FIXME
             reloc => unimplemented!("{:?}", reloc),
         };


### PR DESCRIPTION
Hey,

I've been working on this, but I'm a bit stuck and need some help.

This PR Implements TLS ELF GD relocations for aarch64. ELF GD Relocations are a bit unusual in aarch64 since the default is TLS descriptors (at least in gcc/clang).


Right now I don't think the relocations are being performed correctly.

The only way I have to test this is to run the following command:
`clif-util compile -D --set tls_model=elf_gd --target aarch64 ./filetests/filetests/isa/aarch64/tls-elf-gd.clif`

Which emits the following code:
```
... snipped ...
  20:   00 00 00 90             adrp    x0, #0
  24:   00 00 00 91             add     x0, x0, #0
  28:   00 00 00 94             bl      #0x28
  2c:   1f 20 03 d5             nop
... snipped ...
```

I suspect that this means that the first two relocations are silently not being done?

The other issue that I have, is that I haven't found a way to create a runtest that tests this.