### PR TITLE
Enable the SIMD proposal by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -138,6 +138,7 @@ impl Config {
         ret.wasm_reference_types(true);
         ret.wasm_multi_value(true);
         ret.wasm_bulk_memory(true);
+        ret.wasm_simd(true);
         ret.wasm_backtrace_details(WasmBacktraceDetails::Environment);
         ret
     }
@@ -433,23 +434,15 @@ impl Config {
     /// Configures whether the WebAssembly SIMD proposal will be
     /// enabled for compilation.
     ///
-    /// The [WebAssembly SIMD proposal][proposal] is not currently
-    /// fully standardized and is undergoing development. Additionally the
-    /// support in wasmtime itself is still being worked on. Support for this
-    /// feature can be enabled through this method for appropriate wasm
-    /// modules.
+    /// The [WebAssembly SIMD proposal][proposal]. This feature gates items such
+    /// as the `v128` type and all of its operators being in a module. Note that
+    /// this does not enable the [relaxed simd proposal] as that is not
+    /// implemented in Wasmtime at this time.
     ///
-    /// This feature gates items such as the `v128` type and all of its
-    /// operators being in a module.
-    ///
-    /// This is `false` by default.
-    ///
-    /// > **Note**: Wasmtime does not implement everything for the wasm simd
-    /// > spec at this time, so bugs, panics, and possibly segfaults should be
-    /// > expected. This should not be enabled in a production setting right
-    /// > now.
+    /// This is `true` by default.
     ///
     /// [proposal]: https://github.com/webassembly/simd
+    /// [relaxed simd proposal]: https://github.com/WebAssembly/relaxed-simd
     pub fn wasm_simd(&mut self, enable: bool) -> &mut Self {
         self.features.simd = enable;
         #[cfg(compiler)]


### PR DESCRIPTION
This commit updates Wasmtime to enable the SIMD proposal for WebAssembly
by default. Support has been implemented for quite some time and
recently fuzzing has been running for multiple weeks without incident,
so it seems like it might be time to go ahead and enable this!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
