### PR TITLE
Use relative `call` instructions between wasm functions

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -110,7 +110,13 @@ fn machreg_to_gpr_or_vec(m: Reg) -> u32 {
     u32::try_from(m.to_real_reg().get_hw_encoding()).unwrap()
 }
 
-fn enc_arith_rrr(bits_31_21: u32, bits_15_10: u32, rd: Writable<Reg>, rn: Reg, rm: Reg) -> u32 {
+pub(crate) fn enc_arith_rrr(
+    bits_31_21: u32,
+    bits_15_10: u32,
+    rd: Writable<Reg>,
+    rn: Reg,
+    rm: Reg,
+) -> u32 {
     (bits_31_21 << 21)
         | (bits_15_10 << 10)
         | machreg_to_gpr(rd.to_reg())
@@ -243,7 +249,7 @@ fn enc_ldst_reg(
         | machreg_to_gpr_or_vec(rd)
 }
 
-fn enc_ldst_imm19(op_31_24: u32, imm19: u32, rd: Reg) -> u32 {
+pub(crate) fn enc_ldst_imm19(op_31_24: u32, imm19: u32, rd: Reg) -> u32 {
     (op_31_24 << 24) | (imm19 << 5) | machreg_to_gpr_or_vec(rd)
 }
 
@@ -320,11 +326,11 @@ fn enc_bit_rr(size: u32, opcode2: u32, opcode1: u32, rn: Reg, rd: Writable<Reg>)
         | machreg_to_gpr(rd.to_reg())
 }
 
-fn enc_br(rn: Reg) -> u32 {
+pub(crate) fn enc_br(rn: Reg) -> u32 {
     0b1101011_0000_11111_000000_00000_00000 | (machreg_to_gpr(rn) << 5)
 }
 
-fn enc_adr(off: i32, rd: Writable<Reg>) -> u32 {
+pub(crate) fn enc_adr(off: i32, rd: Writable<Reg>) -> u32 {
     let off = u32::try_from(off).unwrap();
     let immlo = off & 3;
     let immhi = (off >> 2) & ((1 << 19) - 1);
@@ -2694,7 +2700,7 @@ impl MachInstEmit for Inst {
                         dest: BranchTarget::Label(jump_around_label),
                     };
                     jmp.emit(sink, emit_info, state);
-                    sink.emit_island();
+                    sink.emit_island(needed_space + 4);
                     sink.bind_label(jump_around_label);
                 }
             }

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -4,7 +4,10 @@ use crate::ir::condcodes::IntCC;
 use crate::ir::Function;
 use crate::isa::aarch64::settings as aarch64_settings;
 use crate::isa::Builder as IsaBuilder;
-use crate::machinst::{compile, MachBackend, MachCompileResult, TargetIsaAdapter, VCode};
+use crate::machinst::{
+    compile, MachBackend, MachCompileResult, MachTextSectionBuilder, TargetIsaAdapter,
+    TextSectionBuilder, VCode,
+};
 use crate::result::CodegenResult;
 use crate::settings as shared_settings;
 use alloc::{boxed::Box, vec::Vec};
@@ -160,6 +163,10 @@ impl MachBackend for AArch64Backend {
     #[cfg(feature = "unwind")]
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {
         Some(inst::unwind::systemv::create_cie())
+    }
+
+    fn text_section_builder(&self, num_funcs: u32) -> Box<dyn TextSectionBuilder> {
+        Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 }
 

--- a/cranelift/codegen/src/isa/arm32/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/inst/mod.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use crate::binemit::CodeOffset;
+use crate::binemit::{Addend, CodeOffset, Reloc};
 use crate::ir::types::{B1, B16, B32, B8, I16, I32, I8, IFLAGS};
 use crate::ir::{ExternalName, Opcode, TrapCode, Type};
 use crate::machinst::*;
@@ -1316,6 +1316,10 @@ impl MachInstLabelUse for LabelUse {
         _veneer_offset: CodeOffset,
     ) -> (CodeOffset, LabelUse) {
         panic!("Veneer not supported yet.")
+    }
+
+    fn from_reloc(_reloc: Reloc, _addend: Addend) -> Option<LabelUse> {
+        None
     }
 }
 

--- a/cranelift/codegen/src/isa/arm32/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/mod.rs
@@ -3,7 +3,10 @@
 use crate::ir::condcodes::IntCC;
 use crate::ir::Function;
 use crate::isa::Builder as IsaBuilder;
-use crate::machinst::{compile, MachBackend, MachCompileResult, TargetIsaAdapter, VCode};
+use crate::machinst::{
+    compile, MachBackend, MachCompileResult, MachTextSectionBuilder, TargetIsaAdapter,
+    TextSectionBuilder, VCode,
+};
 use crate::result::CodegenResult;
 use crate::settings;
 
@@ -114,6 +117,10 @@ impl MachBackend for Arm32Backend {
     fn unsigned_sub_overflow_condition(&self) -> IntCC {
         // Carry flag clear.
         IntCC::UnsignedLessThan
+    }
+
+    fn text_section_builder(&self, num_funcs: u32) -> Box<dyn TextSectionBuilder> {
+        Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -3,7 +3,7 @@
 // Some variants are not constructed, but we still want them as options in the future.
 #![allow(dead_code)]
 
-use crate::binemit::CodeOffset;
+use crate::binemit::{Addend, CodeOffset, Reloc};
 use crate::ir::{types, ExternalName, Opcode, TrapCode, Type, ValueLabel};
 use crate::isa::unwind::UnwindInst;
 use crate::machinst::*;
@@ -3685,5 +3685,9 @@ impl MachInstLabelUse for LabelUse {
         _veneer_offset: CodeOffset,
     ) -> (CodeOffset, LabelUse) {
         unreachable!();
+    }
+
+    fn from_reloc(_reloc: Reloc, _addend: Addend) -> Option<Self> {
+        None
     }
 }

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -6,7 +6,10 @@ use crate::isa::s390x::settings as s390x_settings;
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv::RegisterMappingError;
 use crate::isa::Builder as IsaBuilder;
-use crate::machinst::{compile, MachBackend, MachCompileResult, TargetIsaAdapter, VCode};
+use crate::machinst::{
+    compile, MachBackend, MachCompileResult, MachTextSectionBuilder, TargetIsaAdapter,
+    TextSectionBuilder, VCode,
+};
 use crate::result::CodegenResult;
 use crate::settings as shared_settings;
 
@@ -164,6 +167,10 @@ impl MachBackend for S390xBackend {
     #[cfg(feature = "unwind")]
     fn map_reg_to_dwarf(&self, reg: Reg) -> Result<u16, RegisterMappingError> {
         inst::unwind::systemv::map_reg(reg).map(|reg| reg.0)
+    }
+
+    fn text_section_builder(&self, num_funcs: u32) -> Box<dyn TextSectionBuilder> {
+        Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1,6 +1,6 @@
 //! This module defines x86_64-specific machine instruction types.
 
-use crate::binemit::{CodeOffset, StackMap};
+use crate::binemit::{Addend, CodeOffset, Reloc, StackMap};
 use crate::ir::{types, ExternalName, Opcode, SourceLoc, TrapCode, Type, ValueLabel};
 use crate::isa::unwind::UnwindInst;
 use crate::isa::x64::abi::X64ABIMachineSpec;
@@ -3003,6 +3003,13 @@ impl MachInstLabelUse for LabelUse {
             LabelUse::JmpRel32 | LabelUse::PCRel32 => {
                 panic!("Veneer not supported for JumpRel32 label-use.");
             }
+        }
+    }
+
+    fn from_reloc(reloc: Reloc, addend: Addend) -> Option<Self> {
+        match (reloc, addend) {
+            (Reloc::X86CallPCRel4, -4) => Some(LabelUse::JmpRel32),
+            _ => None,
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -8,7 +8,10 @@ use crate::ir::{condcodes::IntCC, Function};
 use crate::isa::unwind::systemv;
 use crate::isa::x64::{inst::regs::create_reg_universe_systemv, settings as x64_settings};
 use crate::isa::Builder as IsaBuilder;
-use crate::machinst::{compile, MachBackend, MachCompileResult, TargetIsaAdapter, VCode};
+use crate::machinst::{
+    compile, MachBackend, MachCompileResult, MachTextSectionBuilder, TargetIsaAdapter,
+    TextSectionBuilder, VCode,
+};
 use crate::result::CodegenResult;
 use crate::settings::{self as shared_settings, Flags};
 use alloc::{boxed::Box, vec::Vec};
@@ -157,6 +160,10 @@ impl MachBackend for X64Backend {
     #[cfg(feature = "unwind")]
     fn map_reg_to_dwarf(&self, reg: Reg) -> Result<u16, systemv::RegisterMappingError> {
         inst::unwind::systemv::map_reg(reg).map(|reg| reg.0)
+    }
+
+    fn text_section_builder(&self, num_funcs: u32) -> Box<dyn TextSectionBuilder> {
+        Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 }
 

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -85,6 +85,7 @@ pub mod write;
 
 pub use crate::entity::packed_option;
 pub use crate::machinst::buffer::MachSrcLoc;
+pub use crate::machinst::TextSectionBuilder;
 
 mod abi;
 mod bitset;

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1073,11 +1073,11 @@ impl<I: VCodeInst> MachBuffer<I> {
         self.worst_case_end_of_island(distance) > self.island_deadline
     }
 
-    /// Returns the maximal offset that islands can be reach if `distance` more
+    /// Returns the maximal offset that islands can reach if `distance` more
     /// bytes are appended.
     ///
     /// This is used to determine if veneers need insertions since jumps that
-    /// can't reach past this point must get a veneer of some form
+    /// can't reach past this point must get a veneer of some form.
     fn worst_case_end_of_island(&self, distance: CodeOffset) -> CodeOffset {
         self.cur_offset()
             .saturating_add(distance)
@@ -1130,7 +1130,7 @@ impl<I: VCodeInst> MachBuffer<I> {
             if label_offset != UNKNOWN_LABEL_OFFSET {
                 // If the offset of the label for this fixup is known then
                 // we're going to do something here-and-now. We're either going
-                // to patch the original offset because it's in in-bounds jump,
+                // to patch the original offset because it's an in-bounds jump,
                 // or we're going to generate a veneer, patch the fixup to jump
                 // to the veneer, and then keep going.
                 //
@@ -1275,7 +1275,7 @@ impl<I: VCodeInst> MachBuffer<I> {
         addend: Addend,
     ) {
         let name = name.clone();
-        // FIXME: This should use `I::LabelUse::from_reloc` to optionally
+        // FIXME(#3277): This should use `I::LabelUse::from_reloc` to optionally
         // generate a label-use statement to track whether an island is possibly
         // needed to escape this function to actually get to the external name.
         // This is most likely to come up on AArch64 where calls between

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -143,14 +143,17 @@
 use crate::binemit::{Addend, CodeOffset, CodeSink, Reloc, StackMap};
 use crate::ir::{ExternalName, Opcode, SourceLoc, TrapCode};
 use crate::isa::unwind::UnwindInst;
-use crate::machinst::{BlockIndex, MachInstLabelUse, VCodeConstant, VCodeConstants, VCodeInst};
+use crate::machinst::{
+    BlockIndex, MachInstLabelUse, TextSectionBuilder, VCodeConstant, VCodeConstants, VCodeInst,
+};
 use crate::timing;
 use cranelift_entity::{entity_impl, SecondaryMap};
-
 use log::trace;
 use smallvec::SmallVec;
+use std::convert::TryFrom;
 use std::mem;
 use std::string::String;
+use std::vec::Vec;
 
 /// A buffer of output to be produced, fixed up, and then emitted to a CodeSink
 /// in bulk.
@@ -1067,140 +1070,187 @@ impl<I: VCodeInst> MachBuffer<I> {
 
     /// Is an island needed within the next N bytes?
     pub fn island_needed(&self, distance: CodeOffset) -> bool {
-        let worst_case_end_of_island = self.cur_offset() + distance + self.island_worst_case_size;
-        worst_case_end_of_island > self.island_deadline
+        self.worst_case_end_of_island(distance) > self.island_deadline
     }
 
-    /// Emit all pending constants and veneers. Should only be called if
-    /// `island_needed()` returns true, i.e., if we actually reach a deadline:
-    /// otherwise, unnecessary veneers may be inserted.
-    pub fn emit_island(&mut self) {
+    /// Returns the maximal offset that islands can be reach if `distance` more
+    /// bytes are appended.
+    ///
+    /// This is used to determine if veneers need insertions since jumps that
+    /// can't reach past this point must get a veneer of some form
+    fn worst_case_end_of_island(&self, distance: CodeOffset) -> CodeOffset {
+        self.cur_offset()
+            .saturating_add(distance)
+            .saturating_add(self.island_worst_case_size)
+    }
+
+    /// Emit all pending constants and required pending veneers.
+    ///
+    /// Should only be called if `island_needed()` returns true, i.e., if we
+    /// actually reach a deadline. It's not necessarily a problem to do so
+    /// otherwise but it may result in unnecessary work during emission.
+    pub fn emit_island(&mut self, distance: CodeOffset) {
+        self.emit_island_maybe_forced(false, distance);
+    }
+
+    /// Same as `emit_island`, but an internal API with a `force_veneers`
+    /// argument to force all veneers to always get emitted for debugging.
+    fn emit_island_maybe_forced(&mut self, force_veneers: bool, distance: CodeOffset) {
         // We're going to purge fixups, so no latest-branch editing can happen
         // anymore.
         self.latest_branches.clear();
 
-        let pending_constants = mem::replace(&mut self.pending_constants, SmallVec::new());
-        for MachLabelConstant { label, align, data } in pending_constants.into_iter() {
+        // Reset internal calculations about islands since we're going to
+        // change the calculus as we apply fixups. The `forced_threshold` is
+        // used here to determine whether jumps to unknown labels will require
+        // a veneer or not.
+        let forced_threshold = self.worst_case_end_of_island(distance);
+        self.island_deadline = UNKNOWN_LABEL_OFFSET;
+        self.island_worst_case_size = 0;
+
+        // First flush out all constants so we have more labels in case fixups
+        // are applied against these labels.
+        for MachLabelConstant { label, align, data } in mem::take(&mut self.pending_constants) {
             self.align_to(align);
             self.bind_label(label);
             self.put_data(&data[..]);
         }
 
-        let fixup_records = mem::replace(&mut self.fixup_records, SmallVec::new());
-        let mut new_fixups = SmallVec::new();
-        for MachLabelFixup {
-            label,
-            offset,
-            kind,
-        } in fixup_records.into_iter()
-        {
-            trace!(
-                "emit_island: fixup for label {:?} at offset {} kind {:?}",
+        for fixup in mem::take(&mut self.fixup_records) {
+            trace!("emit_island: fixup {:?}", fixup);
+            let MachLabelFixup {
                 label,
                 offset,
-                kind
-            );
-            // We eagerly perform fixups whose label targets are known, if not out
-            // of range, to avoid unnecessary veneers.
+                kind,
+            } = fixup;
             let label_offset = self.resolve_label_offset(label);
-            let known = label_offset != UNKNOWN_LABEL_OFFSET;
-            let in_range = if known {
-                if label_offset >= offset {
-                    (label_offset - offset) <= kind.max_pos_range()
-                } else {
-                    (offset - label_offset) <= kind.max_neg_range()
-                }
-            } else {
-                false
-            };
-
-            trace!(
-                " -> label_offset = {}, known = {}, in_range = {} (pos {} neg {})",
-                label_offset,
-                known,
-                in_range,
-                kind.max_pos_range(),
-                kind.max_neg_range()
-            );
-
             let start = offset as usize;
             let end = (offset + kind.patch_size()) as usize;
-            if in_range {
-                debug_assert!(known); // implied by in_range.
-                let slice = &mut self.data[start..end];
-                trace!("patching in-range!");
-                kind.patch(slice, offset, label_offset);
-            } else if !known && !kind.supports_veneer() {
-                // Nothing for now. Keep it for next round.
-                new_fixups.push(MachLabelFixup {
-                    label,
-                    offset,
-                    kind,
-                });
-            } else if !in_range && kind.supports_veneer() {
-                // Allocate space for a veneer in the island.
-                self.align_to(I::LabelUse::ALIGN);
-                let veneer_offset = self.cur_offset();
-                trace!("making a veneer at {}", veneer_offset);
-                let slice = &mut self.data[start..end];
-                // Patch the original label use to refer to the veneer.
-                trace!(
-                    "patching original at offset {} to veneer offset {}",
-                    offset,
-                    veneer_offset
-                );
-                kind.patch(slice, offset, veneer_offset);
-                // Generate the veneer.
-                let veneer_slice = self.get_appended_space(kind.veneer_size() as usize);
-                let (veneer_fixup_off, veneer_label_use) =
-                    kind.generate_veneer(veneer_slice, veneer_offset);
-                trace!(
-                    "generated veneer; fixup offset {}, label_use {:?}",
-                    veneer_fixup_off,
-                    veneer_label_use
-                );
-                // If the label is known (but was just out of range), do the
-                // veneer label-use fixup now too; otherwise, save it for later.
-                if known {
-                    let start = veneer_fixup_off as usize;
-                    let end = (veneer_fixup_off + veneer_label_use.patch_size()) as usize;
-                    let veneer_slice = &mut self.data[start..end];
-                    trace!("doing veneer fixup right away too");
-                    veneer_label_use.patch(veneer_slice, veneer_fixup_off, label_offset);
+
+            if label_offset != UNKNOWN_LABEL_OFFSET {
+                // If the offset of the label for this fixup is known then
+                // we're going to do something here-and-now. We're either going
+                // to patch the original offset because it's in in-bounds jump,
+                // or we're going to generate a veneer, patch the fixup to jump
+                // to the veneer, and then keep going.
+                //
+                // If the label comes after the original fixup, then we should
+                // be guaranteed that the jump is in-bounds. Otherwise there's
+                // a bug somewhere because this method wasn't called soon
+                // enough. All forward-jumps are tracked and should get veneers
+                // before their deadline comes and they're unable to jump
+                // further.
+                //
+                // Otherwise if the label is before the fixup, then that's a
+                // backwards jump. If it's past the maximum negative range
+                // then we'll emit a veneer that to jump forward to which can
+                // then jump backwards.
+                let veneer_required = if label_offset >= offset {
+                    assert!((label_offset - offset) <= kind.max_pos_range());
+                    false
                 } else {
-                    new_fixups.push(MachLabelFixup {
-                        label,
-                        offset: veneer_fixup_off,
-                        kind: veneer_label_use,
-                    });
+                    (offset - label_offset) > kind.max_neg_range()
+                };
+                trace!(
+                    " -> label_offset = {}, known, required = {} (pos {} neg {})",
+                    label_offset,
+                    veneer_required,
+                    kind.max_pos_range(),
+                    kind.max_neg_range()
+                );
+
+                if (force_veneers && kind.supports_veneer()) || veneer_required {
+                    self.emit_veneer(label, offset, kind);
+                } else {
+                    let slice = &mut self.data[start..end];
+                    trace!("patching in-range!");
+                    kind.patch(slice, offset, label_offset);
                 }
             } else {
-                panic!(
-                    "Cannot support label-use {:?} (known = {}, in-range = {})",
-                    kind, known, in_range
-                );
+                // If the offset of this label is not known at this time then
+                // there's one of two possibilities:
+                //
+                // * First we may be about to exceed the maximum jump range of
+                //   this fixup. In that case a veneer is inserted to buy some
+                //   more budget for the forward-jump. It's guaranteed that the
+                //   label will eventually come after where we're at, so we know
+                //   that the forward jump is necessary.
+                //
+                // * Otherwise we're still within range of the forward jump but
+                //   the precise target isn't known yet. In that case we
+                //   enqueue the fixup to get processed later.
+                if forced_threshold - offset > kind.max_pos_range() {
+                    self.emit_veneer(label, offset, kind);
+                } else {
+                    self.use_label_at_offset(offset, label, kind);
+                }
             }
         }
-
-        self.fixup_records = new_fixups;
-        self.island_deadline = UNKNOWN_LABEL_OFFSET;
     }
 
-    /// Finish any deferred emissions and/or fixups.
-    pub fn finish(mut self) -> MachBufferFinalized {
-        let _tt = timing::vcode_emit_finish();
+    /// Emits a "veneer" the `kind` code at `offset` to jump to `label`.
+    ///
+    /// This will generate extra machine code, using `kind`, to get a
+    /// larger-jump-kind than `kind` allows. The code at `offset` is then
+    /// patched to jump to our new code, and then the new code is enqueued for
+    /// a fixup to get processed at some later time.
+    fn emit_veneer(&mut self, label: MachLabel, offset: CodeOffset, kind: I::LabelUse) {
+        // If this `kind` doesn't support a veneer then that's a bug in the
+        // backend because we need to implement support for such a veneer.
+        assert!(
+            kind.supports_veneer(),
+            "jump beyond the range of {:?} but a veneer isn't supported",
+            kind,
+        );
 
+        // Allocate space for a veneer in the island.
+        self.align_to(I::LabelUse::ALIGN);
+        let veneer_offset = self.cur_offset();
+        trace!("making a veneer at {}", veneer_offset);
+        let start = offset as usize;
+        let end = (offset + kind.patch_size()) as usize;
+        let slice = &mut self.data[start..end];
+        // Patch the original label use to refer to the veneer.
+        trace!(
+            "patching original at offset {} to veneer offset {}",
+            offset,
+            veneer_offset
+        );
+        kind.patch(slice, offset, veneer_offset);
+        // Generate the veneer.
+        let veneer_slice = self.get_appended_space(kind.veneer_size() as usize);
+        let (veneer_fixup_off, veneer_label_use) =
+            kind.generate_veneer(veneer_slice, veneer_offset);
+        trace!(
+            "generated veneer; fixup offset {}, label_use {:?}",
+            veneer_fixup_off,
+            veneer_label_use
+        );
+        // Register a new use of `label` with our new veneer fixup and offset.
+        // This'll recalculate deadlines accordingly and enqueue this fixup to
+        // get processed at some later time.
+        self.use_label_at_offset(veneer_fixup_off, label, veneer_label_use);
+    }
+
+    fn finish_emission_maybe_forcing_veneers(&mut self, force_veneers: bool) {
         while !self.pending_constants.is_empty() || !self.fixup_records.is_empty() {
             // `emit_island()` will emit any pending veneers and constants, and
             // as a side-effect, will also take care of any fixups with resolved
             // labels eagerly.
-            self.emit_island();
+            self.emit_island_maybe_forced(force_veneers, u32::MAX);
         }
 
         // Ensure that all labels have been fixed up after the last island is emitted. This is a
         // full (release-mode) assert because an unresolved label means the emitted code is
         // incorrect.
         assert!(self.fixup_records.is_empty());
+    }
+
+    /// Finish any deferred emissions and/or fixups.
+    pub fn finish(mut self) -> MachBufferFinalized {
+        let _tt = timing::vcode_emit_finish();
+
+        self.finish_emission_maybe_forcing_veneers(false);
 
         let mut srclocs = self.srclocs;
         srclocs.sort_by_key(|entry| entry.start);
@@ -1225,6 +1275,39 @@ impl<I: VCodeInst> MachBuffer<I> {
         addend: Addend,
     ) {
         let name = name.clone();
+        // FIXME: This should use `I::LabelUse::from_reloc` to optionally
+        // generate a label-use statement to track whether an island is possibly
+        // needed to escape this function to actually get to the external name.
+        // This is most likely to come up on AArch64 where calls between
+        // functions use a 26-bit signed offset which gives +/- 64MB. This means
+        // that if a function is 128MB in size and there's a call in the middle
+        // it's impossible to reach the actual target. Also, while it's
+        // technically possible to jump to the start of a function and then jump
+        // further, island insertion below always inserts islands after
+        // previously appended code so for Cranelift's own implementation this
+        // is also a problem for 64MB functions on AArch64 which start with a
+        // call instruction, those won't be able to escape.
+        //
+        // Ideally what needs to happen here is that a `LabelUse` is
+        // transparently generated (or call-sites of this function are audited
+        // to generate a `LabelUse` instead) and tracked internally. The actual
+        // relocation would then change over time if and when a veneer is
+        // inserted, where the relocation here would be patched by this
+        // `MachBuffer` to jump to the veneer. The problem, though, is that all
+        // this still needs to end up, in the case of a singular function,
+        // generating a final relocation pointing either to this particular
+        // relocation or to the veneer inserted. Additionally
+        // `MachBuffer` needs the concept of a label which will never be
+        // resolved, so `emit_island` doesn't trip over not actually ever
+        // knowning what some labels are. Currently the loop in
+        // `finish_emission_maybe_forcing_veneers` would otherwise infinitely
+        // loop.
+        //
+        // For now this means that because relocs aren't tracked at all that
+        // AArch64 functions have a rough size limits of 64MB. For now that's
+        // somewhat reasonable and the failure mode is a panic in `MachBuffer`
+        // when a relocation can't otherwise be resolved later, so it shouldn't
+        // actually result in any memory unsafety or anything like that.
         self.relocs.push(MachReloc {
             offset: self.data.len() as CodeOffset,
             srcloc,
@@ -1481,6 +1564,79 @@ impl MachBranch {
     }
 }
 
+/// Implementation of the `TextSectionBuilder` trait backed by `MachBuffer`.
+///
+/// Note that `MachBuffer` was primarily written for intra-function references
+/// of jumps between basic blocks, but it's also quite usable for entire text
+/// sections and resolving references between functions themselves. This
+/// builder interprets "blocks" as labeled functions for the purposes of
+/// resolving labels internally in the buffer.
+pub struct MachTextSectionBuilder<I: VCodeInst> {
+    buf: MachBuffer<I>,
+    next_func: u32,
+    force_veneers: bool,
+}
+
+impl<I: VCodeInst> MachTextSectionBuilder<I> {
+    pub fn new(num_funcs: u32) -> MachTextSectionBuilder<I> {
+        let mut buf = MachBuffer::new();
+        buf.reserve_labels_for_blocks(num_funcs);
+        MachTextSectionBuilder {
+            buf,
+            next_func: 0,
+            force_veneers: false,
+        }
+    }
+}
+
+impl<I: VCodeInst> TextSectionBuilder for MachTextSectionBuilder<I> {
+    fn append(&mut self, named: bool, func: &[u8], align: u32) -> u64 {
+        // Conditionally emit an island if it's necessary to resolve jumps
+        // between functions which are too far away.
+        let size = func.len() as u32;
+        if self.force_veneers || self.buf.island_needed(size) {
+            self.buf.emit_island_maybe_forced(self.force_veneers, size);
+        }
+
+        self.buf.align_to(align);
+        let pos = self.buf.cur_offset();
+        if named {
+            self.buf.bind_label(MachLabel::from_block(self.next_func));
+            self.next_func += 1;
+        }
+        self.buf.put_data(func);
+        u64::from(pos)
+    }
+
+    fn resolve_reloc(&mut self, offset: u64, reloc: Reloc, addend: Addend, target: u32) -> bool {
+        let label = MachLabel::from_block(target);
+        let offset = u32::try_from(offset).unwrap();
+        match I::LabelUse::from_reloc(reloc, addend) {
+            Some(label_use) => {
+                self.buf.use_label_at_offset(offset, label, label_use);
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn force_veneers(&mut self) {
+        self.force_veneers = true;
+    }
+
+    fn finish(&mut self) -> Vec<u8> {
+        // Double-check all functions were pushed.
+        assert_eq!(self.next_func, self.buf.label_offsets.len() as u32);
+
+        // Finish up any veneers, if necessary.
+        self.buf
+            .finish_emission_maybe_forcing_veneers(self.force_veneers);
+
+        // We don't need the data any more, so return it to the caller.
+        mem::take(&mut self.buf.data).into_vec()
+    }
+}
+
 // We use an actual instruction definition to do tests, so we depend on the `arm64` feature here.
 #[cfg(all(test, feature = "arm64"))]
 mod test {
@@ -1610,7 +1766,7 @@ mod test {
         buf.bind_label(label(1));
         while buf.cur_offset() < 2000000 {
             if buf.island_needed(0) {
-                buf.emit_island();
+                buf.emit_island(0);
             }
             let inst = Inst::Nop4;
             inst.emit(&mut buf, &info, &mut state);
@@ -1632,7 +1788,23 @@ mod test {
         let mut state = Default::default();
         let inst = Inst::CondBr {
             kind: CondBrKind::NotZero(xreg(0)),
-            taken: BranchTarget::ResolvedOffset(1048576 - 4),
+
+            // This conditionally taken branch has a 19-bit constant, shifted
+            // to the left by two, giving us a 21-bit range in total. Half of
+            // this range positive so the we should be around 1 << 20 bytes
+            // away for our jump target.
+            //
+            // There are two pending fixups by the time we reach this point,
+            // one for this 19-bit jump and one for the unconditional 26-bit
+            // jump below. A 19-bit veneer is 4 bytes large and the 26-bit
+            // veneer is 20 bytes large, which means that pessimistically
+            // assuming we'll need two veneers we need 24 bytes of extra
+            // space, meaning that the actual island should come 24-bytes
+            // before the deadline.
+            taken: BranchTarget::ResolvedOffset((1 << 20) - 4 - 20),
+
+            // This branch is in-range so no veneers should be needed, it should
+            // go directly to the target.
             not_taken: BranchTarget::ResolvedOffset(2000000 + 4 - 4),
         };
         inst.emit(&mut buf2, &info, &mut state);

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -557,7 +557,7 @@ impl<I: VCodeInst> VCode<I> {
                 let next_block_size = next_block_range.1 - next_block_range.0;
                 let worst_case_next_bb = I::worst_case_size() * next_block_size;
                 if buffer.island_needed(worst_case_next_bb) {
-                    buffer.emit_island();
+                    buffer.emit_island(worst_case_next_bb);
                 }
             }
         }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -182,7 +182,7 @@ enum RelocationTarget {
     /// A compiler-generated libcall.
     LibCall(ir::LibCall),
     /// Jump table index.
-    JumpTable(FuncIndex, ir::JumpTable),
+    JumpTable(ir::JumpTable),
 }
 
 /// Creates a new cranelift `Signature` with no wasm params/results for the

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -20,6 +20,7 @@ use arbitrary::{Arbitrary, Unstructured};
 pub struct DifferentialConfig {
     strategy: DifferentialStrategy,
     opt_level: OptLevel,
+    force_jump_veneers: bool,
 }
 
 impl DifferentialConfig {
@@ -30,6 +31,11 @@ impl DifferentialConfig {
             DifferentialStrategy::Lightbeam => wasmtime::Strategy::Lightbeam,
         })?;
         config.cranelift_opt_level(self.opt_level.to_wasmtime());
+        if self.force_jump_veneers {
+            unsafe {
+                config.cranelift_flag_set("wasmtime_linkopt_force_jump_veneer", "true")?;
+            }
+        }
         Ok(config)
     }
 }

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -1,11 +1,10 @@
 //! Linking for JIT-compiled code.
 
 use object::read::{Object, Relocation, RelocationTarget};
-use object::{elf, File, NativeEndian as NE, ObjectSymbol, RelocationEncoding, RelocationKind};
+use object::{File, NativeEndian as NE, ObjectSymbol, RelocationEncoding, RelocationKind};
 use std::convert::TryFrom;
 use wasmtime_runtime::libcalls;
 
-type U32 = object::U32Bytes<NE>;
 type I32 = object::I32Bytes<NE>;
 type U64 = object::U64Bytes<NE>;
 
@@ -36,11 +35,10 @@ pub fn apply_reloc(obj: &File, code: &mut [u8], offset: u64, r: Relocation) {
                 }
             }
         }
-        _ => panic!("unexpected relocation target"),
+        _ => panic!("unexpected relocation target: not a symbol"),
     };
 
     match (r.kind(), r.encoding(), r.size()) {
-        #[cfg(target_pointer_width = "64")]
         (RelocationKind::Absolute, RelocationEncoding::Generic, 64) => {
             let reloc_address = reloc_address::<U64>(code, offset);
             let reloc_abs = (target_func_address as u64)
@@ -48,63 +46,17 @@ pub fn apply_reloc(obj: &File, code: &mut [u8], offset: u64, r: Relocation) {
                 .unwrap();
             reloc_address.set(NE, reloc_abs);
         }
-        #[cfg(target_pointer_width = "32")]
-        (RelocationKind::Relative, RelocationEncoding::Generic, 32) => {
-            let reloc_address = reloc_address::<U32>(code, offset);
-            let reloc_delta_u32 = (target_func_address as u32)
-                .wrapping_sub(reloc_address as *const _ as u32)
-                .checked_add(r.addend() as u32)
-                .unwrap();
-            reloc_address.set(NE, reloc_delta_u32);
-        }
-        #[cfg(target_pointer_width = "32")]
-        (RelocationKind::Relative, RelocationEncoding::X86Branch, 32) => {
-            let reloc_address = reloc_address::<U32>(code, offset);
-            let reloc_delta_u32 = (target_func_address as u32)
-                .wrapping_sub(reloc_address as *const _ as u32)
-                .wrapping_add(r.addend() as u32);
-            reloc_address.set(NE, reloc_delta_u32);
-        }
-        #[cfg(target_pointer_width = "64")]
+
+        // FIXME(#3009) after the old backend is removed this won't ever show up
+        // again so it can be removed.
         (RelocationKind::Relative, RelocationEncoding::Generic, 32) => {
             let reloc_address = reloc_address::<I32>(code, offset);
-            let reloc_delta_i64 = (target_func_address as i64)
-                .wrapping_sub(reloc_address as *const _ as i64)
-                .wrapping_add(r.addend());
-            // TODO implement far calls mode in x64 new backend.
-            reloc_address.set(
-                NE,
-                i32::try_from(reloc_delta_i64).expect("relocation too large to fit in i32"),
-            );
-        }
-        #[cfg(target_pointer_width = "64")]
-        (RelocationKind::Relative, RelocationEncoding::S390xDbl, 32) => {
-            let reloc_address = reloc_address::<I32>(code, offset);
-            let reloc_delta_i64 = (target_func_address as i64)
-                .wrapping_sub(reloc_address as *const _ as i64)
+            let val = (target_func_address as i64)
                 .wrapping_add(r.addend())
-                >> 1;
-            reloc_address.set(
-                NE,
-                i32::try_from(reloc_delta_i64).expect("relocation too large to fit in i32"),
-            );
+                .wrapping_sub(reloc_address as *const _ as i64);
+            reloc_address.set(NE, i32::try_from(val).expect("relocation out-of-bounds"));
         }
-        (RelocationKind::Elf(elf::R_AARCH64_CALL26), RelocationEncoding::Generic, 32) => {
-            let reloc_address = reloc_address::<U32>(code, offset);
-            let reloc_delta = (target_func_address as u64).wrapping_sub(r.addend() as u64);
-            // TODO: come up with a PLT-like solution for longer calls. We can't extend the
-            // code segment at this point, but we could conservatively allocate space at the
-            // end of the function during codegen, a fixed amount per call, to allow for
-            // potential branch islands.
-            assert!((reloc_delta as i64) < (1 << 27));
-            assert!((reloc_delta as i64) >= -(1 << 27));
-            let reloc_delta = reloc_delta as u32;
-            let reloc_delta = reloc_delta.wrapping_add(r.addend() as u32);
-            let delta_bits = reloc_delta >> 2;
-            let insn = reloc_address.get(NE);
-            let new_insn = (insn & 0xfc00_0000) | (delta_bits & 0x03ff_ffff);
-            reloc_address.set(NE, new_insn);
-        }
+
         other => panic!("unsupported reloc kind: {:?}", other),
     }
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -25,6 +25,7 @@ mod module_serialize;
 mod name;
 mod native_hooks;
 mod pooling_allocator;
+mod relocs;
 mod stack_overflow;
 mod store;
 mod table;

--- a/tests/all/relocs.rs
+++ b/tests/all/relocs.rs
@@ -1,0 +1,119 @@
+//! These tests are intended to exercise various relocation-based logic of
+//! Wasmtime, especially the "jump veneer" insertion in the object-file-assembly
+//! for when platform-specific relative call instructios can't always reach
+//! their destination within the platform-specific limits.
+//!
+//! Note that the limits of AArch64 are primarily what's being stressed here
+//! where the jump target for a call is 26-bits. On x86_64 the jump target is
+//! 32-bits, and right now object files aren't supported larger than 4gb anyway
+//! so we would need a lot of other support necessary to exercise that.
+
+#![cfg(not(feature = "old-x86-backend"))] // multi-value not supported here
+
+use anyhow::Result;
+use wasmtime::*;
+
+const MB: usize = 1 << 20;
+
+fn store_with_padding(padding: usize) -> Result<Store<()>> {
+    let mut config = Config::new();
+    // This is an internal debug-only setting specifically recognized for
+    // basically just this set of tests.
+    unsafe {
+        config.cranelift_flag_set(
+            "wasmtime_linkopt_padding_between_functions",
+            &padding.to_string(),
+        )?;
+    }
+    let engine = Engine::new(&config)?;
+    Ok(Store::new(&engine, ()))
+}
+
+#[test]
+fn forward_call_works() -> Result<()> {
+    let mut store = store_with_padding(128 * MB)?;
+    let module = Module::new(
+        store.engine(),
+        r#"
+            (module
+                (func (export "foo") (result i32)
+                    call 1)
+                (func (result i32)
+                    i32.const 4)
+            )
+        "#,
+    )?;
+
+    let i = Instance::new(&mut store, &module, &[])?;
+    let foo = i.get_typed_func::<(), i32, _>(&mut store, "foo")?;
+    assert_eq!(foo.call(&mut store, ())?, 4);
+    Ok(())
+}
+
+#[test]
+fn backwards_call_works() -> Result<()> {
+    let mut store = store_with_padding(128 * MB)?;
+    let module = Module::new(
+        store.engine(),
+        r#"
+            (module
+                (func (result i32)
+                    i32.const 4)
+                (func (export "foo") (result i32)
+                    call 0)
+            )
+        "#,
+    )?;
+
+    let i = Instance::new(&mut store, &module, &[])?;
+    let foo = i.get_typed_func::<(), i32, _>(&mut store, "foo")?;
+    assert_eq!(foo.call(&mut store, ())?, 4);
+    Ok(())
+}
+
+#[test]
+fn mixed() -> Result<()> {
+    test_many_call_module(store_with_padding(MB)?)
+}
+
+#[test]
+fn mixed_forced() -> Result<()> {
+    let mut config = Config::new();
+    unsafe {
+        config.cranelift_flag_set("wasmtime_linkopt_force_jump_veneer", "true")?;
+    }
+    let engine = Engine::new(&config)?;
+    test_many_call_module(Store::new(&engine, ()))
+}
+
+fn test_many_call_module(mut store: Store<()>) -> Result<()> {
+    const N: i32 = 200;
+
+    let mut wat = String::new();
+    wat.push_str("(module\n");
+    wat.push_str("(func $first (result i32) (i32.const 1))\n");
+    for i in 0..N {
+        wat.push_str(&format!("(func (export \"{}\") (result i32 i32)\n", i));
+        wat.push_str("call $first\n");
+        wat.push_str(&format!("i32.const {}\n", i));
+        wat.push_str("i32.add\n");
+        wat.push_str("call $last\n");
+        wat.push_str(&format!("i32.const {}\n", i));
+        wat.push_str("i32.add)\n");
+    }
+    wat.push_str("(func $last (result i32) (i32.const 2))\n");
+    wat.push_str(")\n");
+
+    let module = Module::new(store.engine(), &wat)?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    for i in 0..N {
+        let name = i.to_string();
+        let func = instance.get_typed_func::<(), (i32, i32), _>(&mut store, &name)?;
+        let (a, b) = func.call(&mut store, ())?;
+        assert_eq!(a, i + 1);
+        assert_eq!(b, i + 2);
+    }
+    Ok(())
+}


### PR DESCRIPTION
This commit is a relatively major change to the way that Wasmtime
generates code for Wasm modules and how functions call each other.
Prior to this commit all function calls between functions, even if they
were defined in the same module, were done indirectly through a
register. To implement this the backend would emit an absolute 8-byte
relocation near all function calls, load that address into a register,
and then call it. While this technique is simple to implement and easy
to get right, it has two primary downsides associated with it:

* Function calls are always indirect which means they are more difficult
  to predict, resulting in worse performance.

* Generating a relocation-per-function call requires expensive
  relocation resolution at module-load time, which can be a large
  contributing factor to how long it takes to load a precompiled module.

To fix these issues, while also somewhat compromising on the previously
simple implementation technique, this commit switches wasm calls within
a module to using the `colocated` flag enabled in Cranelift-speak, which
basically means that a relative call instruction is used with a
relocation that's resolved relative to the pc of the call instruction
itself.

When switching the `colocated` flag to `true` this commit is also then
able to move much of the relocation resolution from `wasmtime_jit::link`
into `wasmtime_cranelift::obj` during object-construction time. This
frontloads all relocation work which means that there's actually no
relocations related to function calls in the final image, solving both
of our points above.

The main gotcha in implementing this technique is that there are
hardware limitations to relative function calls which mean we can't
simply blindly use them. AArch64, for example, can only go +/- 64 MB
from the `bl` instruction to the target, which means that if the
function we're calling is a greater distance away then we would fail to
resolve that relocation. On x86_64 the limits are +/- 2GB which are much
larger, but theoretically still feasible to hit. Consequently the main
increase in implementation complexity is fixing this issue.

This issue is actually already present in Cranelift itself, and is
internally one of the invariants handled by the `MachBuffer` type. When
generating a function relative jumps between basic blocks have similar
restrictions. This commit adds new methods for the `MachBackend` trait
and updates the implementation of `MachBuffer` to account for all these
new branches. Specifically the changes to `MachBuffer` are:

* For AAarch64 the `LabelUse::Branch26` value now supports veneers, and
  AArch64 calls use this to resolve relocations.

* The `emit_island` function has been rewritten internally to handle
  some cases which previously didn't come up before, such as:

  * When emitting an island the deadline is now recalculated, where
    previously it was always set to infinitely in the future. This was ok
    prior since only a `Branch19` supported veneers and once it was
    promoted no veneers were supported, so without multiple layers of
    promotion the lack of a new deadline was ok.

  * When emitting an island all pending fixups had veneers forced if
    their branch target wasn't known yet. This was generally ok for
    19-bit fixups since the only kind getting a veneer was a 19-bit
    fixup, but with mixed kinds it's a bit odd to force veneers for a
    26-bit fixup just because a nearby 19-bit fixup needed a veneer.
    Instead fixups are now re-enqueued unless they're known to be
    out-of-bounds. This may run the risk of generating more islands for
    19-bit branches but it should also reduce the number of islands for
    between-function calls.

  * Otherwise the internal logic was tweaked to ideally be a bit more
    simple, but that's a pretty subjective criteria in compilers...

I've added some simple testing of this for now. A synthetic compiler
option was create to simply add padded 0s between functions and test
cases implement various forms of calls that at least need veneers. A
test is also included for x86_64, but it is unfortunately pretty slow
because it requires generating 2GB of output. I'm hoping for now it's
not too bad, but we can disable the test if it's prohibitive and
otherwise just comment the necessary portions to be sure to run the
ignored test if these parts of the code have changed.

The final end-result of this commit is that for a large module I'm
working with the number of relocations dropped to zero, meaning that
nothing actually needs to be done to the text section when it's loaded
into memory (yay!). I haven't run final benchmarks yet but this is the
last remaining source of significant slowdown when loading modules,
after I land a number of other PRs both active and ones that I only have
locally for now.

cc https://github.com/bytecodealliance/wasmtime/issues/3230

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
