### PR TITLE
cranelift: Move most debug-level logs to the trace level

### DIFF
--- a/cranelift/codegen/src/binemit/relaxation.rs
+++ b/cranelift/codegen/src/binemit/relaxation.rs
@@ -38,7 +38,6 @@ use crate::regalloc::RegDiversions;
 use crate::timing;
 use crate::CodegenResult;
 use core::convert::TryFrom;
-use log::debug;
 
 /// Relax branches and compute the final layout of block headers in `func`.
 ///
@@ -334,7 +333,7 @@ fn relax_branch(
     isa: &dyn TargetIsa,
 ) -> CodeOffset {
     let inst = cur.current_inst().unwrap();
-    debug!(
+    log::trace!(
         "Relaxing [{}] {} for {:#x}-{:#x} range",
         encinfo.display(cur.func.encodings[inst]),
         cur.func.dfg.display_inst(inst, isa),
@@ -350,7 +349,7 @@ fn relax_branch(
         .filter(|&enc| {
             let range = encinfo.branch_range(enc).expect("Branch with no range");
             if !range.contains(offset, dest_offset) {
-                debug!("  trying [{}]: out of range", encinfo.display(enc));
+                log::trace!("  trying [{}]: out of range", encinfo.display(enc));
                 false
             } else if encinfo.operand_constraints(enc)
                 != encinfo.operand_constraints(cur.func.encodings[inst])
@@ -360,10 +359,10 @@ fn relax_branch(
                 // which the existing operands don't satisfy. We can't check for
                 // validity directly because we don't have a RegDiversions active so
                 // we don't know which registers are actually in use.
-                debug!("  trying [{}]: constraints differ", encinfo.display(enc));
+                log::trace!("  trying [{}]: constraints differ", encinfo.display(enc));
                 false
             } else {
-                debug!("  trying [{}]: OK", encinfo.display(enc));
+                log::trace!("  trying [{}]: OK", encinfo.display(enc));
                 true
             }
         })

--- a/cranelift/codegen/src/binemit/shrink.rs
+++ b/cranelift/codegen/src/binemit/shrink.rs
@@ -10,7 +10,6 @@ use crate::ir::Function;
 use crate::isa::TargetIsa;
 use crate::regalloc::RegDiversions;
 use crate::timing;
-use log::debug;
 
 /// Pick the smallest valid encodings for instructions.
 pub fn shrink_instructions(func: &mut Function, isa: &dyn TargetIsa) {
@@ -58,7 +57,7 @@ pub fn shrink_instructions(func: &mut Function, isa: &dyn TargetIsa) {
                 if best_enc != enc {
                     func.encodings[inst] = best_enc;
 
-                    debug!(
+                    log::trace!(
                         "Shrunk [{}] to [{}] in {}, reducing the size from {} to {}",
                         encinfo.display(enc),
                         encinfo.display(best_enc),

--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -39,7 +39,6 @@ use crate::verifier::{verify_context, verify_locations, VerifierErrors, Verifier
 #[cfg(feature = "souper-harvest")]
 use alloc::string::String;
 use alloc::vec::Vec;
-use log::debug;
 
 #[cfg(feature = "souper-harvest")]
 use crate::souper_harvest::do_souper_harvest;
@@ -162,7 +161,7 @@ impl Context {
         self.verify_if(isa)?;
 
         let opt_level = isa.flags().opt_level();
-        debug!(
+        log::debug!(
             "Compiling (opt level {:?}):\n{}",
             opt_level,
             self.func.display(isa)
@@ -209,7 +208,7 @@ impl Context {
             }
             let result = self.relax_branches(isa);
 
-            debug!("Compiled:\n{}", self.func.display(isa));
+            log::trace!("Compiled:\n{}", self.func.display(isa));
             result
         }
     }
@@ -377,7 +376,7 @@ impl Context {
             self.verify_if(isa)
         } else {
             legalize_function(&mut self.func, &mut self.cfg, isa);
-            debug!("Legalized:\n{}", self.func.display(isa));
+            log::trace!("Legalized:\n{}", self.func.display(isa));
             self.verify_if(isa)
         }
     }

--- a/cranelift/codegen/src/ir/layout.rs
+++ b/cranelift/codegen/src/ir/layout.rs
@@ -11,7 +11,6 @@ use crate::packed_option::PackedOption;
 use crate::timing;
 use core::cmp;
 use core::iter::{IntoIterator, Iterator};
-use log::debug;
 
 /// The `Layout` struct determines the layout of blocks and instructions in a function. It does not
 /// contain definitions of instructions or blocks, but depends on `Inst` and `Block` entity references
@@ -328,7 +327,7 @@ impl Layout {
                 next_inst = self.insts[inst].next.expand();
             }
         }
-        debug!("Renumbered {} program points", seq / MAJOR_STRIDE);
+        log::trace!("Renumbered {} program points", seq / MAJOR_STRIDE);
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -10,7 +10,6 @@ use crate::machinst::ty_bits;
 use regalloc::{Reg, RegClass, Writable};
 
 use core::convert::TryFrom;
-use log::debug;
 
 /// Memory label/reference finalization: convert a MemLabel to a PC-relative
 /// offset, possibly emitting relocation(s) as necessary.
@@ -42,7 +41,7 @@ pub fn mem_finalize(
             };
             let adj = match mem {
                 &AMode::NominalSPOffset(..) => {
-                    debug!(
+                    log::trace!(
                         "mem_finalize: nominal SP offset {} + adj {} -> {}",
                         off,
                         state.virtual_sp_offset,
@@ -2642,7 +2641,7 @@ impl MachInstEmit for Inst {
                 }
             }
             &Inst::VirtualSPOffsetAdj { offset } => {
-                debug!(
+                log::trace!(
                     "virtual sp offset adjusted by {} -> {}",
                     offset,
                     state.virtual_sp_offset + offset,

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -21,7 +21,6 @@ use crate::isa::aarch64::AArch64Backend;
 use super::lower_inst;
 
 use crate::data_value::DataValue;
-use log::{debug, trace};
 use regalloc::{Reg, Writable};
 use smallvec::SmallVec;
 use std::cmp;
@@ -275,7 +274,7 @@ fn lower_input_to_regs<C: LowerCtx<I = Inst>>(
     ctx: &mut C,
     input: InsnInput,
 ) -> (ValueRegs<Reg>, Type, bool) {
-    debug!("lower_input_to_regs: input {:?}", input);
+    log::trace!("lower_input_to_regs: input {:?}", input);
     let ty = ctx.input_ty(input.insn, input.input);
     let inputs = ctx.get_input_as_source_or_const(input.insn, input.input);
     let is_const = inputs.constant.is_some();
@@ -730,7 +729,7 @@ pub(crate) fn lower_pair_address<C: LowerCtx<I = Inst>>(
     let (mut addends64, mut addends32, args_offset) = collect_address_addends(ctx, roots);
     let offset = args_offset + (offset as i64);
 
-    trace!(
+    log::trace!(
         "lower_pair_address: addends64 {:?}, addends32 {:?}, offset {}",
         addends64,
         addends32,
@@ -791,7 +790,7 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
     let (mut addends64, mut addends32, args_offset) = collect_address_addends(ctx, roots);
     let mut offset = args_offset + (offset as i64);
 
-    trace!(
+    log::trace!(
         "lower_address: addends64 {:?}, addends32 {:?}, offset {}",
         addends64,
         addends32,
@@ -1194,13 +1193,15 @@ pub(crate) fn maybe_input_insn<C: LowerCtx<I = Inst>>(
     op: Opcode,
 ) -> Option<IRInst> {
     let inputs = c.get_input_as_source_or_const(input.insn, input.input);
-    debug!(
+    log::trace!(
         "maybe_input_insn: input {:?} has options {:?}; looking for op {:?}",
-        input, inputs, op
+        input,
+        inputs,
+        op
     );
     if let Some((src_inst, _)) = inputs.inst {
         let data = c.data(src_inst);
-        debug!(" -> input inst {:?}", data);
+        log::trace!(" -> input inst {:?}", data);
         if data.opcode() == op {
             return Some(src_inst);
         }
@@ -1300,9 +1301,11 @@ pub(crate) fn lower_icmp<C: LowerCtx<I = Inst>>(
     condcode: IntCC,
     output: IcmpOutput,
 ) -> CodegenResult<IcmpResult> {
-    debug!(
+    log::trace!(
         "lower_icmp: insn {}, condcode: {}, output: {:?}",
-        insn, condcode, output
+        insn,
+        condcode,
+        output
     );
 
     let rd = output.reg().unwrap_or(writable_zero_reg());

--- a/cranelift/codegen/src/isa/arm32/inst/emit.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/emit.rs
@@ -5,7 +5,6 @@ use crate::ir::SourceLoc;
 use crate::isa::arm32::inst::*;
 
 use core::convert::TryFrom;
-use log::debug;
 
 /// Memory addressing mode finalization: convert "special" modes (e.g.,
 /// nominal stack offset) into real addressing modes, possibly by
@@ -25,7 +24,7 @@ pub fn mem_finalize(mem: &AMode, state: &EmitState) -> (SmallVec<[Inst; 4]>, AMo
             };
             let adj = match mem {
                 &AMode::NominalSPOffset(..) => {
-                    debug!(
+                    log::trace!(
                         "mem_finalize: nominal SP offset {} + adj {} -> {}",
                         off,
                         state.virtual_sp_offset,
@@ -809,7 +808,7 @@ impl MachInstEmit for Inst {
                 trap.emit(sink, emit_info, state);
             }
             &Inst::VirtualSPOffsetAdj { offset } => {
-                debug!(
+                log::trace!(
                     "virtual sp offset adjusted by {} -> {}",
                     offset,
                     state.virtual_sp_offset + offset,

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -7,7 +7,6 @@ use crate::ir::{SourceLoc, TrapCode};
 use crate::isa::s390x::inst::*;
 use crate::isa::s390x::settings as s390x_settings;
 use core::convert::TryFrom;
-use log::debug;
 use regalloc::{Reg, RegClass};
 
 /// Memory addressing mode finalization: convert "special" modes (e.g.,
@@ -322,7 +321,7 @@ fn machreg_to_gpr_or_fpr(m: Reg) -> u8 {
 
 /// E-type instructions.
 ///
-///   15    
+///   15
 ///   opcode
 ///        0
 ///
@@ -2056,7 +2055,7 @@ impl MachInstEmit for Inst {
             }
 
             &Inst::VirtualSPOffsetAdj { offset } => {
-                debug!(
+                log::trace!(
                     "virtual sp offset adjusted by {} -> {}",
                     offset,
                     state.virtual_sp_offset + offset

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -12,7 +12,6 @@ use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::machinst::{inst_common, MachBuffer, MachInstEmit, MachLabel};
 use core::convert::TryInto;
-use log::debug;
 use regalloc::{Reg, Writable};
 
 /// A small helper to generate a signed conversion instruction.
@@ -2548,7 +2547,7 @@ pub(crate) fn emit(
         }
 
         Inst::VirtualSPOffsetAdj { offset } => {
-            debug!(
+            log::trace!(
                 "virtual sp offset adjusted by {} -> {}",
                 offset,
                 state.virtual_sp_offset + offset

--- a/cranelift/codegen/src/legalizer/boundary.rs
+++ b/cranelift/codegen/src/legalizer/boundary.rs
@@ -32,7 +32,6 @@ use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::mem;
 use cranelift_entity::EntityList;
-use log::debug;
 
 /// Legalize all the function signatures in `func`.
 ///
@@ -479,7 +478,7 @@ where
     // Reconstruct how `ty` was legalized into the `arg_type` argument.
     let conversion = legalize_abi_value(ty, &arg_type);
 
-    debug!("convert_from_abi({}): {:?}", ty, conversion);
+    log::trace!("convert_from_abi({}): {:?}", ty, conversion);
 
     // The conversion describes value to ABI argument. We implement the reverse conversion here.
     match conversion {
@@ -488,7 +487,7 @@ where
             let abi_ty = ty.half_width().expect("Invalid type for conversion");
             let lo = convert_from_abi(pos, abi_ty, None, get_arg);
             let hi = convert_from_abi(pos, abi_ty, None, get_arg);
-            debug!(
+            log::trace!(
                 "intsplit {}: {}, {}: {}",
                 lo,
                 pos.func.dfg.value_type(lo),
@@ -877,7 +876,7 @@ pub fn handle_return_abi(inst: Inst, func: &mut Function, cfg: &ControlFlowGraph
     // the legalized signature. These values should simply be propagated from the entry block
     // arguments.
     if special_args > 0 {
-        debug!(
+        log::trace!(
             "Adding {} special-purpose arguments to {}",
             special_args,
             pos.func.dfg.display_inst(inst, None)

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -75,7 +75,6 @@ use crate::ir::{Block, Function, Inst, Opcode};
 use crate::machinst::lower::visit_block_succs;
 use crate::machinst::*;
 
-use log::debug;
 use smallvec::SmallVec;
 
 /// Mapping from CLIF BBs to VCode BBs.
@@ -192,7 +191,7 @@ impl LoweredBlock {
 impl BlockLoweringOrder {
     /// Compute and return a lowered block order for `f`.
     pub fn new(f: &Function) -> BlockLoweringOrder {
-        debug!("BlockLoweringOrder: function body {:?}", f);
+        log::trace!("BlockLoweringOrder: function body {:?}", f);
 
         // Step 1: compute the in-edge and out-edge count of every block.
         let mut block_in_count = SecondaryMap::with_default(0);
@@ -411,7 +410,7 @@ impl BlockLoweringOrder {
             lowered_succ_ranges,
             orig_map,
         };
-        debug!("BlockLoweringOrder: {:?}", result);
+        log::trace!("BlockLoweringOrder: {:?}", result);
         result
     }
 

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -6,7 +6,6 @@ use crate::machinst::*;
 use crate::settings;
 use crate::timing;
 
-use log::debug;
 use regalloc::{allocate_registers_with_opts, Algorithm, Options, PrettyPrint};
 
 /// Compile the given function down to VCode with allocated registers, ready
@@ -32,7 +31,7 @@ where
 
     // Creating the vcode string representation may be costly for large functions, so defer its
     // rendering.
-    debug!(
+    log::trace!(
         "vcode from lowering: \n{}",
         DeferredDisplay::new(|| vcode.show_rru(Some(b.reg_universe())))
     );
@@ -87,7 +86,7 @@ where
             },
         )
         .map_err(|err| {
-            debug!(
+            log::error!(
                 "Register allocation error for vcode\n{}\nError: {:?}",
                 vcode.show_rru(Some(b.reg_universe())),
                 err
@@ -104,7 +103,7 @@ where
         vcode.replace_insns_from_regalloc(result);
     }
 
-    debug!(
+    log::trace!(
         "vcode after regalloc: final version:\n{}",
         DeferredDisplay::new(|| vcode.show_rru(Some(b.reg_universe())))
     );

--- a/cranelift/codegen/src/regalloc/reload.rs
+++ b/cranelift/codegen/src/regalloc/reload.rs
@@ -22,7 +22,6 @@ use crate::regalloc::liveness::Liveness;
 use crate::timing;
 use crate::topo_order::TopoOrder;
 use alloc::vec::Vec;
-use log::debug;
 
 /// Reusable data structures for the reload pass.
 pub struct Reload {
@@ -73,7 +72,7 @@ impl Reload {
         tracker: &mut LiveValueTracker,
     ) {
         let _tt = timing::ra_reload();
-        debug!("Reload for:\n{}", func.display(isa));
+        log::trace!("Reload for:\n{}", func.display(isa));
         let mut ctx = Context {
             cur: EncCursor::new(func, isa),
             encinfo: isa.encoding_info(),
@@ -120,7 +119,7 @@ impl<'a> Context<'a> {
     }
 
     fn visit_block(&mut self, block: Block, tracker: &mut LiveValueTracker) {
-        debug!("Reloading {}:", block);
+        log::trace!("Reloading {}:", block);
         self.visit_block_header(block, tracker);
         tracker.drop_dead_params();
 

--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -108,7 +108,6 @@ impl fmt::Display for Pass {
 #[cfg(feature = "std")]
 mod details {
     use super::{Pass, DESCRIPTIONS, NUM_PASSES};
-    use log::debug;
     use std::cell::{Cell, RefCell};
     use std::fmt;
     use std::mem;
@@ -193,7 +192,7 @@ mod details {
     /// This function is called by the publicly exposed pass functions.
     pub(super) fn start_pass(pass: Pass) -> TimingToken {
         let prev = CURRENT_PASS.with(|p| p.replace(pass));
-        debug!("timing: Starting {}, (during {})", pass, prev);
+        log::debug!("timing: Starting {}, (during {})", pass, prev);
         TimingToken {
             start: Instant::now(),
             pass,
@@ -205,7 +204,7 @@ mod details {
     impl Drop for TimingToken {
         fn drop(&mut self) {
             let duration = self.start.elapsed();
-            debug!("timing: Ending {}", self.pass);
+            log::debug!("timing: Ending {}", self.pass);
             let old_cur = CURRENT_PASS.with(|p| p.replace(self.prev));
             debug_assert_eq!(self.pass, old_cur, "Timing tokens dropped out of order");
             PASS_TIME.with(|rc| {

--- a/cranelift/codegen/src/unreachable_code.rs
+++ b/cranelift/codegen/src/unreachable_code.rs
@@ -5,7 +5,6 @@ use crate::dominator_tree::DominatorTree;
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir;
 use crate::timing;
-use log::debug;
 
 /// Eliminate unreachable code.
 ///
@@ -25,14 +24,14 @@ pub fn eliminate_unreachable_code(
             continue;
         }
 
-        debug!("Eliminating unreachable {}", block);
+        log::trace!("Eliminating unreachable {}", block);
         // Move the cursor out of the way and make sure the next lop iteration goes to the right
         // block.
         pos.prev_block();
 
         // Remove all instructions from `block`.
         while let Some(inst) = pos.func.layout.first_inst(block) {
-            debug!(" - {}", pos.func.dfg.display_inst(inst, None));
+            log::trace!(" - {}", pos.func.dfg.display_inst(inst, None));
             pos.func.layout.remove_inst(inst);
         }
 

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -79,7 +79,6 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt::{self, Display, Formatter, Write};
-use log::debug;
 
 pub use self::cssa::verify_cssa;
 pub use self::liveness::verify_liveness;
@@ -2046,7 +2045,7 @@ impl<'a> Verifier<'a> {
         verify_flags(self.func, &self.expected_cfg, self.isa, errors)?;
 
         if !errors.is_empty() {
-            debug!(
+            log::warn!(
                 "Found verifier errors in function:\n{}",
                 pretty_verifier_error(self.func, None, None, errors.clone())
             );

--- a/cranelift/filetests/src/test_stack_maps.rs
+++ b/cranelift/filetests/src/test_stack_maps.rs
@@ -46,7 +46,6 @@ impl SubTest for TestStackMaps {
         text.push_str("Stack maps:\n");
         text.push('\n');
         text.push_str(&sink.text);
-        log::debug!("FITZGEN:\n{}", text);
 
         run_filecheck(&text, context)
     }

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use core::convert::TryFrom;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::*;
-use log::debug;
 
 type EntryIndex = u128;
 
@@ -77,7 +76,7 @@ impl Switch {
     /// * Between two `ContiguousCaseRange`s there will be at least one entry index.
     /// * No `ContiguousCaseRange`s will be empty.
     fn collect_contiguous_case_ranges(self) -> Vec<ContiguousCaseRange> {
-        debug!("build_contiguous_case_ranges before: {:#?}", self.cases);
+        log::trace!("build_contiguous_case_ranges before: {:#?}", self.cases);
         let mut cases = self.cases.into_iter().collect::<Vec<(_, _)>>();
         cases.sort_by_key(|&(index, _)| index);
 
@@ -100,7 +99,7 @@ impl Switch {
             last_index = Some(index);
         }
 
-        debug!(
+        log::trace!(
             "build_contiguous_case_ranges after: {:#?}",
             contiguous_case_ranges
         );

--- a/cranelift/src/interpret.rs
+++ b/cranelift/src/interpret.rs
@@ -5,7 +5,6 @@ use cranelift_interpreter::environment::FunctionStore;
 use cranelift_interpreter::interpreter::{Interpreter, InterpreterState};
 use cranelift_interpreter::step::ControlFlow;
 use cranelift_reader::{parse_run_command, parse_test, ParseError, ParseOptions};
-use log::debug;
 use std::path::PathBuf;
 use std::{fs, io};
 use structopt::StructOpt;
@@ -76,7 +75,7 @@ impl FileInterpreter {
     /// Construct a file runner from a CLIF file path.
     pub fn from_path(path: impl Into<PathBuf>) -> Result<Self, io::Error> {
         let path = path.into();
-        debug!("New file runner from path: {}:", path.to_string_lossy());
+        log::trace!("New file runner from path: {}:", path.to_string_lossy());
         let contents = fs::read_to_string(&path)?;
         Ok(Self {
             path: Some(path),
@@ -87,7 +86,7 @@ impl FileInterpreter {
     /// Construct a file runner from a CLIF code string. Currently only used for testing.
     #[cfg(test)]
     pub fn from_inline_code(contents: String) -> Self {
-        debug!("New file runner from inline code: {}:", &contents[..20]);
+        log::trace!("New file runner from inline code: {}:", &contents[..20]);
         Self {
             path: None,
             contents,

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -79,7 +79,7 @@ impl FuncTranslator {
     ) -> WasmResult<()> {
         let _tt = timing::wasm_translate_function();
         let mut reader = body.get_binary_reader();
-        log::debug!(
+        log::trace!(
             "translate({} bytes, {}{})",
             reader.bytes_remaining(),
             func.name,


### PR DESCRIPTION
Cranelift crates have historically been much more verbose with debug-level
logging than most other crates in the Rust ecosystem. We log things like how
many parameters a basic block has, the color of virtual registers during
regalloc, etc. Even for Cranelift hackers, these things are largely only useful
when hacking specifically on Cranelift and looking at a particular test case,
not even when using some Cranelift embedding (such as Wasmtime).

Most of the time, when people want logging for their Rust programs, they do
something like:

    RUST_LOG=debug cargo run

This means that they get all that mostly not useful debug logging out of
Cranelift. So they might want to disable logging for Cranelift, or change it to
a higher log level:

    RUST_LOG=debug,cranelift=info cargo run

The problem is that this is already more annoying to type that `RUST_LOG=debug`,
and that Cranelift isn't one single crate, so you actually have to play
whack-a-mole with naming all the Cranelift crates off the top of your head,
something more like this:

    RUST_LOG=debug,cranelift=info,cranelift_codegen=info,cranelift_wasm=info,...

Therefore, we're changing most of the `debug!` logs into `trace!` logs: anything
that is very Cranelift-internal, unlikely to be useful/meaningful to the
"average" Cranelift embedder, or prints a message for each instruction visited
during a pass. On the other hand, things that just report a one line statistic
for a whole pass, for example, are left as `debug!`. The more verbose the log
messages are, the higher the bar they must clear to be `debug!` rather than
`trace!`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
