### PR TITLE
Fix s390x regressions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -201,6 +201,8 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             ("reference_types", _) if cfg!(feature = "old-x86-backend") => return true,
             // No simd support yet for s390x.
             ("simd", _) if platform_is_s390x() => return true,
+            // No memory64 support yet for s390x.
+            ("memory64", _) if platform_is_s390x() => return true,
             _ => {}
         },
         _ => panic!("unrecognized strategy"),

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -61,6 +61,16 @@ fn input_matches_const<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput) -> 
     input.constant
 }
 
+/// Lower an instruction input to a 64-bit signed constant, if possible.
+fn input_matches_sconst<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput) -> Option<i64> {
+    if let Some(imm) = input_matches_const(ctx, input) {
+        let ty = ctx.input_ty(input.insn, input.input);
+        Some(sign_extend_to_u64(imm, ty_bits(ty) as u8) as i64)
+    } else {
+        None
+    }
+}
+
 /// Return false if instruction input cannot have the value Imm, true otherwise.
 fn input_maybe_imm<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput, imm: u64) -> bool {
     if let Some(c) = input_matches_const(ctx, input) {
@@ -79,8 +89,8 @@ fn input_maybe_imm<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput, imm: u6
 
 /// Lower an instruction input to a 16-bit signed constant, if possible.
 fn input_matches_simm16<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput) -> Option<i16> {
-    if let Some(imm_value) = input_matches_const(ctx, input) {
-        if let Ok(imm) = i16::try_from(imm_value as i64) {
+    if let Some(imm_value) = input_matches_sconst(ctx, input) {
+        if let Ok(imm) = i16::try_from(imm_value) {
             return Some(imm);
         }
     }
@@ -89,8 +99,8 @@ fn input_matches_simm16<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput) ->
 
 /// Lower an instruction input to a 32-bit signed constant, if possible.
 fn input_matches_simm32<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput) -> Option<i32> {
-    if let Some(imm_value) = input_matches_const(ctx, input) {
-        if let Ok(imm) = i32::try_from(imm_value as i64) {
+    if let Some(imm_value) = input_matches_sconst(ctx, input) {
+        if let Ok(imm) = i32::try_from(imm_value) {
             return Some(imm);
         }
     }
@@ -112,8 +122,8 @@ fn negated_input_matches_simm16<C: LowerCtx<I = Inst>>(
     ctx: &mut C,
     input: InsnInput,
 ) -> Option<i16> {
-    if let Some(imm_value) = input_matches_const(ctx, input) {
-        if let Ok(imm) = i16::try_from(-(imm_value as i64)) {
+    if let Some(imm_value) = input_matches_sconst(ctx, input) {
+        if let Ok(imm) = i16::try_from(-imm_value) {
             return Some(imm);
         }
     }
@@ -125,8 +135,8 @@ fn negated_input_matches_simm32<C: LowerCtx<I = Inst>>(
     ctx: &mut C,
     input: InsnInput,
 ) -> Option<i32> {
-    if let Some(imm_value) = input_matches_const(ctx, input) {
-        if let Ok(imm) = i32::try_from(-(imm_value as i64)) {
+    if let Some(imm_value) = input_matches_sconst(ctx, input) {
+        if let Ok(imm) = i32::try_from(-imm_value) {
             return Some(imm);
         }
     }

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -597,7 +597,7 @@ impl<I: VCodeInst> MachBuffer<I> {
             self.island_worst_case_size += kind.veneer_size();
             self.island_worst_case_size &= !(I::LabelUse::ALIGN - 1);
         }
-        let deadline = offset + kind.max_pos_range();
+        let deadline = offset.saturating_add(kind.max_pos_range());
         if deadline < self.island_deadline {
             self.island_deadline = deadline;
         }

--- a/cranelift/filetests/filetests/runtests/i128-concat-split.clif
+++ b/cranelift/filetests/filetests/runtests/i128-concat-split.clif
@@ -1,7 +1,6 @@
 test interpret
 test run
 target aarch64
-target s390x
 target x86_64 machinst
 
 function %iconcat_isplit(i64, i64) -> i64, i64 {

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -25,8 +25,8 @@ wasmi = "0.7.0"
 # We rely on precompiled v8 binaries, but rusty-v8 doesn't have a precompiled
 # binary for MinGW which is built on our CI. It does have one for Windows-msvc,
 # though, so we could use that if we wanted. For now though just simplify a bit
-# and don't depend on this on Windows.
-[target.'cfg(not(windows))'.dependencies]
+# and don't depend on this on Windows.  The same applies on s390x.
+[target.'cfg(not(any(windows, target_arch = "s390x")))'.dependencies]
 rusty_v8 = "0.27"
 
 [dev-dependencies]

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -21,9 +21,9 @@ use std::time::{Duration, Instant};
 use wasmtime::*;
 use wasmtime_wast::WastContext;
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_arch = "s390x")))]
 pub use v8::*;
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_arch = "s390x")))]
 mod v8;
 
 static CNT: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
- Add relocation handling needed after PR #3275
- Fix incorrect handling of signed constants detected by PR #3056 test
- Disable fuzzing tests that require pre-built v8 binaries
- Disable cranelift test that depends on i128
- Temporarily disable memory64 tests

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
