### PR TITLE
InstancePre can impl Clone

### DIFF
--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -905,6 +905,17 @@ pub struct InstancePre<T> {
     _marker: std::marker::PhantomData<fn() -> T>,
 }
 
+/// InstancePre's clone does not require T: Clone
+impl<T> Clone for InstancePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            module: self.module.clone(),
+            items: self.items.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
 impl<T> InstancePre<T> {
     pub(crate) unsafe fn new(
         store: &mut StoreOpaque,


### PR DESCRIPTION
Its a manually written impl, not a derive, because `InstancePre<T>: Clone`
is not bound by `T: Clone`.

The clone should be reasonably inexpensive: Clone for `Module` is just an
Arc, and Clone for `Definition` should also just be an Arc on the `HostFunc`
or `Instance` variants. An `InstancePre` shouldnt contain any
`Definition::Extern` variants because there is not yet a `Store` associated
with it- right?

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
