### PR TITLE
cranelift: Enable `umulhi` tests for s390x

### DIFF
--- a/cranelift/filetests/filetests/runtests/umulhi.clif
+++ b/cranelift/filetests/filetests/runtests/umulhi.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 set enable_simd
 target x86_64
+target s390x
 
 function %umulhi_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):


### PR DESCRIPTION
This got fixed somewhere between 16b6a404e419498e6204e6c4855b50105370c7b0 and the current main, so we can enable these tests to prevent regressions.

Closes #3288