### PR TITLE
Add x64 support for remaining int-to-int extend simd instructions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -192,7 +192,6 @@ fn x64_should_panic(testsuite: &str, testname: &str, strategy: &str) -> bool {
     match (testsuite, testname) {
         ("simd", "simd_i16x8_extadd_pairwise_i8x16") => return true,
         ("simd", "simd_i32x4_extadd_pairwise_i16x8") => return true,
-        ("simd", "simd_int_to_int_extend") => return true,
         ("simd", _) => return false,
         _ => {}
     }

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -4941,6 +4941,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         (types::I16X8, types::I32X4) => {
                             ctx.emit(Inst::xmm_mov(SseOpcode::Pmovsxwd, RegMem::reg(src), dst));
                         }
+                        (types::I32X4, types::I64X2) => {
+                            ctx.emit(Inst::xmm_mov(SseOpcode::Pmovsxdq, RegMem::reg(src), dst));
+                        }
                         _ => unreachable!(),
                     },
                     Opcode::SwidenHigh => match (input_ty, output_ty) {
@@ -4966,6 +4969,16 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                             ));
                             ctx.emit(Inst::xmm_mov(SseOpcode::Pmovsxwd, RegMem::from(dst), dst));
                         }
+                        (types::I32X4, types::I64X2) => {
+                            ctx.emit(Inst::xmm_rm_r_imm(
+                                SseOpcode::Pshufd,
+                                RegMem::reg(src),
+                                dst,
+                                0xEE,
+                                OperandSize::Size32,
+                            ));
+                            ctx.emit(Inst::xmm_mov(SseOpcode::Pmovsxdq, RegMem::from(dst), dst));
+                        }
                         _ => unreachable!(),
                     },
                     Opcode::UwidenLow => match (input_ty, output_ty) {
@@ -4975,10 +4988,10 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                         (types::I16X8, types::I32X4) => {
                             ctx.emit(Inst::xmm_mov(SseOpcode::Pmovzxwd, RegMem::reg(src), dst));
                         }
-                        _ => unreachable!(
-                            "In UwidenLow: input_ty {:?}, output_ty {:?}",
-                            input_ty, output_ty
-                        ),
+                        (types::I32X4, types::I64X2) => {
+                            ctx.emit(Inst::xmm_mov(SseOpcode::Pmovzxdq, RegMem::reg(src), dst));
+                        }
+                        _ => unreachable!(),
                     },
                     Opcode::UwidenHigh => match (input_ty, output_ty) {
                         (types::I8X16, types::I16X8) => {
@@ -5002,6 +5015,16 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                                 OperandSize::Size32,
                             ));
                             ctx.emit(Inst::xmm_mov(SseOpcode::Pmovzxwd, RegMem::from(dst), dst));
+                        }
+                        (types::I32X4, types::I64X2) => {
+                            ctx.emit(Inst::xmm_rm_r_imm(
+                                SseOpcode::Pshufd,
+                                RegMem::reg(src),
+                                dst,
+                                0xEE,
+                                OperandSize::Size32,
+                            ));
+                            ctx.emit(Inst::xmm_mov(SseOpcode::Pmovzxdq, RegMem::from(dst), dst));
                         }
                         _ => unreachable!(),
                     },


### PR DESCRIPTION
Adds remaming support for int to int extend simd instructions.
Specifically adds support for remaining I32x4->I64x2 instructions

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
