### PR TITLE
Change how security advisories work on CI

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,12 @@
+name: Run cargo-audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.8.5/cargo-deny-0.8.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
         mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
         echo `pwd` >> $GITHUB_PATH
-    - run: cargo deny check
+    - run: cargo deny check bans licenses
 
   doc:
     name: Doc build
@@ -457,21 +457,6 @@ jobs:
       with:
         files: "dist/*"
         token: ${{ secrets.GITHUB_TOKEN }}
-
-  cargo-audit:
-    env:
-      CARGO_AUDIT_VERSION: 0.11.2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: ${{ runner.tool_cache }}/cargo-audit
-        key: cargo-audit-bin-${{ env.CARGO_AUDIT_VERSION }}
-    - run: echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
-    - run: |
-        cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
-        cargo audit
 
   verify-publish:
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -8,13 +8,6 @@ targets = [
     { triple = "aarch64-linux-android" },
 ]
 
-# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
-[advisories]
-vulnerability = "deny"
-unmaintained = "deny"
-yanked = "deny"
-ignore = []
-
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
 allow = [

--- a/docs/contributing-release-process.md
+++ b/docs/contributing-release-process.md
@@ -10,6 +10,8 @@ made (there's also not really a body governing these decisions, it's more
 whimsical currently, or on request from others) then the following steps need to
 be executed to make the release:
 
+1. Double-check that there are no open [rustsec advisory
+   issues][rustsec-issues] on the Wasmtime repository.
 1. `git pull` - make sure you've got the latest changes
 1. Run `rustc scripts/publish.rs`
 1. Run `./publish bump`
@@ -31,3 +33,5 @@ be executed to make the release:
     a bit between runs of the script.
 
 And that's it, then you've done a Wasmtime release.
+
+[rustsec-issues]: https://github.com/bytecodealliance/wasmtime/issues?q=RUSTSEC+is%3Aissue+is%3Aopen+


### PR DESCRIPTION
Before this commit we actually have two builders checking for security
advisories on CI, one is `cargo audit` and one is `cargo deny`. The
`cargo deny` builder is slightly different in that it checks a few other
things about our dependency tree such as licenses, duplicates, etc. This
commit removes the advisory check from `cargo deny` on CI and then moves
the `cargo audit` check to a separate workflow.

The `cargo audit` check will now run nightly and will open an issue on
the Wasmtime repository when an advisory is found. This should help make
it such that our CI is never broken by the publication of an advisory
but we're still promptly notified whenever an advisory is made. I've
updated the release process notes to indicate that the open issues
should be double-checked to ensure that there are no open advisories
that we need to take care of.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
