### PR TITLE
Fix the publish script to ignore witx more

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -270,6 +270,12 @@ fn bump_version(krate: &Crate, crates: &[Crate], patch: bool) {
         };
 
         for other in crates {
+            // If `other` isn't a published crate then it's not going to get a
+            // bumped version so we don't need to update anything in the
+            // manifest.
+            if !other.publish {
+                continue;
+            }
             if !is_deps || !line.starts_with(&format!("{} ", other.name)) {
                 continue;
             }


### PR DESCRIPTION
This failed on CI [1] I think because the filesystem is traversed
differently than on my local system. This is relatively easily fixable
though where we shouldn't care about witx version when bumping version
requirements since we don't manage the publication of witx anyway.

[1]: https://github.com/bytecodealliance/wasmtime/runs/4038695579?check_suite_focus=true

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
