### PR TITLE
x64: avoid load-coalescing SIMD operations with non-aligned loads

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,7 @@ fn main() -> anyhow::Result<()> {
             test_directory_module(out, "tests/misc_testsuite/reference-types", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/multi-memory", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/module-linking", strategy)?;
+            test_directory_module(out, "tests/misc_testsuite/simd", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/threads", strategy)?;
             Ok(())
         })?;

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -16,15 +16,16 @@ use core::str::FromStr;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::ir::{self, trapcode::TrapCode, types, Block, FuncRef, JumpTable, SigRef, Type, Value};
-use crate::isa;
-
 use crate::bitset::BitSet;
 use crate::data_value::DataValue;
 use crate::entity;
-use ir::condcodes::{FloatCC, IntCC};
-
-use super::MemFlags;
+use crate::ir::{
+    self,
+    condcodes::{FloatCC, IntCC},
+    trapcode::TrapCode,
+    types, Block, FuncRef, JumpTable, MemFlags, SigRef, Type, Value,
+};
+use crate::isa;
 
 /// Some instructions use an external list of argument values because there is not enough space in
 /// the 16-byte `InstructionData` struct. These value lists are stored in a memory pool in

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -24,6 +24,8 @@ use crate::data_value::DataValue;
 use crate::entity;
 use ir::condcodes::{FloatCC, IntCC};
 
+use super::MemFlags;
+
 /// Some instructions use an external list of argument values because there is not enough space in
 /// the 16-byte `InstructionData` struct. These value lists are stored in a memory pool in
 /// `dfg.value_lists`.
@@ -391,6 +393,19 @@ impl InstructionData {
             | &InstructionData::Store { offset, .. }
             | &InstructionData::StackStore { offset, .. }
             | &InstructionData::StoreComplex { offset, .. } => Some(offset.into()),
+            _ => None,
+        }
+    }
+
+    /// If this is a load/store instruction, return its memory flags.
+    pub fn memflags(&self) -> Option<MemFlags> {
+        match self {
+            &InstructionData::Load { flags, .. }
+            | &InstructionData::LoadComplex { flags, .. }
+            | &InstructionData::LoadNoOffset { flags, .. }
+            | &InstructionData::Store { flags, .. }
+            | &InstructionData::StoreComplex { flags, .. }
+            | &InstructionData::StoreNoOffset { flags, .. } => Some(flags),
             _ => None,
         }
     }

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -153,6 +153,12 @@ fn is_mergeable_load<C: LowerCtx<I = Inst>>(
         return None;
     }
 
+    // SIMD instructions can only be load-coalesced when the loaded value comes
+    // from an aligned address.
+    if load_ty.is_vector() && !insn_data.memflags().map_or(false, |f| f.aligned()) {
+        return None;
+    }
+
     // Just testing the opcode is enough, because the width will always match if
     // the type does (and the type should match if the CLIF is properly
     // constructed).

--- a/tests/misc_testsuite/simd/unaligned-load.wast
+++ b/tests/misc_testsuite/simd/unaligned-load.wast
@@ -1,0 +1,13 @@
+(; See discussion at https://github.com/bytecodealliance/wasmtime/issues/2943 ;)
+(module
+  (memory 1)
+  (data (i32.const 1) "\01\00\00\00\01\00\00\00")
+
+  (func $unaligned_load (export "unaligned_load") (result v128)
+    v128.const i32x4 0 0 1 1
+    i32.const 1
+    v128.load
+    v128.xor)
+)
+
+(assert_return (invoke "unaligned_load") (v128.const i32x4 1 1 1 1))


### PR DESCRIPTION
Fixes #2943, though not as optimally as may be desired. With x64 SIMD
instructions, the memory operand must be aligned--this change adds that
check. There are cases, however, where we can do better--see #3106.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
