### PR TITLE
Tidy up redundant `use` declarations.

### DIFF
--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -13,9 +13,6 @@ use cranelift_module::{
     DataContext, DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleCompiledFunction,
     ModuleDeclarations, ModuleError, ModuleResult, RelocRecord,
 };
-use cranelift_native;
-#[cfg(not(windows))]
-use libc;
 use log::info;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
@@ -25,8 +22,6 @@ use std::ptr;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use target_lexicon::PointerWidth;
-#[cfg(windows)]
-use winapi;
 
 const EXECUTABLE_DATA_ALIGNMENT: u64 = 0x10;
 const WRITABLE_DATA_ALIGNMENT: u64 = 0x8;

--- a/crates/lightbeam/src/error.rs
+++ b/crates/lightbeam/src/error.rs
@@ -1,4 +1,3 @@
-use capstone;
 use thiserror::Error;
 use wasmparser::BinaryReaderError;
 

--- a/crates/test-programs/wasi-tests/src/bin/fd_flags_set.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_flags_set.rs
@@ -1,5 +1,4 @@
 use std::{env, process};
-use wasi;
 use wasi_tests::open_scratch_directory;
 
 unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {

--- a/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
+++ b/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
@@ -1,4 +1,3 @@
-use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, open_scratch_directory};

--- a/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
+++ b/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
@@ -1,4 +1,3 @@
-use libc;
 use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::open_scratch_directory;


### PR DESCRIPTION
This is just a minor code cleanup.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
