### PR TITLE
Fix spillslot size bug in SIMD by removing type-dependent spillslot allocation.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1145,12 +1145,11 @@ impl ABIMachineSpec for AArch64MachineDeps {
         insts
     }
 
-    fn get_number_of_spillslots_for_value(rc: RegClass, ty: Type) -> u32 {
+    fn get_number_of_spillslots_for_value(rc: RegClass) -> u32 {
         // We allocate in terms of 8-byte slots.
-        match (rc, ty) {
-            (RegClass::I64, _) => 1,
-            (RegClass::V128, F32) | (RegClass::V128, F64) => 1,
-            (RegClass::V128, _) => 2,
+        match rc {
+            RegClass::I64 => 1,
+            RegClass::V128 => 2,
             _ => panic!("Unexpected register class!"),
         }
     }

--- a/cranelift/codegen/src/isa/arm32/abi.rs
+++ b/cranelift/codegen/src/isa/arm32/abi.rs
@@ -436,7 +436,7 @@ impl ABIMachineSpec for Arm32MachineDeps {
         unimplemented!("StructArgs not implemented for ARM32 yet");
     }
 
-    fn get_number_of_spillslots_for_value(rc: RegClass, _ty: Type) -> u32 {
+    fn get_number_of_spillslots_for_value(rc: RegClass) -> u32 {
         match rc {
             RegClass::I32 => 1,
             _ => panic!("Unexpected register class!"),

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -685,11 +685,11 @@ impl ABIMachineSpec for S390xMachineDeps {
         unimplemented!("StructArgs not implemented for S390X yet");
     }
 
-    fn get_number_of_spillslots_for_value(rc: RegClass, ty: Type) -> u32 {
+    fn get_number_of_spillslots_for_value(rc: RegClass) -> u32 {
         // We allocate in terms of 8-byte slots.
-        match (rc, ty) {
-            (RegClass::I64, _) => 1,
-            (RegClass::F64, _) => 1,
+        match rc {
+            RegClass::I64 => 1,
+            RegClass::F64 => 1,
             _ => panic!("Unexpected register class!"),
         }
     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -719,12 +719,11 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         insts
     }
 
-    fn get_number_of_spillslots_for_value(rc: RegClass, ty: Type) -> u32 {
+    fn get_number_of_spillslots_for_value(rc: RegClass) -> u32 {
         // We allocate in terms of 8-byte slots.
-        match (rc, ty) {
-            (RegClass::I64, _) => 1,
-            (RegClass::V128, types::F32) | (RegClass::V128, types::F64) => 1,
-            (RegClass::V128, _) => 2,
+        match rc {
+            RegClass::I64 => 1,
+            RegClass::V128 => 2,
             _ => panic!("Unexpected register class!"),
         }
     }

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -161,22 +161,13 @@ pub trait ABICallee {
     fn stack_args_size(&self) -> u32;
 
     /// Get the spill-slot size.
-    fn get_spillslot_size(&self, rc: RegClass, ty: Type) -> u32;
+    fn get_spillslot_size(&self, rc: RegClass) -> u32;
 
-    /// Generate a spill. The type, if known, is given; this can be used to
-    /// generate a store instruction optimized for the particular type rather
-    /// than the RegClass (e.g., only F64 that resides in a V128 register). If
-    /// no type is given, the implementation should spill the whole register.
-    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, ty: Option<Type>) -> Self::I;
+    /// Generate a spill.
+    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg) -> Self::I;
 
-    /// Generate a reload (fill). As for spills, the type may be given to allow
-    /// a more optimized load instruction to be generated.
-    fn gen_reload(
-        &self,
-        to_reg: Writable<RealReg>,
-        from_slot: SpillSlot,
-        ty: Option<Type>,
-    ) -> Self::I;
+    /// Generate a reload (fill).
+    fn gen_reload(&self, to_reg: Writable<RealReg>, from_slot: SpillSlot) -> Self::I;
 }
 
 /// Trait implemented by an object that tracks ABI-related state and can

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -688,24 +688,21 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
         self.vreg_types.len()
     }
 
-    fn get_spillslot_size(&self, regclass: RegClass, vreg: VirtualReg) -> u32 {
-        let ty = self.vreg_type(vreg);
-        self.abi.get_spillslot_size(regclass, ty)
+    fn get_spillslot_size(&self, regclass: RegClass, _: VirtualReg) -> u32 {
+        self.abi.get_spillslot_size(regclass)
     }
 
-    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, vreg: Option<VirtualReg>) -> I {
-        let ty = vreg.map(|v| self.vreg_type(v));
-        self.abi.gen_spill(to_slot, from_reg, ty)
+    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, _: Option<VirtualReg>) -> I {
+        self.abi.gen_spill(to_slot, from_reg)
     }
 
     fn gen_reload(
         &self,
         to_reg: Writable<RealReg>,
         from_slot: SpillSlot,
-        vreg: Option<VirtualReg>,
+        _: Option<VirtualReg>,
     ) -> I {
-        let ty = vreg.map(|v| self.vreg_type(v));
-        self.abi.gen_reload(to_reg, from_slot, ty)
+        self.abi.gen_reload(to_reg, from_slot)
     }
 
     fn gen_move(&self, to_reg: Writable<RealReg>, from_reg: RealReg, vreg: VirtualReg) -> I {

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -133,28 +133,28 @@ block0:
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
-; nextln:  sub sp, sp, #32
+; nextln:  sub sp, sp, #48
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  str s0, [sp]
+; nextln:  str q0, [sp]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  str d0, [sp, #8]
+; nextln:  str q0, [sp, #16]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  str d0, [sp, #16]
+; nextln:  str q0, [sp, #32]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  ldr s0, [sp]
+; nextln:  ldr q0, [sp]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  ldr d0, [sp, #8]
+; nextln:  ldr q0, [sp, #16]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  ldr d0, [sp, #16]
+; nextln:  ldr q0, [sp, #32]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  add sp, sp, #32
+; nextln:  add sp, sp, #48
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
 
@@ -223,28 +223,28 @@ block0:
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
-; nextln:  sub sp, sp, #32
+; nextln:  sub sp, sp, #48
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  str s0, [sp]
-; nextln:  ldr x0, 8 ; b 12 ; data
-; nextln:  blr x0
-; nextln:  str d0, [sp, #8]
+; nextln:  str q0, [sp]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
 ; nextln:  str q0, [sp, #16]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  ldr s0, [sp]
+; nextln:  str q0, [sp, #32]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  ldr d0, [sp, #8]
+; nextln:  ldr q0, [sp]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
 ; nextln:  ldr q0, [sp, #16]
 ; nextln:  ldr x0, 8 ; b 12 ; data
 ; nextln:  blr x0
-; nextln:  add sp, sp, #32
+; nextln:  ldr q0, [sp, #32]
+; nextln:  ldr x0, 8 ; b 12 ; data
+; nextln:  blr x0
+; nextln:  add sp, sp, #48
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret
 

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -238,34 +238,34 @@ block0(v0: i64):
 ; nextln: unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ; nextln: movq    %rsp, %rbp
 ; nextln: unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 160 }
-; nextln: subq    $$192, %rsp
-; nextln: movdqu  %xmm6, 32(%rsp)
+; nextln: subq    $$224, %rsp
+; nextln: movdqu  %xmm6, 64(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 0, reg: r6V }
-; nextln: movdqu  %xmm7, 48(%rsp)
+; nextln: movdqu  %xmm7, 80(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 16, reg: r7V }
-; nextln: movdqu  %xmm8, 64(%rsp)
+; nextln: movdqu  %xmm8, 96(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 32, reg: r8V }
-; nextln: movdqu  %xmm9, 80(%rsp)
+; nextln: movdqu  %xmm9, 112(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 48, reg: r9V }
-; nextln: movdqu  %xmm10, 96(%rsp)
+; nextln: movdqu  %xmm10, 128(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 64, reg: r10V }
-; nextln: movdqu  %xmm11, 112(%rsp)
+; nextln: movdqu  %xmm11, 144(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 80, reg: r11V }
-; nextln: movdqu  %xmm12, 128(%rsp)
+; nextln: movdqu  %xmm12, 160(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 96, reg: r12V }
-; nextln: movdqu  %xmm13, 144(%rsp)
+; nextln: movdqu  %xmm13, 176(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 112, reg: r13V }
-; nextln: movdqu  %xmm14, 160(%rsp)
+; nextln: movdqu  %xmm14, 192(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 128, reg: r14V }
-; nextln: movdqu  %xmm15, 176(%rsp)
+; nextln: movdqu  %xmm15, 208(%rsp)
 ; nextln: unwind SaveReg { clobber_offset: 144, reg: r15V }
 ; nextln: movsd   0(%rcx), %xmm4
 ; nextln: movsd   8(%rcx), %xmm1
 ; nextln: movsd   16(%rcx), %xmm0
-; nextln: movsd   %xmm0, rsp(16 + virtual offset)
+; nextln: movdqu  %xmm0, rsp(32 + virtual offset)
 ; nextln: movsd   24(%rcx), %xmm3
 ; nextln: movsd   32(%rcx), %xmm0
-; nextln: movsd   %xmm0, rsp(24 + virtual offset)
+; nextln: movdqu  %xmm0, rsp(48 + virtual offset)
 ; nextln: movsd   40(%rcx), %xmm5
 ; nextln: movsd   48(%rcx), %xmm6
 ; nextln: movsd   56(%rcx), %xmm7
@@ -278,24 +278,24 @@ block0(v0: i64):
 ; nextln: movsd   112(%rcx), %xmm14
 ; nextln: movsd   120(%rcx), %xmm15
 ; nextln: movsd   128(%rcx), %xmm0
-; nextln: movsd   %xmm0, rsp(0 + virtual offset)
+; nextln: movdqu  %xmm0, rsp(0 + virtual offset)
 ; nextln: movsd   136(%rcx), %xmm0
 ; nextln: movsd   144(%rcx), %xmm2
-; nextln: movsd   %xmm2, rsp(8 + virtual offset)
+; nextln: movdqu  %xmm2, rsp(16 + virtual offset)
 ; nextln: movsd   152(%rcx), %xmm2
 ; nextln: addsd   %xmm1, %xmm4
-; nextln: movsd   rsp(16 + virtual offset), %xmm1
+; nextln: movdqu  rsp(32 + virtual offset), %xmm1
 ; nextln: addsd   %xmm3, %xmm1
-; nextln: movsd   rsp(24 + virtual offset), %xmm3
+; nextln: movdqu  rsp(48 + virtual offset), %xmm3
 ; nextln: addsd   %xmm5, %xmm3
 ; nextln: addsd   %xmm7, %xmm6
 ; nextln: addsd   %xmm9, %xmm8
 ; nextln: addsd   %xmm11, %xmm10
 ; nextln: addsd   %xmm13, %xmm12
 ; nextln: addsd   %xmm15, %xmm14
-; nextln: movsd   rsp(0 + virtual offset), %xmm5
+; nextln: movdqu  rsp(0 + virtual offset), %xmm5
 ; nextln: addsd   %xmm0, %xmm5
-; nextln: movsd   rsp(8 + virtual offset), %xmm0
+; nextln: movdqu  rsp(16 + virtual offset), %xmm0
 ; nextln: addsd   %xmm2, %xmm0
 ; nextln: addsd   %xmm1, %xmm4
 ; nextln: addsd   %xmm6, %xmm3
@@ -307,17 +307,17 @@ block0(v0: i64):
 ; nextln: addsd   %xmm8, %xmm4
 ; nextln: addsd   %xmm5, %xmm4
 ; nextln: movaps  %xmm4, %xmm0
-; nextln: movdqu  32(%rsp), %xmm6
-; nextln: movdqu  48(%rsp), %xmm7
-; nextln: movdqu  64(%rsp), %xmm8
-; nextln: movdqu  80(%rsp), %xmm9
-; nextln: movdqu  96(%rsp), %xmm10
-; nextln: movdqu  112(%rsp), %xmm11
-; nextln: movdqu  128(%rsp), %xmm12
-; nextln: movdqu  144(%rsp), %xmm13
-; nextln: movdqu  160(%rsp), %xmm14
-; nextln: movdqu  176(%rsp), %xmm15
-; nextln: addq    $$192, %rsp
+; nextln: movdqu  64(%rsp), %xmm6
+; nextln: movdqu  80(%rsp), %xmm7
+; nextln: movdqu  96(%rsp), %xmm8
+; nextln: movdqu  112(%rsp), %xmm9
+; nextln: movdqu  128(%rsp), %xmm10
+; nextln: movdqu  144(%rsp), %xmm11
+; nextln: movdqu  160(%rsp), %xmm12
+; nextln: movdqu  176(%rsp), %xmm13
+; nextln: movdqu  192(%rsp), %xmm14
+; nextln: movdqu  208(%rsp), %xmm15
+; nextln: addq    $$224, %rsp
 ; nextln: movq    %rbp, %rsp
 ; nextln: popq    %rbp
 ; nextln: ret

--- a/tests/misc_testsuite/simd/spillslot-size-fuzzbug.wast
+++ b/tests/misc_testsuite/simd/spillslot-size-fuzzbug.wast
@@ -1,0 +1,11 @@
+(module
+  (func (export "test") (result f32 f32)
+    i32.const 0
+    f32.convert_i32_s
+    v128.const i32x4 0 0 0 0
+    data.drop 0
+    f32x4.extract_lane 0
+    data.drop 0)
+  (data ""))
+
+(assert_return (invoke "test") (f32.const 0.0) (f32.const 0.0))


### PR DESCRIPTION
Fixes a recently-received fuzzbug exposed by differential fuzzing against V8.

This patch makes spillslot allocation, spilling and reloading all based
on register class only. Hence when we have a 32- or 64-bit value in a
128-bit XMM register on x86-64 or vector register on aarch64, this
results in larger spillslots and spills/restores.

Why make this change, if it results in less efficient stack-frame usage?
Simply put, it is safer: there is always a risk when allocating
spillslots or spilling/reloading that we get the wrong type and make the
spillslot or the store/load too small. This was one contributing factor
to CVE-2021-32629, and is now the source of a fuzzbug in SIMD code that
puns an arbitrary user-controlled vector constant over another
stackslot. (If this were a pointer, that could result in RCE. SIMD is
not yet on by default in a release, fortunately.)

In particular, we have not been particularly careful about using moves
between values of different types, for example with `raw_bitcast` or
with certain SIMD operations, and such moves indicate to regalloc.rs
that vregs are in equivalence classes and some arbitrary vreg in the
class is provided when allocating the spillslot or spilling/reloading.
Since regalloc.rs does not track actual type, and since we haven't been
careful about moves, we can't really trust this "arbitrary vreg in
equivalence class" to provide accurate type information.

In the fix to CVE-2021-32629 we fixed this for integer registers by
always spilling/reloading 64 bits; this fix can be seen as the analogous
change for FP/vector regs.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
