### PR TITLE
Remove code offsets from Function

### DIFF
--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -10,15 +10,14 @@ use crate::ir::{
     HeapData, Inst, InstructionData, JumpTable, JumpTableData, Opcode, SigRef, StackSlot,
     StackSlotData, Table, TableData,
 };
-use crate::ir::{BlockOffsets, SourceLocs, StackSlots};
+use crate::ir::{SourceLocs, StackSlots};
 use crate::ir::{DataFlowGraph, ExternalName, Layout, Signature};
-use crate::ir::{JumpTableOffsets, JumpTables};
+use crate::ir::JumpTables;
 use crate::isa::CallConv;
 use crate::value_label::ValueLabelsRanges;
 use crate::write::write_function;
 #[cfg(feature = "enable-serde")]
 use alloc::string::String;
-use alloc::vec::Vec;
 use core::fmt;
 
 #[cfg(feature = "enable-serde")]
@@ -104,31 +103,11 @@ pub struct Function {
     /// Layout of blocks and instructions in the function body.
     pub layout: Layout,
 
-    /// Code offsets of the block headers.
-    ///
-    /// This information is only transiently available after the `binemit::relax_branches` function
-    /// computes it, and it can easily be recomputed by calling that function. It is not included
-    /// in the textual IR format.
-    pub offsets: BlockOffsets,
-
-    /// Code offsets of Jump Table headers.
-    pub jt_offsets: JumpTableOffsets,
-
     /// Source locations.
     ///
     /// Track the original source location for each instruction. The source locations are not
     /// interpreted by Cranelift, only preserved.
     pub srclocs: SourceLocs,
-
-    /// Instruction that marks the end (inclusive) of the function's prologue.
-    ///
-    /// This is used for some ABIs to generate unwind information.
-    pub prologue_end: Option<Inst>,
-
-    /// The instructions that mark the start (inclusive) of an epilogue in the function.
-    ///
-    /// This is used for some ABIs to generate unwind information.
-    pub epilogues_start: Vec<(Inst, Block)>,
 
     /// An optional global value which represents an expression evaluating to
     /// the stack limit for this function. This `GlobalValue` will be
@@ -153,11 +132,7 @@ impl Function {
             jump_tables: PrimaryMap::new(),
             dfg: DataFlowGraph::new(),
             layout: Layout::new(),
-            offsets: SecondaryMap::new(),
-            jt_offsets: SecondaryMap::new(),
             srclocs: SecondaryMap::new(),
-            prologue_end: None,
-            epilogues_start: Vec::new(),
             stack_limit: None,
         }
     }
@@ -172,11 +147,7 @@ impl Function {
         self.jump_tables.clear();
         self.dfg.clear();
         self.layout.clear();
-        self.offsets.clear();
-        self.jt_offsets.clear();
         self.srclocs.clear();
-        self.prologue_end = None;
-        self.epilogues_start.clear();
         self.stack_limit = None;
     }
 

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -59,17 +59,10 @@ pub use crate::ir::types::Type;
 pub use crate::value_label::LabelValueLoc;
 pub use cranelift_codegen_shared::condcodes;
 
-use crate::binemit;
 use crate::entity::{entity_impl, PrimaryMap, SecondaryMap};
 
 /// Map of jump tables.
 pub type JumpTables = PrimaryMap<JumpTable, JumpTableData>;
-
-/// Code offsets for blocks.
-pub type BlockOffsets = SecondaryMap<Block, binemit::CodeOffset>;
-
-/// Code offsets for Jump Tables.
-pub type JumpTableOffsets = SecondaryMap<JumpTable, binemit::CodeOffset>;
 
 /// Source locations for instructions.
 pub type SourceLocs = SecondaryMap<Inst, SourceLoc>;


### PR DESCRIPTION
A future cleanup could remove the `begin_*` and `end_codegen` functions from `CodeSink` I think.