### PR TITLE
cranelift: Add SIMD `icmp` to interpreter

### DIFF
--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -133,11 +133,11 @@ impl Type {
     /// Scalar types follow this same rule, but `b1` is converted into `i8`
     pub fn as_int(self) -> Self {
         self.replace_lanes(match self.lane_type() {
-            B1 | B8 => I8,
-            B16 => I16,
-            B32 => I32,
-            B64 => I64,
-            B128 => I128,
+            I8 | B1 | B8 => I8,
+            I16 | B16 => I16,
+            I32 | B32 => I32,
+            I64 | B64 => I64,
+            I128 | B128 => I128,
             _ => unimplemented!(),
         })
     }

--- a/cranelift/filetests/filetests/runtests/i128-icmp.clif
+++ b/cranelift/filetests/filetests/runtests/i128-icmp.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target aarch64
 target x86_64 machinst
@@ -186,7 +187,7 @@ block0(v0: i64,v1: i64,v2: i64,v3: i64):
 
 
 ; Icmp Imm Tests
-function %test_icmp_imm_eq_i128() -> b1 {
+function %icmp_imm_eq_i128() -> b1 {
 block0:
     v11 = iconst.i64 0x0
     v12 = iconst.i64 0x0
@@ -195,9 +196,9 @@ block0:
     return v10
 }
 
-; run
+; run: %icmp_imm_eq_i128() == true
 
-function %test_icmp_imm_ne_i128() -> b1 {
+function %icmp_imm_ne_i128() -> b1 {
 block0:
     v11 = iconst.i64 0x0
     v12 = iconst.i64 0x0
@@ -206,4 +207,4 @@ block0:
     return v10
 }
 
-; run
+; run: %icmp_imm_ne_i128() == true

--- a/cranelift/filetests/filetests/runtests/icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-eq.clif
@@ -1,0 +1,40 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+function %icmp_eq_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %icmp_eq_i8(0, 0) == true
+; run: %icmp_eq_i8(1, 0) == false
+; run: %icmp_eq_i8(-1, -1) == true
+
+function %icmp_eq_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %icmp_eq_i16(0, 0) == true
+; run: %icmp_eq_i16(1, 0) == false
+; run: %icmp_eq_i16(-1, -1) == true
+
+function %icmp_eq_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %icmp_eq_i32(0, 0) == true
+; run: %icmp_eq_i32(1, 0) == false
+; run: %icmp_eq_i32(-1, -1) == true
+
+function %icmp_eq_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %icmp_eq_i64(0, 0) == true
+; run: %icmp_eq_i64(1, 0) == false
+; run: %icmp_eq_i64(-1, -1) == true

--- a/cranelift/filetests/filetests/runtests/icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ne.clif
@@ -1,0 +1,40 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+function %icmp_ne_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %icmp_ne_i8(0, 0) == false
+; run: %icmp_ne_i8(1, 0) == true
+; run: %icmp_ne_i8(-1, -1) == false
+
+function %icmp_ne_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %icmp_ne_i16(0, 0) == false
+; run: %icmp_ne_i16(1, 0) == true
+; run: %icmp_ne_i16(-1, -1) == false
+
+function %icmp_ne_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %icmp_ne_i32(0, 0) == false
+; run: %icmp_ne_i32(1, 0) == true
+; run: %icmp_ne_i32(-1, -1) == false
+
+function %icmp_ne_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %icmp_ne_i64(0, 0) == false
+; run: %icmp_ne_i64(1, 0) == true
+; run: %icmp_ne_i64(-1, -1) == false

--- a/cranelift/filetests/filetests/runtests/icmp-nof.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-nof.clif
@@ -1,0 +1,75 @@
+test interpret
+test run
+target x86_64 machinst
+
+function %icmp_nof_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %icmp_nof_i8(0, 0) == true
+; run: %icmp_nof_i8(0, 1) == true
+; run: %icmp_nof_i8(1, 0) == true
+; run: %icmp_nof_i8(0, -1) == true
+; run: %icmp_nof_i8(0x80, 0x80) == true
+; run: %icmp_nof_i8(0x7F, 1) == true
+; run: %icmp_nof_i8(0x7F, 0x7F) == true
+; run: %icmp_nof_i8(0xFF, 1) == true
+; run: %icmp_nof_i8(0x80, 1) == false
+; run: %icmp_nof_i8(0x7F, 0x80) == false
+; run: %icmp_nof_i8(0x80, 0x7F) == false
+; run: %icmp_nof_i8(0x7F, 0xFF) == false
+
+function %icmp_nof_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %icmp_nof_i16(0, 0) == true
+; run: %icmp_nof_i16(0, 1) == true
+; run: %icmp_nof_i16(1, 0) == true
+; run: %icmp_nof_i16(0, -1) == true
+; run: %icmp_nof_i16(0x8000, 0x8000) == true
+; run: %icmp_nof_i16(0x7FFF, 1) == true
+; run: %icmp_nof_i16(0x7FFF, 0x7FFF) == true
+; run: %icmp_nof_i16(0xFFFF, 1) == true
+; run: %icmp_nof_i16(0x8000, 1) == false
+; run: %icmp_nof_i16(0x7FFF, 0x8000) == false
+; run: %icmp_nof_i16(0x8000, 0x7FFF) == false
+; run: %icmp_nof_i16(0x7FFF, 0xFFFF) == false
+
+function %icmp_nof_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %icmp_nof_i32(0, 0) == true
+; run: %icmp_nof_i32(0, 1) == true
+; run: %icmp_nof_i32(1, 0) == true
+; run: %icmp_nof_i32(0, -1) == true
+; run: %icmp_nof_i32(0x80000000, 0x80000000) == true
+; run: %icmp_nof_i32(0x7FFFFFFF, 1) == true
+; run: %icmp_nof_i32(0x7FFFFFFF, 0x7FFFFFFF) == true
+; run: %icmp_nof_i32(0xFFFFFFFF, 1) == true
+; run: %icmp_nof_i32(0x80000000, 1) == false
+; run: %icmp_nof_i32(0x7FFFFFFF, 0x80000000) == false
+; run: %icmp_nof_i32(0x80000000, 0x7FFFFFFF) == false
+; run: %icmp_nof_i32(0x7FFFFFFF, 0xFFFFFFFF) == false
+
+function %icmp_nof_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %icmp_nof_i64(0, 0) == true
+; run: %icmp_nof_i64(0, 1) == true
+; run: %icmp_nof_i64(1, 0) == true
+; run: %icmp_nof_i64(0, -1) == true
+; run: %icmp_nof_i64(0x80000000_00000000, 0x80000000_00000000) == true
+; run: %icmp_nof_i64(0x7FFFFFFF_FFFFFFFF, 1) == true
+; run: %icmp_nof_i64(0x7FFFFFFF_FFFFFFFF, 0x7FFFFFFF_FFFFFFFF) == true
+; run: %icmp_nof_i64(0xFFFFFFFF_FFFFFFFF, 1) == true
+; run: %icmp_nof_i64(0x80000000_00000000, 1) == false
+; run: %icmp_nof_i64(0x7FFFFFFF_FFFFFFFF, 0x80000000_00000000) == false
+; run: %icmp_nof_i64(0x80000000_00000000, 0x7FFFFFFF_FFFFFFFF) == false
+; run: %icmp_nof_i64(0x7FFFFFFF_FFFFFFFF, 0xFFFFFFFF_FFFFFFFF) == false

--- a/cranelift/filetests/filetests/runtests/icmp-of.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-of.clif
@@ -1,0 +1,75 @@
+test interpret
+test run
+target x86_64 machinst
+
+function %icmp_of_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %icmp_of_i8(0, 0) == false
+; run: %icmp_of_i8(0, 1) == false
+; run: %icmp_of_i8(1, 0) == false
+; run: %icmp_of_i8(0, -1) == false
+; run: %icmp_of_i8(0x80, 0x80) == false
+; run: %icmp_of_i8(0x7F, 1) == false
+; run: %icmp_of_i8(0x7F, 0x7F) == false
+; run: %icmp_of_i8(0xFF, 1) == false
+; run: %icmp_of_i8(0x80, 1) == true
+; run: %icmp_of_i8(0x7F, 0x80) == true
+; run: %icmp_of_i8(0x80, 0x7F) == true
+; run: %icmp_of_i8(0x7F, 0xFF) == true
+
+function %icmp_of_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %icmp_of_i16(0, 0) == false
+; run: %icmp_of_i16(0, 1) == false
+; run: %icmp_of_i16(1, 0) == false
+; run: %icmp_of_i16(0, -1) == false
+; run: %icmp_of_i16(0x8000, 0x8000) == false
+; run: %icmp_of_i16(0x7FFF, 1) == false
+; run: %icmp_of_i16(0x7FFF, 0x7FFF) == false
+; run: %icmp_of_i16(0xFFFF, 1) == false
+; run: %icmp_of_i16(0x8000, 1) == true
+; run: %icmp_of_i16(0x7FFF, 0x8000) == true
+; run: %icmp_of_i16(0x8000, 0x7FFF) == true
+; run: %icmp_of_i16(0x7FFF, 0xFFFF) == true
+
+function %icmp_of_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %icmp_of_i32(0, 0) == false
+; run: %icmp_of_i32(0, 1) == false
+; run: %icmp_of_i32(1, 0) == false
+; run: %icmp_of_i32(0, -1) == false
+; run: %icmp_of_i32(0x80000000, 0x80000000) == false
+; run: %icmp_of_i32(0x7FFFFFFF, 1) == false
+; run: %icmp_of_i32(0x7FFFFFFF, 0x7FFFFFFF) == false
+; run: %icmp_of_i32(0xFFFFFFFF, 1) == false
+; run: %icmp_of_i32(0x80000000, 1) == true
+; run: %icmp_of_i32(0x7FFFFFFF, 0x80000000) == true
+; run: %icmp_of_i32(0x80000000, 0x7FFFFFFF) == true
+; run: %icmp_of_i32(0x7FFFFFFF, 0xFFFFFFFF) == true
+
+function %icmp_of_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %icmp_of_i64(0, 0) == false
+; run: %icmp_of_i64(0, 1) == false
+; run: %icmp_of_i64(1, 0) == false
+; run: %icmp_of_i64(0, -1) == false
+; run: %icmp_of_i64(0x80000000_00000000, 0x80000000_00000000) == false
+; run: %icmp_of_i64(0x7FFFFFFF_FFFFFFFF, 1) == false
+; run: %icmp_of_i64(0x7FFFFFFF_FFFFFFFF, 0x7FFFFFFF_FFFFFFFF) == false
+; run: %icmp_of_i64(0xFFFFFFFF_FFFFFFFF, 1) == false
+; run: %icmp_of_i64(0x80000000_00000000, 1) == true
+; run: %icmp_of_i64(0x7FFFFFFF_FFFFFFFF, 0x80000000_00000000) == true
+; run: %icmp_of_i64(0x80000000_00000000, 0x7FFFFFFF_FFFFFFFF) == true
+; run: %icmp_of_i64(0x7FFFFFFF_FFFFFFFF, 0xFFFFFFFF_FFFFFFFF) == true

--- a/cranelift/filetests/filetests/runtests/icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sge.clif
@@ -1,0 +1,53 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+
+function %icmp_sge_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %icmp_sge_i8(0, 0) == true
+; run: %icmp_sge_i8(1, 0) == true
+; run: %icmp_sge_i8(-1, -1) == true
+; run: %icmp_sge_i8(0, 1) == false
+; run: %icmp_sge_i8(-5, -1) == false
+; run: %icmp_sge_i8(1, -1) == true
+
+function %icmp_sge_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %icmp_sge_i16(0, 0) == true
+; run: %icmp_sge_i16(1, 0) == true
+; run: %icmp_sge_i16(-1, -1) == true
+; run: %icmp_sge_i16(0, 1) == false
+; run: %icmp_sge_i16(-5, -1) == false
+; run: %icmp_sge_i16(1, -1) == true
+
+function %icmp_sge_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %icmp_sge_i32(0, 0) == true
+; run: %icmp_sge_i32(1, 0) == true
+; run: %icmp_sge_i32(-1, -1) == true
+; run: %icmp_sge_i32(0, 1) == false
+; run: %icmp_sge_i32(-5, -1) == false
+; run: %icmp_sge_i32(1, -1) == true
+
+function %icmp_sge_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %icmp_sge_i64(0, 0) == true
+; run: %icmp_sge_i64(1, 0) == true
+; run: %icmp_sge_i64(-1, -1) == true
+; run: %icmp_sge_i64(0, 1) == false
+; run: %icmp_sge_i64(-5, -1) == false
+; run: %icmp_sge_i64(1, -1) == true

--- a/cranelift/filetests/filetests/runtests/icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sgt.clif
@@ -1,0 +1,53 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+
+function %icmp_sgt_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %icmp_sgt_i8(0, 0) == false
+; run: %icmp_sgt_i8(1, 0) == true
+; run: %icmp_sgt_i8(-1, -1) == false
+; run: %icmp_sgt_i8(0, 1) == false
+; run: %icmp_sgt_i8(-5, -1) == false
+; run: %icmp_sgt_i8(1, -1) == true
+
+function %icmp_sgt_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %icmp_sgt_i16(0, 0) == false
+; run: %icmp_sgt_i16(1, 0) == true
+; run: %icmp_sgt_i16(-1, -1) == false
+; run: %icmp_sgt_i16(0, 1) == false
+; run: %icmp_sgt_i16(-5, -1) == false
+; run: %icmp_sgt_i16(1, -1) == true
+
+function %icmp_sgt_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %icmp_sgt_i32(0, 0) == false
+; run: %icmp_sgt_i32(1, 0) == true
+; run: %icmp_sgt_i32(-1, -1) == false
+; run: %icmp_sgt_i32(0, 1) == false
+; run: %icmp_sgt_i32(-5, -1) == false
+; run: %icmp_sgt_i32(1, -1) == true
+
+function %icmp_sgt_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %icmp_sgt_i64(0, 0) == false
+; run: %icmp_sgt_i64(1, 0) == true
+; run: %icmp_sgt_i64(-1, -1) == false
+; run: %icmp_sgt_i64(0, 1) == false
+; run: %icmp_sgt_i64(-5, -1) == false
+; run: %icmp_sgt_i64(1, -1) == true

--- a/cranelift/filetests/filetests/runtests/icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sle.clif
@@ -1,0 +1,53 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+
+function %icmp_sle_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %icmp_sle_i8(0, 0) == true
+; run: %icmp_sle_i8(1, 0) == false
+; run: %icmp_sle_i8(-1, -1) == true
+; run: %icmp_sle_i8(0, 1) == true
+; run: %icmp_sle_i8(-5, -1) == true
+; run: %icmp_sle_i8(1, -1) == false
+
+function %icmp_sle_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %icmp_sle_i16(0, 0) == true
+; run: %icmp_sle_i16(1, 0) == false
+; run: %icmp_sle_i16(-1, -1) == true
+; run: %icmp_sle_i16(0, 1) == true
+; run: %icmp_sle_i16(-5, -1) == true
+; run: %icmp_sle_i16(1, -1) == false
+
+function %icmp_sle_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %icmp_sle_i32(0, 0) == true
+; run: %icmp_sle_i32(1, 0) == false
+; run: %icmp_sle_i32(-1, -1) == true
+; run: %icmp_sle_i32(0, 1) == true
+; run: %icmp_sle_i32(-5, -1) == true
+; run: %icmp_sle_i32(1, -1) == false
+
+function %icmp_sle_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %icmp_sle_i64(0, 0) == true
+; run: %icmp_sle_i64(1, 0) == false
+; run: %icmp_sle_i64(-1, -1) == true
+; run: %icmp_sle_i64(0, 1) == true
+; run: %icmp_sle_i64(-5, -1) == true
+; run: %icmp_sle_i64(1, -1) == false

--- a/cranelift/filetests/filetests/runtests/icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-slt.clif
@@ -1,0 +1,52 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+function %icmp_slt_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %icmp_slt_i8(0, 0) == false
+; run: %icmp_slt_i8(1, 0) == false
+; run: %icmp_slt_i8(-1, -1) == false
+; run: %icmp_slt_i8(0, 1) == true
+; run: %icmp_slt_i8(-5, -1) == true
+; run: %icmp_slt_i8(1, -1) == false
+
+function %icmp_slt_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %icmp_slt_i16(0, 0) == false
+; run: %icmp_slt_i16(1, 0) == false
+; run: %icmp_slt_i16(-1, -1) == false
+; run: %icmp_slt_i16(0, 1) == true
+; run: %icmp_slt_i16(-5, -1) == true
+; run: %icmp_slt_i16(1, -1) == false
+
+function %icmp_slt_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %icmp_slt_i32(0, 0) == false
+; run: %icmp_slt_i32(1, 0) == false
+; run: %icmp_slt_i32(-1, -1) == false
+; run: %icmp_slt_i32(0, 1) == true
+; run: %icmp_slt_i32(-5, -1) == true
+; run: %icmp_slt_i32(1, -1) == false
+
+function %icmp_slt_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %icmp_slt_i64(0, 0) == false
+; run: %icmp_slt_i64(1, 0) == false
+; run: %icmp_slt_i64(-1, -1) == false
+; run: %icmp_slt_i64(0, 1) == true
+; run: %icmp_slt_i64(-5, -1) == true
+; run: %icmp_slt_i64(1, -1) == false

--- a/cranelift/filetests/filetests/runtests/icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-uge.clif
@@ -1,0 +1,52 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+function %icmp_uge_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %icmp_uge_i8(0, 0) == true
+; run: %icmp_uge_i8(1, 0) == true
+; run: %icmp_uge_i8(-1, -1) == true
+; run: %icmp_uge_i8(0, 1) == false
+; run: %icmp_uge_i8(-5, -1) == false
+; run: %icmp_uge_i8(1, -1) == false
+
+function %icmp_uge_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %icmp_uge_i16(0, 0) == true
+; run: %icmp_uge_i16(1, 0) == true
+; run: %icmp_uge_i16(-1, -1) == true
+; run: %icmp_uge_i16(0, 1) == false
+; run: %icmp_uge_i16(-5, -1) == false
+; run: %icmp_uge_i16(1, -1) == false
+
+function %icmp_uge_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %icmp_uge_i32(0, 0) == true
+; run: %icmp_uge_i32(1, 0) == true
+; run: %icmp_uge_i32(-1, -1) == true
+; run: %icmp_uge_i32(0, 1) == false
+; run: %icmp_uge_i32(-5, -1) == false
+; run: %icmp_uge_i32(1, -1) == false
+
+function %icmp_uge_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %icmp_uge_i64(0, 0) == true
+; run: %icmp_uge_i64(1, 0) == true
+; run: %icmp_uge_i64(-1, -1) == true
+; run: %icmp_uge_i64(0, 1) == false
+; run: %icmp_uge_i64(-5, -1) == false
+; run: %icmp_uge_i64(1, -1) == false

--- a/cranelift/filetests/filetests/runtests/icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ugt.clif
@@ -1,0 +1,52 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+function %icmp_ugt_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %icmp_ugt_i8(0, 0) == false
+; run: %icmp_ugt_i8(1, 0) == true
+; run: %icmp_ugt_i8(-1, -1) == false
+; run: %icmp_ugt_i8(0, 1) == false
+; run: %icmp_ugt_i8(-5, -1) == false
+; run: %icmp_ugt_i8(1, -1) == false
+
+function %icmp_ugt_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %icmp_ugt_i16(0, 0) == false
+; run: %icmp_ugt_i16(1, 0) == true
+; run: %icmp_ugt_i16(-1, -1) == false
+; run: %icmp_ugt_i16(0, 1) == false
+; run: %icmp_ugt_i16(-5, -1) == false
+; run: %icmp_ugt_i16(1, -1) == false
+
+function %icmp_ugt_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %icmp_ugt_i32(0, 0) == false
+; run: %icmp_ugt_i32(1, 0) == true
+; run: %icmp_ugt_i32(-1, -1) == false
+; run: %icmp_ugt_i32(0, 1) == false
+; run: %icmp_ugt_i32(-5, -1) == false
+; run: %icmp_ugt_i32(1, -1) == false
+
+function %icmp_ugt_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %icmp_ugt_i64(0, 0) == false
+; run: %icmp_ugt_i64(1, 0) == true
+; run: %icmp_ugt_i64(-1, -1) == false
+; run: %icmp_ugt_i64(0, 1) == false
+; run: %icmp_ugt_i64(-5, -1) == false
+; run: %icmp_ugt_i64(1, -1) == false

--- a/cranelift/filetests/filetests/runtests/icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ule.clif
@@ -1,0 +1,52 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+function %icmp_ule_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %icmp_ule_i8(0, 0) == true
+; run: %icmp_ule_i8(1, 0) == false
+; run: %icmp_ule_i8(-1, -1) == true
+; run: %icmp_ule_i8(0, 1) == true
+; run: %icmp_ule_i8(-5, -1) == true
+; run: %icmp_ule_i8(1, -1) == true
+
+function %icmp_ule_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %icmp_ule_i16(0, 0) == true
+; run: %icmp_ule_i16(1, 0) == false
+; run: %icmp_ule_i16(-1, -1) == true
+; run: %icmp_ule_i16(0, 1) == true
+; run: %icmp_ule_i16(-5, -1) == true
+; run: %icmp_ule_i16(1, -1) == true
+
+function %icmp_ule_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %icmp_ule_i32(0, 0) == true
+; run: %icmp_ule_i32(1, 0) == false
+; run: %icmp_ule_i32(-1, -1) == true
+; run: %icmp_ule_i32(0, 1) == true
+; run: %icmp_ule_i32(-5, -1) == true
+; run: %icmp_ule_i32(1, -1) == true
+
+function %icmp_ule_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %icmp_ule_i64(0, 0) == true
+; run: %icmp_ule_i64(1, 0) == false
+; run: %icmp_ule_i64(-1, -1) == true
+; run: %icmp_ule_i64(0, 1) == true
+; run: %icmp_ule_i64(-5, -1) == true
+; run: %icmp_ule_i64(1, -1) == true

--- a/cranelift/filetests/filetests/runtests/icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ult.clif
@@ -1,0 +1,52 @@
+test interpret
+test run
+target aarch64
+target x86_64 machinst
+
+function %icmp_ult_i8(i8, i8) -> b1 {
+block0(v0: i8, v1: i8):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %icmp_ult_i8(0, 0) == false
+; run: %icmp_ult_i8(1, 0) == false
+; run: %icmp_ult_i8(-1, -1) == false
+; run: %icmp_ult_i8(0, 1) == true
+; run: %icmp_ult_i8(-5, -1) == true
+; run: %icmp_ult_i8(1, -1) == true
+
+function %icmp_ult_i16(i16, i16) -> b1 {
+block0(v0: i16, v1: i16):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %icmp_ult_i16(0, 0) == false
+; run: %icmp_ult_i16(1, 0) == false
+; run: %icmp_ult_i16(-1, -1) == false
+; run: %icmp_ult_i16(0, 1) == true
+; run: %icmp_ult_i16(-5, -1) == true
+; run: %icmp_ult_i16(1, -1) == true
+
+function %icmp_ult_i32(i32, i32) -> b1 {
+block0(v0: i32, v1: i32):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %icmp_ult_i32(0, 0) == false
+; run: %icmp_ult_i32(1, 0) == false
+; run: %icmp_ult_i32(-1, -1) == false
+; run: %icmp_ult_i32(0, 1) == true
+; run: %icmp_ult_i32(-5, -1) == true
+; run: %icmp_ult_i32(1, -1) == true
+
+function %icmp_ult_i64(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %icmp_ult_i64(0, 0) == false
+; run: %icmp_ult_i64(1, 0) == false
+; run: %icmp_ult_i64(-1, -1) == false
+; run: %icmp_ult_i64(0, 1) == true
+; run: %icmp_ult_i64(-5, -1) == true
+; run: %icmp_ult_i64(1, -1) == true

--- a/cranelift/filetests/filetests/runtests/icmp.clif
+++ b/cranelift/filetests/filetests/runtests/icmp.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target aarch64
 target s390x
@@ -13,5 +14,5 @@ block0(v0: i8):
     v2 = icmp sge v0, v1
     return v2
 }
-; run: %test(49) == true
-; run: %test(-65) == false
+; run: %overflow_rhs_con(49) == true
+; run: %overflow_rhs_con(-65) == false

--- a/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
@@ -1,0 +1,30 @@
+test interpret
+
+function %simd_icmp_eq_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %simd_icmp_eq_i8([1 0 -1 1 1 1 1 1 1 1 1 1 1 1 1 1], [1 0 -1 0 0 0 0 0 0 0 0 0 0 0 0 0]) == [true true true false false false false false false false false false false false false false]
+
+function %simd_icmp_eq_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %simd_icmp_eq_i16([1 0 -1 1 1 1 1 1], [1 0 -1 0 0 0 0 0]) == [true true true false false false false false]
+
+function %simd_icmp_eq_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %simd_icmp_eq_i32([1 0 -1 1], [1 0 -1 0]) == [true true true false]
+
+function %simd_icmp_eq_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp eq v0, v1
+    return v2
+}
+; run: %simd_icmp_eq_i64([10 0], [1 0]) == [false true]
+; run: %simd_icmp_eq_i64([-1 1], [-1 0]) == [true false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
@@ -1,0 +1,30 @@
+test interpret
+
+function %simd_icmp_ne_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %simd_icmp_ne_i8([1 0 -1 1 1 1 1 1 1 1 1 1 1 1 1 1], [1 0 -1 0 0 0 0 0 0 0 0 0 0 0 0 0]) == [false false false true true true true true true true true true true true true true]
+
+function %simd_icmp_ne_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %simd_icmp_ne_i16([1 0 -1 1 1 1 1 1], [1 0 -1 0 0 0 0 0]) == [false false false true true true true true]
+
+function %simd_icmp_ne_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %simd_icmp_ne_i32([1 0 -1 1], [1 0 -1 0]) == [false false false true]
+
+function %simd_icmp_ne_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp ne v0, v1
+    return v2
+}
+; run: %simd_icmp_ne_i64([10 0], [1 0]) == [true false]
+; run: %simd_icmp_ne_i64([-1 1], [-1 0]) == [false true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-nof.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-nof.clif
@@ -1,0 +1,45 @@
+test interpret
+
+function %simd_icmp_nof_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %simd_icmp_nof_i8([0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0], [0 1 0 0xFF 0 0 0 0 0 0 0 0 0 0 0 0]) == [true true true true true true true true true true true true true true true true]
+; run: %simd_icmp_nof_i8([0x80 0x7F 0x7F 0xFF 0 0 0 0 0 0 0 0 0 0 0 0], [0x80 0x01 0x7F 0x01 0 0 0 0 0 0 0 0 0 0 0 0]) == [true true true true true true true true true true true true true true true true]
+; run: %simd_icmp_nof_i8([0x80 0x7F 0x80 0x7F 0 0 0 0 0 0 0 0 0 0 0 0], [0x01 0x80 0x7F 0xFF 0 0 0 0 0 0 0 0 0 0 0 0]) == [false false false false true true true true true true true true true true true true]
+; run: %simd_icmp_nof_i8([0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F], [0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF]) == [false false false false false false false false false false false false false false false false]
+
+
+function %simd_icmp_nof_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %simd_icmp_nof_i1([0 0 1 0 0 0 0 0], [0 1 0 0xFFFF 0 0 0 0]) == [true true true true true true true true]
+; run: %simd_icmp_nof_i1([0x8000 0x7FFF 0x7FFF 0xFFFF 0 0 0 0], [0x8000 0x0001 0x7FFF 0x0001 0 0 0 0]) == [true true true true true true true true]
+; run: %simd_icmp_nof_i1([0x8000 0x7FFF 0x8000 0x7FFF 0 0 0 0], [0x0001 0x8000 0x7FFF 0xFFFF 0 0 0 0]) == [false false false false true true true true]
+; run: %simd_icmp_nof_i1([0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF], [0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF]) == [false false false false false false false false]
+
+
+function %simd_icmp_nof_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %simd_icmp_nof_i3([0 0 1 0], [0 1 0 0xFFFFFFFF]) == [true true true true]
+; run: %simd_icmp_nof_i3([0x80000000 0x7FFFFFFF 0x7FFFFFFF 0xFFFFFFFF], [0x80000000 0x00000001 0x7FFFFFFF 0x00000001]) == [true true true true]
+; run: %simd_icmp_nof_i3([0x80000000 0x7FFFFFFF 0x80000000 0x7FFFFFFF], [0x00000001 0x80000000 0x7FFFFFFF 0xFFFFFFFF]) == [false false false false]
+; run: %simd_icmp_nof_i3([0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF], [0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF]) == [false false false false]
+
+function %simd_icmp_nof_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp nof v0, v1
+    return v2
+}
+; run: %simd_icmp_nof_i6([0 0], [0 1]) == [true true]
+; run: %simd_icmp_nof_i6([1 0], [0 0xFFFFFFFF_FFFFFFFF]) == [true true]
+; run: %simd_icmp_nof_i6([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x80000000_00000000 0x00000000_00000001]) == [true true]
+; run: %simd_icmp_nof_i6([0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0x00000000_00000001]) == [true true]
+; run: %simd_icmp_nof_i6([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x01 0x80000000_00000000]) == [false false]
+; run: %simd_icmp_nof_i6([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-of.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-of.clif
@@ -1,0 +1,45 @@
+test interpret
+
+function %simd_icmp_of_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %simd_icmp_of_i8([0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0], [0 1 0 0xFF 0 0 0 0 0 0 0 0 0 0 0 0]) == [false false false false false false false false false false false false false false false false]
+; run: %simd_icmp_of_i8([0x80 0x7F 0x7F 0xFF 0 0 0 0 0 0 0 0 0 0 0 0], [0x80 0x01 0x7F 0x01 0 0 0 0 0 0 0 0 0 0 0 0]) == [false false false false false false false false false false false false false false false false]
+; run: %simd_icmp_of_i8([0x80 0x7F 0x80 0x7F 0 0 0 0 0 0 0 0 0 0 0 0], [0x01 0x80 0x7F 0xFF 0 0 0 0 0 0 0 0 0 0 0 0]) == [true true true true false false false false false false false false false false false false]
+; run: %simd_icmp_of_i8([0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F 0x7F], [0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF]) == [true true true true true true true true true true true true true true true true]
+
+
+function %simd_icmp_of_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %simd_icmp_of_i16([0 0 1 0 0 0 0 0], [0 1 0 0xFFFF 0 0 0 0]) == [false false false false false false false false]
+; run: %simd_icmp_of_i16([0x8000 0x7FFF 0x7FFF 0xFFFF 0 0 0 0], [0x8000 0x0001 0x7FFF 0x0001 0 0 0 0]) == [false false false false false false false false]
+; run: %simd_icmp_of_i16([0x8000 0x7FFF 0x8000 0x7FFF 0 0 0 0], [0x0001 0x8000 0x7FFF 0xFFFF 0 0 0 0]) == [true true true true false false false false]
+; run: %simd_icmp_of_i16([0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF], [0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF]) == [true true true true true true true true]
+
+
+function %simd_icmp_of_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %simd_icmp_of_i32([0 0 1 0], [0 1 0 0xFFFFFFFF]) == [false false false false]
+; run: %simd_icmp_of_i32([0x80000000 0x7FFFFFFF 0x7FFFFFFF 0xFFFFFFFF], [0x80000000 0x00000001 0x7FFFFFFF 0x00000001]) == [false false false false]
+; run: %simd_icmp_of_i32([0x80000000 0x7FFFFFFF 0x80000000 0x7FFFFFFF], [0x00000001 0x80000000 0x7FFFFFFF 0xFFFFFFFF]) == [true true true true]
+; run: %simd_icmp_of_i32([0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF], [0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF]) == [true true true true]
+
+function %simd_icmp_of_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp of v0, v1
+    return v2
+}
+; run: %simd_icmp_of_i64([0 0], [0 1]) == [false false]
+; run: %simd_icmp_of_i64([1 0], [0 0xFFFFFFFF_FFFFFFFF]) == [false false]
+; run: %simd_icmp_of_i64([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x80000000_00000000 0x00000000_00000001]) == [false false]
+; run: %simd_icmp_of_i64([0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0x00000000_00000001]) == [false false]
+; run: %simd_icmp_of_i64([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x01 0x80000000_00000000]) == [true true]
+; run: %simd_icmp_of_i64([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -1,0 +1,33 @@
+test interpret
+
+function %simd_icmp_sge_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %simd_icmp_sge_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 1 0 0 0 0 0 0 0 0 0 0]) == [true true true false false true true true true true true true true true true true]
+
+function %simd_icmp_sge_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %simd_icmp_sge_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 1 0 0]) == [true true true false false true true true]
+
+function %simd_icmp_sge_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %simd_icmp_sge_i3([0 1 -1 0], [0 0 -1 1]) == [true true true false]
+; run: %simd_icmp_sge_i3([-5 1 0 0], [-1 1 0 0]) == [false true true true]
+
+function %simd_icmp_sge_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp sge v0, v1
+    return v2
+}
+; run: %simd_icmp_sge_i6([0 1], [0 0]) == [true true]
+; run: %simd_icmp_sge_i6([-1 0], [-1 1]) == [true false]
+; run: %simd_icmp_sge_i6([-5 1], [-1 1]) == [false true]
+; run: %simd_icmp_sge_i6([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -1,0 +1,35 @@
+test interpret
+
+function %simd_icmp_sgt_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %simd_icmp_sgt_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 0]) == [false true false false false true false false false false false false false false false false]
+
+function %simd_icmp_sgt_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %simd_icmp_sgt_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false true false false false true false false]
+
+
+function %simd_icmp_sgt_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %simd_icmp_sgt_i3([0 1 -1 0], [0 0 -1 1]) == [false true false false]
+; run: %simd_icmp_sgt_i3([-5 1 0 0], [-1 -1 0 0]) == [false true false false]
+
+
+function %simd_icmp_sgt_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp sgt v0, v1
+    return v2
+}
+; run: %simd_icmp_sgt_i6([0 1], [0 0 ]) == [false true]
+; run: %simd_icmp_sgt_i6([-1 0], [-1 1]) == [false false]
+; run: %simd_icmp_sgt_i6([-5 1], [-1 -1]) == [false true]
+; run: %simd_icmp_sgt_i6([0 0], [0 0]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -1,0 +1,35 @@
+test interpret
+
+function %simd_icmp_sle_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %simd_icmp_sle_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 0]) == [true false true true true false true true true true true true true true true true]
+
+function %simd_icmp_sle_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %simd_icmp_sle_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true false true true true false true true]
+
+
+function %simd_icmp_sle_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %simd_icmp_sle_i3([0 1 -1 0], [0 0 -1 1]) == [true false true true]
+; run: %simd_icmp_sle_i3([-5 1 0 0], [-1 -1 0 0]) == [true false true true]
+
+
+function %simd_icmp_sle_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp sle v0, v1
+    return v2
+}
+; run: %simd_icmp_sle_i6([0 1], [0 0 ]) == [true false]
+; run: %simd_icmp_sle_i6([-1 0], [-1 1]) == [true true]
+; run: %simd_icmp_sle_i6([-5 1], [-1 -1]) == [true false]
+; run: %simd_icmp_sle_i6([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -1,0 +1,33 @@
+test interpret
+
+function %simd_icmp_slt_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %simd_icmp_slt_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 1 0 0 0 0 0 0 0 0 0 0]) == [false false false true true false false false false false false false false false false false]
+
+function %simd_icmp_slt_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %simd_icmp_slt_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 1 0 0]) == [false false false true true false false false]
+
+function %simd_icmp_slt_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %simd_icmp_slt_i3([0 1 -1 0], [0 0 -1 1]) == [false false false true]
+; run: %simd_icmp_slt_i3([-5 1 0 0], [-1 1 0 0]) == [true false false false]
+
+function %simd_icmp_slt_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp slt v0, v1
+    return v2
+}
+; run: %simd_icmp_slt_i6([0 1], [0 0]) == [false false]
+; run: %simd_icmp_slt_i6([-1 0], [-1 1]) == [false true]
+; run: %simd_icmp_slt_i6([-5 1], [-1 1]) == [true false]
+; run: %simd_icmp_slt_i6([0 0], [0 0]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -1,0 +1,33 @@
+test interpret
+
+function %simd_icmp_uge_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %simd_icmp_uge_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 0]) == [true true true false false false true true true true true true true true true true]
+
+function %simd_icmp_uge_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %simd_icmp_uge_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true true true false false false true true]
+
+function %simd_icmp_uge_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %simd_icmp_uge_i3([0 1 -1 0], [0 0 -1 1]) == [true true true false]
+; run: %simd_icmp_uge_i3([-5 1 0 0], [-1 -1 0 0]) == [false false true true]
+
+function %simd_icmp_uge_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %simd_icmp_uge_i6([0 1], [0 0]) == [true true]
+; run: %simd_icmp_uge_i6([-1 0], [-1 1]) == [true false]
+; run: %simd_icmp_uge_i6([-5 1], [-1 -1]) == [false false]
+; run: %simd_icmp_uge_i6([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -1,0 +1,33 @@
+test interpret
+
+function %simd_icmp_ugt_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %simd_icmp_ugt_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 0]) == [false true false false false false false false false false false false false false false false]
+
+function %simd_icmp_ugt_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %simd_icmp_ugt_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false true false false false false false false]
+
+function %simd_icmp_ugt_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %simd_icmp_ugt_i3([0 1 -1 0], [0 0 -1 1]) == [false true false false]
+; run: %simd_icmp_ugt_i3([-5 1 0 0], [-1 -1 0 0]) == [false false false false]
+
+function %simd_icmp_ugt_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp ugt v0, v1
+    return v2
+}
+; run: %simd_icmp_ugt_i6([0 1], [0 0]) == [false true]
+; run: %simd_icmp_ugt_i6([-1 0], [-1 1]) == [false false]
+; run: %simd_icmp_ugt_i6([-5 1], [-1 -1]) == [false false]
+; run: %simd_icmp_ugt_i6([0 0], [0 0]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -1,0 +1,33 @@
+test interpret
+
+function %simd_icmp_ule_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %simd_icmp_ule_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 0]) == [true false true true true true true true true true true true true true true true]
+
+function %simd_icmp_ule_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %simd_icmp_ule_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true false true true true true true true]
+
+function %simd_icmp_ule_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %simd_icmp_ule_i3([0 1 -1 0], [0 0 -1 1]) == [true false true true]
+; run: %simd_icmp_ule_i3([-5 1 0 0], [-1 -1 0 0]) == [true true true true]
+
+function %simd_icmp_ule_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp ule v0, v1
+    return v2
+}
+; run: %simd_icmp_ule_i6([0 1], [0 0]) == [true false]
+; run: %simd_icmp_ule_i6([-1 0], [-1 1]) == [true true]
+; run: %simd_icmp_ule_i6([-5 1], [-1 -1]) == [true true]
+; run: %simd_icmp_ule_i6([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -1,0 +1,33 @@
+test interpret
+
+function %simd_icmp_ult_i8(i8x16, i8x16) -> b8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %simd_icmp_ult_i8([0 1 -1 0 -5 1 0 0 0 0 0 0 0 0 0 0], [0 0 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 0]) == [false false false true true true false false false false false false false false false false]
+
+function %simd_icmp_ult_i16(i16x8, i16x8) -> b16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %simd_icmp_ult_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false false false true true true false false]
+
+function %simd_icmp_ult_i32(i32x4, i32x4) -> b32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %simd_icmp_ult_i3([0 1 -1 0], [0 0 -1 1]) == [false false false true]
+; run: %simd_icmp_ult_i3([-5 1 0 0], [-1 -1 0 0]) == [true true false false]
+
+function %simd_icmp_ult_i64(i64x2, i64x2) -> b64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %simd_icmp_ult_i6([0 1], [0 0]) == [false false]
+; run: %simd_icmp_ult_i6([-1 0], [-1 1]) == [false true]
+; run: %simd_icmp_ult_i6([-5 1], [-1 -1]) == [true true]
+; run: %simd_icmp_ult_i6([0 0], [0 0]) == [false false]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -983,7 +983,7 @@ pub enum CraneliftTrap {
 }
 
 /// Compare two values using the given integer condition `code`.
-fn icmp<V>(_ty: types::Type, code: IntCC, left: &V, right: &V) -> ValueResult<V>
+fn icmp<V>(ctrl_ty: types::Type, code: IntCC, left: &V, right: &V) -> ValueResult<V>
 where
     V: Value,
 {
@@ -1019,9 +1019,9 @@ where
         )?)
     };
 
-    let dst_ty = _ty.as_bool();
-    Ok(if _ty.is_vector() {
-        let lane_type = _ty.lane_type();
+    let dst_ty = ctrl_ty.as_bool();
+    Ok(if ctrl_ty.is_vector() {
+        let lane_type = ctrl_ty.lane_type();
         let left = extractlanes(left, lane_type)?;
         let right = extractlanes(right, lane_type)?;
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -222,7 +222,9 @@ where
                 .convert(ValueConversionKind::ToBoolean)?
                 .into_bool()?,
         )?,
-        Opcode::BrIcmp => branch_when(icmp(inst.cond_code().unwrap(), &arg(0)?, &arg(1)?)?)?,
+        Opcode::BrIcmp => {
+            branch_when(icmp(ctrl_ty, inst.cond_code().unwrap(), &arg(0)?, &arg(1)?)?.into_bool()?)?
+        }
         Opcode::Brif => branch_when(state.has_iflag(inst.cond_code().unwrap()))?,
         Opcode::Brff => branch_when(state.has_fflag(inst.fp_cond_code().unwrap()))?,
         Opcode::BrTable => {
@@ -451,13 +453,17 @@ where
         Opcode::Regspill => unimplemented!("Regspill"),
         Opcode::Regfill => unimplemented!("Regfill"),
         Opcode::Safepoint => unimplemented!("Safepoint"),
-        Opcode::Icmp => assign(Value::bool(
-            icmp(inst.cond_code().unwrap(), &arg(0)?, &arg(1)?)?,
-            ctrl_ty.as_bool(),
+        Opcode::Icmp => assign(icmp(
+            ctrl_ty,
+            inst.cond_code().unwrap(),
+            &arg(0)?,
+            &arg(1)?,
         )?),
-        Opcode::IcmpImm => assign(Value::bool(
-            icmp(inst.cond_code().unwrap(), &arg(0)?, &imm_as_ctrl_ty()?)?,
-            ctrl_ty.as_bool(),
+        Opcode::IcmpImm => assign(icmp(
+            ctrl_ty,
+            inst.cond_code().unwrap(),
+            &arg(0)?,
+            &imm_as_ctrl_ty()?,
         )?),
         Opcode::Ifcmp | Opcode::IfcmpImm => {
             let arg0 = arg(0)?;
@@ -479,7 +485,7 @@ where
                 IntCC::UnsignedGreaterThan,
                 IntCC::UnsignedLessThanOrEqual,
             ] {
-                if icmp(*f, &arg0, &arg1)? {
+                if icmp(ctrl_ty, *f, &arg0, &arg1)?.into_bool()? {
                     state.set_iflag(*f);
                 }
             }
@@ -977,35 +983,57 @@ pub enum CraneliftTrap {
 }
 
 /// Compare two values using the given integer condition `code`.
-fn icmp<V>(code: IntCC, left: &V, right: &V) -> ValueResult<bool>
+fn icmp<V>(_ty: types::Type, code: IntCC, left: &V, right: &V) -> ValueResult<V>
 where
     V: Value,
 {
-    Ok(match code {
-        IntCC::Equal => Value::eq(left, right)?,
-        IntCC::NotEqual => !Value::eq(left, right)?,
-        IntCC::SignedGreaterThan => Value::gt(left, right)?,
-        IntCC::SignedGreaterThanOrEqual => Value::ge(left, right)?,
-        IntCC::SignedLessThan => Value::lt(left, right)?,
-        IntCC::SignedLessThanOrEqual => Value::le(left, right)?,
-        IntCC::UnsignedGreaterThan => Value::gt(
-            &left.clone().convert(ValueConversionKind::ToUnsigned)?,
-            &right.clone().convert(ValueConversionKind::ToUnsigned)?,
-        )?,
-        IntCC::UnsignedGreaterThanOrEqual => Value::ge(
-            &left.clone().convert(ValueConversionKind::ToUnsigned)?,
-            &right.clone().convert(ValueConversionKind::ToUnsigned)?,
-        )?,
-        IntCC::UnsignedLessThan => Value::lt(
-            &left.clone().convert(ValueConversionKind::ToUnsigned)?,
-            &right.clone().convert(ValueConversionKind::ToUnsigned)?,
-        )?,
-        IntCC::UnsignedLessThanOrEqual => Value::le(
-            &left.clone().convert(ValueConversionKind::ToUnsigned)?,
-            &right.clone().convert(ValueConversionKind::ToUnsigned)?,
-        )?,
-        IntCC::Overflow => Value::overflow(left, right)?,
-        IntCC::NotOverflow => !Value::overflow(left, right)?,
+    let cmp = |bool_ty: types::Type, code: IntCC, left: &V, right: &V| -> ValueResult<V> {
+        Ok(Value::bool(
+            match code {
+                IntCC::Equal => Value::eq(left, right)?,
+                IntCC::NotEqual => !Value::eq(left, right)?,
+                IntCC::SignedGreaterThan => Value::gt(left, right)?,
+                IntCC::SignedGreaterThanOrEqual => Value::ge(left, right)?,
+                IntCC::SignedLessThan => Value::lt(left, right)?,
+                IntCC::SignedLessThanOrEqual => Value::le(left, right)?,
+                IntCC::UnsignedGreaterThan => Value::gt(
+                    &left.clone().convert(ValueConversionKind::ToUnsigned)?,
+                    &right.clone().convert(ValueConversionKind::ToUnsigned)?,
+                )?,
+                IntCC::UnsignedGreaterThanOrEqual => Value::ge(
+                    &left.clone().convert(ValueConversionKind::ToUnsigned)?,
+                    &right.clone().convert(ValueConversionKind::ToUnsigned)?,
+                )?,
+                IntCC::UnsignedLessThan => Value::lt(
+                    &left.clone().convert(ValueConversionKind::ToUnsigned)?,
+                    &right.clone().convert(ValueConversionKind::ToUnsigned)?,
+                )?,
+                IntCC::UnsignedLessThanOrEqual => Value::le(
+                    &left.clone().convert(ValueConversionKind::ToUnsigned)?,
+                    &right.clone().convert(ValueConversionKind::ToUnsigned)?,
+                )?,
+                IntCC::Overflow => Value::overflow(left, right)?,
+                IntCC::NotOverflow => !Value::overflow(left, right)?,
+            },
+            bool_ty,
+        )?)
+    };
+
+    let dst_ty = _ty.as_bool();
+    Ok(if _ty.is_vector() {
+        let lane_type = _ty.lane_type();
+        let left = extractlanes(left, lane_type)?;
+        let right = extractlanes(right, lane_type)?;
+
+        let res = left
+            .into_iter()
+            .zip(right.into_iter())
+            .map(|(l, r)| cmp(dst_ty.lane_type(), code, &l, &r))
+            .collect::<ValueResult<SimdVec<V>>>()?;
+
+        vectorizelanes(&res, dst_ty)?
+    } else {
+        cmp(dst_ty, code, left, right)?
     })
 }
 
@@ -1081,18 +1109,23 @@ fn vectorizelanes<V>(x: &[V], vector_type: types::Type) -> ValueResult<V>
 where
     V: Value,
 {
-    let iterations = match vector_type.lane_type() {
-        types::I8 => 1,
-        types::I16 => 2,
-        types::I32 => 4,
-        types::I64 => 8,
+    let lane_type = vector_type.lane_type();
+    let iterations = match lane_type {
+        types::I8 | types::B1 | types::B8 => 1,
+        types::I16 | types::B16 => 2,
+        types::I32 | types::B32 => 4,
+        types::I64 | types::B64 => 8,
         _ => unimplemented!("Only 128-bit vectors are currently supported."),
     };
     let mut result: [u8; 16] = [0; 16];
     for (i, val) in x.iter().enumerate() {
-        let val = val.clone().into_int()?;
+        let lane_val: i128 = val
+            .clone()
+            .convert(ValueConversionKind::Exact(lane_type.as_int()))?
+            .into_int()?;
+
         for j in 0..iterations {
-            result[(i * iterations) + j] = (val >> (8 * j)) as u8;
+            result[(i * iterations) + j] = (lane_val >> (8 * j)) as u8;
         }
     }
     Value::vector(result, vector_type)

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -250,6 +250,7 @@ impl Value for DataValue {
                 // TODO a lot to do here: from bmask to ireduce to raw_bitcast...
                 (DataValue::I64(n), types::I32) => DataValue::I32(i32::try_from(n)?),
                 (DataValue::I64(n), types::I64) => DataValue::I64(n),
+                (DataValue::I64(n), types::I128) => DataValue::I128(n as i128),
                 (DataValue::B(b), t) if t.is_bool() => DataValue::B(b),
                 (dv, _) => unimplemented!("conversion: {} -> {:?}", dv.ty(), kind),
             },
@@ -311,6 +312,7 @@ impl Value for DataValue {
                 DataValue::I16(n) => DataValue::U16(n as u16),
                 DataValue::I32(n) => DataValue::U32(n as u32),
                 DataValue::I64(n) => DataValue::U64(n as u64),
+                DataValue::I128(n) => DataValue::U128(n as u128),
                 _ => unimplemented!("conversion: {} -> {:?}", self.ty(), kind),
             },
             ValueConversionKind::ToSigned => match self {
@@ -318,6 +320,7 @@ impl Value for DataValue {
                 DataValue::U16(n) => DataValue::I16(n as i16),
                 DataValue::U32(n) => DataValue::I32(n as i32),
                 DataValue::U64(n) => DataValue::I64(n as i64),
+                DataValue::U128(n) => DataValue::I128(n as i128),
                 _ => unimplemented!("conversion: {} -> {:?}", self.ty(), kind),
             },
             ValueConversionKind::RoundNearestEven(ty) => match (self.ty(), ty) {
@@ -342,11 +345,11 @@ impl Value for DataValue {
     }
 
     fn eq(&self, other: &Self) -> ValueResult<bool> {
-        comparison_match!(PartialEq::eq[&self, &other]; [I8, I16, I32, I64, U8, U16, U32, U64, F32, F64])
+        comparison_match!(PartialEq::eq[&self, &other]; [I8, I16, I32, I64, I128, U8, U16, U32, U64, U128, F32, F64])
     }
 
     fn gt(&self, other: &Self) -> ValueResult<bool> {
-        comparison_match!(PartialOrd::gt[&self, &other]; [I8, I16, I32, I64, U8, U16, U32, U64, F32, F64])
+        comparison_match!(PartialOrd::gt[&self, &other]; [I8, I16, I32, I64, I128, U8, U16, U32, U64, U128, F32, F64])
     }
 
     fn uno(&self, other: &Self) -> ValueResult<bool> {
@@ -359,6 +362,7 @@ impl Value for DataValue {
             (DataValue::I16(a), DataValue::I16(b)) => a.checked_sub(*b).is_none(),
             (DataValue::I32(a), DataValue::I32(b)) => a.checked_sub(*b).is_none(),
             (DataValue::I64(a), DataValue::I64(b)) => a.checked_sub(*b).is_none(),
+            (DataValue::I128(a), DataValue::I128(b)) => a.checked_sub(*b).is_none(),
             _ => unimplemented!(),
         })
     }

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -252,6 +252,16 @@ impl Value for DataValue {
                 (DataValue::I64(n), types::I64) => DataValue::I64(n),
                 (DataValue::I64(n), types::I128) => DataValue::I128(n as i128),
                 (DataValue::B(b), t) if t.is_bool() => DataValue::B(b),
+                (DataValue::B(b), t) if t.is_int() => {
+                    let val = if b {
+                        // Bools are represented in memory as all 1's
+                        (1i128 << t.bits()) - 1
+                    } else {
+                        0
+                    };
+                    DataValue::int(val, t)?
+                }
+                (dv, t) if t.is_int() && dv.ty() == t => dv,
                 (dv, _) => unimplemented!("conversion: {} -> {:?}", dv.ty(), kind),
             },
             ValueConversionKind::Truncate(ty) => {


### PR DESCRIPTION
Adds tests for scalar `icmp` and adds SIMD `icmp`.

I found it easier to separate the test files into each comparison type, but let me know if you prefer them all in a single file.