### PR TITLE
Add support for Saturating Rounding Q-format Multiplication for x64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -190,7 +190,6 @@ fn x64_should_panic(testsuite: &str, testname: &str, strategy: &str) -> bool {
 
     match (testsuite, testname) {
         ("simd", "simd_i16x8_extadd_pairwise_i8x16") => return true,
-        ("simd", "simd_i16x8_q15mulr_sat_s") => return true,
         ("simd", "simd_i32x4_extadd_pairwise_i16x8") => return true,
         ("simd", "simd_i32x4_trunc_sat_f64x2") => return true,
         ("simd", "simd_int_to_int_extend") => return true,

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -596,6 +596,7 @@ pub enum SseOpcode {
     Pmuldq,
     Pmulhw,
     Pmulhuw,
+    Pmulhrsw,
     Pmulld,
     Pmullw,
     Pmuludq,
@@ -785,6 +786,7 @@ impl SseOpcode {
             | SseOpcode::Pabsw
             | SseOpcode::Pabsd
             | SseOpcode::Palignr
+            | SseOpcode::Pmulhrsw
             | SseOpcode::Pshufb => SSSE3,
 
             SseOpcode::Blendvpd
@@ -966,6 +968,7 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Pmuldq => "pmuldq",
             SseOpcode::Pmulhw => "pmulhw",
             SseOpcode::Pmulhuw => "pmulhuw",
+            SseOpcode::Pmulhrsw => "pmulhrsw",
             SseOpcode::Pmulld => "pmulld",
             SseOpcode::Pmullw => "pmullw",
             SseOpcode::Pmuludq => "pmuludq",

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1511,6 +1511,7 @@ pub(crate) fn emit(
                 SseOpcode::Pminud => (LegacyPrefixes::_66, 0x0F383B, 3),
                 SseOpcode::Pmuldq => (LegacyPrefixes::_66, 0x0F3828, 3),
                 SseOpcode::Pmulhw => (LegacyPrefixes::_66, 0x0FE5, 2),
+                SseOpcode::Pmulhrsw => (LegacyPrefixes::_66, 0x0F380B, 3),
                 SseOpcode::Pmulhuw => (LegacyPrefixes::_66, 0x0FE4, 2),
                 SseOpcode::Pmulld => (LegacyPrefixes::_66, 0x0F3840, 3),
                 SseOpcode::Pmullw => (LegacyPrefixes::_66, 0x0FD5, 2),
@@ -1755,7 +1756,6 @@ pub(crate) fn emit(
             let (prefix, opcode) = match op {
                 SseOpcode::Movaps => (LegacyPrefixes::None, 0x0F29),
                 SseOpcode::Movapd => (LegacyPrefixes::_66, 0x0F29),
-                SseOpcode::Movdqa => (LegacyPrefixes::_66, 0x0F7F),
                 SseOpcode::Movdqu => (LegacyPrefixes::_F3, 0x0F7F),
                 SseOpcode::Movss => (LegacyPrefixes::_F3, 0x0F11),
                 SseOpcode::Movsd => (LegacyPrefixes::_F2, 0x0F11),

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -6405,6 +6405,42 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         },
 
+        Opcode::SqmulRoundSat => {
+            // Lane-wise saturating rounding multiplication in Q15 format
+            // Optimal lowering taken from instruction proposal https://github.com/WebAssembly/simd/pull/365
+            // y = i16x8.q15mulr_sat_s(a, b) is lowered to:
+            //MOVDQA xmm_y, xmm_a
+            //MOVDQA xmm_tmp, wasm_i16x8_splat(0x8000)
+            //PMULHRSW xmm_y, xmm_b
+            //PCMPEQW xmm_tmp, xmm_y
+            //PXOR xmm_y, xmm_tmp
+            let input_ty = ctx.input_ty(insn, 0);
+            let src1 = put_input_in_reg(ctx, inputs[0]);
+            let src2 = put_input_in_reg(ctx, inputs[1]);
+            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+
+            ctx.emit(Inst::gen_move(dst, src1, input_ty));
+            static SAT_MASK: [u8; 16] = [
+                0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80,
+                0x00, 0x80,
+            ];
+            let mask_const = ctx.use_constant(VCodeConstantData::WellKnown(&SAT_MASK));
+            let mask = ctx.alloc_tmp(types::I16X8).only_reg().unwrap();
+            ctx.emit(Inst::xmm_load_const(mask_const, mask, types::I16X8));
+
+            ctx.emit(Inst::xmm_rm_r(SseOpcode::Pmulhrsw, RegMem::reg(src2), dst));
+            ctx.emit(Inst::xmm_rm_r(
+                SseOpcode::Pcmpeqw,
+                RegMem::reg(dst.to_reg()),
+                mask,
+            ));
+            ctx.emit(Inst::xmm_rm_r(
+                SseOpcode::Pxor,
+                RegMem::reg(mask.to_reg()),
+                dst,
+            ));
+        }
+
         // Unimplemented opcodes below. These are not currently used by Wasm
         // lowering or other known embeddings, but should be either supported or
         // removed eventually.
@@ -6435,8 +6471,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             unimplemented!("Vector split/concat ops not implemented.");
         }
 
-        Opcode::SqmulRoundSat | Opcode::Uunarrow => {
-            unimplemented!("unimplemented lowering for opcode {:?}", op)
+        Opcode::Uunarrow => {
+            unimplemented!("unimplemented lowering for opcode {:?}", op);
         }
 
         // Opcodes that should be removed by legalization. These should


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
