### PR TITLE
Enable simd fuzzing on oss-fuzz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,18 +3446,18 @@ checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3fb3541f4cdc05f0eacd7ce5544d69a4cc3e922ef1e7f37c1e7cb8b1e8e66"
+checksum = "2caacc74c68c74f0008c4055cdf509c43e623775eaf73323bb818dcf666ed9bd"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b73bf3c616211529547284f12db7bb1e4d9bca11c738533490546239bbd120"
+checksum = "f93b328ed4cef568449c185c89816ad587b172681af3b3d57f63178213ae36b4"
 dependencies = [
  "arbitrary",
  "indexmap",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -17,8 +17,8 @@ wasmparser = "0.80"
 wasmprinter = "0.2.28"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
-wasm-encoder = "0.5.0"
-wasm-smith = "0.5.0"
+wasm-encoder = "0.6.0"
+wasm-smith = "0.6.0"
 wasmi = "0.7.0"
 
 [dev-dependencies]

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -116,3 +116,37 @@ impl<'a> Arbitrary<'a> for SpecTest {
         (1, Some(std::mem::size_of::<usize>()))
     }
 }
+
+/// Type alias for wasm-smith generated modules using wasmtime's default
+/// configuration.
+pub type GeneratedModule = wasm_smith::ConfiguredModule<WasmtimeDefaultConfig>;
+
+/// Wasmtime-specific default configuration for wasm-smith-generated modules.
+#[derive(Arbitrary, Clone, Debug)]
+pub struct WasmtimeDefaultConfig;
+
+impl wasm_smith::Config for WasmtimeDefaultConfig {
+    // Allow multi-memory to get exercised
+    fn max_memories(&self) -> usize {
+        2
+    }
+
+    // Allow multi-table (reference types) to get exercised
+    fn max_tables(&self) -> usize {
+        4
+    }
+
+    // Turn some wasm features default-on for those that have a finished
+    // implementation in Wasmtime.
+    fn simd_enabled(&self) -> bool {
+        true
+    }
+
+    fn reference_types_enabled(&self) -> bool {
+        true
+    }
+
+    fn bulk_memory_enabled(&self) -> bool {
+        true
+    }
+}

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -4,7 +4,7 @@ use arbitrary::Arbitrary;
 use std::ops::Range;
 use wasm_encoder::{
     CodeSection, EntityType, Export, ExportSection, Function, FunctionSection, ImportSection,
-    Instruction, Limits, Module, TableSection, TableType, TypeSection, ValType,
+    Instruction, Module, TableSection, TableType, TypeSection, ValType,
 };
 
 /// A description of a Wasm module that makes a series of `externref` table
@@ -57,10 +57,8 @@ impl TableOps {
         let mut tables = TableSection::new();
         tables.table(TableType {
             element_type: ValType::ExternRef,
-            limits: Limits {
-                min: self.table_size(),
-                max: None,
-            },
+            minimum: self.table_size(),
+            maximum: None,
         });
 
         // Encode the types for all functions that we are using.

--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -39,6 +39,8 @@ pub fn fuzz_default_config(strategy: wasmtime::Strategy) -> anyhow::Result<wasmt
         .wasm_bulk_memory(true)
         .wasm_reference_types(true)
         .wasm_module_linking(true)
+        .wasm_multi_memory(true)
+        .wasm_simd(true)
         .strategy(strategy)?;
     Ok(config)
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -243,7 +243,7 @@ pub fn compile(wasm: &[u8], strategy: Strategy) {
 /// or aren't enabled for different configs, we should get the same results when
 /// we call the exported functions for all of our different configs.
 pub fn differential_execution(
-    module: &wasm_smith::Module,
+    module: &crate::generators::GeneratedModule,
     configs: &[crate::generators::DifferentialConfig],
 ) {
     use std::collections::{HashMap, HashSet};
@@ -271,7 +271,7 @@ pub fn differential_execution(
 
     for mut config in configs {
         // Disable module linking since it isn't enabled by default for
-        // `wasm_smith::Module` but is enabled by default for our fuzz config.
+        // `GeneratedModule` but is enabled by default for our fuzz config.
         // Since module linking is currently a breaking change this is required
         // to accept modules that would otherwise be broken by module linking.
         config.wasm_module_linking(false);
@@ -631,7 +631,7 @@ impl wasm_smith::Config for DifferentialWasmiModuleConfig {
         2
     }
 
-    fn max_memory_pages(&self) -> u32 {
+    fn max_memory_pages(&self, _is_64: bool) -> u64 {
         1
     }
 

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -39,7 +39,7 @@ pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Result<Extern> {
     Ok(match ty {
         ExternType::Func(func_ty) => Extern::Func(dummy_func(store, func_ty)),
         ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)),
-        ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)),
+        ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)?),
         ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(store, mem_ty)?),
         ExternType::Instance(instance_ty) => Extern::Instance(dummy_instance(store, instance_ty)?),
         ExternType::Module(module_ty) => Extern::Module(dummy_module(store.engine(), module_ty)),
@@ -81,9 +81,9 @@ pub fn dummy_global<T>(store: &mut Store<T>, ty: GlobalType) -> Global {
 }
 
 /// Construct a dummy table for the given table type.
-pub fn dummy_table<T>(store: &mut Store<T>, ty: TableType) -> Table {
+pub fn dummy_table<T>(store: &mut Store<T>, ty: TableType) -> Result<Table> {
     let init_val = dummy_value(ty.element().clone());
-    Table::new(store, ty, init_val).unwrap()
+    Table::new(store, ty, init_val)
 }
 
 /// Construct a dummy memory for the given memory type.
@@ -393,7 +393,8 @@ mod tests {
         let table = dummy_table(
             &mut store,
             TableType::new(ValType::ExternRef, Limits::at_least(10)),
-        );
+        )
+        .unwrap();
         assert_eq!(table.size(&store), 10);
         for i in 0..10 {
             assert!(table

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ target-lexicon = "0.12"
 peepmatic-fuzzing = { path = "../cranelift/peepmatic/crates/fuzzing", optional = true }
 wasmtime = { path = "../crates/wasmtime" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }
-wasm-smith = "0.5.0"
+wasm-smith = "0.6.0"
 
 [features]
 # Leave a stub feature with no side-effects in place for now: the OSS-Fuzz

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -6,7 +6,7 @@ use wasmtime_fuzzing::{generators, oracles};
 fuzz_target!(|data: (
     generators::DifferentialConfig,
     generators::DifferentialConfig,
-    wasm_smith::Module,
+    generators::GeneratedModule,
 )| {
     let (lhs, rhs, mut wasm) = data;
     wasm.ensure_termination(1000);

--- a/fuzz/fuzz_targets/instantiate-wasm-smith.rs
+++ b/fuzz/fuzz_targets/instantiate-wasm-smith.rs
@@ -1,11 +1,10 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use wasm_smith::Module;
 use wasmtime::Strategy;
-use wasmtime_fuzzing::oracles;
+use wasmtime_fuzzing::{generators::GeneratedModule, oracles};
 
-fuzz_target!(|module: Module| {
+fuzz_target!(|module: GeneratedModule| {
     let mut module = module;
     module.ensure_termination(1000);
     let wasm_bytes = module.to_bytes();


### PR DESCRIPTION
This commit generally enables the simd feature while fuzzing, which
should affect almost all fuzzers. For fuzzers that just throw random
data at the wall and see what sticks, this means that they'll now be
able to throw simd-shaped data at the wall and have it stick. For
wasm-smith-based fuzzers this commit also updates wasm-smith to 0.6.0
which allows further configuring the `SwarmConfig` after generation,
notably allowing `instantiate-swarm` to generate modules using simd
using `wasm-smith`. This should much more reliably feed simd-related
things into the fuzzers.

Finally, this commit updates wasmtime to avoid usage of the general
`wasm_smith::Module` generator to instead use a Wasmtime-specific custom
default configuration which enables various features we have
implemented.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
