### PR TITLE
Remove `scroll` dependency from `wasmtime-jit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,26 +2671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,7 +3763,6 @@ dependencies = [
  "more-asserts",
  "object",
  "region",
- "scroll",
  "serde",
  "target-lexicon",
  "thiserror",

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -26,7 +26,6 @@ object = { version = "0.26.0", default-features = false, features = ["std", "rea
 serde = { version = "1.0.94", features = ["derive"] }
 addr2line = { version = "0.16.0", default-features = false }
 libc = { version = "0.2.60", default-features = false, optional = true }
-scroll = { version = "0.10.1", features = ["derive"], optional = true }
 ittapi-rs = { version = "0.1.5", optional = true  }
 bincode = "1.2.1"
 
@@ -34,7 +33,7 @@ bincode = "1.2.1"
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
 
 [features]
-jitdump = ['libc', 'scroll']
+jitdump = ['libc']
 vtune = ['ittapi-rs']
 
 [badges]


### PR DESCRIPTION
Similar functionality to `scroll` is provided with the `object` crate
and doesn't have a `*_derive` crate to go with it. This commit updates
the jitdump linux support to use `object` instead of `scroll` to achieve
the needs of writing structs-as-bytes onto disk.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
