### PR TITLE
cranelift: in `test_compile` filetest, log disasm not clif

### DIFF
--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -44,12 +44,6 @@ impl SubTest for TestCompile {
             .compile(isa)
             .map_err(|e| crate::pretty_anyhow_error(&comp_ctx.func, e))?;
 
-        info!(
-            "Generated {} bytes of code:\n{}",
-            total_size,
-            comp_ctx.func.display()
-        );
-
         let disasm = comp_ctx
             .mach_compile_result
             .as_ref()
@@ -57,6 +51,9 @@ impl SubTest for TestCompile {
             .disasm
             .as_ref()
             .unwrap();
+
+        info!("Generated {} bytes of code:\n{}", total_size, disasm);
+
         run_filecheck(&disasm, context)
     }
 }


### PR DESCRIPTION
With the old backends, this would log the lowered+legalized clif, but the log is
useles now with the new backends. Logging the disasm is the new moral
equivalent.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
