### PR TITLE
cranelift: Fix `br_table` for `i64` types in x64 backend.

### DIFF
--- a/cranelift/filetests/filetests/runtests/br_table.clif
+++ b/cranelift/filetests/filetests/runtests/br_table.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+target x86_64 machinst
 target s390x
 
 


### PR DESCRIPTION
With this PR we fix the compilation crash for `br_table.i64`. We still only support 2^32 targets, but we now allow that number to come from a i64 value.

I don't really know enough about x86 to improve the `Inst::JmpTableSeq` and enable 2^64 targets, but I suspect its not likely to be an issue.

Fixes #3100. The CLIF Fuzzer found this independently as soon as I added jump tables.