### PR TITLE
List exports of an instance in linking error

### DIFF
--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -24,6 +24,34 @@ fn link_undefined() -> Result<()> {
 }
 
 #[test]
+fn undefined_error_message_with_linking() {
+    let mut config = Config::new();
+    config.wasm_module_linking(true);
+    let engine = Engine::new(&config).unwrap();
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (import "foo" "bar" (func))
+        )
+    "#,
+    )
+    .unwrap();
+    let linker = Linker::new(&engine);
+    let mut store = Store::new(&engine, ());
+    assert!(linker
+        .instantiate(&mut store, &module)
+        .unwrap_err()
+        .to_string()
+        .contains("foo"));
+    assert!(linker
+        .instantiate(&mut store, &module)
+        .unwrap_err()
+        .to_string()
+        .contains("bar"));
+}
+
+#[test]
 fn link_twice_bad() -> Result<()> {
     let mut store = Store::<()>::default();
     let mut linker = Linker::<()>::new(store.engine());


### PR DESCRIPTION
Took a stab at https://github.com/bytecodealliance/wasmtime/issues/3388. The error message is now:
```
unknown import: instance `foo` exporting `bar` has not been defined
```
when module-linking is enabled. Hopefully that's clear for both de-sugared two-level imports and actual instance imports.
