### PR TITLE
Implement `Insertlane` for the Cranelift interpreter

### DIFF
--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -298,6 +298,7 @@ impl InstructionData {
             &InstructionData::UnaryBool { imm, .. } => Some(DataValue::from(imm)),
             // 8-bit.
             &InstructionData::BinaryImm8 { imm, .. }
+            | &InstructionData::TernaryImm8 { imm, .. }
             | &InstructionData::BranchTableEntry { imm, .. } => Some(DataValue::from(imm as i8)), // Note the switch from unsigned to signed.
             // 32-bit
             &InstructionData::UnaryIeee32 { imm, .. } => Some(DataValue::from(imm)),

--- a/cranelift/filetests/filetests/runtests/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insertlane.clif
@@ -1,0 +1,33 @@
+test interpret
+test run
+target aarch64
+set enable_simd
+target x86_64
+
+function %insertlane_15(i8x16, i8) -> i8x16 {
+block0(v0: i8x16, v1: i8):
+    v2 = insertlane v0, v1, 15
+    return v2
+}
+; run: %insertlane_15([1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1], 120) == [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 120]
+
+function %insertlane_5(i16x8, i16) -> i16x8 {
+block0(v0: i16x8, v1: i16):
+    v2 = insertlane v0, v1, 5
+    return v2
+}
+; run: %insertlane_5([1 1 1 1 1 1 1 1], 10000) == [1 1 1 1 1 10000 1 1]
+
+function %insertlane_2(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = insertlane v0, v1, 2
+    return v2
+}
+; run: %insertlane_2([1 1 1 1], 100000) == [1 1 100000 1]
+
+function %insertlane_0(i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64):
+    v2 = insertlane v0, v1, 0
+    return v2
+}
+; run: %insertlane_0([1 1], 5000000000) == [5000000000 1]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -672,7 +672,11 @@ where
         Opcode::Shuffle => unimplemented!("Shuffle"),
         Opcode::Swizzle => unimplemented!("Swizzle"),
         Opcode::Splat => unimplemented!("Splat"),
-        Opcode::Insertlane => unimplemented!("Insertlane"),
+        Opcode::Insertlane => {
+            let mut vector = extractlanes(&arg(0)?, ctrl_ty.lane_type())?;
+            vector[Value::into_int(imm())? as usize] = arg(1)?.into_int()?;
+            assign(vectorizelanes(&vector, ctrl_ty)?)
+        }
         Opcode::Extractlane => {
             let value =
                 extractlanes(&arg(0)?, ctrl_ty.lane_type())?[Value::into_int(imm())? as usize];


### PR DESCRIPTION
Implemented `Insertlane` to insert a value in the lane specified by the
immediate value, overwriting the existing value in that lane.

Added `TernaryImm8` support for the `imm_value` function as part of this work.

Copyright (c) 2021, Arm Limited.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
