### PR TITLE
Don't assume all custom sections are dwarf info

### DIFF
--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -191,12 +191,11 @@ impl<'data> ModuleEnvironment<'data> {
     }
 
     fn register_dwarf_section(&mut self, name: &str, data: &'data [u8]) {
-        if !self.tunables.generate_native_debuginfo && !self.tunables.parse_wasm_debuginfo {
-            self.result.has_unparsed_debuginfo = true;
+        if !name.starts_with(".debug_") {
             return;
         }
-
-        if !name.starts_with(".debug_") {
+        if !self.tunables.generate_native_debuginfo && !self.tunables.parse_wasm_debuginfo {
+            self.result.has_unparsed_debuginfo = true;
             return;
         }
         let info = &mut self.result.debuginfo;


### PR DESCRIPTION
This incorrectly assumed that we had unparsed dwarf information,
regardless of custom section name. This commit updates the logic to
calculate that by first checking the section name before we set the flag
indicating that there's unparsed debuginfo.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
