### PR TITLE
fuzz: use 'fuzzing' branch of Wasm spec mirror

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/build.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/build.rs
@@ -74,6 +74,8 @@ fn is_spec_repository_empty(destination: &str) -> bool {
 fn retrieve_spec_repository(repository: &str, destination: &str) {
     let status = Command::new("git")
         .arg("clone")
+        .arg("--branch")
+        .arg("fuzzing")
         .arg("--depth")
         .arg("1")
         .arg(repository)


### PR DESCRIPTION
With [this fix](https://github.com/bytecodealliance/wasm-spec-mirror/pull/1) to the WebAssembly spec interpreter, the `wasm-spec-interpreter` crate needs to retrieve itself from the 'fuzzing' branch.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
