### PR TITLE
Refactor the internals of `Store<T>`

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -796,11 +796,7 @@ impl Func {
             Ok(values_vec)
         }
 
-        fn read_results(
-            store: &mut StoreOpaque,
-            ty: &FuncType,
-            values_vec: &[u128],
-        ) -> Box<[Val]> {
+        fn read_results(store: &mut StoreOpaque, ty: &FuncType, values_vec: &[u128]) -> Box<[Val]> {
             let mut results = Vec::with_capacity(ty.results().len());
             for (index, ty) in ty.results().enumerate() {
                 unsafe {

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1,4 +1,4 @@
-use crate::store::{StoreData, StoreInnermost, StoreOpaque, Stored};
+use crate::store::{StoreData, StoreOpaque, Stored};
 use crate::{
     AsContext, AsContextMut, Engine, Extern, FuncType, Instance, InterruptHandle, StoreContext,
     StoreContextMut, Trap, Val, ValType,
@@ -259,7 +259,7 @@ macro_rules! generate_wrap_async_func {
         {
             assert!(store.as_context().async_support(), concat!("cannot use `wrap", $num, "_async` without enabling async support on the config"));
             Func::wrap(store, move |mut caller: Caller<'_, T>, $($args: $args),*| {
-                let async_cx = caller.store.as_context_mut().opaque().async_cx();
+                let async_cx = caller.store.as_context_mut().0.async_cx();
                 let mut future = Pin::from(func(caller, $($args),*));
                 match unsafe { async_cx.block_on(future.as_mut()) } {
                     Ok(ret) => ret.into_fallible(),
@@ -307,13 +307,13 @@ impl Func {
         ty: FuncType,
         func: impl Fn(Caller<'_, T>, &[Val], &mut [Val]) -> Result<(), Trap> + Send + Sync + 'static,
     ) -> Self {
-        let mut store = store.as_context_mut().opaque();
+        let store = store.as_context_mut().0;
 
         // part of this unsafety is about matching the `T` to a `Store<T>`,
         // which is done through the `AsContextMut` bound above.
         unsafe {
             let host = HostFunc::new(store.engine(), ty, func);
-            host.into_func(&mut store)
+            host.into_func(store)
         }
     }
 
@@ -398,7 +398,7 @@ impl Func {
             "cannot use `new_async` without enabling async support in the config"
         );
         Func::new(store, ty, move |mut caller, params, results| {
-            let async_cx = caller.store.as_context_mut().opaque().async_cx();
+            let async_cx = caller.store.as_context_mut().0.async_cx();
             let mut future = Pin::from(func(caller, params, results));
             match unsafe { async_cx.block_on(future.as_mut()) } {
                 Ok(Ok(())) => Ok(()),
@@ -631,12 +631,12 @@ impl Func {
         mut store: impl AsContextMut<Data = T>,
         func: impl IntoFunc<T, Params, Results>,
     ) -> Func {
-        let mut store = store.as_context_mut().opaque();
+        let store = store.as_context_mut().0;
         // part of this unsafety is about matching the `T` to a `Store<T>`,
         // which is done through the `AsContextMut` bound above.
         unsafe {
             let host = HostFunc::wrap(store.engine(), func);
-            host.into_func(&mut store)
+            host.into_func(store)
         }
     }
 
@@ -736,7 +736,7 @@ impl Func {
         my_ty: FuncType,
         params: &[Val],
     ) -> Result<Box<[Val]>> {
-        let mut values_vec = write_params(&mut store.as_context_mut().opaque(), &my_ty, params)?;
+        let mut values_vec = write_params(store.0, &my_ty, params)?;
 
         // Call the trampoline.
         unsafe {
@@ -753,14 +753,10 @@ impl Func {
             })?;
         }
 
-        return Ok(read_results(
-            &mut store.as_context_mut().opaque(),
-            &my_ty,
-            &values_vec,
-        ));
+        return Ok(read_results(store.0, &my_ty, &values_vec));
 
         fn write_params(
-            store: &mut StoreOpaque<'_>,
+            store: &mut StoreOpaque,
             ty: &FuncType,
             params: &[Val],
         ) -> Result<Vec<u128>> {
@@ -801,7 +797,7 @@ impl Func {
         }
 
         fn read_results(
-            store: &mut StoreOpaque<'_>,
+            store: &mut StoreOpaque,
             ty: &FuncType,
             values_vec: &[u128],
         ) -> Box<[Val]> {
@@ -819,7 +815,7 @@ impl Func {
     #[inline]
     pub(crate) fn caller_checked_anyfunc(
         &self,
-        store: &StoreInnermost,
+        store: &StoreOpaque,
     ) -> NonNull<VMCallerCheckedAnyfunc> {
         store.store_data()[self.0].export().anyfunc
     }
@@ -834,7 +830,7 @@ impl Func {
         Func(store.store_data_mut().insert(data))
     }
 
-    pub(crate) fn vmimport(&self, store: &mut StoreOpaque<'_>) -> VMFunctionImport {
+    pub(crate) fn vmimport(&self, store: &mut StoreOpaque) -> VMFunctionImport {
         unsafe {
             let f = self.caller_checked_anyfunc(store);
             VMFunctionImport {
@@ -861,10 +857,9 @@ impl Func {
         const STACK_ARGS: usize = 4;
         const STACK_RETURNS: usize = 2;
         let mut args: SmallVec<[Val; STACK_ARGS]> = SmallVec::with_capacity(ty.params().len());
-        let mut store = caller.store.as_context_mut().opaque();
         for (i, ty) in ty.params().enumerate() {
             unsafe {
-                let val = Val::read_value_from(&mut store, values_vec.add(i), ty);
+                let val = Val::read_value_from(caller.store.0, values_vec.add(i), ty);
                 args.push(val);
             }
         }
@@ -878,20 +873,19 @@ impl Func {
         // values produced are correct. There could be a bug in `func` that
         // produces the wrong number, wrong types, or wrong stores of
         // values, and we need to catch that here.
-        let mut store = caller.store.as_context_mut().opaque();
         for (i, (ret, ty)) in returns.into_iter().zip(ty.results()).enumerate() {
             if ret.ty() != ty {
                 return Err(Trap::new(
                     "function attempted to return an incompatible value",
                 ));
             }
-            if !ret.comes_from_same_store(&store) {
+            if !ret.comes_from_same_store(&caller.store.0) {
                 return Err(Trap::new(
                     "cross-`Store` values are not currently supported",
                 ));
             }
             unsafe {
-                ret.write_value_to(&mut store, values_vec.add(i));
+                ret.write_value_to(caller.store.0, values_vec.add(i));
             }
         }
 
@@ -1744,8 +1738,7 @@ macro_rules! impl_into_func {
                                 if let Err(trap) = caller.store.0.entering_native_hook() {
                                     return R::fallible_from_trap(trap);
                                 }
-                                let mut _store = caller.sub_caller().store.opaque();
-                                $(let $args = $args::from_abi($args, &mut _store);)*
+                                $(let $args = $args::from_abi($args, caller.store.0);)*
                                 let r = func(
                                     caller.sub_caller(),
                                     $( $args, )*
@@ -1770,11 +1763,10 @@ macro_rules! impl_into_func {
                                 // Because the wrapped function is not `unsafe`, we
                                 // can't assume it returned a value that is
                                 // compatible with this store.
-                                let mut store = caller.store.opaque();
-                                if !ret.compatible_with_store(&store) {
+                                if !ret.compatible_with_store(caller.store.0) {
                                     CallResult::Trap(cross_store_trap())
                                 } else {
-                                    match ret.into_abi_for_ret(&mut store, retptr) {
+                                    match ret.into_abi_for_ret(caller.store.0, retptr) {
                                         Ok(val) => CallResult::Ok(val),
                                         Err(trap) => CallResult::Trap(trap.into()),
                                     }
@@ -1938,19 +1930,19 @@ impl HostFunc {
     ///
     /// Can only be inserted into stores with a matching `T` relative to when
     /// this `HostFunc` was first created.
-    pub unsafe fn to_func(self: &Arc<Self>, store: &mut StoreOpaque<'_>) -> Func {
+    pub unsafe fn to_func(self: &Arc<Self>, store: &mut StoreOpaque) -> Func {
         self.register_trampoline(store);
         let me = self.clone();
         Func(store.store_data_mut().insert(FuncData::SharedHost(me)))
     }
 
     /// Same as [`HostFunc::to_func`], different ownership.
-    unsafe fn into_func(self, store: &mut StoreOpaque<'_>) -> Func {
+    unsafe fn into_func(self, store: &mut StoreOpaque) -> Func {
         self.register_trampoline(store);
         Func(store.store_data_mut().insert(FuncData::Host(self)))
     }
 
-    unsafe fn register_trampoline(&self, store: &mut StoreOpaque<'_>) {
+    unsafe fn register_trampoline(&self, store: &mut StoreOpaque) {
         let idx = self.export.anyfunc.as_ref().type_index;
         store.register_host_trampoline(idx, self.trampoline);
     }

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -118,7 +118,7 @@ where
         // Validate that all runtime values flowing into this store indeed
         // belong within this store, otherwise it would be unsafe for store
         // values to cross each other.
-        let params = match params.into_abi(&mut store.as_context_mut().opaque()) {
+        let params = match params.into_abi(store.0) {
             Some(abi) => abi,
             None => {
                 return Err(Trap::new(
@@ -154,10 +154,7 @@ where
         let (_, ret, _, returned) = captures;
         debug_assert_eq!(result.is_ok(), returned);
         result?;
-        Ok(Results::from_abi(
-            &mut store.as_context_mut().opaque(),
-            ret.assume_init(),
-        ))
+        Ok(Results::from_abi(store.0, ret.assume_init()))
     }
 }
 

--- a/crates/wasmtime/src/store/data.rs
+++ b/crates/wasmtime/src/store/data.rs
@@ -158,7 +158,7 @@ where
 }
 
 // forward StoreOpaque => StoreData
-impl<I> Index<I> for StoreOpaque<'_>
+impl<I> Index<I> for StoreOpaque
 where
     StoreData: Index<I>,
 {
@@ -169,7 +169,7 @@ where
         self.store_data().index(index)
     }
 }
-impl<I> IndexMut<I> for StoreOpaque<'_>
+impl<I> IndexMut<I> for StoreOpaque
 where
     StoreData: IndexMut<I>,
 {

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -24,7 +24,7 @@ use wasmtime_runtime::{
 
 fn create_handle(
     module: Module,
-    store: &mut StoreOpaque<'_>,
+    store: &mut StoreOpaque,
     host_state: Box<dyn Any + Send + Sync>,
     func_imports: &[VMFunctionImport],
     shared_signature_id: Option<VMSharedSignatureIndex>,
@@ -46,7 +46,7 @@ fn create_handle(
                 imports,
                 shared_signatures: shared_signature_id.into(),
                 host_state,
-                store: Some(store.traitobj),
+                store: Some(store.traitobj()),
                 wasm_data: &[],
             },
         )?;
@@ -56,7 +56,7 @@ fn create_handle(
 }
 
 pub fn generate_global_export(
-    store: &mut StoreOpaque<'_>,
+    store: &mut StoreOpaque,
     gt: &GlobalType,
     val: Val,
 ) -> Result<wasmtime_runtime::ExportGlobal> {
@@ -69,7 +69,7 @@ pub fn generate_global_export(
 }
 
 pub fn generate_memory_export(
-    store: &mut StoreOpaque<'_>,
+    store: &mut StoreOpaque,
     m: &MemoryType,
 ) -> Result<wasmtime_runtime::ExportMemory> {
     let instance = create_memory(store, m)?;
@@ -81,7 +81,7 @@ pub fn generate_memory_export(
 }
 
 pub fn generate_table_export(
-    store: &mut StoreOpaque<'_>,
+    store: &mut StoreOpaque,
     t: &TableType,
 ) -> Result<wasmtime_runtime::ExportTable> {
     let instance = create_table(store, t)?;

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use wasmtime_environ::{EntityIndex, Global, GlobalInit, Module, ModuleType, SignatureIndex};
 use wasmtime_runtime::VMFunctionImport;
 
-pub fn create_global(store: &mut StoreOpaque<'_>, gt: &GlobalType, val: Val) -> Result<InstanceId> {
+pub fn create_global(store: &mut StoreOpaque, gt: &GlobalType, val: Val) -> Result<InstanceId> {
     let mut module = Module::new();
     let mut func_imports = Vec::new();
     let mut externref_init = None;

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use wasmtime_environ::{EntityIndex, MemoryPlan, MemoryStyle, Module, WASM_PAGE_SIZE};
 use wasmtime_runtime::{RuntimeLinearMemory, RuntimeMemoryCreator, VMMemoryDefinition};
 
-pub fn create_memory(store: &mut StoreOpaque<'_>, memory: &MemoryType) -> Result<InstanceId> {
+pub fn create_memory(store: &mut StoreOpaque, memory: &MemoryType) -> Result<InstanceId> {
     let mut module = Module::new();
 
     let memory_plan = wasmtime_environ::MemoryPlan::for_memory(

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -4,7 +4,7 @@ use crate::TableType;
 use anyhow::Result;
 use wasmtime_environ::{EntityIndex, Module};
 
-pub fn create_table(store: &mut StoreOpaque<'_>, table: &TableType) -> Result<InstanceId> {
+pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<InstanceId> {
     let mut module = Module::new();
     let table_plan = wasmtime_environ::TablePlan::for_table(
         table.wasmtime_table().clone(),

--- a/crates/wasmtime/src/types/matching.rs
+++ b/crates/wasmtime/src/types/matching.rs
@@ -1,6 +1,6 @@
 use crate::instance::InstanceData;
 use crate::linker::Definition;
-use crate::store::StoreInnermost;
+use crate::store::StoreOpaque;
 use crate::{signatures::SignatureCollection, Engine, Extern};
 use anyhow::{bail, Context, Result};
 use wasmtime_environ::{
@@ -12,7 +12,7 @@ use wasmtime_runtime::VMSharedSignatureIndex;
 pub struct MatchCx<'a> {
     pub signatures: &'a SignatureCollection,
     pub types: &'a TypeTables,
-    pub store: &'a StoreInnermost,
+    pub store: &'a StoreOpaque,
     pub engine: &'a Engine,
 }
 

--- a/crates/wasmtime/src/unix.rs
+++ b/crates/wasmtime/src/unix.rs
@@ -33,7 +33,7 @@ impl<T> StoreExt for Store<T> {
             + Sync,
     {
         self.as_context_mut()
-            .opaque()
+            .0
             .set_signal_handler(Some(Box::new(handler)));
     }
 }

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -187,7 +187,7 @@ impl Val {
 
     pub(crate) fn into_table_element(
         self,
-        store: &mut StoreOpaque<'_>,
+        store: &mut StoreOpaque,
         ty: ValType,
     ) -> Result<runtime::TableElement> {
         match (self, ty) {
@@ -213,7 +213,7 @@ impl Val {
     }
 
     #[inline]
-    pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque<'_>) -> bool {
+    pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
         match self {
             Val::FuncRef(Some(f)) => f.comes_from_same_store(store),
             Val::FuncRef(None) => true,

--- a/crates/wasmtime/src/windows.rs
+++ b/crates/wasmtime/src/windows.rs
@@ -27,7 +27,7 @@ impl<T> StoreExt for Store<T> {
         H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool + Send + Sync,
     {
         self.as_context_mut()
-            .opaque()
+            .0
             .set_signal_handler(Some(Box::new(handler)));
     }
 }


### PR DESCRIPTION
This commit is an overdue refactoring and renaming of some internals of
the `Store` type in Wasmtime. The actual implementation of `Store<T>`
has evolved from the original implementation to the point where some of
the aspects of how things are structured no longer makes sense. There's
also always been a lot of unnecessary gymnastics when trying to get
access to various store pieces depending on where you are in `wasmtime`.

This refactoring aims to simplify all this and make the internals much
easier to read/write. The following changes were made:

* The `StoreOpaque<'_>` type is deleted, along with the `opaque()`
  method.

* The `StoreInnermost` type was renamed to `StoreOpaque`.
  `StoreOpaque<'_>` is dead. Long live `StoreOpaque`. This renaming
  and a few small tweaks means that this type now suffices for all
  consumers.

* The `AsContextMut` and `AsContext` traits are now implemented for
  `StoreInner<T>`.

These changes, while subtly small, help clean up a lot of the internals
of `wasmtime`. There's a lot less verbose `&mut
store.as_context_mut().opaque()` now. Additionally many methods can
simply start with `let store = store.as_context_mut().0;` and use things
internally. One of the nicer aspects of using references directly is
that the compiler automatically reborrows references as necessary
meaning there's lots of less manual reborrowing.

The main motivation for this change was actually somewhat roundabout
where I found that when `StoreOpaque<'_>` was being captured in closures
and iterators it's 3 pointers wide which is a lot of data to move
around. Now things capture over `&mut StoreOpaque` which is just one
nice and small pointer to move around. In any case though I've long
wanted to revisit the design of these internals to improve the
ergonomics. It's not expected that this change alone will really have
all that much impact on the performance of `wasmtime`.

Finally a doc comment was added to `store.rs` to try to explain all the
`Store`-related types since there are a nontrivial amount.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
