### PR TITLE
Check cranelift benchmarks in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,9 +138,9 @@ jobs:
     - run: cargo check -p wasmtime --no-default-features --features uffd
     - run: cargo check -p wasmtime --no-default-features --features cranelift
     - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache
-    
+
     # Check that benchmarks of the cranelift project build
-    - run: cargo bench -p cranelift-codegen
+    - run: cargo check --benches -p cranelift-codegen
 
     # Check some feature combinations of the `wasmtime-c-api` crate
     - run: cargo check -p wasmtime-c-api --no-default-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,9 @@ jobs:
     - run: cargo check -p wasmtime --no-default-features --features uffd
     - run: cargo check -p wasmtime --no-default-features --features cranelift
     - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache
+    
+    # Check that benchmarks of the cranelift project build
+    - run: cargo bench -p cranelift-codegen
 
     # Check some feature combinations of the `wasmtime-c-api` crate
     - run: cargo check -p wasmtime-c-api --no-default-features


### PR DESCRIPTION
- [ ] This has been discussed in issue https://github.com/bytecodealliance/wasmtime/issues/3436

- [ ] This PR ensures that the cranelift benchmarks are performed (unless they are specifically ignored, right now they still are) to combat regressions 

Hello peers!
Very junior contributor here.
Quite possibly this is not the correct place to include this rather trivial line of code, and since all benches are ignored per default on master, I am unsure of this pr isn't about significantly more than just this.

Though if I haven't misunderstood the usage of the CI, this seems to be the appropriate place in code, to start benchmarks.

I hope you have a beautiful day, feel free to critisise my misunderstandings.
Nils