### PR TITLE
Disable default features of `gimli`

### DIFF
--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-entity = { path = "../../cranelift/entity", version = "0.76.0" }
 cranelift-native = { path = '../../cranelift/native', version = '0.76.0' }
 wasmparser = "0.80.0"
 target-lexicon = "0.12"
-gimli = "0.25.0"
+gimli = { version = "0.25.0", default-features = false }
 object = { version = "0.26.0", default-features = false, features = ['write'] }
 more-asserts = "0.2.1"
 thiserror = "1.0.4"

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-entity = { path = "../../cranelift/entity", version = "0.76.0" }
 cranelift-native = { path = '../../cranelift/native', version = '0.76.0' }
 wasmparser = "0.80.0"
 target-lexicon = "0.12"
-gimli = { version = "0.25.0", default-features = false }
+gimli = { version = "0.25.0", default-features = false, features = ['read', 'std'] }
 object = { version = "0.26.0", default-features = false, features = ['write'] }
 more-asserts = "0.2.1"
 thiserror = "1.0.4"

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.94", features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
 more-asserts = "0.2.1"
 cfg-if = "1.0"
-gimli = { version = "0.25.0", default-features = false }
+gimli = { version = "0.25.0", default-features = false, features = ['read'] }
 target-lexicon = "0.12"
 
 [badges]

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.94", features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
 more-asserts = "0.2.1"
 cfg-if = "1.0"
-gimli = "0.25.0"
+gimli = { version = "0.25.0", default-features = false }
 target-lexicon = "0.12"
 
 [badges]

--- a/crates/profiling/Cargo.toml
+++ b/crates/profiling/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 cfg-if = "1.0"
-gimli = { version = "0.25.0", optional = true }
+gimli = { version = "0.25.0", optional = true, default-features = false }
 lazy_static = "1.4"
 libc = { version = "0.2.60", default-features = false }
 scroll = { version = "0.10.1", features = ["derive"], optional = true }


### PR DESCRIPTION
For cranelift-less builds this avoids pulling in extra dependencies into
`gimli` that we don't need, improving build times slightly.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
