### PR TITLE
Add "cargo:rerun-if-changed=build.rs" to some build.rs files.

### DIFF
--- a/crates/misc/run-examples/build.rs
+++ b/crates/misc/run-examples/build.rs
@@ -3,4 +3,5 @@ fn main() {
         "cargo:rustc-env=TARGET={}",
         std::env::var("TARGET").unwrap()
     );
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/crates/wasi-common/build.rs
+++ b/crates/wasi-common/build.rs
@@ -7,4 +7,6 @@ fn main() {
     println!("cargo:wasi={}", wasi.display());
     // and available to our own crate as WASI_ROOT:
     println!("cargo:rustc-env=WASI_ROOT={}", wasi.display());
+    // and this build.rs script doesn't depend on any files.
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
Add "cargo:rerun-if-changed=build.rs" in some build.rs files to tell
cargo that it doesn't need to scan the whole package. See the
[Cargo docs] for more info.

[Cargo docs]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
