### PR TITLE
Fix some nightly dead code warnings

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift/codegen/meta/src/cdsl/instructions.rs
@@ -35,7 +35,6 @@ impl<'all_inst> InstructionGroupBuilder<'all_inst> {
 pub(crate) struct PolymorphicInfo {
     pub use_typevar_operand: bool,
     pub ctrl_typevar: TypeVar,
-    pub other_typevars: Vec<TypeVar>,
 }
 
 #[derive(Debug)]
@@ -52,8 +51,6 @@ pub(crate) struct InstructionContent {
     pub operands_in: Vec<Operand>,
     /// Output operands. The output operands must be SSA values or `variable_args`.
     pub operands_out: Vec<Operand>,
-    /// Instruction-specific TypeConstraints.
-    pub constraints: Vec<Constraint>,
 
     /// Instruction format, automatically derived from the input operands.
     pub format: Rc<InstructionFormat>,
@@ -296,7 +293,6 @@ impl InstructionBuilder {
             doc: self.doc,
             operands_in,
             operands_out,
-            constraints: self.constraints.unwrap_or_else(Vec::new),
             format: self.format,
             polymorphic_info,
             value_opnums,
@@ -404,11 +400,10 @@ fn verify_polymorphic(
                 || tv.singleton_type().is_some()
             {
                 match is_ctrl_typevar_candidate(tv, &operands_in, &operands_out) {
-                    Ok(other_typevars) => {
+                    Ok(_other_typevars) => {
                         return Some(PolymorphicInfo {
                             use_typevar_operand: true,
                             ctrl_typevar: tv.clone(),
-                            other_typevars,
                         });
                     }
                     Err(error_message) => {
@@ -439,12 +434,11 @@ fn verify_polymorphic(
 
     // At this point, if the next unwrap() fails, it means the output type couldn't be used as a
     // controlling type variable either; panicking is the right behavior.
-    let other_typevars = is_ctrl_typevar_candidate(tv, &operands_in, &operands_out).unwrap();
+    is_ctrl_typevar_candidate(tv, &operands_in, &operands_out).unwrap();
 
     Some(PolymorphicInfo {
         use_typevar_operand: false,
         ctrl_typevar: tv.clone(),
-        other_typevars,
     })
 }
 

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -577,6 +577,7 @@ unsafe fn initialize_vmcontext_globals(instance: &Instance) {
 #[derive(Clone)]
 pub struct OnDemandInstanceAllocator {
     mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
+    #[cfg(feature = "async")]
     stack_size: usize,
 }
 
@@ -594,8 +595,10 @@ fn borrow_limiter<'a>(
 impl OnDemandInstanceAllocator {
     /// Creates a new on-demand instance allocator.
     pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
+        drop(stack_size); // suppress unused warnings w/o async feature
         Self {
             mem_creator,
+            #[cfg(feature = "async")]
             stack_size,
         }
     }
@@ -642,6 +645,7 @@ impl Default for OnDemandInstanceAllocator {
     fn default() -> Self {
         Self {
             mem_creator: None,
+            #[cfg(feature = "async")]
             stack_size: 0,
         }
     }

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -911,6 +911,8 @@ pub struct PoolingInstanceAllocator {
     instances: mem::ManuallyDrop<InstancePool>,
     #[cfg(all(feature = "async", unix))]
     stacks: StackPool,
+    #[cfg(all(feature = "async", windows))]
+    stack_size: usize,
     #[cfg(all(feature = "uffd", target_os = "linux"))]
     _fault_handler: imp::PageFaultHandler,
 }
@@ -941,6 +943,8 @@ impl PoolingInstanceAllocator {
             instances: mem::ManuallyDrop::new(instances),
             #[cfg(all(feature = "async", unix))]
             stacks: StackPool::new(&instance_limits, stack_size)?,
+            #[cfg(all(feature = "async", windows))]
+            stack_size,
             #[cfg(all(feature = "uffd", target_os = "linux"))]
             _fault_handler,
         })


### PR DESCRIPTION
Looks like the "struct field not used" lint has improved on nightly and
caught a few more instances of fields that were never actually read.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
