### PR TITLE
cranelift: Add stack support to the interpreter with virtual addresses

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -4,7 +4,6 @@ use crate::ir::immediates::{Ieee32, Ieee64, Offset32};
 use crate::ir::{types, ConstantData, Type};
 use core::convert::TryInto;
 use core::fmt::{self, Display, Formatter};
-use core::ptr;
 
 /// Represent a data value. Where [Value] is an SSA reference, [DataValue] is the type + value
 /// that would be referred to by a [Value].
@@ -74,36 +73,64 @@ impl DataValue {
         }
     }
 
-    /// Write a [DataValue] to a memory location.
-    pub unsafe fn write_value_to(&self, p: *mut u128) {
+    /// Write a [DataValue] to a slice.
+    ///
+    /// # Panics:
+    ///
+    /// Panics if the slice does not have enough space to accommodate the [DataValue]
+    pub fn write_to_slice(&self, dst: &mut [u8]) {
         match self {
-            DataValue::B(b) => ptr::write(p, if *b { -1i128 as u128 } else { 0u128 }),
-            DataValue::I8(i) => ptr::write(p as *mut i8, *i),
-            DataValue::I16(i) => ptr::write(p as *mut i16, *i),
-            DataValue::I32(i) => ptr::write(p as *mut i32, *i),
-            DataValue::I64(i) => ptr::write(p as *mut i64, *i),
-            DataValue::F32(f) => ptr::write(p as *mut Ieee32, *f),
-            DataValue::F64(f) => ptr::write(p as *mut Ieee64, *f),
-            DataValue::V128(b) => ptr::write(p as *mut [u8; 16], *b),
+            DataValue::B(b) => dst[0] = if *b { 1 } else { 0 },
+            DataValue::I8(i) => dst[..1].copy_from_slice(&i.to_le_bytes()[..]),
+            DataValue::I16(i) => dst[..2].copy_from_slice(&i.to_le_bytes()[..]),
+            DataValue::I32(i) => dst[..4].copy_from_slice(&i.to_le_bytes()[..]),
+            DataValue::I64(i) => dst[..8].copy_from_slice(&i.to_le_bytes()[..]),
+            DataValue::F32(f) => dst[..4].copy_from_slice(&f.bits().to_le_bytes()[..]),
+            DataValue::F64(f) => dst[..8].copy_from_slice(&f.bits().to_le_bytes()[..]),
+            DataValue::V128(v) => dst[..16].copy_from_slice(&v[..]),
+            _ => unimplemented!(),
+        };
+    }
+
+    /// Read a [DataValue] from a slice using a given [Type].
+    ///
+    /// # Panics:
+    ///
+    /// Panics if the slice does not have enough space to accommodate the [DataValue]
+    pub fn read_from_slice(src: &[u8], ty: Type) -> Self {
+        match ty {
+            types::I8 => DataValue::I8(i8::from_le_bytes(src[..1].try_into().unwrap())),
+            types::I16 => DataValue::I16(i16::from_le_bytes(src[..2].try_into().unwrap())),
+            types::I32 => DataValue::I32(i32::from_le_bytes(src[..4].try_into().unwrap())),
+            types::I64 => DataValue::I64(i64::from_le_bytes(src[..8].try_into().unwrap())),
+            types::F32 => DataValue::F32(Ieee32::with_bits(u32::from_le_bytes(
+                src[..4].try_into().unwrap(),
+            ))),
+            types::F64 => DataValue::F64(Ieee64::with_bits(u64::from_le_bytes(
+                src[..8].try_into().unwrap(),
+            ))),
+            _ if ty.is_bool() => DataValue::B(src[0] != 0),
+            _ if ty.is_vector() && ty.bytes() == 16 => {
+                DataValue::V128(src[..16].try_into().unwrap())
+            }
             _ => unimplemented!(),
         }
     }
 
+    /// Write a [DataValue] to a memory location.
+    pub unsafe fn write_value_to(&self, p: *mut u128) {
+        self.write_to_slice(std::slice::from_raw_parts_mut(
+            p as *mut u8,
+            self.ty().bytes() as usize,
+        ));
+    }
+
     /// Read a [DataValue] from a memory location using a given [Type].
     pub unsafe fn read_value_from(p: *const u128, ty: Type) -> Self {
-        match ty {
-            types::I8 => DataValue::I8(ptr::read(p as *const i8)),
-            types::I16 => DataValue::I16(ptr::read(p as *const i16)),
-            types::I32 => DataValue::I32(ptr::read(p as *const i32)),
-            types::I64 => DataValue::I64(ptr::read(p as *const i64)),
-            types::F32 => DataValue::F32(ptr::read(p as *const Ieee32)),
-            types::F64 => DataValue::F64(ptr::read(p as *const Ieee64)),
-            _ if ty.is_bool() => DataValue::B(ptr::read(p) != 0),
-            _ if ty.is_vector() && ty.bytes() == 16 => {
-                DataValue::V128(ptr::read(p as *const [u8; 16]))
-            }
-            _ => unimplemented!(),
-        }
+        DataValue::read_from_slice(
+            std::slice::from_raw_parts(p as *const u8, ty.bytes() as usize),
+            ty,
+        )
     }
 }
 

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -421,6 +421,13 @@ impl Function {
         self.dfg[dst] = self.dfg[src].clone();
         self.layout.remove_inst(src);
     }
+
+    /// Size occupied by all stack slots associated with this function.
+    ///
+    /// Does not include any padding necessary due to offsets
+    pub fn stack_size(&self) -> u32 {
+        self.stack_slots.values().map(|ss| ss.size).sum()
+    }
 }
 
 /// Additional annotations for function display.

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -23,7 +23,7 @@ use crate::ir::{
     self,
     condcodes::{FloatCC, IntCC},
     trapcode::TrapCode,
-    types, Block, FuncRef, JumpTable, MemFlags, SigRef, Type, Value,
+    types, Block, FuncRef, JumpTable, MemFlags, SigRef, StackSlot, Type, Value,
 };
 use crate::isa;
 
@@ -407,6 +407,15 @@ impl InstructionData {
             | &InstructionData::Store { flags, .. }
             | &InstructionData::StoreComplex { flags, .. }
             | &InstructionData::StoreNoOffset { flags, .. } => Some(flags),
+            _ => None,
+        }
+    }
+
+    /// If this instruction references a stack slot, return it
+    pub fn stack_slot(&self) -> Option<StackSlot> {
+        match self {
+            &InstructionData::StackStore { stack_slot, .. }
+            | &InstructionData::StackLoad { stack_slot, .. } => Some(stack_slot),
             _ => None,
         }
     }

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -14,15 +14,6 @@ pub enum TrapCode {
     /// The current stack space was exhausted.
     StackOverflow,
 
-    /// A load was performed to an unmapped address
-    OutOfBoundsLoad,
-
-    /// A store was performed to an unmapped address
-    OutOfBoundsStore,
-
-    /// An operation was performed with an invalid address
-    InvalidAddress,
-
     /// A `heap_addr` instruction detected an out-of-bounds error.
     ///
     /// Note that not all out-of-bounds heap accesses are reported this way;
@@ -67,9 +58,6 @@ impl Display for TrapCode {
         use self::TrapCode::*;
         let identifier = match *self {
             StackOverflow => "stk_ovf",
-            InvalidAddress => "invalid_addr",
-            OutOfBoundsLoad => "oob_load",
-            OutOfBoundsStore => "oob_store",
             HeapOutOfBounds => "heap_oob",
             HeapMisaligned => "heap_misaligned",
             TableOutOfBounds => "table_oob",
@@ -93,9 +81,6 @@ impl FromStr for TrapCode {
         use self::TrapCode::*;
         match s {
             "stk_ovf" => Ok(StackOverflow),
-            "invalid_addr" => Ok(InvalidAddress),
-            "oob_load" => Ok(OutOfBoundsLoad),
-            "oob_store" => Ok(OutOfBoundsStore),
             "heap_oob" => Ok(HeapOutOfBounds),
             "heap_misaligned" => Ok(HeapMisaligned),
             "table_oob" => Ok(TableOutOfBounds),
@@ -118,11 +103,8 @@ mod tests {
     use alloc::string::ToString;
 
     // Everything but user-defined codes.
-    const CODES: [TrapCode; 14] = [
+    const CODES: [TrapCode; 11] = [
         TrapCode::StackOverflow,
-        TrapCode::InvalidAddress,
-        TrapCode::OutOfBoundsLoad,
-        TrapCode::OutOfBoundsStore,
         TrapCode::HeapOutOfBounds,
         TrapCode::HeapMisaligned,
         TrapCode::TableOutOfBounds,

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -20,6 +20,9 @@ pub enum TrapCode {
     /// A store was performed to an unmapped address
     OutOfBoundsStore,
 
+    /// An operation was performed with an invalid address
+    InvalidAddress,
+
     /// A `heap_addr` instruction detected an out-of-bounds error.
     ///
     /// Note that not all out-of-bounds heap accesses are reported this way;
@@ -64,6 +67,7 @@ impl Display for TrapCode {
         use self::TrapCode::*;
         let identifier = match *self {
             StackOverflow => "stk_ovf",
+            InvalidAddress => "invalid_addr",
             OutOfBoundsLoad => "oob_load",
             OutOfBoundsStore => "oob_store",
             HeapOutOfBounds => "heap_oob",
@@ -89,6 +93,7 @@ impl FromStr for TrapCode {
         use self::TrapCode::*;
         match s {
             "stk_ovf" => Ok(StackOverflow),
+            "invalid_addr" => Ok(InvalidAddress),
             "oob_load" => Ok(OutOfBoundsLoad),
             "oob_store" => Ok(OutOfBoundsStore),
             "heap_oob" => Ok(HeapOutOfBounds),
@@ -113,8 +118,9 @@ mod tests {
     use alloc::string::ToString;
 
     // Everything but user-defined codes.
-    const CODES: [TrapCode; 13] = [
+    const CODES: [TrapCode; 14] = [
         TrapCode::StackOverflow,
+        TrapCode::InvalidAddress,
         TrapCode::OutOfBoundsLoad,
         TrapCode::OutOfBoundsStore,
         TrapCode::HeapOutOfBounds,

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -14,6 +14,12 @@ pub enum TrapCode {
     /// The current stack space was exhausted.
     StackOverflow,
 
+    /// A load was performed to an unmapped address
+    OutOfBoundsLoad,
+
+    /// A store was performed to an unmapped address
+    OutOfBoundsStore,
+
     /// A `heap_addr` instruction detected an out-of-bounds error.
     ///
     /// Note that not all out-of-bounds heap accesses are reported this way;
@@ -58,6 +64,8 @@ impl Display for TrapCode {
         use self::TrapCode::*;
         let identifier = match *self {
             StackOverflow => "stk_ovf",
+            OutOfBoundsLoad => "oob_load",
+            OutOfBoundsStore => "oob_store",
             HeapOutOfBounds => "heap_oob",
             HeapMisaligned => "heap_misaligned",
             TableOutOfBounds => "table_oob",
@@ -81,6 +89,8 @@ impl FromStr for TrapCode {
         use self::TrapCode::*;
         match s {
             "stk_ovf" => Ok(StackOverflow),
+            "oob_load" => Ok(OutOfBoundsLoad),
+            "oob_store" => Ok(OutOfBoundsStore),
             "heap_oob" => Ok(HeapOutOfBounds),
             "heap_misaligned" => Ok(HeapMisaligned),
             "table_oob" => Ok(TableOutOfBounds),
@@ -103,8 +113,10 @@ mod tests {
     use alloc::string::ToString;
 
     // Everything but user-defined codes.
-    const CODES: [TrapCode; 11] = [
+    const CODES: [TrapCode; 13] = [
         TrapCode::StackOverflow,
+        TrapCode::OutOfBoundsLoad,
+        TrapCode::OutOfBoundsStore,
         TrapCode::HeapOutOfBounds,
         TrapCode::HeapMisaligned,
         TrapCode::TableOutOfBounds,

--- a/cranelift/filetests/filetests/runtests/stack-addr-32.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-32.clif
@@ -1,0 +1,85 @@
+test interpret
+
+function %stack_addr_iadd(i64) -> b1 {
+    ss0 = explicit_slot 16
+
+block0(v0: i64):
+    v1 = stack_addr.i32 ss0
+    v2 = iadd_imm.i32 v1, 8
+
+    stack_store.i64 v0, ss0+8
+    v3 = load.i64 v2
+
+    v5 = iadd_imm.i64 v0, 20
+    store.i64 v5, v2
+    v6 = stack_load.i64 ss0+8
+
+    v7 = icmp eq v0, v3
+    v8 = icmp eq v5, v6
+    v9 = band v7, v8
+    return v9
+}
+; run: %stack_addr_iadd(0) == true
+; run: %stack_addr_iadd(1) == true
+; run: %stack_addr_iadd(-1) == true
+
+
+function %stack_addr_32(i64) -> b1 {
+    ss0 = explicit_slot 24
+
+block0(v0: i64):
+    v1 = stack_addr.i32 ss0
+    stack_store.i64 v0, ss0
+    v2 = load.i64 v1
+    v3 = icmp eq v0, v2
+
+    v4 = stack_addr.i32 ss0+8
+    store.i64 v0, v4
+    v5 = stack_load.i64 ss0+8
+    v6 = icmp eq v0, v5
+
+    v7 = stack_addr.i32 ss0+16
+    store.i64 v0, v7
+    v8 = load.i64 v7
+    v9 = icmp eq v0, v8
+
+    v10 = band v3, v6
+    v11 = band v10, v9
+    return v11
+}
+; run: %stack_addr_32(0) == true
+; run: %stack_addr_32(1) == true
+; run: %stack_addr_32(-1) == true
+
+
+
+function %addr32_64(i64) -> b1 {
+    ss0 = explicit_slot 16
+
+block0(v0: i64):
+    v1 = stack_addr.i32 ss0+8
+    v2 = stack_addr.i64 ss0+8
+
+    store.i64 v0, v1
+    v3 = load.i64 v2
+
+    v4 = icmp eq v3, v0
+
+    return v4
+}
+; run: %addr32_64(0) == true
+; run: %addr32_64(1) == true
+; run: %addr32_64(-1) == true
+
+
+function %multi_slot_different_addrs() -> b1 {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 8
+
+block0:
+    v0 = stack_addr.i32 ss0
+    v1 = stack_addr.i32 ss1
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %multi_slot_diffe() == true

--- a/cranelift/filetests/filetests/runtests/stack-addr-64.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-64.clif
@@ -1,0 +1,56 @@
+test interpret
+test run
+target x86_64 machinst
+target s390x
+target aarch64
+
+
+function %stack_addr_iadd(i64) -> b1 {
+    ss0 = explicit_slot 16
+
+block0(v0: i64):
+    v1 = stack_addr.i64 ss0
+    v2 = iadd_imm.i64 v1, 8
+
+    stack_store.i64 v0, ss0+8
+    v3 = load.i64 v2
+
+    v5 = iadd_imm.i64 v0, 20
+    store.i64 v5, v2
+    v6 = stack_load.i64 ss0+8
+
+    v7 = icmp eq v0, v3
+    v8 = icmp eq v5, v6
+    v9 = band v7, v8
+    return v9
+}
+; run: %stack_addr_iadd(0) == true
+; run: %stack_addr_iadd(1) == true
+; run: %stack_addr_iadd(-1) == true
+
+function %stack_addr_64(i64) -> b1 {
+    ss0 = explicit_slot 24
+
+block0(v0: i64):
+    v1 = stack_addr.i64 ss0
+    stack_store.i64 v0, ss0
+    v2 = load.i64 v1
+    v3 = icmp eq v0, v2
+
+    v4 = stack_addr.i64 ss0+8
+    store.i64 v0, v4
+    v5 = stack_load.i64 ss0+8
+    v6 = icmp eq v0, v5
+
+    v7 = stack_addr.i64 ss0+16
+    store.i64 v0, v7
+    v8 = load.i64 v7
+    v9 = icmp eq v0, v8
+
+    v10 = band v3, v6
+    v11 = band v10, v9
+    return v11
+}
+; run: %stack_addr_64(0) == true
+; run: %stack_addr_64(1) == true
+; run: %stack_addr_64(-1) == true

--- a/cranelift/filetests/filetests/runtests/stack.clif
+++ b/cranelift/filetests/filetests/runtests/stack.clif
@@ -55,33 +55,6 @@ block0(v0: i64):
 ; run: %offset_unaligned(-1) == -1
 
 
-function %stack_addr(i64) -> b1 {
-    ss0 = explicit_slot 24
-
-block0(v0: i64):
-    v1 = stack_addr.i64 ss0
-    stack_store.i64 v0, ss0
-    v2 = load.i64 v1
-    v3 = icmp eq v0, v2
-
-    v4 = stack_addr.i64 ss0+8
-    store.i64 v0, v4
-    v5 = stack_load.i64 ss0+8
-    v6 = icmp eq v0, v5
-
-    v7 = stack_addr.i64 ss0+16
-    store.i64 v0, v7
-    v8 = load.i64 v7
-    v9 = icmp eq v0, v8
-
-    v10 = band v3, v6
-    v11 = band v10, v9
-    return v11
-}
-; run: %stack_addr(0) == true
-; run: %stack_addr(1) == true
-; run: %stack_addr(-1) == true
-
 
 function %multi_slot_stack(i64, i64) -> i64 {
     ss0 = explicit_slot 8
@@ -98,18 +71,6 @@ block0(v0: i64, v1: i64):
 ; run: %multi_slot_stack(0, 1) == 1
 ; run: %multi_slot_stack(1, 2) == 3
 
-
-function %multi_slot_different_addrs() -> b1 {
-    ss0 = explicit_slot 8
-    ss1 = explicit_slot 8
-
-block0:
-    v0 = stack_addr.i64 ss0
-    v1 = stack_addr.i64 ss1
-    v2 = icmp ne v0, v1
-    return v2
-}
-; run: %multi_slot_diffe() == true
 
 
 function %multi_slot_out_of_bounds_writes(i8, i64) -> i8, i64 {

--- a/cranelift/filetests/filetests/runtests/stack.clif
+++ b/cranelift/filetests/filetests/runtests/stack.clif
@@ -1,0 +1,169 @@
+test interpret
+test run
+target x86_64 machinst
+target s390x
+target aarch64
+
+function %stack_simple(i64) -> i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0
+    v1 = stack_load.i64 ss0
+    return v1
+}
+; run: %stack_simple(0) == 0
+; run: %stack_simple(1) == 1
+; run: %stack_simple(-1) == -1
+
+
+function %slot_offset(i64) -> i64 {
+    ss0 = explicit_slot 8, offset 8
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0
+    v1 = stack_load.i64 ss0
+    return v1
+}
+; run: %slot_offset(0) == 0
+; run: %slot_offset(1) == 1
+; run: %slot_offset(-1) == -1
+
+function %stack_offset(i64) -> i64 {
+    ss0 = explicit_slot 16
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0+8
+    v1 = stack_load.i64 ss0+8
+    return v1
+}
+; run: %stack_offset(0) == 0
+; run: %stack_offset(1) == 1
+; run: %stack_offset(-1) == -1
+
+
+function %offset_unaligned(i64) -> i64 {
+    ss0 = explicit_slot 11
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0+3
+    v1 = stack_load.i64 ss0+3
+    return v1
+}
+; run: %offset_unaligned(0) == 0
+; run: %offset_unaligned(1) == 1
+; run: %offset_unaligned(-1) == -1
+
+
+function %stack_addr(i64) -> b1 {
+    ss0 = explicit_slot 24
+
+block0(v0: i64):
+    v1 = stack_addr.i64 ss0
+    stack_store.i64 v0, ss0
+    v2 = load.i64 v1
+    v3 = icmp eq v0, v2
+
+    v4 = stack_addr.i64 ss0+8
+    store.i64 v0, v4
+    v5 = stack_load.i64 ss0+8
+    v6 = icmp eq v0, v5
+
+    v7 = stack_addr.i64 ss0+16
+    store.i64 v0, v7
+    v8 = load.i64 v7
+    v9 = icmp eq v0, v8
+
+    v10 = band v3, v6
+    v11 = band v10, v9
+    return v11
+}
+; run: %stack_addr(0) == true
+; run: %stack_addr(1) == true
+; run: %stack_addr(-1) == true
+
+
+function %multi_slot_stack(i64, i64) -> i64 {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    stack_store.i64 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i64 ss0
+    v3 = stack_load.i64 ss1
+    v4 = iadd.i64 v2, v3
+    return v4
+}
+; run: %multi_slot_stack(0, 1) == 1
+; run: %multi_slot_stack(1, 2) == 3
+
+
+function %multi_slot_different_addrs() -> b1 {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 8
+
+block0:
+    v0 = stack_addr.i64 ss0
+    v1 = stack_addr.i64 ss1
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %multi_slot_diffe() == true
+
+
+function %multi_slot_out_of_bounds_writes(i8, i64) -> i8, i64 {
+    ss0 = explicit_slot 1
+    ss1 = explicit_slot 8
+
+block0(v0: i8, v1: i64):
+    stack_store.i8 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i8 ss0
+    v3 = stack_load.i64 ss1
+    return v2, v3
+}
+; run: %multi_slot_out_o(10, 1) == [10, 1]
+; run: %multi_slot_out_o(0, 2) == [0, 2]
+
+
+function %multi_slot_offset_writes(i8, i64) -> i8, i64 {
+    ss0 = explicit_slot 8, offset 8
+    ss1 = explicit_slot 8
+
+block0(v0: i8, v1: i64):
+    stack_store.i8 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i8 ss0
+    v3 = stack_load.i64 ss1
+    return v2, v3
+}
+; run: %multi_slot_offse(0, 1) == [0, 1]
+; run: %multi_slot_offse(1, 2) == [1, 2]
+
+function %slot_offset_negative(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+    ss1 = explicit_slot 8, offset -8
+
+block0(v0: i64, v1: i64):
+    stack_store.i64 v0, ss0
+    stack_store.i64 v1, ss1
+    v2 = stack_load.i64 ss0
+    v3 = stack_load.i64 ss1
+    return v2, v3
+}
+; run: %slot_offset_nega(0, 1) == [0, 1]
+; run: %slot_offset_nega(2, 3) == [2, 3]
+
+
+function %huge_slots(i64) -> i64 {
+    ss0 = explicit_slot 1048576 ; 1MB Slot
+
+block0(v0: i64):
+    stack_store.i64 v0, ss0+1048568 ; Store at 1MB - 8bytes
+    v1 = stack_load.i64 ss0+1048568
+    return v1
+}
+; run: %huge_slots(0) == 0
+; run: %huge_slots(1) == 1
+; run: %huge_slots(-1) == -1

--- a/cranelift/interpreter/src/address.rs
+++ b/cranelift/interpreter/src/address.rs
@@ -1,0 +1,286 @@
+//! Virtual Addressing Scheme for the Interpreter
+//!
+//! The interpreter uses virtual memory addresses for its memory operations. These addresses
+//! are obtained by the various `_addr` instructions (e.g. `stack_addr`) and can be either 32 or 64
+//! bits.
+//!
+//! Addresses are composed of 3 fields: "region", "entry" and offset.
+//!
+//! "region" refers to the type of memory that this address points to.
+//! "entry" refers to which instance of this memory the address points to (e.g table1 would be
+//! "entry" 1 of a `Table` region address).
+//! The last field is the "offset", which refers to the offset within the entry.  
+//!
+//! The address has the "region" field as the 2 most significant bits. The following bits
+//! are the "entry" field, the amount of "entry" bits depends on the size of the address and
+//! the "region" of the address. The remaining bits belong to the "offset" field
+//!
+//! An example address could be a 32 bit address, in the `heap` region, which has 2 "entry" bits
+//! this address would have 32 - 2 - 2 = 28 offset bits.
+//!
+//! The only exception to this is the "stack" region, where, because we only have a single "stack"
+//! we have 0 "entry" bits, and thus is all offset.
+
+use crate::state::MemoryError;
+use cranelift_codegen::data_value::DataValue;
+use cranelift_codegen::ir::{types, Type};
+use std::convert::TryFrom;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum AddressSize {
+    _32,
+    _64,
+}
+
+impl AddressSize {
+    pub fn bits(&self) -> u64 {
+        match self {
+            AddressSize::_64 => 64,
+            AddressSize::_32 => 32,
+        }
+    }
+}
+
+impl TryFrom<Type> for AddressSize {
+    type Error = MemoryError;
+
+    fn try_from(ty: Type) -> Result<Self, Self::Error> {
+        match ty {
+            types::I64 => Ok(AddressSize::_64),
+            types::I32 => Ok(AddressSize::_32),
+            _ => Err(MemoryError::InvalidAddressType(ty)),
+        }
+    }
+}
+
+/// Virtual Address region
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum AddressRegion {
+    Stack,
+    Heap,
+    Table,
+    GlobalValue,
+}
+
+impl AddressRegion {
+    pub fn decode(bits: u64) -> Self {
+        assert!(bits < 4);
+        match bits {
+            0 => AddressRegion::Stack,
+            1 => AddressRegion::Heap,
+            2 => AddressRegion::Table,
+            3 => AddressRegion::GlobalValue,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn encode(self) -> u64 {
+        match self {
+            AddressRegion::Stack => 0,
+            AddressRegion::Heap => 1,
+            AddressRegion::Table => 2,
+            AddressRegion::GlobalValue => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Address {
+    pub size: AddressSize,
+    pub region: AddressRegion,
+    pub entry: u64,
+    pub offset: u64,
+}
+
+impl Address {
+    pub fn from_parts(
+        size: AddressSize,
+        region: AddressRegion,
+        entry: u64,
+        offset: u64,
+    ) -> Result<Self, MemoryError> {
+        let entry_bits = Address::entry_bits(size, region);
+        let offset_bits = Address::offset_bits(size, region);
+
+        let max_entries = (1 << entry_bits) - 1;
+        let max_offset = (1 << offset_bits) - 1;
+
+        if entry > max_entries {
+            return Err(MemoryError::InvalidEntry {
+                entry,
+                max: max_entries,
+            });
+        }
+
+        if offset > max_offset {
+            return Err(MemoryError::InvalidOffset {
+                offset,
+                max: max_offset,
+            });
+        }
+
+        Ok(Address {
+            size,
+            region,
+            entry,
+            offset,
+        })
+    }
+
+    fn entry_bits(size: AddressSize, region: AddressRegion) -> u64 {
+        match (size, region) {
+            // We only have one stack, so the whole address is offset
+            (_, AddressRegion::Stack) => 0,
+
+            (AddressSize::_32, AddressRegion::Heap) => 2,
+            (AddressSize::_32, AddressRegion::Table) => 5,
+            (AddressSize::_32, AddressRegion::GlobalValue) => 6,
+
+            (AddressSize::_64, AddressRegion::Heap) => 6,
+            (AddressSize::_64, AddressRegion::Table) => 10,
+            (AddressSize::_64, AddressRegion::GlobalValue) => 12,
+        }
+    }
+
+    fn offset_bits(size: AddressSize, region: AddressRegion) -> u64 {
+        let region_bits = 2;
+        let entry_bits = Address::entry_bits(size, region);
+        size.bits() - entry_bits - region_bits
+    }
+}
+
+impl TryFrom<Address> for DataValue {
+    type Error = MemoryError;
+
+    fn try_from(addr: Address) -> Result<Self, Self::Error> {
+        let entry_bits = Address::entry_bits(addr.size, addr.region);
+        let offset_bits = Address::offset_bits(addr.size, addr.region);
+
+        let entry = addr.entry << offset_bits;
+        let region = addr.region.encode() << (entry_bits + offset_bits);
+
+        let value = region | entry | addr.offset;
+        Ok(match addr.size {
+            AddressSize::_32 => DataValue::I32(value as u32 as i32),
+            AddressSize::_64 => DataValue::I64(value as i64),
+        })
+    }
+}
+
+impl TryFrom<DataValue> for Address {
+    type Error = MemoryError;
+
+    fn try_from(value: DataValue) -> Result<Self, Self::Error> {
+        let addr = match value {
+            DataValue::U32(v) => v as u64,
+            DataValue::I32(v) => v as u32 as u64,
+            DataValue::U64(v) => v,
+            DataValue::I64(v) => v as u64,
+            _ => {
+                return Err(MemoryError::InvalidAddress(value));
+            }
+        };
+
+        let size = match value {
+            DataValue::U32(_) | DataValue::I32(_) => AddressSize::_32,
+            DataValue::U64(_) | DataValue::I64(_) => AddressSize::_64,
+            _ => unreachable!(),
+        };
+
+        let region = AddressRegion::decode(addr >> (size.bits() - 2));
+
+        let entry_bits = Address::entry_bits(size, region);
+        let offset_bits = Address::offset_bits(size, region);
+
+        let entry = (addr >> offset_bits) & ((1 << entry_bits) - 1);
+        let offset = addr & ((1 << offset_bits) - 1);
+
+        Address::from_parts(size, region, entry, offset)
+    }
+}
+
+impl TryFrom<u64> for Address {
+    type Error = MemoryError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let dv = if value > u32::MAX as u64 {
+            DataValue::U64(value)
+        } else {
+            DataValue::U32(value as u32)
+        };
+
+        Address::try_from(dv)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryInto;
+
+    #[test]
+    fn address_region_roundtrip_encode_decode() {
+        let all_regions = [
+            AddressRegion::Stack,
+            AddressRegion::Heap,
+            AddressRegion::Table,
+            AddressRegion::GlobalValue,
+        ];
+
+        for region in all_regions {
+            assert_eq!(AddressRegion::decode(region.encode()), region);
+        }
+    }
+
+    #[test]
+    fn address_roundtrip() {
+        let test_addresses = [
+            (AddressSize::_32, AddressRegion::Stack, 0, 0),
+            (AddressSize::_32, AddressRegion::Stack, 0, 1),
+            (AddressSize::_32, AddressRegion::Stack, 0, 1024),
+            (AddressSize::_32, AddressRegion::Stack, 0, 0x3FFF_FFFF),
+            (AddressSize::_32, AddressRegion::Heap, 0, 0),
+            (AddressSize::_32, AddressRegion::Heap, 1, 1),
+            (AddressSize::_32, AddressRegion::Heap, 3, 1024),
+            (AddressSize::_32, AddressRegion::Heap, 3, 0x0FFF_FFFF),
+            (AddressSize::_32, AddressRegion::Table, 0, 0),
+            (AddressSize::_32, AddressRegion::Table, 1, 1),
+            (AddressSize::_32, AddressRegion::Table, 31, 0x1FF_FFFF),
+            (AddressSize::_32, AddressRegion::GlobalValue, 0, 0),
+            (AddressSize::_32, AddressRegion::GlobalValue, 1, 1),
+            (AddressSize::_32, AddressRegion::GlobalValue, 63, 0xFF_FFFF),
+            (AddressSize::_64, AddressRegion::Stack, 0, 0),
+            (AddressSize::_64, AddressRegion::Stack, 0, 1),
+            (
+                AddressSize::_64,
+                AddressRegion::Stack,
+                0,
+                0x3FFFFFFF_FFFFFFFF,
+            ),
+            (AddressSize::_64, AddressRegion::Heap, 0, 0),
+            (AddressSize::_64, AddressRegion::Heap, 1, 1),
+            (AddressSize::_64, AddressRegion::Heap, 3, 1024),
+            (AddressSize::_64, AddressRegion::Heap, 3, 0x0FFF_FFFF),
+            (AddressSize::_64, AddressRegion::Table, 0, 0),
+            (AddressSize::_64, AddressRegion::Table, 1, 1),
+            (AddressSize::_64, AddressRegion::Table, 31, 0x1FF_FFFF),
+            (AddressSize::_64, AddressRegion::GlobalValue, 0, 0),
+            (AddressSize::_64, AddressRegion::GlobalValue, 1, 1),
+            (AddressSize::_64, AddressRegion::GlobalValue, 63, 0xFF_FFFF),
+        ];
+
+        for (size, region, entry, offset) in test_addresses {
+            let original = Address {
+                size,
+                region,
+                entry,
+                offset,
+            };
+
+            let dv: DataValue = original.clone().try_into().unwrap();
+            let addr = dv.try_into().unwrap();
+
+            assert_eq!(original, addr);
+        }
+    }
+}

--- a/cranelift/interpreter/src/address.rs
+++ b/cranelift/interpreter/src/address.rs
@@ -20,6 +20,17 @@
 //!
 //! The only exception to this is the "stack" region, where, because we only have a single "stack"
 //! we have 0 "entry" bits, and thus is all offset.
+//!
+//! | address size | address kind | region value (2 bits) | entry bits (#) | offset bits (#) |
+//! |--------------|--------------|-----------------------|----------------|-----------------|
+//! | 32           | Stack        | 0b00                  | 0              | 30              |
+//! | 32           | Heap         | 0b01                  | 2              | 28              |
+//! | 32           | Table        | 0b10                  | 5              | 25              |
+//! | 32           | GlobalValue  | 0b11                  | 6              | 24              |
+//! | 64           | Stack        | 0b00                  | 0              | 62              |
+//! | 64           | Heap         | 0b01                  | 6              | 56              |
+//! | 64           | Table        | 0b10                  | 10             | 52              |
+//! | 64           | GlobalValue  | 0b11                  | 12             | 50              |
 
 use crate::state::MemoryError;
 use cranelift_codegen::data_value::DataValue;

--- a/cranelift/interpreter/src/lib.rs
+++ b/cranelift/interpreter/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is a project for interpreting Cranelift IR.
 
+pub mod address;
 pub mod environment;
 pub mod frame;
 pub mod instruction;

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -87,12 +87,12 @@ where
     };
 
     let memerror_to_trap = |e: MemoryError| match e {
-        MemoryError::InvalidAddress(_) => TrapCode::InvalidAddress,
-        MemoryError::InvalidAddressType(_) => TrapCode::InvalidAddress,
-        MemoryError::InvalidOffset { .. } => TrapCode::InvalidAddress,
-        MemoryError::InvalidEntry { .. } => TrapCode::InvalidAddress,
-        MemoryError::OutOfBoundsStore { .. } => TrapCode::OutOfBoundsStore,
-        MemoryError::OutOfBoundsLoad { .. } => TrapCode::OutOfBoundsLoad,
+        MemoryError::InvalidAddress(_) => TrapCode::HeapOutOfBounds,
+        MemoryError::InvalidAddressType(_) => TrapCode::HeapOutOfBounds,
+        MemoryError::InvalidOffset { .. } => TrapCode::HeapOutOfBounds,
+        MemoryError::InvalidEntry { .. } => TrapCode::HeapOutOfBounds,
+        MemoryError::OutOfBoundsStore { .. } => TrapCode::HeapOutOfBounds,
+        MemoryError::OutOfBoundsLoad { .. } => TrapCode::HeapOutOfBounds,
     };
 
     // Assigns or traps depending on the value of the result

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -271,14 +271,14 @@ impl Value for DataValue {
                 (types::I32, types::I64) => unimplemented!(),
                 _ => unimplemented!("conversion: {} -> {:?}", self.ty(), kind),
             },
-            ValueConversionKind::ZeroExtend(ty) => match (self.ty(), ty) {
-                (types::I8, types::I16) => unimplemented!(),
-                (types::I8, types::I32) => unimplemented!(),
-                (types::I8, types::I64) => unimplemented!(),
-                (types::I16, types::I32) => unimplemented!(),
-                (types::I16, types::I64) => unimplemented!(),
-                (types::I32, types::I64) => unimplemented!(),
-                _ => unimplemented!("conversion: {} -> {:?}", self.ty(), kind),
+            ValueConversionKind::ZeroExtend(ty) => match (self, ty) {
+                (DataValue::I8(_), types::I16) => unimplemented!(),
+                (DataValue::I8(_), types::I32) => unimplemented!(),
+                (DataValue::I8(_), types::I64) => unimplemented!(),
+                (DataValue::I16(_), types::I32) => unimplemented!(),
+                (DataValue::I16(_), types::I64) => unimplemented!(),
+                (DataValue::I32(n), types::I64) => DataValue::I64(n as u32 as i64),
+                (dv, _) => unimplemented!("conversion: {} -> {:?}", dv.ty(), kind),
             },
             ValueConversionKind::ToUnsigned => match self {
                 DataValue::I8(n) => DataValue::U8(n as u8),
@@ -386,7 +386,7 @@ impl Value for DataValue {
     }
 
     fn and(self, other: Self) -> ValueResult<Self> {
-        binary_match!(&(&self, &other); [I8, I16, I32, I64])
+        binary_match!(&(&self, &other); [B, I8, I16, I32, I64])
     }
 
     fn or(self, other: Self) -> ValueResult<Self> {


### PR DESCRIPTION
Hey,

This PR is #3164 with an additional Virtual Addressing scheme that was discussed as a better alternative to returning the real addresses.

The virtual addresses are split into 4 regions (stack, heap, tables and global values), and the address itself is composed of an `entry` field and an `offset` field. In general the `entry` field corresponds to the instance of the resource (e.g. table5 is entry 5) and the `offset` field is a byte offset inside that entry.

There is one exception to this which is the stack, where due to only having one stack, the whole address is an offset field.

The number of bits in entry vs offset fields is variable with respect to the region and the address size (32bits vs 64bits). This is done because with 32 bit addresses we would have to compromise on heap size, or have a small number of global values / tables. With 64 bit addresses we do not have to compromise on this, but we need to support 32 bit addresses.

cc: @abrown @cfallin 