### PR TITLE
wiggle: dummy executor traps instead of panics, improve testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,6 +3923,7 @@ dependencies = [
  "bitflags",
  "proptest",
  "thiserror",
+ "tokio",
  "tracing",
  "wasmtime",
  "wiggle-macro",

--- a/crates/wasi-common/tokio/src/lib.rs
+++ b/crates/wasi-common/tokio/src/lib.rs
@@ -108,5 +108,7 @@ where
     Fut: Future<Output = Result<T, Error>>,
     T: Send + 'static,
 {
-    tokio::task::block_in_place(move || wiggle::run_in_dummy_executor(f()))
+    tokio::task::block_in_place(move || {
+        wiggle::run_in_dummy_executor(f()).expect("wrapped operation should be synchronous")
+    })
 }

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -27,6 +27,7 @@ maintenance = { status = "actively-developed" }
 wiggle-test = { path = "test-helpers" }
 anyhow = "1"
 proptest = "1.0.0"
+tokio = { version = "1", features = ["rt-multi-thread","time", "macros"] }
 
 [[test]]
 name = "wasmtime_async"

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -149,7 +149,7 @@ fn generate_func(
                     #field_str,
                     move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> Result<#ret_ty, #rt::wasmtime_crate::Trap> {
                         let result = async { #body };
-                        #rt::run_in_dummy_executor(result)
+                        #rt::run_in_dummy_executor(result)?
                     },
                 )?;
             }

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -933,7 +933,10 @@ impl From<GuestError> for Trap {
     }
 }
 
-pub fn run_in_dummy_executor<F: std::future::Future>(future: F) -> Result<F::Output, Trap> {
+#[cfg(feature = "wasmtime")]
+pub fn run_in_dummy_executor<F: std::future::Future>(
+    future: F,
+) -> Result<F::Output, wasmtime_crate::Trap> {
     use std::pin::Pin;
     use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
@@ -943,7 +946,7 @@ pub fn run_in_dummy_executor<F: std::future::Future>(future: F) -> Result<F::Out
     match f.as_mut().poll(&mut cx) {
         Poll::Ready(val) => return Ok(val),
         Poll::Pending =>
-            return Err(Trap::String("Cannot wait on pending future: must enable wiggle \"async\" future and execute on an async Store".to_owned()))
+            return Err(wasmtime_crate::Trap::new("Cannot wait on pending future: must enable wiggle \"async\" future and execute on an async Store"))
     }
 
     fn dummy_waker() -> Waker {


### PR DESCRIPTION
Some housekeeping that improves the behavior of wiggle failures, and improves the test suite.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
