### PR TITLE
[doc] Add some documentation for debugging

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
   - [Running `hello-world.wasm`](./tutorial-run-hello-world.md)
 - [Examples](./examples.md)
   - [Markdown Parser](./examples-markdown.md)
+  - [Debugging WebAssembly](./examples-debugging.md)
   - [Profiling WebAssembly](./examples-profiling.md)
     - [Profiling with Perf](./examples-profiling-perf.md)
     - [Profiling with VTune](./examples-profiling-vtune.md)

--- a/docs/examples-debugging.md
+++ b/docs/examples-debugging.md
@@ -1,0 +1,24 @@
+# Debugging WebAssembly
+
+The following steps describe a common way to debug a WebAssembly module in
+Wasmtime:
+
+1. Compile your WebAssembly with debug info enabled, usually `-g`; for
+   example: 
+
+    ```sh
+    clang foo.c -g -o foo.wasm
+    ```
+
+2. Run Wasmtime with the debug info enabled; this is `-g` from the CLI and
+   `Config::debug_info(true)` in an embedding (e.g. see [debugging in a Rust
+   embedding](./examples-rust-debugging.md))
+
+3. Use a supported debugger:
+
+    ```sh
+    lldb -- wasmtime run -g foo.wasm
+    ```
+    ```sh
+    gdb --args wasmtime run -g foo.wasm
+    ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,4 @@
 # Examples
 
-This is an explanation of all examples to come
-
-... more coming soon
+The examples contained in this section explain how to use Wasmtime in several
+common scenarios.


### PR DESCRIPTION
The previous documentation only covers how to enable debug info when
embedding Wasmtime. This change should cover the commonly-asked
question: how do I debug in Wasmtime?