### PR TITLE
Some small optimizations for calling wasm functions

### DIFF
--- a/crates/runtime/src/traphandlers/macos.rs
+++ b/crates/runtime/src/traphandlers/macos.rs
@@ -409,7 +409,8 @@ unsafe extern "C" fn unwind(wasm_pc: *const u8) -> ! {
 /// unhandled thread-level exceptions get automatically forwarded to the
 /// task-level port which is where we'd expected things like breakpad/crashpad
 /// exception handlers to get registered.
-pub fn lazy_per_thread_init() -> Result<(), Trap> {
+#[cold]
+pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
     unsafe {
         assert!(WASMTIME_PORT != MACH_PORT_NULL);
         let this_thread = mach_thread_self();

--- a/crates/runtime/src/traphandlers/windows.rs
+++ b/crates/runtime/src/traphandlers/windows.rs
@@ -74,7 +74,7 @@ unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS)
     })
 }
 
-pub fn lazy_per_thread_init() -> Result<(), Trap> {
+pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
     // Unused on Windows
     Ok(())
 }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -87,7 +87,7 @@ impl Engine {
     /// latency of WebAssembly calls are extra-important, which is not
     /// necessarily true of all embeddings.
     pub fn tls_eager_initialize() -> Result<(), Trap> {
-        wasmtime_runtime::tls_eager_initialize().map_err(Trap::from_runtime)
+        wasmtime_runtime::tls_eager_initialize().map_err(Trap::from_runtime_box)
     }
 
     /// Returns the configuration settings that this engine is using.

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1056,7 +1056,7 @@ pub(crate) fn invoke_wasm_and_catch_traps<T>(
         );
         exit_wasm(store, exit);
         store.0.entering_native_hook()?;
-        result.map_err(Trap::from_runtime)
+        result.map_err(Trap::from_runtime_box)
     }
 }
 

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -368,6 +368,7 @@ macro_rules! impl_wasm_params {
                 }
             }
 
+            #[inline]
             fn into_abi(self, _store: &mut StoreOpaque) -> Option<Self::Abi> {
                 let ($($t,)*) = self;
                 $(
@@ -446,6 +447,7 @@ macro_rules! impl_wasm_results {
         {
             type ResultAbi = ($($t::Abi,)*);
 
+            #[inline]
             unsafe fn from_abi(store: &mut StoreOpaque, abi: Self::ResultAbi) -> Self {
                 let ($($t,)*) = abi;
                 ($($t::from_abi($t, store),)*)

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1233,9 +1233,9 @@ impl AsyncCx {
                 Poll::Pending => {}
             }
 
-            let before = wasmtime_runtime::TlsRestore::take().map_err(Trap::from_runtime)?;
+            let before = wasmtime_runtime::TlsRestore::take().map_err(Trap::from_runtime_box)?;
             let res = (*suspend).suspend(());
-            before.replace().map_err(Trap::from_runtime)?;
+            before.replace().map_err(Trap::from_runtime_box)?;
             res?;
         }
     }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -726,6 +726,7 @@ impl StoreInnermost {
 
         Ok(())
     }
+
     #[inline]
     pub fn async_support(&self) -> bool {
         cfg!(feature = "async") && self.engine().config().async_support
@@ -736,10 +737,12 @@ impl StoreInnermost {
         &self.engine
     }
 
+    #[inline]
     pub fn store_data(&self) -> &StoreData {
         &self.store_data
     }
 
+    #[inline]
     pub fn store_data_mut(&mut self) -> &mut StoreData {
         &mut self.store_data
     }

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -162,6 +162,11 @@ impl Trap {
     }
 
     #[cold] // see Trap::new
+    pub(crate) fn from_runtime_box(runtime_trap: Box<wasmtime_runtime::Trap>) -> Self {
+        Self::from_runtime(*runtime_trap)
+    }
+
+    #[cold] // see Trap::new
     pub(crate) fn from_runtime(runtime_trap: wasmtime_runtime::Trap) -> Self {
         match runtime_trap {
             wasmtime_runtime::Trap::User(error) => Trap::from(error),


### PR DESCRIPTION
Not exactly a ground-shaking PR but I've been doing some profiling of wasm->host and host->wasm calls recently and this commit fixes some hotter spots which are on the easier side of how to fix. The biggest change here is working with `Box<Trap>` internally instead of the very large `Trap` enum.