### PR TITLE
Add a rust-toolchain file indicating that latest stable is required

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# If you see this, run `rustup self update` to get rustup 1.24.1 or newer.
+
+# NOTE: above comment is for older `rustup` (before TOML support was added),
+# which will treat the first line as the toolchain name, and therefore show it
+# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
+
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
This enforces the fact that Wasmtime/Cranelift require the latest stable
version of Rust to compile, helping enforcing usage of the latest Rust
version in CI environments that don't run other CI steps from this
repository.

Our internal wasmtime-aarch64 CI builds have been failing for some time because the Rust version there wasn't up to date; this would have prevented it. It's not a big deal if this isn't something we want, or if it interacts badly with other CI steps; just a nice to have.