### PR TITLE
Enable nan canonicalization in differential fuzzing

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -265,6 +265,12 @@ pub fn differential_execution(
         // to accept modules that would otherwise be broken by module linking.
         config.wasm_module_linking(false);
 
+        // We don't want different configurations with different values for nan
+        // canonicalization since that can affect results. All configs should
+        // have the same value configured for this option, so `true` is
+        // arbitrarily chosen here.
+        config.cranelift_nan_canonicalization(true);
+
         let engine = Engine::new(&config).unwrap();
         let mut store = create_store(&engine);
         if fuzz_config.consume_fuel {


### PR DESCRIPTION
This fixes a fuzz issue discovered over the weekend where stores with
different values for nan canonicalization may produce different results.
This is expected, however, so the fix for differential execution is to
always enable nan canonicalization.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
