### PR TITLE
Update v8 used during fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,19 +2510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusty_v8"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fc062fb861b82fa7ac4e1a009da873279a10180d2133574e4219d870038c1c"
-dependencies = [
- "bitflags",
- "fslock",
- "lazy_static",
- "libc",
- "which",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,6 +3044,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "v8"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3adb16fd1af3e28d6fda8348a6d96b5363a128dc5a0216b137b64ecbae6641"
+dependencies = [
+ "bitflags",
+ "fslock",
+ "lazy_static",
+ "libc",
+ "which",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,7 +3532,7 @@ dependencies = [
  "env_logger 0.8.3",
  "log",
  "rayon",
- "rusty_v8",
+ "v8",
  "wasm-encoder",
  "wasm-smith",
  "wasm-spec-interpreter",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -27,7 +27,7 @@ wasmi = "0.7.0"
 # though, so we could use that if we wanted. For now though just simplify a bit
 # and don't depend on this on Windows.  The same applies on s390x.
 [target.'cfg(not(any(windows, target_arch = "s390x")))'.dependencies]
-rusty_v8 = "0.27"
+v8 = "0.33"
 
 [dev-dependencies]
 wat = "1.0.37"

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -22,7 +22,7 @@ use wasmtime::*;
 use wasmtime_wast::WastContext;
 
 #[cfg(not(any(windows, target_arch = "s390x")))]
-pub use v8::*;
+pub use self::v8::*;
 #[cfg(not(any(windows, target_arch = "s390x")))]
 mod v8;
 

--- a/crates/fuzzing/src/oracles/v8.rs
+++ b/crates/fuzzing/src/oracles/v8.rs
@@ -1,5 +1,4 @@
 use super::{first_exported_function, first_exported_memory, log_wasm};
-use rusty_v8 as v8;
 use std::convert::TryFrom;
 use std::sync::Once;
 use wasmtime::*;


### PR DESCRIPTION
This commit updates the crate name from `rusty_v8` to `v8` as well since
the upstream bindings have sinced moved. I originally wanted to do this
to see if a fix for one of our fuzz bugs was pulled in but I don't think
the fix has been pulled in yet. Despite that it seems reasonable to go
ahead and update.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
