### PR TITLE
Remove some dead code in Cranelift

### DIFF
--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -77,7 +77,6 @@ pub mod flowgraph;
 pub mod ir;
 pub mod isa;
 pub mod loop_analysis;
-pub mod machinst;
 pub mod print_errors;
 pub mod settings;
 pub mod timing;
@@ -85,6 +84,7 @@ pub mod verifier;
 pub mod write;
 
 pub use crate::entity::packed_option;
+pub use crate::machinst::buffer::MachSrcLoc;
 
 mod abi;
 mod bitset;
@@ -98,6 +98,7 @@ mod iterators;
 mod legalizer;
 mod licm;
 mod log;
+mod machinst;
 mod nan_canonicalization;
 mod partition_slice;
 mod postopt;

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -111,24 +111,6 @@ pub trait ABICallee {
     /// Get the address of a stackslot.
     fn stackslot_addr(&self, slot: StackSlot, offset: u32, into_reg: Writable<Reg>) -> Self::I;
 
-    /// Load from a stackslot.
-    fn load_stackslot(
-        &self,
-        slot: StackSlot,
-        offset: u32,
-        ty: Type,
-        into_reg: ValueRegs<Writable<Reg>>,
-    ) -> SmallInstVec<Self::I>;
-
-    /// Store to a stackslot.
-    fn store_stackslot(
-        &self,
-        slot: StackSlot,
-        offset: u32,
-        ty: Type,
-        from_reg: ValueRegs<Reg>,
-    ) -> SmallInstVec<Self::I>;
-
     /// Load from a spillslot.
     fn load_spillslot(
         &self,

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -1157,38 +1157,6 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         self.clobbered = clobbered;
     }
 
-    /// Load from a stackslot.
-    fn load_stackslot(
-        &self,
-        slot: StackSlot,
-        offset: u32,
-        ty: Type,
-        into_regs: ValueRegs<Writable<Reg>>,
-    ) -> SmallInstVec<Self::I> {
-        // Offset from beginning of stackslot area, which is at nominal SP (see
-        // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
-        let stack_off = self.stackslots[slot] as i64;
-        let sp_off: i64 = stack_off + (offset as i64);
-        trace!("load_stackslot: slot {} -> sp_off {}", slot, sp_off);
-        gen_load_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), into_regs, ty)
-    }
-
-    /// Store to a stackslot.
-    fn store_stackslot(
-        &self,
-        slot: StackSlot,
-        offset: u32,
-        ty: Type,
-        from_regs: ValueRegs<Reg>,
-    ) -> SmallInstVec<Self::I> {
-        // Offset from beginning of stackslot area, which is at nominal SP (see
-        // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
-        let stack_off = self.stackslots[slot] as i64;
-        let sp_off: i64 = stack_off + (offset as i64);
-        trace!("store_stackslot: slot {} -> sp_off {}", slot, sp_off);
-        gen_store_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), from_regs, ty)
-    }
-
     /// Produce an instruction that computes a stackslot address.
     fn stackslot_addr(&self, slot: StackSlot, offset: u32, into_reg: Writable<Reg>) -> Self::I {
         // Offset from beginning of stackslot area, which is at nominal SP (see

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -420,24 +420,10 @@ impl BlockLoweringOrder {
         &self.lowered_order[..]
     }
 
-    /// Get the successors for a lowered block, by index in `lowered_order()`'s
-    /// returned slice. Each successsor is paired with the edge-instruction
-    /// (branch) corresponding to this edge.
-    pub fn succs(&self, block: BlockIndex) -> &[(Inst, LoweredBlock)] {
-        let range = self.lowered_succ_ranges[block as usize];
-        &self.lowered_succs[range.0..range.1]
-    }
-
     /// Get the successor indices for a lowered block.
     pub fn succ_indices(&self, block: BlockIndex) -> &[(Inst, BlockIndex)] {
         let range = self.lowered_succ_ranges[block as usize];
         &self.lowered_succ_indices[range.0..range.1]
-    }
-
-    /// Get the lowered block index containing a CLIF block, if any. (May not be
-    /// present if the original CLIF block was unreachable.)
-    pub fn lowered_block_for_bb(&self, bb: Block) -> Option<BlockIndex> {
-        self.orig_map[bb]
     }
 }
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -41,8 +41,6 @@ use std::string::String;
 pub type InsnIndex = u32;
 /// Index referring to a basic block in VCode.
 pub type BlockIndex = u32;
-/// Range of an instructions in VCode.
-pub type InsnRange = core::ops::Range<InsnIndex>;
 
 /// VCodeInst wraps all requirements for a MachInst to be in VCode: it must be
 /// a `MachInst` and it must be able to emit itself at least to a `SizeCodeSink`.
@@ -207,11 +205,6 @@ impl<I: VCodeInst> VCodeBuilder<I> {
         }
     }
 
-    /// Are there any reference-typed values at all among the vregs?
-    pub fn have_ref_values(&self) -> bool {
-        self.vcode.have_ref_values()
-    }
-
     /// Set the current block as the entry block.
     pub fn set_entry(&mut self, block: BlockIndex) {
         self.vcode.entry = block;
@@ -262,11 +255,6 @@ impl<I: VCodeInst> VCodeBuilder<I> {
                 .safepoint_insns
                 .push(InstIx::new((self.vcode.insts.len() - 1) as u32));
         }
-    }
-
-    /// Get the current source location.
-    pub fn get_srcloc(&self) -> SourceLoc {
-        self.cur_srcloc
     }
 
     /// Set the current source location.
@@ -344,16 +332,6 @@ impl<I: VCodeInst> VCode<I> {
         self.vreg_types[vreg.get_index()]
     }
 
-    /// Are there any reference-typed values at all among the vregs?
-    pub fn have_ref_values(&self) -> bool {
-        self.have_ref_values
-    }
-
-    /// Get the entry block.
-    pub fn entry(&self) -> BlockIndex {
-        self.entry
-    }
-
     /// Get the number of blocks. Block indices will be in the range `0 ..
     /// (self.num_blocks() - 1)`.
     pub fn num_blocks(&self) -> usize {
@@ -363,11 +341,6 @@ impl<I: VCodeInst> VCode<I> {
     /// Stack frame size for the full function's body.
     pub fn frame_size(&self) -> u32 {
         self.abi.frame_size()
-    }
-
-    /// Inbound stack-args size.
-    pub fn stack_args_size(&self) -> u32 {
-        self.abi.stack_args_size()
     }
 
     /// Get the successors for a block.
@@ -884,11 +857,6 @@ impl VCodeConstants {
                 }
             }
         }
-    }
-
-    /// Retrieve a byte slice for the given [VCodeConstant], if available.
-    pub fn get(&self, constant: VCodeConstant) -> Option<&[u8]> {
-        self.constants.get(constant).map(|d| d.as_slice())
     }
 
     /// Return the number of constants inserted.

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -91,8 +91,8 @@
 use crate::func_environ::{get_func_name, FuncEnvironment};
 use cranelift_codegen::ir::{self, ExternalName};
 use cranelift_codegen::isa::{CallConv, TargetIsa};
-use cranelift_codegen::machinst::buffer::MachSrcLoc;
 use cranelift_codegen::print_errors::pretty_error;
+use cranelift_codegen::MachSrcLoc;
 use cranelift_codegen::{binemit, isa, Context};
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex, FuncTranslator, SignatureIndex, WasmType};
 use std::convert::TryFrom;


### PR DESCRIPTION
Trying to mark a few modules as internal showed that some code as actually unused. This might not be removing *all* the dead code there is in Cranelift, but it's some I've identified a few weeks ago.