### PR TITLE
Temporarily disable SIMD fuzzing on CI

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -142,12 +142,6 @@ impl wasm_smith::Config for WasmtimeDefaultConfig {
         4
     }
 
-    // Turn some wasm features default-on for those that have a finished
-    // implementation in Wasmtime.
-    fn simd_enabled(&self) -> bool {
-        true
-    }
-
     fn reference_types_enabled(&self) -> bool {
         true
     }

--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -40,7 +40,6 @@ pub fn fuzz_default_config(strategy: wasmtime::Strategy) -> anyhow::Result<wasmt
         .wasm_reference_types(true)
         .wasm_module_linking(true)
         .wasm_multi_memory(true)
-        .wasm_simd(true)
         .wasm_memory64(true)
         .strategy(strategy)?;
     Ok(config)

--- a/fuzz/fuzz_targets/differential_v8.rs
+++ b/fuzz/fuzz_targets/differential_v8.rs
@@ -5,7 +5,7 @@ use wasmtime_fuzzing::{generators, oracles};
 
 fuzz_target!(|data: (
     generators::Config,
-    wasm_smith::ConfiguredModule<oracles::SingleFunctionModuleConfig<true, true>>
+    wasm_smith::ConfiguredModule<oracles::SingleFunctionModuleConfig<false, true>>
 )| {
     let (config, mut wasm) = data;
     wasm.module.ensure_termination(1000);


### PR DESCRIPTION
We've got a large crop of fuzz-bugs from fuzzing with
v8-enabled-with-SIMD on CI but at this point the fuzz stats from
oss-fuzz say that the fuzzer is spending less than 50% of its time
actually fuzzing and presumably mostly hitting crashes and such. While
we fix the other issues this disables simd for fuzzing with v8 so we can
try to see if we can weed out other issues.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
