### PR TITLE
cranelift: Add stack support to the interpreter

### DIFF
--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -23,7 +23,7 @@ use crate::ir::{
     self,
     condcodes::{FloatCC, IntCC},
     trapcode::TrapCode,
-    types, Block, FuncRef, JumpTable, MemFlags, SigRef, Type, Value,
+    types, Block, FuncRef, JumpTable, MemFlags, SigRef, StackSlot, Type, Value,
 };
 use crate::isa;
 
@@ -407,6 +407,15 @@ impl InstructionData {
             | &InstructionData::Store { flags, .. }
             | &InstructionData::StoreComplex { flags, .. }
             | &InstructionData::StoreNoOffset { flags, .. } => Some(flags),
+            _ => None,
+        }
+    }
+
+    /// If this instruction references a stack slot, return it
+    pub fn stack_slot(&self) -> Option<StackSlot> {
+        match self {
+            &InstructionData::StackStore { stack_slot, .. }
+            | &InstructionData::StackLoad { stack_slot, .. } => Some(stack_slot),
             _ => None,
         }
     }

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -14,6 +14,12 @@ pub enum TrapCode {
     /// The current stack space was exhausted.
     StackOverflow,
 
+    /// A load was performed to an unmapped address
+    OutOfBoundsLoad,
+
+    /// A store was performed to an unmapped address
+    OutOfBoundsStore,
+
     /// A `heap_addr` instruction detected an out-of-bounds error.
     ///
     /// Note that not all out-of-bounds heap accesses are reported this way;
@@ -58,6 +64,8 @@ impl Display for TrapCode {
         use self::TrapCode::*;
         let identifier = match *self {
             StackOverflow => "stk_ovf",
+            OutOfBoundsLoad => "oob_load",
+            OutOfBoundsStore => "oob_store",
             HeapOutOfBounds => "heap_oob",
             HeapMisaligned => "heap_misaligned",
             TableOutOfBounds => "table_oob",
@@ -81,6 +89,8 @@ impl FromStr for TrapCode {
         use self::TrapCode::*;
         match s {
             "stk_ovf" => Ok(StackOverflow),
+            "oob_load" => Ok(OutOfBoundsLoad),
+            "oob_store" => Ok(OutOfBoundsStore),
             "heap_oob" => Ok(HeapOutOfBounds),
             "heap_misaligned" => Ok(HeapMisaligned),
             "table_oob" => Ok(TableOutOfBounds),
@@ -103,8 +113,10 @@ mod tests {
     use alloc::string::ToString;
 
     // Everything but user-defined codes.
-    const CODES: [TrapCode; 11] = [
+    const CODES: [TrapCode; 13] = [
         TrapCode::StackOverflow,
+        TrapCode::OutOfBoundsLoad,
+        TrapCode::OutOfBoundsStore,
         TrapCode::HeapOutOfBounds,
         TrapCode::HeapMisaligned,
         TrapCode::TableOutOfBounds,

--- a/cranelift/filetests/filetests/runtests/stack.clif
+++ b/cranelift/filetests/filetests/runtests/stack.clif
@@ -1,0 +1,169 @@
+test interpret
+test run
+target x86_64 machinst
+target s390x
+target aarch64
+
+function %stack_simple(i64) -> i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0
+    v1 = stack_load.i64 ss0
+    return v1
+}
+; run: %stack_simple(0) == 0
+; run: %stack_simple(1) == 1
+; run: %stack_simple(-1) == -1
+
+
+function %slot_offset(i64) -> i64 {
+    ss0 = explicit_slot 8, offset 8
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0
+    v1 = stack_load.i64 ss0
+    return v1
+}
+; run: %slot_offset(0) == 0
+; run: %slot_offset(1) == 1
+; run: %slot_offset(-1) == -1
+
+function %stack_offset(i64) -> i64 {
+    ss0 = explicit_slot 16
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0+8
+    v1 = stack_load.i64 ss0+8
+    return v1
+}
+; run: %stack_offset(0) == 0
+; run: %stack_offset(1) == 1
+; run: %stack_offset(-1) == -1
+
+
+function %offset_unaligned(i64) -> i64 {
+    ss0 = explicit_slot 11
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0+3
+    v1 = stack_load.i64 ss0+3
+    return v1
+}
+; run: %offset_unaligned(0) == 0
+; run: %offset_unaligned(1) == 1
+; run: %offset_unaligned(-1) == -1
+
+
+function %stack_addr(i64) -> b1 {
+    ss0 = explicit_slot 24
+
+block0(v0: i64):
+    v1 = stack_addr.i64 ss0
+    stack_store.i64 v0, ss0
+    v2 = load.i64 v1
+    v3 = icmp eq v0, v2
+
+    v4 = stack_addr.i64 ss0+8
+    store.i64 v0, v4
+    v5 = stack_load.i64 ss0+8
+    v6 = icmp eq v0, v5
+
+    v7 = stack_addr.i64 ss0+16
+    store.i64 v0, v7
+    v8 = load.i64 v7
+    v9 = icmp eq v0, v8
+
+    v10 = band v3, v6
+    v11 = band v10, v9
+    return v11
+}
+; run: %stack_addr(0) == true
+; run: %stack_addr(1) == true
+; run: %stack_addr(-1) == true
+
+
+function %multi_slot_stack(i64, i64) -> i64 {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    stack_store.i64 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i64 ss0
+    v3 = stack_load.i64 ss1
+    v4 = iadd.i64 v2, v3
+    return v4
+}
+; run: %multi_slot_stack(0, 1) == 1
+; run: %multi_slot_stack(1, 2) == 3
+
+
+function %multi_slot_different_addrs() -> b1 {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 8
+
+block0:
+    v0 = stack_addr.i64 ss0
+    v1 = stack_addr.i64 ss1
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %multi_slot_diffe() == true
+
+
+function %multi_slot_out_of_bounds_writes(i8, i64) -> i8, i64 {
+    ss0 = explicit_slot 1
+    ss1 = explicit_slot 8
+
+block0(v0: i8, v1: i64):
+    stack_store.i8 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i8 ss0
+    v3 = stack_load.i64 ss1
+    return v2, v3
+}
+; run: %multi_slot_out_o(10, 1) == [10, 1]
+; run: %multi_slot_out_o(0, 2) == [0, 2]
+
+
+function %multi_slot_offset_writes(i8, i64) -> i8, i64 {
+    ss0 = explicit_slot 8, offset 8
+    ss1 = explicit_slot 8
+
+block0(v0: i8, v1: i64):
+    stack_store.i8 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i8 ss0
+    v3 = stack_load.i64 ss1
+    return v2, v3
+}
+; run: %multi_slot_offse(0, 1) == [0, 1]
+; run: %multi_slot_offse(1, 2) == [1, 2]
+
+function %slot_offset_negative(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 8, offset -8
+
+block0(v0: i64, v1: i64):
+    stack_store.i64 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i64 ss0
+    v3 = stack_load.i64 ss1
+    return v2, v3
+}
+; run: %slot_offset_nega(0, 1) == [0, 1]
+; run: %slot_offset_nega(2, 3) == [2, 3]
+
+
+function %huge_slots(i64) -> i64 {
+    ss0 = explicit_slot 1048576 ; 1MB Slot
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0+1048568 ; Store at 1MB - 8bytes
+    v1 = stack_load.i64 ss0+1048568
+    return v1
+}
+; run: %huge_slots(0) == 0
+; run: %huge_slots(1) == 1
+; run: %huge_slots(-1) == -1

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -271,14 +271,14 @@ impl Value for DataValue {
                 (types::I32, types::I64) => unimplemented!(),
                 _ => unimplemented!("conversion: {} -> {:?}", self.ty(), kind),
             },
-            ValueConversionKind::ZeroExtend(ty) => match (self.ty(), ty) {
-                (types::I8, types::I16) => unimplemented!(),
-                (types::I8, types::I32) => unimplemented!(),
-                (types::I8, types::I64) => unimplemented!(),
-                (types::I16, types::I32) => unimplemented!(),
-                (types::I16, types::I64) => unimplemented!(),
-                (types::I32, types::I64) => unimplemented!(),
-                _ => unimplemented!("conversion: {} -> {:?}", self.ty(), kind),
+            ValueConversionKind::ZeroExtend(ty) => match (self, ty) {
+                (DataValue::I8(_), types::I16) => unimplemented!(),
+                (DataValue::I8(_), types::I32) => unimplemented!(),
+                (DataValue::I8(_), types::I64) => unimplemented!(),
+                (DataValue::I16(_), types::I32) => unimplemented!(),
+                (DataValue::I16(_), types::I64) => unimplemented!(),
+                (DataValue::I32(n), types::I64) => DataValue::I64(n as u32 as i64),
+                (dv, _) => unimplemented!("conversion: {} -> {:?}", dv.ty(), kind),
             },
             ValueConversionKind::ToUnsigned => match self {
                 DataValue::I8(n) => DataValue::U8(n as u8),
@@ -386,7 +386,7 @@ impl Value for DataValue {
     }
 
     fn and(self, other: Self) -> ValueResult<Self> {
-        binary_match!(&(&self, &other); [I8, I16, I32, I64])
+        binary_match!(&(&self, &other); [B, I8, I16, I32, I64])
     }
 
     fn or(self, other: Self) -> ValueResult<Self> {

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -92,6 +92,8 @@ impl TrapCode {
     fn from_non_user(code: ir::TrapCode) -> Self {
         match code {
             ir::TrapCode::StackOverflow => TrapCode::StackOverflow,
+            ir::TrapCode::OutOfBoundsLoad => TrapCode::MemoryOutOfBounds,
+            ir::TrapCode::OutOfBoundsStore => TrapCode::MemoryOutOfBounds,
             ir::TrapCode::HeapOutOfBounds => TrapCode::MemoryOutOfBounds,
             ir::TrapCode::HeapMisaligned => TrapCode::HeapMisaligned,
             ir::TrapCode::TableOutOfBounds => TrapCode::TableOutOfBounds,


### PR DESCRIPTION
With this PR we also change the approach for heap loads and stores.

Previously we would use the offset as the address to the heap. However, this approach does not allow using the `load`/`store` instructions to read/write from both the heap and the stack.

We now return the real addresses from the addressing instructions (`stack_addr`/`heap_addr`), and instead check if the address passed into the `load`/`store` instructions points to an area in the heap or the stack.