### PR TITLE
Use `__builtin_setjmp` instead of `sigsetjmp`.

### DIFF
--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -20,7 +20,6 @@ typedef jmp_buf platform_jmp_buf;
 #define platform_setjmp(buf) sigsetjmp(buf, 0)
 #define platform_longjmp(buf, arg) siglongjmp(buf, arg)
 typedef sigjmp_buf platform_jmp_buf;
-#endif
 
 #else
 

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -13,6 +13,11 @@ typedef jmp_buf platform_jmp_buf;
 // and restoring most of the registers. See the [GCC docs] and [clang docs]
 // for more information.
 //
+// Per the caveat in the GCC docs, this assumes that the host compiler (which
+// may be compiling for a generic architecture family) knows about all the
+// register state that Cranelift (which may be specializing for the hardware at
+// runtime) is assuming is callee-saved.
+//
 // [GCC docs]: https://gcc.gnu.org/onlinedocs/gcc/Nonlocal-Gotos.html
 // [clang docs]: https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp
 #define platform_setjmp(buf) __builtin_setjmp(buf)

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -17,7 +17,7 @@ typedef jmp_buf platform_jmp_buf;
 // [clang docs]: https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp
 #define platform_setjmp(buf) __builtin_setjmp(buf)
 #define platform_longjmp(buf, arg) __builtin_longjmp(buf, arg)
-typedef void *platform_jmp_buf[5];
+typedef void *platform_jmp_buf[5]; // this is the documented size; see the docs links for details.
 #endif
 
 int wasmtime_setjmp(


### PR DESCRIPTION
Use [`__builtin_setjmp`] instead of `sigsetjmp`, as it is implemented in
the compiler, performed inline, and saves much less state. This speeds up
calls into wasm by about 8% on my machine.

[`__builtin_setjmp`]: https://gcc.gnu.org/onlinedocs/gcc/Nonlocal-Gotos.html

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
