### PR TITLE
x64: allow vector types in `select` move

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -5297,7 +5297,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 if is_int_or_ref_ty(ty) || ty == types::I128 {
                     emit_cmoves(ctx, size, cc, lhs, dst);
                 } else {
-                    debug_assert!(ty == types::F32 || ty == types::F64);
+                    debug_assert!(
+                        ty == types::F32
+                            || ty == types::F64
+                            || (ty.is_vector() && ty.bits() == 128)
+                    );
                     ctx.emit(Inst::xmm_cmove(
                         if ty == types::F64 {
                             OperandSize::Size64

--- a/tests/misc_testsuite/simd/issue_3173_select_v128.wast
+++ b/tests/misc_testsuite/simd/issue_3173_select_v128.wast
@@ -1,0 +1,10 @@
+(; See issue https://github.com/bytecodealliance/wasmtime/issues/3173. ;)
+
+(module
+  (func (export "select_v128") (result v128)
+    v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000
+    v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000
+    i32.const 0
+    select))
+
+(assert_return (invoke "select_v128") (v128.const i32x4 0 0 0 0))


### PR DESCRIPTION
As reported in #3173, the `select` instruction fails an assertion when it is given `v128` types as operands. This change relaxes the assertion to allow the same type of XMM move that occurs for the f32 and f64 types. This fixes #3173 in the old `lower.rs` code temporarily until the relatively complex `select` lowering can be ported to ISLE.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
