### PR TITLE
Allow wasmtime/v8 to differ on errors slightly

### DIFF
--- a/crates/fuzzing/src/oracles/v8.rs
+++ b/crates/fuzzing/src/oracles/v8.rs
@@ -267,7 +267,21 @@ fn assert_error_matches(wasmtime: &anyhow::Error, v8: &str) {
                     "data segment is out of bounds",
                 ])
             }
-            TrapCode::UnreachableCodeReached => return verify_v8(&["unreachable"]),
+            TrapCode::UnreachableCodeReached => {
+                return verify_v8(&[
+                    "unreachable",
+                    // All the wasms we test use wasm-smith's
+                    // `ensure_termination` option which will `unreachable` when
+                    // "fuel" runs out within the wasm module itself. This
+                    // sometimes manifests as a call stack size exceeded in v8,
+                    // however, since v8 sometimes has different limits on the
+                    // call-stack especially when it's run multiple times. To
+                    // get these error messages to line up allow v8 to say the
+                    // call stack size exceeded when wasmtime says we hit
+                    // unreachable.
+                    "Maximum call stack size exceeded",
+                ]);
+            }
             TrapCode::IntegerDivisionByZero => {
                 return verify_v8(&["divide by zero", "remainder by zero"])
             }


### PR DESCRIPTION
I'm not sure why when run repeatedly v8 has different limits on
call-stack-size but it's not particularly interesting to assert exact
matches here, so this should fix a fuzz-bug-failure found on oss-fuzz.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
