### PR TITLE
CI Check job: run `apt-get update` before `apt-get install`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     - run: |
         rustup target add wasm32-unknown-emscripten
         rustup target add armv7-unknown-linux-gnueabihf
-        sudo apt-get install -y gcc-arm-linux-gnueabihf
+        sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf
     - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
     - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
 


### PR DESCRIPTION
trying to fix  https://github.com/bytecodealliance/wasmtime/runs/4025939586?check_suite_focus=true

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
