### PR TITLE
Fix a panic with an invalid name section

### DIFF
--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -1277,6 +1277,11 @@ and for re-adding support for interface types you can see this issue:
                     let mut names = f.get_map()?;
                     for _ in 0..names.get_count() {
                         let Naming { index, name } = names.read()?;
+                        // Skip this naming if it's naming a function that
+                        // doesn't actually exist.
+                        if (index as usize) >= self.result.module.functions.len() {
+                            continue;
+                        }
                         let index = FuncIndex::from_u32(index);
                         self.result
                             .module
@@ -1305,6 +1310,11 @@ and for re-adding support for interface types you can see this issue:
                     let mut reader = l.get_indirect_map()?;
                     for _ in 0..reader.get_indirect_count() {
                         let f = reader.read()?;
+                        // Skip this naming if it's naming a function that
+                        // doesn't actually exist.
+                        if (f.indirect_index as usize) >= self.result.module.functions.len() {
+                            continue;
+                        }
                         let mut map = f.get_map()?;
                         for _ in 0..map.get_count() {
                             let Naming { index, name } = map.read()?;

--- a/tests/misc_testsuite/empty.wast
+++ b/tests/misc_testsuite/empty.wast
@@ -1,3 +1,46 @@
 (module (func (export "empty")))
 
 (invoke "empty")
+
+(module binary
+  "\00asm\01\00\00\00"    ;; module header
+
+  "\00"             ;; custom section id 0
+  "\0e"             ;; section size
+  "\04name"         ;; this is the `name` custom section
+  "\01"             ;; function name subsection
+  "\07"             ;; function name subsection size
+  "\01"             ;; 1 function name mapping
+  "\ff\ff\ff\ff\0f" ;; index == u32::MAX
+  "\00"             ;; empty string name
+)
+
+(module binary
+  "\00asm\01\00\00\00"    ;; module header
+
+  "\00"             ;; custom section id 0
+  "\10"             ;; section size
+  "\04name"         ;; this is the `name` custom section
+  "\02"             ;; local name subsection
+  "\09"             ;; local name subsection size
+  "\01"             ;; 1 indirect name map
+  "\ff\ff\ff\ff\0f" ;; index == u32::MAX (function)
+  "\01"             ;; 1 name mapping
+  "\00"             ;; index == 0 (local)
+  "\00"             ;; empty string name
+)
+
+(module binary
+  "\00asm\01\00\00\00"    ;; module header
+
+  "\00"             ;; custom section id 0
+  "\10"             ;; section size
+  "\04name"         ;; this is the `name` custom section
+  "\02"             ;; local name subsection
+  "\09"             ;; local name subsection size
+  "\01"             ;; 1 indirect name map
+  "\00"             ;; index == 0 (function)
+  "\01"             ;; 1 name mapping
+  "\ff\ff\ff\ff\0f" ;; index == u32::MAX (local)
+  "\00"             ;; empty string name
+)


### PR DESCRIPTION
This commit fixes a panic which can happen on a module with an invalid
name section where one of the functions named has the index `u32::MAX`.
Previously Wasmtime would create a new `FuncIndex` with the indices
found in the name section but the sentinel `u32::MAX` causes a panic.

Cranelift otherwise limits the number of functions through `wasmparser`
which has a hard limit (lower than `u32::MAX`) so this commit applies a
fix of only recording function names for function indices that are
actually present in the module.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
