### PR TITLE
Remove some allocations in `CodeMemory`

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -95,7 +95,7 @@ use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex, WasmFuncType, WasmType};
 use target_lexicon::CallingConvention;
 use wasmtime_environ::{
-    FilePos, FunctionInfo, InstructionAddressMap, Module, TrapInformation, TypeTables,
+    FilePos, FunctionInfo, InstructionAddressMap, ModuleTranslation, TrapInformation, TypeTables,
 };
 
 pub use builder::builder;
@@ -257,16 +257,16 @@ fn indirect_signature(isa: &dyn TargetIsa, wasm: &WasmFuncType) -> ir::Signature
 /// use a custom theoretically faster calling convention instead of the default.
 fn func_signature(
     isa: &dyn TargetIsa,
-    module: &Module,
+    translation: &ModuleTranslation,
     types: &TypeTables,
     index: FuncIndex,
 ) -> ir::Signature {
-    let call_conv = match module.defined_func_index(index) {
+    let call_conv = match translation.module.defined_func_index(index) {
         // If this is a defined function in the module and it's never possibly
         // exported, then we can optimize this function to use the fastest
         // calling convention since it's purely an internal implementation
         // detail of the module itself.
-        Some(idx) if !module.possibly_exported_funcs.contains(&idx) => CallConv::Fast,
+        Some(idx) if !translation.escaped_funcs.contains(&idx) => CallConv::Fast,
 
         // ... otherwise if it's an imported function or if it's a possibly
         // exported function then we use the default ABI wasmtime would
@@ -277,7 +277,7 @@ fn func_signature(
     push_types(
         isa,
         &mut sig,
-        &types.wasm_signatures[module.functions[index]],
+        &types.wasm_signatures[translation.module.functions[index]],
     );
     return sig;
 }

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -179,7 +179,9 @@ pub trait Compiler: Send + Sync {
     /// the `obj` provided.
     ///
     /// This will configure the same sections as `emit_obj`, but will likely be
-    /// much smaller.
+    /// much smaller. The two returned `Trampoline` structures describe where to
+    /// find the host-to-wasm and wasm-to-host trampolines in the text section,
+    /// respectively.
     fn emit_trampoline_obj(
         &self,
         ty: &WasmFuncType,

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -2,8 +2,8 @@
 //! module.
 
 use crate::{
-    DefinedFuncIndex, FilePos, FunctionBodyData, ModuleTranslation, PrimaryMap, StackMap, Tunables,
-    TypeTables, WasmError, WasmFuncType,
+    DefinedFuncIndex, FilePos, FunctionBodyData, ModuleTranslation, PrimaryMap, SignatureIndex,
+    StackMap, Tunables, TypeTables, WasmError, WasmFuncType,
 };
 use anyhow::Result;
 use object::write::Object;
@@ -22,6 +22,25 @@ use thiserror::Error;
 pub struct FunctionInfo {
     pub start_srcloc: FilePos,
     pub stack_maps: Vec<StackMapInformation>,
+
+    /// Offset in the text section of where this function starts.
+    pub start: u64,
+    /// The size of the compiled function, in bytes.
+    pub length: u32,
+}
+
+/// Information about a compiled trampoline which the host can call to enter
+/// wasm.
+#[derive(Serialize, Deserialize, Clone)]
+#[allow(missing_docs)]
+pub struct Trampoline {
+    /// The signature this trampoline is for
+    pub signature: SignatureIndex,
+
+    /// Offset in the text section of where this function starts.
+    pub start: u64,
+    /// The size of the compiled function, in bytes.
+    pub length: u32,
 }
 
 /// The offset within a function of a GC safepoint, and its associated stack
@@ -154,7 +173,7 @@ pub trait Compiler: Send + Sync {
         funcs: PrimaryMap<DefinedFuncIndex, Box<dyn Any + Send>>,
         emit_dwarf: bool,
         obj: &mut Object,
-    ) -> Result<PrimaryMap<DefinedFuncIndex, FunctionInfo>>;
+    ) -> Result<(PrimaryMap<DefinedFuncIndex, FunctionInfo>, Vec<Trampoline>)>;
 
     /// Inserts two functions for host-to-wasm and wasm-to-host trampolines into
     /// the `obj` provided.
@@ -166,7 +185,7 @@ pub trait Compiler: Send + Sync {
         ty: &WasmFuncType,
         host_fn: usize,
         obj: &mut Object,
-    ) -> Result<()>;
+    ) -> Result<(Trampoline, Trampoline)>;
 
     /// Creates a new `Object` file which is used to build the results of a
     /// compilation into.

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -43,6 +43,7 @@ pub use crate::stack_map::StackMap;
 pub use crate::trap_encoding::*;
 pub use crate::tunables::Tunables;
 pub use crate::vmoffsets::*;
+pub use object;
 
 // Reexport all of these type-level since they're quite commonly used and it's
 // much easier to refer to everything through one crate rather than importing

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -3,7 +3,7 @@
 use crate::{EntityRef, ModuleTranslation, PrimaryMap, Tunables, WASM_PAGE_SIZE};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::ops::Range;
 use wasmtime_types::*;
@@ -422,10 +422,6 @@ pub struct Module {
 
     /// The type of each nested wasm module this module contains.
     pub modules: PrimaryMap<ModuleIndex, ModuleTypeIndex>,
-
-    /// The set of defined functions within this module which are located in
-    /// element segments.
-    pub possibly_exported_funcs: BTreeSet<DefinedFuncIndex>,
 }
 
 /// Initialization routines for creating an instance, encompassing imports,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use cranelift_entity::packed_option::ReservedValue;
 use std::borrow::Cow;
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::mem;
 use std::path::PathBuf;
@@ -60,6 +60,23 @@ pub struct ModuleTranslation<'data> {
 
     /// References to the function bodies.
     pub function_body_inputs: PrimaryMap<DefinedFuncIndex, FunctionBodyData<'data>>,
+
+    /// The set of defined functions within this module which are "possibly
+    /// exported" which means that the host can possibly call them. This
+    /// includes functions such as:
+    ///
+    /// * Exported functions
+    /// * Functions in element segments
+    /// * Functions via `ref.func` instructions
+    ///
+    /// This set is used to determine the set of type signatures that need
+    /// trampolines for the host to call into.
+    pub escaped_funcs: HashSet<DefinedFuncIndex>,
+
+    /// A list of type signatures which are considered exported from this
+    /// module, or those that can possibly be called. This list is sorted, and
+    /// trampolines for each of these signatures are required.
+    pub exported_signatures: Vec<SignatureIndex>,
 
     /// DWARF debug information, if enabled, parsed from the module.
     pub debuginfo: DebugInfoData<'data>,
@@ -220,6 +237,22 @@ impl<'data> ModuleEnvironment<'data> {
 
             Payload::End => {
                 validator.end()?;
+
+                // With the `escaped_funcs` set of functions finished
+                // we can calculate the set of signatures that are exported as
+                // the set of exported functions' signatures.
+                self.result.exported_signatures = self
+                    .result
+                    .module
+                    .functions
+                    .iter()
+                    .filter_map(|(i, sig)| match self.result.module.defined_func_index(i) {
+                        Some(i) if !self.result.escaped_funcs.contains(&i) => None,
+                        _ => Some(*sig),
+                    })
+                    .collect();
+                self.result.exported_signatures.sort_unstable();
+                self.result.exported_signatures.dedup();
 
                 self.result.creation_artifacts.shrink_to_fit();
                 self.result.creation_modules.shrink_to_fit();
@@ -417,7 +450,7 @@ impl<'data> ModuleEnvironment<'data> {
                         Operator::RefNull { ty: _ } => GlobalInit::RefNullConst,
                         Operator::RefFunc { function_index } => {
                             let index = FuncIndex::from_u32(function_index);
-                            self.flag_func_possibly_exported(index);
+                            self.flag_func_escaped(index);
                             GlobalInit::RefFunc(index)
                         }
                         Operator::GlobalGet { global_index } => {
@@ -446,7 +479,7 @@ impl<'data> ModuleEnvironment<'data> {
                     let entity = match kind {
                         ExternalKind::Function => {
                             let index = FuncIndex::from_u32(index);
-                            self.flag_func_possibly_exported(index);
+                            self.flag_func_escaped(index);
                             EntityIndex::Function(index)
                         }
                         ExternalKind::Table => EntityIndex::Table(TableIndex::from_u32(index)),
@@ -471,7 +504,7 @@ impl<'data> ModuleEnvironment<'data> {
                 validator.start_section(func, &range)?;
 
                 let func_index = FuncIndex::from_u32(func);
-                self.flag_func_possibly_exported(func_index);
+                self.flag_func_escaped(func_index);
                 debug_assert!(self.result.module.start_func.is_none());
                 self.result.module.start_func = Some(func_index);
             }
@@ -497,7 +530,7 @@ impl<'data> ModuleEnvironment<'data> {
                         elements.push(match item? {
                             ElementItem::Func(f) => {
                                 let f = FuncIndex::from_u32(f);
-                                self.flag_func_possibly_exported(f);
+                                self.flag_func_escaped(f);
                                 f
                             }
                             ElementItem::Null(_ty) => FuncIndex::reserved_value(),
@@ -1113,9 +1146,9 @@ and for re-adding support for interface types you can see this issue:
             .push(ModuleSignature { imports, exports })
     }
 
-    fn flag_func_possibly_exported(&mut self, func: FuncIndex) {
+    fn flag_func_escaped(&mut self, func: FuncIndex) {
         if let Some(idx) = self.result.module.defined_func_index(func) {
-            self.result.module.possibly_exported_funcs.insert(idx);
+            self.result.escaped_funcs.insert(idx);
         }
     }
 

--- a/crates/jit/src/debug.rs
+++ b/crates/jit/src/debug.rs
@@ -27,9 +27,6 @@ pub fn create_gdbjit_image(
         }
     }
 
-    // let mut file = ::std::fs::File::create(::std::path::Path::new("test.o")).expect("file");
-    // ::std::io::Write::write_all(&mut file, &bytes).expect("write");
-
     Ok(bytes)
 }
 

--- a/crates/jit/src/profiling/jitdump_linux.rs
+++ b/crates/jit/src/profiling/jitdump_linux.rs
@@ -290,7 +290,7 @@ impl State {
         let tid = pid; // ThreadId does appear to track underlying thread. Using PID.
 
         for (idx, func) in module.finished_functions() {
-            let (addr, len) = unsafe { ((**func).as_ptr() as *const u8, (**func).len()) };
+            let (addr, len) = unsafe { ((*func).as_ptr() as *const u8, (*func).len()) };
             if let Some(img) = &dbg_image {
                 if let Err(err) = self.dump_from_debug_image(img, "wasm", addr, len, pid, tid) {
                     println!(

--- a/crates/jit/src/profiling/vtune_linux.rs
+++ b/crates/jit/src/profiling/vtune_linux.rs
@@ -121,7 +121,7 @@ impl State {
         let global_module_id = MODULE_ID.fetch_add(1, atomic::Ordering::SeqCst);
 
         for (idx, func) in module.finished_functions() {
-            let (addr, len) = unsafe { ((**func).as_ptr() as *const u8, (**func).len()) };
+            let (addr, len) = unsafe { ((*func).as_ptr() as *const u8, (*func).len()) };
             let default_filename = "wasm_file";
             let default_module_name = String::from("wasm_module");
             let module_name = module

--- a/crates/lightbeam/wasmtime/src/lib.rs
+++ b/crates/lightbeam/wasmtime/src/lib.rs
@@ -17,7 +17,7 @@ use wasmtime_environ::{
 };
 use wasmtime_environ::{
     DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex,
-    GlobalIndex, MemoryIndex, TableIndex, TypeIndex, WasmFuncType,
+    GlobalIndex, MemoryIndex, TableIndex, Trampoline, TypeIndex, WasmFuncType,
 };
 
 /// A compiler that compiles a WebAssembly module with Lightbeam, directly translating the Wasm file.
@@ -86,7 +86,7 @@ impl Compiler for Lightbeam {
         _funcs: PrimaryMap<DefinedFuncIndex, Box<dyn Any + Send>>,
         _emit_dwarf: bool,
         _obj: &mut Object,
-    ) -> Result<PrimaryMap<DefinedFuncIndex, FunctionInfo>> {
+    ) -> Result<(PrimaryMap<DefinedFuncIndex, FunctionInfo>, Vec<Trampoline>)> {
         unimplemented!()
     }
 
@@ -95,7 +95,7 @@ impl Compiler for Lightbeam {
         _ty: &WasmFuncType,
         _host_fn: usize,
         _obj: &mut Object,
-    ) -> Result<()> {
+    ) -> Result<(Trampoline, Trampoline)> {
         unimplemented!()
     }
 

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -1393,7 +1393,7 @@ mod test {
 
         let mut handles = Vec::new();
         let module = Arc::new(Module::default());
-        let finished_functions = &PrimaryMap::new();
+        let functions = &PrimaryMap::new();
 
         for _ in (0..3).rev() {
             handles.push(
@@ -1402,7 +1402,8 @@ mod test {
                         PoolingAllocationStrategy::NextAvailable,
                         InstanceAllocationRequest {
                             module: module.clone(),
-                            finished_functions,
+                            image_base: 0,
+                            functions,
                             imports: Imports {
                                 functions: &[],
                                 tables: &[],
@@ -1425,7 +1426,8 @@ mod test {
             PoolingAllocationStrategy::NextAvailable,
             InstanceAllocationRequest {
                 module: module.clone(),
-                finished_functions,
+                functions,
+                image_base: 0,
                 imports: Imports {
                     functions: &[],
                     tables: &[],

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -512,7 +512,7 @@ mod test {
 
             let mut handles = Vec::new();
             let module = Arc::new(module);
-            let finished_functions = &PrimaryMap::new();
+            let functions = &PrimaryMap::new();
 
             // Allocate the maximum number of instances with the maximum number of memories
             for _ in 0..instances.max_instances {
@@ -522,7 +522,8 @@ mod test {
                             PoolingAllocationStrategy::Random,
                             InstanceAllocationRequest {
                                 module: module.clone(),
-                                finished_functions,
+                                image_base: 0,
+                                functions,
                                 imports: Imports {
                                     functions: &[],
                                     tables: &[],

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -732,7 +732,8 @@ impl<'a> Instantiator<'a> {
                     .allocator()
                     .allocate(InstanceAllocationRequest {
                         module: compiled_module.module().clone(),
-                        finished_functions: compiled_module.finished_functions(),
+                        image_base: compiled_module.code().range().0,
+                        functions: compiled_module.functions(),
                         imports: self.cur.build(),
                         shared_signatures: self.cur.module.signatures().as_module_map().into(),
                         host_state: Box::new(Instance(instance_to_be)),

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -398,7 +398,7 @@ impl Module {
                 .collect();
 
             let mut obj = engine.compiler().object()?;
-            let funcs = engine.compiler().emit_obj(
+            let (funcs, trampolines) = engine.compiler().emit_obj(
                 &translation,
                 &types,
                 funcs,
@@ -412,7 +412,8 @@ impl Module {
                 translation.try_paged_init();
             }
 
-            let (mmap, info) = wasmtime_jit::finish_compile(translation, obj, funcs, tunables)?;
+            let (mmap, info) =
+                wasmtime_jit::finish_compile(translation, obj, funcs, trampolines, tunables)?;
             Ok((mmap, Some(info)))
         })?;
 
@@ -486,7 +487,7 @@ impl Module {
         let signatures = Arc::new(SignatureCollection::new_for_module(
             engine.signatures(),
             &types.wasm_signatures,
-            modules.iter().flat_map(|m| m.trampolines().iter().cloned()),
+            modules.iter().flat_map(|m| m.trampolines()),
         ));
 
         let module = modules.remove(main_module);

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -52,7 +52,7 @@ impl ModuleRegistry {
         // and for schemes like uffd this performs lazy initialization which
         // could use the module in the future. For that reason we continue to
         // register empty modules and retain them.
-        if compiled_module.finished_functions().is_empty() {
+        if compiled_module.finished_functions().len() == 0 {
             self.modules_without_code.push(compiled_module.clone());
             return;
         }
@@ -539,13 +539,19 @@ fn test_frame_info() -> Result<(), anyhow::Error> {
     GlobalModuleRegistry::with(|modules| {
         for (i, alloc) in module.compiled_module().finished_functions() {
             let (start, end) = unsafe {
-                let ptr = (**alloc).as_ptr();
-                let len = (**alloc).len();
+                let ptr = (*alloc).as_ptr();
+                let len = (*alloc).len();
                 (ptr as usize, ptr as usize + len)
             };
             for pc in start..end {
                 let (frame, _, _) = modules.lookup_frame_info(pc).unwrap();
-                assert!(frame.func_index() == i.as_u32());
+                assert!(
+                    frame.func_index() == i.as_u32(),
+                    "lookup of {:#x} returned {}, expected {}",
+                    pc,
+                    frame.func_index(),
+                    i.as_u32()
+                );
             }
         }
     });

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -194,7 +194,7 @@ impl<T> Store<T> {
     /// tables created to 10,000. This can be overridden with the
     /// [`Store::limiter`] configuration method.
     pub fn new(engine: &Engine, data: T) -> Self {
-        let finished_functions = &Default::default();
+        let functions = &Default::default();
         // Wasmtime uses the callee argument to host functions to learn about
         // the original pointer to the `Store` itself, allowing it to
         // reconstruct a `StoreContextMut<T>`. When we initially call a `Func`,
@@ -206,7 +206,8 @@ impl<T> Store<T> {
             OnDemandInstanceAllocator::default()
                 .allocate(InstanceAllocationRequest {
                     host_state: Box::new(()),
-                    finished_functions,
+                    image_base: 0,
+                    functions,
                     shared_signatures: None.into(),
                     imports: Default::default(),
                     module: Arc::new(wasmtime_environ::Module::default()),

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -2,9 +2,7 @@ use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::{GlobalType, Mutability, Val};
 use anyhow::Result;
-use wasmtime_environ::{
-    EntityIndex, Global, GlobalInit, Module, ModuleType, PrimaryMap, SignatureIndex,
-};
+use wasmtime_environ::{EntityIndex, Global, GlobalInit, Module, ModuleType, SignatureIndex};
 use wasmtime_runtime::VMFunctionImport;
 
 pub fn create_global(store: &mut StoreOpaque<'_>, gt: &GlobalType, val: Val) -> Result<InstanceId> {
@@ -69,7 +67,6 @@ pub fn create_global(store: &mut StoreOpaque<'_>, gt: &GlobalType, val: Val) -> 
     let id = create_handle(
         module,
         store,
-        PrimaryMap::new(),
         Box::new(()),
         &func_imports,
         shared_signature_id,

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -5,7 +5,7 @@ use crate::MemoryType;
 use anyhow::{anyhow, Result};
 use std::convert::TryFrom;
 use std::sync::Arc;
-use wasmtime_environ::{EntityIndex, MemoryPlan, MemoryStyle, Module, PrimaryMap, WASM_PAGE_SIZE};
+use wasmtime_environ::{EntityIndex, MemoryPlan, MemoryStyle, Module, WASM_PAGE_SIZE};
 use wasmtime_runtime::{RuntimeLinearMemory, RuntimeMemoryCreator, VMMemoryDefinition};
 
 pub fn create_memory(store: &mut StoreOpaque<'_>, memory: &MemoryType) -> Result<InstanceId> {
@@ -20,7 +20,7 @@ pub fn create_memory(store: &mut StoreOpaque<'_>, memory: &MemoryType) -> Result
         .exports
         .insert(String::new(), EntityIndex::Memory(memory_id));
 
-    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[], None)
+    create_handle(module, store, Box::new(()), &[], None)
 }
 
 struct LinearMemoryProxy {

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -2,7 +2,7 @@ use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::TableType;
 use anyhow::Result;
-use wasmtime_environ::{EntityIndex, Module, PrimaryMap};
+use wasmtime_environ::{EntityIndex, Module};
 
 pub fn create_table(store: &mut StoreOpaque<'_>, table: &TableType) -> Result<InstanceId> {
     let mut module = Module::new();
@@ -16,5 +16,5 @@ pub fn create_table(store: &mut StoreOpaque<'_>, table: &TableType) -> Result<In
         .exports
         .insert(String::new(), EntityIndex::Table(table_id));
 
-    create_handle(module, store, PrimaryMap::new(), Box::new(()), &[], None)
+    create_handle(module, store, Box::new(()), &[], None)
 }


### PR DESCRIPTION
This commit removes the `FinishedFunctions` type as well as allocations
associated with trampolines when allocating inside of a `CodeMemory`.
The main goal of this commit is to improve the time spent in
`CodeMemory` where currently today a good portion of time is spent
simply parsing symbol names and trying to extract function indices from
them. Instead this commit implements a new strategy (different from #3236)
where compilation records offset/length information for all
functions/trampolines so this doesn't need to be re-learned from the
object file later.

A consequence of this commit is that this offset information will be
decoded/encoded through `bincode` unconditionally, but we can also
optimize that later if necessary as well.

Internally this involved quite a bit of refactoring since the previous
map for `FinishedFunctions` was relatively heavily relied upon.

cc #3230