### PR TITLE
Avoid vector allocations in wasm->host calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,7 +3567,6 @@ dependencies = [
  "region",
  "rustc-demangle",
  "serde",
- "smallvec",
  "target-lexicon",
  "tempfile",
  "wasi-cap-std-sync",

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -1,4 +1,4 @@
-use crate::{wasm_engine_t, wasmtime_error_t, ForeignData};
+use crate::{wasm_engine_t, wasmtime_error_t, wasmtime_val_t, ForeignData};
 use std::cell::UnsafeCell;
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -67,6 +67,10 @@ pub struct StoreData {
     foreign: crate::ForeignData,
     #[cfg(feature = "wasi")]
     pub(crate) wasi: Option<wasmtime_wasi::WasiCtx>,
+
+    /// Temporary storage for usage during a wasm->host call to store values
+    /// in a slice we pass to the C API.
+    pub hostcall_val_storage: Vec<wasmtime_val_t>,
 }
 
 #[no_mangle]
@@ -85,6 +89,7 @@ pub extern "C" fn wasmtime_store_new(
                 foreign: ForeignData { data, finalizer },
                 #[cfg(feature = "wasi")]
                 wasi: None,
+                hostcall_val_storage: Vec::new(),
             },
         ),
     })

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -30,7 +30,6 @@ rustc-demangle = "0.1.16"
 cpp_demangle = "0.3.2"
 log = "0.4.8"
 wat = { version = "1.0.36", optional = true }
-smallvec = "1.6.1"
 serde = { version = "1.0.94", features = ["derive"] }
 bincode = "1.2.1"
 indexmap = "1.6"

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -93,17 +93,17 @@ impl Val {
         }
     }
 
-    pub(crate) unsafe fn write_value_to(self, store: &mut StoreOpaque, p: *mut u128) {
+    pub(crate) unsafe fn write_value_to(&self, store: &mut StoreOpaque, p: *mut u128) {
         match self {
-            Val::I32(i) => ptr::write(p as *mut i32, i),
-            Val::I64(i) => ptr::write(p as *mut i64, i),
-            Val::F32(u) => ptr::write(p as *mut u32, u),
-            Val::F64(u) => ptr::write(p as *mut u64, u),
-            Val::V128(b) => ptr::write(p as *mut u128, b),
+            Val::I32(i) => ptr::write(p as *mut i32, *i),
+            Val::I64(i) => ptr::write(p as *mut i64, *i),
+            Val::F32(u) => ptr::write(p as *mut u32, *u),
+            Val::F64(u) => ptr::write(p as *mut u64, *u),
+            Val::V128(b) => ptr::write(p as *mut u128, *b),
             Val::ExternRef(None) => ptr::write(p, 0),
             Val::ExternRef(Some(x)) => {
                 let externref_ptr = x.inner.as_raw();
-                store.insert_vmexternref(x.inner);
+                store.insert_vmexternref(x.inner.clone());
                 ptr::write(p as *mut *mut u8, externref_ptr)
             }
             Val::FuncRef(f) => ptr::write(


### PR DESCRIPTION
This commit improves the runtime support for wasm-to-host invocations
for functions created with `Func::new` or `wasmtime_func_new` in the C
API. Previously a `Vec` (sometimes a `SmallVec`) would be dynamically
allocated on each host call to store the arguments that are coming from
wasm and going to the host. In the case of the `wasmtime` crate we need
to decode the `u128`-stored values, and in the case of the C API we need
to decode the `Val` into the C API's `wasmtime_val_t`.

The technique used in this commit is to store a singular `Vec<T>` inside
the "store", be it the literal `Store<T>` or within the `T` in the case
of the C API, which can be reused across wasm->host calls. This means
that we're unlikely to actually perform dynamic memory allocation and
instead we should hit a faster path where the `Vec` always has enough
capacity.

Note that this is just a mild improvement for `Func::new`-based
functions. It's still the case that `Func::wrap` is much faster, but
unfortunately the C API doesn't have access to `Func::wrap`, so the main
motivation here is accelerating the C API.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
