### PR TITLE
cranelift codegen & filetests: silence new dead code warnings in rust 1.57

### DIFF
--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -86,6 +86,7 @@ pub struct BlockLoweringOrder {
     lowered_order: Vec<LoweredBlock>,
     /// Successors for all lowered blocks, in one serialized vector. Indexed by
     /// the ranges in `lowered_succ_ranges`.
+    #[allow(dead_code)]
     lowered_succs: Vec<(Inst, LoweredBlock)>,
     /// BlockIndex values for successors for all lowered blocks, in the same
     /// order as `lowered_succs`.
@@ -96,6 +97,7 @@ pub struct BlockLoweringOrder {
     /// Mapping from CLIF BB to BlockIndex (index in lowered order). Note that
     /// some CLIF BBs may not be lowered; in particular, we skip unreachable
     /// blocks.
+    #[allow(dead_code)]
     orig_map: SecondaryMap<Block, Option<BlockIndex>>,
 }
 

--- a/cranelift/filetests/src/runtest_environment.rs
+++ b/cranelift/filetests/src/runtest_environment.rs
@@ -58,6 +58,7 @@ type HeapMemory = Vec<u8>;
 pub struct RuntestContext {
     /// Store the heap memory alongside the context info so that we don't accidentally deallocate
     /// it too early.
+    #[allow(dead_code)]
     heaps: Vec<HeapMemory>,
 
     /// This is the actual struct that gets passed into the `vmctx`  argument of the tests.

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -111,6 +111,7 @@ mod windowsx64 {
         version: u8,
         flags: u8,
         prologue_size: u8,
+        #[allow(dead_code)]
         unwind_code_count_raw: u8,
         frame_register: u8,
         frame_register_offset: u8,


### PR DESCRIPTION
I don't have the expertise in this part of the codebase to know whether we should actually delete these fields.

In `RuntestContext`, it looks like the dead code struct member `heaps` is load-bearing because of unsafe pointer shenanigans.

Either way, this should unblock CI jobs that are now failing due to the upgrade to the latest stable rust.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
