### PR TITLE
Increase the default code section alignment to 64 KB for AArch64 targets

### DIFF
--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -290,6 +290,9 @@ impl<'a> dyn TargetIsa + 'a {
                 | OperatingSystem::Tvos,
                 Architecture::Aarch64(..),
             ) => 0x4000,
+            // 64 KB is the maximal page size (i.e. memory translation granule size)
+            // supported by the architecture and is used on some platforms.
+            (_, Architecture::Aarch64(..)) => 0x10000,
             _ => 0x1000,
         }
     }

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -88,6 +88,7 @@ impl CodeMemory {
             mmap: &self.mmap,
             text: &[],
         };
+        let mmap_ptr = self.mmap.as_ptr() as u64;
 
         // Sanity-check that all sections are aligned correctly.
         for section in ret.obj.sections() {
@@ -98,7 +99,7 @@ impl CodeMemory {
             if section.align() == 0 || data.len() == 0 {
                 continue;
             }
-            if data.as_ptr() as u64 % section.align() != 0 {
+            if (data.as_ptr() as u64 - mmap_ptr) % section.align() != 0 {
                 bail!(
                     "section `{}` isn't aligned to {:#x}",
                     section.name().unwrap_or("ERROR"),


### PR DESCRIPTION
Some platforms such as AArch64 Linux support different memory page sizes, so we need to be conservative when choosing the code section alignment (which is equal to the page size) by using the maximum. This issue has been discussed in #3278; in fact, my changes fix execution on RHEL-based distributions such as CentOS (default kernel configuration with 64 KB pages).