### PR TITLE
Use `ptr::cast` instead of `as` casts in several places.

### DIFF
--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -874,7 +874,7 @@ fn lookup_with_dlsym(name: &str) -> Option<*const u8> {
             // try to find the searched symbol in the currently running executable
             ptr::null_mut(),
             // try to find the searched symbol in local c runtime
-            winapi::um::libloaderapi::GetModuleHandleA(MSVCRT_DLL.as_ptr() as *const i8),
+            winapi::um::libloaderapi::GetModuleHandleA(MSVCRT_DLL.as_ptr().cast::<i8>()),
         ];
 
         for handle in &handles {

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -200,11 +200,7 @@ unsafe fn register_unwind_info(obj: &File, text: &[u8]) -> Result<Option<UnwindR
         return Ok(None);
     }
     Ok(Some(
-        UnwindRegistration::new(
-            text.as_ptr() as *mut _,
-            unwind_info.as_ptr() as *mut _,
-            unwind_info.len(),
-        )
-        .context("failed to create unwind info registration")?,
+        UnwindRegistration::new(text.as_ptr(), unwind_info.as_ptr(), unwind_info.len())
+            .context("failed to create unwind info registration")?,
     ))
 }

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -387,16 +387,13 @@ impl CompiledModule {
     #[inline]
     pub fn finished_functions(
         &self,
-    ) -> impl ExactSizeIterator<Item = (DefinedFuncIndex, *mut [VMFunctionBody])> + '_ {
+    ) -> impl ExactSizeIterator<Item = (DefinedFuncIndex, *const [VMFunctionBody])> + '_ {
         let code = self.code();
         self.funcs.iter().map(move |(i, info)| {
             let func = &code[info.start as usize..][..info.length as usize];
             (
                 i,
-                std::ptr::slice_from_raw_parts_mut(
-                    func.as_ptr() as *mut VMFunctionBody,
-                    func.len(),
-                ),
+                std::ptr::slice_from_raw_parts(func.as_ptr().cast::<VMFunctionBody>(), func.len()),
             )
         })
     }
@@ -423,7 +420,7 @@ impl CompiledModule {
     /// memory with the stack maps associated with those bytes.
     pub fn stack_maps(
         &self,
-    ) -> impl Iterator<Item = (*mut [VMFunctionBody], &[StackMapInformation])> {
+    ) -> impl Iterator<Item = (*const [VMFunctionBody], &[StackMapInformation])> {
         self.finished_functions()
             .map(|(_, f)| f)
             .zip(self.funcs.values().map(|f| f.stack_maps.as_slice()))

--- a/crates/jit/src/profiling/jitdump_linux.rs
+++ b/crates/jit/src/profiling/jitdump_linux.rs
@@ -292,7 +292,7 @@ impl State {
         let tid = pid; // ThreadId does appear to track underlying thread. Using PID.
 
         for (idx, func) in module.finished_functions() {
-            let (addr, len) = unsafe { ((*func).as_ptr() as *const u8, (*func).len()) };
+            let (addr, len) = unsafe { ((*func).as_ptr().cast::<u8>(), (*func).len()) };
             if let Some(img) = &dbg_image {
                 if let Err(err) = self.dump_from_debug_image(img, "wasm", addr, len, pid, tid) {
                     println!(

--- a/crates/jit/src/profiling/vtune_linux.rs
+++ b/crates/jit/src/profiling/vtune_linux.rs
@@ -130,7 +130,7 @@ impl State {
             .unwrap_or_else(|| format!("wasm_module_{}", global_module_id));
 
         for (idx, func) in module.finished_functions() {
-            let (addr, len) = unsafe { ((*func).as_ptr() as *const u8, (*func).len()) };
+            let (addr, len) = unsafe { ((*func).as_ptr().cast::<u8>(), (*func).len()) };
             let method_name = super::debug_name(module.module(), idx);
             let method_id = self.get_method_id();
             log::trace!(

--- a/crates/jit/src/unwind/systemv.rs
+++ b/crates/jit/src/unwind/systemv.rs
@@ -21,8 +21,8 @@ impl UnwindRegistration {
     /// describe an in-memory representation of a `.eh_frame` section. This is
     /// typically arranged for by the `wasmtime-obj` crate.
     pub unsafe fn new(
-        _base_address: *mut u8,
-        unwind_info: *mut u8,
+        _base_address: *const u8,
+        unwind_info: *const u8,
         unwind_len: usize,
     ) -> Result<UnwindRegistration> {
         debug_assert_eq!(

--- a/crates/jit/src/unwind/winx64.rs
+++ b/crates/jit/src/unwind/winx64.rs
@@ -11,8 +11,8 @@ pub struct UnwindRegistration {
 
 impl UnwindRegistration {
     pub unsafe fn new(
-        base_address: *mut u8,
-        unwind_info: *mut u8,
+        base_address: *const u8,
+        unwind_info: *const u8,
         unwind_len: usize,
     ) -> Result<UnwindRegistration> {
         assert!(unwind_info as usize % 4 == 0);

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -100,7 +100,7 @@ impl Instance {
     /// Helper function to access various locations offset from our `*mut
     /// VMContext` object.
     unsafe fn vmctx_plus_offset<T>(&self, offset: u32) -> *mut T {
-        (self.vmctx_ptr() as *mut u8)
+        (self.vmctx_ptr().cast::<u8>())
             .add(usize::try_from(offset).unwrap())
             .cast()
     }
@@ -420,7 +420,8 @@ impl Instance {
 
         // Keep the `VMContext` pointers used by compiled Wasm code up to
         // date.
-        self.set_table(table_index, self.tables[table_index].vmtable());
+        let element = self.tables[table_index].vmtable();
+        self.set_table(table_index, element);
 
         result
     }

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -476,10 +476,10 @@ impl Memory {
     }
 
     /// Return a `VMMemoryDefinition` for exposing the memory to compiled wasm code.
-    pub fn vmmemory(&self) -> VMMemoryDefinition {
+    pub fn vmmemory(&mut self) -> VMMemoryDefinition {
         match self {
             Memory::Static { base, size, .. } => VMMemoryDefinition {
-                base: base.as_ptr() as *mut _,
+                base: base.as_mut_ptr().cast(),
                 current_length: *size,
             },
             Memory::Dynamic(mem) => mem.vmmemory(),

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -398,14 +398,14 @@ impl Table {
     }
 
     /// Return a `VMTableDefinition` for exposing the table to compiled wasm code.
-    pub fn vmtable(&self) -> VMTableDefinition {
+    pub fn vmtable(&mut self) -> VMTableDefinition {
         match self {
             Table::Static { data, size, .. } => VMTableDefinition {
-                base: data.as_ptr() as *mut _,
+                base: data.as_mut_ptr().cast(),
                 current_elements: *size,
             },
             Table::Dynamic { elements, .. } => VMTableDefinition {
-                base: elements.as_ptr() as _,
+                base: elements.as_mut_ptr().cast(),
                 current_elements: elements.len().try_into().unwrap(),
             },
         }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -340,145 +340,157 @@ impl VMGlobalDefinition {
     /// Return a reference to the value as an i32.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i32(&self) -> &i32 {
-        &*(self.storage.as_ref().as_ptr() as *const i32)
+        &*(self.storage.as_ref().as_ptr().cast::<i32>())
     }
 
     /// Return a mutable reference to the value as an i32.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i32_mut(&mut self) -> &mut i32 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut i32)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<i32>())
     }
 
     /// Return a reference to the value as a u32.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u32(&self) -> &u32 {
-        &*(self.storage.as_ref().as_ptr() as *const u32)
+        &*(self.storage.as_ref().as_ptr().cast::<u32>())
     }
 
     /// Return a mutable reference to the value as an u32.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u32_mut(&mut self) -> &mut u32 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut u32)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<u32>())
     }
 
     /// Return a reference to the value as an i64.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i64(&self) -> &i64 {
-        &*(self.storage.as_ref().as_ptr() as *const i64)
+        &*(self.storage.as_ref().as_ptr().cast::<i64>())
     }
 
     /// Return a mutable reference to the value as an i64.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i64_mut(&mut self) -> &mut i64 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut i64)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<i64>())
     }
 
     /// Return a reference to the value as an u64.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u64(&self) -> &u64 {
-        &*(self.storage.as_ref().as_ptr() as *const u64)
+        &*(self.storage.as_ref().as_ptr().cast::<u64>())
     }
 
     /// Return a mutable reference to the value as an u64.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u64_mut(&mut self) -> &mut u64 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut u64)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<u64>())
     }
 
     /// Return a reference to the value as an f32.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32(&self) -> &f32 {
-        &*(self.storage.as_ref().as_ptr() as *const f32)
+        &*(self.storage.as_ref().as_ptr().cast::<f32>())
     }
 
     /// Return a mutable reference to the value as an f32.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32_mut(&mut self) -> &mut f32 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut f32)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<f32>())
     }
 
     /// Return a reference to the value as f32 bits.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32_bits(&self) -> &u32 {
-        &*(self.storage.as_ref().as_ptr() as *const u32)
+        &*(self.storage.as_ref().as_ptr().cast::<u32>())
     }
 
     /// Return a mutable reference to the value as f32 bits.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32_bits_mut(&mut self) -> &mut u32 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut u32)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<u32>())
     }
 
     /// Return a reference to the value as an f64.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64(&self) -> &f64 {
-        &*(self.storage.as_ref().as_ptr() as *const f64)
+        &*(self.storage.as_ref().as_ptr().cast::<f64>())
     }
 
     /// Return a mutable reference to the value as an f64.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64_mut(&mut self) -> &mut f64 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut f64)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<f64>())
     }
 
     /// Return a reference to the value as f64 bits.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64_bits(&self) -> &u64 {
-        &*(self.storage.as_ref().as_ptr() as *const u64)
+        &*(self.storage.as_ref().as_ptr().cast::<u64>())
     }
 
     /// Return a mutable reference to the value as f64 bits.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64_bits_mut(&mut self) -> &mut u64 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut u64)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<u64>())
     }
 
     /// Return a reference to the value as an u128.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128(&self) -> &u128 {
-        &*(self.storage.as_ref().as_ptr() as *const u128)
+        &*(self.storage.as_ref().as_ptr().cast::<u128>())
     }
 
     /// Return a mutable reference to the value as an u128.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128_mut(&mut self) -> &mut u128 {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut u128)
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<u128>())
     }
 
     /// Return a reference to the value as u128 bits.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128_bits(&self) -> &[u8; 16] {
-        &*(self.storage.as_ref().as_ptr() as *const [u8; 16])
+        &*(self.storage.as_ref().as_ptr().cast::<[u8; 16]>())
     }
 
     /// Return a mutable reference to the value as u128 bits.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128_bits_mut(&mut self) -> &mut [u8; 16] {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut [u8; 16])
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<[u8; 16]>())
     }
 
     /// Return a reference to the value as an externref.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_externref(&self) -> &Option<VMExternRef> {
-        &*(self.storage.as_ref().as_ptr() as *const Option<VMExternRef>)
+        &*(self.storage.as_ref().as_ptr().cast::<Option<VMExternRef>>())
     }
 
     /// Return a mutable reference to the value as an externref.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_externref_mut(&mut self) -> &mut Option<VMExternRef> {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut Option<VMExternRef>)
+        &mut *(self
+            .storage
+            .as_mut()
+            .as_mut_ptr()
+            .cast::<Option<VMExternRef>>())
     }
 
     /// Return a reference to the value as an anyfunc.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_anyfunc(&self) -> *const VMCallerCheckedAnyfunc {
-        *(self.storage.as_ref().as_ptr() as *const *const VMCallerCheckedAnyfunc)
+        *(self
+            .storage
+            .as_ref()
+            .as_ptr()
+            .cast::<*const VMCallerCheckedAnyfunc>())
     }
 
     /// Return a mutable reference to the value as an anyfunc.
     #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_anyfunc_mut(&mut self) -> &mut *const VMCallerCheckedAnyfunc {
-        &mut *(self.storage.as_mut().as_mut_ptr() as *mut *const VMCallerCheckedAnyfunc)
+        &mut *(self
+            .storage
+            .as_mut()
+            .as_mut_ptr()
+            .cast::<*const VMCallerCheckedAnyfunc>())
     }
 }
 

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -1553,7 +1553,7 @@ fn dirent_bytes(dirent: types::Dirent) -> Vec<u8> {
         .expect("Dirent is smaller than 2^32");
     let mut bytes = Vec::with_capacity(size);
     bytes.resize(size, 0);
-    let ptr = bytes.as_mut_ptr() as *mut types::Dirent;
+    let ptr = bytes.as_mut_ptr().cast::<types::Dirent>();
     let guest_dirent = types::Dirent {
         d_ino: dirent.d_ino.to_le(),
         d_namlen: dirent.d_namlen.to_le(),

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -346,7 +346,7 @@ impl Global {
                 Val::F64(f) => *definition.as_u64_mut() = f,
                 Val::FuncRef(f) => {
                     *definition.as_anyfunc_mut() = f.map_or(ptr::null(), |f| {
-                        f.caller_checked_anyfunc(store).as_ptr() as *const _
+                        f.caller_checked_anyfunc(store).as_ptr().cast()
                     });
                 }
                 Val::ExternRef(x) => {


### PR DESCRIPTION
`ptr::cast` has the advantage of being unable to silently cast
`*const T` to `*mut T`. This turned up several places that were
performing such casts, which this PR also fixes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
