### PR TITLE
Optimize `Func::call` and its C API

### DIFF
--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -2,7 +2,9 @@ use crate::{wasm_engine_t, wasmtime_error_t, wasmtime_val_t, ForeignData};
 use std::cell::UnsafeCell;
 use std::ffi::c_void;
 use std::sync::Arc;
-use wasmtime::{AsContext, AsContextMut, InterruptHandle, Store, StoreContext, StoreContextMut};
+use wasmtime::{
+    AsContext, AsContextMut, InterruptHandle, Store, StoreContext, StoreContextMut, Val,
+};
 
 /// This representation of a `Store` is used to implement the `wasm.h` API.
 ///
@@ -71,6 +73,10 @@ pub struct StoreData {
     /// Temporary storage for usage during a wasm->host call to store values
     /// in a slice we pass to the C API.
     pub hostcall_val_storage: Vec<wasmtime_val_t>,
+
+    /// Temporary storage for usage during host->wasm calls, same as above but
+    /// for a different direction.
+    pub wasm_val_storage: Vec<Val>,
 }
 
 #[no_mangle]
@@ -90,6 +96,7 @@ pub extern "C" fn wasmtime_store_new(
                 #[cfg(feature = "wasi")]
                 wasi: None,
                 hostcall_val_storage: Vec::new(),
+                wasm_val_storage: Vec::new(),
             },
         ),
     })

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -297,8 +297,10 @@ pub fn differential_execution(
 
             let ty = f.ty(&store);
             let params = dummy::dummy_values(ty.params());
+            let mut results = vec![Val::I32(0); ty.results().len()];
             let this_result = f
-                .call(&mut store, &params)
+                .call(&mut store, &params, &mut results)
+                .map(|()| results.into())
                 .map_err(|e| e.downcast::<Trap>().unwrap());
 
             let existing_result = export_func_results
@@ -312,7 +314,7 @@ pub fn differential_execution(
         match instance.get_export(&mut *store, "hangLimitInitializer") {
             None => return,
             Some(Extern::Func(f)) => {
-                f.call(store, &[])
+                f.call(store, &[], &mut [])
                     .expect("initializing the hang limit should not fail");
             }
             Some(_) => panic!("unexpected hangLimitInitializer export"),
@@ -478,7 +480,8 @@ pub fn make_api_calls(api: crate::generators::api::ApiCalls) {
                 let f = &funcs[nth];
                 let ty = f.ty(&store);
                 let params = dummy::dummy_values(ty.params());
-                let _ = f.call(store, &params);
+                let mut results = vec![Val::I32(0); ty.results().len()];
+                let _ = f.call(store, &params, &mut results);
             }
         }
     }
@@ -549,7 +552,7 @@ pub fn table_ops(
         let args: Vec<_> = (0..ops.num_params())
             .map(|_| Val::ExternRef(Some(ExternRef::new(CountDrops(num_dropped.clone())))))
             .collect();
-        let _ = run.call(&mut store, &args);
+        let _ = run.call(&mut store, &args, &mut []);
     }
 
     assert_eq!(num_dropped.load(SeqCst), ops.num_params() as usize);
@@ -653,7 +656,7 @@ pub fn differential_wasmi_execution(wasm: &[u8], config: &crate::generators::Con
 
     // Introspect wasmtime module to find name of an exported function and of an
     // exported memory.
-    let (func_name, _ty) = first_exported_function(&wasmtime_module)?;
+    let (func_name, ty) = first_exported_function(&wasmtime_module)?;
     let memory_name = first_exported_memory(&wasmtime_module)?;
 
     let wasmi_mem_export = wasmi_instance.export_by_name(memory_name).unwrap();
@@ -668,8 +671,10 @@ pub fn differential_wasmi_execution(wasm: &[u8], config: &crate::generators::Con
     let wasmtime_main = wasmtime_instance
         .get_func(&mut wasmtime_store, func_name)
         .expect("function export is present");
-    let wasmtime_vals = wasmtime_main.call(&mut wasmtime_store, &[]);
-    let wasmtime_val = wasmtime_vals.map(|v| v.iter().next().cloned());
+    let mut wasmtime_results = vec![Val::I32(0); ty.results().len()];
+    let wasmtime_val = wasmtime_main
+        .call(&mut wasmtime_store, &[], &mut wasmtime_results)
+        .map(|()| wasmtime_results.get(0).cloned());
 
     debug!(
         "Successful execution: wasmi returned {:?}, wasmtime returned {:?}",
@@ -831,15 +836,17 @@ fn run_in_wasmtime(
         .context("Wasmtime cannot instantiate module")?;
 
     // Find the first exported function.
-    let (func_name, _ty) =
+    let (func_name, ty) =
         first_exported_function(&wasmtime_module).context("Cannot find exported function")?;
     let wasmtime_main = wasmtime_instance
         .get_func(&mut wasmtime_store, &func_name[..])
         .expect("function export is present");
 
     // Execute the function and return the values.
-    let wasmtime_vals = wasmtime_main.call(&mut wasmtime_store, params);
-    wasmtime_vals.map(|v| v.to_vec())
+    let mut results = vec![Val::I32(0); ty.results().len()];
+    wasmtime_main
+        .call(&mut wasmtime_store, params, &mut results)
+        .map(|()| results)
 }
 
 // Introspect wasmtime module to find the name of the first exported function.

--- a/crates/fuzzing/src/oracles/v8.rs
+++ b/crates/fuzzing/src/oracles/v8.rs
@@ -93,7 +93,9 @@ pub fn differential_v8_execution(wasm: &[u8], config: &crate::generators::Config
     let wasmtime_main = wasmtime_instance
         .get_func(&mut wasmtime_store, func)
         .expect("function export is present");
-    let wasmtime_vals = wasmtime_main.call(&mut wasmtime_store, &wasmtime_params);
+    let mut wasmtime_vals = vec![Val::I32(0); ty.results().len()];
+    let wasmtime_result =
+        wasmtime_main.call(&mut wasmtime_store, &wasmtime_params, &mut wasmtime_vals);
     log::trace!("finished wasmtime invocation");
 
     // V8: call the first exported func
@@ -112,15 +114,15 @@ pub fn differential_v8_execution(wasm: &[u8], config: &crate::generators::Config
     log::trace!("finished v8 invocation");
 
     // Verify V8 and wasmtime match
-    match (wasmtime_vals, v8_vals) {
-        (Ok(wasmtime), Ok(v8)) => {
+    match (wasmtime_result, v8_vals) {
+        (Ok(()), Ok(v8)) => {
             log::trace!("both executed successfully");
-            match wasmtime.len() {
+            match wasmtime_vals.len() {
                 0 => assert!(v8.is_undefined()),
-                1 => assert_val_match(&wasmtime[0], &v8, &mut scope),
+                1 => assert_val_match(&wasmtime_vals[0], &v8, &mut scope),
                 _ => {
                     let array = v8::Local::<'_, v8::Array>::try_from(v8).unwrap();
-                    for (i, wasmtime) in wasmtime.iter().enumerate() {
+                    for (i, wasmtime) in wasmtime_vals.iter().enumerate() {
                         let v8 = array.get_index(&mut scope, i as u32).unwrap();
                         assert_val_match(wasmtime, &v8, &mut scope);
                         // ..
@@ -128,7 +130,7 @@ pub fn differential_v8_execution(wasm: &[u8], config: &crate::generators::Config
                 }
             }
         }
-        (Ok(_), Err(msg)) => {
+        (Ok(()), Err(msg)) => {
             panic!("wasmtime succeeded at invocation, v8 failed: {}", msg)
         }
         (Err(err), Ok(_)) => {

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -4,7 +4,6 @@ use crate::{
     StoreContext, StoreContextMut, Trap, Val, ValType,
 };
 use anyhow::{bail, Context as _, Result};
-use std::cmp::max;
 use std::error::Error;
 use std::fmt;
 use std::future::Future;
@@ -90,13 +89,13 @@ use wasmtime_runtime::{
 ///
 /// // Work with `foo` as a `Func` at this point, such as calling it
 /// // dynamically...
-/// match foo.call(&mut store, &[]) {
-///     Ok(result) => { /* ... */ }
+/// match foo.call(&mut store, &[], &mut []) {
+///     Ok(()) => { /* ... */ }
 ///     Err(trap) => {
 ///         panic!("execution of `foo` resulted in a wasm trap: {}", trap);
 ///     }
 /// }
-/// foo.call(&mut store, &[])?;
+/// foo.call(&mut store, &[], &mut [])?;
 ///
 /// // ... or we can make a static assertion about its signature and call it.
 /// // Our first call here can fail if the signatures don't match, and then the
@@ -184,9 +183,14 @@ use wasmtime_runtime::{
 #[repr(transparent)] // here for the C API
 pub struct Func(Stored<FuncData>);
 
+pub(crate) struct FuncData {
+    kind: FuncKind,
+    ty: FuncType,
+}
+
 /// The three ways that a function can be created and referenced from within a
 /// store.
-pub(crate) enum FuncData {
+enum FuncKind {
     /// A function already owned by the store via some other means. This is
     /// used, for example, when creating a `Func` from an instance's exported
     /// function. The instance's `InstanceHandle` is already owned by the store
@@ -647,42 +651,37 @@ impl Func {
     ///
     /// Panics if `store` does not own this function.
     pub fn ty(&self, store: impl AsContext) -> FuncType {
-        // Signatures should always be registered in the engine's registry of
-        // shared signatures, so we should be able to unwrap safely here.
-        let store = store.as_context();
-        let sig_index = unsafe { store[self.0].export().anyfunc.as_ref().type_index };
-        FuncType::from_wasm_func_type(
-            store
-                .engine()
-                .signatures()
-                .lookup_type(sig_index)
-                .expect("signature should be registered"),
-        )
+        store.as_context()[self.0].ty.clone()
     }
 
     pub(crate) fn sig_index(&self, data: &StoreData) -> VMSharedSignatureIndex {
         unsafe { data[self.0].export().anyfunc.as_ref().type_index }
     }
 
-    /// Invokes this function with the `params` given, returning the results and
-    /// any trap, if one occurs.
+    /// Invokes this function with the `params` given and writes returned values
+    /// to `results`.
     ///
     /// The `params` here must match the type signature of this `Func`, or a
     /// trap will occur. If a trap occurs while executing this function, then a
-    /// trap will also be returned.
+    /// trap will also be returned. Additionally `results` must have the same
+    /// length as the number of results for this function.
     ///
     /// # Panics
     ///
     /// This function will panic if called on a function belonging to an async
     /// store. Asynchronous stores must always use `call_async`.
     /// initiates a panic. Also panics if `store` does not own this function.
-    pub fn call(&self, mut store: impl AsContextMut, params: &[Val]) -> Result<Box<[Val]>> {
+    pub fn call(
+        &self,
+        mut store: impl AsContextMut,
+        params: &[Val],
+        results: &mut [Val],
+    ) -> Result<()> {
         assert!(
             !store.as_context().async_support(),
             "must use `call_async` when async support is enabled on the config",
         );
-        let my_ty = self.ty(&store);
-        self.call_impl(&mut store.as_context_mut(), my_ty, params)
+        self.call_impl(&mut store.as_context_mut(), params, results)
     }
 
     /// Invokes this function with the `params` given, returning the results
@@ -713,7 +712,8 @@ impl Func {
         &self,
         mut store: impl AsContextMut<Data = T>,
         params: &[Val],
-    ) -> Result<Box<[Val]>>
+        results: &mut [Val],
+    ) -> Result<()>
     where
         T: Send,
     {
@@ -722,9 +722,8 @@ impl Func {
             store.0.async_support(),
             "cannot use `call_async` without enabling async support in the config",
         );
-        let my_ty = self.ty(&store);
         let result = store
-            .on_fiber(|store| self.call_impl(store, my_ty, params))
+            .on_fiber(|store| self.call_impl(store, params, results))
             .await??;
         Ok(result)
     }
@@ -732,10 +731,43 @@ impl Func {
     fn call_impl<T>(
         &self,
         store: &mut StoreContextMut<'_, T>,
-        my_ty: FuncType,
         params: &[Val],
-    ) -> Result<Box<[Val]>> {
-        let mut values_vec = write_params(store.0, &my_ty, params)?;
+        results: &mut [Val],
+    ) -> Result<()> {
+        // We need to perform a dynamic check that the arguments given to us
+        // match the signature of this function and are appropriate to pass to
+        // this function. This involves checking to make sure we have the right
+        // number and types of arguments as well as making sure everything is
+        // from the same `Store`.
+        let ty = &store[self.0].ty;
+        if ty.params().len() != params.len() {
+            bail!(
+                "expected {} arguments, got {}",
+                ty.params().len(),
+                params.len()
+            );
+        }
+        if ty.results().len() != results.len() {
+            bail!(
+                "expected {} results, got {}",
+                ty.results().len(),
+                results.len()
+            );
+        }
+        for (ty, arg) in ty.params().zip(params) {
+            if arg.ty() != ty {
+                bail!(
+                    "argument type mismatch: found {} but expected {}",
+                    arg.ty(),
+                    ty
+                );
+            }
+            if !arg.comes_from_same_store(store.0) {
+                bail!("cross-`Store` values are not currently supported");
+            }
+        }
+
+        let mut values_vec = write_params(store.0, params, results)?;
 
         // Call the trampoline.
         unsafe {
@@ -752,41 +784,22 @@ impl Func {
             })?;
         }
 
-        return Ok(read_results(store.0, &my_ty, &values_vec));
+        read_results(store.0, self, values_vec, results);
+        return Ok(());
 
         fn write_params(
             store: &mut StoreOpaque,
-            ty: &FuncType,
             params: &[Val],
+            results: &mut [Val],
         ) -> Result<Vec<u128>> {
-            // We need to perform a dynamic check that the arguments given to us
-            // match the signature of this function and are appropriate to pass to
-            // this function. This involves checking to make sure we have the right
-            // number and types of arguments as well as making sure everything is
-            // from the same `Store`.
-            if ty.params().len() != params.len() {
-                bail!(
-                    "expected {} arguments, got {}",
-                    ty.params().len(),
-                    params.len()
-                );
-            }
+            let values_vec_size = params.len().max(results.len());
 
-            let mut values_vec = vec![0; max(params.len(), ty.results().len())];
+            let mut values_vec = store.take_wasm_u128_storage();
+            debug_assert!(values_vec.is_empty());
+            values_vec.extend((0..values_vec_size).map(|_| 0));
 
             // Store the argument values into `values_vec`.
-            let param_tys = ty.params();
-            for ((arg, slot), ty) in params.iter().cloned().zip(&mut values_vec).zip(param_tys) {
-                if arg.ty() != ty {
-                    bail!(
-                        "argument type mismatch: found {} but expected {}",
-                        arg.ty(),
-                        ty
-                    );
-                }
-                if !arg.comes_from_same_store(store) {
-                    bail!("cross-`Store` values are not currently supported");
-                }
+            for (arg, slot) in params.iter().zip(&mut values_vec) {
                 unsafe {
                     arg.write_value_to(store, slot);
                 }
@@ -795,15 +808,20 @@ impl Func {
             Ok(values_vec)
         }
 
-        fn read_results(store: &mut StoreOpaque, ty: &FuncType, values_vec: &[u128]) -> Box<[Val]> {
-            let mut results = Vec::with_capacity(ty.results().len());
-            for (index, ty) in ty.results().enumerate() {
+        fn read_results(
+            store: &mut StoreOpaque,
+            func: &Func,
+            mut values_vec: Vec<u128>,
+            results: &mut [Val],
+        ) {
+            for (i, (ptr, dst)) in values_vec.iter().zip(results).enumerate() {
+                let ty = store[func.0].ty.results().nth(i).unwrap();
                 unsafe {
-                    let ptr = &values_vec[index];
-                    results.push(Val::read_value_from(store, ptr, ty));
+                    *dst = Val::read_value_from(store, ptr, ty);
                 }
             }
-            results.into()
+            values_vec.truncate(0);
+            store.save_wasm_u128_storage(values_vec);
         }
     }
 
@@ -821,8 +839,21 @@ impl Func {
     ) -> Self {
         let anyfunc = export.anyfunc.as_ref();
         let trampoline = store.lookup_trampoline(&*anyfunc);
-        let data = FuncData::StoreOwned { trampoline, export };
-        Func(store.store_data_mut().insert(data))
+        Func::from_func_kind(FuncKind::StoreOwned { trampoline, export }, store)
+    }
+
+    fn from_func_kind(kind: FuncKind, store: &mut StoreOpaque) -> Self {
+        // Signatures should always be registered in the engine's registry of
+        // shared signatures, so we should be able to unwrap safely here.
+        let ty = unsafe { kind.export().anyfunc.as_ref().type_index };
+        let ty = FuncType::from_wasm_func_type(
+            store
+                .engine()
+                .signatures()
+                .lookup_type(ty)
+                .expect("signature should be registered"),
+        );
+        Func(store.store_data_mut().insert(FuncData { kind, ty }))
     }
 
     pub(crate) fn vmimport(&self, store: &mut StoreOpaque) -> VMFunctionImport {
@@ -1939,13 +1970,13 @@ impl HostFunc {
     pub unsafe fn to_func(self: &Arc<Self>, store: &mut StoreOpaque) -> Func {
         self.register_trampoline(store);
         let me = self.clone();
-        Func(store.store_data_mut().insert(FuncData::SharedHost(me)))
+        Func::from_func_kind(FuncKind::SharedHost(me), store)
     }
 
     /// Same as [`HostFunc::to_func`], different ownership.
     unsafe fn into_func(self, store: &mut StoreOpaque) -> Func {
         self.register_trampoline(store);
-        Func(store.store_data_mut().insert(FuncData::Host(self)))
+        Func::from_func_kind(FuncKind::Host(self), store)
     }
 
     unsafe fn register_trampoline(&self, store: &mut StoreOpaque) {
@@ -1973,20 +2004,28 @@ impl Drop for HostFunc {
 }
 
 impl FuncData {
+    #[inline]
     fn trampoline(&self) -> VMTrampoline {
-        match self {
-            FuncData::StoreOwned { trampoline, .. } => *trampoline,
-            FuncData::SharedHost(host) => host.trampoline,
-            FuncData::Host(host) => host.trampoline,
+        match &self.kind {
+            FuncKind::StoreOwned { trampoline, .. } => *trampoline,
+            FuncKind::SharedHost(host) => host.trampoline,
+            FuncKind::Host(host) => host.trampoline,
         }
     }
 
     #[inline]
     fn export(&self) -> &ExportFunction {
+        self.kind.export()
+    }
+}
+
+impl FuncKind {
+    #[inline]
+    fn export(&self) -> &ExportFunction {
         match self {
-            FuncData::StoreOwned { export, .. } => export,
-            FuncData::SharedHost(host) => &host.export,
-            FuncData::Host(host) => &host.export,
+            FuncKind::StoreOwned { export, .. } => export,
+            FuncKind::SharedHost(host) => &host.export,
+            FuncKind::Host(host) => &host.export,
         }
     }
 }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -440,7 +440,7 @@ fn _assert_send_sync() {
 
     #[cfg(feature = "async")]
     fn _call_async(s: &mut Store<()>, f: Func) {
-        _assert_send(f.call_async(&mut *s, &[]))
+        _assert_send(f.call_async(&mut *s, &[], &mut []))
     }
     #[cfg(feature = "async")]
     fn _typed_call_async(s: &mut Store<()>, f: TypedFunc<(), ()>) {

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -619,20 +619,13 @@ impl<T> Linker<T> {
                                 // `unwrap()` everything here because we know the instance contains a
                                 // function export with the given name and signature because we're
                                 // iterating over the module it was instantiated from.
-                                let command_results = instance
+                                instance
                                     .get_export(&mut caller, &export_name)
                                     .unwrap()
                                     .into_func()
                                     .unwrap()
-                                    .call(&mut caller, params)
+                                    .call(&mut caller, params, results)
                                     .map_err(|error| error.downcast::<Trap>().unwrap())?;
-
-                                // Copy the return values into the output slice.
-                                for (result, command_result) in
-                                    results.iter_mut().zip(command_results.into_vec())
-                                {
-                                    *result = command_result;
-                                }
 
                                 Ok(())
                             },
@@ -688,20 +681,14 @@ impl<T> Linker<T> {
                                 let (instance_pre, export_name) = &*upvars;
                                 let instance = instance_pre.instantiate_async(&mut caller).await?;
 
-                                let command_results = instance
+                                instance
                                     .get_export(&mut caller, &export_name)
                                     .unwrap()
                                     .into_func()
                                     .unwrap()
-                                    .call_async(&mut caller, params)
+                                    .call_async(&mut caller, params, results)
                                     .await
                                     .map_err(|error| error.downcast::<Trap>().unwrap())?;
-
-                                for (result, command_result) in
-                                    results.iter_mut().zip(command_results.into_vec())
-                                {
-                                    *result = command_result;
-                                }
                                 Ok(())
                             })
                         },

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -274,6 +274,9 @@ pub struct StoreOpaque {
     /// `Func::new` to avoid allocating a new vector each time a function is
     /// called.
     hostcall_val_storage: Vec<Val>,
+    /// Same as `hostcall_val_storage`, but for the direction of the host
+    /// calling wasm.
+    wasm_u128_storage: Vec<u128>,
 }
 
 #[cfg(feature = "async")]
@@ -368,6 +371,7 @@ impl<T> Store<T> {
                 store_data: StoreData::new(),
                 default_callee,
                 hostcall_val_storage: Vec::new(),
+                wasm_u128_storage: Vec::new(),
             },
             limiter: None,
             call_hook: None,
@@ -1055,6 +1059,7 @@ impl StoreOpaque {
 
     /// Takes the cached `Vec<Val>` stored internally across hostcalls to get
     /// used as part of calling the host in a `Func::new` method invocation.
+    #[inline]
     pub fn take_hostcall_val_storage(&mut self) -> Vec<Val> {
         mem::take(&mut self.hostcall_val_storage)
     }
@@ -1062,9 +1067,26 @@ impl StoreOpaque {
     /// Restores the vector previously taken by `take_hostcall_val_storage`
     /// above back into the store, allowing it to be used in the future for the
     /// next wasm->host call.
+    #[inline]
     pub fn save_hostcall_val_storage(&mut self, storage: Vec<Val>) {
         if storage.capacity() > self.hostcall_val_storage.capacity() {
             self.hostcall_val_storage = storage;
+        }
+    }
+
+    /// Same as `take_hostcall_val_storage`, but for the direction of the host
+    /// calling wasm.
+    #[inline]
+    pub fn take_wasm_u128_storage(&mut self) -> Vec<u128> {
+        mem::take(&mut self.wasm_u128_storage)
+    }
+
+    /// Same as `save_hostcall_val_storage`, but for the direction of the host
+    /// calling wasm.
+    #[inline]
+    pub fn save_wasm_u128_storage(&mut self, storage: Vec<u128>) {
+        if storage.capacity() > self.wasm_u128_storage.capacity() {
+            self.wasm_u128_storage = storage;
         }
     }
 }

--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -238,11 +238,13 @@ impl FuncType {
     }
 
     /// Returns the list of parameter types for this function.
+    #[inline]
     pub fn params(&self) -> impl ExactSizeIterator<Item = ValType> + '_ {
         self.sig.params.iter().map(ValType::from_wasm_type)
     }
 
     /// Returns the list of result types for this function.
+    #[inline]
     pub fn results(&self) -> impl ExactSizeIterator<Item = ValType> + '_ {
         self.sig.returns.iter().map(ValType::from_wasm_type)
     }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -163,8 +163,10 @@ impl<T> WastContext<T> {
             .get_export(instance_name, field)?
             .into_func()
             .ok_or_else(|| anyhow!("no function named `{}`", field))?;
-        Ok(match func.call(&mut self.store, args) {
-            Ok(result) => Outcome::Ok(result.into()),
+
+        let mut results = vec![Val::null(); func.ty(&self.store).results().len()];
+        Ok(match func.call(&mut self.store, args, &mut results) {
+            Ok(()) => Outcome::Ok(results.into()),
             Err(e) => Outcome::Trap(e.downcast()?),
         })
     }

--- a/crates/wiggle/tests/wasmtime_integration.rs
+++ b/crates/wiggle/tests/wasmtime_integration.rs
@@ -1,4 +1,4 @@
-use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime::{Engine, Linker, Module, Store, Val};
 
 // from_witx invocation says the func is async. This context doesn't support async!
 wiggle::from_witx!({
@@ -49,13 +49,13 @@ fn test_sync_host_func() {
     let shim_mod = shim_module(&engine);
     let shim_inst = linker.instantiate(&mut store, &shim_mod).unwrap();
 
-    let results = shim_inst
+    let mut results = [Val::I32(0)];
+    shim_inst
         .get_func(&mut store, "int_float_args_shim")
         .unwrap()
-        .call(&mut store, &[0i32.into(), 123.45f32.into()])
+        .call(&mut store, &[0i32.into(), 123.45f32.into()], &mut results)
         .unwrap();
 
-    assert_eq!(results.len(), 1, "one return value");
     assert_eq!(
         results[0].unwrap_i32(),
         types::Errno::Ok as i32,
@@ -76,13 +76,17 @@ fn test_async_host_func() {
     let input: i32 = 123;
     let result_location: i32 = 0;
 
-    let results = shim_inst
+    let mut results = [Val::I32(0)];
+    shim_inst
         .get_func(&mut store, "double_int_return_float_shim")
         .unwrap()
-        .call(&mut store, &[input.into(), result_location.into()])
+        .call(
+            &mut store,
+            &[input.into(), result_location.into()],
+            &mut results,
+        )
         .unwrap();
 
-    assert_eq!(results.len(), 1, "one return value");
     assert_eq!(
         results[0].unwrap_i32(),
         types::Errno::Ok as i32,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -332,7 +332,8 @@ impl RunCommand {
 
         // Invoke the function and then afterwards print all the results that came
         // out, if there are any.
-        let results = func.call(store, &values).with_context(|| {
+        let mut results = vec![Val::null(); ty.results().len()];
+        func.call(store, &values, &mut results).with_context(|| {
             if let Some(name) = name {
                 format!("failed to invoke `{}`", name)
             } else {
@@ -346,7 +347,7 @@ impl RunCommand {
             );
         }
 
-        for result in results.into_vec() {
+        for result in results {
             match result {
                 Val::I32(i) => println!("{}", i),
                 Val::I64(i) => println!("{}", i),

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -31,6 +31,7 @@ fn call_wrapped_func() -> Result<(), Error> {
     f.call(
         &mut store,
         &[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()],
+        &mut [],
     )?;
 
     // One switch from vm to host to call f, another in return from f.
@@ -85,6 +86,7 @@ async fn call_wrapped_async_func() -> Result<(), Error> {
     f.call_async(
         &mut store,
         &[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()],
+        &mut [],
     )
     .await?;
 
@@ -154,7 +156,7 @@ fn call_linked_func() -> Result<(), Error> {
         .into_func()
         .expect("export is func");
 
-    export.call(&mut store, &[])?;
+    export.call(&mut store, &[], &mut [])?;
 
     // One switch from vm to host to call f, another in return from f.
     assert_eq!(store.data().calls_into_host, 1);
@@ -225,7 +227,7 @@ async fn call_linked_func_async() -> Result<(), Error> {
         .into_func()
         .expect("export is func");
 
-    export.call_async(&mut store, &[]).await?;
+    export.call_async(&mut store, &[], &mut []).await?;
 
     // One switch from vm to host to call f, another in return from f.
     assert_eq!(store.data().calls_into_host, 1);
@@ -333,7 +335,7 @@ fn recursion() -> Result<(), Error> {
     // Recursion depth:
     let n: usize = 10;
 
-    export.call(&mut store, &[Val::I32(n as i32)])?;
+    export.call(&mut store, &[Val::I32(n as i32)], &mut [])?;
 
     // Recurse down to 0: n+1 calls
     assert_eq!(store.data().calls_into_host, n + 1);
@@ -423,6 +425,7 @@ fn trapping() -> Result<(), Error> {
         let r = export.call(
             &mut store,
             &[Val::I32(action), Val::I32(if recur { 1 } else { 0 })],
+            &mut [],
         );
         (store.into_data(), r.err())
     };

--- a/tests/all/externals.rs
+++ b/tests/all/externals.rs
@@ -114,16 +114,24 @@ fn cross_store() -> anyhow::Result<()> {
     let s1_f = s1_inst.get_func(&mut store1, "f").unwrap();
     let s2_f = s2_inst.get_func(&mut store2, "f").unwrap();
 
-    assert!(s1_f.call(&mut store1, &[Val::FuncRef(None)]).is_ok());
-    assert!(s2_f.call(&mut store2, &[Val::FuncRef(None)]).is_ok());
-    assert!(s1_f.call(&mut store1, &[Some(s1_f.clone()).into()]).is_ok());
     assert!(s1_f
-        .call(&mut store1, &[Some(s2_f.clone()).into()])
+        .call(&mut store1, &[Val::FuncRef(None)], &mut [])
+        .is_ok());
+    assert!(s2_f
+        .call(&mut store2, &[Val::FuncRef(None)], &mut [])
+        .is_ok());
+    assert!(s1_f
+        .call(&mut store1, &[Some(s1_f.clone()).into()], &mut [])
+        .is_ok());
+    assert!(s1_f
+        .call(&mut store1, &[Some(s2_f.clone()).into()], &mut [])
         .is_err());
     assert!(s2_f
-        .call(&mut store2, &[Some(s1_f.clone()).into()])
+        .call(&mut store2, &[Some(s1_f.clone()).into()], &mut [])
         .is_err());
-    assert!(s2_f.call(&mut store2, &[Some(s2_f.clone()).into()]).is_ok());
+    assert!(s2_f
+        .call(&mut store2, &[Some(s2_f.clone()).into()], &mut [])
+        .is_ok());
 
     let s1_f_t = s1_f.typed::<Option<Func>, (), _>(&store1)?;
     let s2_f_t = s2_f.typed::<Option<Func>, (), _>(&store2)?;

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -193,10 +193,12 @@ fn import_works() -> Result<()> {
                     f.as_ref().unwrap().data().downcast_ref::<String>().unwrap(),
                     "hello"
                 );
-                assert_eq!(
-                    g.as_ref().unwrap().call(&mut caller, &[]).unwrap()[0].unwrap_i32(),
-                    42
-                );
+                let mut results = [Val::I32(0)];
+                g.as_ref()
+                    .unwrap()
+                    .call(&mut caller, &[], &mut results)
+                    .unwrap();
+                assert_eq!(results[0].unwrap_i32(), 42);
                 assert_eq!(HITS.fetch_add(1, SeqCst), 3);
             },
         )
@@ -211,6 +213,7 @@ fn import_works() -> Result<()> {
             Val::ExternRef(Some(ExternRef::new("hello".to_string()))),
             funcref,
         ],
+        &mut [],
     )?;
     assert_eq!(HITS.load(SeqCst), 4);
     Ok(())
@@ -222,7 +225,10 @@ fn trap_smoke() -> Result<()> {
     let f = Func::wrap(&mut store, || -> Result<(), Trap> {
         Err(Trap::new("test"))
     });
-    let err = f.call(&mut store, &[]).unwrap_err().downcast::<Trap>()?;
+    let err = f
+        .call(&mut store, &[], &mut [])
+        .unwrap_err()
+        .downcast::<Trap>()?;
     assert!(err.to_string().contains("test"));
     assert!(err.i32_exit_status().is_none());
     Ok(())
@@ -347,31 +353,29 @@ fn call_wrapped_func() -> Result<()> {
     f.call(
         &mut store,
         &[Val::I32(1), Val::I64(2), 3.0f32.into(), 4.0f64.into()],
+        &mut [],
     )?;
     f.typed::<(i32, i64, f32, f64), (), _>(&store)?
         .call(&mut store, (1, 2, 3.0, 4.0))?;
 
+    let mut results = [Val::I32(0)];
     let f = Func::wrap(&mut store, || 1i32);
-    let results = f.call(&mut store, &[])?;
-    assert_eq!(results.len(), 1);
+    f.call(&mut store, &[], &mut results)?;
     assert_eq!(results[0].unwrap_i32(), 1);
     assert_eq!(f.typed::<(), i32, _>(&store)?.call(&mut store, ())?, 1);
 
     let f = Func::wrap(&mut store, || 2i64);
-    let results = f.call(&mut store, &[])?;
-    assert_eq!(results.len(), 1);
+    f.call(&mut store, &[], &mut results)?;
     assert_eq!(results[0].unwrap_i64(), 2);
     assert_eq!(f.typed::<(), i64, _>(&store)?.call(&mut store, ())?, 2);
 
     let f = Func::wrap(&mut store, || 3.0f32);
-    let results = f.call(&mut store, &[])?;
-    assert_eq!(results.len(), 1);
+    f.call(&mut store, &[], &mut results)?;
     assert_eq!(results[0].unwrap_f32(), 3.0);
     assert_eq!(f.typed::<(), f32, _>(&store)?.call(&mut store, ())?, 3.0);
 
     let f = Func::wrap(&mut store, || 4.0f64);
-    let results = f.call(&mut store, &[])?;
-    assert_eq!(results.len(), 1);
+    f.call(&mut store, &[], &mut results)?;
     assert_eq!(results[0].unwrap_f64(), 4.0);
     assert_eq!(f.typed::<(), f64, _>(&store)?.call(&mut store, ())?, 4.0);
     Ok(())
@@ -385,7 +389,7 @@ fn caller_memory() -> anyhow::Result<()> {
         assert!(c.get_export("y").is_none());
         assert!(c.get_export("z").is_none());
     });
-    f.call(&mut store, &[])?;
+    f.call(&mut store, &[], &mut [])?;
 
     let f = Func::wrap(&mut store, |mut c: Caller<'_, ()>| {
         assert!(c.get_export("x").is_none());
@@ -447,7 +451,10 @@ fn func_write_nothing() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let ty = FuncType::new(None, Some(ValType::I32));
     let f = Func::new(&mut store, ty, |_, _, _| Ok(()));
-    let err = f.call(&mut store, &[]).unwrap_err().downcast::<Trap>()?;
+    let err = f
+        .call(&mut store, &[], &mut [Val::I32(0)])
+        .unwrap_err()
+        .downcast::<Trap>()?;
     assert!(err
         .to_string()
         .contains("function attempted to return an incompatible value"));
@@ -479,7 +486,7 @@ fn return_cross_store_value() -> anyhow::Result<()> {
     let instance = Instance::new(&mut store1, &module, &[return_cross_store_func.into()])?;
 
     let run = instance.get_func(&mut store1, "run").unwrap();
-    let result = run.call(&mut store1, &[]);
+    let result = run.call(&mut store1, &[], &mut [Val::I32(0)]);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("cross-`Store`"));
 
@@ -500,7 +507,11 @@ fn pass_cross_store_arg() -> anyhow::Result<()> {
 
     // Using regular `.call` fails with cross-Store arguments.
     assert!(store1_func
-        .call(&mut store1, &[Val::FuncRef(Some(store2_func.clone()))])
+        .call(
+            &mut store1,
+            &[Val::FuncRef(Some(store2_func.clone()))],
+            &mut []
+        )
         .is_err());
 
     // And using `.get` followed by a function call also fails with cross-Store
@@ -553,7 +564,7 @@ fn trampolines_always_valid() -> anyhow::Result<()> {
     drop(module2);
 
     // ... and no segfaults! right? right? ...
-    func.call(&mut store, &[])?;
+    func.call(&mut store, &[], &mut [])?;
     Ok(())
 }
 
@@ -616,7 +627,7 @@ fn trap_doesnt_leak() -> anyhow::Result<()> {
         Err(Trap::new(""))
     });
     assert!(f1.typed::<(), (), _>(&store)?.call(&mut store, ()).is_err());
-    assert!(f1.call(&mut store, &[]).is_err());
+    assert!(f1.call(&mut store, &[], &mut []).is_err());
 
     // test that `Func::new` is correct
     let canary2 = Canary::default();
@@ -626,7 +637,7 @@ fn trap_doesnt_leak() -> anyhow::Result<()> {
         Err(Trap::new(""))
     });
     assert!(f2.typed::<(), (), _>(&store)?.call(&mut store, ()).is_err());
-    assert!(f2.call(&mut store, &[]).is_err());
+    assert!(f2.call(&mut store, &[], &mut []).is_err());
 
     // drop everything and ensure dtors are run
     drop(store);
@@ -651,15 +662,18 @@ fn wrap_multiple_results() -> anyhow::Result<()> {
             + Sync,
     {
         let f = Func::wrap(&mut *store, move || t);
-        assert_eq!(f.typed::<(), T, _>(&store,)?.call(&mut *store, ())?, t);
-        assert!(t.eq_values(&f.call(&mut *store, &[])?));
+        let mut results = vec![Val::I32(0); f.ty(&store).results().len()];
+        assert_eq!(f.typed::<(), T, _>(&store)?.call(&mut *store, ())?, t);
+        f.call(&mut *store, &[], &mut results)?;
+        assert!(t.eq_values(&results));
 
         let module = Module::new(store.engine(), &T::gen_wasm())?;
         let instance = Instance::new(&mut *store, &module, &[f.into()])?;
         let f = instance.get_func(&mut *store, "foo").unwrap();
 
         assert_eq!(f.typed::<(), T, _>(&store)?.call(&mut *store, ())?, t);
-        assert!(t.eq_values(&f.call(&mut *store, &[])?));
+        f.call(&mut *store, &[], &mut results)?;
+        assert!(t.eq_values(&results));
         Ok(())
     }
 
@@ -820,7 +834,7 @@ fn trampoline_for_declared_elem() -> anyhow::Result<()> {
     let g = instance.get_typed_func::<(), Option<Func>, _>(&mut store, "g")?;
 
     let func = g.call(&mut store, ())?;
-    func.unwrap().call(&mut store, &[])?;
+    func.unwrap().call(&mut store, &[], &mut [])?;
     Ok(())
 }
 

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -24,7 +24,7 @@ fn test_import_calling_export() {
             caller
                 .data()
                 .unwrap()
-                .call(&mut caller, &[])
+                .call(&mut caller, &[], &mut [])
                 .expect("expected function not to trap");
             Ok(())
         },
@@ -44,7 +44,7 @@ fn test_import_calling_export() {
     *store.data_mut() = Some(other_func);
 
     run_func
-        .call(&mut store, &[])
+        .call(&mut store, &[], &mut [])
         .expect("expected function not to trap");
 }
 
@@ -79,8 +79,9 @@ fn test_returns_incorrect_type() -> Result<()> {
         .get_func(&mut store, "run")
         .expect("expected a run func in the module");
 
+    let mut result = [Val::I32(0)];
     let trap = run_func
-        .call(&mut store, &[])
+        .call(&mut store, &[], &mut result)
         .expect_err("the execution should fail")
         .downcast::<Trap>()?;
     assert!(trap

--- a/tests/all/invoke_func_via_table.rs
+++ b/tests/all/invoke_func_via_table.rs
@@ -26,7 +26,8 @@ fn test_invoke_func_via_table() -> Result<()> {
         .unwrap()
         .unwrap()
         .clone();
-    let result = f.call(&mut store, &[]).unwrap();
-    assert_eq!(result[0].unwrap_i64(), 42);
+    let mut results = [Val::I32(0)];
+    f.call(&mut store, &[], &mut results).unwrap();
+    assert_eq!(results[0].unwrap_i64(), 42);
     Ok(())
 }

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -256,7 +256,7 @@ fn get_host_function() -> Result<()> {
 
     let mut linker = Linker::new(&engine);
     linker.func_wrap("mod", "f1", || {})?;
-    let mut store = Store::<()>::default();
+    let mut store = Store::new(&engine, ());
     assert!(linker
         .get_by_import(&mut store, &module.imports().nth(0).unwrap())
         .is_some());
@@ -285,7 +285,7 @@ fn funcs_live_on_to_fight_another_day() -> Result<()> {
         assert_eq!(flag.load(SeqCst), 0);
         let mut store = Store::new(&engine, ());
         let func = linker.get(&mut store, "", Some("")).unwrap();
-        func.into_func().unwrap().call(&mut store, &[])?;
+        func.into_func().unwrap().call(&mut store, &[], &mut [])?;
         assert_eq!(flag.load(SeqCst), 0);
         Ok(())
     };

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -329,17 +329,17 @@ fn mismatched_arguments() -> Result<()> {
     let instance = Instance::new(&mut store, &module, &[])?;
     let func = instance.get_func(&mut store, "foo").unwrap();
     assert_eq!(
-        func.call(&mut store, &[]).unwrap_err().to_string(),
+        func.call(&mut store, &[], &mut []).unwrap_err().to_string(),
         "expected 1 arguments, got 0"
     );
     assert_eq!(
-        func.call(&mut store, &[Val::F32(0)])
+        func.call(&mut store, &[Val::F32(0)], &mut [])
             .unwrap_err()
             .to_string(),
         "argument type mismatch: found f32 but expected i32",
     );
     assert_eq!(
-        func.call(&mut store, &[Val::I32(0), Val::I32(1)])
+        func.call(&mut store, &[Val::I32(0), Val::I32(1)], &mut [])
             .unwrap_err()
             .to_string(),
         "expected 1 arguments, got 2"
@@ -519,7 +519,10 @@ fn parse_dwarf_info() -> Result<()> {
     );
     linker.module(&mut store, "", &module)?;
     let run = linker.get_default(&mut store, "")?;
-    let trap = run.call(&mut store, &[]).unwrap_err().downcast::<Trap>()?;
+    let trap = run
+        .call(&mut store, &[], &mut [])
+        .unwrap_err()
+        .downcast::<Trap>()?;
 
     let mut found = false;
     for frame in trap.trace() {

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -139,7 +139,7 @@ fn main() {
                         overrun_the_stack();
                     })
                 });
-                run_future(f.call_async(&mut store, &[])).unwrap();
+                run_future(f.call_async(&mut store, &[], &mut [])).unwrap();
                 unreachable!();
             },
             true,
@@ -157,7 +157,7 @@ fn main() {
                         overrun_the_stack();
                     })
                 });
-                run_future(f.call_async(&mut store, &[])).unwrap();
+                run_future(f.call_async(&mut store, &[], &mut [])).unwrap();
                 unreachable!();
             },
             true,


### PR DESCRIPTION
This commit is an alternative to #3298 which achieves effectively the
same goal of optimizing the `Func::call` API as well as its C API
sibling of `wasmtime_func_call`. The strategy taken here is different
than #3298 though where a new API isn't created, rather a small tweak to
an existing API is done. Specifically this commit handles the major
sources of slowness with `Func::call` with:

* Looking up the type of a function, to typecheck the arguments with and
  use to guide how the results should be loaded, no longer hits the
  rwlock in the `Engine` but instead each `Func` contains its own
  `FuncType`. This can be an unnecessary allocation for funcs not used
  with `Func::call`, so this is a downside of this implementation
  relative to #3298. A mitigating factor, though, is that instance
  exports are loaded lazily into the `Store` and in theory not too many
  funcs are active in the store as `Func` objects.

* Temporary storage is amortized with a long-lived `Vec` in the `Store`
  rather than allocating a new vector on each call. This is basically
  the same strategy as #3294 only applied to different types in
  different places. Specifically `wasmtime::Store` now retains a
  `Vec<u128>` for `Func::call`, and the C API retains a `Vec<Val>` for
  calling `Func::call`.

* Finally, an API breaking change is made to `Func::call` and its type
  signature (as well as `Func::call_async`). Instead of returning
  `Box<[Val]>` as it did before this function now takes a
  `results: &mut [Val]` parameter. This allows the caller to manage the
  allocation and we can amortize-remove it in `wasmtime_func_call` by
  using space after the parameters in the `Vec<Val>` we're passing in.
  This change is naturally a breaking change and we'll want to consider
  it carefully, but mitigating factors are that most embeddings are
  likely using `TypedFunc::call` instead and this signature taking a
  mutable slice better aligns with `Func::new` which receives a mutable
  slice for the results.

Overall this change, in the benchmark of "call a nop function from the C
API" is not quite as good as #3298. It's still a bit slower, on the
order of 15ns, because there's lots of capacity checks around vectors
and the type checks are slightly less optimized than before. Overall
though this is still significantly better than today because allocations
and the rwlock to acquire the type information are both avoided. I
personally feel that this change is the best to do because it has less
of an API impact than #3298.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
