### PR TITLE
Move definition of ModuleMemoryOffset

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -1,3 +1,4 @@
+use crate::debug::ModuleMemoryOffset;
 use crate::func_environ::{get_func_name, FuncEnvironment};
 use crate::obj::{ObjectBuilder, ObjectBuilderTarget};
 use crate::{
@@ -25,8 +26,8 @@ use std::mem;
 use std::sync::Mutex;
 use wasmtime_environ::{
     CompileError, FilePos, FlagValue, FunctionAddressMap, FunctionBodyData, FunctionInfo,
-    InstructionAddressMap, Module, ModuleMemoryOffset, ModuleTranslation, StackMapInformation,
-    TrapCode, TrapInformation, Tunables, TypeTables, VMOffsets,
+    InstructionAddressMap, Module, ModuleTranslation, StackMapInformation, TrapCode,
+    TrapInformation, Tunables, TypeTables, VMOffsets,
 };
 
 /// A compiler that compiles a WebAssembly module with Compiler, translating

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -2,6 +2,17 @@
 
 #![allow(clippy::cast_ptr_alignment)]
 
+/// Memory definition offset in the VMContext structure.
+#[derive(Debug, Clone)]
+pub enum ModuleMemoryOffset {
+    /// Not available.
+    None,
+    /// Offset to the defined memory.
+    Defined(u32),
+    /// Offset to the imported memory.
+    Imported(u32),
+}
+
 pub use write_debuginfo::{emit_dwarf, DwarfSection, DwarfSectionRelocTarget};
 
 mod gc;

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -1,4 +1,5 @@
 use super::address_transform::AddressTransform;
+use crate::debug::ModuleMemoryOffset;
 use anyhow::{Context, Error, Result};
 use cranelift_codegen::ir::{LabelValueLoc, StackSlots, ValueLabel, ValueLoc};
 use cranelift_codegen::isa::TargetIsa;
@@ -10,7 +11,7 @@ use std::cmp::PartialEq;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
-use wasmtime_environ::{DefinedFuncIndex, EntityRef, ModuleMemoryOffset};
+use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 
 #[derive(Debug)]
 pub struct FunctionFrameInfo<'a> {
@@ -1267,8 +1268,9 @@ mod tests {
     #[test]
     fn test_debug_value_range_builder() {
         use super::ValueLabelRangesBuilder;
+        use crate::debug::ModuleMemoryOffset;
         use cranelift_codegen::ir::StackSlots;
-        use wasmtime_environ::{DefinedFuncIndex, EntityRef, ModuleMemoryOffset};
+        use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 
         let addr_tr = create_mock_address_transform();
         let stack_slots = StackSlots::new();

--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -2,6 +2,7 @@ use self::refs::DebugInfoRefsMap;
 use self::simulate::generate_simulated_dwarf;
 use self::unit::clone_unit;
 use crate::debug::gc::build_dependencies;
+use crate::debug::ModuleMemoryOffset;
 use crate::CompiledFunctions;
 use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
@@ -11,7 +12,7 @@ use gimli::{
 };
 use std::collections::HashSet;
 use thiserror::Error;
-use wasmtime_environ::{DebugInfoData, ModuleMemoryOffset};
+use wasmtime_environ::DebugInfoData;
 
 pub use address_transform::AddressTransform;
 

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -1,6 +1,7 @@
 use super::expression::{CompiledExpression, FunctionFrameInfo};
 use super::utils::{add_internal_types, append_vmctx_info, get_function_frame_info};
 use super::AddressTransform;
+use crate::debug::ModuleMemoryOffset;
 use crate::CompiledFunctions;
 use anyhow::{Context, Error};
 use cranelift_codegen::isa::TargetIsa;
@@ -12,7 +13,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmparser::Type as WasmType;
 use wasmtime_environ::{
-    DebugInfoData, DefinedFuncIndex, EntityRef, FunctionMetadata, ModuleMemoryOffset, WasmFileInfo,
+    DebugInfoData, DefinedFuncIndex, EntityRef, FunctionMetadata, WasmFileInfo,
 };
 
 const PRODUCER_NAME: &str = "wasmtime";

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -6,6 +6,7 @@ use super::range_info_builder::RangeInfoBuilder;
 use super::refs::{PendingDebugInfoRefs, PendingUnitRefs, UnitRefsMap};
 use super::utils::{add_internal_types, append_vmctx_info, get_function_frame_info};
 use super::{DebugInputContext, Reader, TransformError};
+use crate::debug::ModuleMemoryOffset;
 use crate::CompiledFunctions;
 use anyhow::{Context, Error};
 use cranelift_codegen::ir::Endianness;
@@ -13,7 +14,7 @@ use cranelift_codegen::isa::TargetIsa;
 use gimli::write;
 use gimli::{AttributeValue, DebuggingInformationEntry, Unit};
 use std::collections::HashSet;
-use wasmtime_environ::{DefinedFuncIndex, ModuleMemoryOffset};
+use wasmtime_environ::DefinedFuncIndex;
 
 struct InheritedAttr<T> {
     stack: Vec<(usize, T)>,

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -1,10 +1,11 @@
 use super::address_transform::AddressTransform;
 use super::expression::{CompiledExpression, FunctionFrameInfo};
+use crate::debug::ModuleMemoryOffset;
 use crate::CompiledFunctions;
 use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::write;
-use wasmtime_environ::{DefinedFuncIndex, ModuleMemoryOffset};
+use wasmtime_environ::DefinedFuncIndex;
 
 /// Adds internal Wasm utility types DIEs such as WebAssemblyPtr and
 /// WasmtimeVMContext.

--- a/crates/cranelift/src/debug/write_debuginfo.rs
+++ b/crates/cranelift/src/debug/write_debuginfo.rs
@@ -1,11 +1,12 @@
 pub use crate::debug::transform::transform_dwarf;
+use crate::debug::ModuleMemoryOffset;
 use crate::CompiledFunctions;
 use cranelift_codegen::ir::Endianness;
 use cranelift_codegen::isa::{unwind::UnwindInfo, TargetIsa};
 use cranelift_entity::EntityRef;
 use gimli::write::{Address, Dwarf, EndianVec, FrameTable, Result, Sections, Writer};
 use gimli::{RunTimeEndian, SectionId};
-use wasmtime_environ::{DebugInfoData, ModuleMemoryOffset};
+use wasmtime_environ::DebugInfoData;
 
 #[allow(missing_docs)]
 pub struct DwarfSection {

--- a/crates/environ/src/address_map.rs
+++ b/crates/environ/src/address_map.rs
@@ -74,14 +74,3 @@ impl Default for FilePos {
         FilePos(u32::MAX)
     }
 }
-
-/// Memory definition offset in the VMContext structure.
-#[derive(Debug, Clone)]
-pub enum ModuleMemoryOffset {
-    /// Not available.
-    None,
-    /// Offset to the defined memory.
-    Defined(u32),
-    /// Offset to the imported memory.
-    Imported(u32),
-}


### PR DESCRIPTION
This was historically defined in `wasmtime-environ` but it's only used
in `wasmtime-cranelift`, so this commit moves the definition to the
`debug` module where it's primarily used.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
