### PR TITLE
Add a `Module::deserialize_file` method

### DIFF
--- a/crates/c-api/include/wasmtime/module.h
+++ b/crates/c-api/include/wasmtime/module.h
@@ -165,6 +165,26 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_module_deserialize(
     wasmtime_module_t **ret
 );
 
+/**
+ * \brief Deserialize a module from an on-disk file.
+ *
+ * This function is the same as #wasmtime_module_deserialize except that it
+ * reads the data for the serialized module from the path on disk. This can be
+ * faster than the alternative which may require copying the data around.
+ *
+ * This function does not take ownership of any of its arguments, but the
+ * returned error and module are owned by the caller.
+ *
+ * This function is not safe to receive arbitrary user input. See the Rust
+ * documentation for more information on what inputs are safe to pass in here
+ * (e.g. only that of #wasmtime_module_serialize)
+ */
+WASM_API_EXTERN wasmtime_error_t *wasmtime_module_deserialize_file(
+    wasm_engine_t *engine,
+    const char *path,
+    wasmtime_module_t **ret
+);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -134,23 +134,18 @@ impl CodeMemory {
         //   both the actual unwinding tables as well as the validity of the
         //   pointers we pass in itself.
         unsafe {
-            assert!(
-                ret.text.as_ptr() as usize % region::page::size() == 0,
-                "text section is not page-aligned"
-            );
             let text_mut =
                 std::slice::from_raw_parts_mut(ret.text.as_ptr() as *mut u8, ret.text.len());
+            let text_offset = ret.text.as_ptr() as usize - ret.mmap.as_ptr() as usize;
+            let text_range = text_offset..text_offset + text_mut.len();
             let mut text_section_readwrite = false;
             for (offset, r) in text.relocations() {
                 // If the text section was mapped at readonly we need to make it
                 // briefly read/write here as we apply relocations.
                 if !text_section_readwrite && self.mmap.is_readonly() {
-                    region::protect(
-                        text_mut.as_ptr(),
-                        text_mut.len(),
-                        region::Protection::READ_WRITE,
-                    )
-                    .expect("unable to make memory readonly and executable");
+                    self.mmap
+                        .make_writable(text_range.clone())
+                        .expect("unable to make memory writable");
                     text_section_readwrite = true;
                 }
                 crate::link::apply_reloc(&ret.obj, text_mut, offset, r);
@@ -159,12 +154,9 @@ impl CodeMemory {
             // Switch the executable portion from read/write to
             // read/execute, notably not using read/write/execute to prevent
             // modifications.
-            region::protect(
-                ret.text.as_ptr() as *mut _,
-                ret.text.len(),
-                region::Protection::READ_EXECUTE,
-            )
-            .expect("unable to make memory readonly and executable");
+            self.mmap
+                .make_executable(text_range.clone())
+                .expect("unable to make memory executable");
 
             // With all our memory set up use the platform-specific
             // `UnwindRegistration` implementation to inform the general

--- a/crates/jit/src/mmap_vec.rs
+++ b/crates/jit/src/mmap_vec.rs
@@ -96,6 +96,11 @@ impl MmapVec {
         Ok(MmapVec::new(mmap, len))
     }
 
+    /// Returns whether the original mmap was created from a readonly mapping.
+    pub fn is_readonly(&self) -> bool {
+        self.mmap.is_readonly()
+    }
+
     /// "Drains" leading bytes up to the end specified in `range` from this
     /// `MmapVec`, returning a separately owned `MmapVec` which retains access
     /// to the bytes.
@@ -140,6 +145,7 @@ impl Deref for MmapVec {
 
 impl DerefMut for MmapVec {
     fn deref_mut(&mut self) -> &mut [u8] {
+        debug_assert!(!self.is_readonly());
         // SAFETY: The underlying mmap is protected behind an `Arc` which means
         // there there can be many references to it. We are guaranteed, though,
         // that each reference to the underlying `mmap` has a disjoint `range`

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.38"
 mach = "0.3.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi"] }
+winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi", "handleapi"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 userfaultfd = { version = "0.3.0", optional = true }

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -309,6 +309,7 @@ impl Mmap {
 
     /// Return the allocated memory as a mutable slice of u8.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        debug_assert!(!self.is_readonly());
         unsafe { slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
     }
 
@@ -330,6 +331,12 @@ impl Mmap {
     /// Return whether any memory has been allocated.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Returns whether the underlying mapping is readonly, meaning that
+    /// attempts to write will fault.
+    pub fn is_readonly(&self) -> bool {
+        self.file.is_some()
     }
 }
 

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -1,10 +1,14 @@
 //! Low-level abstraction for allocating and managing zero-filled pages
 //! of memory.
 
+use anyhow::anyhow;
 use anyhow::{bail, Context, Result};
 use more_asserts::assert_le;
+use std::convert::TryFrom;
 use std::fs::File;
 use std::io;
+use std::ops::Range;
+use std::path::Path;
 use std::ptr;
 use std::slice;
 
@@ -47,19 +51,26 @@ impl Mmap {
         Self::accessible_reserved(rounded_size, rounded_size)
     }
 
-    /// Creates a new `Mmap` from the specified open `file` with the `len`
-    /// specified.
+    /// Creates a new `Mmap` by opening the file located at `path` and mapping
+    /// it into memory.
     ///
     /// The memory is mapped in read-only mode for the entire file. If portions
     /// of the file need to be modified then the `region` crate can be use to
     /// alter permissions of each page.
     ///
-    /// Note that `len` doesn't have to be page-aligned, but rather it's
-    /// expected to be the length of the `file` provided.
-    pub fn new_file(file: File, len: usize) -> Result<Self> {
+    /// The memory mapping and the length of the file within the mapping are
+    /// returned.
+    pub fn from_file(path: &Path) -> Result<Self> {
         #[cfg(unix)]
         {
             use std::os::unix::prelude::*;
+
+            let file = File::open(path).context("failed to open file")?;
+            let len = file
+                .metadata()
+                .context("failed to get file metadata")?
+                .len();
+            let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
             let ptr = unsafe {
                 libc::mmap(
                     ptr::null_mut(),
@@ -81,36 +92,72 @@ impl Mmap {
                 file: Some(file),
             })
         }
+
         #[cfg(windows)]
         {
+            use std::fs::OpenOptions;
             use std::os::windows::prelude::*;
             use winapi::um::handleapi::*;
             use winapi::um::memoryapi::*;
             use winapi::um::winnt::*;
             unsafe {
+                // Open the file with read/execute access and only share for
+                // read. This will enable us to perform the proper mmap below
+                // while also disallowing other processes modifying the file
+                // and having those modifications show up in our address space.
+                let file = OpenOptions::new()
+                    .read(true)
+                    .access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE)
+                    .share_mode(FILE_SHARE_READ)
+                    .open(path)
+                    .context("failed to open file")?;
+
+                let len = file
+                    .metadata()
+                    .context("failed to get file metadata")?
+                    .len();
+                let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
+
+                // Create a file mapping that allows PAGE_EXECUTE_READ which
+                // we'll be using for mapped text sections in ELF images later.
                 let mapping = CreateFileMappingW(
                     file.as_raw_handle().cast(),
                     ptr::null_mut(),
-                    PAGE_READONLY,
+                    PAGE_EXECUTE_READ,
                     0,
                     0,
                     ptr::null(),
                 );
                 if mapping.is_null() {
                     return Err(io::Error::last_os_error())
-                        .context(format!("failed to create file mapping of {:#x} bytes", len));
+                        .context("failed to create file mapping");
                 }
-                let ptr = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, len);
+
+                // Create a view for the entire file using `FILE_MAP_EXECUTE`
+                // here so that we can later change the text section to execute.
+                let ptr = MapViewOfFile(mapping, FILE_MAP_READ | FILE_MAP_EXECUTE, 0, 0, len);
+                let err = io::Error::last_os_error();
                 CloseHandle(mapping);
                 if ptr.is_null() {
-                    return Err(io::Error::last_os_error())
+                    return Err(err)
                         .context(format!("failed to create map view of {:#x} bytes", len));
                 }
-                Ok(Self {
+
+                let ret = Self {
                     ptr: ptr as usize,
                     len,
                     file: Some(file),
-                })
+                };
+
+                // Protect the entire file as PAGE_READONLY to start (i.e.
+                // remove the execute bit)
+                let mut old = 0;
+                if VirtualProtect(ret.ptr as *mut _, ret.len, PAGE_READONLY, &mut old) == 0 {
+                    return Err(io::Error::last_os_error())
+                        .context("failed change pages to `PAGE_READONLY`");
+                }
+
+                Ok(ret)
             }
         }
     }
@@ -337,6 +384,61 @@ impl Mmap {
     /// attempts to write will fault.
     pub fn is_readonly(&self) -> bool {
         self.file.is_some()
+    }
+
+    /// Makes the specified `range` within this `Mmap` to be read/write.
+    pub unsafe fn make_writable(&self, range: Range<usize>) -> Result<()> {
+        assert!(range.start <= self.len());
+        assert!(range.end <= self.len());
+        assert!(range.start <= range.end);
+        assert!(
+            range.start % region::page::size() == 0,
+            "changing of protections isn't page-aligned",
+        );
+
+        let base = self.as_ptr().add(range.start);
+        let len = range.end - range.start;
+
+        // On Windows when we have a file mapping we need to specifically use
+        // `PAGE_WRITECOPY` to ensure that pages are COW'd into place because
+        // we don't want our modifications to go back to the original file.
+        #[cfg(windows)]
+        {
+            use winapi::um::memoryapi::*;
+            use winapi::um::winnt::*;
+
+            if self.file.is_some() {
+                let mut old = 0;
+                if VirtualProtect(base as *mut _, len, PAGE_WRITECOPY, &mut old) == 0 {
+                    return Err(io::Error::last_os_error())
+                        .context("failed to change pages to `PAGE_WRITECOPY`");
+                }
+                return Ok(());
+            }
+        }
+
+        // If we're not on Windows or if we're on Windows with an anonymous
+        // mapping then we can use the `region` crate.
+        region::protect(base, len, region::Protection::READ_WRITE)?;
+        Ok(())
+    }
+
+    /// Makes the specified `range` within this `Mmap` to be read/execute.
+    pub unsafe fn make_executable(&self, range: Range<usize>) -> Result<()> {
+        assert!(range.start <= self.len());
+        assert!(range.end <= self.len());
+        assert!(range.start <= range.end);
+        assert!(
+            range.start % region::page::size() == 0,
+            "changing of protections isn't page-aligned",
+        );
+
+        region::protect(
+            self.as_ptr().add(range.start),
+            range.end - range.start,
+            region::Protection::READ_EXECUTE,
+        )?;
+        Ok(())
     }
 }
 

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -474,6 +474,25 @@ impl Module {
         module.into_module(engine)
     }
 
+    /// Same as [`deserialize`], except that the contents of `path` are read to
+    /// deserialize into a [`Module`].
+    ///
+    /// For more information see the documentation of the [`deserialize`]
+    /// method for why this function is `unsafe`.
+    ///
+    /// This method is provided because it can be faster than [`deserialize`]
+    /// since the data doesn't need to be copied around, but rather the module
+    /// can be used directly from an mmap'd view of the file provided.
+    ///
+    /// [`deserialize`]: Module::deserialize
+    pub unsafe fn deserialize_file(engine: &Engine, path: impl AsRef<Path>) -> Result<Module> {
+        let module = SerializedModule::from_file(
+            path.as_ref(),
+            engine.config().deserialize_check_wasmtime_version,
+        )?;
+        module.into_module(engine)
+    }
+
     fn from_parts(
         engine: &Engine,
         mut modules: Vec<Arc<CompiledModule>>,

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -55,6 +55,7 @@ use object::{Bytes, File, Object, ObjectSection};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use wasmtime_environ::{Compiler, FlagValue, Tunables};
@@ -365,6 +366,10 @@ impl<'a> SerializedModule<'a> {
 
     pub fn from_bytes(bytes: &[u8], check_version: bool) -> Result<Self> {
         Self::from_mmap(MmapVec::from_slice(bytes)?, check_version)
+    }
+
+    pub fn from_file(path: &Path, check_version: bool) -> Result<Self> {
+        Self::from_mmap(MmapVec::from_file(path)?, check_version)
     }
 
     pub fn from_mmap(mut mmap: MmapVec, check_version: bool) -> Result<Self> {

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -369,7 +369,12 @@ impl<'a> SerializedModule<'a> {
     }
 
     pub fn from_file(path: &Path, check_version: bool) -> Result<Self> {
-        Self::from_mmap(MmapVec::from_file(path)?, check_version)
+        Self::from_mmap(
+            MmapVec::from_file(path).with_context(|| {
+                format!("failed to create file mapping for: {}", path.display())
+            })?,
+            check_version,
+        )
     }
 
     pub fn from_mmap(mut mmap: MmapVec, check_version: bool) -> Result<Self> {


### PR DESCRIPTION
This commit adds a new method to the `wasmtime::Module` type,
`deserialize_file`. This is intended to be the same as the `deserialize`
method except for the serialized module is present as an on-disk file.
This enables Wasmtime to internally use `mmap` to avoid copying bytes
around and generally makes loading a module much faster.

A C API is added in this commit as well for various bindings to use this
accelerated path now as well. Another option perhaps for a Rust-based
API is to have an API taking a `File` itself to allow for a custom file
descriptor in one way or another, but for now that's left for a possible
future refactoring if we find a use case.

cc #3230