### PR TITLE
Wastime: Enable nightly doc features on docs.rs

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -9,9 +9,8 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition = "2018"
 
-# FIXME(rust-lang/cargo#9300): uncomment once that lands
-# [package.metadata.docs.rs]
-# rustdoc-args = ["--cfg", "nightlydoc"]
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "nightlydoc"]
 
 [dependencies]
 wasmtime-runtime = { path = "../runtime", version = "0.28.0" }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -528,6 +528,7 @@ impl Config {
     ///
     /// By default this option is 2 MiB.
     #[cfg(feature = "async")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
     pub fn async_stack_size(&mut self, size: usize) -> Result<&mut Self> {
         if size < self.max_wasm_stack {
             bail!("async stack size cannot be less than the maximum wasm stack size");


### PR DESCRIPTION
It was disabled in #2766, and can be re-enabled now that rust-lang/cargo#9300 has landed.