### PR TITLE
cranelift: Fix invalid trampoline when returning boolean vectors

### DIFF
--- a/cranelift/filetests/filetests/runtests/simd-vconst.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst.clif
@@ -38,3 +38,11 @@ block0:
     return v8
 }
 ; run
+
+
+function %vconst_b16x8() -> b16x8 {
+block0:
+    v0 = vconst.b16x8 [true false true false true false true true]
+    return v0
+}
+; run: %vconst_b16x8() == [true false true false true false true true]

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -332,8 +332,11 @@ fn make_trampoline(signature: &ir::Signature, isa: &dyn TargetIsa) -> Function {
     let results = builder.func.dfg.inst_results(call).to_vec();
     for ((i, value), param) in results.iter().enumerate().zip(&signature.returns) {
         // Before storing return values, we convert booleans to their integer representation.
-        let value = if param.value_type.lane_type().is_bool() {
-            let ty = param.value_type.lane_type().as_int();
+        let value = if param.value_type.is_bool_vector() {
+            let ty = param.value_type.as_int();
+            builder.ins().raw_bitcast(ty, *value)
+        } else if param.value_type.is_bool() {
+            let ty = param.value_type.as_int();
             builder.ins().bint(ty, *value)
         } else {
             *value


### PR DESCRIPTION
Hey,

This is a extension of #3306. In that PR we accidentally only dealt with receiving bool vectors as arguments to the callee function. This caused issues in #3332 where those tests were failing to run on the real backends, due to the generated trampoline being invalid when the callee returns bool vectors.

For more context about this, see this [comment](https://github.com/bytecodealliance/wasmtime/issues/3335#issuecomment-918163632) with the invalid trampoline, and the rest of the thread with a proposed solution.

The solution here is not great, `bint` with the correct type would fix this, but is not implemented in some backends, same with `bmask`. `raw_bitcast` solves the issue, but we really should fix `bmask`/`bint` and use that.

Fixing trampoline bool args is tracked in #2237

Fixes #3334
Fixes #3335