### PR TITLE
Update io-lifetimes, cap-std, and rsix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92bb3f74a5c7bab38a4670171299803994c100da721a71542acc0481f49aaab"
+checksum = "18e04805737d22cbff289ece81123d4b26e4bc57014e41333a10cc86521e3943"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6f8dc570bc41f9750f726f39f27a73673fee6658835f413c973264b5d9d60f"
+checksum = "f697a6f29f9226d68a62d181662c4e7b609880c475249c21879eefde5239d2e7"
 dependencies = [
  "ambient-authority",
  "errno",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569d2ab5b8d34efd3c80e635eb7d8ff6f873c4b705454cc375b5e95fc6cdf67f"
+checksum = "62bcf8f5a6595520aca4f29328871f446217e32ab040a7b591c212b45f741ebc"
 dependencies = [
  "ambient-authority",
  "rand 0.8.3",
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021833fb391c63aee948efc616db343f24280d56195576c4a2ca35237553a840"
+checksum = "85bf379a5dbf406dbb3e09846e3f084130b65b7cde2d57c8aefd049f90ff9336"
 dependencies = [
  "cap-primitives",
  "io-lifetimes",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0943ff89dd6de302b45729408e715a14c316a86aab2b64e29613c6dde3bf45c1"
+checksum = "c1f6d28e385915d8589cfa7f6a0bba93007cb931b6b2861a393845193450a858"
 dependencies = [
  "cap-std",
  "rand 0.8.3",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29ebef47fc5209c8d8c0967c1a3ead141286fbedf348a83713e17d04289a28a"
+checksum = "1b33b3e580fb3b5649292132906813ab483ee4d8f6fb9356ae313c71a43519dd"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -1265,9 +1265,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef88dceefe321e9c9dc3e7ed98b77dfc56015855b88c326382daac2fe5035e7"
+checksum = "570474d675e834ccbe9871fb09a6e7a60611b51540662c1294c8a4c3ef52da3f"
 dependencies = [
  "io-lifetimes",
  "rsix",
@@ -1480,10 +1480,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11409ea45cce1f5ddc21b3c69e8167f7c65d2bc4c828ac2deaca9dc96d5c0d83"
+checksum = "e94e87a80ab2e1aad23d4b8c4feb954125ac4da906891e041d93f5861a5fdd78"
 dependencies = [
+ "libc",
  "rustc_version",
  "winapi",
 ]
@@ -1648,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.19"
+version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59032f8fc703723b4e913546a9b59facd8b8d783ca22f2af672cf1bf08113a62"
+checksum = "77da217e847c30f41d9f4340b62d0e9c327f114a57b55f87e235b9d48b841a66"
 
 [[package]]
 name = "lock_api"
@@ -2603,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "rsix"
-version = "0.18.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bc6e554e7708e70db95c9b4e09095b1b84a821c6fe66541150f87f19825850"
+checksum = "2bfd382d98c6cdfe6627eabef5f3410e21e0aacb16fea83963d93eeae0dea392"
 dependencies = [
  "bitflags",
  "cc",
@@ -2934,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a24c3cb74e86013d16739200866f8f4641a838a066f3e6ae71d6c178d8e6e4"
+checksum = "69f9e64878557db3497b0f15d360da5078e361d100eef8c8deedc91388c2b55b"
 dependencies = [
  "atty",
  "bitflags",
@@ -3238,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-io"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e204e8d8b19d00d5bded5563d6ffc55e3e1a223c794e9007134431101d08301"
+checksum = "11e8cceed59fe60bd092be347343917cbc14b9239536980f09fe34e22c8efbc7"
 dependencies = [
  "io-lifetimes",
  "rustc_version",
@@ -4027,9 +4028,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875be8fe56d24544e337a607c3d62be8af72175a76c8cc96378a7def89763899"
+checksum = "4ecd175b4077107a91bb6bbb34aa9a691d8b45314791776f78b63a1cb8a08928"
 dependencies = [
  "bitflags",
  "io-lifetimes",

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.17.0"
+cap-std = "0.18.0"
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -30,7 +30,7 @@ wat = { version = "1.0.36", optional = true }
 wasi-common = { path = "../wasi-common", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.17.0", optional = true }
+cap-std = { version = "0.18.0", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache']

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
-cap-std = "0.17.0"
+cap-std = "0.18.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,13 +22,13 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "0.29.0" }
 tracing = "0.1.19"
-cap-std = "0.17.0"
-cap-rand = "0.17.0"
+cap-std = "0.18.0"
+cap-rand = "0.18.0"
 bitflags = "1.2"
-io-lifetimes = { version = "0.2.3", default-features = false }
+io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.18.0"
+rsix = "0.20.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,18 +15,18 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "0.29.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.17.0"
-cap-fs-ext = "0.17.0"
-cap-time-ext = "0.17.0"
-cap-rand = "0.17.0"
-fs-set-times = "0.7.0"
-system-interface = { version = "0.11.0", features = ["cap_std_impls"] }
+cap-std = "0.18.0"
+cap-fs-ext = "0.18.0"
+cap-time-ext = "0.18.0"
+cap-rand = "0.18.0"
+fs-set-times = "0.9.0"
+system-interface = { version = "0.12.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
-io-lifetimes = { version = "0.2.3", default-features = false }
+io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.18.0"
+rsix = "0.20.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -23,13 +23,15 @@
 //! is in the `Sched` abstraction. Once we can build an async scheduler based
 //! on Rust `Future`s, async impls will be able to interoperate, but the
 //! synchronous scheduler depends on downcasting the `WasiFile` type down to
-//! concrete types it knows about (which in turn impl `AsRawFd` for passing to
+//! concrete types it knows about (which in turn impl `AsFd` for passing to
 //! unix `poll`, or the analogous traits on windows).
 //!
 //! Why is this impl suffixed with `-sync`? Because `async` is coming soon!
 //! The async impl may end up depending on tokio or other relatively heavy
 //! deps, so we will retain a sync implementation so that wasi-common users
 //! have an option of not pulling in an async runtime.
+
+#![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
 pub mod clocks;
 pub mod dir;

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,18 +15,18 @@ wasi-common = { path = "../", version = "0.29.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "0.29.0" }
 wiggle = { path = "../../wiggle", version = "0.29.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.17.0"
-cap-fs-ext = "0.17.0"
-cap-time-ext = "0.17.0"
-fs-set-times = "0.7.0"
-system-interface = { version = "0.11.0", features = ["cap_std_impls"] }
+cap-std = "0.18.0"
+cap-fs-ext = "0.18.0"
+cap-time-ext = "0.18.0"
+fs-set-times = "0.9.0"
+system-interface = { version = "0.12.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 anyhow = "1"
-io-lifetimes = { version = "0.2.3", default-features = false }
+io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.18.0"
+rsix = "0.20.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
@@ -36,4 +36,4 @@ lazy_static = "1.4"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.17.0"
+cap-tempfile = "0.18.0"

--- a/crates/wasi-common/tokio/src/lib.rs
+++ b/crates/wasi-common/tokio/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
+
 mod dir;
 mod file;
 pub mod sched;


### PR DESCRIPTION
Highlights:

 - Fixes for compiling on OpenBSD

 - io-lifetimes 0.3.0 has an option (io_lifetimes_use_std, which is off
   by default) for testing the `io_safety` feature in Rust nightly.



<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
