### PR TITLE
x64: upgrade ittapi-rs crate (for VTune support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -1466,11 +1466,11 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "ittapi-rs"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa16daf7106319e5c4456733e33aeb64d8c986af0127bc25eb6d9e84e2f1f8b0"
+checksum = "265ed25cd5b53e9b02bf97a1f66ab7af1af7ab61f5d9ce1e05aeaed098723658"
 dependencies = [
- "cmake",
+ "cc",
 ]
 
 [[package]]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -22,7 +22,7 @@ gimli = { version = "0.26.0", default-features = false, features = ["std", "read
 object = { version = "0.27.0", default-features = false, features = ["std", "read_core", "elf"] }
 serde = { version = "1.0.94", features = ["derive"] }
 addr2line = { version = "0.17.0", default-features = false }
-ittapi-rs = { version = "0.1.5", optional = true  }
+ittapi-rs = { version = "0.1.6", optional = true  }
 bincode = "1.2.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
This update is no real change in functionality but brings in several of the latest changes to the `ittapi-rs` library: minor fixes to the C library, a new license expression for the Cargo crate, better documentation, updated Rust bindings, and the removal of `cmake` as a dependency (uses `cc` directly instead).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
