### PR TITLE
Docs: Removed the extra markdown example from the Summary

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,7 +42,6 @@
   - [C/C++](./wasm-c.md)
   - [AssemblyScript](./wasm-assemblyscript.md)
   - [WebAssembly Text Format (`*.wat`)](./wasm-wat.md)
-  - [Example: Markdown Parser](./wasm-markdown.md)
 - [Stability](stability.md)
   - [Release Process](./stability-release.md)
   - [Platform Support](./stability-platform-support.md)

--- a/docs/wasm-markdown.md
+++ b/docs/wasm-markdown.md
@@ -1,1 +1,0 @@
-# Example: Markdown Parser


### PR DESCRIPTION
Small fix, since we now have #3193 , I think it's a bit odd to also have the markdown example under this section. So I went ahead and removed it, as I assume this got here on accident? 🤔 😄 

# Example

**It's no longer in the sidebar**

![Screenshot from 2021-08-16 15-34-05](https://user-images.githubusercontent.com/1448289/129637509-cd264d51-7ec1-4dcd-b58c-2c4c85fc982b.png)
