### PR TITLE
wasmtime: Make rustix an unconditional dependency

### DIFF
--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -29,10 +29,10 @@ bincode = "1.2.1"
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "0.31.0", optional = true }
+rustix = "0.31.0"
 
 [features]
-jitdump = ['rustix']
+jitdump = []
 vtune = ['ittapi-rs']
 
 [badges]


### PR DESCRIPTION
This is unconditionally used on aarch64 and otherwise trying to manage
the precise clause for making it conditional vs unconditional probably
isn't worth it.

Closes #3672

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
