### PR TITLE
More flexible versioning for module serialization

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -148,7 +148,8 @@ impl Engine {
         let bytes = wat::parse_bytes(&bytes)?;
         let (_, artifacts, types) = crate::Module::build_artifacts(self, &bytes)?;
         let artifacts = artifacts.into_iter().map(|i| i.0).collect::<Vec<_>>();
-        crate::module::SerializedModule::from_artifacts(self, &artifacts, &types).to_bytes()
+        crate::module::SerializedModule::from_artifacts(self, &artifacts, &types)
+            .to_bytes(&self.config().module_version)
     }
 
     pub(crate) fn run_maybe_parallel<


### PR DESCRIPTION
replace Config::deserialize_check_wasmtime_version with Config::module_version, which is more expressive.

Instead of just configuring Module::deserialize to ignore version
information, we can configure Module::serialize to emit a custom version
string, and Module::deserialize to check for that string. A new enum
ModuleVersionStrategy is declared, and
Config::deserialize_check_wasmtime_version:bool is replaced with
Config::module_version:ModuleVersionStrategy.

For custom versioning, it used to be reasonable to wrap up a serialized module in your own container with its own version information. Now that we have mmap-based module loading, this is no longer as attractive, since it means giving up `Module::deserialize_file`.