### PR TITLE
Tidy up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,6 @@ version = "0.1.0"
 dependencies = [
  "env_logger 0.8.3",
  "isle",
- "log",
  "miette",
  "structopt",
 ]
@@ -3163,7 +3162,6 @@ dependencies = [
  "bitflags",
  "cap-rand",
  "cap-std",
- "io-lifetimes",
  "rustix",
  "thiserror",
  "tracing",
@@ -3452,11 +3450,9 @@ dependencies = [
  "humantime 2.1.0",
  "lazy_static",
  "libc",
- "log",
  "memchr",
  "more-asserts",
  "num_cpus",
- "object",
  "pretty_env_logger",
  "rayon",
  "rustix",
@@ -3651,7 +3647,6 @@ name = "wasmtime-wasi-nn"
 version = "0.31.0"
 dependencies = [
  "anyhow",
- "log",
  "openvino",
  "thiserror",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,11 @@ wasmtime-wasi = { path = "crates/wasi", version = "0.31.0" }
 wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "0.31.0", optional = true }
 wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.31.0", optional = true }
 structopt = { version = "0.3.5", features = ["color", "suggestions"] }
-object = { version = "0.27.0", default-features = false, features = ["write"] }
 anyhow = "1.0.19"
 target-lexicon = { version = "0.12.0", default-features = false }
 pretty_env_logger = "0.4.0"
 file-per-thread-logger = "0.1.1"
-wat = "1.0.40"
 libc = "0.2.60"
-log = "0.4.8"
 rayon = "1.5.0"
 humantime = "2.0.0"
 wasmparser = "0.81.0"
@@ -62,6 +59,7 @@ num_cpus = "1.13.0"
 winapi = { version = "0.3.9", features = ['memoryapi'] }
 memchr = "2.4"
 async-trait = "0.1"
+wat = "1.0.40"
 
 [build-dependencies]
 anyhow = "1.0.19"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -36,7 +36,7 @@ criterion = "0.3"
 [build-dependencies]
 cranelift-codegen-meta = { path = "meta", version = "0.78.0" }
 isle = { path = "../isle/isle", version = "0.78.0", optional = true }
-miette = { version = "3", features = ["fancy"] }
+miette = { version = "3", features = ["fancy"], optional = true }
 sha2 = "0.9.8"
 
 [features]
@@ -91,7 +91,7 @@ regalloc-snapshot = ["bincode", "regalloc/enable-serde"]
 souper-harvest = ["souper-ir", "souper-ir/stringify"]
 
 # Recompile ISLE DSL source files into their generated Rust code.
-rebuild-isle = ["isle", "cranelift-codegen-meta/rebuild-isle"]
+rebuild-isle = ["isle", "miette", "cranelift-codegen-meta/rebuild-isle"]
 
 # A hack to skip the ISLE-rebuild logic when testing for determinism
 # with the "Meta deterministic check" CI job.

--- a/cranelift/isle/islec/Cargo.toml
+++ b/cranelift/isle/islec/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0 WITH LLVM-exception"
 publish = false
 
 [dependencies]
-log = "0.4"
 isle = { version = "*", path = "../isle/" }
 env_logger = { version = "0.8", default-features = false }
 miette = { version = "3.0.0", features = ["fancy"] }

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -25,7 +25,6 @@ tracing = "0.1.19"
 cap-std = "0.21.1"
 cap-rand = "0.21.1"
 bitflags = "1.2"
-io-lifetimes = { version = "0.3.1", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 rustix = "0.26.2"

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 [dependencies]
 # These dependencies are necessary for the witx-generation macros to work:
 anyhow = "1.0"
-log = { version = "0.4", default-features = false }
 wiggle = { path = "../wiggle", version = "=0.31.0" }
 
 # These dependencies are necessary for the wasi-nn implementation:


### PR DESCRIPTION
- First commit makes `miette` optional in cranelift-codegen, as it's only used when rebuilding ISLE.
- Second commit removes apparently unused dependencies.