### PR TITLE
Fix unused borrow warning

### DIFF
--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -435,7 +435,7 @@ impl CompiledExpression {
                             let new_to = landing_positions[&marker];
                             let new_diff = new_to as isize - new_from as isize;
                             // FIXME: use encoding? LittleEndian for now...
-                            &code_buf[new_from - 2..new_from]
+                            code_buf[new_from - 2..new_from]
                                 .copy_from_slice(&(new_diff as i16).to_le_bytes());
                         }
                         Ok(Some((func_index, start, end, code_buf)))


### PR DESCRIPTION
`#[warn(unused_must_use)]` is on, prompting a compiler warning like:
"unused borrow that must be used".

```
warning: unused borrow that must be used
   --> crates/debug/src/transform/expression.rs:438:29
    |
438 | / ...                   &code_buf[new_from - 2..new_from]
439 | | ...                       .copy_from_slice(&(new_diff as i16).to_le_bytes());
    | |____________________________________________________________________________^
    |
    = note: `#[warn(unused_must_use)]` on by default
```
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
