### PR TITLE
Really fix PRs from bump-version for patch releases

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -92,7 +92,7 @@ jobs:
             --data @- << EOF
           {
             "head": "ci/bump-version",
-            "base": "${{ github.base_ref }}",
+            "base": "${{ github.ref_name }}",
             "title": "Release Wasmtime ${{ steps.bump.outputs.version }}",
             "body": $body,
             "maintainer_can_modify": true


### PR DESCRIPTION
Actually poking around the `github` context it looks like for
workflow-dispatch-triggered-events `base_ref` is blank but `ref_name`
has the branch name we're interested in.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
