### PR TITLE
Make the trap name for `unreachable` traps more descriptive.

### DIFF
--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -119,7 +119,7 @@ impl fmt::Display for TrapCode {
             IntegerOverflow => "integer overflow",
             IntegerDivisionByZero => "integer divide by zero",
             BadConversionToInteger => "invalid conversion to integer",
-            UnreachableCodeReached => "unreachable",
+            UnreachableCodeReached => "wasm `unreachable` instruction executed",
             Interrupt => "interrupt",
         };
         write!(f, "{}", desc)

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -160,7 +160,7 @@ fn trap_display_pretty() -> Result<()> {
     assert_eq!(
         e.to_string(),
         "\
-wasm trap: unreachable
+wasm trap: wasm `unreachable` instruction executed
 wasm backtrace:
     0:   0x23 - m!die
     1:   0x27 - m!<wasm function 1>
@@ -206,7 +206,7 @@ fn trap_display_multi_module() -> Result<()> {
     assert_eq!(
         e.to_string(),
         "\
-wasm trap: unreachable
+wasm trap: wasm `unreachable` instruction executed
 wasm backtrace:
     0:   0x23 - a!die
     1:   0x27 - a!<wasm function 1>
@@ -400,7 +400,7 @@ fn start_trap_pretty() -> Result<()> {
     assert_eq!(
         e.to_string(),
         "\
-wasm trap: unreachable
+wasm trap: wasm `unreachable` instruction executed
 wasm backtrace:
     0:   0x1d - m!die
     1:   0x21 - m!<wasm function 1>
@@ -565,7 +565,7 @@ fn no_hint_even_with_dwarf_info() -> Result<()> {
     assert_eq!(
         trap.to_string(),
         "\
-wasm trap: unreachable
+wasm trap: wasm `unreachable` instruction executed
 wasm backtrace:
     0:   0x1a - <unknown>!start
 "
@@ -600,7 +600,7 @@ fn hint_with_dwarf_info() -> Result<()> {
     assert_eq!(
         trap.to_string(),
         "\
-wasm trap: unreachable
+wasm trap: wasm `unreachable` instruction executed
 wasm backtrace:
     0:   0x1a - <unknown>!start
 note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information


### PR DESCRIPTION
Following up on WebAssembly/wasi-sdk#210, this makes the trap message
for `unreachable` traps more descriptive of what actually caused the
trap, so that it doesn't sound like maybe Wasmtime itself executed a
`unreachable!()` macro in Rust.

Before:
```
wasm trap: unreachable
wasm backtrace:
     [...]
```

After:
```
wasm trap: wasm `unreachable` instruction executed
wasm backtrace:
     [...]
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
