### PR TITLE
Cranelift AArch64: Improve the type checks for IR operations

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -550,6 +550,8 @@ impl OperandSize {
 
     /// Convert from an integer type into the smallest size that fits.
     pub fn from_ty(ty: Type) -> OperandSize {
+        debug_assert!(!ty.is_vector());
+
         Self::from_bits(ty_bits(ty))
     }
 
@@ -611,6 +613,8 @@ impl ScalarSize {
 
     /// Convert from a type into the smallest size that fits.
     pub fn from_ty(ty: Type) -> ScalarSize {
+        debug_assert!(!ty.is_vector());
+
         Self::from_bits(ty_bits(ty))
     }
 
@@ -655,6 +659,8 @@ impl VectorSize {
 
     /// Convert from a type into a vector operand size.
     pub fn from_ty(ty: Type) -> VectorSize {
+        debug_assert!(ty.is_vector());
+
         match ty {
             B8X16 => VectorSize::Size8x16,
             B16X8 => VectorSize::Size16x8,


### PR DESCRIPTION
There were cases where the AArch64 backend assumed that an IR operation would always operate on certain types (the most likely reason being that the corresponding WebAssembly instruction did not cover anything else), even though the definition of the IR operation imposed no constraints like that.