### PR TITLE
aarch64: Fix incorrect encoding of large const values in icmp.

### DIFF
--- a/cranelift/filetests/filetests/runtests/icmp.clif
+++ b/cranelift/filetests/filetests/runtests/icmp.clif
@@ -1,0 +1,17 @@
+test run
+target aarch64
+target s390x
+target x86_64 machinst
+
+; This test is also a regression test for aarch64.
+; We were not correctly handling the fact that the rhs constant value
+; overflows its type when viewed as a signed value, and thus encoding the wrong
+; value into the resulting instruction.
+function %overflow_rhs_const(i8) -> b1 {
+block0(v0: i8):
+    v1 = iconst.i8 192
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %test(49) == true
+; run: %test(-65) == false


### PR DESCRIPTION
When encoding constants as immediates into an RSE Imm12 instruction we need to take special care to check if the value that we are trying to input does not overflow its type when viewed as a signed value. (i.e. iconst.i8 200)

We cannot both put an immediate and sign extend it, so we need to lower it into a separate reg, and emit the sign extend into the instruction.

For more details see the [cg_clif bug report](https://github.com/bjorn3/rustc_codegen_cranelift/issues/1184#issuecomment-873214796).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
