### PR TITLE
Fix cross-compilation via the CLI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,13 +298,15 @@ impl CommonOptions {
     fn config(&self, target: Option<&str>) -> Result<Config> {
         let mut config = Config::new();
 
-        // Set the target before setting any cranelift options
+        // Set the compiler and target before setting any cranelift options,
+        // since the strategy determines which compiler is in use and the target
+        // will reset any target-specific options.
+        config.strategy(pick_compilation_strategy(self.cranelift, self.lightbeam)?)?;
         if let Some(target) = target {
             config.target(target)?;
         }
 
         config
-            .strategy(pick_compilation_strategy(self.cranelift, self.lightbeam)?)?
             .cranelift_debug_verifier(self.enable_cranelift_debug_verifier)
             .debug_info(self.debug_info)
             .cranelift_opt_level(self.opt_level())


### PR DESCRIPTION
The `strategy` was chosen after the `target` which meant that the target
choice was blown away because the `strategy` method overwrites the
currently configured compiler.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
