### PR TITLE
Update to regalloc.rs 0.0.32.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "a6304468554ed921da3d32c355ea107b8d13d7b8996c3adfb7aab48d3bc321f4"
 dependencies = [
  "log",
  "rustc-hash",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = { version = "1.6.1" }
 peepmatic = { path = "../peepmatic", optional = true, version = "0.77.0" }
 peepmatic-traits = { path = "../peepmatic/crates/traits", optional = true, version = "0.77.0" }
 peepmatic-runtime = { path = "../peepmatic/crates/runtime", optional = true, version = "0.77.0" }
-regalloc = { version = "0.0.31" }
+regalloc = { version = "0.0.32" }
 souper-ir = { version = "2.1.0", optional = true }
 wast = { version = "38.0.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -52,11 +52,11 @@ block0(v0: i16, v1: i16):
 }
 
 ; check:  llhr %r2, %r2
-; nextln: lr %r5, %r3
-; nextln: lcr %r4, %r3
-; nextln: nill %r5, 15
+; nextln: lr %r3, %r4
+; nextln: lcr %r4, %r4
+; nextln: nill %r3, 15
 ; nextln: nill %r4, 15
-; nextln: sllk %r3, %r2, 0(%r5)
+; nextln: sllk %r3, %r2, 0(%r3)
 ; nextln: srlk %r2, %r2, 0(%r4)
 ; nextln: ork %r2, %r3, %r2
 ; nextln: br %r14
@@ -81,11 +81,11 @@ block0(v0: i8, v1: i8):
 }
 
 ; check:  llcr %r2, %r2
-; nextln: lr %r5, %r3
-; nextln: lcr %r4, %r3
-; nextln: nill %r5, 7
+; nextln: lr %r3, %r4
+; nextln: lcr %r4, %r4
+; nextln: nill %r3, 7
 ; nextln: nill %r4, 7
-; nextln: sllk %r3, %r2, 0(%r5)
+; nextln: sllk %r3, %r2, 0(%r3)
 ; nextln: srlk %r2, %r2, 0(%r4)
 ; nextln: ork %r2, %r3, %r2
 ; nextln: br %r14

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -238,35 +238,34 @@ block0(v0: i64):
 ; nextln: unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ; nextln: movq    %rsp, %rbp
 ; nextln: unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 160 }
-; nextln: subq    $$208, %rsp
-; nextln: movdqu  %xmm6, 48(%rsp)
+; nextln: subq    $$192, %rsp
+; nextln: movdqu  %xmm6, 32(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 0, reg: r6V }
-; nextln: movdqu  %xmm7, 64(%rsp)
+; nextln: movdqu  %xmm7, 48(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 16, reg: r7V }
-; nextln: movdqu  %xmm8, 80(%rsp)
+; nextln: movdqu  %xmm8, 64(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 32, reg: r8V }
-; nextln: movdqu  %xmm9, 96(%rsp)
+; nextln: movdqu  %xmm9, 80(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 48, reg: r9V }
-; nextln: movdqu  %xmm10, 112(%rsp)
+; nextln: movdqu  %xmm10, 96(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 64, reg: r10V }
-; nextln: movdqu  %xmm11, 128(%rsp)
+; nextln: movdqu  %xmm11, 112(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 80, reg: r11V }
-; nextln: movdqu  %xmm12, 144(%rsp)
+; nextln: movdqu  %xmm12, 128(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 96, reg: r12V }
-; nextln: movdqu  %xmm13, 160(%rsp)
+; nextln: movdqu  %xmm13, 144(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 112, reg: r13V }
-; nextln: movdqu  %xmm14, 176(%rsp)
+; nextln: movdqu  %xmm14, 160(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 128, reg: r14V }
-; nextln: movdqu  %xmm15, 192(%rsp)
+; nextln: movdqu  %xmm15, 176(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 144, reg: r15V }
-; nextln: movsd   0(%rcx), %xmm0
-; nextln: movsd   %xmm0, rsp(16 + virtual offset)
+; nextln: movsd   0(%rcx), %xmm4
 ; nextln: movsd   8(%rcx), %xmm1
 ; nextln: movsd   16(%rcx), %xmm0
-; nextln: movsd   %xmm0, rsp(24 + virtual offset)
+; nextln: movsd   %xmm0, rsp(16 + virtual offset)
 ; nextln: movsd   24(%rcx), %xmm3
 ; nextln: movsd   32(%rcx), %xmm0
-; nextln: movsd   %xmm0, rsp(32 + virtual offset)
+; nextln: movsd   %xmm0, rsp(24 + virtual offset)
 ; nextln: movsd   40(%rcx), %xmm5
 ; nextln: movsd   48(%rcx), %xmm6
 ; nextln: movsd   56(%rcx), %xmm7
@@ -284,45 +283,41 @@ block0(v0: i64):
 ; nextln: movsd   144(%rcx), %xmm2
 ; nextln: movsd   %xmm2, rsp(8 + virtual offset)
 ; nextln: movsd   152(%rcx), %xmm2
-; nextln: nop     len=0
-; nextln: movsd   rsp(16 + virtual offset), %xmm4
 ; nextln: addsd   %xmm1, %xmm4
-; nextln: movsd   %xmm4, rsp(16 + virtual offset)
-; nextln: movsd   rsp(24 + virtual offset), %xmm1
+; nextln: movsd   rsp(16 + virtual offset), %xmm1
 ; nextln: addsd   %xmm3, %xmm1
-; nextln: movsd   rsp(32 + virtual offset), %xmm4
-; nextln: addsd   %xmm5, %xmm4
+; nextln: movsd   rsp(24 + virtual offset), %xmm3
+; nextln: addsd   %xmm5, %xmm3
 ; nextln: addsd   %xmm7, %xmm6
 ; nextln: addsd   %xmm9, %xmm8
 ; nextln: addsd   %xmm11, %xmm10
 ; nextln: addsd   %xmm13, %xmm12
 ; nextln: addsd   %xmm15, %xmm14
-; nextln: movsd   rsp(0 + virtual offset), %xmm3
-; nextln: addsd   %xmm0, %xmm3
+; nextln: movsd   rsp(0 + virtual offset), %xmm5
+; nextln: addsd   %xmm0, %xmm5
 ; nextln: movsd   rsp(8 + virtual offset), %xmm0
 ; nextln: addsd   %xmm2, %xmm0
-; nextln: movsd   rsp(16 + virtual offset), %xmm2
-; nextln: addsd   %xmm1, %xmm2
-; nextln: addsd   %xmm6, %xmm4
+; nextln: addsd   %xmm1, %xmm4
+; nextln: addsd   %xmm6, %xmm3
 ; nextln: addsd   %xmm10, %xmm8
 ; nextln: addsd   %xmm14, %xmm12
-; nextln: addsd   %xmm0, %xmm3
-; nextln: addsd   %xmm4, %xmm2
+; nextln: addsd   %xmm0, %xmm5
+; nextln: addsd   %xmm3, %xmm4
 ; nextln: addsd   %xmm12, %xmm8
-; nextln: addsd   %xmm8, %xmm2
-; nextln: addsd   %xmm3, %xmm2
-; nextln: movaps  %xmm2, %xmm0
-; nextln: movdqu  48(%rsp), %xmm6
-; nextln: movdqu  64(%rsp), %xmm7
-; nextln: movdqu  80(%rsp), %xmm8
-; nextln: movdqu  96(%rsp), %xmm9
-; nextln: movdqu  112(%rsp), %xmm10
-; nextln: movdqu  128(%rsp), %xmm11
-; nextln: movdqu  144(%rsp), %xmm12
-; nextln: movdqu  160(%rsp), %xmm13
-; nextln: movdqu  176(%rsp), %xmm14
-; nextln: movdqu  192(%rsp), %xmm15
-; nextln: addq    $$208, %rsp
+; nextln: addsd   %xmm8, %xmm4
+; nextln: addsd   %xmm5, %xmm4
+; nextln: movaps  %xmm4, %xmm0
+; nextln: movdqu  32(%rsp), %xmm6
+; nextln: movdqu  48(%rsp), %xmm7
+; nextln: movdqu  64(%rsp), %xmm8
+; nextln: movdqu  80(%rsp), %xmm9
+; nextln: movdqu  96(%rsp), %xmm10
+; nextln: movdqu  112(%rsp), %xmm11
+; nextln: movdqu  128(%rsp), %xmm12
+; nextln: movdqu  144(%rsp), %xmm13
+; nextln: movdqu  160(%rsp), %xmm14
+; nextln: movdqu  176(%rsp), %xmm15
+; nextln: addq    $$192, %rsp
 ; nextln: movq    %rbp, %rsp
 ; nextln: popq    %rbp
 ; nextln: ret

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -99,12 +99,15 @@ function %f5(i128) -> i128 {
 block0(v0: i128):
 
     v1 = bnot v0
-; nextln:  notq    %rdi
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rdi, %rsi
 ; nextln:  notq    %rsi
+; nextln:  movq    %rax, %rdi
+; nextln:  notq    %rdi
 
     return v1
-; nextln:  movq    %rdi, %rax
-; nextln:  movq    %rsi, %rdx
+; nextln:  movq    %rsi, %rax
+; nextln:  movq    %rdi, %rdx
 ; nextln:  movq    %rbp, %rsp
 ; nextln:  popq    %rbp
 ; nextln:  ret
@@ -741,30 +744,34 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 
 ; check:  pushq   %rbp
 ; nextln: movq    %rsp, %rbp
-; nextln: subq    $$16, %rsp
+; nextln: subq    $$32, %rsp
 ; nextln: movq    %r12, 0(%rsp)
 ; nextln: movq    %r13, 8(%rsp)
+; nextln: movq    %r14, 16(%rsp)
+; nextln: movq    %r8, %r14
 ; nextln: movq    16(%rbp), %r10
 ; nextln: movq    24(%rbp), %r12
 ; nextln: movq    32(%rbp), %r11
 ; nextln: movq    40(%rbp), %rax
 ; nextln: movq    48(%rbp), %r13
+; nextln: movq    %rsi, %r8
 ; nextln: addq    %rdx, %rdi
-; nextln: adcq    %rcx, %rsi
-; nextln: xorq    %rcx, %rcx
-; nextln: addq    %r8, %r9
-; nextln: adcq    %rcx, %r10
+; nextln: adcq    %rcx, %r8
+; nextln: xorq    %rsi, %rsi
+; nextln: addq    %r14, %r9
+; nextln: adcq    %rsi, %r10
 ; nextln: addq    %rax, %r12
 ; nextln: adcq    %r13, %r11
 ; nextln: addq    %r9, %rdi
-; nextln: adcq    %r10, %rsi
+; nextln: adcq    %r10, %r8
 ; nextln: addq    %rdi, %r12
-; nextln: adcq    %rsi, %r11
+; nextln: adcq    %r8, %r11
 ; nextln: movq    %r12, %rax
 ; nextln: movq    %r11, %rdx
 ; nextln: movq    0(%rsp), %r12
 ; nextln: movq    8(%rsp), %r13
-; nextln: addq    $$16, %rsp
+; nextln: movq    16(%rsp), %r14
+; nextln: addq    $$32, %rsp
 ; nextln: movq    %rbp, %rsp
 ; nextln: popq    %rbp
 ; nextln: ret
@@ -1059,25 +1066,26 @@ block0(v0: i128, v1: i128):
 
 ; check:  pushq   %rbp
 ; nextln: movq    %rsp, %rbp
-; nextln: movq    %rsi, %r9
+; nextln: movq    %rsi, %rax
+; nextln: movq    %rax, %r9
 ; nextln: movq    %rdx, %rcx
 ; nextln: shrq    %cl, %r9
-; nextln: movq    %rdi, %rax
+; nextln: movq    %rdi, %rsi
 ; nextln: movq    %rdx, %rcx
-; nextln: shrq    %cl, %rax
+; nextln: shrq    %cl, %rsi
 ; nextln: movl    $$64, %ecx
 ; nextln: subq    %rdx, %rcx
-; nextln: movq    %rsi, %r10
+; nextln: movq    %rax, %r10
 ; nextln: shlq    %cl, %r10
 ; nextln: xorq    %rcx, %rcx
 ; nextln: testq   $$127, %rdx
 ; nextln: cmovzq  %rcx, %r10
-; nextln: orq     %rax, %r10
-; nextln: xorq    %rax, %rax
+; nextln: orq     %rsi, %r10
+; nextln: xorq    %rsi, %rsi
 ; nextln: xorq    %r8, %r8
 ; nextln: movq    %rdx, %rcx
 ; nextln: andq    $$64, %rcx
-; nextln: cmovzq  %r9, %rax
+; nextln: cmovzq  %r9, %rsi
 ; nextln: cmovzq  %r10, %r8
 ; nextln: cmovnzq %r9, %r8
 ; nextln: movl    $$128, %r9d
@@ -1085,25 +1093,24 @@ block0(v0: i128, v1: i128):
 ; nextln: movq    %rdi, %rdx
 ; nextln: movq    %r9, %rcx
 ; nextln: shlq    %cl, %rdx
-; nextln: movq    %rsi, %r10
 ; nextln: movq    %r9, %rcx
-; nextln: shlq    %cl, %r10
+; nextln: shlq    %cl, %rax
 ; nextln: movl    $$64, %ecx
 ; nextln: subq    %r9, %rcx
 ; nextln: shrq    %cl, %rdi
-; nextln: xorq    %rsi, %rsi
-; nextln: testq   $$127, %r9
-; nextln: cmovzq  %rsi, %rdi
-; nextln: orq     %r10, %rdi
 ; nextln: xorq    %rcx, %rcx
+; nextln: testq   $$127, %r9
+; nextln: cmovzq  %rcx, %rdi
+; nextln: orq     %rax, %rdi
+; nextln: xorq    %rax, %rax
 ; nextln: andq    $$64, %r9
-; nextln: cmovzq  %rdi, %rcx
-; nextln: cmovzq  %rdx, %rsi
-; nextln: cmovnzq %rdx, %rcx
-; nextln: orq     %r8, %rsi
-; nextln: orq     %rax, %rcx
-; nextln: movq    %rsi, %rax
-; nextln: movq    %rcx, %rdx
+; nextln: cmovzq  %rdi, %rax
+; nextln: cmovzq  %rdx, %rcx
+; nextln: cmovnzq %rdx, %rax
+; nextln: orq     %r8, %rcx
+; nextln: orq     %rsi, %rax
+; nextln: movq    %rax, %rdx
+; nextln: movq    %rcx, %rax
 ; nextln: movq    %rbp, %rsp
 ; nextln: popq    %rbp
 ; nextln: ret


### PR DESCRIPTION
This pulls in a change from regalloc.rs to address some quadratic behavior
(thanks @adamrk!).

It appears that some allocation heuristics have changed slightly since
0.0.31, so some of the golden-output filetests are updated as well.
Ideally we would rely more on runtests rather than golden-compilation
tests; but for now this is sufficient. (I'm not sure exactly what in
regalloc.rs changed to alter these heuristics; it's actually been almost
a year since the 0.0.31 release with several refactorings and tweaks
merged since then.)

Fixes #3441.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
