### PR TITLE
Riscv disassembler support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "capstone"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e4890dad38e19668a2a9bce54242e6b0dece021b862ba25ae80b439c6d36b6"
+checksum = "178b3c80b4ce3939792d1dd6600575e012da806a10e81abe812dc29cbfe629ec"
 dependencies = [
  "capstone-sys",
  "libc",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "capstone-sys"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c2624132869952c2db6f1d77e24da16b6db5f5a918270c5685a5ea8db822c4"
+checksum = "cf2f3d97b88fa4a9a6464c7c08b8c4588aaea8c18d0651eca11f2ca15f50f1f6"
 dependencies = [
  "cc",
  "libc",

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -33,7 +33,7 @@ cranelift-fuzzgen = { path = "fuzzgen", version = "0.75.0" }
 filecheck = "0.5.0"
 log = "0.4.8"
 termcolor = "1.1.2"
-capstone = { version = "0.8.0", optional = true }
+capstone = { version = "0.9.0", optional = true }
 wat = { version = "1.0.36", optional = true }
 target-lexicon = { version = "0.12", features = ["std"] }
 peepmatic-souper = { path = "./peepmatic/crates/souper", version = "0.75.0", optional = true }

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -111,8 +111,27 @@ cfg_if! {
 
         fn get_disassembler(isa: &dyn TargetIsa) -> Result<Capstone> {
             let cs = match isa.triple().architecture {
-                Architecture::Riscv32(_) | Architecture::Riscv64(_) => {
-                    anyhow::bail!("No disassembler for RiscV");
+                Architecture::Riscv32(_) => {
+                    let mut cs = Capstone::new()
+                        .riscv()
+                        .mode(arch::riscv::ArchMode::RiscV32)
+                        .extra_mode(std::iter::once(arch::riscv::ArchExtraMode::RiscVC))
+                        .build()
+                        .map_err(map_caperr)?;
+                    // See the comment of AArch64 below
+                    cs.set_skipdata(true).map_err(map_caperr)?;
+                    cs
+                }
+                Architecture::Riscv64(_) => {
+                    let mut cs = Capstone::new()
+                        .riscv()
+                        .mode(arch::riscv::ArchMode::RiscV64)
+                        .extra_mode(std::iter::once(arch::riscv::ArchExtraMode::RiscVC))
+                        .build()
+                        .map_err(map_caperr)?;
+                    // See the comment of AArch64 below
+                    cs.set_skipdata(true).map_err(map_caperr)?;
+                    cs
                 }
                 Architecture::X86_32(_) => Capstone::new()
                     .x86()

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 arrayvec = "0.5"
-capstone = "0.8.0"
+capstone = "0.9.0"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.75.0" }
 derive_more = "0.99"
 dynasm = "1.0.0"


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

capstone v0.9 released recently support RISC-V already.