### PR TITLE
Update to cap-std 0.22.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,22 +269,21 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8499797f7e264c83334d9fc98b2c9889ebe5839514a14d81769ca09d71fd1d"
+checksum = "28c920cce6be66349c19b15f149741ac63a99c62c001eac873011cdea38801e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "rustc_version",
  "winapi",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5998b8b3a49736500aec3c123fa3f6f605a125b41a6df725e6b7c924a612ab4"
+checksum = "a2737eb174c9482c865789a428bfbddfdf284317d466ebbc637eee2e1242bfaa"
 dependencies = [
  "ambient-authority",
  "errno",
@@ -293,7 +292,6 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustc_version",
  "rustix",
  "winapi",
  "winapi-util",
@@ -302,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafda903eb4a85903b106439cf62524275f3ae0609bb9e1ae9da7e7c26d4150c"
+checksum = "d14abeb7657b6740639c7e33534633412643ddc96aa24143e9fe531ab56a23bb"
 dependencies = [
  "ambient-authority",
  "rand 0.8.3",
@@ -312,23 +310,22 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811de89a7ede4ba32f2b75fe5c668a534da24942d81c081248a9d2843ebd517d"
+checksum = "7a9ba199282865f3e3c3e7afc6907a3a27896435e24209e035c8a24d4fbcf43a"
 dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
  "ipnet",
- "rustc_version",
  "rustix",
 ]
 
 [[package]]
 name = "cap-tempfile"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4fa925a69a454293146bc04dfcbeba993093b1816531f9408e229130d7fc465"
+checksum = "2c472ee35e2073a74a3d882c21745e7db2d573825e2e0a754dbffaeef97f4458"
 dependencies = [
  "cap-std",
  "rand 0.8.3",
@@ -337,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f263d62447efe8829efdf947bbb4824ba2a3e2852b3be1d62f76fc05c326b0"
+checksum = "ecbb6ba1f840b5b22fedaa6956ddf2e1e77604e986e23f7238c8ba509ce0bb9f"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -882,7 +879,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -1189,9 +1186,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa838950e8e36a567ce96a945c303e88d9916ff97df27c315a0d263a72bd816f"
+checksum = "34ebf75299c070b6b4da3c9da0be01fee7388fb919fd4e6bad5b4f94923d08f1"
 dependencies = [
  "io-lifetimes",
  "rustix",
@@ -1398,22 +1395,20 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1d9a66d8b0312e3601a04a2dcf8f0ddd873319560ddeabe2110fa1e5af781a"
+checksum = "9c9132d2d6504f4e348b8e16787f01613b4d0e587458641a40e727304416ac8d"
 dependencies = [
  "io-lifetimes",
- "rustc_version",
  "winapi",
 ]
 
 [[package]]
 name = "io-lifetimes"
-version = "0.3.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278e90d6f8a6c76a8334b336e306efa3c5f2b604048cbfd486d6f49878e3af14"
+checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
 dependencies = [
- "rustc_version",
  "winapi",
 ]
 
@@ -1463,6 +1458,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "ittapi-rs"
@@ -2456,18 +2457,17 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.26.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c44018277ec7195538f5631b90def7ad975bb46370cb0f4eff4012de9333f8"
+checksum = "c9f93a06380ac0b4210538cbb392381faca6f7eba0bedd6c61f2a52514896560"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
- "itoa",
+ "itoa 1.0.1",
  "libc",
  "linux-raw-sys",
  "once_cell",
- "rustc_version",
  "winapi",
 ]
 
@@ -2546,7 +2546,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b5163055c386394170493ec1827cf7975035dc0bb23dcb7070bd1b1f672baa"
+checksum = "bfc4f831d868c8fe30ef417d6d6cba0cd8c95688a179c2bb0ce339aee44ffdab"
 dependencies = [
  "atty",
  "bitflags",
@@ -3787,9 +3787,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecd175b4077107a91bb6bbb34aa9a691d8b45314791776f78b63a1cb8a08928"
+checksum = "c54de2ce52a3e5839e129c7859e2b1f581769bbef57c0a2a09a12a5a3a5b3c2a"
 dependencies = [
  "bitflags",
  "io-lifetimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ wasmparser = "0.81.0"
 lazy_static = "1.4.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.26.2"
+rustix = "0.31.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.21.1"
+cap-std = "0.22.0"
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -272,20 +272,20 @@ pub extern "C" fn wasm_bench_create(
 
                 let stdout = std::fs::File::create(&stdout_path)
                     .with_context(|| format!("failed to create {}", stdout_path.display()))?;
-                let stdout = cap_std::fs::File::from_std(stdout, cap_std::ambient_authority());
+                let stdout = cap_std::fs::File::from_std(stdout);
                 let stdout = wasi_cap_std_sync::file::File::from_cap_std(stdout);
                 cx = cx.stdout(Box::new(stdout));
 
                 let stderr = std::fs::File::create(&stderr_path)
                     .with_context(|| format!("failed to create {}", stderr_path.display()))?;
-                let stderr = cap_std::fs::File::from_std(stderr, cap_std::ambient_authority());
+                let stderr = cap_std::fs::File::from_std(stderr);
                 let stderr = wasi_cap_std_sync::file::File::from_cap_std(stderr);
                 cx = cx.stderr(Box::new(stderr));
 
                 if let Some(stdin_path) = &stdin_path {
                     let stdin = std::fs::File::open(stdin_path)
                         .with_context(|| format!("failed to open {}", stdin_path.display()))?;
-                    let stdin = cap_std::fs::File::from_std(stdin, cap_std::ambient_authority());
+                    let stdin = cap_std::fs::File::from_std(stdin);
                     let stdin = wasi_cap_std_sync::file::File::from_cap_std(stdin);
                     cx = cx.stdin(Box::new(stdin));
                 }

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -29,7 +29,7 @@ wat = { version = "1.0.36", optional = true }
 # Optional dependencies for the `wasi` feature
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.21.1", optional = true }
+cap-std = { version = "0.22.0", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache']

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -24,7 +24,7 @@ zstd = { version = "0.9", default-features = false }
 winapi = "0.3.7"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rustix = "0.26.2"
+rustix = "0.31.0"
 
 [dev-dependencies]
 filetime = "0.2.7"

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 links = "wasmtime-fiber-shims"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.26.2"
+rustix = "0.31.0"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -29,7 +29,7 @@ bincode = "1.2.1"
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "0.26.2", optional = true }
+rustix = { version = "0.31.0", optional = true }
 
 [features]
 jitdump = ['rustix']

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.38"
 mach = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.26.2"
+rustix = "0.31.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi", "handleapi"] }

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
-cap-std = "0.21.1"
+cap-std = "0.22.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,12 +22,12 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "=0.32.0" }
 tracing = "0.1.19"
-cap-std = "0.21.1"
-cap-rand = "0.21.1"
+cap-std = "0.22.0"
+cap-rand = "0.22.0"
 bitflags = "1.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.26.2"
+rustix = "0.31.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,17 +15,17 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "=0.32.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.21.1"
-cap-fs-ext = "0.21.1"
-cap-time-ext = "0.21.1"
-cap-rand = "0.21.1"
-fs-set-times = "0.13.1"
-system-interface = { version = "0.16.0", features = ["cap_std_impls"] }
+cap-std = "0.22.0"
+cap-fs-ext = "0.22.0"
+cap-time-ext = "0.22.0"
+cap-rand = "0.22.0"
+fs-set-times = "0.14.1"
+system-interface = { version = "0.17.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
-io-lifetimes = { version = "0.3.3", default-features = false }
+io-lifetimes = { version = "0.4.4", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.26.2"
+rustix = "0.31.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -122,7 +122,7 @@ impl TryFrom<std::io::Error> for types::Errno {
                 Some(Error::IO) => Some(types::Errno::Io),
                 Some(Error::BADF) => Some(types::Errno::Badf),
                 Some(Error::BUSY) => Some(types::Errno::Busy),
-                Some(Error::ACCES) => Some(types::Errno::Acces),
+                Some(Error::ACCESS) => Some(types::Errno::Acces),
                 Some(Error::FAULT) => Some(types::Errno::Fault),
                 Some(Error::NOTDIR) => Some(types::Errno::Notdir),
                 Some(Error::ISDIR) => Some(types::Errno::Isdir),

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,12 +15,12 @@ wasi-common = { path = "../", version = "=0.32.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "=0.32.0" }
 wiggle = { path = "../../wiggle", version = "=0.32.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.21.1"
+cap-std = "0.22.0"
 anyhow = "1"
-io-lifetimes = { version = "0.3.0", default-features = false }
+io-lifetimes = { version = "0.4.4", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.26.2"
+rustix = "0.31.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
@@ -30,4 +30,4 @@ lazy_static = "1.4"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.21.1"
+cap-tempfile = "0.22.0"


### PR DESCRIPTION
The main change relevant to Wasmtime here is that this includes the
rustix fix for compilation errors on Rust nightly with the `asm!` macro.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
