### PR TITLE
Fix error messages reporting number of expected vs actual params

### DIFF
--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -347,17 +347,23 @@ macro_rules! impl_wasm_params {
 
             fn typecheck(mut params: impl ExactSizeIterator<Item = crate::ValType>) -> Result<()> {
                 let mut _n = 0;
+
                 $(
                     match params.next() {
-                        Some(t) => $t::typecheck(t)?,
-                        None => bail!("expected {} types, found {}", $n, _n),
+                        Some(t) => {
+                            _n += 1;
+                            $t::typecheck(t)?
+                        },
+                        None => bail!("expected {} types, found {}", $n, params.len() + _n),
                     }
-                    _n += 1;
                 )*
 
                 match params.next() {
                     None => Ok(()),
-                    Some(_) => bail!("expected {} types, found {}", $n, params.len() + _n),
+                    Some(_) => {
+                        _n += 1;
+                        bail!("expected {} types, found {}", $n, params.len() + _n)
+                    },
                 }
             }
 


### PR DESCRIPTION
We previously had some off-by-one errors in our error messages and this led to
very confusing messages like "expected 0 types, found 0" that were quite
annoying to debug as an API consumer.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
