### PR TITLE
🌈 cranelift: Provide an `entity_impl!` variation for external handles

### DIFF
--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -280,4 +280,35 @@ mod tests {
             assert_eq!(alloc::format!("{}", e), "prefix-0");
         }
     }
+
+    /// Test cases for an `EntityRef` implementation for a type we can only construct through
+    /// other means, such as calls to `core::convert::From<u32>`.
+    mod other_entity {
+        mod inner {
+            #[derive(Clone, Copy, PartialEq, Eq)]
+            pub struct InnerEntity(u32);
+
+            impl From<u32> for InnerEntity {
+                fn from(x: u32) -> Self {
+                    Self(x)
+                }
+            }
+
+            impl From<InnerEntity> for u32 {
+                fn from(x: InnerEntity) -> Self {
+                    x.0
+                }
+            }
+        }
+
+        use {crate::EntityRef, self::inner::InnerEntity};
+        entity_impl!(InnerEntity, "inner-", i, InnerEntity::from(i), u32::from(i));
+        entity_test!(InnerEntity);
+
+        #[test]
+        fn display_prefix_works() {
+            let e = InnerEntity::new(0);
+            assert_eq!(alloc::format!("{}", e), "inner-0");
+        }
+    }
 }

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -129,6 +129,68 @@ macro_rules! entity_impl {
             }
         }
     };
+
+    // Alternate form for tuples we can't directly construct; providing "to" and "from" expressions
+    // to turn an index *into* an entity, or get an index *from* an entity.
+    ($entity:ident, $display_prefix:expr, $arg:ident, $to_expr:expr, $from_expr:expr) => {
+        impl $crate::EntityRef for $entity {
+            #[inline]
+            fn new(index: usize) -> Self {
+                debug_assert!(index < ($crate::__core::u32::MAX as usize));
+                let $arg = index as u32;
+                $to_expr
+            }
+
+            #[inline]
+            fn index(self) -> usize {
+                let $arg = self;
+                $from_expr as usize
+            }
+        }
+
+        impl $crate::packed_option::ReservedValue for $entity {
+            #[inline]
+            fn reserved_value() -> $entity {
+                $entity::from_u32($crate::__core::u32::MAX)
+            }
+
+            #[inline]
+            fn is_reserved_value(&self) -> bool {
+                self.as_u32() == $crate::__core::u32::MAX
+            }
+        }
+
+        impl $entity {
+            /// Create a new instance from a `u32`.
+            #[allow(dead_code)]
+            #[inline]
+            pub fn from_u32(x: u32) -> Self {
+                debug_assert!(x < $crate::__core::u32::MAX);
+                let $arg = x;
+                $to_expr
+            }
+
+            /// Return the underlying index value as a `u32`.
+            #[allow(dead_code)]
+            #[inline]
+            pub fn as_u32(self) -> u32 {
+                let $arg = self;
+                $from_expr
+            }
+        }
+
+        impl $crate::__core::fmt::Display for $entity {
+            fn fmt(&self, f: &mut $crate::__core::fmt::Formatter) -> $crate::__core::fmt::Result {
+                write!(f, concat!($display_prefix, "{}"), self.as_u32())
+            }
+        }
+
+        impl $crate::__core::fmt::Debug for $entity {
+            fn fmt(&self, f: &mut $crate::__core::fmt::Formatter) -> $crate::__core::fmt::Result {
+                (self as &dyn $crate::__core::fmt::Display).fmt(f)
+            }
+        }
+    };
 }
 
 pub mod packed_option;

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -301,7 +301,7 @@ mod tests {
             }
         }
 
-        use {crate::EntityRef, self::inner::InnerEntity};
+        use {self::inner::InnerEntity, crate::EntityRef};
         entity_impl!(InnerEntity, "inner-", i, InnerEntity::from(i), u32::from(i));
         entity_test!(InnerEntity);
 


### PR DESCRIPTION
This fixes #3047; building on @cfallin's outline [here](https://github.com/bytecodealliance/wasmtime/issues/3047#issuecomment-871749805).

This branch expands `entity_impl!` so that it can be used in conjunction with handle types that don't expose a tuple constructor e.g. `Type(0)`. This is motivated by use-cases involving `wiggle`, see fastly/Viceroy#16, or the `other_entity` test cases in this diff, for more information!