### PR TITLE
aarch64: Remove manual sign extension in lowering

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -41,20 +41,16 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
     match op {
         Opcode::Iconst | Opcode::Bconst | Opcode::Null => {
             let value = ctx.get_constant(insn).unwrap();
-            // Sign extend constant if necessary
-            let value = match ty.unwrap() {
-                I8 => (((value as i64) << 56) >> 56) as u64,
-                I16 => (((value as i64) << 48) >> 48) as u64,
-                I32 => (((value as i64) << 32) >> 32) as u64,
-                I64 | R64 => value,
-                ty if ty.is_bool() => value,
+            match ty.unwrap() {
+                I8 | I16 | I32 | I64 | R64 => {}
+                ty if ty.is_bool() => {}
                 ty => {
                     return Err(CodegenError::Unsupported(format!(
                         "{}: Unsupported type: {:?}",
                         op, ty
-                    )))
+                    )));
                 }
-            };
+            }
             let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             lower_constant_u64(ctx, rd, value);
         }


### PR DESCRIPTION
Currently the lowering for `iconst` will sign-extend the payload value
of the `iconst` instruction itself, but the payload is already
sign-extended to this isn't necessary. This commit removes the redundant
sign extension.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
