### PR TITLE
Remove unnecessary annotations on `Module::get_export`

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -894,7 +894,7 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_export<'module>(&'module self, name: &'module str) -> Option<ExternType> {
+    pub fn get_export(&self, name: &str) -> Option<ExternType> {
         let module = self.compiled_module().module();
         let entity_index = module.exports.get(name)?;
         Some(ExternType::from_wasmtime(


### PR DESCRIPTION
I think these were historically needed but nowadays not necessary!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
