### PR TITLE
Parse fewer names in linking

### DIFF
--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -430,12 +430,7 @@ fn build_code_memory(
         trampolines.push((i, fnptr));
     }
 
-    link_module(
-        &allocation.obj,
-        &module,
-        allocation.code_range,
-        &finished_functions,
-    );
+    link_module(&allocation.obj, allocation.code_range);
 
     let code_range = (allocation.code_range.as_ptr(), allocation.code_range.len());
 


### PR DESCRIPTION
We don't need an auxiliary map to tell us function addresses, we can
query the symbol instead.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
