### PR TITLE
docs: update VTune documentation

### DIFF
--- a/crates/jit/src/profiling/vtune_linux.rs
+++ b/crates/jit/src/profiling/vtune_linux.rs
@@ -1,11 +1,20 @@
-//! Adds support for profiling jitted code using VTune Amplifier
+//! Adds support for profiling JIT-ed code using VTune.
 //!
-//! Build:
-//!     cargo build --features=vtune
-//! Profile:
-//!     amplxe-cl -run-pass-thru=--no-altstack -v -collect hotspots target/debug/wasmtime --vtune test.wasm
+//! ### Build
 //!
-//! Note: amplxe-cl is a command-line tool for Vtune which should be installed.
+//! ```ignore
+//! cargo build --features=vtune
+//! ```
+//!
+//! ### Profile
+//!
+//! ```ignore
+//! amplxe-cl -run-pass-thru=--no-altstack -v -collect hotspots target/debug/wasmtime --vtune test.wasm
+//! ```
+//!
+//! Note: `amplxe-cl` is a command-line tool for VTune which must [be
+//! installed](https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html#standalone)
+//! for this to work.
 
 use crate::{CompiledModule, ProfilingAgent};
 use anyhow::Result;


### PR DESCRIPTION
While using VTune, it seemed a good idea to check that the VTune
documentation for Wasmtime was still correct. It is and VTune support
still works (improvements: click-through to x86 assembly is not
available). These changes simply re-organize the documentation and add a
section for running VTune from a GUI.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
