### PR TITLE
Use `empty()` instead of `NONE` with rsix flags types.

### DIFF
--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -60,7 +60,7 @@ impl FiberStack {
             let mmap = rsix::io::mmap_anonymous(
                 ptr::null_mut(),
                 mmap_len,
-                rsix::io::ProtFlags::NONE,
+                rsix::io::ProtFlags::empty(),
                 rsix::io::MapFlags::PRIVATE,
             )?;
 

--- a/crates/runtime/src/instance/allocator/pooling/unix.rs
+++ b/crates/runtime/src/instance/allocator/pooling/unix.rs
@@ -14,7 +14,7 @@ fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
             addr as _,
             len,
             if protect {
-                rsix::io::ProtFlags::NONE
+                rsix::io::ProtFlags::empty()
             } else {
                 rsix::io::ProtFlags::READ | rsix::io::ProtFlags::WRITE
             },

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -190,7 +190,7 @@ impl Mmap {
                 rsix::io::mmap_anonymous(
                     ptr::null_mut(),
                     mapping_size,
-                    rsix::io::ProtFlags::NONE,
+                    rsix::io::ProtFlags::empty(),
                     rsix::io::MapFlags::PRIVATE,
                 )
                 .context(format!("mmap failed to allocate {:#x} bytes", mapping_size))?

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -297,7 +297,7 @@ pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
         let ptr = rsix::io::mmap_anonymous(
             null_mut(),
             alloc_size,
-            rsix::io::ProtFlags::NONE,
+            rsix::io::ProtFlags::empty(),
             rsix::io::MapFlags::PRIVATE,
         )
         .map_err(|_| Box::new(Trap::oom()))?;

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -60,7 +60,12 @@ mod tests {
 
         // So we can later trigger SIGSEGV by performing a read
         unsafe {
-            mprotect(base as *mut std::ffi::c_void, length, MprotectFlags::NONE).unwrap();
+            mprotect(
+                base as *mut std::ffi::c_void,
+                length,
+                MprotectFlags::empty(),
+            )
+            .unwrap();
         }
 
         println!("memory: base={:?}, length={}", base, length);

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -24,7 +24,7 @@ mod not_for_windows {
             let size = maximum + guard_size;
             assert_eq!(size % page_size, 0); // we rely on WASM_PAGE_SIZE being multiple of host page size
 
-            let mem = mmap_anonymous(null_mut(), size, ProtFlags::NONE, MapFlags::PRIVATE)
+            let mem = mmap_anonymous(null_mut(), size, ProtFlags::empty(), MapFlags::PRIVATE)
                 .expect("mmap failed");
 
             mprotect(mem, minimum, MprotectFlags::READ | MprotectFlags::WRITE)


### PR DESCRIPTION
`empty()` is provided by all `bitflags` types, so it's more idiomatic
than having `NONE` values.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
