### PR TITLE
Implement `Smulhi` for interpreter

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -2469,8 +2469,7 @@ pub(crate) fn define(
         Signed integer multiplication, producing the high half of a
         double-length result.
 
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
+        Polymorphic over all integer types (vector and scalar).
         "#,
             &formats.binary,
         )

--- a/cranelift/filetests/filetests/runtests/simd-smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/simd-smulhi.clif
@@ -1,0 +1,30 @@
+test interpret
+; The AArch64 and x86_64 backends only support scalar values.
+
+function %smulhi_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i8x16([1 -2 3 -4 5 -6 7 -8 127 127 127 127 -128 -128 -128 -128], [9 10 -11 -12 13 14 -15 -16 17 18 -19 -20 21 22 -128 127]) == [0 -1 -1 0 0 -1 -1 0 8 8 -10 -10 -11 -11 64 -64]
+
+function %smulhi_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i16x8([1 -2 255 -255 255 -255 32767 -32768], [3 4 -5 -6 7 8 -32768 -32768]) == [0 -1 -1 0 0 -1 -16384 16384]
+
+function %smulhi_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i32x4([1 -255 65535 -2147483648], [2 65535 -2147483647 -2147483647]) == [0 -1 -32768 1073741823]
+
+function %smulhi_i64x2(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i64x2([-1 9223372036854775807], [-2 -9223372036854775808]) == [0 -4611686018427387904]

--- a/cranelift/filetests/filetests/runtests/smulhi-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi-aarch64.clif
@@ -1,0 +1,13 @@
+test interpret
+test run
+target aarch64
+; x86_64 backend only supports `i16`, `i32`, and `i64` types.
+
+function %smulhi_i8(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i8(-2, -4) == 0
+; run: %smulhi_i8(2, -4) == -1
+; run: %smulhi_i8(127, 127) == 63

--- a/cranelift/filetests/filetests/runtests/smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi.clif
@@ -1,0 +1,32 @@
+test interpret
+test run
+target aarch64
+set enable_simd
+target x86_64 machinst
+
+function %smulhi_i16(i16, i16) -> i16 {
+block0(v0: i16, v1: i16):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i16(-2, -4) == 0
+; run: %smulhi_i16(2, -4) == -1
+; run: %smulhi_i16(32767, 32767) == 16383
+
+function %smulhi_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i32(-500, -700) == 0
+; run: %smulhi_i32(500, -700) == -1
+; run: %smulhi_i32(2147483647, 2147483647) == 1073741823
+
+function %smulhi_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = smulhi v0, v1
+    return v2
+}
+; run: %smulhi_i64(-4294967295, -4294967295) == 0
+; run: %smulhi_i64(4294967295, -4294967295) == -1
+; run: %smulhi_i64(9223372036854775807, 9223372036854775807) == 4611686018427387903

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -308,6 +308,7 @@ impl Value for DataValue {
                 (DataValue::I16(n), types::I32) => DataValue::I32(n as i32),
                 (DataValue::I16(n), types::I64) => DataValue::I64(n as i64),
                 (DataValue::I32(n), types::I64) => DataValue::I64(n as i64),
+                (DataValue::I64(n), types::I128) => DataValue::I128(n as i128),
                 (dv, _) => unimplemented!("conversion: {} -> {:?}", dv.ty(), kind),
             },
             ValueConversionKind::ZeroExtend(ty) => match (self, ty) {


### PR DESCRIPTION
Implemented `Smulhi` for the Cranelift interpreter, performing signed
integer multiplication and producing the high half of a double-length
result.

Copyright (c) 2021, Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
