### PR TITLE
Implement `bmask` in AArch64

### DIFF
--- a/cranelift/filetests/filetests/runtests/bextend.clif
+++ b/cranelift/filetests/filetests/runtests/bextend.clif
@@ -1,4 +1,6 @@
 test interpret
+test run
+target aarch64
 
 function %bextend_b1_b8(b1) -> b8 {
 block0(v0: b1):

--- a/cranelift/filetests/filetests/runtests/bmask.clif
+++ b/cranelift/filetests/filetests/runtests/bmask.clif
@@ -1,4 +1,6 @@
 test interpret
+test run
+target aarch64
 
 function %bmask_b64_i64(b64) -> i64 {
 block0(v0: b64):

--- a/cranelift/filetests/filetests/runtests/breduce.clif
+++ b/cranelift/filetests/filetests/runtests/breduce.clif
@@ -1,4 +1,6 @@
 test interpret
+test run
+target aarch64
 
 function %breduce_b8_b1(b8) -> b1 {
 block0(v0: b8):

--- a/cranelift/filetests/filetests/runtests/i128-bextend.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bextend.clif
@@ -1,4 +1,6 @@
 test interpret
+test run
+target aarch64
 
 function %bextend_b1_b128(b1) -> b128 {
 block0(v0: b1):

--- a/cranelift/filetests/filetests/runtests/i128-bmask.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bmask.clif
@@ -1,4 +1,6 @@
 test interpret
+test run
+target aarch64
 
 function %bmask_b128_i128(b128) -> i128 {
 block0(v0: b128):

--- a/cranelift/filetests/filetests/runtests/i128-breduce.clif
+++ b/cranelift/filetests/filetests/runtests/i128-breduce.clif
@@ -1,4 +1,7 @@
 test interpret
+test run
+target aarch64
+
 
 function %breduce_b128_b1(b128) -> b1 {
 block0(v0: b128):

--- a/cranelift/filetests/filetests/runtests/i128-ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/i128-ireduce.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64

--- a/cranelift/filetests/filetests/runtests/ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/ireduce.clif
@@ -1,0 +1,57 @@
+test run
+target x86_64 machinst
+
+
+function %ireduce_i16_i8(i16) -> i8 {
+block0(v0: i16):
+  v1 = ireduce.i8 v0
+  return v1
+}
+; run: %ireduce_i16_i8(0xFF00) == 0x00
+; run: %ireduce_i16_i8(0x0042) == 0x42
+; run: %ireduce_i16_i8(0xFFFF) == 0xFF
+
+function %ireduce_i32_i8(i32) -> i8 {
+block0(v0: i32):
+  v1 = ireduce.i8 v0
+  return v1
+}
+; run: %ireduce_i32_i8(0xFFFFFF00) == 0x00
+; run: %ireduce_i32_i8(0x00000042) == 0x42
+; run: %ireduce_i32_i8(0xFFFFFFFF) == 0xFF
+
+function %ireduce_i32_i16(i32) -> i16 {
+block0(v0: i32):
+  v1 = ireduce.i16 v0
+  return v1
+}
+; run: %ireduce_i32_i16(0xFFFF0000) == 0x0000
+; run: %ireduce_i32_i16(0x00004242) == 0x4242
+; run: %ireduce_i32_i16(0xFFFFFFFF) == 0xFFFF
+
+function %ireduce_i64_i8(i64) -> i8 {
+block0(v0: i64):
+  v1 = ireduce.i8 v0
+  return v1
+}
+; run: %ireduce_i64_i8(0xFFFFFFFF_FFFFFF00) == 0x00
+; run: %ireduce_i64_i8(0x00000000_00000042) == 0x42
+; run: %ireduce_i64_i8(0xFFFFFFFF_FFFFFFFF) == 0xFF
+
+function %ireduce_i64_i16(i64) -> i16 {
+block0(v0: i64):
+  v1 = ireduce.i16 v0
+  return v1
+}
+; run: %ireduce_i64_i16(0xFFFFFFFF_FFFF0000) == 0x0000
+; run: %ireduce_i64_i16(0x00000000_00004242) == 0x4242
+; run: %ireduce_i64_i16(0xFFFFFFFF_FFFFFFFF) == 0xFFFF
+
+function %ireduce_i64_i32(i64) -> i32 {
+block0(v0: i64):
+  v1 = ireduce.i32 v0
+  return v1
+}
+; run: %ireduce_i64_i16(0xFFFFFFFF_00000000) == 0x00000000
+; run: %ireduce_i64_i16(0x00000000_42424242) == 0x42424242
+; run: %ireduce_i64_i16(0xFFFFFFFF_FFFFFFFF) == 0xFFFFFFFF

--- a/cranelift/filetests/filetests/runtests/ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/ireduce.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target aarch64
 target x86_64 machinst
@@ -53,6 +54,6 @@ block0(v0: i64):
   v1 = ireduce.i32 v0
   return v1
 }
-; run: %ireduce_i64_i16(0xFFFFFFFF_00000000) == 0x00000000
-; run: %ireduce_i64_i16(0x00000000_42424242) == 0x42424242
-; run: %ireduce_i64_i16(0xFFFFFFFF_FFFFFFFF) == 0xFFFFFFFF
+; run: %ireduce_i64_i32(0xFFFFFFFF_00000000) == 0x00000000
+; run: %ireduce_i64_i32(0x00000000_42424242) == 0x42424242
+; run: %ireduce_i64_i32(0xFFFFFFFF_FFFFFFFF) == 0xFFFFFFFF

--- a/cranelift/filetests/filetests/runtests/ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/ireduce.clif
@@ -1,4 +1,5 @@
 test run
+target aarch64
 target x86_64 machinst
 
 

--- a/cranelift/filetests/filetests/runtests/simd-bmask.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bmask.clif
@@ -1,5 +1,6 @@
 test interpret
-
+test run
+target aarch64
 
 function %bmask_i8x16(b8x16) -> i8x16 {
 block0(v0: b8x16):

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -311,7 +311,14 @@ fn make_trampoline(signature: &ir::Signature, isa: &dyn TargetIsa) -> Function {
             // that we are using the architecture's canonical boolean representation (presumably
             // comparison will emit this).
             if param.value_type.is_bool() {
-                builder.ins().icmp_imm(IntCC::NotEqual, loaded, 0)
+                let b = builder.ins().icmp_imm(IntCC::NotEqual, loaded, 0);
+
+                // icmp_imm always produces a `b1`, `bextend` it if we need a larger bool
+                if param.value_type.bits() > 1 {
+                    builder.ins().bextend(param.value_type, b)
+                } else {
+                    b
+                }
             } else if param.value_type.is_bool_vector() {
                 let zero_constant = builder.func.dfg.constants.insert(vec![0; 16].into());
                 let zero_vec = builder.ins().vconst(ty, zero_constant);

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -789,10 +789,13 @@ where
         | Opcode::ScalarToVector
         | Opcode::Breduce
         | Opcode::Bextend
-        | Opcode::Bint
-        | Opcode::Ireduce => assign(Value::convert(
+        | Opcode::Bint => assign(Value::convert(
             arg(0)?,
             ValueConversionKind::Exact(ctrl_ty),
+        )?),
+        Opcode::Ireduce => assign(Value::convert(
+            arg(0)?,
+            ValueConversionKind::Truncate(ctrl_ty),
         )?),
         Opcode::Snarrow | Opcode::Unarrow | Opcode::Uunarrow => {
             let arg0 = extractlanes(&arg(0)?, ctrl_ty.lane_type())?;


### PR DESCRIPTION
Hey, this PR Implements `bmask` for all types in the AArch64 backend, as well as fixes for `ireduce`, `breduce` and `bextend` for some types.

We have to make some changes in the trampoline to make bool args with size larger than 1 work.