### PR TITLE
Add `paged_memory_initialization` to Config.

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -380,7 +380,7 @@ impl Module {
 
             // If configured, attempt to use paged memory initialization
             // instead of the default mode of memory initialization
-            if cfg!(all(feature = "uffd", target_os = "linux")) {
+            if engine.config().paged_memory_initialization {
                 translation.try_paged_init();
             }
 

--- a/tests/all/instance.rs
+++ b/tests/all/instance.rs
@@ -33,6 +33,29 @@ fn initializes_linear_memory() -> Result<()> {
 }
 
 #[test]
+fn initializes_linear_memory_paged() -> Result<()> {
+    let wat = r#"
+        (module
+            (memory (export "memory") 2)
+            (data (i32.const 0) "Hello World!")
+        )"#;
+
+    let mut config = Config::new();
+    config.paged_memory_initialization(true);
+
+    let module = Module::new(&Engine::new(&config)?, wat)?;
+
+    let mut store = Store::new(module.engine(), ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let memory = instance.get_memory(&mut store, "memory").unwrap();
+
+    let mut bytes = [0; 12];
+    memory.read(&store, 0, &mut bytes)?;
+    assert_eq!(bytes, "Hello World!".as_bytes());
+    Ok(())
+}
+
+#[test]
 fn linear_memory_limits() -> Result<()> {
     // this test will allocate 4GB of virtual memory space, and may not work in
     // situations like CI QEMU emulation where it triggers SIGKILL.


### PR DESCRIPTION
This commit adds a `paged_memory_initialization` setting to `Config`.

The setting controls whether or not an attempt is made to organize data
segments into Wasm pages during compilation.

When used in conjunction with the `uffd` feature on Linux, Wasmtime can
completely skip initializing linear memories and instead initialize any pages
that are accessed for the first time during Wasm execution.