### PR TITLE
Bump the wasm-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
  "smallvec",
  "souper-ir",
  "target-lexicon",
- "wast 36.0.0",
+ "wast 37.0.0",
 ]
 
 [[package]]
@@ -2020,7 +2020,7 @@ dependencies = [
  "peepmatic-test-operator",
  "peepmatic-traits",
  "serde",
- "wast 36.0.0",
+ "wast 37.0.0",
  "z3",
 ]
 
@@ -2048,7 +2048,7 @@ dependencies = [
  "peepmatic-traits",
  "rand 0.8.3",
  "serde",
- "wast 36.0.0",
+ "wast 37.0.0",
 ]
 
 [[package]]
@@ -2073,7 +2073,7 @@ dependencies = [
  "serde",
  "serde_test",
  "thiserror",
- "wast 36.0.0",
+ "wast 37.0.0",
 ]
 
 [[package]]
@@ -2085,7 +2085,7 @@ dependencies = [
  "peepmatic",
  "peepmatic-test-operator",
  "souper-ir",
- "wast 36.0.0",
+ "wast 37.0.0",
 ]
 
 [[package]]
@@ -2106,7 +2106,7 @@ version = "0.76.0"
 dependencies = [
  "peepmatic-traits",
  "serde",
- "wast 36.0.0",
+ "wast 37.0.0",
 ]
 
 [[package]]
@@ -3491,15 +3491,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5894be15a559c85779254700e1d35f02f843b5a69152e5c82c626d9fd66c0e"
+checksum = "a5f71b80b8193e50910919e7d1bc956d2b4f42b1cb1fad84bacb59332c16f2cf"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6f65000c9b653a87ba9b8bebe9230371337db2b7e70db724ee4b79d2b9936f"
+checksum = "b48e4f2999b9930e9b037e328357d7d2367e0d8ea6e534be90aeff60976c0452"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3639,7 +3639,7 @@ dependencies = [
  "wasmtime-wasi-crypto",
  "wasmtime-wasi-nn",
  "wasmtime-wast",
- "wast 36.0.0",
+ "wast 37.0.0",
  "wat",
  "winapi",
 ]
@@ -3874,7 +3874,7 @@ version = "0.29.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 36.0.0",
+ "wast 37.0.0",
 ]
 
 [[package]]
@@ -3888,20 +3888,20 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5d7ba374a364571da1cb0a379a3dc302582a2d9937a183bfe35b68ad5bb9c4"
+checksum = "9bc7b9a76845047ded00e031754ff410afee0d50fbdf62b55bdeecd245063d68"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16383df7f0e3901484c2dda6294ed6895caa3627ce4f6584141dcf30a33a23e6"
+checksum = "2ab2cc8d9a69d1ab28a41d9149bb06bb927aba8fc9d56625f8b597a564c83f50"
 dependencies = [
- "wast 36.0.0",
+ "wast 37.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ anyhow = "1.0.19"
 target-lexicon = { version = "0.12.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.38"
+wat = "1.0.39"
 libc = "0.2.60"
 log = "0.4.8"
 rayon = "1.5.0"
 humantime = "2.0.0"
-wasmparser = "0.79.0"
+wasmparser = "0.80.0"
 lazy_static = "1.4.0"
 
 [dev-dependencies]
@@ -56,7 +56,7 @@ wasmtime-fuzzing = { path = "crates/fuzzing" }
 wasmtime-runtime = { path = "crates/runtime" }
 tokio = { version = "1.8.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
 tracing-subscriber = "0.2.16"
-wast = "36.0.0"
+wast = "37.0.0"
 criterion = "0.3.4"
 num_cpus = "1.13.0"
 winapi = { version = "0.3.9", features = ['memoryapi'] }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -28,7 +28,7 @@ peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, versi
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.76.0" }
 regalloc = { version = "0.0.31" }
 souper-ir = { version = "2.1.0", optional = true }
-wast = { version = "36.0.0", optional = true }
+wast = { version = "37.0.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/peepmatic/Cargo.toml
+++ b/cranelift/peepmatic/Cargo.toml
@@ -15,7 +15,7 @@ peepmatic-macro = { version = "0.76.0", path = "crates/macro" }
 peepmatic-runtime = { version = "0.76.0", path = "crates/runtime", features = ["construct"] }
 peepmatic-traits = { version = "0.76.0", path = "crates/traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "36.0.0"
+wast = "37.0.0"
 z3 = { version = "0.7.1", features = ["static-link-z3"] }
 
 [dev-dependencies]

--- a/cranelift/peepmatic/crates/fuzzing/Cargo.toml
+++ b/cranelift/peepmatic/crates/fuzzing/Cargo.toml
@@ -21,4 +21,4 @@ peepmatic-test-operator = { path = "../test-operator" }
 peepmatic-traits = { path = "../traits" }
 rand = { version = "0.8.3", features = ["small_rng"] }
 serde = "1.0.106"
-wast = "36.0.0"
+wast = "37.0.0"

--- a/cranelift/peepmatic/crates/runtime/Cargo.toml
+++ b/cranelift/peepmatic/crates/runtime/Cargo.toml
@@ -16,7 +16,7 @@ peepmatic-automata = { version = "0.76.0", path = "../automata", features = ["se
 peepmatic-traits = { version = "0.76.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
 thiserror = "1.0.15"
-wast = { version = "36.0.0", optional = true }
+wast = { version = "37.0.0", optional = true }
 
 [dev-dependencies]
 peepmatic-test-operator = { version = "0.76.0", path = "../test-operator" }

--- a/cranelift/peepmatic/crates/souper/Cargo.toml
+++ b/cranelift/peepmatic/crates/souper/Cargo.toml
@@ -16,4 +16,4 @@ log = "0.4.8"
 [dev-dependencies]
 peepmatic = { path = "../..", version = "0.76.0" }
 peepmatic-test-operator = { version = "0.76.0", path = "../test-operator" }
-wast = "36.0.0"
+wast = "37.0.0"

--- a/cranelift/peepmatic/crates/test-operator/Cargo.toml
+++ b/cranelift/peepmatic/crates/test-operator/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 [dependencies]
 peepmatic-traits = { version = "0.76.0", path = "../traits" }
 serde = { version = "1.0.105", features = ["derive"] }
-wast = "36.0.0"
+wast = "37.0.0"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.79", default-features = false }
+wasmparser = { version = "0.80", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.76.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.76.0" }
 cranelift-frontend = { path = "../frontend", version = "0.76.0", default-features = false }

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -8,9 +8,9 @@
 
 use crate::state::FuncTranslationState;
 use crate::translation_utils::{
-    DataIndex, ElemIndex, EntityIndex, EntityType, Event, EventIndex, FuncIndex, Global,
-    GlobalIndex, InstanceIndex, InstanceTypeIndex, Memory, MemoryIndex, ModuleIndex,
-    ModuleTypeIndex, SignatureIndex, Table, TableIndex, TypeIndex,
+    DataIndex, ElemIndex, EntityIndex, EntityType, FuncIndex, Global, GlobalIndex, InstanceIndex,
+    InstanceTypeIndex, Memory, MemoryIndex, ModuleIndex, ModuleTypeIndex, SignatureIndex, Table,
+    TableIndex, Tag, TagIndex, TypeIndex,
 };
 use core::convert::From;
 use core::convert::TryFrom;
@@ -771,15 +771,15 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         field: Option<&'data str>,
     ) -> WasmResult<()>;
 
-    /// Declares an event import to the environment.
-    fn declare_event_import(
+    /// Declares an tag import to the environment.
+    fn declare_tag_import(
         &mut self,
-        event: Event,
+        tag: Tag,
         module: &'data str,
         field: Option<&'data str>,
     ) -> WasmResult<()> {
-        drop((event, module, field));
-        Err(WasmError::Unsupported("wasm events".to_string()))
+        drop((tag, module, field));
+        Err(WasmError::Unsupported("wasm tags".to_string()))
     }
 
     /// Declares a global import to the environment.
@@ -844,16 +844,16 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
     /// Declares a memory to the environment
     fn declare_memory(&mut self, memory: Memory) -> WasmResult<()>;
 
-    /// Provides the number of defined events up front. By default this does nothing, but
+    /// Provides the number of defined tags up front. By default this does nothing, but
     /// implementations can use this to preallocate memory if desired.
-    fn reserve_events(&mut self, _num: u32) -> WasmResult<()> {
+    fn reserve_tags(&mut self, _num: u32) -> WasmResult<()> {
         Ok(())
     }
 
-    /// Declares an event to the environment
-    fn declare_event(&mut self, event: Event) -> WasmResult<()> {
-        drop(event);
-        Err(WasmError::Unsupported("wasm events".to_string()))
+    /// Declares an tag to the environment
+    fn declare_tag(&mut self, tag: Tag) -> WasmResult<()> {
+        drop(tag);
+        Err(WasmError::Unsupported("wasm tags".to_string()))
     }
 
     /// Provides the number of defined globals up front. By default this does nothing, but
@@ -885,14 +885,10 @@ pub trait ModuleEnvironment<'data>: TargetEnvironment {
         name: &'data str,
     ) -> WasmResult<()>;
 
-    /// Declares an event export to the environment.
-    fn declare_event_export(
-        &mut self,
-        event_index: EventIndex,
-        name: &'data str,
-    ) -> WasmResult<()> {
-        drop((event_index, name));
-        Err(WasmError::Unsupported("wasm events".to_string()))
+    /// Declares an tag export to the environment.
+    fn declare_tag_export(&mut self, tag_index: TagIndex, name: &'data str) -> WasmResult<()> {
+        drop((tag_index, name));
+        Err(WasmError::Unsupported("wasm tags".to_string()))
     }
 
     /// Declares a global export to the environment.

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -2,10 +2,10 @@
 //! to deal with each part of it.
 use crate::environ::{ModuleEnvironment, WasmResult};
 use crate::sections_translator::{
-    parse_alias_section, parse_data_section, parse_element_section, parse_event_section,
-    parse_export_section, parse_function_section, parse_global_section, parse_import_section,
-    parse_instance_section, parse_memory_section, parse_name_section, parse_start_section,
-    parse_table_section, parse_type_section,
+    parse_alias_section, parse_data_section, parse_element_section, parse_export_section,
+    parse_function_section, parse_global_section, parse_import_section, parse_instance_section,
+    parse_memory_section, parse_name_section, parse_start_section, parse_table_section,
+    parse_tag_section, parse_type_section,
 };
 use crate::state::ModuleTranslationState;
 use cranelift_codegen::timing;
@@ -59,9 +59,9 @@ pub fn translate_module<'data>(
                 parse_memory_section(memories, environ)?;
             }
 
-            Payload::EventSection(events) => {
-                validator.event_section(&events)?;
-                parse_event_section(events, environ)?;
+            Payload::TagSection(tags) => {
+                validator.tag_section(&tags)?;
+                parse_tag_section(tags, environ)?;
             }
 
             Payload::GlobalSection(globals) => {

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -95,8 +95,8 @@ entity_impl!(InstanceIndex);
 /// Index type of an event inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct EventIndex(u32);
-entity_impl!(EventIndex);
+pub struct TagIndex(u32);
+entity_impl!(TagIndex);
 
 /// Specialized index for just module types.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
@@ -139,7 +139,7 @@ pub enum EntityType {
     /// A linear memory with the specified limits
     Memory(Memory),
     /// An event definition.
-    Event(Event),
+    Tag(Tag),
     /// A table with the specified element type and limits
     Table(Table),
     /// A function type where the index points to the type section and records a
@@ -236,7 +236,7 @@ pub struct Memory {
 /// WebAssembly event.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct Event {
+pub struct Tag {
     /// The event signature type.
     pub ty: TypeIndex,
 }

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -16,5 +16,5 @@ cranelift-wasm = { path = "../../cranelift/wasm", version = "0.76.0" }
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.76.0" }
 cranelift-frontend = { path = "../../cranelift/frontend", version = "0.76.0" }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.76.0" }
-wasmparser = "0.79.0"
+wasmparser = "0.80.0"
 target-lexicon = "0.12"

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.25.0"
-wasmparser = "0.79"
+wasmparser = "0.80"
 object = { version = "0.26.0", default-features = false, features = ["read_core", "elf", "write"] }
 wasmtime-environ = { path = "../environ", version = "0.29.0" }
 target-lexicon = { version = "0.12.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.76.0", features = ["enable-serde"] }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.76.0", features = ["enable-serde"] }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.76.0", features = ["enable-serde"] }
-wasmparser = "0.79"
+wasmparser = "0.80"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -339,7 +339,7 @@ impl<'data> ModuleEnvironment<'data> {
                 EntityIndex::Instance(self.result.module.instances.push(ty))
             }
             EntityType::Module(ty) => EntityIndex::Module(self.result.module.modules.push(ty)),
-            EntityType::Event(_) => unimplemented!(),
+            EntityType::Tag(_) => unimplemented!(),
         }
     }
 
@@ -1088,7 +1088,7 @@ and for re-adding support for interface types you can see this issue:
                     EntityType::Module(sig) => {
                         self.result.module.modules.push(*sig);
                     }
-                    EntityType::Event(_) => unimplemented!(),
+                    EntityType::Tag(_) => unimplemented!(),
                 }
                 self.result
                     .module

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,8 +13,8 @@ arbitrary = { version = "1.0.0", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
-wasmparser = "0.79"
-wasmprinter = "0.2.27"
+wasmparser = "0.80"
+wasmprinter = "0.2.28"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 wasm-encoder = "0.5.0"

--- a/crates/fuzzing/src/generators/api.rs
+++ b/crates/fuzzing/src/generators/api.rs
@@ -221,10 +221,7 @@ fn predict_rss(wasm: &[u8]) -> Result<usize> {
             // the minimum amount of memory to our predicted rss.
             Payload::MemorySection(s) => {
                 for entry in s {
-                    let initial = match entry? {
-                        MemoryType::M32 { limits, .. } => limits.initial as usize,
-                        MemoryType::M64 { limits, .. } => limits.initial as usize,
-                    };
+                    let initial = entry?.initial as usize;
                     prediction += initial * 64 * 1024;
                 }
             }
@@ -233,7 +230,7 @@ fn predict_rss(wasm: &[u8]) -> Result<usize> {
             // currently this is 3 pointers per table entry.
             Payload::TableSection(s) => {
                 for entry in s {
-                    let initial = entry?.limits.initial as usize;
+                    let initial = entry?.initial as usize;
                     prediction += initial * 3 * mem::size_of::<usize>();
                 }
             }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -27,7 +27,7 @@ rayon = { version = "1.0", optional = true }
 region = "2.2.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.12.0", default-features = false }
-wasmparser = "0.79"
+wasmparser = "0.80"
 more-asserts = "0.2.1"
 anyhow = "1.0"
 cfg-if = "1.0"

--- a/crates/lightbeam/Cargo.toml
+++ b/crates/lightbeam/Cargo.toml
@@ -24,7 +24,7 @@ more-asserts = "0.2.1"
 smallvec = "1.6.1"
 thiserror = "1.0.9"
 typemap = "0.3"
-wasmparser = "0.79"
+wasmparser = "0.80"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/crates/lightbeam/src/microwasm.rs
+++ b/crates/lightbeam/src/microwasm.rs
@@ -440,7 +440,7 @@ impl From<WasmMemoryImmediate> for MemoryImmediate {
         assert_eq!(other.memory, 0);
         MemoryImmediate {
             flags: other.align.into(),
-            offset: other.offset,
+            offset: other.offset as u32,
         }
     }
 }

--- a/crates/lightbeam/wasmtime/Cargo.toml
+++ b/crates/lightbeam/wasmtime/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 lightbeam = { path = "..", version = "0.29.0" }
-wasmparser = "0.79"
+wasmparser = "0.80"
 cranelift-codegen = { path = "../../../cranelift/codegen", version = "0.76.0" }
 wasmtime-environ = { path = "../../environ", version = "0.29.0" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -20,7 +20,7 @@ wasmtime-cache = { path = "../cache", version = "0.29.0", optional = true }
 wasmtime-profiling = { path = "../profiling", version = "0.29.0" }
 wasmtime-fiber = { path = "../fiber", version = "0.29.0", optional = true }
 target-lexicon = { version = "0.12.0", default-features = false }
-wasmparser = "0.79"
+wasmparser = "0.80"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"

--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -217,7 +217,7 @@ impl ExternType {
                 let ty = &types.instance_signatures[*ty];
                 InstanceType::from_wasmtime(types, ty).into()
             }
-            EntityType::Event(_) => unimplemented!("wasm event support"),
+            EntityType::Tag(_) => unimplemented!("wasm tag support"),
         }
     }
 }

--- a/crates/wasmtime/src/types/matching.rs
+++ b/crates/wasmtime/src/types/matching.rs
@@ -236,7 +236,7 @@ impl MatchCx<'_> {
             EntityType::Global(_) => "global",
             EntityType::Module(_) => "module",
             EntityType::Memory(_) => "memory",
-            EntityType::Event(_) => "event",
+            EntityType::Tag(_) => "tag",
             EntityType::Instance(_) => "instance",
             EntityType::Table(_) => "table",
             EntityType::Function(_) => "function",
@@ -301,7 +301,7 @@ impl MatchCx<'_> {
                 }
                 _ => bail!("expected module, but found {}", actual_desc),
             },
-            EntityType::Event(_) => unimplemented!(),
+            EntityType::Tag(_) => unimplemented!(),
         }
     }
 
@@ -332,7 +332,7 @@ impl MatchCx<'_> {
                 Extern::Module(actual) => self.module(*expected, actual),
                 _ => bail!("expected module, but found {}", actual.desc()),
             },
-            EntityType::Event(_) => unimplemented!(),
+            EntityType::Tag(_) => unimplemented!(),
         }
     }
 
@@ -373,6 +373,6 @@ fn entity_desc(ty: &EntityType) -> &'static str {
         EntityType::Function(_) => "func",
         EntityType::Instance(_) => "instance",
         EntityType::Module(_) => "module",
-        EntityType::Event(_) => "event",
+        EntityType::Tag(_) => "tag",
     }
 }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.29.0", default-features = false }
-wast = "36.0.0"
+wast = "37.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -302,9 +302,15 @@ impl<T> WastContext<T> {
             }
             AssertInvalid {
                 span: _,
-                mut module,
+                module,
                 message,
             } => {
+                let mut module = match module {
+                    wast::QuoteModule::Module(m) => m,
+                    // This is a `*.wat` parser test which we're not
+                    // interested in.
+                    wast::QuoteModule::Quote(_) => return Ok(()),
+                };
                 let bytes = module.encode()?;
                 let err = match self.module(None, &bytes) {
                     Ok(()) => bail!("expected module to fail to build"),
@@ -354,6 +360,7 @@ impl<T> WastContext<T> {
                     )
                 }
             }
+            AssertUncaughtException { .. } => bail!("unimplemented assert_uncaught_exception"),
         }
 
         Ok(())


### PR DESCRIPTION
Pulls in some updates here and there, mostly for updating crates to the
latest version to prepare for later memory64 work.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
