### PR TITLE
Remove the rsix dependency in cranelift-native.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ name = "cranelift-native"
 version = "0.77.0"
 dependencies = [
  "cranelift-codegen",
- "rsix",
+ "libc",
  "target-lexicon",
 ]
 

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-codegen = { path = "../codegen", version = "0.77.0", default-features 
 target-lexicon = "0.12"
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
-rsix = "0.23.0"
+libc = "0.2.95"
 
 [features]
 default = ["std"]

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -126,7 +126,7 @@ pub fn builder_with_options(
     }
 
     // There is no is_s390x_feature_detected macro yet, so for now
-    // we use linux_hwcap from the rsix crate directly.
+    // we use getauxval from the libc crate directly.
     #[cfg(all(target_arch = "s390x", target_os = "linux"))]
     {
         use cranelift_codegen::settings::Configurable;
@@ -135,8 +135,8 @@ pub fn builder_with_options(
             return Ok(isa_builder);
         }
 
-        let v = rsix::process::linux_hwcap().0;
-        const HWCAP_S390X_VXRS_EXT2: usize = 32768;
+        let v = unsafe { libc::getauxval(libc::AT_HWCAP) };
+        const HWCAP_S390X_VXRS_EXT2: libc::c_ulong = 32768;
         if (v & HWCAP_S390X_VXRS_EXT2) != 0 {
             isa_builder.enable("has_vxrs_ext2").unwrap();
             // There is no separate HWCAP bit for mie2, so assume


### PR DESCRIPTION
Revert the part of 47490b4383bf48cbde8b1c33301a7f7d326ee7cc which
changed cranelift-native to use rsix. It's just one call, and this lets
Cranelift users that don't otherwise depend on rsix to avoid it.

@bjorn3 
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
