### PR TITLE
cranelift: Fix big-endian regression in data_value.rs

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -82,12 +82,12 @@ impl DataValue {
         match self {
             DataValue::B(true) => dst[..16].copy_from_slice(&[u8::MAX; 16][..]),
             DataValue::B(false) => dst[..16].copy_from_slice(&[0; 16][..]),
-            DataValue::I8(i) => dst[..1].copy_from_slice(&i.to_le_bytes()[..]),
-            DataValue::I16(i) => dst[..2].copy_from_slice(&i.to_le_bytes()[..]),
-            DataValue::I32(i) => dst[..4].copy_from_slice(&i.to_le_bytes()[..]),
-            DataValue::I64(i) => dst[..8].copy_from_slice(&i.to_le_bytes()[..]),
-            DataValue::F32(f) => dst[..4].copy_from_slice(&f.bits().to_le_bytes()[..]),
-            DataValue::F64(f) => dst[..8].copy_from_slice(&f.bits().to_le_bytes()[..]),
+            DataValue::I8(i) => dst[..1].copy_from_slice(&i.to_ne_bytes()[..]),
+            DataValue::I16(i) => dst[..2].copy_from_slice(&i.to_ne_bytes()[..]),
+            DataValue::I32(i) => dst[..4].copy_from_slice(&i.to_ne_bytes()[..]),
+            DataValue::I64(i) => dst[..8].copy_from_slice(&i.to_ne_bytes()[..]),
+            DataValue::F32(f) => dst[..4].copy_from_slice(&f.bits().to_ne_bytes()[..]),
+            DataValue::F64(f) => dst[..8].copy_from_slice(&f.bits().to_ne_bytes()[..]),
             DataValue::V128(v) => dst[..16].copy_from_slice(&v[..]),
             _ => unimplemented!(),
         };
@@ -100,14 +100,14 @@ impl DataValue {
     /// Panics if the slice does not have enough space to accommodate the [DataValue]
     pub fn read_from_slice(src: &[u8], ty: Type) -> Self {
         match ty {
-            types::I8 => DataValue::I8(i8::from_le_bytes(src[..1].try_into().unwrap())),
-            types::I16 => DataValue::I16(i16::from_le_bytes(src[..2].try_into().unwrap())),
-            types::I32 => DataValue::I32(i32::from_le_bytes(src[..4].try_into().unwrap())),
-            types::I64 => DataValue::I64(i64::from_le_bytes(src[..8].try_into().unwrap())),
-            types::F32 => DataValue::F32(Ieee32::with_bits(u32::from_le_bytes(
+            types::I8 => DataValue::I8(i8::from_ne_bytes(src[..1].try_into().unwrap())),
+            types::I16 => DataValue::I16(i16::from_ne_bytes(src[..2].try_into().unwrap())),
+            types::I32 => DataValue::I32(i32::from_ne_bytes(src[..4].try_into().unwrap())),
+            types::I64 => DataValue::I64(i64::from_ne_bytes(src[..8].try_into().unwrap())),
+            types::F32 => DataValue::F32(Ieee32::with_bits(u32::from_ne_bytes(
                 src[..4].try_into().unwrap(),
             ))),
-            types::F64 => DataValue::F64(Ieee64::with_bits(u64::from_le_bytes(
+            types::F64 => DataValue::F64(Ieee64::with_bits(u64::from_ne_bytes(
                 src[..8].try_into().unwrap(),
             ))),
             _ if ty.is_bool() => {


### PR DESCRIPTION
PR https://github.com/bytecodealliance/wasmtime/pull/3187 introduced a
change to the write_to_slice and read_from_slice routines in
data_value.rs that switched byte order on big-endian systems:
the code used to use native byte order, and now hard-codes
little-endian byte order.

Fix by using native byte order again.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
