### PR TITLE
Decrease memory limit in fuzzing to 1gb

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -46,9 +46,9 @@ fn create_store(engine: &Engine) -> Store<StoreLimits> {
     let mut store = Store::new(
         &engine,
         StoreLimits {
-            // Limits tables/memories within a store to at most 2gb for now to
+            // Limits tables/memories within a store to at most 1gb for now to
             // exercise some larger address but not overflow various limits.
-            remaining_memory: 2 << 30,
+            remaining_memory: 1 << 30,
             oom: false,
         },
     );


### PR DESCRIPTION
This should keep us under the default 2gb limit when fuzzing

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
