### PR TITLE
Upgrade Tokio to 1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",
@@ -3027,6 +3027,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tempfile = "3.1.0"
 test-programs = { path = "crates/test-programs" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
 wasmtime-runtime = { path = "crates/runtime" }
-tokio = { version = "1.5.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
+tokio = { version = "1.8.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
 tracing-subscriber = "0.2.16"
 wast = "36.0.0"
 criterion = "0.3.4"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -22,7 +22,7 @@ os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
 cap-std = "0.13"
-tokio = { version = "1.5.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]
 test_programs = []

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "LICENSE" ]
 wasi-common = { path = "../", version = "0.28.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "0.28.0" }
 wiggle = { path = "../../wiggle", version = "0.28.0" }
-tokio = { version = "1.5.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
+tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
 cap-std = "0.13.7"
 cap-fs-ext = "0.13.7"
 cap-time-ext = "0.13.7"
@@ -36,6 +36,6 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 tempfile = "3.1.0"
-tokio = { version = "1.5.0", features = [ "macros" ] }
+tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
 cap-tempfile = "0.13.7"


### PR DESCRIPTION
This contains a fix for a vulnerability reported as RUSTSEC-2021-0072.