### PR TITLE
Change the injection count of fuel in a store from u32 to u64

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1606,7 +1606,7 @@ impl<T> Caller<'_, T> {
     ///
     /// For more information see
     /// [`Store::out_of_fuel_async_yield`](crate::Store::out_of_fuel_async_yield)
-    pub fn out_of_fuel_async_yield(&mut self, injection_count: u32, fuel_to_inject: u64) {
+    pub fn out_of_fuel_async_yield(&mut self, injection_count: u64, fuel_to_inject: u64) {
         self.store
             .out_of_fuel_async_yield(injection_count, fuel_to_inject)
     }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -178,7 +178,7 @@ struct StoreInstance {
 enum OutOfGas {
     Trap,
     InjectFuel {
-        injection_count: u32,
+        injection_count: u64,
         fuel_to_inject: u64,
     },
 }
@@ -558,7 +558,7 @@ impl<T> Store<T> {
     ///
     /// This method will panic if it is not called on a store associated with an [async
     /// config](crate::Config::async_support).
-    pub fn out_of_fuel_async_yield(&mut self, injection_count: u32, fuel_to_inject: u64) {
+    pub fn out_of_fuel_async_yield(&mut self, injection_count: u64, fuel_to_inject: u64) {
         self.inner
             .out_of_fuel_async_yield(injection_count, fuel_to_inject)
     }
@@ -655,7 +655,7 @@ impl<'a, T> StoreContextMut<'a, T> {
     /// runs out.
     ///
     /// For more information see [`Store::out_of_fuel_async_yield`]
-    pub fn out_of_fuel_async_yield(&mut self, injection_count: u32, fuel_to_inject: u64) {
+    pub fn out_of_fuel_async_yield(&mut self, injection_count: u64, fuel_to_inject: u64) {
         self.0
             .out_of_fuel_async_yield(injection_count, fuel_to_inject)
     }
@@ -838,7 +838,7 @@ impl StoreInnermost {
         self.out_of_gas_behavior = OutOfGas::Trap;
     }
 
-    fn out_of_fuel_async_yield(&mut self, injection_count: u32, fuel_to_inject: u64) {
+    fn out_of_fuel_async_yield(&mut self, injection_count: u64, fuel_to_inject: u64) {
         assert!(
             self.async_support(),
             "cannot use `out_of_fuel_async_yield` without enabling async support in the config"

--- a/examples/tokio/main.rs
+++ b/examples/tokio/main.rs
@@ -95,8 +95,8 @@ async fn run_wasm(inputs: Inputs) -> Result<(), Error> {
     let mut store = Store::new(&inputs.env.engine, wasi);
 
     // WebAssembly execution will be paused for an async yield every time it
-    // consumes 10000 fuel. Fuel will be refilled u32::MAX times.
-    store.out_of_fuel_async_yield(u32::MAX, 10000);
+    // consumes 10000 fuel. Fuel will be refilled u64::MAX times.
+    store.out_of_fuel_async_yield(u64::MAX, 10000);
 
     // Instantiate into our own unique store using the shared linker, afterwards
     // acquiring the `_start` function for the module and executing it.

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -392,7 +392,7 @@ fn iloop_with_fuel() {
 fn fuel_eventually_finishes() {
     let engine = Engine::new(Config::new().async_support(true).consume_fuel(true)).unwrap();
     let mut store = Store::new(&engine, ());
-    store.out_of_fuel_async_yield(u32::max_value(), 10);
+    store.out_of_fuel_async_yield(u64::max_value(), 10);
     let module = Module::new(
         &engine,
         "


### PR DESCRIPTION
This commit updates the type of the amount of times to inject fuel in
the `out_of_fuel_async_yield` to `u64` instead of `u32`. This should
allow effectively infinite fuel to get injected, even if a small amount
of fuel is injected per iteration.

Closes #2927
Closes #3046

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
