### PR TITLE
Revert "Temporarily disable SIMD fuzzing on CI"

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -213,6 +213,12 @@ impl wasm_smith::Config for WasmtimeDefaultConfig {
         4
     }
 
+    // Turn some wasm features default-on for those that have a finished
+    // implementation in Wasmtime.
+    fn simd_enabled(&self) -> bool {
+        true
+    }
+
     fn reference_types_enabled(&self) -> bool {
         true
     }

--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -40,6 +40,7 @@ pub fn fuzz_default_config(strategy: wasmtime::Strategy) -> anyhow::Result<wasmt
         .wasm_reference_types(true)
         .wasm_module_linking(true)
         .wasm_multi_memory(true)
+        .wasm_simd(true)
         .wasm_memory64(true)
         .strategy(strategy)?;
     Ok(config)

--- a/fuzz/fuzz_targets/differential_v8.rs
+++ b/fuzz/fuzz_targets/differential_v8.rs
@@ -5,7 +5,7 @@ use wasmtime_fuzzing::{generators, oracles};
 
 fuzz_target!(|data: (
     generators::Config,
-    wasm_smith::ConfiguredModule<oracles::SingleFunctionModuleConfig<false, true>>
+    wasm_smith::ConfiguredModule<oracles::SingleFunctionModuleConfig<true, true>>
 )| {
     let (config, mut wasm) = data;
     wasm.module.ensure_termination(1000);


### PR DESCRIPTION
This reverts commit 95e8723d0767556f0ddbc9151bce269464852bb1.

With all known simd fuzz bugs fixed let's turn it back on for oss-fuzz!