### PR TITLE
Remove some uses of `foo.expect(&format!(...))` anti-pattern

### DIFF
--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -43,7 +43,7 @@ fn bench_sequential(c: &mut Criterion, modules: &[&str]) {
 
             let engine = Engine::new(&config).expect("failed to create engine");
             let module = Module::from_file(&engine, &path)
-                .expect(&format!("failed to load benchmark `{}`", path.display()));
+                .unwrap_or_else(|_| panic!("failed to load benchmark `{}`", path.display()));
             let mut linker = Linker::new(&engine);
             wasmtime_wasi::add_to_linker(&mut linker, |cx| cx).unwrap();
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -349,7 +349,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         to_bits: u8,
     ) -> Self::I {
         let ext_mode = ExtMode::new(from_bits as u16, to_bits as u16)
-            .expect(&format!("invalid extension: {} -> {}", from_bits, to_bits));
+            .unwrap_or_else(|| panic!("invalid extension: {} -> {}", from_bits, to_bits));
         if is_signed {
             Inst::movsx_rm_r(ext_mode, RegMem::reg(from_reg), to_reg)
         } else {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -236,7 +236,7 @@ fn extend_input_to_reg<C: LowerCtx<I = Inst>>(
     let ext_mode = match (input_size, requested_size) {
         (a, b) if a == b => return put_input_in_reg(ctx, spec),
         (1, 8) => return put_input_in_reg(ctx, spec),
-        (a, b) => ExtMode::new(a, b).expect(&format!("invalid extension: {} -> {}", a, b)),
+        (a, b) => ExtMode::new(a, b).unwrap_or_else(|| panic!("invalid extension: {} -> {}", a, b)),
     };
 
     let src = input_to_reg_mem(ctx, spec);
@@ -5847,11 +5847,13 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             if ty_access == types::I64 {
                 ctx.emit(Inst::mov64_rm_r(rm, data));
             } else {
-                let ext_mode = ExtMode::new(ty_access.bits(), 64).expect(&format!(
-                    "invalid extension during AtomicLoad: {} -> {}",
-                    ty_access.bits(),
-                    64
-                ));
+                let ext_mode = ExtMode::new(ty_access.bits(), 64).unwrap_or_else(|| {
+                    panic!(
+                        "invalid extension during AtomicLoad: {} -> {}",
+                        ty_access.bits(),
+                        64
+                    )
+                });
                 ctx.emit(Inst::movzx_rm_r(ext_mode, rm, data));
             }
         }


### PR DESCRIPTION
This eagerly evaluates the `format!` and produces a `String` with a heap
allocation, regardless whether `foo` is `Some`/`Ok` or `None`/`Err`. Using
`foo.unwrap_or_else(|| panic!(...))` makes it so that the error message
formatting is only evaluated if `foo` is `None`/`Err`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
