### PR TITLE
Update to cap-std 0.19.0 and rsix 0.22.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -287,9 +287,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e04805737d22cbff289ece81123d4b26e4bc57014e41333a10cc86521e3943"
+checksum = "a3e78f3c966b077a24e7bab715b983989b775f6e4fc925555b4cc64ede44022e"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f697a6f29f9226d68a62d181662c4e7b609880c475249c21879eefde5239d2e7"
+checksum = "53cdbdb79473b78acebdef84f853914cbda08f29d4fc80d8f647f68372e3b6bb"
 dependencies = [
  "ambient-authority",
  "errno",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bcf8f5a6595520aca4f29328871f446217e32ab040a7b591c212b45f741ebc"
+checksum = "ce38e251919457b5e2808d53d8982a6a267898907a57c4fd909305c93300efd2"
 dependencies = [
  "ambient-authority",
  "rand 0.8.3",
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf379a5dbf406dbb3e09846e3f084130b65b7cde2d57c8aefd049f90ff9336"
+checksum = "2f659706c014c6cfdbf1e13903699bc1c2d8bb84c1a0e1ae9b4cb333e8c6f3de"
 dependencies = [
  "cap-primitives",
  "io-lifetimes",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f6d28e385915d8589cfa7f6a0bba93007cb931b6b2861a393845193450a858"
+checksum = "b3ec13e2e4ebce1d22ccb4553264fdb5c170d2070839d17540ddf17c05642d96"
 dependencies = [
  "cap-std",
  "rand 0.8.3",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b33b3e580fb3b5649292132906813ab483ee4d8f6fb9356ae313c71a43519dd"
+checksum = "79d636df2f22174ea46acd0ca12b6f884139f82afbf10d9e91bdab694f988213"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -1265,9 +1265,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570474d675e834ccbe9871fb09a6e7a60611b51540662c1294c8a4c3ef52da3f"
+checksum = "b05f9ac4aceff7d9f3cd1701217aa72f87a0bf7c6592886efe819727292a4c7f"
 dependencies = [
  "io-lifetimes",
  "rsix",
@@ -1484,7 +1484,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e87a80ab2e1aad23d4b8c4feb954125ac4da906891e041d93f5861a5fdd78"
 dependencies = [
- "libc",
  "rustc_version",
  "winapi",
 ]
@@ -1649,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.21"
+version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77da217e847c30f41d9f4340b62d0e9c327f114a57b55f87e235b9d48b841a66"
+checksum = "5802c30e8a573a9af97d504e9e66a076e0b881112222a67a8e037a79658447d6"
 
 [[package]]
 name = "lock_api"
@@ -2604,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "rsix"
-version = "0.20.4"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfd382d98c6cdfe6627eabef5f3410e21e0aacb16fea83963d93eeae0dea392"
+checksum = "19dc84e006a7522c44207fcd9c1f504f7c9a503093070840105930a685e299a0"
 dependencies = [
  "bitflags",
  "cc",
@@ -2935,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9e64878557db3497b0f15d360da5078e361d100eef8c8deedc91388c2b55b"
+checksum = "8687be991be7468d6042aeecaedea242221afadbec8d0cb86f5a0df1a4206dc7"
 dependencies = [
  "atty",
  "bitflags",

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.18.0"
+cap-std = "0.19.0"
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -30,7 +30,7 @@ wat = { version = "1.0.36", optional = true }
 wasi-common = { path = "../wasi-common", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.18.0", optional = true }
+cap-std = { version = "0.19.0", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache']

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
-cap-std = "0.18.0"
+cap-std = "0.19.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,13 +22,13 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "0.29.0" }
 tracing = "0.1.19"
-cap-std = "0.18.0"
-cap-rand = "0.18.0"
+cap-std = "0.19.0"
+cap-rand = "0.19.0"
 bitflags = "1.2"
 io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.20.4"
+rsix = "0.22.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,18 +15,18 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "0.29.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.18.0"
-cap-fs-ext = "0.18.0"
-cap-time-ext = "0.18.0"
-cap-rand = "0.18.0"
-fs-set-times = "0.9.0"
-system-interface = { version = "0.12.0", features = ["cap_std_impls"] }
+cap-std = "0.19.0"
+cap-fs-ext = "0.19.0"
+cap-time-ext = "0.19.0"
+cap-rand = "0.19.0"
+fs-set-times = "0.11.0"
+system-interface = { version = "0.14.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.20.4"
+rsix = "0.22.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,18 +15,18 @@ wasi-common = { path = "../", version = "0.29.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "0.29.0" }
 wiggle = { path = "../../wiggle", version = "0.29.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.18.0"
-cap-fs-ext = "0.18.0"
-cap-time-ext = "0.18.0"
-fs-set-times = "0.9.0"
-system-interface = { version = "0.12.0", features = ["cap_std_impls"] }
+cap-std = "0.19.0"
+cap-fs-ext = "0.19.0"
+cap-time-ext = "0.19.0"
+fs-set-times = "0.11.0"
+system-interface = { version = "0.14.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 bitflags = "1.2"
 anyhow = "1"
 io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.20.4"
+rsix = "0.22.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
@@ -36,4 +36,4 @@ lazy_static = "1.4"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.18.0"
+cap-tempfile = "0.19.0"


### PR DESCRIPTION
This pulls in the s390x fix needed by #3330.

Also a small `rsix` API update; `PollFdVec` has been removed in favor of
just using `Vec<PollFd>`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
