### PR TITLE
Implement `VhighBits` & `Vselect` for interpreter

### DIFF
--- a/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
@@ -1,0 +1,53 @@
+test interpret
+test run
+target aarch64
+set enable_simd
+target x86_64
+
+function %vhighbits_i8x16(i8x16) -> i16 {
+block0(v0: i8x16):
+    v1 = vhigh_bits.i16 v0
+    return v1
+}
+; run: %vhighbits_i8x16([0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]) == 0
+; run: %vhighbits_i8x16([0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0]) == 0
+; run: %vhighbits_i8x16([1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7]) == 0
+; run: %vhighbits_i8x16([128 128 128 128 128 128 128 128 128 128 128 128 128 128 128 128]) == -1
+; run: %vhighbits_i8x16([128 128 128 128 128 128 128 128 128 128 128 128 128 128 128 8]) == 32767
+
+function %vhighbits_i16x8(i16x8) -> i8 {
+block0(v0: i16x8):
+    v1 = vhigh_bits.i8 v0
+    return v1
+}
+; run: %vhighbits_i16x8([0 0 0 0 0 0 0 0]) == 0
+; run: %vhighbits_i16x8([0 0 0 0 0 0 0 1]) == 0
+; run: %vhighbits_i16x8([1 2 3 4 5 6 7 8]) == 0
+; run: %vhighbits_i16x8([128 128 128 128 128 128 128 128]) == 0
+; run: %vhighbits_i16x8([32768 32768 32768 32768 32768 32768 32768 0]) == 127
+
+
+function %vhighbits_i32x4(i32x4) -> i8 {
+block0(v0: i32x4):
+    v1 = vhigh_bits.i8 v0
+    return v1
+}
+; run: %vhighbits_i32x4([0 0 0 0]) == 0
+; run: %vhighbits_i32x4([0 0 0 1]) == 0
+; run: %vhighbits_i32x4([1 2 3 4]) == 0
+; run: %vhighbits_i32x4([128 128 128 128]) == 0
+; run: %vhighbits_i32x4([2147483648 2147483648 2147483648 2147483648]) == 15
+; run: %vhighbits_i32x4([2147483648 0 2147483648 0]) == 5
+
+
+function %vhighbits_i64x2(i64x2) -> i8 {
+block0(v0: i64x2):
+    v1 = vhigh_bits.i8 v0
+    return v1
+}
+; run: %vhighbits_i64x2([0 0]) == 0
+; run: %vhighbits_i64x2([0 1]) == 0
+; run: %vhighbits_i64x2([1 2]) == 0
+; run: %vhighbits_i64x2([128 128]) == 0
+; run: %vhighbits_i64x2([18446744073709551615 18446744073709551615]) == 3
+; run: %vhighbits_i64x2([18446744073709551615 0]) == 1

--- a/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
@@ -2,7 +2,7 @@ test interpret
 test run
 target aarch64
 set enable_simd
-target x86_64
+target x86_64 machinst
 
 function %vhighbits_i8x16(i8x16) -> i16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-vselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vselect.clif
@@ -4,8 +4,6 @@ test run
 target aarch64
 set enable_simd
 target x86_64 machinst
-set enable_simd
-target x86_64 legacy haswell
 
 function %vselect_i8x16() -> i8x16 {
 block0:

--- a/cranelift/filetests/filetests/runtests/simd-vselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vselect.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 ; target s390x TODO: Not yet implemented on s390x
 target aarch64
@@ -45,3 +46,31 @@ block0:
     return v4
 }
 ; run: %vselect_i64x2() == [200 101]
+
+function %vselect_p_i8x16(b8x16, i8x16, i8x16) -> i8x16 {
+block0(v0: b8x16, v1: i8x16, v2: i8x16):
+    v3 = vselect v0, v1, v2
+    return v3
+}
+; run: %vselect_p_i8x16([true false true true true false false false true false true true true false false false], [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]) == [1 18 3 4 5 22 23 24 9 26 11 12 13 30 31 32]
+
+function %vselect_p_i16x8(b16x8, i16x8, i16x8) -> i16x8 {
+block0(v0: b16x8, v1: i16x8, v2: i16x8):
+    v3 = vselect v0, v1, v2
+    return v3
+}
+; run: %vselect_p_i16x8([true false true true true false false false], [1 2 3 4 5 6 7 8], [17 18 19 20 21 22 23 24]) == [1 18 3 4 5 22 23 24]
+
+function %vselect_p_i32x4(b32x4, i32x4, i32x4) -> i32x4 {
+block0(v0: b32x4, v1: i32x4, v2: i32x4):
+    v3 = vselect v0, v1, v2
+    return v3
+}
+; run: %vselect_p_i32x4([true false true true], [1 2 3 4], [100000 200000 300000 400000]) == [1 200000 3 4]
+
+function %vselect_p_i64x2(b64x2, i64x2, i64x2) -> i64x2 {
+block0(v0: b64x2, v1: i64x2, v2: i64x2):
+    v3 = vselect v0, v1, v2
+    return v3
+}
+; run: %vselect_p_i64x2([true false], [1 2], [100000000000 200000000000]) == [1 200000000000]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -824,10 +824,37 @@ where
             let lanes = extractlanes(&arg(0)?, ctrl_ty.lane_type())?;
             assign(lanes[idx].clone())
         }
-        Opcode::VhighBits => unimplemented!("VhighBits"),
+        Opcode::VhighBits => {
+            // `ctrl_ty` controls the return type for this, so the input type
+            // must be retrieved via `inst_context`.
+            let lane_type = inst_context
+                .type_of(inst_context.args()[0])
+                .unwrap()
+                .lane_type();
+            let a = extractlanes(&arg(0)?, lane_type)?;
+            let mut result: i128 = 0;
+            for (i, val) in a.into_iter().enumerate() {
+                let val = val.reverse_bits()?.into_int()?; // MSB -> LSB
+                result |= (val & 1) << i;
+            }
+            assign(Value::int(result, ctrl_ty)?)
+        }
         Opcode::Vsplit => unimplemented!("Vsplit"),
         Opcode::Vconcat => unimplemented!("Vconcat"),
-        Opcode::Vselect => unimplemented!("Vselect"),
+        Opcode::Vselect => {
+            let c = extractlanes(&arg(0)?, ctrl_ty.lane_type())?;
+            let x = extractlanes(&arg(1)?, ctrl_ty.lane_type())?;
+            let y = extractlanes(&arg(2)?, ctrl_ty.lane_type())?;
+            let mut new_vec = SimdVec::new();
+            for (c, (x, y)) in c.into_iter().zip(x.into_iter().zip(y.into_iter())) {
+                if Value::eq(&c, &Value::int(0, ctrl_ty.lane_type())?)? {
+                    new_vec.push(y);
+                } else {
+                    new_vec.push(x);
+                }
+            }
+            assign(vectorizelanes(&new_vec, ctrl_ty)?)
+        }
         Opcode::VanyTrue => assign(fold_vector(
             arg(0)?,
             ctrl_ty,


### PR DESCRIPTION
Implemented the following Opcodes for the Cranelift interpreter:
- `VhighBits` to reduce a vector to a scalar integer formed by
concatenating the MSB of each lane.
- `Vselect` to select lanes from two vectors controlled by a boolean
vector.

Copyright (c) 2021, Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
