### PR TITLE
Expose DefaultMemoryCreator in wasmtime_runtime's API

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -46,7 +46,7 @@ pub use crate::instance::{
     DEFAULT_MEMORY_LIMIT, DEFAULT_TABLE_LIMIT,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
-pub use crate::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};
+pub use crate::memory::{DefaultMemoryCreator, Memory, RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::mmap::Mmap;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{


### PR DESCRIPTION
This exposes the standard implementation of `RuntimeMemoryCreator` in wasmtime_runtime's API and thus allows indirectly using  the handy but private `MmapMemory` implementation.
Exposing `DefaultMemoryCreator` in `wasmtime-runtime` seems mostly harmless. Feel free to reject this though and/or yell at me for not opening an issue first.

---

Memories can also be created with `OnDemandInstanceAllocator` (pub) which can fall back to `DefaultMemoryCreator` internally.
This requires passing in a `Module` though, which might not be relevant when looking to create memories.