### PR TITLE
Replace some cfg(debug) with cfg(debug_assertions)

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -321,8 +321,10 @@ impl<I: VCodeInst> MachBuffer<I> {
 
     /// Debug-only: check invariants of labels and branch-records described
     /// under "Branch-optimization Correctness" above.
-    #[cfg(debug)]
     fn check_label_branch_invariants(&self) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
         let cur_off = self.cur_offset();
         // Check that every entry in latest_branches has *correct*
         // labels_at_this_branch lists. We do not check completeness because
@@ -361,11 +363,6 @@ impl<I: VCodeInst> MachBuffer<I> {
                 debug_assert_eq!(self.label_aliases[l.0 as usize], UNKNOWN_LABEL);
             }
         }
-    }
-
-    #[cfg(not(debug))]
-    fn check_label_branch_invariants(&self) {
-        // Nothing.
     }
 
     /// Current offset from start of buffer.

--- a/crates/cranelift/src/debug/transform/address_transform.rs
+++ b/crates/cranelift/src/debug/transform/address_transform.rs
@@ -212,7 +212,7 @@ fn build_function_addr_map(
             });
         }
 
-        if cfg!(debug) {
+        if cfg!(debug_assertions) {
             // fn_map is sorted by the generated field -- see FunctionAddressMap::instructions.
             for i in 1..fn_map.len() {
                 assert_le!(fn_map[i - 1].generated, fn_map[i].generated);


### PR DESCRIPTION
Cargo nor rustc ever sets `cfg(debug)` automatically, so it's expected
that these usages were intended to be `cfg(debug_assertions)`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
