### PR TITLE
x64: Add test for a fixed issue

### DIFF
--- a/tests/misc_testsuite/simd/almost-extmul.wast
+++ b/tests/misc_testsuite/simd/almost-extmul.wast
@@ -1,0 +1,16 @@
+;; regression test from #3337, there's a multiplication that sort of
+;; looks like an extmul and codegen shouldn't pattern match too much
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000
+    i64x2.extend_low_i32x4_u
+    v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000
+    i64x2.mul
+    i32x4.all_true
+    i64.load offset=1 align=1
+    drop
+    unreachable)
+  (func (;1;) (type 0)
+    nop)
+  (memory (;0;) 5613 17832))

--- a/tests/misc_testsuite/simd/almost-extmul.wast
+++ b/tests/misc_testsuite/simd/almost-extmul.wast
@@ -13,4 +13,4 @@
     unreachable)
   (func (;1;) (type 0)
     nop)
-  (memory (;0;) 5613 17832))
+  (memory (;0;) 1 1))


### PR DESCRIPTION
This commit adds a test from #3337 which is an issue that was fixed
in #3506 due to moving `imul` lowering rules to ISLE which fixed the
underlying issue of accidentally not falling through to the necessary
case for general `i64x2.mul` multiplication.

Closes #3337

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
