### PR TITLE
Add `bextend`,`breduce` and `bmask` to interpreter

### DIFF
--- a/cranelift/filetests/filetests/runtests/bextend.clif
+++ b/cranelift/filetests/filetests/runtests/bextend.clif
@@ -1,0 +1,84 @@
+test interpret
+
+function %bextend_b1_b8(b1) -> b8 {
+block0(v0: b1):
+  v1 = bextend.b8 v0
+  return v1
+}
+; run: %bextend_b1_b8(true) == true
+; run: %bextend_b1_b8(false) == false
+
+function %bextend_b1_b16(b1) -> b16 {
+block0(v0: b1):
+  v1 = bextend.b16 v0
+  return v1
+}
+; run: %bextend_b1_b16(true) == true
+; run: %bextend_b1_b16(false) == false
+
+function %bextend_b1_b32(b1) -> b32 {
+block0(v0: b1):
+  v1 = bextend.b32 v0
+  return v1
+}
+; run: %bextend_b1_b32(true) == true
+; run: %bextend_b1_b32(false) == false
+
+function %bextend_b1_b64(b1) -> b64 {
+block0(v0: b1):
+  v1 = bextend.b64 v0
+  return v1
+}
+; run: %bextend_b1_b64(true) == true
+; run: %bextend_b1_b64(false) == false
+
+
+function %bextend_b8_b16(b8) -> b16 {
+block0(v0: b8):
+  v1 = bextend.b16 v0
+  return v1
+}
+; run: %bextend_b8_b16(true) == true
+; run: %bextend_b8_b16(false) == false
+
+function %bextend_b8_b32(b8) -> b32 {
+block0(v0: b8):
+  v1 = bextend.b32 v0
+  return v1
+}
+; run: %bextend_b8_b32(true) == true
+; run: %bextend_b8_b32(false) == false
+
+function %bextend_b8_b64(b8) -> b64 {
+block0(v0: b8):
+  v1 = bextend.b64 v0
+  return v1
+}
+; run: %bextend_b8_b64(true) == true
+; run: %bextend_b8_b64(false) == false
+
+
+function %bextend_b16_b32(b16) -> b32 {
+block0(v0: b16):
+  v1 = bextend.b32 v0
+  return v1
+}
+; run: %bextend_b16_b32(true) == true
+; run: %bextend_b16_b32(false) == false
+
+function %bextend_b16_b64(b16) -> b64 {
+block0(v0: b16):
+  v1 = bextend.b64 v0
+  return v1
+}
+; run: %bextend_b16_b64(true) == true
+; run: %bextend_b16_b64(false) == false
+
+
+function %bextend_b32_b64(b32) -> b64 {
+block0(v0: b32):
+  v1 = bextend.b64 v0
+  return v1
+}
+; run: %bextend_b32_b64(true) == true
+; run: %bextend_b32_b64(false) == false

--- a/cranelift/filetests/filetests/runtests/bmask.clif
+++ b/cranelift/filetests/filetests/runtests/bmask.clif
@@ -1,0 +1,161 @@
+test interpret
+
+function %bmask_b64_i64(b64) -> i64 {
+block0(v0: b64):
+  v1 = bmask.i64 v0
+  return v1
+}
+; run: %bmask_b64_i64(true) == -1
+; run: %bmask_b64_i64(false) == 0
+
+function %bmask_b64_i32(b64) -> i32 {
+block0(v0: b64):
+  v1 = bmask.i32 v0
+  return v1
+}
+; run: %bmask_b64_i32(true) == -1
+; run: %bmask_b64_i32(false) == 0
+
+function %bmask_b64_i16(b64) -> i16 {
+block0(v0: b64):
+  v1 = bmask.i16 v0
+  return v1
+}
+; run: %bmask_b64_i16(true) == -1
+; run: %bmask_b64_i16(false) == 0
+
+function %bmask_b64_i8(b64) -> i8 {
+block0(v0: b64):
+  v1 = bmask.i8 v0
+  return v1
+}
+; run: %bmask_b64_i8(true) == -1
+; run: %bmask_b64_i8(false) == 0
+
+function %bmask_b32_i64(b32) -> i64 {
+block0(v0: b32):
+  v1 = bmask.i64 v0
+  return v1
+}
+; run: %bmask_b32_i64(true) == -1
+; run: %bmask_b32_i64(false) == 0
+
+function %bmask_b32_i32(b32) -> i32 {
+block0(v0: b32):
+  v1 = bmask.i32 v0
+  return v1
+}
+; run: %bmask_b32_i32(true) == -1
+; run: %bmask_b32_i32(false) == 0
+
+function %bmask_b32_i16(b32) -> i16 {
+block0(v0: b32):
+  v1 = bmask.i16 v0
+  return v1
+}
+; run: %bmask_b32_i16(true) == -1
+; run: %bmask_b32_i16(false) == 0
+
+function %bmask_b32_i8(b32) -> i8 {
+block0(v0: b32):
+  v1 = bmask.i8 v0
+  return v1
+}
+; run: %bmask_b32_i8(true) == -1
+; run: %bmask_b32_i8(false) == 0
+
+function %bmask_b16_i64(b16) -> i64 {
+block0(v0: b16):
+  v1 = bmask.i64 v0
+  return v1
+}
+; run: %bmask_b16_i64(true) == -1
+; run: %bmask_b16_i64(false) == 0
+
+function %bmask_b16_i32(b16) -> i32 {
+block0(v0: b16):
+  v1 = bmask.i32 v0
+  return v1
+}
+; run: %bmask_b16_i32(true) == -1
+; run: %bmask_b16_i32(false) == 0
+
+function %bmask_b16_i16(b16) -> i16 {
+block0(v0: b16):
+  v1 = bmask.i16 v0
+  return v1
+}
+; run: %bmask_b16_i16(true) == -1
+; run: %bmask_b16_i16(false) == 0
+
+function %bmask_b16_i8(b16) -> i8 {
+block0(v0: b16):
+  v1 = bmask.i8 v0
+  return v1
+}
+; run: %bmask_b16_i8(true) == -1
+; run: %bmask_b16_i8(false) == 0
+
+function %bmask_b8_i64(b8) -> i64 {
+block0(v0: b8):
+  v1 = bmask.i64 v0
+  return v1
+}
+; run: %bmask_b8_i64(true) == -1
+; run: %bmask_b8_i64(false) == 0
+
+function %bmask_b8_i32(b8) -> i32 {
+block0(v0: b8):
+  v1 = bmask.i32 v0
+  return v1
+}
+; run: %bmask_b8_i32(true) == -1
+; run: %bmask_b8_i32(false) == 0
+
+function %bmask_b8_i16(b8) -> i16 {
+block0(v0: b8):
+  v1 = bmask.i16 v0
+  return v1
+}
+; run: %bmask_b8_i16(true) == -1
+; run: %bmask_b8_i16(false) == 0
+
+function %bmask_b8_i8(b8) -> i8 {
+block0(v0: b8):
+  v1 = bmask.i8 v0
+  return v1
+}
+; run: %bmask_b8_i8(true) == -1
+; run: %bmask_b8_i8(false) == 0
+
+function %bmask_b1_i64(b1) -> i64 {
+block0(v0: b1):
+  v1 = bmask.i64 v0
+  return v1
+}
+; run: %bmask_b1_i64(true) == -1
+; run: %bmask_b1_i64(false) == 0
+
+function %bmask_b1_i32(b1) -> i32 {
+block0(v0: b1):
+  v1 = bmask.i32 v0
+  return v1
+}
+; run: %bmask_b1_i32(true) == -1
+; run: %bmask_b1_i32(false) == 0
+
+function %bmask_b1_i16(b1) -> i16 {
+block0(v0: b1):
+  v1 = bmask.i16 v0
+  return v1
+}
+; run: %bmask_b1_i16(true) == -1
+; run: %bmask_b1_i16(false) == 0
+
+function %bmask_b1_i8(b1) -> i8 {
+block0(v0: b1):
+  v1 = bmask.i8 v0
+  return v1
+}
+; run: %bmask_b1_i8(true) == -1
+; run: %bmask_b1_i8(false) == 0

--- a/cranelift/filetests/filetests/runtests/breduce.clif
+++ b/cranelift/filetests/filetests/runtests/breduce.clif
@@ -1,0 +1,85 @@
+test interpret
+
+function %breduce_b8_b1(b8) -> b1 {
+block0(v0: b8):
+  v1 = breduce.b1 v0
+  return v1
+}
+; run: %breduce_b8_b1(true) == true
+; run: %breduce_b8_b1(false) == false
+
+
+function %breduce_b16_b1(b16) -> b1 {
+block0(v0: b16):
+  v1 = breduce.b1 v0
+  return v1
+}
+; run: %breduce_b16_b1(true) == true
+; run: %breduce_b16_b1(false) == false
+
+function %breduce_b16_b8(b16) -> b8 {
+block0(v0: b16):
+  v1 = breduce.b8 v0
+  return v1
+}
+; run: %breduce_b16_b8(true) == true
+; run: %breduce_b16_b8(false) == false
+
+
+function %breduce_b32_b1(b32) -> b1 {
+block0(v0: b32):
+  v1 = breduce.b1 v0
+  return v1
+}
+; run: %breduce_b32_b1(true) == true
+; run: %breduce_b32_b1(false) == false
+
+function %breduce_b32_b8(b32) -> b8 {
+block0(v0: b32):
+  v1 = breduce.b8 v0
+  return v1
+}
+; run: %breduce_b32_b8(true) == true
+; run: %breduce_b32_b8(false) == false
+
+function %breduce_b32_b16(b32) -> b16 {
+block0(v0: b32):
+  v1 = breduce.b16 v0
+  return v1
+}
+; run: %breduce_b32_b16(true) == true
+; run: %breduce_b32_b16(false) == false
+
+
+
+function %breduce_b64_b1(b64) -> b1 {
+block0(v0: b64):
+  v1 = breduce.b1 v0
+  return v1
+}
+; run: %breduce_b64_b1(true) == true
+; run: %breduce_b64_b1(false) == false
+
+function %breduce_b64_b8(b64) -> b8 {
+block0(v0: b64):
+  v1 = breduce.b8 v0
+  return v1
+}
+; run: %breduce_b64_b8(true) == true
+; run: %breduce_b64_b8(false) == false
+
+function %breduce_b64_b16(b64) -> b16 {
+block0(v0: b64):
+  v1 = breduce.b16 v0
+  return v1
+}
+; run: %breduce_b64_b16(true) == true
+; run: %breduce_b64_b16(false) == false
+
+function %breduce_b64_b32(b64) -> b32 {
+block0(v0: b64):
+  v1 = breduce.b32 v0
+  return v1
+}
+; run: %breduce_b64_b32(true) == true
+; run: %breduce_b64_b32(false) == false

--- a/cranelift/filetests/filetests/runtests/i128-bextend.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bextend.clif
@@ -1,0 +1,42 @@
+test interpret
+
+function %bextend_b1_b128(b1) -> b128 {
+block0(v0: b1):
+  v1 = bextend.b128 v0
+  return v1
+}
+; run: %bextend_b1_b128(true) == true
+; run: %bextend_b1_b128(false) == false
+
+function %bextend_b8_b128(b8) -> b128 {
+block0(v0: b8):
+  v1 = bextend.b128 v0
+  return v1
+}
+; run: %bextend_b8_b128(true) == true
+; run: %bextend_b8_b128(false) == false
+
+function %bextend_b16_b128(b16) -> b128 {
+block0(v0: b16):
+  v1 = bextend.b128 v0
+  return v1
+}
+; run: %bextend_b16_b128(true) == true
+; run: %bextend_b16_b128(false) == false
+
+function %bextend_b32_b128(b32) -> b128 {
+block0(v0: b32):
+  v1 = bextend.b128 v0
+  return v1
+}
+; run: %bextend_b32_b128(true) == true
+; run: %bextend_b32_b128(false) == false
+
+
+function %bextend_b64_b128(b64) -> b128 {
+block0(v0: b64):
+  v1 = bextend.b128 v0
+  return v1
+}
+; run: %bextend_b64_b128(true) == true
+; run: %bextend_b64_b128(false) == false

--- a/cranelift/filetests/filetests/runtests/i128-bmask.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bmask.clif
@@ -1,0 +1,82 @@
+test interpret
+
+function %bmask_b128_i128(b128) -> i128 {
+block0(v0: b128):
+  v1 = bmask.i128 v0
+  return v1
+}
+; run: %bmask_b128_i128(true) == -1
+; run: %bmask_b128_i128(false) == 0
+
+function %bmask_b128_i64(b128) -> i64 {
+block0(v0: b128):
+  v1 = bmask.i64 v0
+  return v1
+}
+; run: %bmask_b128_i64(true) == -1
+; run: %bmask_b128_i64(false) == 0
+
+function %bmask_b128_i32(b128) -> i32 {
+block0(v0: b128):
+  v1 = bmask.i32 v0
+  return v1
+}
+; run: %bmask_b128_i32(true) == -1
+; run: %bmask_b128_i32(false) == 0
+
+function %bmask_b128_i16(b128) -> i16 {
+block0(v0: b128):
+  v1 = bmask.i16 v0
+  return v1
+}
+; run: %bmask_b128_i16(true) == -1
+; run: %bmask_b128_i16(false) == 0
+
+function %bmask_b128_i8(b128) -> i8 {
+block0(v0: b128):
+  v1 = bmask.i8 v0
+  return v1
+}
+; run: %bmask_b128_i8(true) == -1
+; run: %bmask_b128_i8(false) == 0
+
+
+function %bmask_b64_i128(b64) -> i128 {
+block0(v0: b64):
+  v1 = bmask.i128 v0
+  return v1
+}
+; run: %bmask_b64_i128(true) == -1
+; run: %bmask_b64_i128(false) == 0
+
+function %bmask_b32_i128(b32) -> i128 {
+block0(v0: b32):
+  v1 = bmask.i128 v0
+  return v1
+}
+; run: %bmask_b32_i128(true) == -1
+; run: %bmask_b32_i128(false) == 0
+
+function %bmask_b16_i128(b16) -> i128 {
+block0(v0: b16):
+  v1 = bmask.i128 v0
+  return v1
+}
+; run: %bmask_b16_i128(true) == -1
+; run: %bmask_b16_i128(false) == 0
+
+function %bmask_b8_i128(b8) -> i128 {
+block0(v0: b8):
+  v1 = bmask.i128 v0
+  return v1
+}
+; run: %bmask_b8_i128(true) == -1
+; run: %bmask_b8_i128(false) == 0
+
+function %bmask_b1_i128(b1) -> i128 {
+block0(v0: b1):
+  v1 = bmask.i128 v0
+  return v1
+}
+; run: %bmask_b1_i128(true) == -1
+; run: %bmask_b1_i128(false) == 0

--- a/cranelift/filetests/filetests/runtests/i128-breduce.clif
+++ b/cranelift/filetests/filetests/runtests/i128-breduce.clif
@@ -1,0 +1,41 @@
+test interpret
+
+function %breduce_b128_b1(b128) -> b1 {
+block0(v0: b128):
+  v1 = breduce.b1 v0
+  return v1
+}
+; run: %breduce_b128_b1(true) == true
+; run: %breduce_b128_b1(false) == false
+
+function %breduce_b128_b8(b128) -> b8 {
+block0(v0: b128):
+  v1 = breduce.b8 v0
+  return v1
+}
+; run: %breduce_b128_b8(true) == true
+; run: %breduce_b128_b8(false) == false
+
+function %breduce_b128_b16(b128) -> b16 {
+block0(v0: b128):
+  v1 = breduce.b16 v0
+  return v1
+}
+; run: %breduce_b128_b16(true) == true
+; run: %breduce_b128_b16(false) == false
+
+function %breduce_b128_b32(b128) -> b32 {
+block0(v0: b128):
+  v1 = breduce.b32 v0
+  return v1
+}
+; run: %breduce_b128_b32(true) == true
+; run: %breduce_b128_b32(false) == false
+
+function %breduce_b128_b64(b128) -> b64 {
+block0(v0: b128):
+  v1 = breduce.b64 v0
+  return v1
+}
+; run: %breduce_b128_b64(true) == true
+; run: %breduce_b128_b64(false) == false

--- a/cranelift/filetests/filetests/runtests/simd-bmask.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bmask.clif
@@ -1,0 +1,30 @@
+test interpret
+
+
+function %bmask_i8x16(b8x16) -> i8x16 {
+block0(v0: b8x16):
+    v1 = bmask.i8x16 v0
+    return v1
+}
+; run: %bmask_i8x16([true false true false true false true false true false true false true false true false]) == [-1 0 -1 0 -1 0 -1 0 -1 0 -1 0 -1 0 -1 0]
+
+function %bmask_i16x8(b16x8) -> i16x8 {
+block0(v0: b16x8):
+    v1 = bmask.i16x8 v0
+    return v1
+}
+; run: %bmask_i16x8([true false true false true false true false]) == [-1 0 -1 0 -1 0 -1 0]
+
+function %bmask_i32x4(b32x4) -> i32x4 {
+block0(v0: b32x4):
+    v1 = bmask.i32x4 v0
+    return v1
+}
+; run: %bmask_i32x4([true false true false]) == [-1 0 -1 0]
+
+function %bmask_i64x2(b64x2) -> i64x2 {
+block0(v0: b64x2):
+    v1 = bmask.i64x2 v0
+    return v1
+}
+; run: %bmask_i64x2([true false]) == [-1 0]

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -277,11 +277,11 @@ impl Value for DataValue {
                 (DataValue::I64(n), types::I128) => DataValue::I128(n as i128),
                 (DataValue::B(b), t) if t.is_bool() => DataValue::B(b),
                 (DataValue::B(b), t) if t.is_int() => {
-                    let val = if b {
-                        // Bools are represented in memory as all 1's
-                        (1i128 << t.bits()) - 1
-                    } else {
-                        0
+                    // Bools are represented in memory as all 1's
+                    let val = match (b, t) {
+                        (true, types::I128) => -1,
+                        (true, t) => (1i128 << t.bits()) - 1,
+                        _ => 0,
                     };
                     DataValue::int(val, t)?
                 }


### PR DESCRIPTION
Hey,

A few more ops for the interpreter. `bextend` and `breduce` were already implemented, but we add a testsuite for it here.

Needs #3351 for CI to pass