### PR TITLE
Port wasi-common from unsafe-io to io-lifetimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2021-07-13
+        toolchain: nightly-2021-07-12
 
     # Build C API documentation
     - run: sudo apt-get update -y && sudo apt-get install -y libclang1-9 libclang-cpp9
@@ -175,7 +175,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2021-07-13
+        toolchain: nightly-2021-07-12
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2021-04-11
+        toolchain: nightly-2021-07-13
 
     # Build C API documentation
     - run: sudo apt-get update -y && sudo apt-get install -y libclang1-9 libclang-cpp9
@@ -175,7 +175,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2021-04-11
+        toolchain: nightly-2021-07-13
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0612772f30c7c0f946a4248bcff6e71a2512c725f30f8c1e2ad8e796aa54d14"
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,31 +287,32 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.13.10"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3a1e32332db9ad29d6da34693ce9a7ac26a9edf96abb5c1788d193410031ab"
+checksum = "85890e8cdb89e266c160c459eb8fe6086df5ae0f442ad4a1e80257d379aef756"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustc_version",
- "unsafe-io",
+ "io-lifetimes",
+ "rustc_version 0.4.0",
  "winapi",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "0.13.10"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d253b74de50b097594462618e7dd17b93b3e3bef19f32d2e512996f9095661f"
+checksum = "43ab5acb88adba626ff5f1d8d14014cc3a38cdb17fde4510c62ed543efd7adf0"
 dependencies = [
+ "ambient-authority",
  "errno",
  "fs-set-times",
+ "io-lifetimes",
  "ipnet",
- "libc",
  "maybe-owned",
  "once_cell",
  "posish",
- "rustc_version",
+ "rustc_version 0.4.0",
  "unsafe-io",
  "winapi",
  "winapi-util",
@@ -314,30 +321,33 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.13.10"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458e98ed00e4276d0ac60da888d80957a177dfa7efa8dbb3be59f1e2b0e02ae5"
+checksum = "95673f68299fd98b188b6495b1dacf3a97fa676459435c08b553b2b3e03933d8"
 dependencies = [
+ "ambient-authority",
  "rand 0.8.3",
 ]
 
 [[package]]
 name = "cap-std"
-version = "0.13.10"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7019d48ea53c5f378e0fdab0fe5f627fc00e76d65e75dffd6fb1cbc0c9b382ee"
+checksum = "e9d4aab5331ede34897fe0a5e6b5329e664e33875b7118d63236652db2e96d04"
 dependencies = [
  "cap-primitives",
+ "io-lifetimes",
+ "ipnet",
  "posish",
- "rustc_version",
+ "rustc_version 0.4.0",
  "unsafe-io",
 ]
 
 [[package]]
 name = "cap-tempfile"
-version = "0.13.10"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1090f8597e39d10588664760f081edb5748562396a490a75615eafc99d1c8f"
+checksum = "d4dde73ca05bb33139945653649f64692d91a0aa409a5d0c1c6dd0eb2e8bf732"
 dependencies = [
  "cap-std",
  "rand 0.8.3",
@@ -346,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.13.10"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90585adeada7f804e6dcf71b8ff74217ad8742188fc870b9da5deab4722baa04"
+checksum = "975c4e86f1fd36da61ed68517961ca4c36ae954cb5522e54f792668a8ec04f31"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -382,7 +392,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
@@ -900,6 +910,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11a39d776a3b35896711da8a04dc1835169dcd36f710878187637314e47941b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,12 +1269,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f1ca01f517bba5770c067dc6c466d290b962e08214c8f2598db98d66087e55"
+checksum = "0d44f0304c28578c196cb438f08743f66bc675852724b0e1e40fff194a46b06f"
 dependencies = [
+ "io-lifetimes",
  "posish",
- "unsafe-io",
  "winapi",
 ]
 
@@ -1453,6 +1473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d009010297118b0a443fef912b92e3482e6e6f46ab31e5d60f68b39a553ca9"
+dependencies = [
+ "libc",
+ "rustc_version 0.4.0",
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,9 +1586,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1609,6 +1640,12 @@ dependencies = [
  "wasmparser",
  "wat",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0e0375b6446268ee5299c8e92f90030c719b8bb6fcc303a704080da790654"
 
 [[package]]
 name = "lock_api"
@@ -2164,15 +2201,20 @@ dependencies = [
 
 [[package]]
 name = "posish"
-version = "0.6.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1601f90b2342aaf3aadb891b71f584155d176b0e891bea92eeb11995e0ab25"
+checksum = "b1ae2d51d465d59b35ec50c8c525666692042181b1a9a093b1a1571163293ba1"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cc",
+ "cstr",
  "errno",
+ "io-lifetimes",
  "itoa",
  "libc",
+ "linux-raw-sys",
+ "once_cell",
+ "rustc_version 0.4.0",
  "unsafe-io",
 ]
 
@@ -2579,7 +2621,16 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.3",
 ]
 
 [[package]]
@@ -2643,6 +2694,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
@@ -2882,17 +2939,17 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a6aa8a77b9b8b533ec5a178ce0ea749c3a6cc6a79d0d38c89cd257dc4e34eb"
+checksum = "a58a74baa3466b49df60c6b8fb99b86b18369848f36ffe0f7f8a81800c05dc6b"
 dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
  "cap-std",
+ "io-lifetimes",
  "posish",
- "rustc_version",
- "unsafe-io",
+ "rustc_version 0.4.0",
  "winapi",
  "winx",
 ]
@@ -3192,11 +3249,12 @@ dependencies = [
 
 [[package]]
 name = "unsafe-io"
-version = "0.6.9"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f372ce89b46cb10aace91021ff03f26cf97594f7515c0a8c1c2839c13814665d"
+checksum = "afa405eddb270f365a62386dd1f5d0925f0c0df6921abf95eb1f5bc8519339b1"
 dependencies = [
- "rustc_version",
+ "io-lifetimes",
+ "rustc_version 0.3.3",
  "winapi",
 ]
 
@@ -3296,12 +3354,13 @@ dependencies = [
  "cap-std",
  "cap-time-ext",
  "fs-set-times",
+ "io-lifetimes",
  "lazy_static",
  "libc",
+ "posish",
  "system-interface",
  "tempfile",
  "tracing",
- "unsafe-io",
  "wasi-common",
  "winapi",
 ]
@@ -3314,6 +3373,7 @@ dependencies = [
  "bitflags",
  "cap-rand",
  "cap-std",
+ "io-lifetimes",
  "libc",
  "thiserror",
  "tracing",
@@ -3361,14 +3421,13 @@ dependencies = [
  "cap-tempfile",
  "cap-time-ext",
  "fs-set-times",
+ "io-lifetimes",
  "lazy_static",
- "libc",
  "posish",
  "system-interface",
  "tempfile",
  "tokio",
  "tracing",
- "unsafe-io",
  "wasi-cap-std-sync",
  "wasi-common",
  "wiggle",
@@ -3591,6 +3650,7 @@ dependencies = [
 name = "wasmtime-cli"
 version = "0.28.0"
 dependencies = [
+ "ambient-authority",
  "anyhow",
  "criterion",
  "env_logger 0.8.3",
@@ -3985,11 +4045,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdb79e12a5ac98f09e863b99c38c72f942a41f643ae0bb05d4d6d2633481341"
+checksum = "cc8ca6af61cfeed1e071b19f44cf4a7683addd863f28fef69cdf251bc034050e"
 dependencies = [
  "bitflags",
+ "io-lifetimes",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,7 +3606,6 @@ dependencies = [
 name = "wasmtime-cli"
 version = "0.28.0"
 dependencies = [
- "ambient-authority",
  "anyhow",
  "criterion",
  "env_logger 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "rustc_version 0.4.0",
+ "rustc_version",
  "winapi",
 ]
 
@@ -312,7 +312,7 @@ dependencies = [
  "maybe-owned",
  "once_cell",
  "posish",
- "rustc_version 0.4.0",
+ "rustc_version",
  "unsafe-io",
  "winapi",
  "winapi-util",
@@ -339,7 +339,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "posish",
- "rustc_version 0.4.0",
+ "rustc_version",
  "unsafe-io",
 ]
 
@@ -388,11 +388,11 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.3.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1479,7 +1479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78d009010297118b0a443fef912b92e3482e6e6f46ab31e5d60f68b39a553ca9"
 dependencies = [
  "libc",
- "rustc_version 0.4.0",
+ "rustc_version",
  "winapi",
 ]
 
@@ -2125,15 +2125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2205,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2616,20 +2607,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.3",
+ "semver",
 ]
 
 [[package]]
@@ -2687,27 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -2948,7 +2912,7 @@ dependencies = [
  "cap-std",
  "io-lifetimes",
  "posish",
- "rustc_version 0.4.0",
+ "rustc_version",
  "winapi",
  "winx",
 ]
@@ -3204,12 +3168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,7 +3211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56d1d7067d6e88dfdede7f668ea51800785fc8fcaf82d8fecdeaa678491e629"
 dependencies = [
  "io-lifetimes",
- "rustc_version 0.4.0",
+ "rustc_version",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "posish"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ae2d51d465d59b35ec50c8c525666692042181b1a9a093b1a1571163293ba1"
+checksum = "c9fd5be0a6fa79962a8e67f67bde3e08c47b21c7fa5b0e0efc3e4788dc952c3e"
 dependencies = [
  "bitflags",
  "cc",
@@ -3356,7 +3356,6 @@ dependencies = [
  "fs-set-times",
  "io-lifetimes",
  "lazy_static",
- "libc",
  "posish",
  "system-interface",
  "tempfile",
@@ -3374,7 +3373,7 @@ dependencies = [
  "cap-rand",
  "cap-std",
  "io-lifetimes",
- "libc",
+ "posish",
  "thiserror",
  "tracing",
  "wiggle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "posish"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fd5be0a6fa79962a8e67f67bde3e08c47b21c7fa5b0e0efc3e4788dc952c3e"
+checksum = "1763adf4e26429fd4e075fc46343f77da38d4c711b19f06943e506ce10d67270"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85890e8cdb89e266c160c459eb8fe6086df5ae0f442ad4a1e80257d379aef756"
+checksum = "0a43efcdd826967e3290b6a7ef739c1fc1d061fcba73f487716f4e579fc49160"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ab5acb88adba626ff5f1d8d14014cc3a38cdb17fde4510c62ed543efd7adf0"
+checksum = "06ebdaf00e31635731cb79a58d495f4e9566cfcf7f992774913209edc4a8400a"
 dependencies = [
  "ambient-authority",
  "errno",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95673f68299fd98b188b6495b1dacf3a97fa676459435c08b553b2b3e03933d8"
+checksum = "053048ae91b2a2243496e6cb1fc7fed999bd0996335899037b157ac1b2e5941b"
 dependencies = [
  "ambient-authority",
  "rand 0.8.3",
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d4aab5331ede34897fe0a5e6b5329e664e33875b7118d63236652db2e96d04"
+checksum = "dc0db75321794c647dc4a4288570db267263b2645c72a357f679ed537dc7a364"
 dependencies = [
  "cap-primitives",
  "io-lifetimes",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dde73ca05bb33139945653649f64692d91a0aa409a5d0c1c6dd0eb2e8bf732"
+checksum = "d9d897dd9bcb53f69b3613f3d317b4492a7f85c3eef950a59126b9f4f83c7d0e"
 dependencies = [
  "cap-std",
  "rand 0.8.3",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975c4e86f1fd36da61ed68517961ca4c36ae954cb5522e54f792668a8ec04f31"
+checksum = "f093889016cd7cea400030dd352557c61fd974b99c504f3a5cdc409f9d18b18b"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -1269,9 +1269,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d44f0304c28578c196cb438f08743f66bc675852724b0e1e40fff194a46b06f"
+checksum = "56af20dae05f9fae64574ead745ced5f08ae7dc6f42b9facd93a43d4b7adf982"
 dependencies = [
  "io-lifetimes",
  "posish",
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "posish"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1763adf4e26429fd4e075fc46343f77da38d4c711b19f06943e506ce10d67270"
+checksum = "2de73ab12ea55715a4217377e614fc2900f84e9366d1f5c0601fe2aa5e25fe86"
 dependencies = [
  "bitflags",
  "cc",
@@ -2215,7 +2215,6 @@ dependencies = [
  "linux-raw-sys",
  "once_cell",
  "rustc_version 0.4.0",
- "unsafe-io",
 ]
 
 [[package]]
@@ -2939,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58a74baa3466b49df60c6b8fb99b86b18369848f36ffe0f7f8a81800c05dc6b"
+checksum = "7adf9f33595b165d9d2897c548750a1141fc531a2492f7d365b71190c063e836"
 dependencies = [
  "atty",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,12 +3249,12 @@ dependencies = [
 
 [[package]]
 name = "unsafe-io"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa405eddb270f365a62386dd1f5d0925f0c0df6921abf95eb1f5bc8519339b1"
+checksum = "f56d1d7067d6e88dfdede7f668ea51800785fc8fcaf82d8fecdeaa678491e629"
 dependencies = [
  "io-lifetimes",
- "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rayon = "1.5.0"
 humantime = "2.0.0"
 wasmparser = "0.79.0"
 lazy_static = "1.4.0"
+ambient-authority = "0.0.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ rayon = "1.5.0"
 humantime = "2.0.0"
 wasmparser = "0.79.0"
 lazy_static = "1.4.0"
-ambient-authority = "0.0.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.15.2"
+cap-std = "0.16.0"
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.13"
+cap-std = "0.15.2"
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -244,13 +244,14 @@ pub extern "C" fn wasm_bench_create(
 ) -> ExitCode {
     let result = (|| -> Result<_> {
         let working_dir = config.working_dir()?;
-        let working_dir = unsafe { cap_std::fs::Dir::open_ambient_dir(&working_dir) }
-            .with_context(|| {
-                format!(
-                    "failed to preopen the working directory: {}",
-                    working_dir.display(),
-                )
-            })?;
+        let working_dir =
+            cap_std::fs::Dir::open_ambient_dir(&working_dir, cap_std::ambient_authority())
+                .with_context(|| {
+                    format!(
+                        "failed to preopen the working directory: {}",
+                        working_dir.display(),
+                    )
+                })?;
 
         let stdout_path = config.stdout_path()?;
         let stderr_path = config.stderr_path()?;
@@ -271,20 +272,20 @@ pub extern "C" fn wasm_bench_create(
 
                 let stdout = std::fs::File::create(&stdout_path)
                     .with_context(|| format!("failed to create {}", stdout_path.display()))?;
-                let stdout = unsafe { cap_std::fs::File::from_std(stdout) };
+                let stdout = cap_std::fs::File::from_std(stdout, cap_std::ambient_authority());
                 let stdout = wasi_cap_std_sync::file::File::from_cap_std(stdout);
                 cx = cx.stdout(Box::new(stdout));
 
                 let stderr = std::fs::File::create(&stderr_path)
                     .with_context(|| format!("failed to create {}", stderr_path.display()))?;
-                let stderr = unsafe { cap_std::fs::File::from_std(stderr) };
+                let stderr = cap_std::fs::File::from_std(stderr, cap_std::ambient_authority());
                 let stderr = wasi_cap_std_sync::file::File::from_cap_std(stderr);
                 cx = cx.stderr(Box::new(stderr));
 
                 if let Some(stdin_path) = &stdin_path {
                     let stdin = std::fs::File::open(stdin_path)
                         .with_context(|| format!("failed to open {}", stdin_path.display()))?;
-                    let stdin = unsafe { cap_std::fs::File::from_std(stdin) };
+                    let stdin = cap_std::fs::File::from_std(stdin, cap_std::ambient_authority());
                     let stdin = wasi_cap_std_sync::file::File::from_cap_std(stdin);
                     cx = cx.stdin(Box::new(stdin));
                 }

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -30,7 +30,7 @@ wat = { version = "1.0.36", optional = true }
 wasi-common = { path = "../wasi-common", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.15.2", optional = true }
+cap-std = { version = "0.16.0", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache']

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -30,7 +30,7 @@ wat = { version = "1.0.36", optional = true }
 wasi-common = { path = "../wasi-common", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.13", optional = true }
+cap-std = { version = "0.15.2", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache']

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -1,6 +1,7 @@
 //! The WASI embedding API definitions for Wasmtime.
 
 use anyhow::Result;
+use cap_std::ambient_authority;
 use std::ffi::CStr;
 use std::fs::File;
 use std::os::raw::{c_char, c_int};
@@ -69,21 +70,21 @@ impl wasi_config_t {
         if self.inherit_stdin {
             builder = builder.inherit_stdin();
         } else if let Some(file) = self.stdin {
-            let file = unsafe { cap_std::fs::File::from_std(file) };
+            let file = cap_std::fs::File::from_std(file, ambient_authority());
             let file = wasi_cap_std_sync::file::File::from_cap_std(file);
             builder = builder.stdin(Box::new(file));
         }
         if self.inherit_stdout {
             builder = builder.inherit_stdout();
         } else if let Some(file) = self.stdout {
-            let file = unsafe { cap_std::fs::File::from_std(file) };
+            let file = cap_std::fs::File::from_std(file, ambient_authority());
             let file = wasi_cap_std_sync::file::File::from_cap_std(file);
             builder = builder.stdout(Box::new(file));
         }
         if self.inherit_stderr {
             builder = builder.inherit_stderr();
         } else if let Some(file) = self.stderr {
-            let file = unsafe { cap_std::fs::File::from_std(file) };
+            let file = cap_std::fs::File::from_std(file, ambient_authority());
             let file = wasi_cap_std_sync::file::File::from_cap_std(file);
             builder = builder.stderr(Box::new(file));
         }
@@ -227,7 +228,7 @@ pub unsafe extern "C" fn wasi_config_preopen_dir(
     };
 
     let dir = match cstr_to_path(path) {
-        Some(p) => match Dir::open_ambient_dir(p) {
+        Some(p) => match Dir::open_ambient_dir(p, ambient_authority()) {
             Ok(d) => d,
             Err(_) => return false,
         },

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
-cap-std = "0.15.2"
+cap-std = "0.16.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
-cap-std = "0.13"
+cap-std = "0.15.2"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
@@ -46,7 +46,8 @@ fn run(
 
         if let Some(workspace) = workspace {
             println!("preopen: {:?}", workspace);
-            let preopen_dir = unsafe { cap_std::fs::Dir::open_ambient_dir(workspace) }?;
+            let preopen_dir =
+                cap_std::fs::Dir::open_ambient_dir(workspace, cap_std::ambient_authority())?;
             builder = builder.preopened_dir(preopen_dir, ".")?;
         }
         for (var, val) in super::test_suite_environment() {

--- a/crates/test-programs/tests/wasm_tests/runtime/tokio.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/tokio.rs
@@ -51,7 +51,8 @@ fn run(
 
             if let Some(workspace) = workspace {
                 println!("preopen: {:?}", workspace);
-                let preopen_dir = unsafe { cap_std::fs::Dir::open_ambient_dir(workspace) }?;
+                let preopen_dir =
+                    cap_std::fs::Dir::open_ambient_dir(workspace, cap_std::ambient_authority())?;
                 builder = builder.preopened_dir(preopen_dir, ".")?;
             }
 

--- a/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
+++ b/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
@@ -43,7 +43,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
         wasi::path_open(dir_fd, 0, "dir/nested/file\0", 0, 0, 0, 0)
             .expect_err("opening a file with a trailing NUL")
             .raw_error(),
-        wasi::ERRNO_INVAL
+        wasi::ERRNO_INVAL,
+        wasi::ERRNO_ILSEQ
     );
 
     // Now open it with a trailing slash.

--- a/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
+++ b/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
@@ -43,7 +43,7 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
         wasi::path_open(dir_fd, 0, "dir/nested/file\0", 0, 0, 0, 0)
             .expect_err("opening a file with a trailing NUL")
             .raw_error(),
-        wasi::ERRNO_ILSEQ
+        wasi::ERRNO_INVAL
     );
 
     // Now open it with a trailing slash.

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,13 +22,13 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "0.28.0" }
 tracing = "0.1.19"
-cap-std = "0.15.2"
-cap-rand = "0.15.2"
+cap-std = "0.16.0"
+cap-rand = "0.16.0"
 bitflags = "1.2"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-posish = "0.15.3"
+posish = "0.16.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = "1.2"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+posish = "0.15.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = "1.2"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-posish = "0.15.2"
+posish = "0.15.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,9 +22,10 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "0.28.0" }
 tracing = "0.1.19"
-cap-std = "0.13"
-cap-rand = "0.13"
+cap-std = "0.15.2"
+cap-rand = "0.15.2"
 bitflags = "1.2"
+io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -26,8 +26,7 @@ bitflags = "1.2"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
-posish = "0.15.1"
+posish = "0.15.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,18 +15,19 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "0.28.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.13.10"
-cap-fs-ext = "0.13.10"
-cap-time-ext = "0.13.10"
-cap-rand = "0.13.10"
-fs-set-times = "0.3.1"
-unsafe-io = "0.6.5"
-system-interface = { version = "0.6.4", features = ["cap_std_impls"] }
+cap-std = "0.15.2"
+cap-fs-ext = "0.15.2"
+cap-time-ext = "0.15.2"
+cap-rand = "0.15.2"
+fs-set-times = "0.5.1"
+system-interface = { version = "0.7.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
+io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+posish = "0.15.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,18 +15,18 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "0.28.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.15.2"
-cap-fs-ext = "0.15.2"
-cap-time-ext = "0.15.2"
-cap-rand = "0.15.2"
-fs-set-times = "0.5.1"
-system-interface = { version = "0.7.0", features = ["cap_std_impls"] }
+cap-std = "0.16.0"
+cap-fs-ext = "0.16.0"
+cap-time-ext = "0.16.0"
+cap-rand = "0.16.0"
+fs-set-times = "0.6.0"
+system-interface = { version = "0.8.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-posish = "0.15.3"
+posish = "0.16.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1.2"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-posish = "0.15.2"
+posish = "0.15.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/src/clocks.rs
+++ b/crates/wasi-common/cap-std-sync/src/clocks.rs
@@ -1,13 +1,13 @@
-use cap_std::ambient_authority;
 use cap_std::time::{Duration, Instant, SystemTime};
+use cap_std::{ambient_authority, AmbientAuthority};
 use cap_time_ext::{MonotonicClockExt, SystemClockExt};
 use wasi_common::clocks::{WasiClocks, WasiMonotonicClock, WasiSystemClock};
 
 pub struct SystemClock(cap_std::time::SystemClock);
 
 impl SystemClock {
-    pub unsafe fn new() -> Self {
-        SystemClock(cap_std::time::SystemClock::new(ambient_authority()))
+    pub fn new(ambient_authority: AmbientAuthority) -> Self {
+        SystemClock(cap_std::time::SystemClock::new(ambient_authority))
     }
 }
 impl WasiSystemClock for SystemClock {
@@ -21,8 +21,8 @@ impl WasiSystemClock for SystemClock {
 
 pub struct MonotonicClock(cap_std::time::MonotonicClock);
 impl MonotonicClock {
-    pub unsafe fn new() -> Self {
-        MonotonicClock(cap_std::time::MonotonicClock::new(ambient_authority()))
+    pub fn new(ambient_authority: AmbientAuthority) -> Self {
+        MonotonicClock(cap_std::time::MonotonicClock::new(ambient_authority))
     }
 }
 impl WasiMonotonicClock for MonotonicClock {
@@ -35,7 +35,7 @@ impl WasiMonotonicClock for MonotonicClock {
 }
 
 pub fn clocks_ctx() -> WasiClocks {
-    let system = Box::new(unsafe { SystemClock::new() });
+    let system = Box::new(SystemClock::new(ambient_authority()));
     let monotonic = cap_std::time::MonotonicClock::new(ambient_authority());
     let creation_time = monotonic.now();
     let monotonic = Box::new(MonotonicClock(monotonic));

--- a/crates/wasi-common/cap-std-sync/src/clocks.rs
+++ b/crates/wasi-common/cap-std-sync/src/clocks.rs
@@ -1,3 +1,4 @@
+use cap_std::ambient_authority;
 use cap_std::time::{Duration, Instant, SystemTime};
 use cap_time_ext::{MonotonicClockExt, SystemClockExt};
 use wasi_common::clocks::{WasiClocks, WasiMonotonicClock, WasiSystemClock};
@@ -6,7 +7,7 @@ pub struct SystemClock(cap_std::time::SystemClock);
 
 impl SystemClock {
     pub unsafe fn new() -> Self {
-        SystemClock(cap_std::time::SystemClock::new())
+        SystemClock(cap_std::time::SystemClock::new(ambient_authority()))
     }
 }
 impl WasiSystemClock for SystemClock {
@@ -21,7 +22,7 @@ impl WasiSystemClock for SystemClock {
 pub struct MonotonicClock(cap_std::time::MonotonicClock);
 impl MonotonicClock {
     pub unsafe fn new() -> Self {
-        MonotonicClock(cap_std::time::MonotonicClock::new())
+        MonotonicClock(cap_std::time::MonotonicClock::new(ambient_authority()))
     }
 }
 impl WasiMonotonicClock for MonotonicClock {
@@ -35,7 +36,7 @@ impl WasiMonotonicClock for MonotonicClock {
 
 pub fn clocks_ctx() -> WasiClocks {
     let system = Box::new(unsafe { SystemClock::new() });
-    let monotonic = unsafe { cap_std::time::MonotonicClock::new() };
+    let monotonic = cap_std::time::MonotonicClock::new(ambient_authority());
     let creation_time = monotonic.now();
     let monotonic = Box::new(MonotonicClock(monotonic));
     WasiClocks {

--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -37,12 +37,12 @@ pub mod file;
 pub mod sched;
 pub mod stdio;
 
+pub use cap_std::ambient_authority;
 pub use cap_std::fs::Dir;
 pub use clocks::clocks_ctx;
 pub use sched::sched_ctx;
 
 use cap_rand::RngCore;
-use cap_std::ambient_authority;
 use std::path::Path;
 use wasi_common::{table::Table, Error, WasiCtx, WasiFile};
 

--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -42,6 +42,7 @@ pub use clocks::clocks_ctx;
 pub use sched::sched_ctx;
 
 use cap_rand::RngCore;
+use cap_std::ambient_authority;
 use std::path::Path;
 use wasi_common::{table::Table, Error, WasiCtx, WasiFile};
 
@@ -123,5 +124,5 @@ impl WasiCtxBuilder {
 }
 
 pub fn random_ctx() -> Box<dyn RngCore + Send + Sync> {
-    Box::new(unsafe { cap_rand::rngs::OsRng::default() })
+    Box::new(cap_rand::rngs::OsRng::default(ambient_authority()))
 }

--- a/crates/wasi-common/cap-std-sync/src/sched/unix.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/unix.rs
@@ -1,7 +1,7 @@
 use cap_std::time::Duration;
-use io_lifetimes::AsFd;
+use io_lifetimes::{AsFd, BorrowedFd};
+use posish::io::{PollFd, PollFdVec, PollFlags};
 use std::convert::TryInto;
-use std::os::unix::io::{AsRawFd, RawFd};
 use wasi_common::{
     file::WasiFile,
     sched::{
@@ -11,27 +11,25 @@ use wasi_common::{
     Error, ErrorExt,
 };
 
-use poll::{PollFd, PollFlags};
-
 pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
     if poll.is_empty() {
         return Ok(());
     }
-    let mut pollfds = Vec::new();
+    let mut pollfds = PollFdVec::new();
     for s in poll.rw_subscriptions() {
         match s {
             Subscription::Read(f) => {
-                let raw_fd = wasi_file_raw_fd(f.file).ok_or(
+                let fd = wasi_file_fd(f.file).ok_or(
                     Error::invalid_argument().context("read subscription fd downcast failed"),
                 )?;
-                pollfds.push(unsafe { PollFd::new(raw_fd, PollFlags::POLLIN) });
+                pollfds.push(PollFd::from_borrowed_fd(fd, PollFlags::IN));
             }
 
             Subscription::Write(f) => {
-                let raw_fd = wasi_file_raw_fd(f.file).ok_or(
+                let fd = wasi_file_fd(f.file).ok_or(
                     Error::invalid_argument().context("write subscription fd downcast failed"),
                 )?;
-                pollfds.push(unsafe { PollFd::new(raw_fd, PollFlags::POLLOUT) });
+                pollfds.push(PollFd::from_borrowed_fd(fd, PollFlags::OUT));
             }
             Subscription::MonotonicClock { .. } => unreachable!(),
         }
@@ -44,46 +42,39 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
                 .try_into()
                 .map_err(|_| Error::overflow().context("poll timeout"))?
         } else {
-            libc::c_int::max_value()
+            std::os::raw::c_int::max_value()
         };
         tracing::debug!(
             poll_timeout = tracing::field::debug(poll_timeout),
             poll_fds = tracing::field::debug(&pollfds),
             "poll"
         );
-        match poll::poll(&mut pollfds, poll_timeout) {
+        match pollfds.poll(poll_timeout) {
             Ok(ready) => break ready,
-            Err(_) => {
-                let last_err = std::io::Error::last_os_error();
-                if last_err.raw_os_error().unwrap() == libc::EINTR {
-                    continue;
-                } else {
-                    return Err(last_err.into());
-                }
-            }
+            Err(posish::io::Error::INTR) => continue,
+            Err(err) => return Err(err.into()),
         }
     };
     if ready > 0 {
         for (rwsub, pollfd) in poll.rw_subscriptions().zip(pollfds.into_iter()) {
-            if let Some(revents) = pollfd.revents() {
-                let (nbytes, rwsub) = match rwsub {
-                    Subscription::Read(sub) => {
-                        let ready = sub.file.num_ready_bytes().await?;
-                        (std::cmp::max(ready, 1), sub)
-                    }
-                    Subscription::Write(sub) => (0, sub),
-                    _ => unreachable!(),
-                };
-                if revents.contains(PollFlags::POLLNVAL) {
-                    rwsub.error(Error::badf());
-                } else if revents.contains(PollFlags::POLLERR) {
-                    rwsub.error(Error::io());
-                } else if revents.contains(PollFlags::POLLHUP) {
-                    rwsub.complete(nbytes, RwEventFlags::HANGUP);
-                } else {
-                    rwsub.complete(nbytes, RwEventFlags::empty());
-                };
-            }
+            let revents = pollfd.revents();
+            let (nbytes, rwsub) = match rwsub {
+                Subscription::Read(sub) => {
+                    let ready = sub.file.num_ready_bytes().await?;
+                    (std::cmp::max(ready, 1), sub)
+                }
+                Subscription::Write(sub) => (0, sub),
+                _ => unreachable!(),
+            };
+            if revents.contains(PollFlags::NVAL) {
+                rwsub.error(Error::badf());
+            } else if revents.contains(PollFlags::ERR) {
+                rwsub.error(Error::io());
+            } else if revents.contains(PollFlags::HUP) {
+                rwsub.complete(nbytes, RwEventFlags::HANGUP);
+            } else {
+                rwsub.complete(nbytes, RwEventFlags::empty());
+            };
         }
     } else {
         poll.earliest_clock_deadline()
@@ -95,93 +86,17 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
     Ok(())
 }
 
-fn wasi_file_raw_fd(f: &dyn WasiFile) -> Option<RawFd> {
+fn wasi_file_fd(f: &dyn WasiFile) -> Option<BorrowedFd<'_>> {
     let a = f.as_any();
     if a.is::<crate::file::File>() {
-        Some(
-            a.downcast_ref::<crate::file::File>()
-                .unwrap()
-                .as_fd()
-                .as_raw_fd(),
-        )
+        Some(a.downcast_ref::<crate::file::File>().unwrap().as_fd())
     } else if a.is::<crate::stdio::Stdin>() {
-        Some(
-            a.downcast_ref::<crate::stdio::Stdin>()
-                .unwrap()
-                .as_fd()
-                .as_raw_fd(),
-        )
+        Some(a.downcast_ref::<crate::stdio::Stdin>().unwrap().as_fd())
     } else if a.is::<crate::stdio::Stdout>() {
-        Some(
-            a.downcast_ref::<crate::stdio::Stdout>()
-                .unwrap()
-                .as_fd()
-                .as_raw_fd(),
-        )
+        Some(a.downcast_ref::<crate::stdio::Stdout>().unwrap().as_fd())
     } else if a.is::<crate::stdio::Stderr>() {
-        Some(
-            a.downcast_ref::<crate::stdio::Stderr>()
-                .unwrap()
-                .as_fd()
-                .as_raw_fd(),
-        )
+        Some(a.downcast_ref::<crate::stdio::Stderr>().unwrap().as_fd())
     } else {
         None
-    }
-}
-
-mod poll {
-    use bitflags::bitflags;
-    use std::convert::TryInto;
-    use std::os::unix::io::RawFd;
-
-    bitflags! {
-        pub struct PollFlags: libc::c_short {
-            const POLLIN = libc::POLLIN;
-            const POLLPRI = libc::POLLPRI;
-            const POLLOUT = libc::POLLOUT;
-            const POLLRDNORM = libc::POLLRDNORM;
-            const POLLWRNORM = libc::POLLWRNORM;
-            const POLLRDBAND = libc::POLLRDBAND;
-            const POLLWRBAND = libc::POLLWRBAND;
-            const POLLERR = libc::POLLERR;
-            const POLLHUP = libc::POLLHUP;
-            const POLLNVAL = libc::POLLNVAL;
-        }
-    }
-
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    #[repr(C)]
-    pub struct PollFd(libc::pollfd);
-
-    impl PollFd {
-        pub unsafe fn new(fd: RawFd, events: PollFlags) -> Self {
-            Self(libc::pollfd {
-                fd,
-                events: events.bits(),
-                revents: PollFlags::empty().bits(),
-            })
-        }
-
-        pub fn revents(self) -> Option<PollFlags> {
-            PollFlags::from_bits(self.0.revents)
-        }
-    }
-
-    pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<usize, std::io::Error> {
-        let nready = unsafe {
-            libc::poll(
-                fds.as_mut_ptr() as *mut libc::pollfd,
-                fds.len() as libc::nfds_t,
-                timeout,
-            )
-        };
-        if nready == -1 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            // When poll doesn't fail, its return value is a non-negative int, which will
-            // always be convertable to usize, so we can unwrap() here.
-            Ok(nready.try_into().unwrap())
-        }
     }
 }

--- a/crates/wasi-common/cap-std-sync/src/sched/unix.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/unix.rs
@@ -1,4 +1,5 @@
 use cap_std::time::Duration;
+use io_lifetimes::AsFd;
 use std::convert::TryInto;
 use std::os::unix::io::{AsRawFd, RawFd};
 use wasi_common::{
@@ -97,19 +98,31 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
 fn wasi_file_raw_fd(f: &dyn WasiFile) -> Option<RawFd> {
     let a = f.as_any();
     if a.is::<crate::file::File>() {
-        Some(a.downcast_ref::<crate::file::File>().unwrap().as_raw_fd())
+        Some(
+            a.downcast_ref::<crate::file::File>()
+                .unwrap()
+                .as_fd()
+                .as_raw_fd(),
+        )
     } else if a.is::<crate::stdio::Stdin>() {
-        Some(a.downcast_ref::<crate::stdio::Stdin>().unwrap().as_raw_fd())
+        Some(
+            a.downcast_ref::<crate::stdio::Stdin>()
+                .unwrap()
+                .as_fd()
+                .as_raw_fd(),
+        )
     } else if a.is::<crate::stdio::Stdout>() {
         Some(
             a.downcast_ref::<crate::stdio::Stdout>()
                 .unwrap()
+                .as_fd()
                 .as_raw_fd(),
         )
     } else if a.is::<crate::stdio::Stderr>() {
         Some(
             a.downcast_ref::<crate::stdio::Stderr>()
                 .unwrap()
+                .as_fd()
                 .as_raw_fd(),
         )
     } else {

--- a/crates/wasi-common/cap-std-sync/src/sched/windows.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/windows.rs
@@ -9,6 +9,7 @@
 // taken the time to improve it. See bug #2880.
 
 use anyhow::Context;
+use io_lifetimes::AsHandle;
 use std::ops::Deref;
 use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
@@ -145,24 +146,28 @@ pub fn wasi_file_raw_handle(f: &dyn WasiFile) -> Option<RawHandle> {
         Some(
             a.downcast_ref::<crate::file::File>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else if a.is::<crate::stdio::Stdin>() {
         Some(
             a.downcast_ref::<crate::stdio::Stdin>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else if a.is::<crate::stdio::Stdout>() {
         Some(
             a.downcast_ref::<crate::stdio::Stdout>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else if a.is::<crate::stdio::Stderr>() {
         Some(
             a.downcast_ref::<crate::stdio::Stderr>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else {

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,18 +15,18 @@ wasi-common = { path = "../", version = "0.28.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "0.28.0" }
 wiggle = { path = "../../wiggle", version = "0.28.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.15.2"
-cap-fs-ext = "0.15.2"
-cap-time-ext = "0.15.2"
-fs-set-times = "0.5.1"
-system-interface = { version = "0.7.0", features = ["cap_std_impls"] }
+cap-std = "0.16.0"
+cap-fs-ext = "0.16.0"
+cap-time-ext = "0.16.0"
+fs-set-times = "0.6.0"
+system-interface = { version = "0.8.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 anyhow = "1"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-posish = "0.15.3"
+posish = "0.16.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
@@ -36,4 +36,4 @@ lazy_static = "1.4"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.15.2"
+cap-tempfile = "0.16.0"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = "1"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-posish = "0.15.2"
+posish = "0.15.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -26,8 +26,7 @@ anyhow = "1"
 io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-posish = "0.15.1"
-
+posish = "0.15.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,19 +15,18 @@ wasi-common = { path = "../", version = "0.28.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "0.28.0" }
 wiggle = { path = "../../wiggle", version = "0.28.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.13.7"
-cap-fs-ext = "0.13.7"
-cap-time-ext = "0.13.7"
-fs-set-times = "0.3.1"
-unsafe-io = "0.6.5"
-system-interface = { version = "0.6.4", features = ["cap_std_impls"] }
+cap-std = "0.15.2"
+cap-fs-ext = "0.15.2"
+cap-time-ext = "0.15.2"
+fs-set-times = "0.5.1"
+system-interface = { version = "0.7.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 anyhow = "1"
+io-lifetimes = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
-posish = "0.6.1"
+posish = "0.15.1"
 
 
 [target.'cfg(windows)'.dependencies]
@@ -38,4 +37,4 @@ lazy_static = "1.4"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.13.7"
+cap-tempfile = "0.15.2"

--- a/crates/wasi-common/tokio/src/dir.rs
+++ b/crates/wasi-common/tokio/src/dir.rs
@@ -126,13 +126,15 @@ impl WasiDir for Dir {
 #[cfg(test)]
 mod test {
     use super::Dir;
+    use cap_std::ambient_authority;
+
     #[tokio::test(flavor = "multi_thread")]
     async fn scratch_dir() {
         let tempdir = tempfile::Builder::new()
             .prefix("cap-std-sync")
             .tempdir()
             .expect("create temporary dir");
-        let preopen_dir = unsafe { cap_std::fs::Dir::open_ambient_dir(tempdir.path()) }
+        let preopen_dir = cap_std::fs::Dir::open_ambient_dir(tempdir.path(), ambient_authority())
             .expect("open ambient temporary dir");
         let preopen_dir = Dir::from_cap_std(preopen_dir);
         wasi_common::WasiDir::open_dir(&preopen_dir, false, ".")
@@ -165,7 +167,7 @@ mod test {
             .prefix("cap-std-sync")
             .tempdir()
             .expect("create temporary dir");
-        let preopen_dir = unsafe { cap_std::fs::Dir::open_ambient_dir(tempdir.path()) }
+        let preopen_dir = cap_std::fs::Dir::open_ambient_dir(tempdir.path(), ambient_authority())
             .expect("open ambient temporary dir");
         let preopen_dir = Dir::from_cap_std(preopen_dir);
 

--- a/crates/wasi-common/tokio/src/file.rs
+++ b/crates/wasi-common/tokio/src/file.rs
@@ -1,8 +1,12 @@
 use crate::block_on_dummy_executor;
+#[cfg(not(windows))]
+use io_lifetimes::AsFd;
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle};
 use std::any::Any;
 use std::io;
 #[cfg(windows)]
-use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::os::windows::io::RawHandle;
 use wasi_common::{
     file::{Advice, FdFlags, FileType, Filestat, WasiFile},
     Error,
@@ -118,9 +122,9 @@ macro_rules! wasi_file_impl {
                 // mutability to let it own the `Inner`, we are depending on the `&mut self` bound on this
                 // async method to ensure this is the only Future which can access the RawFd during the
                 // lifetime of the AsyncFd.
+                use std::os::unix::io::AsRawFd;
                 use tokio::io::{unix::AsyncFd, Interest};
-                use unsafe_io::os::posish::AsRawFd;
-                let rawfd = self.0.as_raw_fd();
+                let rawfd = self.0.as_fd().as_raw_fd();
                 match AsyncFd::with_interest(rawfd, Interest::READABLE) {
                     Ok(asyncfd) => {
                         let _ = asyncfd.readable().await?;
@@ -148,9 +152,9 @@ macro_rules! wasi_file_impl {
                 // mutability to let it own the `Inner`, we are depending on the `&mut self` bound on this
                 // async method to ensure this is the only Future which can access the RawFd during the
                 // lifetime of the AsyncFd.
+                use std::os::unix::io::AsRawFd;
                 use tokio::io::{unix::AsyncFd, Interest};
-                use unsafe_io::os::posish::AsRawFd;
-                let rawfd = self.0.as_raw_fd();
+                let rawfd = self.0.as_fd().as_raw_fd();
                 match AsyncFd::with_interest(rawfd, Interest::WRITABLE) {
                     Ok(asyncfd) => {
                         let _ = asyncfd.writable().await?;
@@ -172,9 +176,9 @@ macro_rules! wasi_file_impl {
             }
         }
         #[cfg(windows)]
-        impl AsRawHandle for $ty {
-            fn as_raw_handle(&self) -> RawHandle {
-                self.0.as_raw_handle()
+        impl AsHandle for $ty {
+            fn as_handle(&self) -> BorrowedHandle<'_> {
+                self.0.as_handle()
             }
         }
     };

--- a/crates/wasi-common/tokio/src/file.rs
+++ b/crates/wasi-common/tokio/src/file.rs
@@ -5,8 +5,6 @@ use io_lifetimes::AsFd;
 use io_lifetimes::{AsHandle, BorrowedHandle};
 use std::any::Any;
 use std::io;
-#[cfg(windows)]
-use std::os::windows::io::RawHandle;
 use wasi_common::{
     file::{Advice, FdFlags, FileType, Filestat, WasiFile},
     Error,

--- a/crates/wasi-common/tokio/src/sched/windows.rs
+++ b/crates/wasi-common/tokio/src/sched/windows.rs
@@ -1,4 +1,5 @@
 use crate::block_on_dummy_executor;
+use io_lifetimes::AsHandle;
 use std::os::windows::io::{AsRawHandle, RawHandle};
 use wasi_cap_std_sync::sched::windows::poll_oneoff_;
 use wasi_common::{file::WasiFile, sched::Poll, Error};
@@ -21,24 +22,28 @@ fn wasi_file_raw_handle(f: &dyn WasiFile) -> Option<RawHandle> {
         Some(
             a.downcast_ref::<crate::file::File>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else if a.is::<crate::stdio::Stdin>() {
         Some(
             a.downcast_ref::<crate::stdio::Stdin>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else if a.is::<crate::stdio::Stdout>() {
         Some(
             a.downcast_ref::<crate::stdio::Stdout>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else if a.is::<crate::stdio::Stderr>() {
         Some(
             a.downcast_ref::<crate::stdio::Stderr>()
                 .unwrap()
+                .as_handle()
                 .as_raw_handle(),
         )
     } else {

--- a/crates/wasi-common/tokio/tests/poll_oneoff.rs
+++ b/crates/wasi-common/tokio/tests/poll_oneoff.rs
@@ -14,7 +14,8 @@ const TIMEOUT: Duration = Duration::from_millis(200); // Required for slow execu
 async fn empty_file_readable() -> Result<(), Error> {
     let clocks = clocks_ctx();
 
-    let workspace = unsafe { cap_tempfile::tempdir().expect("create tempdir") };
+    let workspace =
+        cap_tempfile::tempdir(cap_tempfile::ambient_authority()).expect("create tempdir");
     workspace.create_dir("d").context("create dir")?;
     let d = workspace.open_dir("d").context("open dir")?;
     let d = Dir::from_cap_std(d);
@@ -66,7 +67,8 @@ async fn empty_file_readable() -> Result<(), Error> {
 async fn empty_file_writable() -> Result<(), Error> {
     let clocks = clocks_ctx();
 
-    let workspace = unsafe { cap_tempfile::tempdir().expect("create tempdir") };
+    let workspace =
+        cap_tempfile::tempdir(cap_tempfile::ambient_authority()).expect("create tempdir");
     workspace.create_dir("d").context("create dir")?;
     let d = workspace.open_dir("d").context("open dir")?;
     let d = Dir::from_cap_std(d);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,7 @@
 //! The module that implements the `wasmtime run` command.
 
 use crate::{CommonOptions, WasiModules};
+use ambient_authority::ambient_authority;
 use anyhow::{anyhow, bail, Context as _, Result};
 use std::thread;
 use std::time::Duration;
@@ -215,7 +216,7 @@ impl RunCommand {
         for dir in self.dirs.iter() {
             preopen_dirs.push((
                 dir.clone(),
-                unsafe { Dir::open_ambient_dir(dir) }
+                Dir::open_ambient_dir(dir, ambient_authority())
                     .with_context(|| format!("failed to open directory '{}'", dir))?,
             ));
         }
@@ -223,7 +224,7 @@ impl RunCommand {
         for (guest, host) in self.map_dirs.iter() {
             preopen_dirs.push((
                 guest.clone(),
-                unsafe { Dir::open_ambient_dir(host) }
+                Dir::open_ambient_dir(host, ambient_authority())
                     .with_context(|| format!("failed to open directory '{}'", host))?,
             ));
         }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,7 +1,6 @@
 //! The module that implements the `wasmtime run` command.
 
 use crate::{CommonOptions, WasiModules};
-use ambient_authority::ambient_authority;
 use anyhow::{anyhow, bail, Context as _, Result};
 use std::thread;
 use std::time::Duration;
@@ -12,7 +11,7 @@ use std::{
 };
 use structopt::{clap::AppSettings, StructOpt};
 use wasmtime::{Engine, Func, Linker, Module, Store, Trap, Val, ValType};
-use wasmtime_wasi::sync::{Dir, WasiCtxBuilder};
+use wasmtime_wasi::sync::{ambient_authority, Dir, WasiCtxBuilder};
 
 #[cfg(feature = "wasi-nn")]
 use wasmtime_wasi_nn::WasiNnCtx;


### PR DESCRIPTION
This ports wasi-common from unsafe-io to io-lifetimes.

Ambient authority is now indicated via calls to `ambient_authority()`
from the ambient-authority crate, rather than using `unsafe` blocks.

The `GetSetFdFlags::set_fd_flags` function is now split into two phases,
to simplify lifetimes in implementations which need to close and re-open
the underlying file.

And wasi-common no longer directly depends on `libc`. It now goes
through `posish` to do everything, which in particular simplifies the use
of `poll`.