### PR TITLE
Add `*_unchecked` variants of `Func` APIs for the C API

### DIFF
--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -88,6 +88,75 @@ WASM_API_EXTERN void wasmtime_func_new(
 );
 
 /**
+ * \brief Callback signature for #wasmtime_func_new_unchecked.
+ *
+ * This is the function signature for host functions that can be made accessible
+ * to WebAssembly. The arguments to this function are:
+ *
+ * \param env user-provided argument passed to #wasmtime_func_new_unchecked
+ * \param caller a temporary object that can only be used during this function
+ *        call. Used to acquire #wasmtime_context_t or caller's state
+ * \param args_and_results storage space for both the parameters to the
+ *        function as well as the results of the function. The size of this
+ *        array depends on the function type that the host function is created
+ *        with, but it will be the maximum of the number of parameters and
+ *        number of results.
+ *
+ * This callback can optionally return a #wasm_trap_t indicating that a trap
+ * should be raised in WebAssembly. It's expected that in this case the caller
+ * relinquishes ownership of the trap and it is passed back to the engine.
+ *
+ * This differs from #wasmtime_func_callback_t in that the payload of
+ * `args_and_results` does not have type information, nor does it have sizing
+ * information. This is especially unsafe because it's only valid within the
+ * particular #wasm_functype_t that the function was created with. The onus is
+ * on the embedder to ensure that `args_and_results` are all read correctly
+ * for parameters and all written for results within the execution of a
+ * function.
+ *
+ * Parameters will be listed starting at index 0 in the `args_and_results`
+ * array. Results are also written starting at index 0, which will overwrite
+ * the arguments.
+ */
+typedef wasm_trap_t* (*wasmtime_func_unchecked_callback_t)(
+    void *env,
+    wasmtime_caller_t* caller,
+    wasmtime_val_raw_t *args_and_results);
+
+/**
+ * \brief Creates a new host function in the same manner of #wasmtime_func_new,
+ *        but the function-to-call has no type information available at runtime.
+ *
+ * This function is very similar to #wasmtime_func_new. The difference is that
+ * this version is "more unsafe" in that when the host callback is invoked there
+ * is no type information and no checks that the right types of values are
+ * produced. The onus is on the consumer of this API to ensure that all
+ * invariants are upheld such as:
+ *
+ * * The host callback reads parameters correctly and interprets their types
+ *   correctly.
+ * * If a trap doesn't happen then all results are written to the results
+ *   pointer. All results must have the correct type.
+ * * Types such as `funcref` cannot cross stores.
+ * * Types such as `externref` have valid reference counts.
+ *
+ * It's generally only recommended to use this if your application can wrap
+ * this in a safe embedding. This should not be frequently used due to the
+ * number of invariants that must be upheld on the wasm<->host boundary. On the
+ * upside, though, this flavor of host function will be faster to call than
+ * those created by #wasmtime_func_new (hence the reason for this function's
+ * existence).
+ */
+WASM_API_EXTERN void wasmtime_func_new_unchecked(
+  wasmtime_context_t *store,
+  const wasm_functype_t* type,
+  wasmtime_func_unchecked_callback_t callback,
+  void *env,
+  void (*finalizer)(void*),
+  wasmtime_func_t *ret
+);
+
+/**
  * \brief Returns the type of the function specified
  *
  * The returned #wasm_functype_t is owned by the caller.
@@ -143,6 +212,39 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call(
 );
 
 /**
+ * \brief Call a WebAssembly function in an "unchecked" fashion.
+ *
+ * This function is similar to #wasmtime_func_call except that there is no type
+ * information provided with the arguments (or sizing information). Consequently
+ * this is less safe to call since it's up to the caller to ensure that `args`
+ * has an appropriate size and all the parameters are configured with their
+ * appropriate values/types. Additionally all the results must be interpreted
+ * correctly if this function returns successfully.
+ *
+ * Parameters must be specified starting at index 0 in the `args_and_results`
+ * array. Results are written starting at index 0, which will overwrite
+ * the arguments.
+ *
+ * Callers must ensure that various correctness variants are upheld when this
+ * API is called such as:
+ *
+ * * The `args_and_results` pointer has enough space to hold all the parameters
+ *   and all the results (but not at the same time).
+ * * Parameters must all be configured as if they were the correct type.
+ * * Values such as `externref` and `funcref` are valid within the store being
+ *   called.
+ *
+ * When in doubt it's much safer to call #wasmtime_func_call. This function is
+ * faster than that function, but the tradeoff is that embeddings must uphold
+ * more invariants rather than relying on Wasmtime to check them for you.
+ */
+WASM_API_EXTERN wasm_trap_t *wasmtime_func_call_unchecked(
+    wasmtime_context_t *store,
+    const wasmtime_func_t *func,
+    wasmtime_val_raw_t *args_and_results
+);
+
+/**
  * \brief Loads a #wasmtime_extern_t from the caller's context
  *
  * This function will attempt to look up the export named `name` on the caller
@@ -171,6 +273,32 @@ WASM_API_EXTERN bool wasmtime_caller_export_get(
  * \brief Returns the store context of the caller object.
  */
 WASM_API_EXTERN wasmtime_context_t* wasmtime_caller_context(wasmtime_caller_t* caller);
+
+/**
+ * \brief Converts a `raw` nonzero `funcref` value from #wasmtime_val_raw_t
+ * into a #wasmtime_func_t.
+ *
+ * This function can be used to interpret nonzero values of the `funcref` field
+ * of the #wasmtime_val_raw_t structure. It is assumed that `raw` does not have
+ * a value of 0, or otherwise the program will abort.
+ *
+ * Note that this function is unchecked and unsafe. It's only safe to pass
+ * values learned from #wasmtime_val_raw_t with the same corresponding
+ * #wasmtime_context_t that they were produced from. Providing arbitrary values
+ * to `raw` here or cross-context values with `context` is UB.
+ */
+WASM_API_EXTERN void wasmtime_func_from_raw(
+    wasmtime_context_t* context,
+    size_t raw,
+    wasmtime_func_t *ret);
+
+/**
+ * \brief Converts a `func`  which belongs to `context` into a `usize`
+ * parameter that is suitable for insertion into a #wasmtime_val_raw_t.
+ */
+WASM_API_EXTERN size_t wasmtime_func_to_raw(
+    wasmtime_context_t* context,
+    const wasmtime_func_t *func);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -102,6 +102,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
  * Note that this function does not create a #wasmtime_func_t. This creates a
  * store-independent function within the linker, allowing this function
  * definition to be used with multiple stores.
+ *
+ * For more information about host callbacks see #wasmtime_func_new.
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
     wasmtime_linker_t *linker,
@@ -111,6 +113,27 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
     size_t name_len,
     const wasm_functype_t *ty,
     wasmtime_func_callback_t cb,
+    void *data,
+    void (*finalizer)(void*)
+);
+
+/**
+ * \brief Defines a new function in this linker.
+ *
+ * This is the same as #wasmtime_linker_define_func except that it's the analog
+ * of #wasmtime_func_new_unchecked instead of #wasmtime_func_new. Be sure to
+ * consult the documentation of #wasmtime_linker_define_func for argument
+ * information as well as #wasmtime_func_new_unchecked for why this is an
+ * unsafe API.
+ */
+WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func_unchecked(
+    wasmtime_linker_t *linker,
+    const char *module,
+    size_t module_len,
+    const char *name,
+    size_t name_len,
+    const wasm_functype_t *ty,
+    wasmtime_func_unchecked_callback_t cb,
     void *data,
     void (*finalizer)(void*)
 );

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -63,6 +63,23 @@ WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_clone(wasmtime_externre
  */
 WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t *ref);
 
+/**
+ * \brief Converts a raw `externref` value coming from #wasmtime_val_raw_t into
+ * a #wasmtime_externref_t.
+ */
+WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_context_t *context, size_t raw);
+
+/**
+ * \brief Converts a #wasmtime_externref_t to a raw value suitable for storing
+ * into a #wasmtime_val_raw_t.
+ *
+ * Note that after this function is called callers must not execute GC within
+ * the store or the raw value returned here will become invalid.
+ */
+WASM_API_EXTERN size_t wasmtime_externref_to_raw(
+    wasmtime_context_t *context,
+    wasmtime_externref_t *ref);
+
 /// \brief Discriminant stored in #wasmtime_val::kind
 typedef uint8_t wasmtime_valkind_t;
 /// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is an i32
@@ -116,6 +133,43 @@ typedef union wasmtime_valunion {
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
   wasmtime_v128 v128;
 } wasmtime_valunion_t;
+
+/**
+ * \typedef wasmtime_val_raw_t
+ * \brief Convenience alias for #wasmtime_val_raw
+ *
+ * \union wasmtime_val_raw
+ * \brief Container for possible wasm values.
+ *
+ * This type is used on conjunction with #wasmtime_func_new_unchecked as well
+ * as #wasmtime_func_call_unchecked. Instances of this type do not have type
+ * information associated with them, it's up to the embedder to figure out
+ * how to interpret the bits contained within, often using some other channel
+ * to determine the type.
+ */
+typedef union wasmtime_val_raw {
+  /// Field for when this val is a WebAssembly `i32` value.
+  int32_t i32;
+  /// Field for when this val is a WebAssembly `i64` value.
+  int64_t i64;
+  /// Field for when this val is a WebAssembly `f32` value.
+  float32_t f32;
+  /// Field for when this val is a WebAssembly `f64` value.
+  float64_t f64;
+  /// Field for when this val is a WebAssembly `v128` value.
+  wasmtime_v128 v128;
+  /// Field for when this val is a WebAssembly `funcref` value.
+  ///
+  /// If this is set to 0 then it's a null funcref, otherwise this must be
+  /// passed to `wasmtime_func_from_raw` to determine the `wasmtime_func_t`.
+  size_t funcref;
+  /// Field for when this val is a WebAssembly `externref` value.
+  ///
+  /// If this is set to 0 then it's a null externref, otherwise this must be
+  /// passed to `wasmtime_externref_from_raw` to determine the
+  /// `wasmtime_externref_t`.
+  size_t externref;
+} wasmtime_val_raw_t;
 
 /**
  * \typedef wasmtime_val_t

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -66,6 +66,9 @@ WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t *ref);
 /**
  * \brief Converts a raw `externref` value coming from #wasmtime_val_raw_t into
  * a #wasmtime_externref_t.
+ *
+ * Note that the returned #wasmtime_externref_t is an owned value that must be
+ * deleted via #wasmtime_externref_delete by the caller if it is non-null.
  */
 WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_context_t *context, size_t raw);
 
@@ -73,12 +76,15 @@ WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_conte
  * \brief Converts a #wasmtime_externref_t to a raw value suitable for storing
  * into a #wasmtime_val_raw_t.
  *
- * Note that after this function is called callers must not execute GC within
- * the store or the raw value returned here will become invalid.
+ * Note that the returned underlying value is not tracked by Wasmtime's garbage
+ * collector until it enters WebAssembly. This means that a GC may release the
+ * context's reference to the raw value, making the raw value invalid within the
+ * context of the store. Do not perform a GC between calling this function and
+ * passing it to WebAssembly.
  */
 WASM_API_EXTERN size_t wasmtime_externref_to_raw(
     wasmtime_context_t *context,
-    wasmtime_externref_t *ref);
+    const wasmtime_externref_t *ref);
 
 /// \brief Discriminant stored in #wasmtime_val::kind
 typedef uint8_t wasmtime_valkind_t;

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -1,5 +1,8 @@
 use crate::r#ref::{ref_to_val, WasmRefInner};
-use crate::{from_valtype, into_valtype, wasm_ref_t, wasm_valkind_t, wasmtime_valkind_t, WASM_I32};
+use crate::{
+    from_valtype, into_valtype, wasm_ref_t, wasm_valkind_t, wasmtime_valkind_t, CStoreContextMut,
+    WASM_I32,
+};
 use std::ffi::c_void;
 use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::ptr;
@@ -288,3 +291,22 @@ pub extern "C" fn wasmtime_externref_clone(externref: ManuallyDrop<ExternRef>) -
 
 #[no_mangle]
 pub extern "C" fn wasmtime_externref_delete(_val: Option<ExternRef>) {}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_externref_to_raw(
+    cx: CStoreContextMut<'_>,
+    val: Option<ManuallyDrop<ExternRef>>,
+) -> usize {
+    match val {
+        Some(ptr) => ptr.to_raw(cx),
+        None => 0,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_externref_from_raw(
+    _cx: CStoreContextMut<'_>,
+    val: usize,
+) -> Option<ExternRef> {
+    ExternRef::from_raw(val)
+}

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -344,6 +344,7 @@ impl VMExternRef {
     ///  Nor does this method increment the reference count. You must ensure
     ///  that `self` (or some other clone of `self`) stays alive until
     ///  `clone_from_raw` is called.
+    #[inline]
     pub fn as_raw(&self) -> *mut u8 {
         let ptr = self.0.cast::<u8>().as_ptr();
         ptr

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::traphandlers::{
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
     VMGlobalImport, VMInterrupts, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport,
-    VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMTrampoline,
+    VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMTrampoline, ValRaw,
 };
 
 /// Version number of this crate.

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -790,10 +790,28 @@ impl VMContext {
     }
 }
 
+/// A "raw" and unsafe representation of a WebAssembly value.
+///
+/// This is provided for use with the `Func::new_unchecked` and
+/// `Func::call_unchecked` APIs. In general it's unlikely you should be using
+/// this from Rust, rather using APIs like `Func::wrap` and `TypedFunc::call`.
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union ValRaw {
+    pub i32: i32,
+    pub i64: i64,
+    pub f32: u32,
+    pub f64: u64,
+    pub v128: u128,
+    pub funcref: usize,
+    pub externref: usize,
+}
+
 /// Trampoline function pointer type.
 pub type VMTrampoline = unsafe extern "C" fn(
     *mut VMContext,        // callee vmctx
     *mut VMContext,        // caller vmctx
     *const VMFunctionBody, // function we're actually calling
-    *mut u128,             // space for arguments and return values
+    *mut ValRaw,           // space for arguments and return values
 );

--- a/crates/wasmtime/src/ref.rs
+++ b/crates/wasmtime/src/ref.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+use crate::AsContextMut;
 use std::any::Any;
 use wasmtime_runtime::VMExternRef;
 
@@ -39,5 +40,63 @@ impl ExternRef {
     /// `Eq` implementation.
     pub fn ptr_eq(&self, other: &ExternRef) -> bool {
         VMExternRef::eq(&self.inner, &other.inner)
+    }
+
+    /// Creates a new strongly-owned [`ExternRef`] from the raw value provided.
+    ///
+    /// This is intended to be used in conjunction with [`Func::new_unchecked`],
+    /// [`Func::call_unchecked`], and [`ValRaw`] with its `externref` field.
+    ///
+    /// This function assumes that `raw` is an externref value which is
+    /// currently rooted within the [`Store`].
+    ///
+    /// # Unsafety
+    ///
+    /// This function is particularly `unsafe` because `raw` not only must be a
+    /// valid externref value produced prior by `to_raw` but it must also be
+    /// correctly rooted within the store. When arguments are provided to a
+    /// callback with [`Func::new_unchecked`], for example, or returned via
+    /// [`Func::call_unchecked`], if a GC is performed within the store then
+    /// floating externref values are not rooted and will be GC'd, meaning that
+    /// this function will no longer be safe to call with the values cleaned up.
+    /// This function must be invoked *before* possible GC operations can happen
+    /// (such as calling wasm).
+    ///
+    /// When in doubt try to not use this. Instead use the safe Rust APIs of
+    /// [`TypedFunc`] and friends.
+    ///
+    /// [`Func::call_unchecked`]: crate::Func::call_unchecked
+    /// [`Func::new_unchecked`]: crate::Func::new_unchecked
+    /// [`Store`]: crate::Store
+    /// [`TypedFunc`]: crate::TypedFunc
+    /// [`ValRaw`]: crate::ValRaw
+    pub unsafe fn from_raw(raw: usize) -> Option<ExternRef> {
+        let raw = raw as *mut u8;
+        if raw.is_null() {
+            None
+        } else {
+            Some(ExternRef {
+                inner: VMExternRef::clone_from_raw(raw),
+            })
+        }
+    }
+
+    /// Converts this [`ExternRef`] to a raw value suitable to store within a
+    /// [`ValRaw`].
+    ///
+    /// # Unsafety
+    ///
+    /// Produces a raw value which is only safe to pass into a store if a GC
+    /// doesn't happen between when the value is produce and when it's passed
+    /// into the store.
+    ///
+    /// [`ValRaw`]: crate::ValRaw
+    pub unsafe fn to_raw(&self, mut store: impl AsContextMut) -> usize {
+        let externref_ptr = self.inner.as_raw();
+        store
+            .as_context_mut()
+            .0
+            .insert_vmexternref_without_gc(self.inner.clone());
+        externref_ptr as usize
     }
 }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -76,7 +76,7 @@
 //! contents of `StoreOpaque`. This is an invariant that we, as the authors of
 //! `wasmtime`, must uphold for the public interface to be safe.
 
-use crate::{module::ModuleRegistry, Engine, Module, Trap, Val};
+use crate::{module::ModuleRegistry, Engine, Module, Trap, Val, ValRaw};
 use anyhow::{bail, Result};
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
@@ -276,7 +276,7 @@ pub struct StoreOpaque {
     hostcall_val_storage: Vec<Val>,
     /// Same as `hostcall_val_storage`, but for the direction of the host
     /// calling wasm.
-    wasm_u128_storage: Vec<u128>,
+    wasm_val_raw_storage: Vec<ValRaw>,
 }
 
 #[cfg(feature = "async")]
@@ -433,7 +433,7 @@ impl<T> Store<T> {
                 store_data: StoreData::new(),
                 default_callee,
                 hostcall_val_storage: Vec::new(),
-                wasm_u128_storage: Vec::new(),
+                wasm_val_raw_storage: Vec::new(),
             },
             limiter: None,
             call_hook: None,
@@ -1182,16 +1182,16 @@ impl StoreOpaque {
     /// Same as `take_hostcall_val_storage`, but for the direction of the host
     /// calling wasm.
     #[inline]
-    pub fn take_wasm_u128_storage(&mut self) -> Vec<u128> {
-        mem::take(&mut self.wasm_u128_storage)
+    pub fn take_wasm_val_raw_storage(&mut self) -> Vec<ValRaw> {
+        mem::take(&mut self.wasm_val_raw_storage)
     }
 
     /// Same as `save_hostcall_val_storage`, but for the direction of the host
     /// calling wasm.
     #[inline]
-    pub fn save_wasm_u128_storage(&mut self, storage: Vec<u128>) {
-        if storage.capacity() > self.wasm_u128_storage.capacity() {
-            self.wasm_u128_storage = storage;
+    pub fn save_wasm_val_raw_storage(&mut self, storage: Vec<ValRaw>) {
+        if storage.capacity() > self.wasm_val_raw_storage.capacity() {
+            self.wasm_val_raw_storage = storage;
         }
     }
 }

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -1,6 +1,6 @@
 //! Support for a calling of an imported function.
 
-use crate::{Engine, FuncType, Trap};
+use crate::{Engine, FuncType, Trap, ValRaw};
 use anyhow::Result;
 use std::any::Any;
 use std::panic::{self, AssertUnwindSafe};
@@ -21,9 +21,9 @@ struct TrampolineState<F> {
 unsafe extern "C" fn stub_fn<F>(
     vmctx: *mut VMContext,
     caller_vmctx: *mut VMContext,
-    values_vec: *mut u128,
+    values_vec: *mut ValRaw,
 ) where
-    F: Fn(*mut VMContext, *mut u128) -> Result<(), Trap> + 'static,
+    F: Fn(*mut VMContext, *mut ValRaw) -> Result<(), Trap> + 'static,
 {
     // Here we are careful to use `catch_unwind` to ensure Rust panics don't
     // unwind past us. The primary reason for this is that Rust considers it UB
@@ -72,7 +72,7 @@ pub fn create_function<F>(
     engine: &Engine,
 ) -> Result<(InstanceHandle, VMTrampoline)>
 where
-    F: Fn(*mut VMContext, *mut u128) -> Result<(), Trap> + Send + Sync + 'static,
+    F: Fn(*mut VMContext, *mut ValRaw) -> Result<(), Trap> + Send + Sync + 'static,
 {
     let mut obj = engine.compiler().object()?;
     let (t1, t2) = engine.compiler().emit_trampoline_obj(


### PR DESCRIPTION
This commit is what is hopefully going to be my last installment within
the saga of optimizing function calls in/out of WebAssembly modules in
the C API. This is yet another alternative approach to #3345 (sorry) but
also contains everything necessary to make the C API fast. As in #3345
the general idea is just moving checks out of the call path in the same
style of `TypedFunc`.

This new strategy takes inspiration from previously learned attempts
effectively "just" exposes how we previously passed `*mut u128` through
trampolines for arguments/results. This storage format is formalized
through a new `ValRaw` union that is exposed from the `wasmtime` crate.
By doing this it made it relatively easy to expose two new APIs:

* `Func::new_unchecked`
* `Func::call_unchecked`

These are the same as their checked equivalents except that they're
`unsafe` and they work with `*mut ValRaw` rather than safe slices of
`Val`. Working with these eschews type checks and such and requires
callers/embedders to do the right thing.

These two new functions are then exposed via the C API with new
functions, enabling C to have a fast-path of calling/defining functions.
This fast path is akin to `Func::wrap` in Rust, although that API can't
be built in C due to C not having generics in the same way that Rust
has.

For some benchmarks, the benchmarks here are:

* `nop` - Call a wasm function from the host that does nothing and
  returns nothing.
* `i64` - Call a wasm function from the host, the wasm function calls a
  host function, and the host function returns an `i64` all the way out to
  the original caller.
* `many` - Call a wasm function from the host, the wasm calls
   host function with 5 `i32` parameters, and then an `i64` result is
   returned back to the original host
* `i64` host - just the overhead of the wasm calling the host, so the
  wasm calls the host function in a loop.
* `many` host - same as `i64` host, but calling the `many` host function.

All numbers in this table are in nanoseconds, and this is just one
measurement as well so there's bound to be some variation in the precise
numbers here.

| Name      | Rust | C (before) | C (after) |
|-----------|------|------------|-----------|
| nop       | 19   | 112        | 25        |
| i64       | 22   | 207        | 32        |
| many      | 27   | 189        | 34        |
| i64 host  | 2    | 38         | 5         |
| many host | 7    | 75         | 8         |

The main conclusion here is that the C API is significantly faster than
before when using the `*_unchecked` variants of APIs. The Rust
implementation is still the ceiling (or floor I guess?) for performance
The main reason that C is slower than Rust is that a little bit more has
to travel through memory where on the Rust side of things we can
monomorphize and inline a bit more to get rid of that. Overall though
the costs are way way down from where they were originally and I don't
plan on doing a whole lot more myself at this time. There's various
things we theoretically could do I've considered but implementation-wise
I think they'll be much more weighty.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
