### PR TITLE
Allow another trap mismatch with v8

### DIFF
--- a/crates/fuzzing/src/oracles/v8.rs
+++ b/crates/fuzzing/src/oracles/v8.rs
@@ -287,7 +287,18 @@ fn assert_error_matches(wasmtime: &anyhow::Error, v8: &str) {
             TrapCode::IntegerDivisionByZero => {
                 return verify_v8(&["divide by zero", "remainder by zero"])
             }
-            TrapCode::StackOverflow => return verify_v8(&["call stack size exceeded"]),
+            TrapCode::StackOverflow => {
+                return verify_v8(&[
+                    "call stack size exceeded",
+                    // Similar to the above comment in `UnreachableCodeReached`
+                    // if wasmtime hits a stack overflow but v8 ran all the way
+                    // to when the `unreachable` instruction was hit then that's
+                    // ok. This just means that wasmtime either has less optimal
+                    // codegen or different limits on the stack than v8 does,
+                    // which isn't an issue per-se.
+                    "unreachable",
+                ]);
+            }
             TrapCode::IndirectCallToNull => return verify_v8(&["null function"]),
             TrapCode::TableOutOfBounds => {
                 return verify_v8(&[


### PR DESCRIPTION
If Wasmtime thinks a module stack-overflows and v8 says that it does
something else that's ok. This means that the limits on v8 and Wasmtime
are different which is expected and not something we want fuzz-bugs
about.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
