### PR TITLE
fuzz: Don't canonicalize NaN while fuzzing

### DIFF
--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -35,7 +35,6 @@ pub fn fuzz_default_config(strategy: wasmtime::Strategy) -> anyhow::Result<wasmt
     init_fuzzing();
     let mut config = wasmtime::Config::new();
     config
-        .cranelift_nan_canonicalization(true)
         .wasm_bulk_memory(true)
         .wasm_reference_types(true)
         .wasm_module_linking(true)


### PR DESCRIPTION
This came up over the weekend where the spec interpreter and Wasmtime
were differing on the result of a wasm program, but the difference came
down to how nan bits are represented. Because Wasmtime was forcibly
canonicalizing nan representations it created a mismatch in the results
of the interpreter and not. While permissible by the spec this hinders
fuzzing, so this commit attempts to address this to ensure that the spec
interpreter produces the same NaN values as Wasmtime does (and vice
versa).

NaN canonicalization was enabled for fuzzing in #1334 which tracks back
to #1332 and a desire for more determinism when fuzzing. I believe,
though, that NaN bits are always deterministic within one machine,
they're just "nondeterministic" across machines (although I think in
practice all cpus produce the same nan bits?) In any case I don't think
that canonicalization is required for the fuzzers and disabling it helps
us align with what the spec interpreter is doing as well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
