### PR TITLE
Add a new API to make `Func::call` faster

### DIFF
--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -172,6 +172,63 @@ WASM_API_EXTERN bool wasmtime_caller_export_get(
  */
 WASM_API_EXTERN wasmtime_context_t* wasmtime_caller_context(wasmtime_caller_t* caller);
 
+
+/**
+ * \typedef wasmtime_func_storage_t
+ * \brief Alias to #wasmtime_func_storage_t
+ *
+ * \brief Structure used to optimize calling WebAssembly functions.
+ * \struct wasmtime_func_storage_t
+ *
+ * This structure is used in conjunction with the
+ * #wasmtime_func_call_with_storage API where storage necessary for the call
+ * into WebAssembly can be allocated ahead of time with a particular function
+ * type, and then when calling a function of that type the storage can be used
+ * to avoid extra allocations when calling the function.
+ */
+typedef struct wasmtime_func_storage wasmtime_func_storage_t;
+
+/**
+ * \brief Creates a new storage area used to invoke functions of the specified
+ * type signature.
+ *
+ * \param engine the engine in which the area will be used
+ * \param ty the function type this allocated area can be used to call
+ *
+ * The returned pointer must be deleted with #wasmtime_func_storage_delete when
+ * it's done being used.
+ */
+wasmtime_func_storage_t *wasmtime_func_storage_new(wasm_engine_t *engine, wasm_functype_t *ty);
+
+/**
+ * \brief Deallocates a previously allocated #wasmtime_func_storage_t
+ */
+void wasmtime_func_storage_delete(wasmtime_func_storage_t *storage);
+
+/**
+ * \brief Same as #wasmtime_func_call, but has an extra #wasmtime_func_storage_t
+ * parameter.
+ *
+ * This function behaves the same way as #wasmtime_func_call for a host to call
+ * a WebAssembly function. Unlike #wasmtime_func_call, though, this function
+ * uses a #wasmtime_func_storage_t to help optimize this call with pre-allocated
+ * storage.
+ *
+ * In addition to the errors of #wasmtime_func_call this function can also
+ * return an error if the function type of `storage` does not match the type for
+ * the function being called.
+ */
+WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call_with_storage(
+    wasmtime_context_t *store,
+    const wasmtime_func_t *func,
+    wasmtime_func_storage_t *storage,
+    const wasmtime_val_t *args,
+    size_t nargs,
+    wasmtime_val_t *results,
+    size_t nresults,
+    wasm_trap_t **trap
+);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -330,7 +330,7 @@ fn mismatched_arguments() -> Result<()> {
     let func = instance.get_func(&mut store, "foo").unwrap();
     assert_eq!(
         func.call(&mut store, &[]).unwrap_err().to_string(),
-        "expected 1 arguments, got 0"
+        "too few parameters supplied to call",
     );
     assert_eq!(
         func.call(&mut store, &[Val::F32(0)])
@@ -342,7 +342,7 @@ fn mismatched_arguments() -> Result<()> {
         func.call(&mut store, &[Val::I32(0), Val::I32(1)])
             .unwrap_err()
             .to_string(),
-        "expected 1 arguments, got 2"
+        "too many parameters supplied to call",
     );
     Ok(())
 }


### PR DESCRIPTION
The fastest way to call a WebAssembly function with Wasmtime is to use
the `TypedFunc` API and methods. This is only available to Rust code,
however, due to the usage of generics. The C API as a result is left to
only be able to use `Func::call`, which is quite slow today. While
`Func::call` has a lot of reasons that it's slow, some major
contributors are:

* Space must be allocated for the arguments/return values to call the
  trampoline with. This `u128` storage is allocated on all
  `Func::call`-based calls today.

* The function's type is loaded to typecheck the arguments, and this
  requires taking an rwlock in the `Engine` as well as cloning out the
  `FuncType` itself.

* For the C API the slice of inputs needs to be translated to a slice of
  `Val`, and the results are translated from a vector of `Val` back to a
  vector of `wasmtime_val_t`.

These two operations are particularly costly and the goal of this commit
is to solve these two issues. The solution implemented here is a new
structure, called `FuncStorage`, which can be created within an `Engine`
on a per-function-type basis. This storage is then used with a new API,
`Func::call_with_storage`, which removes the first two slowdowns mentioned
above. Each `FuncStorage` stores a copy of the `FuncType` it's intended
to be used with. Additionally it stores an appropriately-sized
`Vec<u128>` for storage of trampoline-encoded arguments.

The final bullet above is solved with tweaks to the
`Func::call_with_storage` API relative to `Func::call` where the
parameters/results are both iterators instead of slices.

This new API is intended to be a "power user" API for the Rust crate,
but is expected to be more commonly used with the C API since it's such
a large performance improvement to calling wasm functions.

Overall I'm not overly happy with this API. It solves a lot of the slow
`wasmtime_func_call` problem, but the APIs added here are pretty
unfortunate I think. Ideally we could solve this issue with no
additional API surface area. For example the first bullet could be
solved with a solution along the lines of #3294 where vectors are stored
in a `Store` and reused per-call. The third bullet could probably be
fixed with the same style and also changing `Func::call` to taking a
`&mut [Val]` as an argument instead of returning a boxed slice. The
second bullet though is probably one of the harder ones to fix. Each
`Func` could store it's fully-fleshed-out `FuncType`, but that's a
relatively large impact and would also likely require changing
`FuncType` to internally use `Arc<[WasmType]>` or similar. In any case
I'm hoping that this can help spur on some creativity for someone to
find a better solution to this issue.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
