### PR TITLE
Actually process memory64 feature in CLI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,7 @@ impl CommonOptions {
             .wasm_multi_value(features.multi_value || self.enable_multi_value || self.enable_all)
             .wasm_threads(features.threads || self.enable_threads || self.enable_all)
             .wasm_multi_memory(features.multi_memory || self.enable_multi_memory || self.enable_all)
+            .wasm_memory64(features.memory64 || self.enable_all)
             .wasm_module_linking(
                 features.module_linking || self.enable_module_linking || self.enable_all,
             );


### PR DESCRIPTION
I forgot the last step to actually set it in `Config`...

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
