### PR TITLE
Restore running precompiled modules with the CLI

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -381,3 +381,18 @@ fn exit_with_saved_fprs() -> Result<()> {
     assert!(output.stdout.is_empty());
     Ok(())
 }
+
+#[test]
+fn run_cwasm() -> Result<()> {
+    let cwasm = NamedTempFile::new()?;
+    let stdout = run_wasmtime(&[
+        "compile",
+        "tests/all/cli_tests/simple.wat",
+        "-o",
+        cwasm.path().to_str().unwrap(),
+    ])?;
+    assert_eq!(stdout, "");
+    let stdout = run_wasmtime(&["run", "--allow-precompiled", cwasm.path().to_str().unwrap()])?;
+    assert_eq!(stdout, "");
+    Ok(())
+}

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output};
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 // Run the wasmtime CLI with the provided args and return the `Output`.
 fn run_wasmtime_for_output(args: &[&str]) -> Result<Output> {
@@ -384,15 +384,16 @@ fn exit_with_saved_fprs() -> Result<()> {
 
 #[test]
 fn run_cwasm() -> Result<()> {
-    let cwasm = NamedTempFile::new()?;
+    let td = TempDir::new()?;
+    let cwasm = td.path().join("foo.cwasm");
     let stdout = run_wasmtime(&[
         "compile",
         "tests/all/cli_tests/simple.wat",
         "-o",
-        cwasm.path().to_str().unwrap(),
+        cwasm.to_str().unwrap(),
     ])?;
     assert_eq!(stdout, "");
-    let stdout = run_wasmtime(&["run", "--allow-precompiled", cwasm.path().to_str().unwrap()])?;
+    let stdout = run_wasmtime(&["run", "--allow-precompiled", cwasm.to_str().unwrap()])?;
     assert_eq!(stdout, "");
     Ok(())
 }


### PR DESCRIPTION
This was accidentally broken when `Module::deserialize` was split out of
`Module::new` long ago, so this adds the detection in the CLI to call
the appropriate method to load the module.

Closes #3338

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
