### PR TITLE
Fix some warnings on nightly Rust

### DIFF
--- a/cranelift/codegen/meta/src/srcgen.rs
+++ b/cranelift/codegen/meta/src/srcgen.rs
@@ -19,19 +19,19 @@ static SHIFTWIDTH: usize = 4;
 /// strings.
 macro_rules! fmtln {
     ($fmt:ident, $fmtstring:expr, $($fmtargs:expr),*) => {
-        $fmt.line(format!($fmtstring, $($fmtargs),*));
+        $fmt.line(format!($fmtstring, $($fmtargs),*))
     };
 
     ($fmt:ident, $arg:expr) => {
-        $fmt.line($arg);
+        $fmt.line($arg)
     };
 
     ($_:tt, $($args:expr),+) => {
-        compile_error!("This macro requires at least two arguments: the Formatter instance and a format string.");
+        compile_error!("This macro requires at least two arguments: the Formatter instance and a format string.")
     };
 
     ($_:tt) => {
-        compile_error!("This macro requires at least two arguments: the Formatter instance and a format string.");
+        compile_error!("This macro requires at least two arguments: the Formatter instance and a format string.")
     };
 }
 

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -556,7 +556,7 @@ impl WorkerThread {
                     vec.push(CacheEntry::Unrecognized {
                         path: $path.to_path_buf(),
                         is_dir: $is_dir,
-                    });
+                    })
                 };
             }
             macro_rules! add_unrecognized_and {

--- a/crates/debug/src/transform/expression.rs
+++ b/crates/debug/src/transform/expression.rs
@@ -386,7 +386,7 @@ impl CompiledExpression {
                                     }
                                 } else {
                                     return Ok(None);
-                                };
+                                }
                             };
                         }
                         for part in &self.parts {


### PR DESCRIPTION
Looks like these trailing-semicolons-in-macros are likely to become a
hard error in the future, so this updates to remove them as necessary.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
