### PR TITLE
Implement `Unarrow`, `Uunarrow`, and `Snarrow` for the interpreter

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -4048,7 +4048,7 @@ pub(crate) fn define(
         Combine `x` and `y` into a vector with twice the lanes but half the integer width while
         saturating overflowing values to the unsigned maximum and minimum.
 
-        Note that all input lanes are considered unsigned.
+        Note that all input lanes are considered unsigned: any negative values will be interpreted as unsigned, overflowing and being replaced with the unsigned maximum.
 
         The lanes will be concatenated after narrowing. For example, when `x` and `y` are `i32x4`
         and `x = [x3, x2, x1, x0]` and `y = [y3, y2, y1, y0]`, then after narrowing the value

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -79,6 +79,29 @@ impl Type {
         }
     }
 
+    /// Get the (minimum, maximum) values represented by each lane in the type.
+    pub fn bounds(self, signed: bool) -> (i128, i128) {
+        if signed {
+            match self.lane_type() {
+                I8 => (i8::MIN as i128, i8::MAX as i128),
+                I16 => (i16::MIN as i128, i16::MAX as i128),
+                I32 => (i32::MIN as i128, i32::MAX as i128),
+                I64 => (i64::MIN as i128, i64::MAX as i128),
+                I128 => (i128::MIN, i128::MAX),
+                _ => unimplemented!(),
+            }
+        } else {
+            match self.lane_type() {
+                I8 => (u8::MIN as i128, u8::MAX as i128),
+                I16 => (u16::MIN as i128, u16::MAX as i128),
+                I32 => (u32::MIN as i128, u32::MAX as i128),
+                I64 => (u64::MIN as i128, u64::MAX as i128),
+                I128 => (u128::MIN as i128, u128::MAX as i128),
+                _ => unimplemented!(),
+            }
+        }
+    }
+
     /// Get an integer type with the requested number of bits.
     pub fn int(bits: u16) -> Option<Self> {
         match bits {

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -80,23 +80,24 @@ impl Type {
     }
 
     /// Get the (minimum, maximum) values represented by each lane in the type.
-    pub fn bounds(self, signed: bool) -> (i128, i128) {
+    /// Note that these are returned as unsigned 'bit patterns'.
+    pub fn bounds(self, signed: bool) -> (u128, u128) {
         if signed {
             match self.lane_type() {
-                I8 => (i8::MIN as i128, i8::MAX as i128),
-                I16 => (i16::MIN as i128, i16::MAX as i128),
-                I32 => (i32::MIN as i128, i32::MAX as i128),
-                I64 => (i64::MIN as i128, i64::MAX as i128),
-                I128 => (i128::MIN, i128::MAX),
+                I8 => (i8::MIN as u128, i8::MAX as u128),
+                I16 => (i16::MIN as u128, i16::MAX as u128),
+                I32 => (i32::MIN as u128, i32::MAX as u128),
+                I64 => (i64::MIN as u128, i64::MAX as u128),
+                I128 => (i128::MIN as u128, i128::MAX as u128),
                 _ => unimplemented!(),
             }
         } else {
             match self.lane_type() {
-                I8 => (u8::MIN as i128, u8::MAX as i128),
-                I16 => (u16::MIN as i128, u16::MAX as i128),
-                I32 => (u32::MIN as i128, u32::MAX as i128),
-                I64 => (u64::MIN as i128, u64::MAX as i128),
-                I128 => (u128::MIN as i128, u128::MAX as i128),
+                I8 => (u8::MIN as u128, u8::MAX as u128),
+                I16 => (u16::MIN as u128, u16::MAX as u128),
+                I32 => (u32::MIN as u128, u32::MAX as u128),
+                I64 => (u64::MIN as u128, u64::MAX as u128),
+                I128 => (u128::MIN, u128::MAX),
                 _ => unimplemented!(),
             }
         }

--- a/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
@@ -1,0 +1,11 @@
+test interpret
+test run
+target aarch64
+; x86_64 considers the case `i64x2` -> `i32x4` to be 'unreachable'
+
+function %snarrow_i64x2(i64x2, i64x2) -> i32x4 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = snarrow v0, v1
+    return v2
+}
+; run: %snarrow_i64x2([65535 -100000], [5000000000 73]) == [65535 -100000 2147483647 73]

--- a/cranelift/filetests/filetests/runtests/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow.clif
@@ -1,0 +1,19 @@
+test interpret
+test run
+target aarch64
+set enable_simd
+target x86_64
+
+function %snarrow_i16x8(i16x8, i16x8) -> i8x16 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = snarrow v0, v1
+    return v2
+}
+; run: %snarrow_i16x8([1 127 128 15 32767 -32 48 0], [8 255 -100 100 -32768 73 80 42]) == [1 127 127 15 127 -32 48 0 8 127 -100 100 -128 73 80 42]
+
+function %snarrow_i32x4(i32x4, i32x4) -> i16x8 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = snarrow v0, v1
+    return v2
+}
+; run: %snarrow_i32x4([32767 1048575 -70000 -5], [268435455 73 268435455 42]) == [32767 32767 -32768 -5 32767 73 32767 42]

--- a/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
@@ -1,0 +1,11 @@
+test interpret
+test run
+target aarch64
+; x86_64 considers the case `i64x2 -> i32x4` to be 'unreachable'
+
+function %unarrow_i64x2(i64x2, i64x2) -> i32x4 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = unarrow v0, v1
+    return v2
+}
+; run: %unarrow_i64x2([65535 -100000], [5000000000 73]) == [65535 0 4294967295 73]

--- a/cranelift/filetests/filetests/runtests/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow.clif
@@ -1,0 +1,19 @@
+test interpret
+test run
+target aarch64
+set enable_simd
+target x86_64
+
+function %unarrow_i16x8(i16x8, i16x8) -> i8x16 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = unarrow v0, v1
+    return v2
+}
+; run: %unarrow_i16x8([1 127 128 15 65535 -32 48 0], [8 255 -100 100 65534 73 80 42]) == [1 127 128 15 0 0 48 0 8 255 0 100 0 73 80 42]
+
+function %unarrow_i32x4(i32x4, i32x4) -> i16x8 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = unarrow v0, v1
+    return v2
+}
+; run: %unarrow_i32x4([65535 1048575 -70000 -5], [268435455 73 268435455 42]) == [65535 65535 0 0 65535 73 65535 42]

--- a/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
@@ -1,0 +1,26 @@
+test interpret
+test run
+target aarch64
+; x86_64 panics: `Did not match fcvt input!
+; thread 'worker #0' panicked at 'register allocation: Analysis(EntryLiveinValues([v2V]))', cranelift/codegen/src/machinst/compile.rs:96:10`
+
+function %uunarrow_i16x8(i16x8, i16x8) -> i8x16 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uunarrow v0, v1
+    return v2
+}
+; run: %uunarrow_i16x8([1 127 128 15 65535 -32 48 0], [8 255 -100 100 65534 73 80 42]) == [1 127 128 15 255 255 48 0 8 255 255 100 255 73 80 42]
+
+function %uunarrow_i32x4(i32x4, i32x4) -> i16x8 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uunarrow v0, v1
+    return v2
+}
+; run: %uunarrow_i32x4([65535 1048575 -70000 -5], [268435455 73 268435455 42]) == [65535 65535 65535 65535 65535 73 65535 42]
+
+function %uunarrow_i64x2(i64x2, i64x2) -> i32x4 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = uunarrow v0, v1
+    return v2
+}
+; run: %uunarrow_i64x2([65535 -100000], [5000000000 73]) == [65535 4294967295 4294967295 73]


### PR DESCRIPTION
Implemented the following Opcodes for the Cranelift interpreter:
- `Unarrow` to combine two SIMD vectors into a new vector with twice
the lanes but half the width, with signed inputs which are clamped to
`0x00`.
- `Uunarrow` to perform the same operation as `Unarrow` but treating
inputs as unsigned.
- `Snarrow` to perform the same operation as `Unarrow` but treating
both inputs and outputs as signed, and saturating accordingly.

Note that all 3 instructions saturate at the type boundaries.

Copyright (c) 2021, Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
