### PR TITLE
Remove the sarg_t type and dummy_sarg_t instruction

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/types.rs
+++ b/cranelift/codegen/meta/src/cdsl/types.rs
@@ -393,8 +393,6 @@ impl fmt::Debug for VectorType {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum SpecialType {
     Flag(shared_types::Flag),
-    // FIXME remove once the old style backends are removed.
-    StructArgument,
 }
 
 impl SpecialType {
@@ -409,9 +407,6 @@ impl SpecialType {
                 "CPU flags representing the result of a floating point comparison. These
                 flags can be tested with a :type:`floatcc` condition code.",
             ),
-            SpecialType::StructArgument => {
-                String::from("After legalization sarg_t arguments will get this type.")
-            }
         }
     }
 
@@ -419,7 +414,6 @@ impl SpecialType {
     pub fn lane_bits(self) -> u64 {
         match self {
             SpecialType::Flag(_) => 0,
-            SpecialType::StructArgument => 0,
         }
     }
 
@@ -428,7 +422,6 @@ impl SpecialType {
         match self {
             SpecialType::Flag(shared_types::Flag::IFlags) => 1,
             SpecialType::Flag(shared_types::Flag::FFlags) => 2,
-            SpecialType::StructArgument => 3,
         }
     }
 }
@@ -438,7 +431,6 @@ impl fmt::Display for SpecialType {
         match *self {
             SpecialType::Flag(shared_types::Flag::IFlags) => write!(f, "iflags"),
             SpecialType::Flag(shared_types::Flag::FFlags) => write!(f, "fflags"),
-            SpecialType::StructArgument => write!(f, "sarg_t"),
         }
     }
 }
@@ -450,7 +442,6 @@ impl fmt::Debug for SpecialType {
             "{}",
             match *self {
                 SpecialType::Flag(_) => format!("FlagsType({})", self),
-                SpecialType::StructArgument => format!("StructArgument"),
             }
         )
     }
@@ -464,14 +455,12 @@ impl From<shared_types::Flag> for SpecialType {
 
 pub(crate) struct SpecialTypeIterator {
     flag_iter: shared_types::FlagIterator,
-    done: bool,
 }
 
 impl SpecialTypeIterator {
     fn new() -> Self {
         Self {
             flag_iter: shared_types::FlagIterator::new(),
-            done: false,
         }
     }
 }
@@ -479,16 +468,7 @@ impl SpecialTypeIterator {
 impl Iterator for SpecialTypeIterator {
     type Item = SpecialType;
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(f) = self.flag_iter.next() {
-            Some(SpecialType::from(f))
-        } else {
-            if !self.done {
-                self.done = true;
-                Some(SpecialType::StructArgument)
-            } else {
-                None
-            }
-        }
+        self.flag_iter.next().map(SpecialType::from)
     }
 }
 

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1929,31 +1929,6 @@ pub(crate) fn define(
         .can_load(true),
     );
 
-    let Sarg = &TypeVar::new(
-        "Sarg",
-        "Any scalar or vector type with at most 128 lanes",
-        TypeSetBuilder::new()
-            .specials(vec![crate::cdsl::types::SpecialType::StructArgument])
-            .build(),
-    );
-    let sarg_t = &Operand::new("sarg_t", Sarg);
-
-    // FIXME remove once the old style codegen backends are removed.
-    ig.push(
-        Inst::new(
-            "dummy_sarg_t",
-            r#"
-        This creates a sarg_t
-
-        This instruction is internal and should not be created by
-        Cranelift users.
-        "#,
-            &formats.nullary,
-        )
-        .operands_in(vec![])
-        .operands_out(vec![sarg_t]),
-    );
-
     ig.push(
         Inst::new(
             "copy_nop",

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -400,7 +400,6 @@ impl Display for Type {
             f.write_str(match *self {
                 IFLAGS => "iflags",
                 FFLAGS => "fflags",
-                SARG_T => "sarg_t",
                 INVALID => panic!("INVALID encountered"),
                 _ => panic!("Unknown Type(0x{:x})", self.0),
             })

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -3560,8 +3560,6 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             panic!("ALU+imm and ALU+carry ops should not appear here!");
         }
 
-        Opcode::DummySargT => unreachable!(),
-
         Opcode::Iabs => {
             let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -2895,7 +2895,6 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::AdjustSpDown
         | Opcode::AdjustSpUpImm
         | Opcode::AdjustSpDownImm
-        | Opcode::DummySargT
         | Opcode::IfcmpSp => {
             panic!("Unused opcode should not be encountered.");
         }

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -6870,8 +6870,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::AdjustSpUpImm
         | Opcode::AdjustSpDownImm
         | Opcode::IfcmpSp
-        | Opcode::Copy
-        | Opcode::DummySargT => {
+        | Opcode::Copy => {
             panic!("Unused opcode should not be encountered.");
         }
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -451,7 +451,6 @@ where
         Opcode::Spill => unimplemented!("Spill"),
         Opcode::Fill => unimplemented!("Fill"),
         Opcode::FillNop => assign(arg(0)?),
-        Opcode::DummySargT => unimplemented!("DummySargT"),
         Opcode::CopyNop => unimplemented!("CopyNop"),
         Opcode::AdjustSpDown => unimplemented!("AdjustSpDown"),
         Opcode::AdjustSpUpImm => unimplemented!("AdjustSpUpImm"),

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -326,7 +326,6 @@ impl<'a> Lexer<'a> {
                 .unwrap_or_else(|| match text {
                     "iflags" => Token::Type(types::IFLAGS),
                     "fflags" => Token::Type(types::FFLAGS),
-                    "sarg_t" => Token::Type(types::SARG_T),
                     _ => Token::Identifier(text),
                 }),
             loc,
@@ -620,7 +619,7 @@ mod tests {
         let mut lex = Lexer::new(
             "v0 v00 vx01 block1234567890 block5234567890 v1x vx1 vxvx4 \
              function0 function b1 i32x4 f32x5 \
-             iflags fflags sarg_t iflagss",
+             iflags fflags iflagss",
         );
         assert_eq!(
             lex.next(),
@@ -643,7 +642,6 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Identifier("f32x5"), 1));
         assert_eq!(lex.next(), token(Token::Type(types::IFLAGS), 1));
         assert_eq!(lex.next(), token(Token::Type(types::FFLAGS), 1));
-        assert_eq!(lex.next(), token(Token::Type(types::SARG_T), 1));
         assert_eq!(lex.next(), token(Token::Identifier("iflagss"), 1));
         assert_eq!(lex.next(), None);
     }


### PR DESCRIPTION
They are no longer necessary with the new style backends.