### PR TITLE
cranelift: Fix build error

### DIFF
--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -791,7 +791,7 @@ where
         Opcode::Splat => {
             let mut new_vector = SimdVec::new();
             for _ in 0..ctrl_ty.lane_count() {
-                new_vector.push(arg(0)?.into_int()?);
+                new_vector.push(arg(0)?);
             }
             assign(vectorizelanes(&new_vector, ctrl_ty)?)
         }


### PR DESCRIPTION
#3304 and #3268 are slightly incompatible and caused the build to fail when they were merged together

https://github.com/bytecodealliance/wasmtime/pull/3306/checks?check_run_id=3536214204#step:14:596

cc: @abrown 