### PR TITLE
Give accessors to `wasmtime::Trap` causes

### DIFF
--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -264,6 +264,16 @@ impl Trap {
         }
     }
 
+    /// Displays the error reason for this trap.
+    ///
+    /// In particular, it differs from this struct's `Display` by *only*
+    /// showing the reason, and not the full backtrace. This is useful to
+    /// customize the way the trap is reported, for instance to display a short
+    /// message for user-facing errors.
+    pub fn display_reason<'a>(&'a self) -> impl fmt::Display + 'a {
+        &self.inner.reason
+    }
+
     /// Returns a list of function frames in WebAssembly code that led to this
     /// trap happening.
     pub fn trace(&self) -> &[FrameInfo] {


### PR DESCRIPTION
It wasn't possible to just retrieve a user-created error description in `wasmtime::Trap` (i.e. created with `wasmtime::Trap::new("hi there")`). This user message would only show up as part of the full `Display` impl for `Trap`, which also prints out the unmangled backtrace and other information. A first commit adds a `user_message()` accessor to retrieve it, if it was set.

As I was trying to find another way to get a custom error message, I saw that `Trap` implemented `std::error::Error` if the trap was created from an `StdError`. Unfortunately, it doesn't give access to it directly either, but it gives access to the underlying `source()` of the error itself. It would be nice to have access to the error itself, to not lose one layer of error information. As a result, I've tweaked `source()` so it returns the error that was used to create the trap, and not the error's source directly. Conceptually it makes sense that the first source of the trap is the error that it was converted from, but it would also be reasonable to say that the trap *is* the error (so instead, we could just add another accessor to get the error). Discuss. :)