### PR TITLE
Enable simd_extmul_* for AArch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -225,7 +225,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             // These are new instructions that are not really implemented in any backend.
             ("simd", "simd_i16x8_extadd_pairwise_i8x16")
             | ("simd", "simd_i32x4_extadd_pairwise_i16x8") => return true,
-
             _ => {}
         },
         _ => panic!("unrecognized strategy"),

--- a/build.rs
+++ b/build.rs
@@ -225,6 +225,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             // These are new instructions that are not really implemented in any backend.
             ("simd", "simd_i16x8_extadd_pairwise_i8x16")
             | ("simd", "simd_i32x4_extadd_pairwise_i16x8") => return true,
+
             _ => {}
         },
         _ => panic!("unrecognized strategy"),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -287,13 +287,21 @@ fn enc_vec_rrr(top11: u32, rm: Reg, bit15_10: u32, rn: Reg, rd: Writable<Reg>) -
         | machreg_to_vec(rd.to_reg())
 }
 
-fn enc_vec_rrr_long(q: u32, u: u32, size: u32, bit14: u32, rm: Reg, rn: Reg, rd: Writable<Reg>) -> u32 {
-  debug_assert_eq!(q & 0b1, q);
-  debug_assert_eq!(u & 0b1, u);
-  debug_assert_eq!(size & 0b11, size);
-  debug_assert_eq!(bit14 & 0b1, bit14);
+fn enc_vec_rrr_long(
+    q: u32,
+    u: u32,
+    size: u32,
+    bit14: u32,
+    rm: Reg,
+    rn: Reg,
+    rd: Writable<Reg>,
+) -> u32 {
+    debug_assert_eq!(q & 0b1, q);
+    debug_assert_eq!(u & 0b1, u);
+    debug_assert_eq!(size & 0b11, size);
+    debug_assert_eq!(bit14 & 0b1, bit14);
 
-  0b0_0_0_01110_00_1_00000_100000_00000_00000
+    0b0_0_0_01110_00_1_00000_100000_00000_00000
         | q << 30
         | u << 29
         | size << 22
@@ -2207,7 +2215,15 @@ impl MachInstEmit for Inst {
                     VecRRRLongOp::Umlal16 => (0b1, 0b01, 0b0),
                     VecRRRLongOp::Umlal32 => (0b1, 0b10, 0b0),
                 };
-                sink.put4(enc_vec_rrr_long(high_half as u32, u, size, bit14, rm, rn, rd));
+                sink.put4(enc_vec_rrr_long(
+                    high_half as u32,
+                    u,
+                    size,
+                    bit14,
+                    rm,
+                    rn,
+                    rd,
+                ));
             }
             &Inst::VecRRR {
                 rd,
@@ -2289,9 +2305,9 @@ impl MachInstEmit for Inst {
                     }
                 };
                 let top11 = if is_float {
-                  top11 | enc_float_size << 1
+                    top11 | enc_float_size << 1
                 } else {
-                  top11
+                    top11
                 };
                 sink.put4(enc_vec_rrr(top11 | q << 9, rm, bit15_10, rn, rd));
             }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -287,6 +287,22 @@ fn enc_vec_rrr(top11: u32, rm: Reg, bit15_10: u32, rn: Reg, rd: Writable<Reg>) -
         | machreg_to_vec(rd.to_reg())
 }
 
+fn enc_vec_rrr_long(q: u32, u: u32, size: u32, bit14: u32, rm: Reg, rn: Reg, rd: Writable<Reg>) -> u32 {
+  debug_assert_eq!(q & 0b1, q);
+  debug_assert_eq!(u & 0b1, u);
+  debug_assert_eq!(size & 0b11, size);
+  debug_assert_eq!(bit14 & 0b1, bit14);
+
+  0b0_0_0_01110_00_1_00000_100000_00000_00000
+        | q << 30
+        | u << 29
+        | size << 22
+        | bit14 << 14
+        | (machreg_to_vec(rm) << 16)
+        | (machreg_to_vec(rn) << 5)
+        | machreg_to_vec(rd.to_reg())
+}
+
 fn enc_bit_rr(size: u32, opcode2: u32, opcode1: u32, rn: Reg, rd: Writable<Reg>) -> u32 {
     (0b01011010110 << 21)
         | size << 31
@@ -2173,6 +2189,26 @@ impl MachInstEmit for Inst {
 
                 sink.put4(enc_vec_rr_pair(bits_12_16, rd, rn));
             }
+            &Inst::VecRRRLong {
+                rd,
+                rn,
+                rm,
+                alu_op,
+                high_half,
+            } => {
+                let (u, size, bit14) = match alu_op {
+                    VecRRRLongOp::Smull8 => (0b0, 0b00, 0b1),
+                    VecRRRLongOp::Smull16 => (0b0, 0b01, 0b1),
+                    VecRRRLongOp::Smull32 => (0b0, 0b10, 0b1),
+                    VecRRRLongOp::Umull8 => (0b1, 0b00, 0b1),
+                    VecRRRLongOp::Umull16 => (0b1, 0b01, 0b1),
+                    VecRRRLongOp::Umull32 => (0b1, 0b10, 0b1),
+                    VecRRRLongOp::Umlal8 => (0b1, 0b00, 0b0),
+                    VecRRRLongOp::Umlal16 => (0b1, 0b01, 0b0),
+                    VecRRRLongOp::Umlal32 => (0b1, 0b10, 0b0),
+                };
+                sink.put4(enc_vec_rrr_long(high_half as u32, u, size, bit14, rm, rn, rd));
+            }
             &Inst::VecRRR {
                 rd,
                 rn,
@@ -2242,13 +2278,7 @@ impl MachInstEmit for Inst {
                     VecALUOp::Fmin => (0b000_01110_10_1, 0b111101),
                     VecALUOp::Fmul => (0b001_01110_00_1, 0b110111),
                     VecALUOp::Addp => (0b000_01110_00_1 | enc_size << 1, 0b101111),
-                    VecALUOp::Umlal => {
-                        debug_assert!(!size.is_128bits());
-                        (0b001_01110_00_1 | enc_size << 1, 0b100000)
-                    }
                     VecALUOp::Zip1 => (0b01001110_00_0 | enc_size << 1, 0b001110),
-                    VecALUOp::Smull => (0b000_01110_00_1 | enc_size << 1, 0b110000),
-                    VecALUOp::Smull2 => (0b010_01110_00_1 | enc_size << 1, 0b110000),
                     VecALUOp::Sqrdmulh => {
                         debug_assert!(
                             size.lane_size() == ScalarSize::Size16
@@ -2258,12 +2288,12 @@ impl MachInstEmit for Inst {
                         (0b001_01110_00_1 | enc_size << 1, 0b101101)
                     }
                 };
-                let top11 = match alu_op {
-                    VecALUOp::Smull | VecALUOp::Smull2 => top11,
-                    _ if is_float => top11 | (q << 9) | enc_float_size << 1,
-                    _ => top11 | (q << 9),
+                let top11 = if is_float {
+                  top11 | enc_float_size << 1
+                } else {
+                  top11
                 };
-                sink.put4(enc_vec_rrr(top11, rm, bit15_10, rn, rd));
+                sink.put4(enc_vec_rrr(top11 | q << 9, rm, bit15_10, rn, rd));
             }
             &Inst::VecLoadReplicate { rd, rn, size } => {
                 let (q, size) = size.enc_size();

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -3705,7 +3705,7 @@ fn test_aarch64_binemit() {
             rd: writable_vreg(16),
             rn: vreg(12),
             rm: vreg(1),
-            high_half: false
+            high_half: false,
         },
         "90C1210E",
         "smull v16.8h, v12.8b, v1.8b",
@@ -3717,7 +3717,7 @@ fn test_aarch64_binemit() {
             rd: writable_vreg(15),
             rn: vreg(11),
             rm: vreg(2),
-            high_half: false
+            high_half: false,
         },
         "6FC1222E",
         "umull v15.8h, v11.8b, v2.8b",
@@ -3729,7 +3729,7 @@ fn test_aarch64_binemit() {
             rd: writable_vreg(4),
             rn: vreg(8),
             rm: vreg(16),
-            high_half: false
+            high_half: false,
         },
         "0481302E",
         "umlal v4.8h, v8.8b, v16.8b",

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -3653,18 +3653,6 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::VecRRR {
-            alu_op: VecALUOp::Umlal,
-            rd: writable_vreg(9),
-            rn: vreg(20),
-            rm: vreg(17),
-            size: VectorSize::Size32x2,
-        },
-        "8982B12E",
-        "umlal v9.2d, v20.2s, v17.2s",
-    ));
-
-    insns.push((
-        Inst::VecRRR {
             alu_op: VecALUOp::Zip1,
             rd: writable_vreg(16),
             rn: vreg(12),
@@ -3712,75 +3700,219 @@ fn test_aarch64_binemit() {
     ));
 
     insns.push((
-        Inst::VecRRR {
-            alu_op: VecALUOp::Smull,
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Smull8,
             rd: writable_vreg(16),
             rn: vreg(12),
             rm: vreg(1),
-            size: VectorSize::Size8x16,
+            high_half: false
         },
         "90C1210E",
         "smull v16.8h, v12.8b, v1.8b",
     ));
 
     insns.push((
-        Inst::VecRRR {
-            alu_op: VecALUOp::Smull,
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umull8,
+            rd: writable_vreg(15),
+            rn: vreg(11),
+            rm: vreg(2),
+            high_half: false
+        },
+        "6FC1222E",
+        "umull v15.8h, v11.8b, v2.8b",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umlal8,
+            rd: writable_vreg(4),
+            rn: vreg(8),
+            rm: vreg(16),
+            high_half: false
+        },
+        "0481302E",
+        "umlal v4.8h, v8.8b, v16.8b",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Smull16,
             rd: writable_vreg(2),
             rn: vreg(13),
             rm: vreg(6),
-            size: VectorSize::Size16x8,
+            high_half: false,
         },
         "A2C1660E",
         "smull v2.4s, v13.4h, v6.4h",
     ));
 
     insns.push((
-        Inst::VecRRR {
-            alu_op: VecALUOp::Smull,
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umull16,
+            rd: writable_vreg(3),
+            rn: vreg(14),
+            rm: vreg(7),
+            high_half: false,
+        },
+        "C3C1672E",
+        "umull v3.4s, v14.4h, v7.4h",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umlal16,
+            rd: writable_vreg(7),
+            rn: vreg(14),
+            rm: vreg(21),
+            high_half: false,
+        },
+        "C781752E",
+        "umlal v7.4s, v14.4h, v21.4h",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Smull32,
             rd: writable_vreg(8),
             rn: vreg(12),
             rm: vreg(14),
-            size: VectorSize::Size32x4,
+            high_half: false,
         },
         "88C1AE0E",
         "smull v8.2d, v12.2s, v14.2s",
     ));
 
     insns.push((
-        Inst::VecRRR {
-            alu_op: VecALUOp::Smull2,
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umull32,
+            rd: writable_vreg(9),
+            rn: vreg(5),
+            rm: vreg(6),
+            high_half: false,
+        },
+        "A9C0A62E",
+        "umull v9.2d, v5.2s, v6.2s",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umlal32,
+            rd: writable_vreg(9),
+            rn: vreg(20),
+            rm: vreg(17),
+            high_half: false,
+        },
+        "8982B12E",
+        "umlal v9.2d, v20.2s, v17.2s",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Smull8,
             rd: writable_vreg(16),
             rn: vreg(12),
             rm: vreg(1),
-            size: VectorSize::Size8x16,
+            high_half: true,
         },
         "90C1214E",
         "smull2 v16.8h, v12.16b, v1.16b",
     ));
 
     insns.push((
-        Inst::VecRRR {
-            alu_op: VecALUOp::Smull2,
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umull8,
+            rd: writable_vreg(29),
+            rn: vreg(22),
+            rm: vreg(10),
+            high_half: true,
+        },
+        "DDC22A6E",
+        "umull2 v29.8h, v22.16b, v10.16b",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umlal8,
+            rd: writable_vreg(1),
+            rn: vreg(5),
+            rm: vreg(15),
+            high_half: true,
+        },
+        "A1802F6E",
+        "umlal2 v1.8h, v5.16b, v15.16b",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Smull16,
             rd: writable_vreg(2),
             rn: vreg(13),
             rm: vreg(6),
-            size: VectorSize::Size16x8,
+            high_half: true,
         },
         "A2C1664E",
         "smull2 v2.4s, v13.8h, v6.8h",
     ));
 
     insns.push((
-        Inst::VecRRR {
-            alu_op: VecALUOp::Smull2,
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umull16,
+            rd: writable_vreg(19),
+            rn: vreg(18),
+            rm: vreg(17),
+            high_half: true,
+        },
+        "53C2716E",
+        "umull2 v19.4s, v18.8h, v17.8h",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umlal16,
+            rd: writable_vreg(11),
+            rn: vreg(10),
+            rm: vreg(12),
+            high_half: true,
+        },
+        "4B816C6E",
+        "umlal2 v11.4s, v10.8h, v12.8h",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Smull32,
             rd: writable_vreg(8),
             rn: vreg(12),
             rm: vreg(14),
-            size: VectorSize::Size32x4,
+            high_half: true,
         },
         "88C1AE4E",
         "smull2 v8.2d, v12.4s, v14.4s",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umull32,
+            rd: writable_vreg(4),
+            rn: vreg(12),
+            rm: vreg(16),
+            high_half: true,
+        },
+        "84C1B06E",
+        "umull2 v4.2d, v12.4s, v16.4s",
+    ));
+
+    insns.push((
+        Inst::VecRRRLong {
+            alu_op: VecRRRLongOp::Umlal32,
+            rd: writable_vreg(10),
+            rn: vreg(29),
+            rm: vreg(2),
+            high_half: true,
+        },
+        "AA83A26E",
+        "umlal2 v10.2d, v29.4s, v2.4s",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -412,7 +412,6 @@ pub enum VecRRRLongOp {
     Umlal32,
 }
 
-
 /// A vector operation on a pair of elements with one register.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum VecPairOp {
@@ -2159,9 +2158,9 @@ fn aarch64_get_regs(inst: &Inst, collector: &mut RegUsageCollector) {
             alu_op, rd, rn, rm, ..
         } => {
             match alu_op {
-                VecRRRLongOp::Umlal8
-                | VecRRRLongOp::Umlal16
-                | VecRRRLongOp::Umlal32 => collector.add_mod(rd),
+                VecRRRLongOp::Umlal8 | VecRRRLongOp::Umlal16 | VecRRRLongOp::Umlal32 => {
+                    collector.add_mod(rd)
+                }
                 _ => collector.add_def(rd),
             };
             collector.add_use(rn);
@@ -2985,9 +2984,9 @@ fn aarch64_map_regs<RUM: RegUsageMapper>(inst: &mut Inst, mapper: &RUM) {
             ..
         } => {
             match alu_op {
-                VecRRRLongOp::Umlal8
-                | VecRRRLongOp::Umlal16
-                | VecRRRLongOp::Umlal32 => map_mod(mapper, rd),
+                VecRRRLongOp::Umlal8 | VecRRRLongOp::Umlal16 | VecRRRLongOp::Umlal32 => {
+                    map_mod(mapper, rd)
+                }
                 _ => map_def(mapper, rd),
             };
             map_use(mapper, rn);
@@ -4212,42 +4211,60 @@ impl Inst {
                 high_half,
             } => {
                 let (op, dest_size, src_size) = match (alu_op, high_half) {
-                    (VecRRRLongOp::Smull8, false) =>
-                        ("smull", VectorSize::Size16x8, VectorSize::Size8x8),
-                    (VecRRRLongOp::Smull8, true) =>
-                        ("smull2", VectorSize::Size16x8, VectorSize::Size8x16),
-                    (VecRRRLongOp::Smull16, false) =>
-                        ("smull", VectorSize::Size32x4, VectorSize::Size16x4),
-                    (VecRRRLongOp::Smull16, true) =>
-                        ("smull2", VectorSize::Size32x4, VectorSize::Size16x8),
-                    (VecRRRLongOp::Smull32, false) =>
-                        ("smull", VectorSize::Size64x2, VectorSize::Size32x2),
-                    (VecRRRLongOp::Smull32, true) =>
-                        ("smull2", VectorSize::Size64x2, VectorSize::Size32x4),
-                    (VecRRRLongOp::Umull8, false) =>
-                        ("umull", VectorSize::Size16x8, VectorSize::Size8x8),
-                    (VecRRRLongOp::Umull8, true) =>
-                        ("umull2", VectorSize::Size16x8, VectorSize::Size8x16),
-                    (VecRRRLongOp::Umull16, false) =>
-                        ("umull", VectorSize::Size32x4, VectorSize::Size16x4),
-                    (VecRRRLongOp::Umull16, true) =>
-                        ("umull2", VectorSize::Size32x4, VectorSize::Size16x8),
-                    (VecRRRLongOp::Umull32, false) =>
-                        ("umull", VectorSize::Size64x2, VectorSize::Size32x2),
-                    (VecRRRLongOp::Umull32, true) =>
-                        ("umull2", VectorSize::Size64x2, VectorSize::Size32x4),
-                    (VecRRRLongOp::Umlal8, false) =>
-                        ("umlal", VectorSize::Size16x8, VectorSize::Size8x8),
-                    (VecRRRLongOp::Umlal8, true) =>
-                        ("umlal2", VectorSize::Size16x8, VectorSize::Size8x16),
-                    (VecRRRLongOp::Umlal16, false) =>
-                        ("umlal", VectorSize::Size32x4, VectorSize::Size16x4),
-                    (VecRRRLongOp::Umlal16, true) =>
-                        ("umlal2", VectorSize::Size32x4, VectorSize::Size16x8),
-                    (VecRRRLongOp::Umlal32, false) =>
-                        ("umlal", VectorSize::Size64x2, VectorSize::Size32x2),
-                    (VecRRRLongOp::Umlal32, true) =>
-                        ("umlal2", VectorSize::Size64x2, VectorSize::Size32x4),
+                    (VecRRRLongOp::Smull8, false) => {
+                        ("smull", VectorSize::Size16x8, VectorSize::Size8x8)
+                    }
+                    (VecRRRLongOp::Smull8, true) => {
+                        ("smull2", VectorSize::Size16x8, VectorSize::Size8x16)
+                    }
+                    (VecRRRLongOp::Smull16, false) => {
+                        ("smull", VectorSize::Size32x4, VectorSize::Size16x4)
+                    }
+                    (VecRRRLongOp::Smull16, true) => {
+                        ("smull2", VectorSize::Size32x4, VectorSize::Size16x8)
+                    }
+                    (VecRRRLongOp::Smull32, false) => {
+                        ("smull", VectorSize::Size64x2, VectorSize::Size32x2)
+                    }
+                    (VecRRRLongOp::Smull32, true) => {
+                        ("smull2", VectorSize::Size64x2, VectorSize::Size32x4)
+                    }
+                    (VecRRRLongOp::Umull8, false) => {
+                        ("umull", VectorSize::Size16x8, VectorSize::Size8x8)
+                    }
+                    (VecRRRLongOp::Umull8, true) => {
+                        ("umull2", VectorSize::Size16x8, VectorSize::Size8x16)
+                    }
+                    (VecRRRLongOp::Umull16, false) => {
+                        ("umull", VectorSize::Size32x4, VectorSize::Size16x4)
+                    }
+                    (VecRRRLongOp::Umull16, true) => {
+                        ("umull2", VectorSize::Size32x4, VectorSize::Size16x8)
+                    }
+                    (VecRRRLongOp::Umull32, false) => {
+                        ("umull", VectorSize::Size64x2, VectorSize::Size32x2)
+                    }
+                    (VecRRRLongOp::Umull32, true) => {
+                        ("umull2", VectorSize::Size64x2, VectorSize::Size32x4)
+                    }
+                    (VecRRRLongOp::Umlal8, false) => {
+                        ("umlal", VectorSize::Size16x8, VectorSize::Size8x8)
+                    }
+                    (VecRRRLongOp::Umlal8, true) => {
+                        ("umlal2", VectorSize::Size16x8, VectorSize::Size8x16)
+                    }
+                    (VecRRRLongOp::Umlal16, false) => {
+                        ("umlal", VectorSize::Size32x4, VectorSize::Size16x4)
+                    }
+                    (VecRRRLongOp::Umlal16, true) => {
+                        ("umlal2", VectorSize::Size32x4, VectorSize::Size16x8)
+                    }
+                    (VecRRRLongOp::Umlal32, false) => {
+                        ("umlal", VectorSize::Size64x2, VectorSize::Size32x2)
+                    }
+                    (VecRRRLongOp::Umlal32, true) => {
+                        ("umlal2", VectorSize::Size64x2, VectorSize::Size32x4)
+                    }
                 };
                 let rd = show_vreg_vector(rd.to_reg(), mb_rru, dest_size);
                 let rn = show_vreg_vector(rn, mb_rru, src_size);

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -1253,6 +1253,166 @@ pub(crate) fn maybe_input_insn_via_conv<C: LowerCtx<I = Inst>>(
     None
 }
 
+
+pub(crate) fn match_vec_long_mul<C: LowerCtx<I = Inst>>(
+    c: &mut C,
+    insn: IRInst,
+    ext_op: Opcode
+) -> Option<(VecRRRLongOp, regalloc::Reg, regalloc::Reg, bool)> {
+    let inputs = insn_inputs(c, insn);
+    if let Some(lhs) = maybe_input_insn(c, inputs[0], ext_op) {
+        if let Some(rhs) = maybe_input_insn(c, inputs[1], ext_op) {
+            let lhs_input = insn_inputs(c, lhs)[0];
+            let rhs_input = insn_inputs(c, rhs)[0];
+            let rn = put_input_in_reg(c, lhs_input, NarrowValueMode::None);
+            let rm = put_input_in_reg(c, rhs_input, NarrowValueMode::None);
+            let lane_type = c.output_ty(insn, 0).lane_type();
+            match (lane_type, ext_op) {
+                (I16, Opcode::SwidenLow) =>
+                    return Some((VecRRRLongOp::Smull8, rn, rm, false)),
+                (I16, Opcode::SwidenHigh) =>
+                    return Some((VecRRRLongOp::Smull8, rn, rm, true)),
+                (I16, Opcode::UwidenLow) =>
+                    return Some((VecRRRLongOp::Umull8, rn, rm, false)),
+                (I16, Opcode::UwidenHigh) =>
+                    return Some((VecRRRLongOp::Umull8, rn, rm, true)),
+                (I32, Opcode::SwidenLow) =>
+                    return Some((VecRRRLongOp::Smull16, rn, rm, false)),
+                (I32, Opcode::SwidenHigh) =>
+                    return Some((VecRRRLongOp::Smull16, rn, rm, true)),
+                (I32, Opcode::UwidenLow) =>
+                    return Some((VecRRRLongOp::Umull16, rn, rm, false)),
+                (I32, Opcode::UwidenHigh) =>
+                    return Some((VecRRRLongOp::Umull16, rn, rm, true)),
+                (I64, Opcode::SwidenLow) =>
+                    return Some((VecRRRLongOp::Smull32, rn, rm, false)),
+                (I64, Opcode::SwidenHigh) =>
+                    return Some((VecRRRLongOp::Smull32, rn, rm, true)),
+                (I64, Opcode::UwidenLow) =>
+                    return Some((VecRRRLongOp::Umull32, rn, rm, false)),
+                (I64, Opcode::UwidenHigh) =>
+                    return Some((VecRRRLongOp::Umull32, rn, rm, true)),
+                _ => {},
+             };
+         }
+    }
+    None
+}
+
+pub(crate) fn lower_i64x2_mul<C: LowerCtx<I = Inst>>(
+    c: &mut C,
+    insn: IRInst,
+) {
+    let inputs = insn_inputs(c, insn);
+    let outputs = insn_outputs(c, insn);
+    let rd = get_output_reg(c, outputs[0]).regs()[0];
+    let rn = put_input_in_regs(c, inputs[0]).regs()[0];
+    let rm = put_input_in_regs(c, inputs[1]).regs()[0];
+
+    let tmp1 = c.alloc_tmp(I64X2).only_reg().unwrap();
+    let tmp2 = c.alloc_tmp(I64X2).only_reg().unwrap();
+
+    // This I64X2 multiplication is performed with several 32-bit
+    // operations.
+
+    // 64-bit numbers x and y, can be represented as:
+    //   x = a + 2^32(b)
+    //   y = c + 2^32(d)
+
+    // A 64-bit multiplication is:
+    //   x * y = ac + 2^32(ad + bc) + 2^64(bd)
+    // note: `2^64(bd)` can be ignored, the value is too large to fit in
+    // 64 bits.
+
+    // This sequence implements a I64X2 multiply, where the registers
+    // `rn` and `rm` are split up into 32-bit components:
+    //   rn = |d|c|b|a|
+    //   rm = |h|g|f|e|
+    //
+    //   rn * rm = |cg + 2^32(ch + dg)|ae + 2^32(af + be)|
+    //
+    //  The sequence is:
+    //  rev64 rd.4s, rm.4s
+    //  mul rd.4s, rd.4s, rn.4s
+    //  xtn tmp1.2s, rn.2d
+    //  addp rd.4s, rd.4s, rd.4s
+    //  xtn tmp2.2s, rm.2d
+    //  shll rd.2d, rd.2s, #32
+    //  umlal rd.2d, tmp2.2s, tmp1.2s
+
+    // Reverse the 32-bit elements in the 64-bit words.
+    //   rd = |g|h|e|f|
+    c.emit(Inst::VecMisc {
+        op: VecMisc2::Rev64,
+        rd,
+        rn: rm,
+        size: VectorSize::Size32x4,
+    });
+
+    // Calculate the high half components.
+    //   rd = |dg|ch|be|af|
+    //
+    // Note that this 32-bit multiply of the high half
+    // discards the bits that would overflow, same as
+    // if 64-bit operations were used. Also the Shll
+    // below would shift out the overflow bits anyway.
+    c.emit(Inst::VecRRR {
+        alu_op: VecALUOp::Mul,
+        rd,
+        rn: rd.to_reg(),
+        rm: rn,
+        size: VectorSize::Size32x4,
+    });
+
+    // Extract the low half components of rn.
+    //   tmp1 = |c|a|
+    c.emit(Inst::VecRRNarrow {
+        op: VecRRNarrowOp::Xtn64,
+        rd: tmp1,
+        rn,
+        high_half: false,
+    });
+
+    // Sum the respective high half components.
+    //   rd = |dg+ch|be+af||dg+ch|be+af|
+    c.emit(Inst::VecRRR {
+        alu_op: VecALUOp::Addp,
+        rd: rd,
+        rn: rd.to_reg(),
+        rm: rd.to_reg(),
+        size: VectorSize::Size32x4,
+    });
+
+    // Extract the low half components of rm.
+    //   tmp2 = |g|e|
+    c.emit(Inst::VecRRNarrow {
+        op: VecRRNarrowOp::Xtn64,
+        rd: tmp2,
+        rn: rm,
+        high_half: false,
+    });
+
+    // Shift the high half components, into the high half.
+    //   rd = |dg+ch << 32|be+af << 32|
+    c.emit(Inst::VecRRLong {
+        op: VecRRLongOp::Shll32,
+        rd,
+        rn: rd.to_reg(),
+        high_half: false,
+    });
+
+    // Multiply the low components together, and accumulate with the high
+    // half.
+    //   rd = |rd[1] + cg|rd[0] + ae|
+    c.emit(Inst::VecRRRLong {
+        alu_op: VecRRRLongOp::Umlal32,
+        rd,
+        rn: tmp2.to_reg(),
+        rm: tmp1.to_reg(),
+        high_half: false,
+    });
+}
+
 /// Specifies what [lower_icmp] should do when lowering
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum IcmpOutput {

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -1253,11 +1253,10 @@ pub(crate) fn maybe_input_insn_via_conv<C: LowerCtx<I = Inst>>(
     None
 }
 
-
 pub(crate) fn match_vec_long_mul<C: LowerCtx<I = Inst>>(
     c: &mut C,
     insn: IRInst,
-    ext_op: Opcode
+    ext_op: Opcode,
 ) -> Option<(VecRRRLongOp, regalloc::Reg, regalloc::Reg, bool)> {
     let inputs = insn_inputs(c, insn);
     if let Some(lhs) = maybe_input_insn(c, inputs[0], ext_op) {
@@ -1268,41 +1267,26 @@ pub(crate) fn match_vec_long_mul<C: LowerCtx<I = Inst>>(
             let rm = put_input_in_reg(c, rhs_input, NarrowValueMode::None);
             let lane_type = c.output_ty(insn, 0).lane_type();
             match (lane_type, ext_op) {
-                (I16, Opcode::SwidenLow) =>
-                    return Some((VecRRRLongOp::Smull8, rn, rm, false)),
-                (I16, Opcode::SwidenHigh) =>
-                    return Some((VecRRRLongOp::Smull8, rn, rm, true)),
-                (I16, Opcode::UwidenLow) =>
-                    return Some((VecRRRLongOp::Umull8, rn, rm, false)),
-                (I16, Opcode::UwidenHigh) =>
-                    return Some((VecRRRLongOp::Umull8, rn, rm, true)),
-                (I32, Opcode::SwidenLow) =>
-                    return Some((VecRRRLongOp::Smull16, rn, rm, false)),
-                (I32, Opcode::SwidenHigh) =>
-                    return Some((VecRRRLongOp::Smull16, rn, rm, true)),
-                (I32, Opcode::UwidenLow) =>
-                    return Some((VecRRRLongOp::Umull16, rn, rm, false)),
-                (I32, Opcode::UwidenHigh) =>
-                    return Some((VecRRRLongOp::Umull16, rn, rm, true)),
-                (I64, Opcode::SwidenLow) =>
-                    return Some((VecRRRLongOp::Smull32, rn, rm, false)),
-                (I64, Opcode::SwidenHigh) =>
-                    return Some((VecRRRLongOp::Smull32, rn, rm, true)),
-                (I64, Opcode::UwidenLow) =>
-                    return Some((VecRRRLongOp::Umull32, rn, rm, false)),
-                (I64, Opcode::UwidenHigh) =>
-                    return Some((VecRRRLongOp::Umull32, rn, rm, true)),
-                _ => {},
-             };
-         }
+                (I16, Opcode::SwidenLow) => return Some((VecRRRLongOp::Smull8, rn, rm, false)),
+                (I16, Opcode::SwidenHigh) => return Some((VecRRRLongOp::Smull8, rn, rm, true)),
+                (I16, Opcode::UwidenLow) => return Some((VecRRRLongOp::Umull8, rn, rm, false)),
+                (I16, Opcode::UwidenHigh) => return Some((VecRRRLongOp::Umull8, rn, rm, true)),
+                (I32, Opcode::SwidenLow) => return Some((VecRRRLongOp::Smull16, rn, rm, false)),
+                (I32, Opcode::SwidenHigh) => return Some((VecRRRLongOp::Smull16, rn, rm, true)),
+                (I32, Opcode::UwidenLow) => return Some((VecRRRLongOp::Umull16, rn, rm, false)),
+                (I32, Opcode::UwidenHigh) => return Some((VecRRRLongOp::Umull16, rn, rm, true)),
+                (I64, Opcode::SwidenLow) => return Some((VecRRRLongOp::Smull32, rn, rm, false)),
+                (I64, Opcode::SwidenHigh) => return Some((VecRRRLongOp::Smull32, rn, rm, true)),
+                (I64, Opcode::UwidenLow) => return Some((VecRRRLongOp::Umull32, rn, rm, false)),
+                (I64, Opcode::UwidenHigh) => return Some((VecRRRLongOp::Umull32, rn, rm, true)),
+                _ => {}
+            };
+        }
     }
     None
 }
 
-pub(crate) fn lower_i64x2_mul<C: LowerCtx<I = Inst>>(
-    c: &mut C,
-    insn: IRInst,
-) {
+pub(crate) fn lower_i64x2_mul<C: LowerCtx<I = Inst>>(c: &mut C, insn: IRInst) {
     let inputs = insn_inputs(c, insn);
     let outputs = insn_outputs(c, insn);
     let rd = get_output_reg(c, outputs[0]).regs()[0];

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -1253,6 +1253,9 @@ pub(crate) fn maybe_input_insn_via_conv<C: LowerCtx<I = Inst>>(
     None
 }
 
+/// Pattern match an extending vector multiplication.
+/// Returns a tuple of the opcode to use, the two input registers and whether
+/// it's the 'high half' version of the instruction.
 pub(crate) fn match_vec_long_mul<C: LowerCtx<I = Inst>>(
     c: &mut C,
     insn: IRInst,

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -246,80 +246,86 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         Opcode::Imul => {
             let ty = ty.unwrap();
             if ty == I128 {
-              let lhs = put_input_in_regs(ctx, inputs[0]);
-              let rhs = put_input_in_regs(ctx, inputs[1]);
-              let dst = get_output_reg(ctx, outputs[0]);
-              assert_eq!(lhs.len(), 2);
-              assert_eq!(rhs.len(), 2);
-              assert_eq!(dst.len(), 2);
+                let lhs = put_input_in_regs(ctx, inputs[0]);
+                let rhs = put_input_in_regs(ctx, inputs[1]);
+                let dst = get_output_reg(ctx, outputs[0]);
+                assert_eq!(lhs.len(), 2);
+                assert_eq!(rhs.len(), 2);
+                assert_eq!(dst.len(), 2);
 
-              // 128bit mul formula:
-              //   dst_lo = lhs_lo * rhs_lo
-              //   dst_hi = umulhi(lhs_lo, rhs_lo) + (lhs_lo * rhs_hi) + (lhs_hi * rhs_lo)
-              //
-              // We can convert the above formula into the following
-              // umulh   dst_hi, lhs_lo, rhs_lo
-              // madd    dst_hi, lhs_lo, rhs_hi, dst_hi
-              // madd    dst_hi, lhs_hi, rhs_lo, dst_hi
-              // mul     dst_lo, lhs_lo, rhs_lo
+                // 128bit mul formula:
+                //   dst_lo = lhs_lo * rhs_lo
+                //   dst_hi = umulhi(lhs_lo, rhs_lo) + (lhs_lo * rhs_hi) + (lhs_hi * rhs_lo)
+                //
+                // We can convert the above formula into the following
+                // umulh   dst_hi, lhs_lo, rhs_lo
+                // madd    dst_hi, lhs_lo, rhs_hi, dst_hi
+                // madd    dst_hi, lhs_hi, rhs_lo, dst_hi
+                // mul     dst_lo, lhs_lo, rhs_lo
 
-              ctx.emit(Inst::AluRRR {
-                  alu_op: ALUOp::UMulH,
-                  rd: dst.regs()[1],
-                  rn: lhs.regs()[0],
-                  rm: rhs.regs()[0],
-              });
-              ctx.emit(Inst::AluRRRR {
-                  alu_op: ALUOp3::MAdd64,
-                  rd: dst.regs()[1],
-                  rn: lhs.regs()[0],
-                  rm: rhs.regs()[1],
-                  ra: dst.regs()[1].to_reg(),
-              });
-              ctx.emit(Inst::AluRRRR {
-                  alu_op: ALUOp3::MAdd64,
-                  rd: dst.regs()[1],
-                  rn: lhs.regs()[1],
-                  rm: rhs.regs()[0],
-                  ra: dst.regs()[1].to_reg(),
-              });
-              ctx.emit(Inst::AluRRRR {
-                  alu_op: ALUOp3::MAdd64,
-                  rd: dst.regs()[0],
-                  rn: lhs.regs()[0],
-                  rm: rhs.regs()[0],
-                  ra: zero_reg(),
-              });
+                ctx.emit(Inst::AluRRR {
+                    alu_op: ALUOp::UMulH,
+                    rd: dst.regs()[1],
+                    rn: lhs.regs()[0],
+                    rm: rhs.regs()[0],
+                });
+                ctx.emit(Inst::AluRRRR {
+                    alu_op: ALUOp3::MAdd64,
+                    rd: dst.regs()[1],
+                    rn: lhs.regs()[0],
+                    rm: rhs.regs()[1],
+                    ra: dst.regs()[1].to_reg(),
+                });
+                ctx.emit(Inst::AluRRRR {
+                    alu_op: ALUOp3::MAdd64,
+                    rd: dst.regs()[1],
+                    rn: lhs.regs()[1],
+                    rm: rhs.regs()[0],
+                    ra: dst.regs()[1].to_reg(),
+                });
+                ctx.emit(Inst::AluRRRR {
+                    alu_op: ALUOp3::MAdd64,
+                    rd: dst.regs()[0],
+                    rn: lhs.regs()[0],
+                    rm: rhs.regs()[0],
+                    ra: zero_reg(),
+                });
             } else if ty.is_vector() {
-                for ext_op in &[Opcode::SwidenLow, Opcode::SwidenHigh,
-                                Opcode::UwidenLow, Opcode::UwidenHigh] {
-                  if let Some((alu_op, rn, rm, high_half)) = match_vec_long_mul(ctx, insn, *ext_op) {
+                for ext_op in &[
+                    Opcode::SwidenLow,
+                    Opcode::SwidenHigh,
+                    Opcode::UwidenLow,
+                    Opcode::UwidenHigh,
+                ] {
+                    if let Some((alu_op, rn, rm, high_half)) =
+                        match_vec_long_mul(ctx, insn, *ext_op)
+                    {
+                        let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                        ctx.emit(Inst::VecRRRLong {
+                            alu_op,
+                            rd,
+                            rn,
+                            rm,
+                            high_half,
+                        });
+                        return Ok(());
+                    }
+                }
+                if ty == I64X2 {
+                    lower_i64x2_mul(ctx, insn);
+                } else {
+                    let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
+                    let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
                     let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-                    ctx.emit(Inst::VecRRRLong {
-                        alu_op,
+                    ctx.emit(Inst::VecRRR {
+                        alu_op: VecALUOp::Mul,
                         rd,
                         rn,
                         rm,
-                        high_half,
+                        size: VectorSize::from_ty(ty),
                     });
-                    return Ok(());
-                  }
                 }
-                if ty == I64X2 {
-                  lower_i64x2_mul(ctx, insn);
-                } else {
-                  let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-                  let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-                  let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-                  ctx.emit(Inst::VecRRR {
-                      alu_op: VecALUOp::Mul,
-                      rd,
-                      rn,
-                      rm,
-                      size: VectorSize::from_ty(ty),
-                  });
-                }
-             } else {
+            } else {
                 let alu_op = choose_32_64(ty, ALUOp3::MAdd32, ALUOp3::MAdd64);
                 let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
                 let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -244,183 +244,93 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Imul => {
-            let lhs = put_input_in_regs(ctx, inputs[0]);
-            let rhs = put_input_in_regs(ctx, inputs[1]);
-            let dst = get_output_reg(ctx, outputs[0]);
-
-            let rd = dst.regs()[0];
-            let rn = lhs.regs()[0];
-            let rm = rhs.regs()[0];
-
             let ty = ty.unwrap();
-            match ty {
-                I128 => {
-                    assert_eq!(lhs.len(), 2);
-                    assert_eq!(rhs.len(), 2);
-                    assert_eq!(dst.len(), 2);
+            if ty == I128 {
+              let lhs = put_input_in_regs(ctx, inputs[0]);
+              let rhs = put_input_in_regs(ctx, inputs[1]);
+              let dst = get_output_reg(ctx, outputs[0]);
+              assert_eq!(lhs.len(), 2);
+              assert_eq!(rhs.len(), 2);
+              assert_eq!(dst.len(), 2);
 
-                    // 128bit mul formula:
-                    //   dst_lo = lhs_lo * rhs_lo
-                    //   dst_hi = umulhi(lhs_lo, rhs_lo) + (lhs_lo * rhs_hi) + (lhs_hi * rhs_lo)
-                    //
-                    // We can convert the above formula into the following
-                    // umulh   dst_hi, lhs_lo, rhs_lo
-                    // madd    dst_hi, lhs_lo, rhs_hi, dst_hi
-                    // madd    dst_hi, lhs_hi, rhs_lo, dst_hi
-                    // mul     dst_lo, lhs_lo, rhs_lo
+              // 128bit mul formula:
+              //   dst_lo = lhs_lo * rhs_lo
+              //   dst_hi = umulhi(lhs_lo, rhs_lo) + (lhs_lo * rhs_hi) + (lhs_hi * rhs_lo)
+              //
+              // We can convert the above formula into the following
+              // umulh   dst_hi, lhs_lo, rhs_lo
+              // madd    dst_hi, lhs_lo, rhs_hi, dst_hi
+              // madd    dst_hi, lhs_hi, rhs_lo, dst_hi
+              // mul     dst_lo, lhs_lo, rhs_lo
 
-                    ctx.emit(Inst::AluRRR {
-                        alu_op: ALUOp::UMulH,
-                        rd: dst.regs()[1],
-                        rn: lhs.regs()[0],
-                        rm: rhs.regs()[0],
-                    });
-                    ctx.emit(Inst::AluRRRR {
-                        alu_op: ALUOp3::MAdd64,
-                        rd: dst.regs()[1],
-                        rn: lhs.regs()[0],
-                        rm: rhs.regs()[1],
-                        ra: dst.regs()[1].to_reg(),
-                    });
-                    ctx.emit(Inst::AluRRRR {
-                        alu_op: ALUOp3::MAdd64,
-                        rd: dst.regs()[1],
-                        rn: lhs.regs()[1],
-                        rm: rhs.regs()[0],
-                        ra: dst.regs()[1].to_reg(),
-                    });
-                    ctx.emit(Inst::AluRRRR {
-                        alu_op: ALUOp3::MAdd64,
-                        rd: dst.regs()[0],
-                        rn: lhs.regs()[0],
-                        rm: rhs.regs()[0],
-                        ra: zero_reg(),
-                    });
-                }
-                ty if !ty.is_vector() => {
-                    let alu_op = choose_32_64(ty, ALUOp3::MAdd32, ALUOp3::MAdd64);
-                    ctx.emit(Inst::AluRRRR {
+              ctx.emit(Inst::AluRRR {
+                  alu_op: ALUOp::UMulH,
+                  rd: dst.regs()[1],
+                  rn: lhs.regs()[0],
+                  rm: rhs.regs()[0],
+              });
+              ctx.emit(Inst::AluRRRR {
+                  alu_op: ALUOp3::MAdd64,
+                  rd: dst.regs()[1],
+                  rn: lhs.regs()[0],
+                  rm: rhs.regs()[1],
+                  ra: dst.regs()[1].to_reg(),
+              });
+              ctx.emit(Inst::AluRRRR {
+                  alu_op: ALUOp3::MAdd64,
+                  rd: dst.regs()[1],
+                  rn: lhs.regs()[1],
+                  rm: rhs.regs()[0],
+                  ra: dst.regs()[1].to_reg(),
+              });
+              ctx.emit(Inst::AluRRRR {
+                  alu_op: ALUOp3::MAdd64,
+                  rd: dst.regs()[0],
+                  rn: lhs.regs()[0],
+                  rm: rhs.regs()[0],
+                  ra: zero_reg(),
+              });
+            } else if ty.is_vector() {
+                for ext_op in &[Opcode::SwidenLow, Opcode::SwidenHigh,
+                                Opcode::UwidenLow, Opcode::UwidenHigh] {
+                  if let Some((alu_op, rn, rm, high_half)) = match_vec_long_mul(ctx, insn, *ext_op) {
+                    let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                    ctx.emit(Inst::VecRRRLong {
                         alu_op,
                         rd,
                         rn,
                         rm,
-                        ra: zero_reg(),
+                        high_half,
                     });
+                    return Ok(());
+                  }
                 }
-                I64X2 => {
-                    let tmp1 = ctx.alloc_tmp(I64X2).only_reg().unwrap();
-                    let tmp2 = ctx.alloc_tmp(I64X2).only_reg().unwrap();
-
-                    // This I64X2 multiplication is performed with several 32-bit
-                    // operations.
-
-                    // 64-bit numbers x and y, can be represented as:
-                    //   x = a + 2^32(b)
-                    //   y = c + 2^32(d)
-
-                    // A 64-bit multiplication is:
-                    //   x * y = ac + 2^32(ad + bc) + 2^64(bd)
-                    // note: `2^64(bd)` can be ignored, the value is too large to fit in
-                    // 64 bits.
-
-                    // This sequence implements a I64X2 multiply, where the registers
-                    // `rn` and `rm` are split up into 32-bit components:
-                    //   rn = |d|c|b|a|
-                    //   rm = |h|g|f|e|
-                    //
-                    //   rn * rm = |cg + 2^32(ch + dg)|ae + 2^32(af + be)|
-                    //
-                    //  The sequence is:
-                    //  rev64 rd.4s, rm.4s
-                    //  mul rd.4s, rd.4s, rn.4s
-                    //  xtn tmp1.2s, rn.2d
-                    //  addp rd.4s, rd.4s, rd.4s
-                    //  xtn tmp2.2s, rm.2d
-                    //  shll rd.2d, rd.2s, #32
-                    //  umlal rd.2d, tmp2.2s, tmp1.2s
-
-                    // Reverse the 32-bit elements in the 64-bit words.
-                    //   rd = |g|h|e|f|
-                    ctx.emit(Inst::VecMisc {
-                        op: VecMisc2::Rev64,
-                        rd,
-                        rn: rm,
-                        size: VectorSize::Size32x4,
-                    });
-
-                    // Calculate the high half components.
-                    //   rd = |dg|ch|be|af|
-                    //
-                    // Note that this 32-bit multiply of the high half
-                    // discards the bits that would overflow, same as
-                    // if 64-bit operations were used. Also the Shll
-                    // below would shift out the overflow bits anyway.
-                    ctx.emit(Inst::VecRRR {
-                        alu_op: VecALUOp::Mul,
-                        rd,
-                        rn: rd.to_reg(),
-                        rm: rn,
-                        size: VectorSize::Size32x4,
-                    });
-
-                    // Extract the low half components of rn.
-                    //   tmp1 = |c|a|
-                    ctx.emit(Inst::VecRRNarrow {
-                        op: VecRRNarrowOp::Xtn64,
-                        rd: tmp1,
-                        rn,
-                        high_half: false,
-                    });
-
-                    // Sum the respective high half components.
-                    //   rd = |dg+ch|be+af||dg+ch|be+af|
-                    ctx.emit(Inst::VecRRR {
-                        alu_op: VecALUOp::Addp,
-                        rd: rd,
-                        rn: rd.to_reg(),
-                        rm: rd.to_reg(),
-                        size: VectorSize::Size32x4,
-                    });
-
-                    // Extract the low half components of rm.
-                    //   tmp2 = |g|e|
-                    ctx.emit(Inst::VecRRNarrow {
-                        op: VecRRNarrowOp::Xtn64,
-                        rd: tmp2,
-                        rn: rm,
-                        high_half: false,
-                    });
-
-                    // Shift the high half components, into the high half.
-                    //   rd = |dg+ch << 32|be+af << 32|
-                    ctx.emit(Inst::VecRRLong {
-                        op: VecRRLongOp::Shll32,
-                        rd,
-                        rn: rd.to_reg(),
-                        high_half: false,
-                    });
-
-                    // Multiply the low components together, and accumulate with the high
-                    // half.
-                    //   rd = |rd[1] + cg|rd[0] + ae|
-                    ctx.emit(Inst::VecRRR {
-                        alu_op: VecALUOp::Umlal,
-                        rd,
-                        rn: tmp2.to_reg(),
-                        rm: tmp1.to_reg(),
-                        size: VectorSize::Size32x2,
-                    });
+                if ty == I64X2 {
+                  lower_i64x2_mul(ctx, insn);
+                } else {
+                  let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
+                  let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
+                  let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                  ctx.emit(Inst::VecRRR {
+                      alu_op: VecALUOp::Mul,
+                      rd,
+                      rn,
+                      rm,
+                      size: VectorSize::from_ty(ty),
+                  });
                 }
-                ty if ty.is_vector() => {
-                    ctx.emit(Inst::VecRRR {
-                        alu_op: VecALUOp::Mul,
-                        rd,
-                        rn,
-                        rm,
-                        size: VectorSize::from_ty(ty),
-                    });
-                }
-                _ => panic!("Unable to emit mul for {}", ty),
+             } else {
+                let alu_op = choose_32_64(ty, ALUOp3::MAdd32, ALUOp3::MAdd64);
+                let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
+                let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
+                let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+                ctx.emit(Inst::AluRRRR {
+                    alu_op,
+                    rd,
+                    rn,
+                    rm,
+                    ra: zero_reg(),
+                });
             }
         }
 
@@ -2740,19 +2650,19 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 // => smull  tmp, a, b
                 //    smull2 y,   a, b
                 //    addp   y,   tmp, y
-                ctx.emit(Inst::VecRRR {
-                    alu_op: VecALUOp::Smull,
+                ctx.emit(Inst::VecRRRLong {
+                    alu_op: VecRRRLongOp::Smull16,
                     rd: tmp,
                     rn: r_a,
                     rm: r_b,
-                    size: VectorSize::Size16x8,
+                    high_half: false,
                 });
-                ctx.emit(Inst::VecRRR {
-                    alu_op: VecALUOp::Smull2,
+                ctx.emit(Inst::VecRRRLong {
+                    alu_op: VecRRRLongOp::Smull16,
                     rd: r_y,
                     rn: r_a,
                     rm: r_b,
-                    size: VectorSize::Size16x8,
+                    high_half: true,
                 });
                 ctx.emit(Inst::VecRRR {
                     alu_op: VecALUOp::Addp,

--- a/cranelift/filetests/filetests/isa/aarch64/simd-extmul.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-extmul.clif
@@ -1,0 +1,159 @@
+test compile
+set unwind_info=false
+target aarch64
+
+function %fn1(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+  v2 = swiden_low v0
+  v3 = swiden_low v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: sxtl
+; check: smull v0.8h, v0.8b, v1.8b
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn2(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+  v2 = swiden_high v0
+  v3 = swiden_high v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: sxtl
+; check: smull2 v0.8h, v0.16b, v1.16b
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn3(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+  v2 = swiden_low v0
+  v3 = swiden_low v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: sxtl
+; check: smull v0.4s, v0.4h, v1.4h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn4(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+  v2 = swiden_high v0
+  v3 = swiden_high v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: sxtl
+; check: smull2 v0.4s, v0.8h, v1.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn5(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+  v2 = swiden_low v0
+  v3 = swiden_low v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: sxtl
+; check: smull v0.2d, v0.2s, v1.2s
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn6(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+  v2 = swiden_high v0
+  v3 = swiden_high v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: sxtl
+; check: smull2 v0.2d, v0.4s, v1.4s
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn7(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+  v2 = uwiden_low v0
+  v3 = uwiden_low v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: uxtl
+; check: umull v0.8h, v0.8b, v1.8b
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn8(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+  v2 = uwiden_high v0
+  v3 = uwiden_high v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: uxtl
+; check: umull2 v0.8h, v0.16b, v1.16b
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn9(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+  v2 = uwiden_low v0
+  v3 = uwiden_low v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: uxtl
+; check: umull v0.4s, v0.4h, v1.4h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn10(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+  v2 = uwiden_high v0
+  v3 = uwiden_high v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: uxtl
+; check: umull2 v0.4s, v0.8h, v1.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn11(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+  v2 = uwiden_low v0
+  v3 = uwiden_low v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: uxtl
+; check: umull v0.2d, v0.2s, v1.2s
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn12(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+  v2 = uwiden_high v0
+  v3 = uwiden_high v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; check-not: uxtl2
+; check: umull2 v0.2d, v0.4s, v1.4s
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1879,6 +1879,37 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, I32X4, builder);
             state.push1(builder.ins().uwiden_high(a))
         }
+        Operator::F32x4Ceil | Operator::F64x2Ceil => {
+            // This is something of a misuse of `type_of`, because that produces the return type
+            // of `op`.  In this case we want the arg type, but we know it's the same as the
+            // return type.  Same for the 3 cases below.
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().ceil(arg));
+        }
+        Operator::F32x4Floor | Operator::F64x2Floor => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().floor(arg));
+        }
+        Operator::F32x4Trunc | Operator::F64x2Trunc => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().trunc(arg));
+        }
+        Operator::F32x4Nearest | Operator::F64x2Nearest => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().nearest(arg));
+        }
+        Operator::I32x4DotI16x8S => {
+            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            state.push1(builder.ins().widening_pairwise_dot_product_s(a, b));
+        }
+        Operator::I8x16Popcnt => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().popcnt(arg));
+        }
+        Operator::I16x8Q15MulrSatS => {
+            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            state.push1(builder.ins().sqmul_round_sat(a, b))
+        }
         Operator::I16x8ExtMulLowI8x16S => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
             let a_low = builder.ins().swiden_low(a);
@@ -1950,37 +1981,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a_high = builder.ins().uwiden_high(a);
             let b_high = builder.ins().uwiden_high(b);
             state.push1(builder.ins().imul(a_high, b_high));
-        }
-        Operator::F32x4Ceil | Operator::F64x2Ceil => {
-            // This is something of a misuse of `type_of`, because that produces the return type
-            // of `op`.  In this case we want the arg type, but we know it's the same as the
-            // return type.  Same for the 3 cases below.
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().ceil(arg));
-        }
-        Operator::F32x4Floor | Operator::F64x2Floor => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().floor(arg));
-        }
-        Operator::F32x4Trunc | Operator::F64x2Trunc => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().trunc(arg));
-        }
-        Operator::F32x4Nearest | Operator::F64x2Nearest => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().nearest(arg));
-        }
-        Operator::I32x4DotI16x8S => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().widening_pairwise_dot_product_s(a, b));
-        }
-        Operator::I8x16Popcnt => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().popcnt(arg));
-        }
-        Operator::I16x8Q15MulrSatS => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().sqmul_round_sat(a, b))
         }
         Operator::I16x8ExtAddPairwiseI8x16S
         | Operator::I16x8ExtAddPairwiseI8x16U

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1879,38 +1879,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a = pop1_with_bitcast(state, I32X4, builder);
             state.push1(builder.ins().uwiden_high(a))
         }
-        Operator::F32x4Ceil | Operator::F64x2Ceil => {
-            // This is something of a misuse of `type_of`, because that produces the return type
-            // of `op`.  In this case we want the arg type, but we know it's the same as the
-            // return type.  Same for the 3 cases below.
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().ceil(arg));
-        }
-        Operator::F32x4Floor | Operator::F64x2Floor => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().floor(arg));
-        }
-        Operator::F32x4Trunc | Operator::F64x2Trunc => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().trunc(arg));
-        }
-        Operator::F32x4Nearest | Operator::F64x2Nearest => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().nearest(arg));
-        }
-        Operator::I32x4DotI16x8S => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().widening_pairwise_dot_product_s(a, b));
-        }
-        Operator::I8x16Popcnt => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().popcnt(arg));
-        }
-        Operator::I16x8Q15MulrSatS => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-
-            state.push1(builder.ins().sqmul_round_sat(a, b))
-        }
         Operator::I16x8ExtMulLowI8x16S => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
             let a_low = builder.ins().swiden_low(a);
@@ -1982,6 +1950,37 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let a_high = builder.ins().uwiden_high(a);
             let b_high = builder.ins().uwiden_high(b);
             state.push1(builder.ins().imul(a_high, b_high));
+        }
+        Operator::F32x4Ceil | Operator::F64x2Ceil => {
+            // This is something of a misuse of `type_of`, because that produces the return type
+            // of `op`.  In this case we want the arg type, but we know it's the same as the
+            // return type.  Same for the 3 cases below.
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().ceil(arg));
+        }
+        Operator::F32x4Floor | Operator::F64x2Floor => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().floor(arg));
+        }
+        Operator::F32x4Trunc | Operator::F64x2Trunc => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().trunc(arg));
+        }
+        Operator::F32x4Nearest | Operator::F64x2Nearest => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().nearest(arg));
+        }
+        Operator::I32x4DotI16x8S => {
+            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            state.push1(builder.ins().widening_pairwise_dot_product_s(a, b));
+        }
+        Operator::I8x16Popcnt => {
+            let arg = pop1_with_bitcast(state, type_of(op), builder);
+            state.push1(builder.ins().popcnt(arg));
+        }
+        Operator::I16x8Q15MulrSatS => {
+            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            state.push1(builder.ins().sqmul_round_sat(a, b))
         }
         Operator::I16x8ExtAddPairwiseI8x16S
         | Operator::I16x8ExtAddPairwiseI8x16U


### PR DESCRIPTION
Lower simd_extmul_[low/high][signed/unsigned] to [s|u]widen inputs to
an imul node.

This also reorganises the aarch64 'long mul' operations and their assembly.

Copyright (c) 2021, Arm Limited.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
