### PR TITLE
Align order of wasm types/values across Wasmtime

### DIFF
--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -22,6 +22,8 @@ pub enum Mutability {
 /// A list of all possible value types in WebAssembly.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum ValType {
+    // NB: the ordering here is intended to match the ordering in
+    // `wasmtime_types::WasmType` to help improve codegen when converting.
     /// Signed 32 bit integer.
     I32,
     /// Signed 64 bit integer.
@@ -32,10 +34,10 @@ pub enum ValType {
     F64,
     /// A 128 bit number.
     V128,
-    /// A reference to opaque data in the Wasm instance.
-    ExternRef, /* = 128 */
     /// A reference to a Wasm function.
     FuncRef,
+    /// A reference to opaque data in the Wasm instance.
+    ExternRef,
 }
 
 impl fmt::Display for ValType {


### PR DESCRIPTION
Wasmtime has a few representations of `Val` and `ValType` across the
internal crates, the `wasmtime` crate, and the C API. These were
previously sometimes mentioned in different orders which means that
converting between the two took a little extra code than before. This
commit is a micro-optimization to align the types across the various
places we define these to help reduce the codegen burden when converting
between these types.

This is not expected to have a major impact on performance, rather it's
a small cleanup which should be easy-ish to preserve I've noticed while
staring at assembly.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
