### PR TITLE
Fix issues with the C API vector implementation

### DIFF
--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -120,8 +120,8 @@ macro_rules! declare_vecs {
             size: usize,
             ptr: *const $elem_ty,
         ) {
-            let slice = slice::from_raw_parts(ptr, size);
-            out.set_buffer(slice.to_vec());
+            let vec = (0..size).map(|i| ptr.add(i).read()).collect();
+            out.set_buffer(vec);
         }
 
         #[no_mangle]

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -29,7 +29,6 @@ macro_rules! declare_vecs {
         ))*
     ) => {$(
         #[repr(C)]
-        #[derive(Clone)]
         pub struct $name {
             size: usize,
             data: *mut $elem_ty,
@@ -77,6 +76,12 @@ macro_rules! declare_vecs {
                 self.data = ptr::null_mut();
                 self.size = 0;
                 return vec;
+            }
+        }
+
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                self.as_slice().to_vec().into()
             }
         }
 


### PR DESCRIPTION
While working on https://github.com/wasmerio/wasmer/pull/2683 I noticed a few bugs in wasmtime's implementation of the Wasm C API, specifically the vector types.

The first issue is the incorrect implementation of `Clone` using `#[derive]`. This only performs a shallow copy of the vector, which means that you can end up with a double-free once both clones are freed.

The second issue is that the `wasm_*_vec_new` functions are supposed to take ownership of objects in the given slice, not clone them. This is apparent if you look at the [declaration](https://github.com/WebAssembly/wasm-c-api/blob/c9d31284651b975f05ac27cee0bab1377560b87e/include/wasm.h#L85) and how it is [used](https://github.com/WebAssembly/wasm-c-api/blob/c9d31284651b975f05ac27cee0bab1377560b87e/include/wasm.h#L567) in the C API header.