### PR TITLE
fuzz: Fix infinite loops in table_ops fuzzers

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -58,7 +58,7 @@ pub struct WasmtimeConfig {
     debug_info: bool,
     canonicalize_nans: bool,
     interruptable: bool,
-    consume_fuel: bool,
+    pub(crate) consume_fuel: bool,
     memory_config: MemoryConfig,
     force_jump_veneers: bool,
 }


### PR DESCRIPTION
I forgot in the recent refactoring to add back in fuel support to the
`table_ops` fuzzer. This commit re-adds the previously existent logic to
always use fuel to cancel execution of the table_ops fuzzer.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
