### PR TITLE
Fix "Doc build" CI job.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
 
     # Build C API documentation
     - run: sudo apt-get update -y && sudo apt-get install -y libclang1-9 libclang-cpp9
-    - run: curl -L https://doxygen.nl/files/doxygen-1.9.1.linux.bin.tar.gz | tar xzf -
-    - run: echo "`pwd`/doxygen-1.9.1/bin" >> $GITHUB_PATH
+    - run: curl -L https://www.doxygen.nl/files/doxygen-1.9.3.linux.bin.tar.gz | tar xzf -
+    - run: echo "`pwd`/doxygen-1.9.3/bin" >> $GITHUB_PATH
     - run: cd crates/c-api && doxygen doxygen.conf
 
     # install mdbook, build the docs, and test the docs


### PR DESCRIPTION
The URL that this CI job curls to install Doxygen is now returning a
redirect from `https://doxygen.nl/...` to `https://www.doxygen.nl/...`
and curl doesn't seem to follow it. This should fix the download.

First saw failing job in #3635, e.g. [here](https://github.com/bytecodealliance/wasmtime/runs/4686950669?check_suite_focus=true).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
