### PR TITLE
Update to rustix 0.26.2, fixing a crash on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,9 +269,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf5c3b436b94a1adac74032ff35d8aa5bae6ec2a7900e76432c9ae8dac4d673"
+checksum = "4f8499797f7e264c83334d9fc98b2c9889ebe5839514a14d81769ca09d71fd1d"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -282,20 +282,19 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51bd736eec54ae6552d18b0c958885b01d88c84c5fe6985e28c2b57ff385e94"
+checksum = "c5998b8b3a49736500aec3c123fa3f6f605a125b41a6df725e6b7c924a612ab4"
 dependencies = [
  "ambient-authority",
  "errno",
  "fs-set-times",
+ "io-extras",
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "once_cell",
- "rsix",
  "rustc_version",
- "unsafe-io",
+ "rustix",
  "winapi",
  "winapi-util",
  "winx",
@@ -303,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6e89d00b0cebeb6da7a459b81e6a49cf2092cc4afe03f28eb99b8f0e889344"
+checksum = "fafda903eb4a85903b106439cf62524275f3ae0609bb9e1ae9da7e7c26d4150c"
 dependencies = [
  "ambient-authority",
  "rand 0.8.3",
@@ -313,23 +312,23 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037334fe2f30ec71bcc51af1e8cbb8a9f9ac6a6b8cbd657d58dfef2ad5b9f19a"
+checksum = "811de89a7ede4ba32f2b75fe5c668a534da24942d81c081248a9d2843ebd517d"
 dependencies = [
  "cap-primitives",
+ "io-extras",
  "io-lifetimes",
  "ipnet",
- "rsix",
  "rustc_version",
- "unsafe-io",
+ "rustix",
 ]
 
 [[package]]
 name = "cap-tempfile"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5160158dd17a01cfaf359e27a17fb6cc37c083347ed8c6e10583e08055d12c94"
+checksum = "a4fa925a69a454293146bc04dfcbeba993093b1816531f9408e229130d7fc465"
 dependencies = [
  "cap-std",
  "rand 0.8.3",
@@ -338,13 +337,13 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea5319ada3a9517fc70eafe9cf3275f04da795c53770ebc5d91f4a33f4dd2b5"
+checksum = "85f263d62447efe8829efdf947bbb4824ba2a3e2852b3be1d62f76fc05c326b0"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rsix",
+ "rustix",
  "winx",
 ]
 
@@ -1096,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1183,12 +1182,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807e3ef0de04fbe498bebd560ae041e006d97bf9f726dc0b485a86316be0ebc8"
+checksum = "aa838950e8e36a567ce96a945c303e88d9916ff97df27c315a0d263a72bd816f"
 dependencies = [
  "io-lifetimes",
- "rsix",
+ "rustix",
  "winapi",
 ]
 
@@ -1397,10 +1396,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "0.3.1"
+name = "io-extras"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f5ce4afb9bf504b9f496a3307676bc232122f91a93c4da6d540aa99a0a0e0b"
+checksum = "2a1d9a66d8b0312e3601a04a2dcf8f0ddd873319560ddeabe2110fa1e5af781a"
+dependencies = [
+ "io-lifetimes",
+ "rustc_version",
+ "winapi",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "278e90d6f8a6c76a8334b336e306efa3c5f2b604048cbfd486d6f49878e3af14"
 dependencies = [
  "rustc_version",
  "winapi",
@@ -1531,9 +1541,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.24"
+version = "0.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d803e4a041d0deed25db109ac7ba704d1edd62588b623feb8beed5da78e579"
+checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
 
 [[package]]
 name = "lock_api"
@@ -2465,23 +2475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb64fd899aa29c8f920e52732489630b55dba438039eee73ee068e995f64ef2"
-dependencies = [
- "bitflags",
- "cc",
- "errno",
- "io-lifetimes",
- "itoa",
- "libc",
- "linux-raw-sys",
- "once_cell",
- "rustc_version",
-]
-
-[[package]]
 name = "run-examples"
 version = "0.19.0"
 dependencies = [
@@ -2508,6 +2501,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c44018277ec7195538f5631b90def7ad975bb46370cb0f4eff4012de9333f8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "itoa",
+ "libc",
+ "linux-raw-sys",
+ "once_cell",
+ "rustc_version",
+ "winapi",
 ]
 
 [[package]]
@@ -2761,17 +2771,17 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb3a23bf923c3fdaf0c36a8c016047e415f0559a5b891de7ec3d19d58b9b503"
+checksum = "b1b5163055c386394170493ec1827cf7975035dc0bb23dcb7070bd1b1f672baa"
 dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
  "cap-std",
  "io-lifetimes",
- "rsix",
  "rustc_version",
+ "rustix",
  "winapi",
  "winx",
 ]
@@ -3018,17 +3028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-io"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e8cceed59fe60bd092be347343917cbc14b9239536980f09fe34e22c8efbc7"
-dependencies = [
- "io-lifetimes",
- "rustc_version",
- "winapi",
-]
-
-[[package]]
 name = "userfaultfd"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,7 +3131,7 @@ dependencies = [
  "fs-set-times",
  "io-lifetimes",
  "lazy_static",
- "rsix",
+ "rustix",
  "system-interface",
  "tempfile",
  "tracing",
@@ -3149,7 +3148,7 @@ dependencies = [
  "cap-rand",
  "cap-std",
  "io-lifetimes",
- "rsix",
+ "rustix",
  "thiserror",
  "tracing",
  "wiggle",
@@ -3194,7 +3193,7 @@ dependencies = [
  "cap-tempfile",
  "io-lifetimes",
  "lazy_static",
- "rsix",
+ "rustix",
  "tempfile",
  "tokio",
  "wasi-cap-std-sync",
@@ -3415,7 +3414,7 @@ dependencies = [
  "log",
  "more-asserts",
  "pretty_env_logger",
- "rsix",
+ "rustix",
  "serde",
  "sha2",
  "tempfile",
@@ -3444,7 +3443,7 @@ dependencies = [
  "object",
  "pretty_env_logger",
  "rayon",
- "rsix",
+ "rustix",
  "structopt",
  "target-lexicon",
  "tempfile",
@@ -3511,7 +3510,7 @@ version = "0.31.0"
 dependencies = [
  "backtrace",
  "cc",
- "rsix",
+ "rustix",
  "winapi",
 ]
 
@@ -3566,7 +3565,7 @@ dependencies = [
  "ittapi-rs",
  "object",
  "region",
- "rsix",
+ "rustix",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -3592,7 +3591,7 @@ dependencies = [
  "more-asserts",
  "rand 0.8.3",
  "region",
- "rsix",
+ "rustix",
  "thiserror",
  "userfaultfd",
  "wasmtime-environ",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ wasmparser = "0.81.0"
 lazy_static = "1.4.0"
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.23.0"
+rustix = "0.26.2"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.19.1"
+cap-std = "0.21.1"
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -29,7 +29,7 @@ wat = { version = "1.0.36", optional = true }
 # Optional dependencies for the `wasi` feature
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.19.1", optional = true }
+cap-std = { version = "0.21.1", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache']

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -24,7 +24,7 @@ zstd = { version = "0.9", default-features = false }
 winapi = "0.3.7"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rsix = "0.23.0"
+rustix = "0.26.2"
 
 [dev-dependencies]
 filetime = "0.2.7"

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -256,7 +256,7 @@ impl WorkerThread {
 
         const NICE_DELTA_FOR_BACKGROUND_TASKS: i32 = 3;
 
-        match rsix::process::nice(NICE_DELTA_FOR_BACKGROUND_TASKS) {
+        match rustix::process::nice(NICE_DELTA_FOR_BACKGROUND_TASKS) {
             Ok(current_nice) => {
                 debug!("New nice value of worker thread: {}", current_nice);
             }

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 links = "wasmtime-fiber-shims"
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.23.0"
+rustix = "0.26.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -47,7 +47,7 @@ impl FiberStack {
     pub fn new(size: usize) -> io::Result<Self> {
         // Round up our stack size request to the nearest multiple of the
         // page size.
-        let page_size = rsix::process::page_size();
+        let page_size = rustix::process::page_size();
         let size = if size == 0 {
             page_size
         } else {
@@ -57,17 +57,17 @@ impl FiberStack {
         unsafe {
             // Add in one page for a guard page and then ask for some memory.
             let mmap_len = size + page_size;
-            let mmap = rsix::io::mmap_anonymous(
+            let mmap = rustix::io::mmap_anonymous(
                 ptr::null_mut(),
                 mmap_len,
-                rsix::io::ProtFlags::empty(),
-                rsix::io::MapFlags::PRIVATE,
+                rustix::io::ProtFlags::empty(),
+                rustix::io::MapFlags::PRIVATE,
             )?;
 
-            rsix::io::mprotect(
+            rustix::io::mprotect(
                 mmap.cast::<u8>().add(page_size).cast(),
                 size,
-                rsix::io::MprotectFlags::READ | rsix::io::MprotectFlags::WRITE,
+                rustix::io::MprotectFlags::READ | rustix::io::MprotectFlags::WRITE,
             )?;
 
             Ok(Self {
@@ -90,7 +90,7 @@ impl Drop for FiberStack {
     fn drop(&mut self) {
         unsafe {
             if let Some(len) = self.len {
-                let ret = rsix::io::munmap(self.top.sub(len) as _, len);
+                let ret = rustix::io::munmap(self.top.sub(len) as _, len);
                 debug_assert!(ret.is_ok());
             }
         }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -29,10 +29,10 @@ bincode = "1.2.1"
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rsix = { version = "0.23.0", optional = true }
+rustix = { version = "0.26.2", optional = true }
 
 [features]
-jitdump = ['rsix']
+jitdump = ['rustix']
 vtune = ['ittapi-rs']
 
 [badges]

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -57,8 +57,8 @@ impl CodeMemory {
         #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
         {
             // This is a requirement of the `membarrier` call executed by the `publish` method.
-            rsix::process::membarrier(
-                rsix::process::MembarrierCommand::RegisterPrivateExpeditedSyncCore,
+            rustix::process::membarrier(
+                rustix::process::MembarrierCommand::RegisterPrivateExpeditedSyncCore,
             )
             .unwrap();
         }
@@ -171,8 +171,8 @@ impl CodeMemory {
             #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
             {
                 // Ensure that no processor has fetched a stale instruction stream.
-                rsix::process::membarrier(
-                    rsix::process::MembarrierCommand::PrivateExpeditedSyncCore,
+                rustix::process::membarrier(
+                    rustix::process::MembarrierCommand::PrivateExpeditedSyncCore,
                 )
                 .unwrap();
             }

--- a/crates/jit/src/profiling/jitdump_linux.rs
+++ b/crates/jit/src/profiling/jitdump_linux.rs
@@ -176,11 +176,11 @@ impl JitDumpAgent {
         // To match what some perf examples are doing we keep this `mmap` alive
         // until this agent goes away.
         let map_addr = unsafe {
-            let ptr = rsix::io::mmap(
+            let ptr = rustix::io::mmap(
                 ptr::null_mut(),
-                rsix::process::page_size(),
-                rsix::io::ProtFlags::EXEC | rsix::io::ProtFlags::READ,
-                rsix::io::MapFlags::PRIVATE,
+                rustix::process::page_size(),
+                rustix::io::ProtFlags::EXEC | rustix::io::ProtFlags::READ,
+                rustix::io::MapFlags::PRIVATE,
                 &jitdump_file,
                 0,
             )?;
@@ -215,7 +215,7 @@ impl State {
         // conveniently also uses, but `Instant` doesn't allow us to get access
         // to nanoseconds as an internal detail, so we calculate the nanoseconds
         // ourselves here.
-        let ts = rsix::time::clock_gettime(rsix::time::ClockId::Monotonic);
+        let ts = rustix::time::clock_gettime(rustix::time::ClockId::Monotonic);
         // TODO: What does it mean for either sec or nsec to be negative?
         (ts.tv_sec * 1_000_000_000 + ts.tv_nsec) as u64
     }
@@ -687,7 +687,7 @@ impl State {
 impl Drop for State {
     fn drop(&mut self) {
         unsafe {
-            rsix::io::munmap(self.map_addr as *mut _, rsix::process::page_size()).unwrap();
+            rustix::io::munmap(self.map_addr as *mut _, rustix::process::page_size()).unwrap();
         }
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.38"
 mach = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.23.2"
+rustix = "0.26.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi", "handleapi"] }

--- a/crates/runtime/src/instance/allocator/pooling/linux.rs
+++ b/crates/runtime/src/instance/allocator/pooling/linux.rs
@@ -12,7 +12,7 @@ fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
         }
 
         // On Linux, this is enough to cause the kernel to initialize the pages to 0 on next access
-        rsix::io::madvise(addr as _, len, rsix::io::Advice::LinuxDontNeed)
+        rustix::io::madvise(addr as _, len, rustix::io::Advice::LinuxDontNeed)
             .context("madvise failed to decommit: {}")?;
     }
 

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -33,7 +33,7 @@
 use super::{InstancePool, MemoryPool};
 use crate::instance::Instance;
 use anyhow::{bail, Context, Result};
-use rsix::io::{madvise, Advice};
+use rustix::io::{madvise, Advice};
 use std::thread;
 use userfaultfd::{Event, FeatureFlags, IoctlFlags, Uffd, UffdBuilder};
 use wasmtime_environ::{DefinedMemoryIndex, EntityRef, MemoryInitialization};

--- a/crates/runtime/src/instance/allocator/pooling/unix.rs
+++ b/crates/runtime/src/instance/allocator/pooling/unix.rs
@@ -10,15 +10,15 @@ fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
     // The new mapping will be to the CoW zero page, so this effectively
     // zeroes the pages.
     unsafe {
-        rsix::io::mmap_anonymous(
+        rustix::io::mmap_anonymous(
             addr as _,
             len,
             if protect {
-                rsix::io::ProtFlags::empty()
+                rustix::io::ProtFlags::empty()
             } else {
-                rsix::io::ProtFlags::READ | rsix::io::ProtFlags::WRITE
+                rustix::io::ProtFlags::READ | rustix::io::ProtFlags::WRITE
             },
-            rsix::io::MapFlags::PRIVATE | rsix::io::MapFlags::FIXED,
+            rustix::io::MapFlags::PRIVATE | rustix::io::MapFlags::FIXED,
         )
         .context("mmap failed to remap pages: {}")?;
     }

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -63,11 +63,11 @@ impl Mmap {
                 .len();
             let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
             let ptr = unsafe {
-                rsix::io::mmap(
+                rustix::io::mmap(
                     ptr::null_mut(),
                     len,
-                    rsix::io::ProtFlags::READ,
-                    rsix::io::MapFlags::PRIVATE,
+                    rustix::io::ProtFlags::READ,
+                    rustix::io::MapFlags::PRIVATE,
                     &file,
                     0,
                 )
@@ -170,11 +170,11 @@ impl Mmap {
         Ok(if accessible_size == mapping_size {
             // Allocate a single read-write region at once.
             let ptr = unsafe {
-                rsix::io::mmap_anonymous(
+                rustix::io::mmap_anonymous(
                     ptr::null_mut(),
                     mapping_size,
-                    rsix::io::ProtFlags::READ | rsix::io::ProtFlags::WRITE,
-                    rsix::io::MapFlags::PRIVATE,
+                    rustix::io::ProtFlags::READ | rustix::io::ProtFlags::WRITE,
+                    rustix::io::MapFlags::PRIVATE,
                 )
                 .context(format!("mmap failed to allocate {:#x} bytes", mapping_size))?
             };
@@ -187,11 +187,11 @@ impl Mmap {
         } else {
             // Reserve the mapping size.
             let ptr = unsafe {
-                rsix::io::mmap_anonymous(
+                rustix::io::mmap_anonymous(
                     ptr::null_mut(),
                     mapping_size,
-                    rsix::io::ProtFlags::empty(),
-                    rsix::io::MapFlags::PRIVATE,
+                    rustix::io::ProtFlags::empty(),
+                    rustix::io::MapFlags::PRIVATE,
                 )
                 .context(format!("mmap failed to allocate {:#x} bytes", mapping_size))?
             };
@@ -424,7 +424,7 @@ impl Drop for Mmap {
     #[cfg(not(target_os = "windows"))]
     fn drop(&mut self) {
         if self.len != 0 {
-            unsafe { rsix::io::munmap(self.ptr as *mut std::ffi::c_void, self.len) }
+            unsafe { rustix::io::munmap(self.ptr as *mut std::ffi::c_void, self.len) }
                 .expect("munmap failed");
         }
     }

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -294,21 +294,21 @@ pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
         let guard_size = page_size;
         let alloc_size = guard_size + MIN_STACK_SIZE;
 
-        let ptr = rsix::io::mmap_anonymous(
+        let ptr = rustix::io::mmap_anonymous(
             null_mut(),
             alloc_size,
-            rsix::io::ProtFlags::empty(),
-            rsix::io::MapFlags::PRIVATE,
+            rustix::io::ProtFlags::empty(),
+            rustix::io::MapFlags::PRIVATE,
         )
         .map_err(|_| Box::new(Trap::oom()))?;
 
         // Prepare the stack with readable/writable memory and then register it
         // with `sigaltstack`.
         let stack_ptr = (ptr as usize + guard_size) as *mut std::ffi::c_void;
-        rsix::io::mprotect(
+        rustix::io::mprotect(
             stack_ptr,
             MIN_STACK_SIZE,
-            rsix::io::MprotectFlags::READ | rsix::io::MprotectFlags::WRITE,
+            rustix::io::MprotectFlags::READ | rustix::io::MprotectFlags::WRITE,
         )
         .expect("mprotect to configure memory for sigaltstack failed");
         let new_stack = libc::stack_t {
@@ -334,7 +334,7 @@ pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
         fn drop(&mut self) {
             unsafe {
                 // Deallocate the stack memory.
-                let r = rsix::io::munmap(self.mmap_ptr, self.mmap_size);
+                let r = rustix::io::munmap(self.mmap_ptr, self.mmap_size);
                 debug_assert!(r.is_ok(), "munmap failed during thread shutdown");
             }
         }

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
-cap-std = "0.19.1"
+cap-std = "0.21.1"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,13 +22,13 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "=0.31.0" }
 tracing = "0.1.19"
-cap-std = "0.19.1"
-cap-rand = "0.19.1"
+cap-std = "0.21.1"
+cap-rand = "0.21.1"
 bitflags = "1.2"
 io-lifetimes = { version = "0.3.1", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.23.0"
+rustix = "0.26.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,17 +15,17 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "=0.31.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.19.1"
-cap-fs-ext = "0.19.1"
-cap-time-ext = "0.19.1"
-cap-rand = "0.19.1"
-fs-set-times = "0.12.0"
-system-interface = { version = "0.15.0", features = ["cap_std_impls"] }
+cap-std = "0.21.1"
+cap-fs-ext = "0.21.1"
+cap-time-ext = "0.21.1"
+cap-rand = "0.21.1"
+fs-set-times = "0.13.1"
+system-interface = { version = "0.16.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
-io-lifetimes = { version = "0.3.0", default-features = false }
+io-lifetimes = { version = "0.3.3", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.23.0"
+rustix = "0.26.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/src/sched/unix.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/unix.rs
@@ -1,6 +1,6 @@
 use cap_std::time::Duration;
 use io_lifetimes::{AsFd, BorrowedFd};
-use rsix::io::{PollFd, PollFlags};
+use rustix::io::{PollFd, PollFlags};
 use std::convert::TryInto;
 use wasi_common::{
     file::WasiFile,
@@ -49,9 +49,9 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
             poll_fds = tracing::field::debug(&pollfds),
             "poll"
         );
-        match rsix::io::poll(&mut pollfds, poll_timeout) {
+        match rustix::io::poll(&mut pollfds, poll_timeout) {
             Ok(ready) => break ready,
-            Err(rsix::io::Error::INTR) => continue,
+            Err(rustix::io::Error::INTR) => continue,
             Err(err) => return Err(err.into()),
         }
     };

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -112,7 +112,7 @@ impl TryFrom<std::io::Error> for types::Errno {
     fn try_from(err: std::io::Error) -> Result<types::Errno, Error> {
         #[cfg(unix)]
         fn raw_error_code(err: &std::io::Error) -> Option<types::Errno> {
-            use rsix::io::Error;
+            use rustix::io::Error;
             match Error::from_io_error(err) {
                 Some(Error::PIPE) => Some(types::Errno::Pipe),
                 Some(Error::PERM) => Some(types::Errno::Perm),

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,12 +15,12 @@ wasi-common = { path = "../", version = "=0.31.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "=0.31.0" }
 wiggle = { path = "../../wiggle", version = "=0.31.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.19.1"
+cap-std = "0.21.1"
 anyhow = "1"
 io-lifetimes = { version = "0.3.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rsix = "0.23.0"
+rustix = "0.26.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
@@ -30,4 +30,4 @@ lazy_static = "1.4"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.19.1"
+cap-tempfile = "0.21.1"

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -4,7 +4,7 @@
 ))]
 mod tests {
     use anyhow::Result;
-    use rsix::io::{mprotect, MprotectFlags};
+    use rustix::io::{mprotect, MprotectFlags};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use wasmtime::unix::StoreExt;

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -3,7 +3,7 @@ mod not_for_windows {
     use wasmtime::*;
     use wasmtime_environ::{WASM32_MAX_PAGES, WASM_PAGE_SIZE};
 
-    use rsix::io::{mmap_anonymous, mprotect, munmap, MapFlags, MprotectFlags, ProtFlags};
+    use rustix::io::{mmap_anonymous, mprotect, munmap, MapFlags, MprotectFlags, ProtFlags};
 
     use std::convert::TryFrom;
     use std::ptr::null_mut;
@@ -19,7 +19,7 @@ mod not_for_windows {
 
     impl CustomMemory {
         unsafe fn new(minimum: usize, maximum: usize, glob_counter: Arc<Mutex<usize>>) -> Self {
-            let page_size = rsix::process::page_size();
+            let page_size = rustix::process::page_size();
             let guard_size = page_size;
             let size = maximum + guard_size;
             assert_eq!(size % page_size, 0); // we rely on WASM_PAGE_SIZE being multiple of host page size


### PR DESCRIPTION
This pulls in a fix for Android, where Android's seccomp policy on older
versions is to make `openat2` irrecoverably crash the process, so we have
to do a version check up front rather than relying on `ENOSYS` to
determine if `openat2` is supported.

And it pulls in the fix for the link errors when multiple versions of
rsix/rustix are linked in.

And it has updates for two crate renamings: rsix has been renamed to
rustix, and unsafe-io has been renamed to io-extras.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
