### PR TITLE
Adjust date of v0.29 release in RELEASES.md to today.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@
 
 ## 0.29.0
 
-Released 2021-07-28.
+Released 2021-08-02.
 
 ### Changed
 


### PR DESCRIPTION
This was a bit of an oversight in the relnotes updates for the
just-released v0.29: since the release PR was prepared a few days before
the actual release, I should have updated the "released on" date in
RELEASES.md (oops!). I don't think it's a big enough deal to re-roll
anything but we should have the correct date in the version on `main`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
