### PR TITLE
Add a `wasmtime_linker_define_func` C API function

### DIFF
--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -81,6 +81,41 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
 );
 
 /**
+ * \brief Defines a new function in this linker.
+ *
+ * \param linker the linker the name is being defined in.
+ * \param module the module name the item is defined under.
+ * \param module_len the byte length of `module`
+ * \param name the field name the item is defined under
+ * \param name_len the byte length of `name`
+ * \param ty the type of the function that's being defined
+ * \param cb the host callback to invoke when the function is called
+ * \param data the host-provided data to provide as the first argument to the callback
+ * \param finalizer an optional finalizer for the `data` argument.
+ *
+ * \return On success `NULL` is returned, otherwise an error is returned which
+ * describes why the definition failed.
+ *
+ * For more information about name resolution consult the [Rust
+ * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
+ *
+ * Note that this function does not create a #wasmtime_func_t. This creates a
+ * store-independent function within the linker, allowing this function
+ * definition to be used with multiple stores.
+ */
+WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
+    wasmtime_linker_t *linker,
+    const char *module,
+    size_t module_len,
+    const char *name,
+    size_t name_len,
+    const wasm_functype_t *ty,
+    wasmtime_func_callback_t cb,
+    void *data,
+    void (*finalizer)(void*)
+);
+
+/**
  * \brief Defines WASI functions in this linker.
  *
  * \param linker the linker the name is being defined in.


### PR DESCRIPTION
This exposes the functionality of the `Linker` type where a
store-independent function can be created and inserted, allowing a
linker's functions to be used across many stores (instead of requiring
one linker-per-store).

Closes #3110

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
