### PR TITLE
cranelift: Fix trampoline args for b1 types

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -62,10 +62,18 @@ impl DataValue {
         }
     }
 
+    /// Return true if the value is a bool (i.e. `DataValue::B`).
+    pub fn is_bool(&self) -> bool {
+        match self {
+            DataValue::B(_) => true,
+            _ => false,
+        }
+    }
+
     /// Write a [DataValue] to a memory location.
     pub unsafe fn write_value_to(&self, p: *mut u128) {
         match self {
-            DataValue::B(b) => ptr::write(p as *mut bool, *b),
+            DataValue::B(b) => ptr::write(p, if *b { -1i128 as u128 } else { 0u128 }),
             DataValue::I8(i) => ptr::write(p as *mut i8, *i),
             DataValue::I16(i) => ptr::write(p as *mut i16, *i),
             DataValue::I32(i) => ptr::write(p as *mut i32, *i),
@@ -86,7 +94,7 @@ impl DataValue {
             types::I64 => DataValue::I64(ptr::read(p as *const i64)),
             types::F32 => DataValue::F32(ptr::read(p as *const Ieee32)),
             types::F64 => DataValue::F64(ptr::read(p as *const Ieee64)),
-            _ if ty.is_bool() => DataValue::B(ptr::read(p as *const bool)),
+            _ if ty.is_bool() => DataValue::B(ptr::read(p) != 0),
             _ if ty.is_vector() && ty.bytes() == 16 => {
                 DataValue::V128(ptr::read(p as *const [u8; 16]))
             }

--- a/cranelift/filetests/filetests/runtests/br.clif
+++ b/cranelift/filetests/filetests/runtests/br.clif
@@ -90,10 +90,8 @@ block2:
 ; run: %brz_i8(-1) == false
 
 
-; TODO: Merge this with brz_b1_false when we are able to pass bool imm's in test params
-function %brz_b1_true() -> b1 {
-block0:
-    v1 = bconst.b1 true
+function %brz_b1(b1) -> b1 {
+block0(v1: b1):
     brz v1, block1
     jump block2
 
@@ -105,24 +103,8 @@ block2:
     v3 = bconst.b1 false
     return v3
 }
-; run: %brz_b1_true() == false
-
-function %brz_b1_false() -> b1 {
-block0:
-    v1 = bconst.b1 false
-    brz v1, block1
-    jump block2
-
-block1:
-    v2 = bconst.b1 true
-    return v2
-
-block2:
-    v3 = bconst.b1 false
-    return v3
-}
-; run: %brz_b1_false() == true
-
+; run: %brz_b1(true) == false
+; run: %brz_b1(false) == true
 
 
 function %brnz_i64(i64) -> b1 {
@@ -194,10 +176,8 @@ block2:
 ; run: %brnz_i8(-1) == true
 
 
-; TODO: Merge this with brz_b1_false when we are able to pass bool imm's in test params
-function %brnz_b1_true() -> b1 {
-block0:
-    v1 = bconst.b1 true
+function %brnz_b1(b1) -> b1 {
+block0(v1: b1):
     brnz v1, block1
     jump block2
 
@@ -209,20 +189,5 @@ block2:
     v3 = bconst.b1 false
     return v3
 }
-; run: %brnz_b1_true() == true
-
-function %brnz_b1_false() -> b1 {
-block0:
-    v1 = bconst.b1 false
-    brnz v1, block1
-    jump block2
-
-block1:
-    v2 = bconst.b1 true
-    return v2
-
-block2:
-    v3 = bconst.b1 false
-    return v3
-}
-; run: %brnz_b1_false() == false
+; run: %brnz_b1(true) == true
+; run: %brnz_b1(false) == false

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -198,7 +198,7 @@ impl UnboxedValues {
         // Store the argument values into `values_vec`.
         for ((arg, slot), param) in arguments.iter().zip(&mut values_vec).zip(&signature.params) {
             assert!(
-                arg.ty() == param.value_type || arg.is_vector(),
+                arg.ty() == param.value_type || arg.is_vector() || arg.is_bool(),
                 "argument type mismatch: {} != {}",
                 arg.ty(),
                 param.value_type


### PR DESCRIPTION
Hey,

We're now having issues with this on the fuzzer, since we introduced b1 types in #3094.

The assert was complaining because we identify `DataValue::B`'s as `B8`'s. I think we are ok disabling this assert for bools, because we are always going to have a size mismatch, and this check is not meaningful for this type.

Fixing trampoline bool args is tracked in #2237 