### PR TITLE
Add support for `Arm64Call` relocations in `cranelift-jit`

### DIFF
--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -98,7 +98,9 @@ impl CompiledBlob {
                     let chop = 32 - 26;
                     let imm26 = (diff as u32) << chop >> chop;
                     let ins = unsafe { iptr.read_unaligned() } | imm26;
-                    unsafe { iptr.write_unaligned(ins); }
+                    unsafe {
+                        iptr.write_unaligned(ins);
+                    }
                 }
                 _ => unimplemented!(),
             }

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -81,6 +81,17 @@ impl CompiledBlob {
                         write_unaligned(at as *mut i32, pcrel)
                     };
                 }
+                Reloc::Arm64Call => {
+                    let base = get_address(name);
+                    // The instruction is 32 bits long.
+                    let iptr = at as *mut u32;
+                    let diff = (base as isize) - (at as isize);
+                    // The lower 26 bits of the `bl` instruction form the
+                    // immediate offset argument.
+                    let chop = 32 - 26;
+                    let imm26 = ((diff >> 2) as u32) << chop >> chop;
+                    unsafe { *iptr |= imm26; }
+                }
                 _ => unimplemented!(),
             }
         }

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -97,7 +97,8 @@ impl CompiledBlob {
                     // immediate offset argument.
                     let chop = 32 - 26;
                     let imm26 = (diff as u32) << chop >> chop;
-                    unsafe { *iptr |= imm26; }
+                    let ins = unsafe { iptr.read_unaligned() } | imm26;
+                    unsafe { iptr.write_unaligned(ins); }
                 }
                 _ => unimplemented!(),
             }


### PR DESCRIPTION
I'm trying to use `cranelift-jit` to do some basic JIT compilation on aarch64, but it doesn't support `Arm64Call` relocations.
This PR fixes that.

Relevant ARM docs [here](https://developer.arm.com/documentation/ddi0596/2021-09/Base-Instructions/BL--Branch-with-Link-).