### PR TITLE
Add CLI options for more configuration options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,19 @@ struct CommonOptions {
     /// Enable Cranelift's internal NaN canonicalization
     #[structopt(long)]
     enable_cranelift_nan_canonicalization: bool,
+
+    /// Executing wasm code will consume fuel, limiting its execution.
+    #[structopt(long)]
+    consume_fuel: bool,
+
+    /// Disables the on-by-default address map from native code to wasm code.
+    #[structopt(long)]
+    disable_address_map: bool,
+
+    /// Switches memory initialization to happen in a paged fashion instead of
+    /// the data segments specified in the original wasm module.
+    #[structopt(long)]
+    paged_memory_initialization: bool,
 }
 
 impl CommonOptions {
@@ -300,6 +313,10 @@ impl CommonOptions {
         if let Some(size) = self.dynamic_memory_guard_size {
             config.dynamic_memory_guard_size(size);
         }
+
+        config.consume_fuel(self.consume_fuel);
+        config.generate_address_map(!self.disable_address_map);
+        config.paged_memory_initialization(self.paged_memory_initialization);
 
         Ok(config)
     }


### PR DESCRIPTION
This commit adds a few more CLI flags for random fiddly bits in the
`Config` structure to make it a bit easier to play around on the command
line and see the effect of various flags on compiled code.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
