### PR TITLE
Fix for 3089 X64 ext_mul_i8x16 has incorrect lowering

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -1699,20 +1699,17 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         match (input0_ty, input1_ty, output_ty) {
                             (types::I8X16, types::I8X16, types::I16X8) => {
                                 // i16x8.extmul_high_i8x16_s
-
-                                let tmp_reg = ctx.alloc_tmp(types::I16X8).only_reg().unwrap();
-                                ctx.emit(Inst::gen_move(tmp_reg, lhs, output_ty));
                                 ctx.emit(Inst::xmm_rm_r_imm(
                                     SseOpcode::Palignr,
                                     RegMem::reg(lhs),
-                                    tmp_reg,
+                                    Writable::from_reg(lhs),
                                     8,
                                     OperandSize::Size32,
                                 ));
                                 ctx.emit(Inst::xmm_mov(
                                     SseOpcode::Pmovsxbw,
                                     RegMem::reg(lhs),
-                                    tmp_reg,
+                                    Writable::from_reg(lhs),
                                 ));
 
                                 ctx.emit(Inst::gen_move(dst, rhs, output_ty));
@@ -1723,12 +1720,12 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                                     8,
                                     OperandSize::Size32,
                                 ));
-                                ctx.emit(Inst::xmm_mov(SseOpcode::Pmovsxbw, RegMem::reg(rhs), dst));
-                                ctx.emit(Inst::xmm_rm_r(
-                                    SseOpcode::Pmullw,
-                                    RegMem::reg(tmp_reg.to_reg()),
+                                ctx.emit(Inst::xmm_mov(
+                                    SseOpcode::Pmovsxbw,
+                                    RegMem::reg(dst.to_reg()),
                                     dst,
                                 ));
+                                ctx.emit(Inst::xmm_rm_r(SseOpcode::Pmullw, RegMem::reg(lhs), dst));
                             }
                             (types::I16X8, types::I16X8, types::I32X4) => {
                                 // i32x4.extmul_high_i16x8_s
@@ -1876,19 +1873,17 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         match (input0_ty, input1_ty, output_ty) {
                             (types::I8X16, types::I8X16, types::I16X8) => {
                                 // i16x8.extmul_high_i8x16_u
-                                let tmp_reg = ctx.alloc_tmp(types::I16X8).only_reg().unwrap();
-                                ctx.emit(Inst::gen_move(tmp_reg, lhs, output_ty));
                                 ctx.emit(Inst::xmm_rm_r_imm(
                                     SseOpcode::Palignr,
                                     RegMem::reg(lhs),
-                                    tmp_reg,
+                                    Writable::from_reg(lhs),
                                     8,
                                     OperandSize::Size32,
                                 ));
                                 ctx.emit(Inst::xmm_mov(
                                     SseOpcode::Pmovzxbw,
                                     RegMem::reg(lhs),
-                                    tmp_reg,
+                                    Writable::from_reg(lhs),
                                 ));
                                 ctx.emit(Inst::gen_move(dst, rhs, output_ty));
                                 ctx.emit(Inst::xmm_rm_r_imm(
@@ -1898,12 +1893,12 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                                     8,
                                     OperandSize::Size32,
                                 ));
-                                ctx.emit(Inst::xmm_mov(SseOpcode::Pmovzxbw, RegMem::reg(rhs), dst));
-                                ctx.emit(Inst::xmm_rm_r(
-                                    SseOpcode::Pmullw,
-                                    RegMem::reg(tmp_reg.to_reg()),
+                                ctx.emit(Inst::xmm_mov(
+                                    SseOpcode::Pmovzxbw,
+                                    RegMem::reg(dst.to_reg()),
                                     dst,
                                 ));
+                                ctx.emit(Inst::xmm_rm_r(SseOpcode::Pmullw, RegMem::reg(lhs), dst));
                             }
                             (types::I16X8, types::I16X8, types::I32X4) => {
                                 // i32x4.extmul_high_i16x8_u


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
