### PR TITLE
Cranelift CLIF Fuzzer generate blocks and branches

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -9,6 +9,13 @@ pub struct Config {
     /// Number of variables that we allocate per function
     /// This value does not include the signature params
     pub vars_per_function: RangeInclusive<usize>,
+    /// Number of blocks that we generate per function.
+    /// This value does not include the entry block
+    pub blocks_per_function: RangeInclusive<usize>,
+    /// Number of params a block should take
+    /// This value does not apply to block0 which takes the function params
+    /// and is thus governed by `signature_params`
+    pub block_signature_params: RangeInclusive<usize>,
 }
 
 impl Default for Config {
@@ -19,6 +26,8 @@ impl Default for Config {
             signature_rets: 0..=16,
             instructions_per_block: 0..=64,
             vars_per_function: 0..=16,
+            blocks_per_function: 0..=16,
+            block_signature_params: 0..=16,
         }
     }
 }

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -7,14 +7,17 @@ use cranelift_filetests::function_runner::{CompiledFunction, SingleFunctionCompi
 use cranelift_fuzzgen::*;
 use cranelift_interpreter::environment::FuncIndex;
 use cranelift_interpreter::environment::FunctionStore;
-use cranelift_interpreter::interpreter::{Interpreter, InterpreterState};
+use cranelift_interpreter::interpreter::{Interpreter, InterpreterError, InterpreterState};
 use cranelift_interpreter::step::ControlFlow;
 use cranelift_interpreter::step::CraneliftTrap;
+
+const INTERPRETER_FUEL: u64 = 4096;
 
 #[derive(Debug)]
 enum RunResult {
     Success(Vec<DataValue>),
     Trap(CraneliftTrap),
+    Timeout,
     Error(Box<dyn std::error::Error>),
 }
 
@@ -36,7 +39,8 @@ fn run_in_interpreter(interpreter: &mut Interpreter, args: &[DataValue]) -> RunR
         Ok(ControlFlow::Return(results)) => RunResult::Success(results.to_vec()),
         Ok(ControlFlow::Trap(trap)) => RunResult::Trap(trap),
         Ok(cf) => RunResult::Error(format!("Unrecognized exit ControlFlow: {:?}", cf).into()),
-        Err(e) => RunResult::Error(format!("InterpreterError: {:?}", e).into()),
+        Err(InterpreterError::FuelExhausted) => RunResult::Timeout,
+        Err(e) => RunResult::Error(e.into()),
     }
 }
 
@@ -46,12 +50,12 @@ fn run_in_host(compiled_fn: &CompiledFunction, args: &[DataValue]) -> RunResult 
 }
 
 fuzz_target!(|testcase: TestCase| {
-    let mut interpreter = {
+    let build_interpreter = || {
         let mut env = FunctionStore::default();
         env.add(testcase.func.name.to_string(), &testcase.func);
 
         let state = InterpreterState::default().with_function_store(env);
-        let interpreter = Interpreter::new(state);
+        let interpreter = Interpreter::new(state).with_fuel(Some(INTERPRETER_FUEL));
         interpreter
     };
 
@@ -60,6 +64,9 @@ fuzz_target!(|testcase: TestCase| {
     let compiled_fn = host_compiler.compile(testcase.func.clone()).unwrap();
 
     for args in &testcase.inputs {
+        // We rebuild the interpreter every run so that we don't accidentally carry over any state
+        // between runs, such as fuel remaining.
+        let mut interpreter = build_interpreter();
         let int_res = run_in_interpreter(&mut interpreter, args);
         match int_res {
             RunResult::Success(_) => {}
@@ -69,6 +76,10 @@ fuzz_target!(|testcase: TestCase| {
                 // interpreter traps, but since we already test trap cases with
                 // wasm tests and wasm-level fuzzing, the amount of effort does
                 // not justify implementing it again here.
+                return;
+            }
+            RunResult::Timeout => {
+                // We probably generated an infinite loop, we can ignore this
                 return;
             }
             RunResult::Error(_) => panic!("interpreter failed: {:?}", int_res),


### PR DESCRIPTION
Hey,

Continuing the implementation of the CLIF Fuzzer (tracked in #3050), this PR implements block generation and generating basic branch instructions (jump, brnz, brz, br_icmp).

In this implementation we generate all blocks and signatures up front, and then while generating instructions pick random target blocks to jump to.

This PR is based on top of #3062 which should be merged soon, but I think we can get some issues sorted out while waiting for that to be merged.