### PR TITLE
A round of Mac M1 fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,12 +166,6 @@ jobs:
     - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
     - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
 
-    # Check that codegen and wasm crates typecheck on 1.43.0; this is required
-    # for Firefox.
-    - run: rustup install 1.43.0
-    - run: cargo +1.43.0 check -p cranelift-codegen
-    - run: cargo +1.43.0 check -p cranelift-wasm
-
   fuzz_targets:
     name: Fuzz Targets
     runs-on: ubuntu-latest

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -619,9 +619,8 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
     }
 
-    fn gen_prologue_frame_setup(flags: &settings::Flags) -> SmallInstVec<Inst> {
+    fn gen_debug_frame_info(flags: &settings::Flags) -> SmallInstVec<Inst> {
         let mut insts = SmallVec::new();
-
         if flags.unwind_info() {
             insts.push(Inst::Unwind {
                 inst: UnwindInst::Aarch64SetPointerAuth {
@@ -629,6 +628,11 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 },
             });
         }
+        insts
+    }
+
+    fn gen_prologue_frame_setup(flags: &settings::Flags) -> SmallInstVec<Inst> {
+        let mut insts = SmallVec::new();
 
         // stp fp (x29), lr (x30), [sp, #-16]!
         insts.push(Inst::StoreP64 {

--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -143,7 +143,10 @@ mod tests {
             _ => panic!("expected unwind information"),
         };
 
-        assert_eq!(format!("{:?}", fde), "FrameDescriptionEntry { address: Constant(4321), length: 16, lsda: None, instructions: [] }");
+        assert_eq!(
+            format!("{:?}", fde),
+            "FrameDescriptionEntry { address: Constant(4321), length: 16, lsda: None, instructions: [(0, ValExpression(Register(34), Expression { operations: [Simple(DwOp(48))] }))] }"
+        );
     }
 
     fn create_multi_return_function(call_conv: CallConv) -> Function {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -314,6 +314,21 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
         }
     }
 
+    /// Returns the code (text) section alignment for this ISA.
+    fn code_section_alignment(&self) -> u64 {
+        use target_lexicon::*;
+        match (self.triple().operating_system, self.triple().architecture) {
+            (
+                OperatingSystem::MacOSX { .. }
+                | OperatingSystem::Darwin
+                | OperatingSystem::Ios
+                | OperatingSystem::Tvos,
+                Architecture::Aarch64(..),
+            ) => 0x4000,
+            _ => 0x1000,
+        }
+    }
+
     /// Get the pointer type of this ISA.
     fn pointer_type(&self) -> ir::Type {
         ir::Type::int(u16::from(self.pointer_bits())).unwrap()

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -417,6 +417,13 @@ pub trait ABIMachineSpec {
     /// Generate a meta-instruction that adjusts the nominal SP offset.
     fn gen_nominal_sp_adj(amount: i32) -> Self::I;
 
+    /// Generates extra unwind instructions for a new frame  for this
+    /// architecture, whether the frame has a prologue sequence or not.
+    fn gen_debug_frame_info(_flags: &settings::Flags) -> SmallInstVec<Self::I> {
+        // By default, generates nothing.
+        smallvec![]
+    }
+
     /// Generate the usual frame-setup sequence for this architecture: e.g.,
     /// `push rbp / mov rbp, rsp` on x86-64, or `stp fp, lr, [sp, #-16]!` on
     /// AArch64.
@@ -1288,6 +1295,8 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
                 clobbered_callee_saves.len(),
                 self.fixed_frame_storage_size,
             );
+
+            insts.extend(M::gen_debug_frame_info(&self.flags).into_iter());
 
             if self.setup_frame {
                 // set up frame

--- a/crates/fiber/src/arch/aarch64.S
+++ b/crates/fiber/src/arch/aarch64.S
@@ -86,6 +86,7 @@ FUNCTION(wasmtime_fiber_start):
         0x06,            /* DW_OP_deref */ \
         0x23, 0xa0, 0x1  /* DW_OP_plus_uconst 0xa0 */
 
+    .cfi_rel_offset x29, -0x08
     .cfi_rel_offset lr, -0x10
     .cfi_rel_offset x19, -0x18
     .cfi_rel_offset x20, -0x20
@@ -96,7 +97,6 @@ FUNCTION(wasmtime_fiber_start):
     .cfi_rel_offset x25, -0x48
     .cfi_rel_offset x26, -0x50
     .cfi_rel_offset x27, -0x58
-    .cfi_rel_offset x29, -0x60
 
     // Load our two arguments from the stack, where x1 is our start procedure
     // and x0 is its first argument. This also blows away the stack space used


### PR DESCRIPTION
Three commits that make the Mac M1 pass all the tests run in CI:

- in the custom asm code for the fibers, on aarch64, the custom CFI directive that was indicating where FP (x29) lives was completely incorrect. The pushes in wasmtime_fiber_switch start with `stp lr, fp, [sp, -16]!`, so FP was at CFA - 0x8, not CFA - 0x60. Unclear why it did work in the first place, and why it stopped working at some point; likely that something in Apple's libunwind has changed in the meanwhile.
- the OS page size is 16K, not 4K on Mac M1: a constant is used for the code section page's size, and defined per target, and reused in a few places in the code base. Thanks to @alexcrichton for indicating me the place to look at!
- unfortunately we need to disable pointer authentication (until we implement it!) for function frames that don't have a prologue too. Preferred to split `gen_prologue_frame_setup`, so there's a new function `gen_debug_frame_info` that's defaulting to doing nothing, and implemented on aarch64 and disabling pointer auth. This function is called independently from the fact that the function requires a prologue/epilogue, so we can put the unwind instruction that will generate the CFI directive in there. cc @cfallin @akirilov-arm for this change

Fixes https://github.com/bytecodealliance/wasmtime/issues/3256.