### PR TITLE
Fix wiggle code generation for correct span usage

### DIFF
--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "README.md", "LICENSE"]
 thiserror = "1"
 witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9.1", optional = true }
 wiggle-macro = { path = "macro", version = "0.29.0" }
-tracing = "0.1.15"
+tracing = "0.1.26"
 bitflags = "1.2"
 async-trait = "0.1.42"
 wasmtime = { path = "../wasmtime", version = "0.29.0", optional = true, default-features = false }

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -97,26 +97,27 @@ fn _define_func(
                     _span.in_scope(|| {
                       #body
                     })
-              }
+                }
             ),
             bounds,
         )
     } else {
         (
             quote!(
-            #[allow(unreachable_code)] // deals with warnings in noreturn functions
-            pub fn #ident<'a>(
-                ctx: &'a mut (impl #(#bounds)+*),
-                memory: &'a dyn #rt::GuestMemory,
-                #(#abi_params),*
-            ) -> impl std::future::Future<Output = Result<#abi_ret, #rt::Trap>> + 'a {
-                use std::convert::TryFrom as _;
-                use #rt::tracing::Instrument as _;
-                #mk_span
-                async move {
-                    #body
-                }.instrument(_span)
-            }),
+                #[allow(unreachable_code)] // deals with warnings in noreturn functions
+                pub fn #ident<'a>(
+                    ctx: &'a mut (impl #(#bounds)+*),
+                    memory: &'a dyn #rt::GuestMemory,
+                    #(#abi_params),*
+                ) -> impl std::future::Future<Output = Result<#abi_ret, #rt::Trap>> + 'a {
+                    use std::convert::TryFrom as _;
+                    use #rt::tracing::Instrument as _;
+                    #mk_span
+                    async move {
+                        #body
+                    }.instrument(_span)
+                }
+            ),
             bounds,
         )
     }

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -73,36 +73,55 @@ fn _define_func(
         },
     );
 
-    let asyncness = if settings.get_async(&module, &func).is_sync() {
-        quote!()
-    } else {
-        quote!(async)
-    };
     let mod_name = &module.name.as_str();
     let func_name = &func.name.as_str();
-    (
-        quote! {
+    if settings.get_async(&module, &func).is_sync() {
+        (
+            quote!(
+                #[allow(unreachable_code)] // deals with warnings in noreturn functions
+                pub fn #ident(
+                    ctx: &mut (impl #(#bounds)+*),
+                    memory: &dyn #rt::GuestMemory,
+                    #(#abi_params),*
+                ) -> Result<#abi_ret, #rt::Trap> {
+                    use std::convert::TryFrom as _;
+                    let _span = #rt::tracing::span!(
+                        #rt::tracing::Level::TRACE,
+                        "wiggle abi",
+                        module = #mod_name,
+                        function = #func_name
+                    );
+                    _span.in_scope(|| {
+                      #body
+                    })
+              }
+            ),
+            bounds,
+        )
+    } else {
+        (
+            quote!(
             #[allow(unreachable_code)] // deals with warnings in noreturn functions
-            pub #asyncness fn #ident(
-                ctx: &mut (impl #(#bounds)+*),
-                memory: &dyn #rt::GuestMemory,
+            pub fn #ident<'a>(
+                ctx: &'a mut (impl #(#bounds)+*),
+                memory: &'a dyn #rt::GuestMemory,
                 #(#abi_params),*
-            ) -> Result<#abi_ret, #rt::Trap> {
+            ) -> impl std::future::Future<Output = Result<#abi_ret, #rt::Trap>> + 'a {
                 use std::convert::TryFrom as _;
-
+                use #rt::tracing::Instrument as _;
                 let _span = #rt::tracing::span!(
                     #rt::tracing::Level::TRACE,
                     "wiggle abi",
                     module = #mod_name,
                     function = #func_name
                 );
-                let _enter = _span.enter();
-
+              async move {
                 #body
-            }
-        },
-        bounds,
-    )
+              }.instrument(_span)
+            }),
+            bounds,
+        )
+    }
 }
 
 struct Rust<'a> {

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -17,7 +17,7 @@ wiggle = { path = "..", features = ["tracing_log"] }
 
 [dev-dependencies]
 thiserror = "1.0"
-tracing = "0.1.14"
+tracing = "0.1.26"
 tracing-subscriber = "0.2.4"
 env_logger = "0.8"
 


### PR DESCRIPTION
- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
  This was an issue that @pchickey stumbled on internally at work when testing
  out some things and I was asked to take a look at it and figure out what was going on
  
- [X] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
  
  Fixes incorrect behavior with spans generated by wiggle in asynchronous code.
  
- [X] This PR contains test cases, if meaningful.

  N/A but have confirmed in internal testing that this does indeed fix the issue and doesn't break
  functionality, just changes the function signatures.
  
- [X] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.
  
  @pchickey asked for me to tag him for review when I put this PR up.

## Commit Message Follows:

Up to this point when using wiggle to generate functions we could end up
with two types of functions an async or sync one with this proc macro

```
  #[allow(unreachable_code)] // deals with warnings in noreturn functions
  pub #asyncness fn #ident(
      ctx: &mut (impl #(#bounds)+*),
      memory: &dyn #rt::GuestMemory,
      #(#abi_params),*
  ) -> Result<#abi_ret, #rt::Trap> {
      use std::convert::TryFrom as _;

      let _span = #rt::tracing::span!(
          #rt::tracing::Level::TRACE,
          "wiggle abi",
          module = #mod_name,
          function = #func_name
      );
      let _enter = _span.enter();

      #body
  }
```

Now this might seem fine, we just create a span and enter it and run the
body code and we get async versions as well. However, this is where the
source of our problem lies. The impetus for this fix was seeing multiple
request IDs output in the logs for a single function call of a generated
function. Something was clearly happening that shouldn't have been. If
we take a look at the tracing docs here we can see why the above code
will not work in asynchronous code.

https://docs.rs/tracing/0.1.26/tracing/span/struct.Span.html#in-asynchronous-code

> Warning: in asynchronous code that uses async/await syntax,
> Span::enter should be used very carefully or avoided entirely.
> Holding the drop guard returned by Span::enter across .await points
> will result in incorrect traces.

The above documentation provides some more information, but what could
happen is that the `#body` itself could contain code that would await
and mess up the tracing that occurred and causing output that would be
completely nonsensical. The code itself should work fine in the
synchronous case though and in cases where await was not called again
inside the body as the future would poll to completion as if it was a
synchronous function.

The solution then is to use the newer `Instrument` trait which can make
sure that the span will be entered on every poll of the future. In order
to make sure that we have the same behavior as before we generate
synchronous functions and the ones that were async instead return a
future that uses the instrument trait. This way we can guarantee that
the span is created in synchronous code before being passed into a
future. This does change the function signature, but the functionality
itself is exactly as before and so we should see no actual difference in
how it's used by others. We also just to be safe call the synchronous
version's body with `in_scope` now as per the docs recommendation even
though it's more intended for calling sync code inside async functions.
Functionally it's the same as before with the call to enter. We also
bump the version of tracing uses so that wiggle can reexport tracing
with the instrument changes.