### PR TITLE
Don't require `DW_AT_comp_dir` for debuginfo

### DIFF
--- a/crates/debug/src/transform/line_program.rs
+++ b/crates/debug/src/transform/line_program.rs
@@ -63,17 +63,20 @@ where
     };
     let comp_dir = root.attr_value(gimli::DW_AT_comp_dir)?;
     let comp_name = root.attr_value(gimli::DW_AT_name)?;
-    let out_comp_dir = clone_attr_string(
-        comp_dir.as_ref().context("comp_dir")?,
-        gimli::DW_FORM_strp,
-        unit,
-        debug_str,
-        debug_str_offsets,
-        debug_line_str,
-        out_strings,
-    )?;
+    let out_comp_dir = match &comp_dir {
+        Some(comp_dir) => Some(clone_attr_string(
+            comp_dir,
+            gimli::DW_FORM_strp,
+            unit,
+            debug_str,
+            debug_str_offsets,
+            debug_line_str,
+            out_strings,
+        )?),
+        None => None,
+    };
     let out_comp_name = clone_attr_string(
-        comp_name.as_ref().context("comp_name")?,
+        comp_name.as_ref().context("missing DW_AT_name attribute")?,
         gimli::DW_FORM_strp,
         unit,
         debug_str,
@@ -102,7 +105,7 @@ where
         let mut out_program = write::LineProgram::new(
             out_encoding,
             line_encoding,
-            out_comp_dir,
+            out_comp_dir.unwrap_or_else(|| write::LineString::String(Vec::new())),
             out_comp_name,
             None,
         );


### PR DESCRIPTION
I'm not too well-versed in this area of debuginfo, but I think this
should address #3184 where it appears not all compilers emit
`DW_AT_comp_dir`. This seems to match the default behavior of `gimli`
when it maps an existing line program to a new line program as well
(choosing an empty name for the compilation directory).

Closes #3184

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
