### PR TITLE
Enable stable wasm features for spectest fuzzing

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -497,8 +497,6 @@ pub fn spectest(fuzz_config: crate::generators::Config, test: crate::generators:
     log::debug!("running {:?} with {:?}", test.file, fuzz_config);
     let mut config = fuzz_config.to_wasmtime();
     config.wasm_memory64(false);
-    config.wasm_reference_types(false);
-    config.wasm_bulk_memory(false);
     config.wasm_module_linking(false);
     config.wasm_multi_memory(false);
     let mut store = create_store(&Engine::new(&config).unwrap());


### PR DESCRIPTION
These are now required for the general suite of spec tests we're running
by default.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
