### PR TITLE
Validate functions in parallel in `Module::validate`

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::mem;
 use std::path::Path;
 use std::sync::Arc;
-use wasmparser::Validator;
+use wasmparser::{Parser, ValidPayload, Validator};
 use wasmtime_environ::{ModuleEnvironment, ModuleIndex, PrimaryMap};
 use wasmtime_jit::{CompiledModule, CompiledModuleInfo, MmapVec, TypeTables};
 
@@ -593,7 +593,15 @@ impl Module {
     pub fn validate(engine: &Engine, binary: &[u8]) -> Result<()> {
         let mut validator = Validator::new();
         validator.wasm_features(engine.config().features);
-        validator.validate_all(binary)?;
+
+        let mut functions = Vec::new();
+        for payload in Parser::new(0).parse_all(binary) {
+            if let ValidPayload::Func(a, b) = validator.payload(&payload?)? {
+                functions.push((a, b));
+            }
+        }
+
+        engine.run_maybe_parallel(functions, |(mut validator, body)| validator.validate(&body))?;
         Ok(())
     }
 


### PR DESCRIPTION
We already validate wasm functions in parallel when compiling a module,
but the same parallelism wasn't available to the `Module::validate` API.
This commit peforms a minor tweak to the validate-the-whole-module API
to validate all functions in parallel in the same manner that module
compilation does.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
