### PR TITLE
Allow for opting out of uffd even if the uffd feature is enabled.

### DIFF
--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -16,10 +16,14 @@ fn instantiate(linker: &Linker<WasiCtx>, module: &Module) -> Result<()> {
 fn benchmark_name<'a>(strategy: &InstanceAllocationStrategy) -> &'static str {
     match strategy {
         InstanceAllocationStrategy::OnDemand => "default",
-        #[cfg(any(not(feature = "uffd"), not(target_os = "linux")))]
-        InstanceAllocationStrategy::Pooling { .. } => "pooling",
-        #[cfg(all(feature = "uffd", target_os = "linux"))]
-        InstanceAllocationStrategy::Pooling { .. } => "uffd",
+        InstanceAllocationStrategy::Pooling {
+            page_fault_strategy,
+            ..
+        } => match page_fault_strategy {
+            PoolingPageFaultStrategy::OperatingSystem => "pooling",
+            #[cfg(all(feature = "uffd", target_os = "linux"))]
+            PoolingPageFaultStrategy::Wasmtime => "uffd",
+        },
     }
 }
 

--- a/benches/thread_eager_init.rs
+++ b/benches/thread_eager_init.rs
@@ -99,6 +99,7 @@ fn test_setup() -> (Engine, Module) {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: pool_count },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     let engine = Engine::new(&config).unwrap();
 

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -27,6 +27,7 @@ mod pooling;
 
 pub use self::pooling::{
     InstanceLimits, ModuleLimits, PoolingAllocationStrategy, PoolingInstanceAllocator,
+    PoolingPageFaultStrategy,
 };
 
 /// Represents a request for a new runtime instance.

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -39,7 +39,12 @@ use wasmtime_environ::{DefinedMemoryIndex, EntityRef, MemoryInitialization};
 
 const WASM_PAGE_SIZE: usize = wasmtime_environ::WASM_PAGE_SIZE as usize;
 
-fn decommit(addr: *mut u8, len: usize) -> Result<()> {
+pub fn commit_memory_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+    // A no-op as memory pages remain READ|WRITE with uffd
+    Ok(())
+}
+
+pub fn decommit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
     if len == 0 {
         return Ok(());
     }
@@ -61,35 +66,6 @@ fn decommit(addr: *mut u8, len: usize) -> Result<()> {
     Ok(())
 }
 
-pub fn commit_memory_pages(_addr: *mut u8, _len: usize) -> Result<()> {
-    // A no-op as memory pages remain READ|WRITE with uffd
-    Ok(())
-}
-
-pub fn decommit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
-    decommit(addr, len)
-}
-
-pub fn commit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
-    // A no-op as table pages remain READ|WRITE
-    Ok(())
-}
-
-pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
-    decommit(addr, len)
-}
-
-#[cfg(feature = "async")]
-pub fn commit_stack_pages(_addr: *mut u8, _len: usize) -> Result<()> {
-    // A no-op as stack pages remain READ|WRITE
-    Ok(())
-}
-
-#[cfg(feature = "async")]
-pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
-    decommit(addr, len)
-}
-
 /// This is used to initialize the memory pool when uffd is enabled.
 ///
 /// Without uffd, all of the memory pool's pages are initially protected with `NONE` to treat the entire
@@ -99,7 +75,7 @@ pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
 /// With uffd, however, the potentially accessible pages of the each linear memory are made `READ_WRITE` and
 /// the page fault handler will detect an out of bounds access and treat the page, temporarily,
 /// as a guard page.
-pub(super) fn initialize_memory_pool(pool: &MemoryPool) -> Result<()> {
+pub fn initialize_memory_pool(pool: &MemoryPool) -> Result<()> {
     if pool.memory_size == 0 || pool.max_wasm_pages == 0 {
         return Ok(());
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -42,8 +42,8 @@ pub use crate::imports::Imports;
 pub use crate::instance::{
     InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstanceLimits,
     InstantiationError, LinkError, ModuleLimits, OnDemandInstanceAllocator,
-    PoolingAllocationStrategy, PoolingInstanceAllocator, ResourceLimiter, DEFAULT_INSTANCE_LIMIT,
-    DEFAULT_MEMORY_LIMIT, DEFAULT_TABLE_LIMIT,
+    PoolingAllocationStrategy, PoolingInstanceAllocator, PoolingPageFaultStrategy, ResourceLimiter,
+    DEFAULT_INSTANCE_LIMIT, DEFAULT_MEMORY_LIMIT, DEFAULT_TABLE_LIMIT,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -429,6 +429,7 @@ fn async_with_pooling_stacks() {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -458,6 +459,7 @@ fn async_host_func_with_pooling_stacks() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);

--- a/tests/all/instance.rs
+++ b/tests/all/instance.rs
@@ -48,6 +48,7 @@ fn linear_memory_limits() -> Result<()> {
                 ..ModuleLimits::default()
             },
             instance_limits: InstanceLimits::default(),
+            page_fault_strategy: PoolingPageFaultStrategy::default(),
         },
     ))?)?;
     return Ok(());

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -245,6 +245,7 @@ fn test_pooling_allocator_initial_limits_exceeded() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
 
     let engine = Engine::new(&config)?;

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -198,6 +198,7 @@ fn guards_present_pooling() -> Result<()> {
             ..ModuleLimits::default()
         },
         instance_limits: InstanceLimits { count: 2 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     let engine = Engine::new(&config)?;
 

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -13,6 +13,7 @@ fn successful_instantiation() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -39,6 +40,7 @@ fn memory_limit() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(65536);
@@ -110,6 +112,7 @@ fn memory_init() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
 
     let engine = Engine::new(&config)?;
@@ -146,6 +149,7 @@ fn memory_guard_page_trap() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
 
     let engine = Engine::new(&config)?;
@@ -202,6 +206,7 @@ fn memory_zeroed() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -245,6 +250,7 @@ fn table_limit() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -325,6 +331,7 @@ fn table_init() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
 
     let engine = Engine::new(&config)?;
@@ -375,6 +382,7 @@ fn table_zeroed() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -421,6 +429,7 @@ fn instantiation_limit() -> Result<()> {
         instance_limits: InstanceLimits {
             count: INSTANCE_LIMIT,
         },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -471,6 +480,7 @@ fn preserve_data_segments() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 2 },
+        page_fault_strategy: PoolingPageFaultStrategy::default(),
     });
     let engine = Engine::new(&config)?;
     let m = Module::new(

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::{Condvar, Mutex};
 use wasmtime::{
     Config, Engine, InstanceAllocationStrategy, InstanceLimits, ModuleLimits,
-    PoolingAllocationStrategy, Store, Strategy,
+    PoolingAllocationStrategy, PoolingPageFaultStrategy, Store, Strategy,
 };
 use wasmtime_wast::WastContext;
 
@@ -104,6 +104,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
                 count: 450,
                 ..Default::default()
             },
+            page_fault_strategy: PoolingPageFaultStrategy::default(),
         });
         Some(lock_pooling())
     } else {


### PR DESCRIPTION
This PR adds a `PoolingPageFaultStrategy` enum to the Wasmtime API to
control whether the operating system or Wasmtime will handle page faults in
linear memory.

The latter requires the `uffd` feature and Linux as the target OS.

With this change, a pooling allocator can be created that uses the operating
system's page fault handling even on Linux with the `uffd` feature enabled.