### PR TITLE
Fix warning on new-stable

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/isa.rs
+++ b/cranelift/codegen/meta/src/cdsl/isa.rs
@@ -10,6 +10,7 @@ use crate::cdsl::xform::{TransformGroupIndex, TransformGroups};
 
 pub(crate) struct TargetIsa {
     pub name: &'static str,
+    #[allow(dead_code)]
     pub instructions: InstructionGroup,
     pub settings: SettingGroup,
     pub regs: IsaRegs,


### PR DESCRIPTION
One of the fields of `TargetIsa` isn't used in the
cranelift-codegen-meta crate, but instead of refactoring to try to
remove it this just adds `#[allow(dead_code)]` for now in the assumption
that when the old backends go away this will probably go away as well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
