### PR TITLE
Add a manual trigger to force CI to bump crate versions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,6 +16,14 @@ on:
     # https://crontab.guru/#0_0_8-14_*_1
     - cron: '0 0 8-14 * 1'
 
+  # Allow manually triggering this workflow remotely via a curl request,
+  # described at
+  # https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
+  #
+  # Note that this can be also triggered by running the script in
+  # `ci/force-ci-bump-version.sh`
+  workflow_dispatch:
+
 jobs:
   bump_version:
     runs-on: ubuntu-latest

--- a/ci/force-ci-bump-version.sh
+++ b/ci/force-ci-bump-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "$PERSONAL_ACCESS_TOKEN" ]; then
+  echo "need to set \$PERSONAL_ACCESS_TOKEN to a github token"
+  exit 1
+fi
+
+exec curl --include --request POST \
+  https://api.github.com/repos/bytecodealliance/wasmtime/actions/workflows/bump-version.yml/dispatches \
+  --header "Authorization: token $PERSONAL_ACCESS_TOKEN" \
+  --data @- << EOF
+{
+  "ref": "main"
+}
+EOF
+


### PR DESCRIPTION
I'm curious to try out the full workflow so instead of waiting a few
weeks I figured I'd add a manual trigger here too

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
