### PR TITLE
Implement `Shuffle` for the interpreter

### DIFF
--- a/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-shuffle.clif
@@ -1,0 +1,12 @@
+test interpret
+test run
+target aarch64
+set enable_simd
+target x86_64
+
+function %shuffle_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = shuffle v0, v1, [3 0 31 26 100 6 12 11 23 13 24 4 2 15 17 5]
+    return v2
+}
+; run: %shuffle_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]) == [4 1 32 27 0 7 13 12 24 14 25 5 3 16 18 6]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -776,7 +776,30 @@ where
             arg(0)?,
             ValueConversionKind::RoundNearestEven(ctrl_ty),
         )?),
-        Opcode::Shuffle => unimplemented!("Shuffle"),
+        Opcode::Shuffle => {
+            if let InstructionData::Shuffle { mask, .. } = inst {
+                let mask = state
+                    .get_current_function()
+                    .dfg
+                    .immediates
+                    .get(mask)
+                    .unwrap()
+                    .as_slice();
+                let a = Value::into_array(&arg(0)?)?;
+                let b = Value::into_array(&arg(1)?)?;
+                let mut new = [0u8; 16];
+                for i in 0..mask.len() {
+                    if (mask[i] as usize) < a.len() {
+                        new[i] = a[mask[i] as usize];
+                    } else if (mask[i] as usize - a.len()) < b.len() {
+                        new[i] = b[mask[i] as usize - a.len()];
+                    } // else leave as 0.
+                }
+                assign(Value::vector(new, ctrl_ty)?)
+            } else {
+                unreachable!();
+            }
+        }
         Opcode::Swizzle => {
             let x = Value::into_array(&arg(0)?)?;
             let s = Value::into_array(&arg(1)?)?;

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -76,6 +76,16 @@ where
                     .as_slice();
                 DataValue::V128(buffer.try_into().expect("a 16-byte data buffer"))
             }
+            InstructionData::Shuffle { mask, .. } => {
+                let mask = state
+                    .get_current_function()
+                    .dfg
+                    .immediates
+                    .get(mask)
+                    .unwrap()
+                    .as_slice();
+                DataValue::V128(mask.try_into().expect("a 16-byte vector mask"))
+            }
             _ => inst.imm_value().unwrap(),
         })
     };
@@ -777,28 +787,18 @@ where
             ValueConversionKind::RoundNearestEven(ctrl_ty),
         )?),
         Opcode::Shuffle => {
-            if let InstructionData::Shuffle { mask, .. } = inst {
-                let mask = state
-                    .get_current_function()
-                    .dfg
-                    .immediates
-                    .get(mask)
-                    .unwrap()
-                    .as_slice();
-                let a = Value::into_array(&arg(0)?)?;
-                let b = Value::into_array(&arg(1)?)?;
-                let mut new = [0u8; 16];
-                for i in 0..mask.len() {
-                    if (mask[i] as usize) < a.len() {
-                        new[i] = a[mask[i] as usize];
-                    } else if (mask[i] as usize - a.len()) < b.len() {
-                        new[i] = b[mask[i] as usize - a.len()];
-                    } // else leave as 0.
-                }
-                assign(Value::vector(new, ctrl_ty)?)
-            } else {
-                unreachable!();
+            let mask = imm().into_array()?;
+            let a = Value::into_array(&arg(0)?)?;
+            let b = Value::into_array(&arg(1)?)?;
+            let mut new = [0u8; 16];
+            for i in 0..mask.len() {
+                if (mask[i] as usize) < a.len() {
+                    new[i] = a[mask[i] as usize];
+                } else if (mask[i] as usize - a.len()) < b.len() {
+                    new[i] = b[mask[i] as usize - a.len()];
+                } // else leave as 0.
             }
+            assign(Value::vector(new, ctrl_ty)?)
         }
         Opcode::Swizzle => {
             let x = Value::into_array(&arg(0)?)?;


### PR DESCRIPTION
Implemented `Shuffle` for the Cranelift interpreter, to shuffle two SIMD
vectors together based on an immediate mask of 16 bytes.

Copyright (c) 2021, Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
