### PR TITLE
Spec-interpreter fuzzing: check out `fuzzing` branch of our mirror.

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/build.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/build.rs
@@ -11,6 +11,7 @@ const LIB_NAME: &'static str = "interpret";
 const OCAML_DIR: &'static str = "ocaml";
 const SPEC_DIR: &'static str = "ocaml/spec";
 const SPEC_REPOSITORY: &'static str = "https://github.com/bytecodealliance/wasm-spec-mirror";
+const SPEC_REPOSITORY_BRANCH: &'static str = "fuzzing";
 
 fn main() {
     if cfg!(feature = "build-libinterpret") {
@@ -32,7 +33,7 @@ fn build() {
     } else {
         // Ensure the spec repository is present.
         if is_spec_repository_empty(SPEC_DIR) {
-            retrieve_spec_repository(SPEC_REPOSITORY, SPEC_DIR)
+            retrieve_spec_repository(SPEC_REPOSITORY, SPEC_REPOSITORY_BRANCH, SPEC_DIR)
         }
 
         // Build the library to link to.
@@ -71,12 +72,14 @@ fn is_spec_repository_empty(destination: &str) -> bool {
 // Clone the spec repository into `destination`. This exists due to the large
 // size of the dependencies (e.g. KaTeX) that are pulled if this were cloned
 // recursively as a submodule.
-fn retrieve_spec_repository(repository: &str, destination: &str) {
+fn retrieve_spec_repository(repository: &str, branch: &str, destination: &str) {
     let status = Command::new("git")
         .arg("clone")
         .arg("--depth")
         .arg("1")
         .arg(repository)
+        .arg("-b")
+        .arg(branch)
         .arg(destination)
         .status()
         .expect("Failed to execute 'git' command to clone spec repository.");


### PR DESCRIPTION
In #3186, we found an issue that requires patching the spec interpreter
for now. Our plan is to have a `fuzzing` branch in our spec-repo mirror
that lets us make these fixes locally before they are upstreamed.
This PR updates the build script for the spec-interpreter wrapper
crate to clone this particular `fuzzing` branch instead of the main
branch.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
