### PR TITLE
Remove unnecessary into_iter/collect

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -942,20 +942,14 @@ struct HashedEngineCompileEnv<'a>(&'a Engine);
 #[cfg(all(feature = "cache", compiler))]
 impl std::hash::Hash for HashedEngineCompileEnv<'_> {
     fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
-        use std::collections::BTreeMap;
-
         // Hash the compiler's state based on its target and configuration.
         let compiler = self.0.compiler();
         compiler.triple().hash(hasher);
         compiler
             .flags()
-            .into_iter()
-            .collect::<BTreeMap<_, _>>()
             .hash(hasher);
         compiler
             .isa_flags()
-            .into_iter()
-            .collect::<BTreeMap<_, _>>()
             .hash(hasher);
 
         // Hash configuration state read for compilation

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -945,12 +945,8 @@ impl std::hash::Hash for HashedEngineCompileEnv<'_> {
         // Hash the compiler's state based on its target and configuration.
         let compiler = self.0.compiler();
         compiler.triple().hash(hasher);
-        compiler
-            .flags()
-            .hash(hasher);
-        compiler
-            .isa_flags()
-            .hash(hasher);
+        compiler.flags().hash(hasher);
+        compiler.isa_flags().hash(hasher);
 
         // Hash configuration state read for compilation
         let config = self.0.config();


### PR DESCRIPTION
`flags` and `isa_flags` were already of the correct type in HashedEngineCompileEnv's implementation. #3666 