### PR TITLE
Add a new `Func::wrap_cabi` API

### DIFF
--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -81,7 +81,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
 );
 
 /**
- * \brief Defines a new function in this linker.
+ * \brief Defines a new function in this linker along the lines of
+ * #wasmtime_func_new.
  *
  * \param linker the linker the name is being defined in.
  * \param module the module name the item is defined under.
@@ -111,6 +112,46 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
     size_t name_len,
     const wasm_functype_t *ty,
     wasmtime_func_callback_t cb,
+    void *data,
+    void (*finalizer)(void*)
+);
+
+/**
+ * \brief Defines a new function in this linker along the lines of
+ * #wasmtime_func_wrap.
+ *
+ * \param linker the linker the name is being defined in.
+ * \param module the module name the item is defined under.
+ * \param module_len the byte length of `module`
+ * \param name the field name the item is defined under
+ * \param name_len the byte length of `name`
+ * \param ty the type of the function that's being defined
+ * \param cb the host callback to invoke when the function is called
+ * \param data the host-provided data to provide as the first argument to the callback
+ * \param finalizer an optional finalizer for the `data` argument.
+ *
+ * \return On success `NULL` is returned, otherwise an error is returned which
+ * describes why the definition failed.
+ *
+ * For more information about name resolution consult the [Rust
+ * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
+ *
+ * Note that this function does not create a #wasmtime_func_t. This creates a
+ * store-independent function within the linker, allowing this function
+ * definition to be used with multiple stores.
+ *
+ * Also note that the documentation of #wasmtime_func_wrap should be consulted
+ * to determine the correct function signature for the function provided in
+ * `cb`.
+ */
+WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_func_wrap(
+    wasmtime_linker_t *linker,
+    const char *module,
+    size_t module_len,
+    const char *name,
+    size_t name_len,
+    const wasm_functype_t *ty,
+    size_t cb,
     void *data,
     void (*finalizer)(void*)
 );

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -75,6 +75,29 @@ pub unsafe extern "C" fn wasmtime_linker_define_func(
     handle_result(linker.linker.func_new(module, name, ty, cb), |_linker| ())
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_linker_func_wrap(
+    linker: &mut wasmtime_linker_t,
+    module: *const u8,
+    module_len: usize,
+    name: *const u8,
+    name_len: usize,
+    ty: &wasm_functype_t,
+    callback: usize,
+    data: usize,
+    finalizer: Option<extern "C" fn(usize)>,
+) -> Option<Box<wasmtime_error_t>> {
+    let ty = ty.ty().ty.clone();
+    let module = to_str!(module, module_len);
+    let name = to_str!(name, name_len);
+    handle_result(
+        linker
+            .linker
+            .func_wrap_cabi(module, name, ty, callback, data, finalizer),
+        |_linker| (),
+    )
+}
+
 #[cfg(feature = "wasi")]
 #[no_mangle]
 pub extern "C" fn wasmtime_linker_define_wasi(

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -2,7 +2,12 @@ use crate::{wasm_frame_vec_t, wasm_instance_t, wasm_name_t, wasm_store_t};
 use once_cell::unsync::OnceCell;
 use wasmtime::{Trap, TrapCode};
 
-#[repr(C)]
+// Note the `transparent` representation here which is required by the
+// `wasmtime_func_wrap` API since the C-ABI function pointers return `*mut
+// wasm_trap_t` which is interpreted as `Option<Box<Trap>>` in Rust. Note that
+// `wasm_trap_t` is opaque in C, though, so it's always asking this library to
+// allocate.
+#[repr(transparent)]
 #[derive(Clone)]
 pub struct wasm_trap_t {
     pub(crate) trap: Trap,

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -175,19 +175,23 @@ pub trait Compiler: Send + Sync {
         obj: &mut Object,
     ) -> Result<(PrimaryMap<DefinedFuncIndex, FunctionInfo>, Vec<Trampoline>)>;
 
-    /// Inserts two functions for host-to-wasm and wasm-to-host trampolines into
-    /// the `obj` provided.
+    /// Inserts various trampolines for interacting with the wasm function
+    /// siganture `ty` into the `obj` provided.
     ///
     /// This will configure the same sections as `emit_obj`, but will likely be
-    /// much smaller. The two returned `Trampoline` structures describe where to
-    /// find the host-to-wasm and wasm-to-host trampolines in the text section,
-    /// respectively.
+    /// much smaller. The returned `Trampoline` structures at this time are:
+    ///
+    /// * Where to find the host-to-wasm trampoline.
+    /// * Where to find the wasm-to-host trampoline.
+    /// * Where to fidn the host-to-c trampoline.
+    ///
+    /// All trampoline offsets are relative to the text section.
     fn emit_trampoline_obj(
         &self,
         ty: &WasmFuncType,
         host_fn: usize,
         obj: &mut Object,
-    ) -> Result<(Trampoline, Trampoline)>;
+    ) -> Result<(Trampoline, Trampoline, Trampoline)>;
 
     /// Creates a new `Object` file which is used to build the results of a
     /// compilation into.

--- a/crates/lightbeam/wasmtime/src/lib.rs
+++ b/crates/lightbeam/wasmtime/src/lib.rs
@@ -95,7 +95,7 @@ impl Compiler for Lightbeam {
         _ty: &WasmFuncType,
         _host_fn: usize,
         _obj: &mut Object,
-    ) -> Result<(Trampoline, Trampoline)> {
+    ) -> Result<(Trampoline, Trampoline, Trampoline)> {
         unimplemented!()
     }
 

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -402,7 +402,7 @@ impl Func {
     /// }
     ///
     /// // (func (param i64 f64 v128) (result f32 i32))
-    /// extern "C" fn f3(
+    /// extern "C" fn f4(
     ///     userdata: usize,
     ///     caller: &mut Caller<'_, ()>,
     ///     wasm_param1: i64,

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -304,6 +304,26 @@ impl<T> Linker<T> {
         Ok(self)
     }
 
+    /// Creates a [`Func::wrap_cabi`]-style function named in this linker.
+    ///
+    /// For more information see [`Linker::func_wrap`].
+    #[cfg(compiler)]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "cranelift")))] // see build.rs
+    pub unsafe fn func_wrap_cabi(
+        &mut self,
+        module: &str,
+        name: &str,
+        ty: FuncType,
+        func: usize,
+        data: usize,
+        finalizer: Option<extern "C" fn(usize)>,
+    ) -> Result<&mut Self> {
+        let func = HostFunc::wrap_cabi::<T>(&self.engine, ty, func, data, finalizer)?;
+        let key = self.import_key(module, Some(name));
+        self.insert(key, Definition::HostFunc(Arc::new(func)))?;
+        Ok(self)
+    }
+
     /// Creates a [`Func::new_async`]-style function named in this linker.
     ///
     /// For more information see [`Linker::func_wrap`].

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -12,7 +12,7 @@ use self::global::create_global;
 use self::memory::create_memory;
 use self::table::create_table;
 use crate::store::{InstanceId, StoreOpaque};
-use crate::{GlobalType, MemoryType, TableType, Val};
+use crate::{GlobalType, MemoryType, TableType, Trap, Val};
 use anyhow::Result;
 use std::any::Any;
 use std::sync::Arc;
@@ -21,6 +21,14 @@ use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstanceAllocator, OnDemandInstanceAllocator,
     VMFunctionImport, VMSharedSignatureIndex,
 };
+
+// For more information see `host_to_c_trampoline` in the cranelift compiler.
+pub type CTrampoline = extern "C" fn(
+    usize,     // user-provided void*
+    usize,     // &mut Caller<'_, T>
+    *mut u128, // storage for parameters and results
+    usize,     // actual host function to indirectly call
+) -> *mut Trap;
 
 fn create_handle(
     module: Module,

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -1016,6 +1016,7 @@ fn cabi_trap() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg(not(feature = "old-x86-backend"))] // v128 not really supported well
 fn cabi_type_mappings() -> anyhow::Result<()> {
     unsafe {
         let mut store = Store::<()>::default();


### PR DESCRIPTION
This commit adds a new API to the `wasmtime::Func` type for wrapping a
C-ABI function with a well-defined signature derived from a wasm type
signature. The purpose of this API is to add the-most-optimized-we-can
path for using the C API and having wasm call host functions. Previously
when wasm called a host function it would perform these steps:

1. Using a trampoline, place all arguments into a `u128*` array on the
   stack.
2. Call `Func::invoke` which uses the type of the function (dynamically)
   to read values from this `u128*`.
3. Values are placed within a `Vec<Val>` after being read.
4. The C API receives `&[Val]` and translates this to
   `&[wasmtime_val_t]`, iterating over each value and copying its
   contents into a new vector.
5. Then the host function is actually called.
6. The above argument-shuffling steps are all performed in reverse for
   the results, shipping everything through `wasmtime_val_t` and `Val`.

PRs such as #3319 and related attempts have made this sequence faster,
but the numbers on #3319 show that even after we get all the allocation
and such bits out of the way we're still spending quite a lot of time
shuffling arguments back-and-forth relative to the `Func::wrap` API that
Rust can use.

This commit fixes the issue by eliminating all steps except 1/5 above.
Although we still place all arguments on the stack and read them out
again to call the C-defined function with it's much faster than pushing
this all through the `Val` and `wasmtime_val_t` machinery. This overall
gets the cost of a wasm->host call basically on-par with `Func::wrap`,
although it's still not as optimized. Benchmarking the overhead of
wasm->host calls, where `i64` returns one i64 value and `many` takes 5
`i32` parameters and returns one `i64` value, the numbers I get are:

| Import | Rust | C before | C after |
|--------|------|----------|---------|
| `i64`  | 1ns  | 40ns     | 7ns     |
| `many` | 1ns  | 91ns     | 10ns    |

This commit is a clear win over the previous implementation, but it's
even still somewhat far away from Rust. That being said I think I'm out
of ideas of how to make this better. Without open-coding much larger
portions of `wasmtime` I'm not sure how much better we can get here. The
time in C after this commit is almost entirely spent in trampolines
storing the arguments to the stack and loading them later, and at this
point I'm not sure how much more optimized we can get than that since
Rust needs to enter the picture here somehow to handle the Wasmtime
fiddly-bits of calling back into C. I'm hopeful, though, that this is
such a large improvement from before that the question of optimizing
this further in C is best left for another day.

The new `Func::wrap_cabi` method is unlikely to ever get used from Rust,
but a `wasmtime_func_wrap` API was added to the C API to mirror
`Func::wrap` where if the host function pointer has a specific ABI this
function can be called instead of `wasmtime_func_new`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
