### PR TITLE
Fix VTune build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,7 @@ jobs:
     - run: cargo check -p wasmtime --no-default-features --features wat
     - run: cargo check -p wasmtime --no-default-features --features lightbeam
     - run: cargo check -p wasmtime --no-default-features --features jitdump
+    - run: cargo check -p wasmtime --no-default-features --features vtune
     - run: cargo check -p wasmtime --no-default-features --features cache
     - run: cargo check -p wasmtime --no-default-features --features async
     - run: cargo check -p wasmtime --no-default-features --features uffd

--- a/crates/profiling/src/jitdump_linux.rs
+++ b/crates/profiling/src/jitdump_linux.rs
@@ -336,13 +336,13 @@ impl State {
         let rh = RecordHeader {
             id: RecordId::JitCodeLoad as u32,
             record_size: size_limit as u32 + name_len as u32 + len as u32,
-            timestamp: timestamp,
+            timestamp,
         };
 
         let clr = CodeLoadRecord {
             header: rh,
-            pid: pid,
-            tid: tid,
+            pid,
+            tid,
             virtual_address: addr as u64,
             address: addr as u64,
             size: len as u64,
@@ -435,8 +435,8 @@ impl State {
 
                 let mut clr = CodeLoadRecord {
                     header: record_header,
-                    pid: pid,
-                    tid: tid,
+                    pid,
+                    tid,
                     virtual_address: 0,
                     address: 0,
                     size: 0,

--- a/crates/profiling/src/vtune_linux.rs
+++ b/crates/profiling/src/vtune_linux.rs
@@ -10,13 +10,11 @@
 use crate::ProfilingAgent;
 use anyhow::Result;
 use core::ptr;
-use cranelift_entity::PrimaryMap;
-use cranelift_wasm_types::DefinedFuncIndex;
 use ittapi_rs::*;
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::sync::Mutex;
-use wasmtime_environ::Module;
+use std::sync::{atomic, Mutex};
+use wasmtime_environ::{DefinedFuncIndex, Module, PrimaryMap};
 use wasmtime_runtime::VMFunctionBody;
 
 /// Interface for driving the ittapi for VTune support
@@ -76,7 +74,7 @@ impl State {
         len: usize,
     ) -> () {
         let mut jmethod = _iJIT_Method_Load {
-            method_id: method_id,
+            method_id,
             method_name: CString::new(method_name)
                 .expect("CString::new failed")
                 .into_raw(),
@@ -132,13 +130,17 @@ impl State {
         functions: &PrimaryMap<DefinedFuncIndex, *mut [VMFunctionBody]>,
         _dbg_image: Option<&[u8]>,
     ) -> () {
+        // Global counter for module ids.
+        static MODULE_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
+
         for (idx, func) in functions.iter() {
             let (addr, len) = unsafe { ((**func).as_ptr() as *const u8, (**func).len()) };
             let default_filename = "wasm_file";
             let default_module_name = String::from("wasm_module");
             let module_name = module.name.as_ref().unwrap_or(&default_module_name);
             let method_name = super::debug_name(module, idx);
-            let method_id = self.get_method_id(module.id, idx);
+            let global_module_id = MODULE_ID.fetch_add(1, atomic::Ordering::SeqCst);
+            let method_id = self.get_method_id(global_module_id, idx);
             println!(
                 "Event Load: ({}) {:?}::{:?} Addr:{:?}\n",
                 method_id, module_name, method_name, addr

--- a/crates/profiling/src/vtune_linux.rs
+++ b/crates/profiling/src/vtune_linux.rs
@@ -132,6 +132,7 @@ impl State {
     ) -> () {
         // Global counter for module ids.
         static MODULE_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
+        let global_module_id = MODULE_ID.fetch_add(1, atomic::Ordering::SeqCst);
 
         for (idx, func) in functions.iter() {
             let (addr, len) = unsafe { ((**func).as_ptr() as *const u8, (**func).len()) };
@@ -139,7 +140,6 @@ impl State {
             let default_module_name = String::from("wasm_module");
             let module_name = module.name.as_ref().unwrap_or(&default_module_name);
             let method_name = super::debug_name(module, idx);
-            let global_module_id = MODULE_ID.fetch_add(1, atomic::Ordering::SeqCst);
             let method_id = self.get_method_id(global_module_id, idx);
             println!(
                 "Event Load: ({}) {:?}::{:?} Addr:{:?}\n",


### PR DESCRIPTION
This fixes the VTune build, which was broken on main (and on the latest stable release too, at least).

I've copied the previous strategy to generate global module identifiers (atomic uint incremented as we compile new modules).

Second commit adds the vtune build to CI, so it's not broken again in the future.

Other than that, the vtune profiling page is still up to date, and vtune integration still works on Linux; great stuff!