### PR TITLE
Enable simd_X_extadd_pairwise_X for AArch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -202,23 +202,12 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("simd", _) if cfg!(feature = "old-x86-backend") => return true,
             // No simd support yet for s390x.
             ("simd", _) if platform_is_s390x() => return true,
-            // These are new instructions that are only known to be supported for x64.
-            ("simd", "simd_i16x8_extadd_pairwise_i8x16")
-            | ("simd", "simd_i32x4_extadd_pairwise_i16x8")
-                if !platform_is_x64() =>
-            {
-                return true
-            }
             _ => {}
         },
         _ => panic!("unrecognized strategy"),
     }
 
     false
-}
-
-fn platform_is_x64() -> bool {
-    env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64"
 }
 
 fn platform_is_s390x() -> bool {

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -2644,6 +2644,46 @@ fn test_aarch64_binemit() {
     ));
 
     insns.push((
+        Inst::VecRRPairLong {
+            op: VecRRPairLongOp::Uaddlp8,
+            rd: writable_vreg(0),
+            rn: vreg(1),
+        },
+        "2028206E",
+        "uaddlp v0.8h, v1.16b",
+    ));
+
+    insns.push((
+        Inst::VecRRPairLong {
+            op: VecRRPairLongOp::Saddlp8,
+            rd: writable_vreg(3),
+            rn: vreg(11),
+        },
+        "6329204E",
+        "saddlp v3.8h, v11.16b",
+    ));
+
+    insns.push((
+        Inst::VecRRPairLong {
+            op: VecRRPairLongOp::Uaddlp16,
+            rd: writable_vreg(14),
+            rn: vreg(23),
+        },
+        "EE2A606E",
+        "uaddlp v14.4s, v23.8h",
+    ));
+
+    insns.push((
+        Inst::VecRRPairLong {
+            op: VecRRPairLongOp::Saddlp16,
+            rd: writable_vreg(29),
+            rn: vreg(0),
+        },
+        "1D28604E",
+        "saddlp v29.4s, v0.8h",
+    ));
+
+    insns.push((
         Inst::VecRRR {
             alu_op: VecALUOp::Sqadd,
             rd: writable_vreg(1),

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -2644,6 +2644,58 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             });
         }
 
+        Opcode::IaddPairwise => {
+            let ty = ty.unwrap();
+            let lane_type = ty.lane_type();
+            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
+
+            let mut match_long_pair =
+                |ext_low_op, ext_high_op| -> Option<(VecRRPairLongOp, regalloc::Reg)> {
+                    if let Some(lhs) = maybe_input_insn(ctx, inputs[0], ext_low_op) {
+                        if let Some(rhs) = maybe_input_insn(ctx, inputs[1], ext_high_op) {
+                            let lhs_inputs = insn_inputs(ctx, lhs);
+                            let rhs_inputs = insn_inputs(ctx, rhs);
+                            let low = put_input_in_reg(ctx, lhs_inputs[0], NarrowValueMode::None);
+                            let high = put_input_in_reg(ctx, rhs_inputs[0], NarrowValueMode::None);
+                            if low == high {
+                                match (lane_type, ext_low_op) {
+                                    (I16, Opcode::SwidenLow) => {
+                                        return Some((VecRRPairLongOp::Saddlp8, low))
+                                    }
+                                    (I32, Opcode::SwidenLow) => {
+                                        return Some((VecRRPairLongOp::Saddlp16, low))
+                                    }
+                                    (I16, Opcode::UwidenLow) => {
+                                        return Some((VecRRPairLongOp::Uaddlp8, low))
+                                    }
+                                    (I32, Opcode::UwidenLow) => {
+                                        return Some((VecRRPairLongOp::Uaddlp16, low))
+                                    }
+                                    _ => (),
+                                };
+                            }
+                        }
+                    }
+                    None
+                };
+
+            if let Some((op, rn)) = match_long_pair(Opcode::SwidenLow, Opcode::SwidenHigh) {
+                ctx.emit(Inst::VecRRPairLong { op, rd, rn });
+            } else if let Some((op, rn)) = match_long_pair(Opcode::UwidenLow, Opcode::UwidenHigh) {
+                ctx.emit(Inst::VecRRPairLong { op, rd, rn });
+            } else {
+                let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
+                let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
+                ctx.emit(Inst::VecRRR {
+                    alu_op: VecALUOp::Addp,
+                    rd: rd,
+                    rn: rn,
+                    rm: rm,
+                    size: VectorSize::from_ty(ty),
+                });
+            }
+        }
+
         Opcode::WideningPairwiseDotProductS => {
             let r_y = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let r_a = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
@@ -3519,7 +3571,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             });
         }
 
-        Opcode::IaddPairwise | Opcode::ConstAddr | Opcode::Vconcat | Opcode::Vsplit => {
+        Opcode::ConstAddr | Opcode::Vconcat | Opcode::Vsplit => {
             unimplemented!("lowering {}", op)
         }
     }

--- a/cranelift/filetests/filetests/isa/aarch64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-pairwise-add.clif
@@ -1,0 +1,124 @@
+test compile
+set unwind_info=false
+target aarch64
+
+
+function %fn1(i8x16) -> i16x8 {
+block0(v0: i8x16):
+  v1 = swiden_low v0
+  v2 = swiden_high v0
+  v3 = iadd_pairwise v1, v2
+  return v3
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: saddlp v0.8h, v0.16b
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn2(i8x16) -> i16x8 {
+block0(v0: i8x16):
+  v1 = uwiden_low v0
+  v2 = uwiden_high v0
+  v3 = iadd_pairwise v1, v2
+  return v3
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: uaddlp v0.8h, v0.16b
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn3(i16x8) -> i32x4 {
+block0(v0: i16x8):
+  v1 = swiden_low v0
+  v2 = swiden_high v0
+  v3 = iadd_pairwise v1, v2
+  return v3
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: saddlp v0.4s, v0.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn4(i16x8) -> i32x4 {
+block0(v0: i16x8):
+  v1 = uwiden_low v0
+  v2 = uwiden_high v0
+  v3 = iadd_pairwise v1, v2
+  return v3
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: uaddlp v0.4s, v0.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn5(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+  v2 = swiden_low v0
+  v3 = swiden_high v1
+  v4 = iadd_pairwise v2, v3
+  return v4
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: sxtl v0.8h, v0.8b
+; nextln: sxtl2 v1.8h, v1.16b
+; nextln: addp v0.8h, v0.8h, v1.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn6(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+  v2 = uwiden_low v0
+  v3 = uwiden_high v1
+  v4 = iadd_pairwise v2, v3
+  return v4
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: uxtl v0.8h, v0.8b
+; nextln: uxtl2 v1.8h, v1.16b
+; nextln: addp v0.8h, v0.8h, v1.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn7(i8x16) -> i16x8 {
+block0(v0: i8x16):
+  v1 = uwiden_low v0
+  v2 = swiden_high v0
+  v3 = iadd_pairwise v1, v2
+  return v3
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: uxtl v1.8h, v0.8b
+; nextln: sxtl2 v0.8h, v0.16b
+; nextln: addp v0.8h, v1.8h, v0.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret
+
+function %fn8(i8x16) -> i16x8 {
+block0(v0: i8x16):
+  v1 = swiden_low v0
+  v2 = uwiden_high v0
+  v3 = iadd_pairwise v1, v2
+  return v3
+}
+
+; check: stp fp
+; nextln: mov fp, sp
+; nextln: sxtl v1.8h, v0.8b
+; nextln: uxtl2 v0.8h, v0.16b
+; nextln: addp v0.8h, v1.8h, v0.8h
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret


### PR DESCRIPTION
Lower to [u|s]addlp for AArch64.

Copyright (c) 2021, Arm Limited.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
