### PR TITLE
Reword env var hint for dwarf debug info

### DIFF
--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -355,7 +355,7 @@ impl fmt::Display for Trap {
             }
         }
         if self.inner.hint_wasm_backtrace_details_env {
-            writeln!(f, "note: run with `WASMTIME_BACKTRACE_DETAILS=1` environment variable to display more information")?;
+            writeln!(f, "note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information")?;
         }
         Ok(())
     }

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -600,7 +600,7 @@ fn hint_with_dwarf_info() -> Result<()> {
 wasm trap: unreachable
 wasm backtrace:
     0:   0x1a - <unknown>!start
-note: run with `WASMTIME_BACKTRACE_DETAILS=1` environment variable to display more information
+note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information
 "
     );
     Ok(())


### PR DESCRIPTION
Try not to declare that more information will indeed be displayed,
instead suggest that the output may improve if the env var is set since
dwarf debug info wasn't parsed.

cc bytecodealliance/wasmtime-go#90

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
