### PR TITLE
x64: port select to ISLE

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1486,9 +1486,9 @@
 
 (decl cmp64_imm (Reg Imm12) ProducesFlags)
 (rule (cmp64_imm src1 src2)
-      (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
+      (ProducesFlags.ProducesFlagsSideEffect
        (MInst.AluRRImm12 (ALUOp.SubS) (OperandSize.Size64) (writable_zero_reg)
-        src1 src2) (zero_reg)))
+        src1 src2)))
 
 ;; Helper for emitting `sbc` instructions.
 (decl sbc_paired (Type Reg Reg) ConsumesFlags)

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1461,37 +1461,42 @@
         (writable_reg_to_reg dst)))
 
 ;; Helper for emitting `adds` instructions.
-(decl add_with_flags (Type Reg Reg) ProducesFlags)
-(rule (add_with_flags ty src1 src2)
+(decl add_with_flags_paired (Type Reg Reg) ProducesFlags)
+(rule (add_with_flags_paired ty src1 src2)
       (let ((dst WritableReg (temp_writable_reg $I64)))
-        (ProducesFlags.ProducesFlags (MInst.AluRRR (ALUOp.AddS) (operand_size ty) dst src1 src2)
-                                     (writable_reg_to_reg dst))))
+        (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
+         (MInst.AluRRR (ALUOp.AddS) (operand_size ty) dst src1 src2)
+         (writable_reg_to_reg dst))))
 
 ;; Helper for emitting `adc` instructions.
-(decl adc (Type Reg Reg) ConsumesFlags)
-(rule (adc ty src1 src2)
+(decl adc_paired (Type Reg Reg) ConsumesFlags)
+(rule (adc_paired ty src1 src2)
       (let ((dst WritableReg (temp_writable_reg $I64)))
-        (ConsumesFlags.ConsumesFlags (MInst.AluRRR (ALUOp.Adc) (operand_size ty) dst src1 src2)
-                                     (writable_reg_to_reg dst))))
+        (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
+         (MInst.AluRRR (ALUOp.Adc) (operand_size ty) dst src1 src2)
+         (writable_reg_to_reg dst))))
 
 ;; Helper for emitting `subs` instructions.
-(decl sub_with_flags (Type Reg Reg) ProducesFlags)
-(rule (sub_with_flags ty src1 src2)
+(decl sub_with_flags_paired (Type Reg Reg) ProducesFlags)
+(rule (sub_with_flags_paired ty src1 src2)
       (let ((dst WritableReg (temp_writable_reg $I64)))
-        (ProducesFlags.ProducesFlags (MInst.AluRRR (ALUOp.SubS) (operand_size ty) dst src1 src2)
-                                     (writable_reg_to_reg dst))))
+        (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
+         (MInst.AluRRR (ALUOp.SubS) (operand_size ty) dst src1 src2)
+         (writable_reg_to_reg dst))))
 
 (decl cmp64_imm (Reg Imm12) ProducesFlags)
 (rule (cmp64_imm src1 src2)
-      (ProducesFlags.ProducesFlags (MInst.AluRRImm12 (ALUOp.SubS) (OperandSize.Size64) (writable_zero_reg) src1 src2)
-                                   (zero_reg)))
+      (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
+       (MInst.AluRRImm12 (ALUOp.SubS) (OperandSize.Size64) (writable_zero_reg)
+        src1 src2) (zero_reg)))
 
 ;; Helper for emitting `sbc` instructions.
-(decl sbc (Type Reg Reg) ConsumesFlags)
-(rule (sbc ty src1 src2)
+(decl sbc_paired (Type Reg Reg) ConsumesFlags)
+(rule (sbc_paired ty src1 src2)
       (let ((dst WritableReg (temp_writable_reg $I64)))
-        (ConsumesFlags.ConsumesFlags (MInst.AluRRR (ALUOp.Sbc) (operand_size ty) dst src1 src2)
-                                     (writable_reg_to_reg dst))))
+        (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
+         (MInst.AluRRR (ALUOp.Sbc) (operand_size ty) dst src1 src2)
+         (writable_reg_to_reg dst))))
 
 ;; Helper for emitting `MInst.VecMisc` instructions.
 (decl vec_misc (VecMisc2 Reg VectorSize) Reg)
@@ -1581,12 +1586,12 @@
 ;; which must be paired with `with_flags*` helpers.
 (decl tst_imm (Type Reg ImmLogic) ProducesFlags)
 (rule (tst_imm ty reg imm)
-      (ProducesFlags.ProducesFlags (MInst.AluRRImmLogic (ALUOp.AndS)
-                                                        (operand_size ty)
-                                                        (writable_zero_reg)
-                                                        reg
-                                                        imm)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect
+       (MInst.AluRRImmLogic (ALUOp.AndS)
+                            (operand_size ty)
+                            (writable_zero_reg)
+                            reg
+                            imm)))
 
 ;; Helper for generating a `CSel` instruction.
 ;;
@@ -1596,8 +1601,9 @@
 (decl csel (Cond Reg Reg) ConsumesFlags)
 (rule (csel cond if_true if_false)
       (let ((dst WritableReg (temp_writable_reg $I64)))
-        (ConsumesFlags.ConsumesFlags (MInst.CSel dst cond if_true if_false)
-                                     (writable_reg_to_reg dst))))
+        (ConsumesFlags.ConsumesFlagsReturnsReg
+         (MInst.CSel dst cond if_true if_false)
+         (writable_reg_to_reg dst))))
 
 ;; Helpers for generating `add` instructions.
 

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -91,8 +91,8 @@
         ;; the actual addition is `adds` followed by `adc` which comprises the
         ;; low/high bits of the result
         (with_flags
-          (add_with_flags $I64 x_lo y_lo)
-          (adc $I64 x_hi y_hi))))
+          (add_with_flags_paired $I64 x_lo y_lo)
+          (adc_paired $I64 x_hi y_hi))))
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -142,8 +142,8 @@
         ;; the actual subtraction is `subs` followed by `sbc` which comprises
         ;; the low/high bits of the result
         (with_flags
-          (sub_with_flags $I64 x_lo y_lo)
-          (sbc $I64 x_hi y_hi))))
+          (sub_with_flags_paired $I64 x_lo y_lo)
+          (sbc_paired $I64 x_hi y_hi))))
 
 ;;;; Rules for `uadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -708,10 +708,11 @@
                                 inv_amt))
           (maybe_hi Reg (orr $I64 hi_lshift lo_rshift))
         )
-        (with_flags_2
-          (tst_imm $I64 amt (u64_into_imm_logic $I64 64))
+        (with_flags
+         (tst_imm $I64 amt (u64_into_imm_logic $I64 64))
+         (consumes_flags_concat
           (csel (Cond.Ne) (zero_reg) lo_lshift)
-          (csel (Cond.Ne) lo_lshift maybe_hi))))
+          (csel (Cond.Ne) lo_lshift maybe_hi)))))
 
 ;; Shift for vector types.
 (rule (lower (has_type (vec128 ty) (ishl x y)))
@@ -805,10 +806,11 @@
                                 inv_amt))
           (maybe_lo Reg (orr $I64 lo_rshift hi_lshift))
         )
-        (with_flags_2
-          (tst_imm $I64 amt (u64_into_imm_logic $I64 64))
+        (with_flags
+         (tst_imm $I64 amt (u64_into_imm_logic $I64 64))
+         (consumes_flags_concat
           (csel (Cond.Ne) hi_rshift maybe_lo)
-          (csel (Cond.Ne) (zero_reg) hi_rshift))))
+          (csel (Cond.Ne) (zero_reg) hi_rshift)))))
 
 ;;;; Rules for `sshr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -858,10 +860,11 @@
           (hi_sign Reg (asr_imm $I64 src_hi (imm_shift_from_u8 63)))
           (maybe_lo Reg (orr $I64 lo_rshift hi_lshift))
         )
-        (with_flags_2
-          (tst_imm $I64 amt (u64_into_imm_logic $I64 64))
+        (with_flags
+         (tst_imm $I64 amt (u64_into_imm_logic $I64 64))
+         (consumes_flags_concat
           (csel (Cond.Ne) hi_rshift maybe_lo)
-          (csel (Cond.Ne) hi_sign hi_rshift))))
+          (csel (Cond.Ne) hi_sign hi_rshift)))))
 
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1123,9 +1126,9 @@
           (sign_eq_eon Reg (eon $I64 hi lo))
           (sign_eq Reg (lsr_imm $I64 sign_eq_eon (imm_shift_from_u8 63)))
           (lo_sign_bits Reg (madd64 lo_cls sign_eq sign_eq))
-          (maybe_lo Reg (with_flags_1
-            (cmp64_imm hi_cls (u8_into_imm12 63))
-            (csel (Cond.Eq) lo_sign_bits (zero_reg))
+          (maybe_lo Reg (with_flags_reg
+                         (cmp64_imm hi_cls (u8_into_imm12 63))
+                         (csel (Cond.Eq) lo_sign_bits (zero_reg))
           ))
         )
         (value_regs (add $I64 maybe_lo hi_cls) (imm $I64 0))))

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 73285cd431346d53
-src/isa/aarch64/inst.isle 4c176462894836e5
-src/isa/aarch64/lower.isle aff657984bf30686
+src/prelude.isle 980b300b3ec3e338
+src/isa/aarch64/inst.isle be5744f443a5e400
+src/isa/aarch64/lower.isle 534c135b5f535f33

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle 980b300b3ec3e338
-src/isa/aarch64/inst.isle be5744f443a5e400
+src/isa/aarch64/inst.isle a7f3572a5cf2f201
 src/isa/aarch64/lower.isle 534c135b5f535f33

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
@@ -108,16 +108,30 @@ pub enum SideEffectNoResult {
     Inst { inst: MInst },
 }
 
-/// Internal type ProducesFlags: defined at src/prelude.isle line 327.
+/// Internal type ProducesFlags: defined at src/prelude.isle line 330.
 #[derive(Clone, Debug)]
 pub enum ProducesFlags {
-    ProducesFlags { inst: MInst, result: Reg },
+    ProducesFlagsSideEffect { inst: MInst },
+    ProducesFlagsReturnsReg { inst: MInst, result: Reg },
+    ProducesFlagsReturnsResultWithConsumer { inst: MInst, result: Reg },
 }
 
-/// Internal type ConsumesFlags: defined at src/prelude.isle line 330.
+/// Internal type ConsumesFlags: defined at src/prelude.isle line 341.
 #[derive(Clone, Debug)]
 pub enum ConsumesFlags {
-    ConsumesFlags { inst: MInst, result: Reg },
+    ConsumesFlagsReturnsResultWithProducer {
+        inst: MInst,
+        result: Reg,
+    },
+    ConsumesFlagsReturnsReg {
+        inst: MInst,
+        result: Reg,
+    },
+    ConsumesFlagsTwiceReturnsValueRegs {
+        inst1: MInst,
+        inst2: MInst,
+        result: ValueRegs,
+    },
 }
 
 /// Internal type MInst: defined at src/isa/aarch64/inst.isle line 2.
@@ -1013,7 +1027,7 @@ pub fn constructor_value_regs_none<C: Context>(
     } = pattern0_0
     {
         // Rule at src/prelude.isle line 313.
-        let expr0_0 = C::emit(ctx, &pattern1_0);
+        let expr0_0 = C::emit(ctx, pattern1_0);
         let expr1_0 = C::value_regs_invalid(ctx);
         return Some(expr1_0);
     }
@@ -1031,9 +1045,40 @@ pub fn constructor_safepoint<C: Context>(
     } = pattern0_0
     {
         // Rule at src/prelude.isle line 319.
-        let expr0_0 = C::emit_safepoint(ctx, &pattern1_0);
+        let expr0_0 = C::emit_safepoint(ctx, pattern1_0);
         let expr1_0 = C::value_regs_invalid(ctx);
         return Some(expr1_0);
+    }
+    return None;
+}
+
+// Generated as internal constructor for term consumes_flags_concat.
+pub fn constructor_consumes_flags_concat<C: Context>(
+    ctx: &mut C,
+    arg0: &ConsumesFlags,
+    arg1: &ConsumesFlags,
+) -> Option<ConsumesFlags> {
+    let pattern0_0 = arg0;
+    if let &ConsumesFlags::ConsumesFlagsReturnsReg {
+        inst: ref pattern1_0,
+        result: pattern1_1,
+    } = pattern0_0
+    {
+        let pattern2_0 = arg1;
+        if let &ConsumesFlags::ConsumesFlagsReturnsReg {
+            inst: ref pattern3_0,
+            result: pattern3_1,
+        } = pattern2_0
+        {
+            // Rule at src/prelude.isle line 353.
+            let expr0_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
+            let expr1_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
+                inst1: pattern1_0.clone(),
+                inst2: pattern3_0.clone(),
+                result: expr0_0,
+            };
+            return Some(expr1_0);
+        }
     }
     return None;
 }
@@ -1045,89 +1090,71 @@ pub fn constructor_with_flags<C: Context>(
     arg1: &ConsumesFlags,
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
-        inst: ref pattern1_0,
-        result: pattern1_1,
-    } = pattern0_0
-    {
-        let pattern2_0 = arg1;
-        if let &ConsumesFlags::ConsumesFlags {
-            inst: ref pattern3_0,
-            result: pattern3_1,
-        } = pattern2_0
-        {
-            // Rule at src/prelude.isle line 340.
-            let expr0_0 = C::emit(ctx, &pattern1_0);
-            let expr1_0 = C::emit(ctx, &pattern3_0);
-            let expr2_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
-            return Some(expr2_0);
+    match pattern0_0 {
+        &ProducesFlags::ProducesFlagsSideEffect {
+            inst: ref pattern1_0,
+        } => {
+            let pattern2_0 = arg1;
+            match pattern2_0 {
+                &ConsumesFlags::ConsumesFlagsReturnsReg {
+                    inst: ref pattern3_0,
+                    result: pattern3_1,
+                } => {
+                    // Rule at src/prelude.isle line 378.
+                    let expr0_0 = C::emit(ctx, pattern1_0);
+                    let expr1_0 = C::emit(ctx, pattern3_0);
+                    let expr2_0 = C::value_reg(ctx, pattern3_1);
+                    return Some(expr2_0);
+                }
+                &ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
+                    inst1: ref pattern3_0,
+                    inst2: ref pattern3_1,
+                    result: pattern3_2,
+                } => {
+                    // Rule at src/prelude.isle line 384.
+                    let expr0_0 = C::emit(ctx, pattern1_0);
+                    let expr1_0 = C::emit(ctx, pattern3_1);
+                    let expr2_0 = C::emit(ctx, pattern3_0);
+                    return Some(pattern3_2);
+                }
+                _ => {}
+            }
         }
+        &ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
+            inst: ref pattern1_0,
+            result: pattern1_1,
+        } => {
+            let pattern2_0 = arg1;
+            if let &ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
+                inst: ref pattern3_0,
+                result: pattern3_1,
+            } = pattern2_0
+            {
+                // Rule at src/prelude.isle line 372.
+                let expr0_0 = C::emit(ctx, pattern1_0);
+                let expr1_0 = C::emit(ctx, pattern3_0);
+                let expr2_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
+                return Some(expr2_0);
+            }
+        }
+        _ => {}
     }
     return None;
 }
 
-// Generated as internal constructor for term with_flags_1.
-pub fn constructor_with_flags_1<C: Context>(
+// Generated as internal constructor for term with_flags_reg.
+pub fn constructor_with_flags_reg<C: Context>(
     ctx: &mut C,
     arg0: &ProducesFlags,
     arg1: &ConsumesFlags,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
-        inst: ref pattern1_0,
-        result: pattern1_1,
-    } = pattern0_0
-    {
-        let pattern2_0 = arg1;
-        if let &ConsumesFlags::ConsumesFlags {
-            inst: ref pattern3_0,
-            result: pattern3_1,
-        } = pattern2_0
-        {
-            // Rule at src/prelude.isle line 348.
-            let expr0_0 = C::emit(ctx, &pattern1_0);
-            let expr1_0 = C::emit(ctx, &pattern3_0);
-            return Some(pattern3_1);
-        }
-    }
-    return None;
-}
-
-// Generated as internal constructor for term with_flags_2.
-pub fn constructor_with_flags_2<C: Context>(
-    ctx: &mut C,
-    arg0: &ProducesFlags,
-    arg1: &ConsumesFlags,
-    arg2: &ConsumesFlags,
-) -> Option<ValueRegs> {
-    let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
-        inst: ref pattern1_0,
-        result: pattern1_1,
-    } = pattern0_0
-    {
-        let pattern2_0 = arg1;
-        if let &ConsumesFlags::ConsumesFlags {
-            inst: ref pattern3_0,
-            result: pattern3_1,
-        } = pattern2_0
-        {
-            let pattern4_0 = arg2;
-            if let &ConsumesFlags::ConsumesFlags {
-                inst: ref pattern5_0,
-                result: pattern5_1,
-            } = pattern4_0
-            {
-                // Rule at src/prelude.isle line 358.
-                let expr0_0 = C::emit(ctx, &pattern1_0);
-                let expr1_0 = C::emit(ctx, &pattern5_0);
-                let expr2_0 = C::emit(ctx, &pattern3_0);
-                let expr3_0 = C::value_regs(ctx, pattern3_1, pattern5_1);
-                return Some(expr3_0);
-            }
-        }
-    }
-    return None;
+    let pattern1_0 = arg1;
+    // Rule at src/prelude.isle line 397.
+    let expr0_0 = constructor_with_flags(ctx, pattern0_0, pattern1_0)?;
+    let expr1_0: usize = 0;
+    let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
+    return Some(expr2_0);
 }
 
 // Generated as internal constructor for term operand_size.
@@ -1530,8 +1557,8 @@ pub fn constructor_bit_rr<C: Context>(ctx: &mut C, arg0: &BitOp, arg1: Reg) -> O
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term add_with_flags.
-pub fn constructor_add_with_flags<C: Context>(
+// Generated as internal constructor for term add_with_flags_paired.
+pub fn constructor_add_with_flags_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Reg,
@@ -1553,15 +1580,15 @@ pub fn constructor_add_with_flags<C: Context>(
         rm: pattern2_0,
     };
     let expr5_0 = C::writable_reg_to_reg(ctx, expr1_0);
-    let expr6_0 = ProducesFlags::ProducesFlags {
+    let expr6_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
         inst: expr4_0,
         result: expr5_0,
     };
     return Some(expr6_0);
 }
 
-// Generated as internal constructor for term adc.
-pub fn constructor_adc<C: Context>(
+// Generated as internal constructor for term adc_paired.
+pub fn constructor_adc_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Reg,
@@ -1570,7 +1597,7 @@ pub fn constructor_adc<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1472.
+    // Rule at src/isa/aarch64/inst.isle line 1473.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = ALUOp::Adc;
@@ -1583,15 +1610,15 @@ pub fn constructor_adc<C: Context>(
         rm: pattern2_0,
     };
     let expr5_0 = C::writable_reg_to_reg(ctx, expr1_0);
-    let expr6_0 = ConsumesFlags::ConsumesFlags {
+    let expr6_0 = ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
         inst: expr4_0,
         result: expr5_0,
     };
     return Some(expr6_0);
 }
 
-// Generated as internal constructor for term sub_with_flags.
-pub fn constructor_sub_with_flags<C: Context>(
+// Generated as internal constructor for term sub_with_flags_paired.
+pub fn constructor_sub_with_flags_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Reg,
@@ -1600,7 +1627,7 @@ pub fn constructor_sub_with_flags<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1479.
+    // Rule at src/isa/aarch64/inst.isle line 1481.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = ALUOp::SubS;
@@ -1613,7 +1640,7 @@ pub fn constructor_sub_with_flags<C: Context>(
         rm: pattern2_0,
     };
     let expr5_0 = C::writable_reg_to_reg(ctx, expr1_0);
-    let expr6_0 = ProducesFlags::ProducesFlags {
+    let expr6_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
         inst: expr4_0,
         result: expr5_0,
     };
@@ -1628,7 +1655,7 @@ pub fn constructor_cmp64_imm<C: Context>(
 ) -> Option<ProducesFlags> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1485.
+    // Rule at src/isa/aarch64/inst.isle line 1488.
     let expr0_0 = ALUOp::SubS;
     let expr1_0 = OperandSize::Size64;
     let expr2_0 = C::writable_zero_reg(ctx);
@@ -1640,15 +1667,15 @@ pub fn constructor_cmp64_imm<C: Context>(
         imm12: pattern1_0,
     };
     let expr4_0 = C::zero_reg(ctx);
-    let expr5_0 = ProducesFlags::ProducesFlags {
+    let expr5_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
         inst: expr3_0,
         result: expr4_0,
     };
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term sbc.
-pub fn constructor_sbc<C: Context>(
+// Generated as internal constructor for term sbc_paired.
+pub fn constructor_sbc_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Reg,
@@ -1657,7 +1684,7 @@ pub fn constructor_sbc<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1491.
+    // Rule at src/isa/aarch64/inst.isle line 1495.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = ALUOp::Sbc;
@@ -1670,7 +1697,7 @@ pub fn constructor_sbc<C: Context>(
         rm: pattern2_0,
     };
     let expr5_0 = C::writable_reg_to_reg(ctx, expr1_0);
-    let expr6_0 = ConsumesFlags::ConsumesFlags {
+    let expr6_0 = ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
         inst: expr4_0,
         result: expr5_0,
     };
@@ -1687,7 +1714,7 @@ pub fn constructor_vec_misc<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1498.
+    // Rule at src/isa/aarch64/inst.isle line 1503.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecMisc {
@@ -1713,7 +1740,7 @@ pub fn constructor_vec_rrr_long<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1505.
+    // Rule at src/isa/aarch64/inst.isle line 1510.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecRRRLong {
@@ -1742,7 +1769,7 @@ pub fn constructor_vec_rrrr_long<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/aarch64/inst.isle line 1515.
+    // Rule at src/isa/aarch64/inst.isle line 1520.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuMove128 {
@@ -1772,7 +1799,7 @@ pub fn constructor_vec_rr_narrow<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1523.
+    // Rule at src/isa/aarch64/inst.isle line 1528.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecRRNarrow {
@@ -1796,7 +1823,7 @@ pub fn constructor_vec_rr_long<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1530.
+    // Rule at src/isa/aarch64/inst.isle line 1535.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecRRLong {
@@ -1818,7 +1845,7 @@ pub fn constructor_mov_to_fpu<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1537.
+    // Rule at src/isa/aarch64/inst.isle line 1542.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovToFpu {
@@ -1843,7 +1870,7 @@ pub fn constructor_mov_to_vec<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1544.
+    // Rule at src/isa/aarch64/inst.isle line 1549.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuMove128 {
@@ -1872,7 +1899,7 @@ pub fn constructor_mov_from_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1552.
+    // Rule at src/isa/aarch64/inst.isle line 1557.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovFromVec {
@@ -1898,7 +1925,7 @@ pub fn constructor_mov_from_vec_signed<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1559.
+    // Rule at src/isa/aarch64/inst.isle line 1564.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovFromVecSigned {
@@ -1925,7 +1952,7 @@ pub fn constructor_extend<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1566.
+    // Rule at src/isa/aarch64/inst.isle line 1571.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::Extend {
@@ -1944,7 +1971,7 @@ pub fn constructor_extend<C: Context>(
 pub fn constructor_load_acquire<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1573.
+    // Rule at src/isa/aarch64/inst.isle line 1578.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::LoadAcquire {
@@ -1967,7 +1994,7 @@ pub fn constructor_tst_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1583.
+    // Rule at src/isa/aarch64/inst.isle line 1588.
     let expr0_0 = ALUOp::AndS;
     let expr1_0 = constructor_operand_size(ctx, pattern0_0)?;
     let expr2_0 = C::writable_zero_reg(ctx);
@@ -1978,12 +2005,8 @@ pub fn constructor_tst_imm<C: Context>(
         rn: pattern1_0,
         imml: pattern2_0,
     };
-    let expr4_0 = C::invalid_reg(ctx);
-    let expr5_0 = ProducesFlags::ProducesFlags {
-        inst: expr3_0,
-        result: expr4_0,
-    };
-    return Some(expr5_0);
+    let expr4_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr3_0 };
+    return Some(expr4_0);
 }
 
 // Generated as internal constructor for term csel.
@@ -1996,7 +2019,7 @@ pub fn constructor_csel<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1597.
+    // Rule at src/isa/aarch64/inst.isle line 1602.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::CSel {
@@ -2006,7 +2029,7 @@ pub fn constructor_csel<C: Context>(
         rm: pattern2_0,
     };
     let expr3_0 = C::writable_reg_to_reg(ctx, expr1_0);
-    let expr4_0 = ConsumesFlags::ConsumesFlags {
+    let expr4_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
         inst: expr2_0,
         result: expr3_0,
     };
@@ -2018,7 +2041,7 @@ pub fn constructor_add<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1605.
+    // Rule at src/isa/aarch64/inst.isle line 1611.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2034,7 +2057,7 @@ pub fn constructor_add_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1608.
+    // Rule at src/isa/aarch64/inst.isle line 1614.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rr_imm12(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2050,7 +2073,7 @@ pub fn constructor_add_extend<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1611.
+    // Rule at src/isa/aarch64/inst.isle line 1617.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rr_extend_reg(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2068,7 +2091,7 @@ pub fn constructor_add_shift<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1614.
+    // Rule at src/isa/aarch64/inst.isle line 1620.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rrr_shift(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2086,7 +2109,7 @@ pub fn constructor_add_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1617.
+    // Rule at src/isa/aarch64/inst.isle line 1623.
     let expr0_0 = VecALUOp::Add;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2097,7 +2120,7 @@ pub fn constructor_sub<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1622.
+    // Rule at src/isa/aarch64/inst.isle line 1628.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2113,7 +2136,7 @@ pub fn constructor_sub_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1625.
+    // Rule at src/isa/aarch64/inst.isle line 1631.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rr_imm12(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2129,7 +2152,7 @@ pub fn constructor_sub_extend<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1628.
+    // Rule at src/isa/aarch64/inst.isle line 1634.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rr_extend_reg(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2147,7 +2170,7 @@ pub fn constructor_sub_shift<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1631.
+    // Rule at src/isa/aarch64/inst.isle line 1637.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rrr_shift(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2165,7 +2188,7 @@ pub fn constructor_sub_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1634.
+    // Rule at src/isa/aarch64/inst.isle line 1640.
     let expr0_0 = VecALUOp::Sub;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2184,7 +2207,7 @@ pub fn constructor_madd<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/inst.isle line 1640.
+        // Rule at src/isa/aarch64/inst.isle line 1646.
         let expr0_0 = constructor_madd64(ctx, pattern2_0, pattern3_0, pattern4_0)?;
         return Some(expr0_0);
     }
@@ -2192,7 +2215,7 @@ pub fn constructor_madd<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/inst.isle line 1639.
+        // Rule at src/isa/aarch64/inst.isle line 1645.
         let expr0_0 = constructor_madd32(ctx, pattern2_0, pattern3_0, pattern4_0)?;
         return Some(expr0_0);
     }
@@ -2204,7 +2227,7 @@ pub fn constructor_madd32<C: Context>(ctx: &mut C, arg0: Reg, arg1: Reg, arg2: R
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1643.
+    // Rule at src/isa/aarch64/inst.isle line 1649.
     let expr0_0 = ALUOp3::MAdd32;
     let expr1_0 = constructor_alu_rrrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2215,7 +2238,7 @@ pub fn constructor_madd64<C: Context>(ctx: &mut C, arg0: Reg, arg1: Reg, arg2: R
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1646.
+    // Rule at src/isa/aarch64/inst.isle line 1652.
     let expr0_0 = ALUOp3::MAdd64;
     let expr1_0 = constructor_alu_rrrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2226,7 +2249,7 @@ pub fn constructor_msub64<C: Context>(ctx: &mut C, arg0: Reg, arg1: Reg, arg2: R
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1651.
+    // Rule at src/isa/aarch64/inst.isle line 1657.
     let expr0_0 = ALUOp3::MSub64;
     let expr1_0 = constructor_alu_rrrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2242,7 +2265,7 @@ pub fn constructor_uqadd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1655.
+    // Rule at src/isa/aarch64/inst.isle line 1661.
     let expr0_0 = VecALUOp::Uqadd;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2258,7 +2281,7 @@ pub fn constructor_sqadd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1659.
+    // Rule at src/isa/aarch64/inst.isle line 1665.
     let expr0_0 = VecALUOp::Sqadd;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2274,7 +2297,7 @@ pub fn constructor_uqsub<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1663.
+    // Rule at src/isa/aarch64/inst.isle line 1669.
     let expr0_0 = VecALUOp::Uqsub;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2290,7 +2313,7 @@ pub fn constructor_sqsub<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1667.
+    // Rule at src/isa/aarch64/inst.isle line 1673.
     let expr0_0 = VecALUOp::Sqsub;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2301,7 +2324,7 @@ pub fn constructor_umulh<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: R
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1671.
+    // Rule at src/isa/aarch64/inst.isle line 1677.
     let expr0_0 = ALUOp::UMulH;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2312,7 +2335,7 @@ pub fn constructor_smulh<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: R
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1675.
+    // Rule at src/isa/aarch64/inst.isle line 1681.
     let expr0_0 = ALUOp::SMulH;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2328,7 +2351,7 @@ pub fn constructor_mul<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1679.
+    // Rule at src/isa/aarch64/inst.isle line 1685.
     let expr0_0 = VecALUOp::Mul;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2338,7 +2361,7 @@ pub fn constructor_mul<C: Context>(
 pub fn constructor_neg<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1683.
+    // Rule at src/isa/aarch64/inst.isle line 1689.
     let expr0_0 = VecMisc2::Neg;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2348,7 +2371,7 @@ pub fn constructor_neg<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) ->
 pub fn constructor_rev64<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1687.
+    // Rule at src/isa/aarch64/inst.isle line 1693.
     let expr0_0 = VecMisc2::Rev64;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2358,7 +2381,7 @@ pub fn constructor_rev64<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) 
 pub fn constructor_xtn64<C: Context>(ctx: &mut C, arg0: Reg, arg1: bool) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1691.
+    // Rule at src/isa/aarch64/inst.isle line 1697.
     let expr0_0 = VecRRNarrowOp::Xtn64;
     let expr1_0 = constructor_vec_rr_narrow(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2374,7 +2397,7 @@ pub fn constructor_addp<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1695.
+    // Rule at src/isa/aarch64/inst.isle line 1701.
     let expr0_0 = VecALUOp::Addp;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2384,7 +2407,7 @@ pub fn constructor_addp<C: Context>(
 pub fn constructor_addv<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1699.
+    // Rule at src/isa/aarch64/inst.isle line 1705.
     let expr0_0 = VecLanesOp::Addv;
     let expr1_0 = constructor_vec_lanes(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2394,7 +2417,7 @@ pub fn constructor_addv<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -
 pub fn constructor_shll32<C: Context>(ctx: &mut C, arg0: Reg, arg1: bool) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1703.
+    // Rule at src/isa/aarch64/inst.isle line 1709.
     let expr0_0 = VecRRLongOp::Shll32;
     let expr1_0 = constructor_vec_rr_long(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2412,7 +2435,7 @@ pub fn constructor_umlal32<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1707.
+    // Rule at src/isa/aarch64/inst.isle line 1713.
     let expr0_0 = VecRRRLongOp::Umlal32;
     let expr1_0 = constructor_vec_rrrr_long(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2430,7 +2453,7 @@ pub fn constructor_smull8<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1711.
+    // Rule at src/isa/aarch64/inst.isle line 1717.
     let expr0_0 = VecRRRLongOp::Smull8;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2446,7 +2469,7 @@ pub fn constructor_umull8<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1715.
+    // Rule at src/isa/aarch64/inst.isle line 1721.
     let expr0_0 = VecRRRLongOp::Umull8;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2462,7 +2485,7 @@ pub fn constructor_smull16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1719.
+    // Rule at src/isa/aarch64/inst.isle line 1725.
     let expr0_0 = VecRRRLongOp::Smull16;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2478,7 +2501,7 @@ pub fn constructor_umull16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1723.
+    // Rule at src/isa/aarch64/inst.isle line 1729.
     let expr0_0 = VecRRRLongOp::Umull16;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2494,7 +2517,7 @@ pub fn constructor_smull32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1727.
+    // Rule at src/isa/aarch64/inst.isle line 1733.
     let expr0_0 = VecRRRLongOp::Smull32;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2510,7 +2533,7 @@ pub fn constructor_umull32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1731.
+    // Rule at src/isa/aarch64/inst.isle line 1737.
     let expr0_0 = VecRRRLongOp::Umull32;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2521,7 +2544,7 @@ pub fn constructor_asr<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1735.
+    // Rule at src/isa/aarch64/inst.isle line 1741.
     let expr0_0 = ALUOp::Asr;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2537,7 +2560,7 @@ pub fn constructor_asr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1738.
+    // Rule at src/isa/aarch64/inst.isle line 1744.
     let expr0_0 = ALUOp::Asr;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2548,7 +2571,7 @@ pub fn constructor_lsr<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1742.
+    // Rule at src/isa/aarch64/inst.isle line 1748.
     let expr0_0 = ALUOp::Lsr;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2564,7 +2587,7 @@ pub fn constructor_lsr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1745.
+    // Rule at src/isa/aarch64/inst.isle line 1751.
     let expr0_0 = ALUOp::Lsr;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2575,7 +2598,7 @@ pub fn constructor_lsl<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1749.
+    // Rule at src/isa/aarch64/inst.isle line 1755.
     let expr0_0 = ALUOp::Lsl;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2591,7 +2614,7 @@ pub fn constructor_lsl_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1752.
+    // Rule at src/isa/aarch64/inst.isle line 1758.
     let expr0_0 = ALUOp::Lsl;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2607,7 +2630,7 @@ pub fn constructor_a64_udiv<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1756.
+    // Rule at src/isa/aarch64/inst.isle line 1762.
     let expr0_0 = ALUOp::UDiv;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2623,7 +2646,7 @@ pub fn constructor_a64_sdiv<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1760.
+    // Rule at src/isa/aarch64/inst.isle line 1766.
     let expr0_0 = ALUOp::SDiv;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2633,7 +2656,7 @@ pub fn constructor_a64_sdiv<C: Context>(
 pub fn constructor_not<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1764.
+    // Rule at src/isa/aarch64/inst.isle line 1770.
     let expr0_0 = VecMisc2::Not;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2649,7 +2672,7 @@ pub fn constructor_orr_not<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1769.
+    // Rule at src/isa/aarch64/inst.isle line 1775.
     let expr0_0 = ALUOp::OrrNot;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2667,7 +2690,7 @@ pub fn constructor_orr_not_shift<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1772.
+    // Rule at src/isa/aarch64/inst.isle line 1778.
     let expr0_0 = ALUOp::OrrNot;
     let expr1_0 = constructor_alu_rrr_shift(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2680,7 +2703,7 @@ pub fn constructor_orr<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1777.
+    // Rule at src/isa/aarch64/inst.isle line 1783.
     let expr0_0 = ALUOp::Orr;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2696,7 +2719,7 @@ pub fn constructor_orr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1780.
+    // Rule at src/isa/aarch64/inst.isle line 1786.
     let expr0_0 = ALUOp::Orr;
     let expr1_0 = constructor_alu_rr_imm_logic(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2712,7 +2735,7 @@ pub fn constructor_orr_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1783.
+    // Rule at src/isa/aarch64/inst.isle line 1789.
     let expr0_0 = VecALUOp::Orr;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2728,7 +2751,7 @@ pub fn constructor_and_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1788.
+    // Rule at src/isa/aarch64/inst.isle line 1794.
     let expr0_0 = ALUOp::And;
     let expr1_0 = constructor_alu_rr_imm_logic(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2744,7 +2767,7 @@ pub fn constructor_and_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1791.
+    // Rule at src/isa/aarch64/inst.isle line 1797.
     let expr0_0 = VecALUOp::And;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2760,7 +2783,7 @@ pub fn constructor_eor_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1795.
+    // Rule at src/isa/aarch64/inst.isle line 1801.
     let expr0_0 = VecALUOp::Eor;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2776,7 +2799,7 @@ pub fn constructor_bic_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1799.
+    // Rule at src/isa/aarch64/inst.isle line 1805.
     let expr0_0 = VecALUOp::Bic;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2792,7 +2815,7 @@ pub fn constructor_sshl<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1803.
+    // Rule at src/isa/aarch64/inst.isle line 1809.
     let expr0_0 = VecALUOp::Sshl;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2808,7 +2831,7 @@ pub fn constructor_ushl<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1807.
+    // Rule at src/isa/aarch64/inst.isle line 1813.
     let expr0_0 = VecALUOp::Ushl;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2824,7 +2847,7 @@ pub fn constructor_a64_rotr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1812.
+    // Rule at src/isa/aarch64/inst.isle line 1818.
     let expr0_0 = ALUOp::RotR;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2840,7 +2863,7 @@ pub fn constructor_a64_rotr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1815.
+    // Rule at src/isa/aarch64/inst.isle line 1821.
     let expr0_0 = ALUOp::RotR;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2849,7 +2872,7 @@ pub fn constructor_a64_rotr_imm<C: Context>(
 // Generated as internal constructor for term rbit32.
 pub fn constructor_rbit32<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1820.
+    // Rule at src/isa/aarch64/inst.isle line 1826.
     let expr0_0 = BitOp::RBit32;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -2858,7 +2881,7 @@ pub fn constructor_rbit32<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
 // Generated as internal constructor for term rbit64.
 pub fn constructor_rbit64<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1823.
+    // Rule at src/isa/aarch64/inst.isle line 1829.
     let expr0_0 = BitOp::RBit64;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -2867,7 +2890,7 @@ pub fn constructor_rbit64<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
 // Generated as internal constructor for term clz32.
 pub fn constructor_clz32<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1828.
+    // Rule at src/isa/aarch64/inst.isle line 1834.
     let expr0_0 = BitOp::Clz32;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -2876,7 +2899,7 @@ pub fn constructor_clz32<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
 // Generated as internal constructor for term clz64.
 pub fn constructor_clz64<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1831.
+    // Rule at src/isa/aarch64/inst.isle line 1837.
     let expr0_0 = BitOp::Clz64;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -2885,7 +2908,7 @@ pub fn constructor_clz64<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
 // Generated as internal constructor for term cls32.
 pub fn constructor_cls32<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1836.
+    // Rule at src/isa/aarch64/inst.isle line 1842.
     let expr0_0 = BitOp::Cls32;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -2894,7 +2917,7 @@ pub fn constructor_cls32<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
 // Generated as internal constructor for term cls64.
 pub fn constructor_cls64<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1839.
+    // Rule at src/isa/aarch64/inst.isle line 1845.
     let expr0_0 = BitOp::Cls64;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -2905,7 +2928,7 @@ pub fn constructor_eon<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1844.
+    // Rule at src/isa/aarch64/inst.isle line 1850.
     let expr0_0 = ALUOp::EorNot;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2915,7 +2938,7 @@ pub fn constructor_eon<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
 pub fn constructor_vec_cnt<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1849.
+    // Rule at src/isa/aarch64/inst.isle line 1855.
     let expr0_0 = VecMisc2::Cnt;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2932,7 +2955,7 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
         };
         if let Some(pattern3_0) = closure3() {
             if let Some(pattern4_0) = C::imm_logic_from_u64(ctx, pattern2_0, pattern3_0) {
-                // Rule at src/isa/aarch64/inst.isle line 1864.
+                // Rule at src/isa/aarch64/inst.isle line 1870.
                 let expr0_0: Type = I64;
                 let expr1_0 = C::zero_reg(ctx);
                 let expr2_0 = constructor_orr_imm(ctx, expr0_0, expr1_0, pattern4_0)?;
@@ -2940,18 +2963,18 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
             }
         }
         if let Some(pattern3_0) = C::move_wide_const_from_u64(ctx, pattern2_0) {
-            // Rule at src/isa/aarch64/inst.isle line 1856.
+            // Rule at src/isa/aarch64/inst.isle line 1862.
             let expr0_0 = OperandSize::Size64;
             let expr1_0 = constructor_movz(ctx, pattern3_0, &expr0_0)?;
             return Some(expr1_0);
         }
         if let Some(pattern3_0) = C::move_wide_const_from_negated_u64(ctx, pattern2_0) {
-            // Rule at src/isa/aarch64/inst.isle line 1860.
+            // Rule at src/isa/aarch64/inst.isle line 1866.
             let expr0_0 = OperandSize::Size64;
             let expr1_0 = constructor_movn(ctx, pattern3_0, &expr0_0)?;
             return Some(expr1_0);
         }
-        // Rule at src/isa/aarch64/inst.isle line 1871.
+        // Rule at src/isa/aarch64/inst.isle line 1877.
         let expr0_0 = C::load_constant64_full(ctx, pattern2_0);
         return Some(expr0_0);
     }
@@ -2963,17 +2986,17 @@ pub fn constructor_put_in_reg_sext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I32 {
-        // Rule at src/isa/aarch64/inst.isle line 1882.
+        // Rule at src/isa/aarch64/inst.isle line 1888.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1883.
+        // Rule at src/isa/aarch64/inst.isle line 1889.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1878.
+        // Rule at src/isa/aarch64/inst.isle line 1884.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = true;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -2989,17 +3012,17 @@ pub fn constructor_put_in_reg_zext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I32 {
-        // Rule at src/isa/aarch64/inst.isle line 1891.
+        // Rule at src/isa/aarch64/inst.isle line 1897.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1892.
+        // Rule at src/isa/aarch64/inst.isle line 1898.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1887.
+        // Rule at src/isa/aarch64/inst.isle line 1893.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = false;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -3015,12 +3038,12 @@ pub fn constructor_put_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1900.
+        // Rule at src/isa/aarch64/inst.isle line 1906.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1896.
+        // Rule at src/isa/aarch64/inst.isle line 1902.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = true;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -3036,12 +3059,12 @@ pub fn constructor_put_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1908.
+        // Rule at src/isa/aarch64/inst.isle line 1914.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1904.
+        // Rule at src/isa/aarch64/inst.isle line 1910.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = false;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -3055,7 +3078,7 @@ pub fn constructor_put_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
 // Generated as internal constructor for term trap_if_zero_divisor.
 pub fn constructor_trap_if_zero_divisor<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1913.
+    // Rule at src/isa/aarch64/inst.isle line 1919.
     let expr0_0 = C::cond_br_zero(ctx, pattern0_0);
     let expr1_0 = C::trap_code_division_by_zero(ctx);
     let expr2_0 = MInst::TrapIf {
@@ -3070,12 +3093,12 @@ pub fn constructor_trap_if_zero_divisor<C: Context>(ctx: &mut C, arg0: Reg) -> O
 pub fn constructor_size_from_ty<C: Context>(ctx: &mut C, arg0: Type) -> Option<OperandSize> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1919.
+        // Rule at src/isa/aarch64/inst.isle line 1925.
         let expr0_0 = OperandSize::Size64;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::fits_in_32(ctx, pattern0_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1918.
+        // Rule at src/isa/aarch64/inst.isle line 1924.
         let expr0_0 = OperandSize::Size32;
         return Some(expr0_0);
     }
@@ -3092,7 +3115,7 @@ pub fn constructor_trap_if_div_overflow<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1925.
+    // Rule at src/isa/aarch64/inst.isle line 1931.
     let expr0_0 = ALUOp::AddS;
     let expr1_0 = constructor_operand_size(ctx, pattern0_0)?;
     let expr2_0 = C::writable_zero_reg(ctx);
@@ -3152,7 +3175,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                 opcode: ref pattern5_0,
                 imm: pattern5_1,
             } => {
-                if let &Opcode::Iconst = &pattern5_0 {
+                if let &Opcode::Iconst = pattern5_0 {
                     let closure7 = || {
                         return Some(pattern1_0);
                     };
@@ -3161,7 +3184,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                             C::imm_logic_from_imm64(ctx, pattern5_1, pattern7_0)
                         {
                             let pattern9_0 = arg3;
-                            // Rule at src/isa/aarch64/inst.isle line 1970.
+                            // Rule at src/isa/aarch64/inst.isle line 1976.
                             let expr0_0 = C::put_in_reg(ctx, pattern9_0);
                             let expr1_0 = constructor_alu_rr_imm_logic(
                                 ctx, pattern0_0, pattern1_0, expr0_0, pattern8_0,
@@ -3175,8 +3198,8 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                 opcode: ref pattern5_0,
                 args: ref pattern5_1,
             } => {
-                if let &Opcode::Ishl = &pattern5_0 {
-                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                if let &Opcode::Ishl = pattern5_0 {
+                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                     if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                         let pattern9_0 = C::inst_data(ctx, pattern8_0);
                         if let &InstructionData::UnaryImm {
@@ -3184,7 +3207,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                             imm: pattern10_1,
                         } = &pattern9_0
                         {
-                            if let &Opcode::Iconst = &pattern10_0 {
+                            if let &Opcode::Iconst = pattern10_0 {
                                 let closure12 = || {
                                     return Some(pattern1_0);
                                 };
@@ -3193,7 +3216,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                                         C::lshl_from_imm64(ctx, pattern10_1, pattern12_0)
                                     {
                                         let pattern14_0 = arg3;
-                                        // Rule at src/isa/aarch64/inst.isle line 1976.
+                                        // Rule at src/isa/aarch64/inst.isle line 1982.
                                         let expr0_0 = C::put_in_reg(ctx, pattern14_0);
                                         let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                         let expr2_0 = constructor_alu_rrr_shift(
@@ -3223,7 +3246,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                 opcode: ref pattern6_0,
                 imm: pattern6_1,
             } => {
-                if let &Opcode::Iconst = &pattern6_0 {
+                if let &Opcode::Iconst = pattern6_0 {
                     let closure8 = || {
                         return Some(pattern1_0);
                     };
@@ -3231,7 +3254,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                         if let Some(pattern9_0) =
                             C::imm_logic_from_imm64(ctx, pattern6_1, pattern8_0)
                         {
-                            // Rule at src/isa/aarch64/inst.isle line 1968.
+                            // Rule at src/isa/aarch64/inst.isle line 1974.
                             let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                             let expr1_0 = constructor_alu_rr_imm_logic(
                                 ctx, pattern0_0, pattern1_0, expr0_0, pattern9_0,
@@ -3245,8 +3268,8 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                 opcode: ref pattern6_0,
                 args: ref pattern6_1,
             } => {
-                if let &Opcode::Ishl = &pattern6_0 {
-                    let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, &pattern6_1);
+                if let &Opcode::Ishl = pattern6_0 {
+                    let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, pattern6_1);
                     if let Some(pattern9_0) = C::def_inst(ctx, pattern8_1) {
                         let pattern10_0 = C::inst_data(ctx, pattern9_0);
                         if let &InstructionData::UnaryImm {
@@ -3254,7 +3277,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                             imm: pattern11_1,
                         } = &pattern10_0
                         {
-                            if let &Opcode::Iconst = &pattern11_0 {
+                            if let &Opcode::Iconst = pattern11_0 {
                                 let closure13 = || {
                                     return Some(pattern1_0);
                                 };
@@ -3262,7 +3285,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                                     if let Some(pattern14_0) =
                                         C::lshl_from_imm64(ctx, pattern11_1, pattern13_0)
                                     {
-                                        // Rule at src/isa/aarch64/inst.isle line 1974.
+                                        // Rule at src/isa/aarch64/inst.isle line 1980.
                                         let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                                         let expr1_0 = C::put_in_reg(ctx, pattern8_0);
                                         let expr2_0 = constructor_alu_rrr_shift(
@@ -3284,7 +3307,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
             _ => {}
         }
     }
-    // Rule at src/isa/aarch64/inst.isle line 1964.
+    // Rule at src/isa/aarch64/inst.isle line 1970.
     let expr0_0 = C::put_in_reg(ctx, pattern2_0);
     let expr1_0 = C::put_in_reg(ctx, pattern3_0);
     let expr2_0 = constructor_alu_rrr(ctx, pattern0_0, pattern1_0, expr0_0, expr1_0)?;
@@ -3310,7 +3333,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
                 opcode: ref pattern6_0,
                 imm: pattern6_1,
             } => {
-                if let &Opcode::Iconst = &pattern6_0 {
+                if let &Opcode::Iconst = pattern6_0 {
                     let closure8 = || {
                         return Some(pattern1_0);
                     };
@@ -3318,7 +3341,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
                         if let Some(pattern9_0) =
                             C::imm_logic_from_imm64(ctx, pattern6_1, pattern8_0)
                         {
-                            // Rule at src/isa/aarch64/inst.isle line 1984.
+                            // Rule at src/isa/aarch64/inst.isle line 1990.
                             let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                             let expr1_0 = constructor_alu_rr_imm_logic(
                                 ctx, pattern0_0, pattern1_0, expr0_0, pattern9_0,
@@ -3332,8 +3355,8 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
                 opcode: ref pattern6_0,
                 args: ref pattern6_1,
             } => {
-                if let &Opcode::Ishl = &pattern6_0 {
-                    let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, &pattern6_1);
+                if let &Opcode::Ishl = pattern6_0 {
+                    let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, pattern6_1);
                     if let Some(pattern9_0) = C::def_inst(ctx, pattern8_1) {
                         let pattern10_0 = C::inst_data(ctx, pattern9_0);
                         if let &InstructionData::UnaryImm {
@@ -3341,7 +3364,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
                             imm: pattern11_1,
                         } = &pattern10_0
                         {
-                            if let &Opcode::Iconst = &pattern11_0 {
+                            if let &Opcode::Iconst = pattern11_0 {
                                 let closure13 = || {
                                     return Some(pattern1_0);
                                 };
@@ -3349,7 +3372,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
                                     if let Some(pattern14_0) =
                                         C::lshl_from_imm64(ctx, pattern11_1, pattern13_0)
                                     {
-                                        // Rule at src/isa/aarch64/inst.isle line 1986.
+                                        // Rule at src/isa/aarch64/inst.isle line 1992.
                                         let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                                         let expr1_0 = C::put_in_reg(ctx, pattern8_0);
                                         let expr2_0 = constructor_alu_rrr_shift(
@@ -3371,7 +3394,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
             _ => {}
         }
     }
-    // Rule at src/isa/aarch64/inst.isle line 1982.
+    // Rule at src/isa/aarch64/inst.isle line 1988.
     let expr0_0 = C::put_in_reg(ctx, pattern2_0);
     let expr1_0 = C::put_in_reg(ctx, pattern3_0);
     let expr2_0 = constructor_alu_rrr(ctx, pattern0_0, pattern1_0, expr0_0, expr1_0)?;
@@ -3390,7 +3413,7 @@ pub fn constructor_i128_alu_bitop<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1994.
+    // Rule at src/isa/aarch64/inst.isle line 2000.
     let expr0_0 = C::put_in_regs(ctx, pattern2_0);
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -3419,9 +3442,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 arg: pattern5_1,
             } = &pattern4_0
             {
-                match &pattern5_0 {
+                match pattern5_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 1013.
+                        // Rule at src/isa/aarch64/lower.isle line 1016.
                         let expr0_0: Type = I32;
                         let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr2_0 = constructor_rbit32(ctx, expr1_0)?;
@@ -3432,7 +3455,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr6_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1038.
+                        // Rule at src/isa/aarch64/lower.isle line 1041.
                         let expr0_0: Type = I32;
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
                         let expr2_0 = constructor_clz32(ctx, expr1_0)?;
@@ -3443,7 +3466,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr6_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1095.
+                        // Rule at src/isa/aarch64/lower.isle line 1098.
                         let expr0_0: Type = I32;
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
                         let expr2_0 = constructor_cls32(ctx, expr1_0)?;
@@ -3454,7 +3477,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr6_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1073.
+                        // Rule at src/isa/aarch64/lower.isle line 1076.
                         let expr0_0: Type = I32;
                         let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr2_0 = constructor_rbit32(ctx, expr1_0)?;
@@ -3467,7 +3490,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr8_0);
                     }
                     &Opcode::Popcnt => {
-                        // Rule at src/isa/aarch64/lower.isle line 1152.
+                        // Rule at src/isa/aarch64/lower.isle line 1155.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3490,9 +3513,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 arg: pattern5_1,
             } = &pattern4_0
             {
-                match &pattern5_0 {
+                match pattern5_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 1019.
+                        // Rule at src/isa/aarch64/lower.isle line 1022.
                         let expr0_0: Type = I32;
                         let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr2_0 = constructor_rbit32(ctx, expr1_0)?;
@@ -3503,7 +3526,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr6_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1041.
+                        // Rule at src/isa/aarch64/lower.isle line 1044.
                         let expr0_0: Type = I32;
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
                         let expr2_0 = constructor_clz32(ctx, expr1_0)?;
@@ -3514,7 +3537,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr6_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1098.
+                        // Rule at src/isa/aarch64/lower.isle line 1101.
                         let expr0_0: Type = I32;
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
                         let expr2_0 = constructor_cls32(ctx, expr1_0)?;
@@ -3525,7 +3548,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr6_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1076.
+                        // Rule at src/isa/aarch64/lower.isle line 1079.
                         let expr0_0: Type = I32;
                         let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr2_0 = constructor_rbit32(ctx, expr1_0)?;
@@ -3538,7 +3561,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr8_0);
                     }
                     &Opcode::Popcnt => {
-                        // Rule at src/isa/aarch64/lower.isle line 1160.
+                        // Rule at src/isa/aarch64/lower.isle line 1163.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3563,10 +3586,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Rotl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                                 let pattern9_0 = C::inst_data(ctx, pattern8_0);
                                 if let &InstructionData::UnaryImm {
@@ -3574,7 +3596,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Iconst = &pattern10_0 {
+                                    if let &Opcode::Iconst = pattern10_0 {
                                         let closure12 = || {
                                             let expr0_0: Type = I32;
                                             return Some(expr0_0);
@@ -3585,7 +3607,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 896.
+                                                // Rule at src/isa/aarch64/lower.isle line 899.
                                                 let expr0_0: Type = I32;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0: Type = I32;
@@ -3601,7 +3623,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 886.
+                            // Rule at src/isa/aarch64/lower.isle line 889.
                             let expr0_0: Type = I32;
                             let expr1_0 = C::zero_reg(ctx);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3613,8 +3635,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr7_0);
                         }
                         &Opcode::Rotr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                                 let pattern9_0 = C::inst_data(ctx, pattern8_0);
                                 if let &InstructionData::UnaryImm {
@@ -3622,7 +3643,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Iconst = &pattern10_0 {
+                                    if let &Opcode::Iconst = pattern10_0 {
                                         let closure12 = || {
                                             let expr0_0: Type = I32;
                                             return Some(expr0_0);
@@ -3633,7 +3654,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 940.
+                                                // Rule at src/isa/aarch64/lower.isle line 943.
                                                 let expr0_0: Type = I32;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0 = constructor_a64_rotr_imm(
@@ -3649,7 +3670,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 928.
+                            // Rule at src/isa/aarch64/lower.isle line 931.
                             let expr0_0: Type = I32;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3664,30 +3685,30 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Bitrev => {
-                            // Rule at src/isa/aarch64/lower.isle line 1022.
+                            // Rule at src/isa/aarch64/lower.isle line 1025.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_rbit32(ctx, expr0_0)?;
                             let expr2_0 = C::value_reg(ctx, expr1_0);
                             return Some(expr2_0);
                         }
                         &Opcode::Clz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1044.
+                            // Rule at src/isa/aarch64/lower.isle line 1047.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_clz32(ctx, expr0_0)?;
                             let expr2_0 = C::value_reg(ctx, expr1_0);
                             return Some(expr2_0);
                         }
                         &Opcode::Cls => {
-                            // Rule at src/isa/aarch64/lower.isle line 1101.
+                            // Rule at src/isa/aarch64/lower.isle line 1104.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_cls32(ctx, expr0_0)?;
                             let expr2_0 = C::value_reg(ctx, expr1_0);
                             return Some(expr2_0);
                         }
                         &Opcode::Ctz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1079.
+                            // Rule at src/isa/aarch64/lower.isle line 1082.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_rbit32(ctx, expr0_0)?;
                             let expr2_0 = constructor_clz32(ctx, expr1_0)?;
@@ -3695,7 +3716,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Popcnt => {
-                            // Rule at src/isa/aarch64/lower.isle line 1168.
+                            // Rule at src/isa/aarch64/lower.isle line 1171.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = ScalarSize::Size32;
                             let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3723,10 +3744,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Umulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 374.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
@@ -3736,8 +3756,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Smulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 360.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
@@ -3747,8 +3766,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Band => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 609.
                             let expr0_0 = ALUOp::And;
                             let expr1_0: Type = I64;
@@ -3759,8 +3777,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Bor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 622.
                             let expr0_0 = ALUOp::Orr;
                             let expr1_0: Type = I64;
@@ -3771,8 +3788,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 635.
                             let expr0_0 = ALUOp::Eor;
                             let expr1_0: Type = I64;
@@ -3783,8 +3799,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::BandNot => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 648.
                             let expr0_0 = ALUOp::AndNot;
                             let expr1_0: Type = I64;
@@ -3795,8 +3810,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::BorNot => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 661.
                             let expr0_0 = ALUOp::OrrNot;
                             let expr1_0: Type = I64;
@@ -3807,8 +3821,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::BxorNot => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 671.
                             let expr0_0 = ALUOp::EorNot;
                             let expr1_0: Type = I64;
@@ -3819,8 +3832,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Rotl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                                 let pattern9_0 = C::inst_data(ctx, pattern8_0);
                                 if let &InstructionData::UnaryImm {
@@ -3828,7 +3840,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Iconst = &pattern10_0 {
+                                    if let &Opcode::Iconst = pattern10_0 {
                                         let closure12 = || {
                                             let expr0_0: Type = I64;
                                             return Some(expr0_0);
@@ -3839,7 +3851,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 900.
+                                                // Rule at src/isa/aarch64/lower.isle line 903.
                                                 let expr0_0: Type = I64;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0: Type = I64;
@@ -3855,7 +3867,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 891.
+                            // Rule at src/isa/aarch64/lower.isle line 894.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::zero_reg(ctx);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3867,8 +3879,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr7_0);
                         }
                         &Opcode::Rotr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                                 let pattern9_0 = C::inst_data(ctx, pattern8_0);
                                 if let &InstructionData::UnaryImm {
@@ -3876,7 +3887,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Iconst = &pattern10_0 {
+                                    if let &Opcode::Iconst = pattern10_0 {
                                         let closure12 = || {
                                             let expr0_0: Type = I64;
                                             return Some(expr0_0);
@@ -3887,7 +3898,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 944.
+                                                // Rule at src/isa/aarch64/lower.isle line 947.
                                                 let expr0_0: Type = I64;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0 = constructor_a64_rotr_imm(
@@ -3903,7 +3914,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 932.
+                            // Rule at src/isa/aarch64/lower.isle line 935.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3912,8 +3923,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Ishl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 683.
                             let expr0_0 = ALUOp::Lsl;
                             let expr1_0: Type = I64;
@@ -3924,9 +3934,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 771.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 772.
                             let expr0_0 = ALUOp::Lsr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
@@ -3936,9 +3945,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Sshr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 820.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 822.
                             let expr0_0 = ALUOp::Asr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
@@ -3954,30 +3962,30 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Bitrev => {
-                            // Rule at src/isa/aarch64/lower.isle line 1025.
+                            // Rule at src/isa/aarch64/lower.isle line 1028.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_rbit64(ctx, expr0_0)?;
                             let expr2_0 = C::value_reg(ctx, expr1_0);
                             return Some(expr2_0);
                         }
                         &Opcode::Clz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1047.
+                            // Rule at src/isa/aarch64/lower.isle line 1050.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_clz64(ctx, expr0_0)?;
                             let expr2_0 = C::value_reg(ctx, expr1_0);
                             return Some(expr2_0);
                         }
                         &Opcode::Cls => {
-                            // Rule at src/isa/aarch64/lower.isle line 1104.
+                            // Rule at src/isa/aarch64/lower.isle line 1107.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_cls64(ctx, expr0_0)?;
                             let expr2_0 = C::value_reg(ctx, expr1_0);
                             return Some(expr2_0);
                         }
                         &Opcode::Ctz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1082.
+                            // Rule at src/isa/aarch64/lower.isle line 1085.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_rbit64(ctx, expr0_0)?;
                             let expr2_0 = constructor_clz64(ctx, expr1_0)?;
@@ -3985,7 +3993,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Popcnt => {
-                            // Rule at src/isa/aarch64/lower.isle line 1176.
+                            // Rule at src/isa/aarch64/lower.isle line 1179.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = ScalarSize::Size64;
                             let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -4013,10 +4021,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Iadd => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 79.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
@@ -4030,15 +4037,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr9_0 = C::value_regs_get(ctx, expr5_0, expr8_0);
                             let expr10_0: Type = I64;
                             let expr11_0 =
-                                constructor_add_with_flags(ctx, expr10_0, expr2_0, expr7_0)?;
+                                constructor_add_with_flags_paired(ctx, expr10_0, expr2_0, expr7_0)?;
                             let expr12_0: Type = I64;
-                            let expr13_0 = constructor_adc(ctx, expr12_0, expr4_0, expr9_0)?;
+                            let expr13_0 = constructor_adc_paired(ctx, expr12_0, expr4_0, expr9_0)?;
                             let expr14_0 = constructor_with_flags(ctx, &expr11_0, &expr13_0)?;
                             return Some(expr14_0);
                         }
                         &Opcode::Isub => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 130.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
@@ -4052,15 +4058,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr9_0 = C::value_regs_get(ctx, expr5_0, expr8_0);
                             let expr10_0: Type = I64;
                             let expr11_0 =
-                                constructor_sub_with_flags(ctx, expr10_0, expr2_0, expr7_0)?;
+                                constructor_sub_with_flags_paired(ctx, expr10_0, expr2_0, expr7_0)?;
                             let expr12_0: Type = I64;
-                            let expr13_0 = constructor_sbc(ctx, expr12_0, expr4_0, expr9_0)?;
+                            let expr13_0 = constructor_sbc_paired(ctx, expr12_0, expr4_0, expr9_0)?;
                             let expr14_0 = constructor_with_flags(ctx, &expr11_0, &expr13_0)?;
                             return Some(expr14_0);
                         }
                         &Opcode::Imul => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 185.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
@@ -4082,8 +4087,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr16_0);
                         }
                         &Opcode::Band => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 612.
                             let expr0_0 = ALUOp::And;
                             let expr1_0: Type = I64;
@@ -4093,8 +4097,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr2_0);
                         }
                         &Opcode::Bor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 625.
                             let expr0_0 = ALUOp::Orr;
                             let expr1_0: Type = I64;
@@ -4104,8 +4107,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr2_0);
                         }
                         &Opcode::Bxor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 638.
                             let expr0_0 = ALUOp::Eor;
                             let expr1_0: Type = I64;
@@ -4115,8 +4117,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr2_0);
                         }
                         &Opcode::BandNot => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 651.
                             let expr0_0 = ALUOp::AndNot;
                             let expr1_0: Type = I64;
@@ -4126,8 +4127,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr2_0);
                         }
                         &Opcode::BorNot => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 664.
                             let expr0_0 = ALUOp::OrrNot;
                             let expr1_0: Type = I64;
@@ -4137,8 +4137,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr2_0);
                         }
                         &Opcode::BxorNot => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 674.
                             let expr0_0 = ALUOp::EorNot;
                             let expr1_0: Type = I64;
@@ -4148,9 +4147,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr2_0);
                         }
                         &Opcode::Rotl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 909.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 912.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4178,9 +4176,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr23_0);
                         }
                         &Opcode::Rotr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 996.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 999.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4208,8 +4205,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr23_0);
                         }
                         &Opcode::Ishl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 687.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
@@ -4219,9 +4215,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 775.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 776.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4230,9 +4225,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Sshr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 824.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 826.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4247,7 +4241,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Bnot => {
                             // Rule at src/isa/aarch64/lower.isle line 590.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
@@ -4265,7 +4259,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr11_0);
                         }
                         &Opcode::Bitrev => {
-                            // Rule at src/isa/aarch64/lower.isle line 1028.
+                            // Rule at src/isa/aarch64/lower.isle line 1031.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4277,13 +4271,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr7_0);
                         }
                         &Opcode::Clz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1050.
+                            // Rule at src/isa/aarch64/lower.isle line 1053.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0 = constructor_lower_clz128(ctx, expr0_0)?;
                             return Some(expr1_0);
                         }
                         &Opcode::Cls => {
-                            // Rule at src/isa/aarch64/lower.isle line 1116.
+                            // Rule at src/isa/aarch64/lower.isle line 1119.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4304,7 +4298,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr17_0 = Cond::Eq;
                             let expr18_0 = C::zero_reg(ctx);
                             let expr19_0 = constructor_csel(ctx, &expr17_0, expr13_0, expr18_0)?;
-                            let expr20_0 = constructor_with_flags_1(ctx, &expr16_0, &expr19_0)?;
+                            let expr20_0 = constructor_with_flags_reg(ctx, &expr16_0, &expr19_0)?;
                             let expr21_0: Type = I64;
                             let expr22_0 = constructor_add(ctx, expr21_0, expr20_0, expr6_0)?;
                             let expr23_0: Type = I64;
@@ -4314,7 +4308,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr26_0);
                         }
                         &Opcode::Ctz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1085.
+                            // Rule at src/isa/aarch64/lower.isle line 1088.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4327,7 +4321,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr8_0);
                         }
                         &Opcode::Popcnt => {
-                            // Rule at src/isa/aarch64/lower.isle line 1184.
+                            // Rule at src/isa/aarch64/lower.isle line 1187.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4362,7 +4356,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern9_2,
                                 } = &pattern8_0
                                 {
-                                    if let &Opcode::Extractlane = &pattern9_0 {
+                                    if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
                                         // Rule at src/isa/aarch64/lower.isle line 514.
@@ -4399,7 +4393,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern9_2,
                                 } = &pattern8_0
                                 {
-                                    if let &Opcode::Extractlane = &pattern9_0 {
+                                    if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         if pattern11_0 == I64X2 {
                                             let pattern13_0 = C::u8_from_uimm8(ctx, pattern9_2);
@@ -4470,8 +4464,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 arg: pattern5_1,
             } = &pattern4_0
             {
-                if let &Opcode::Popcnt = &pattern5_0 {
-                    // Rule at src/isa/aarch64/lower.isle line 1194.
+                if let &Opcode::Popcnt = pattern5_0 {
+                    // Rule at src/isa/aarch64/lower.isle line 1197.
                     let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                     let expr1_0 = VectorSize::Size8x16;
                     let expr2_0 = constructor_vec_cnt(ctx, expr0_0, &expr1_0)?;
@@ -4487,8 +4481,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern5_1,
             } = &pattern4_0
             {
-                if let &Opcode::Imul = &pattern5_0 {
-                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                if let &Opcode::Imul = pattern5_0 {
+                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                     if let Some(pattern8_0) = C::def_inst(ctx, pattern7_0) {
                         let pattern9_0 = C::inst_data(ctx, pattern8_0);
                         if let &InstructionData::Unary {
@@ -4496,7 +4490,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             arg: pattern10_1,
                         } = &pattern9_0
                         {
-                            match &pattern10_0 {
+                            match pattern10_0 {
                                 &Opcode::SwidenLow => {
                                     let pattern12_0 = C::value_type(ctx, pattern10_1);
                                     if pattern12_0 == I8X16 {
@@ -4507,7 +4501,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::SwidenLow = &pattern16_0 {
+                                                if let &Opcode::SwidenLow = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
@@ -4538,7 +4532,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::SwidenHigh = &pattern16_0 {
+                                                if let &Opcode::SwidenHigh = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
@@ -4569,7 +4563,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::UwidenLow = &pattern16_0 {
+                                                if let &Opcode::UwidenLow = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
@@ -4600,7 +4594,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::UwidenHigh = &pattern16_0 {
+                                                if let &Opcode::UwidenHigh = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
@@ -4635,8 +4629,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern5_1,
             } = &pattern4_0
             {
-                if let &Opcode::Imul = &pattern5_0 {
-                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                if let &Opcode::Imul = pattern5_0 {
+                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                     if let Some(pattern8_0) = C::def_inst(ctx, pattern7_0) {
                         let pattern9_0 = C::inst_data(ctx, pattern8_0);
                         if let &InstructionData::Unary {
@@ -4644,7 +4638,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             arg: pattern10_1,
                         } = &pattern9_0
                         {
-                            match &pattern10_0 {
+                            match pattern10_0 {
                                 &Opcode::SwidenLow => {
                                     let pattern12_0 = C::value_type(ctx, pattern10_1);
                                     if pattern12_0 == I16X8 {
@@ -4655,7 +4649,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::SwidenLow = &pattern16_0 {
+                                                if let &Opcode::SwidenLow = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
@@ -4686,7 +4680,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::SwidenHigh = &pattern16_0 {
+                                                if let &Opcode::SwidenHigh = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
@@ -4717,7 +4711,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::UwidenLow = &pattern16_0 {
+                                                if let &Opcode::UwidenLow = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
@@ -4748,7 +4742,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::UwidenHigh = &pattern16_0 {
+                                                if let &Opcode::UwidenHigh = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
@@ -4783,8 +4777,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern5_1,
             } = &pattern4_0
             {
-                if let &Opcode::Imul = &pattern5_0 {
-                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                if let &Opcode::Imul = pattern5_0 {
+                    let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                     if let Some(pattern8_0) = C::def_inst(ctx, pattern7_0) {
                         let pattern9_0 = C::inst_data(ctx, pattern8_0);
                         if let &InstructionData::Unary {
@@ -4792,7 +4786,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             arg: pattern10_1,
                         } = &pattern9_0
                         {
-                            match &pattern10_0 {
+                            match pattern10_0 {
                                 &Opcode::SwidenLow => {
                                     let pattern12_0 = C::value_type(ctx, pattern10_1);
                                     if pattern12_0 == I32X4 {
@@ -4803,7 +4797,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::SwidenLow = &pattern16_0 {
+                                                if let &Opcode::SwidenLow = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
@@ -4834,7 +4828,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::SwidenHigh = &pattern16_0 {
+                                                if let &Opcode::SwidenHigh = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
@@ -4865,7 +4859,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::UwidenLow = &pattern16_0 {
+                                                if let &Opcode::UwidenLow = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
@@ -4896,7 +4890,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 arg: pattern16_1,
                                             } = &pattern15_0
                                             {
-                                                if let &Opcode::UwidenHigh = &pattern16_0 {
+                                                if let &Opcode::UwidenHigh = pattern16_0 {
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
@@ -4948,7 +4942,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             &InstructionData::NullAry {
                 opcode: ref pattern4_0,
             } => {
-                if let &Opcode::Null = &pattern4_0 {
+                if let &Opcode::Null = pattern4_0 {
                     // Rule at src/isa/aarch64/lower.isle line 22.
                     let expr0_0: u64 = 0;
                     let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
@@ -4960,7 +4954,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 opcode: ref pattern4_0,
                 imm: pattern4_1,
             } => {
-                if let &Opcode::Iconst = &pattern4_0 {
+                if let &Opcode::Iconst = pattern4_0 {
                     let pattern6_0 = C::u64_from_imm64(ctx, pattern4_1);
                     // Rule at src/isa/aarch64/lower.isle line 9.
                     let expr0_0 = constructor_imm(ctx, pattern2_0, pattern6_0)?;
@@ -4972,7 +4966,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 opcode: ref pattern4_0,
                 imm: pattern4_1,
             } => {
-                if let &Opcode::Bconst = &pattern4_0 {
+                if let &Opcode::Bconst = pattern4_0 {
                     if pattern4_1 == true {
                         // Rule at src/isa/aarch64/lower.isle line 17.
                         let expr0_0: u64 = 1;
@@ -4998,9 +4992,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern5_1,
             } = &pattern4_0
             {
-                match &pattern5_0 {
+                match pattern5_0 {
                     &Opcode::Iadd => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 75.
                         let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5010,7 +5004,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr4_0);
                     }
                     &Opcode::Isub => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 126.
                         let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5030,9 +5024,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern5_1,
             } = &pattern4_0
             {
-                match &pattern5_0 {
+                match pattern5_0 {
                     &Opcode::Rotl => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                             let pattern9_0 = C::inst_data(ctx, pattern8_0);
                             if let &InstructionData::UnaryImm {
@@ -5040,7 +5034,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 imm: pattern10_1,
                             } = &pattern9_0
                             {
-                                if let &Opcode::Iconst = &pattern10_0 {
+                                if let &Opcode::Iconst = pattern10_0 {
                                     let closure12 = || {
                                         return Some(pattern3_0);
                                     };
@@ -5048,7 +5042,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         if let Some(pattern13_0) =
                                             C::imm_shift_from_imm64(ctx, pattern10_1, pattern12_0)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 874.
+                                            // Rule at src/isa/aarch64/lower.isle line 877.
                                             let expr0_0 =
                                                 constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                                             let expr1_0 =
@@ -5063,7 +5057,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/aarch64/lower.isle line 869.
+                        // Rule at src/isa/aarch64/lower.isle line 872.
                         let expr0_0: Type = I32;
                         let expr1_0 = C::zero_reg(ctx);
                         let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5074,7 +5068,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr6_0);
                     }
                     &Opcode::Rotr => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                             let pattern9_0 = C::inst_data(ctx, pattern8_0);
                             if let &InstructionData::UnaryImm {
@@ -5082,7 +5076,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 imm: pattern10_1,
                             } = &pattern9_0
                             {
-                                if let &Opcode::Iconst = &pattern10_0 {
+                                if let &Opcode::Iconst = pattern10_0 {
                                     let closure12 = || {
                                         return Some(pattern3_0);
                                     };
@@ -5090,7 +5084,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         if let Some(pattern13_0) =
                                             C::imm_shift_from_imm64(ctx, pattern10_1, pattern12_0)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 936.
+                                            // Rule at src/isa/aarch64/lower.isle line 939.
                                             let expr0_0 =
                                                 constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                                             let expr1_0 = constructor_small_rotr_imm(
@@ -5106,7 +5100,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/aarch64/lower.isle line 924.
+                        // Rule at src/isa/aarch64/lower.isle line 927.
                         let expr0_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr2_0 = constructor_small_rotr(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -5124,9 +5118,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern5_1,
             } = &pattern4_0
             {
-                match &pattern5_0 {
+                match pattern5_0 {
                     &Opcode::Umulhi => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 377.
                         let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_1)?;
@@ -5140,7 +5134,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr8_0);
                     }
                     &Opcode::Smulhi => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 363.
                         let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_reg_sext64(ctx, pattern7_1)?;
@@ -5154,7 +5148,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr8_0);
                     }
                     &Opcode::Band => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 606.
                         let expr0_0 = ALUOp::And;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
@@ -5164,7 +5158,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr2_0);
                     }
                     &Opcode::Bor => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 619.
                         let expr0_0 = ALUOp::Orr;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
@@ -5174,7 +5168,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr2_0);
                     }
                     &Opcode::Bxor => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 632.
                         let expr0_0 = ALUOp::Eor;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
@@ -5184,7 +5178,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr2_0);
                     }
                     &Opcode::BandNot => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 645.
                         let expr0_0 = ALUOp::AndNot;
                         let expr1_0 = constructor_alu_rs_imm_logic(
@@ -5194,7 +5188,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr2_0);
                     }
                     &Opcode::BorNot => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 658.
                         let expr0_0 = ALUOp::OrrNot;
                         let expr1_0 = constructor_alu_rs_imm_logic(
@@ -5204,7 +5198,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr2_0);
                     }
                     &Opcode::BxorNot => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 668.
                         let expr0_0 = ALUOp::EorNot;
                         let expr1_0: Type = I32;
@@ -5215,7 +5209,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Ishl => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/aarch64/lower.isle line 679.
                         let expr0_0 = ALUOp::Lsl;
                         let expr1_0 = C::put_in_reg(ctx, pattern7_0);
@@ -5225,8 +5219,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Ushr => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 767.
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                        // Rule at src/isa/aarch64/lower.isle line 768.
                         let expr0_0 = ALUOp::Lsr;
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr2_0 =
@@ -5235,8 +5229,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Sshr => {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 816.
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                        // Rule at src/isa/aarch64/lower.isle line 818.
                         let expr0_0 = ALUOp::Asr;
                         let expr1_0 = constructor_put_in_reg_sext32(ctx, pattern7_0)?;
                         let expr2_0 =
@@ -5255,10 +5249,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Iadd => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_0) {
                                 let pattern9_0 = C::inst_data(ctx, pattern8_0);
                                 match &pattern9_0 {
@@ -5266,7 +5259,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         opcode: ref pattern10_0,
                                         imm: pattern10_1,
                                     } => {
-                                        if let &Opcode::Iconst = &pattern10_0 {
+                                        if let &Opcode::Iconst = pattern10_0 {
                                             let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
                                             if let Some(pattern13_0) =
                                                 C::imm12_from_u64(ctx, pattern12_0)
@@ -5302,10 +5295,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         opcode: ref pattern10_0,
                                         args: ref pattern10_1,
                                     } => {
-                                        match &pattern10_0 {
+                                        match pattern10_0 {
                                             &Opcode::Imul => {
                                                 let (pattern12_0, pattern12_1) =
-                                                    C::unpack_value_array_2(ctx, &pattern10_1);
+                                                    C::unpack_value_array_2(ctx, pattern10_1);
                                                 // Rule at src/isa/aarch64/lower.isle line 70.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern12_0);
                                                 let expr1_0 = C::put_in_reg(ctx, pattern12_1);
@@ -5318,7 +5311,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             }
                                             &Opcode::Ishl => {
                                                 let (pattern12_0, pattern12_1) =
-                                                    C::unpack_value_array_2(ctx, &pattern10_1);
+                                                    C::unpack_value_array_2(ctx, pattern10_1);
                                                 if let Some(pattern13_0) =
                                                     C::def_inst(ctx, pattern12_1)
                                                 {
@@ -5329,7 +5322,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         imm: pattern15_1,
                                                     } = &pattern14_0
                                                     {
-                                                        if let &Opcode::Iconst = &pattern15_0 {
+                                                        if let &Opcode::Iconst = pattern15_0 {
                                                             let closure17 = || {
                                                                 return Some(pattern3_0);
                                                             };
@@ -5388,7 +5381,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         opcode: ref pattern10_0,
                                         imm: pattern10_1,
                                     } => {
-                                        if let &Opcode::Iconst = &pattern10_0 {
+                                        if let &Opcode::Iconst = pattern10_0 {
                                             let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
                                             if let Some(pattern13_0) =
                                                 C::imm12_from_u64(ctx, pattern12_0)
@@ -5424,10 +5417,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         opcode: ref pattern10_0,
                                         args: ref pattern10_1,
                                     } => {
-                                        match &pattern10_0 {
+                                        match pattern10_0 {
                                             &Opcode::Imul => {
                                                 let (pattern12_0, pattern12_1) =
-                                                    C::unpack_value_array_2(ctx, &pattern10_1);
+                                                    C::unpack_value_array_2(ctx, pattern10_1);
                                                 // Rule at src/isa/aarch64/lower.isle line 67.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern12_0);
                                                 let expr1_0 = C::put_in_reg(ctx, pattern12_1);
@@ -5440,7 +5433,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             }
                                             &Opcode::Ishl => {
                                                 let (pattern12_0, pattern12_1) =
-                                                    C::unpack_value_array_2(ctx, &pattern10_1);
+                                                    C::unpack_value_array_2(ctx, pattern10_1);
                                                 if let Some(pattern13_0) =
                                                     C::def_inst(ctx, pattern12_1)
                                                 {
@@ -5451,7 +5444,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         imm: pattern15_1,
                                                     } = &pattern14_0
                                                     {
-                                                        if let &Opcode::Iconst = &pattern15_0 {
+                                                        if let &Opcode::Iconst = pattern15_0 {
                                                             let closure17 = || {
                                                                 return Some(pattern3_0);
                                                             };
@@ -5511,8 +5504,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Isub => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                                 let pattern9_0 = C::inst_data(ctx, pattern8_0);
                                 match &pattern9_0 {
@@ -5520,7 +5512,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         opcode: ref pattern10_0,
                                         imm: pattern10_1,
                                     } => {
-                                        if let &Opcode::Iconst = &pattern10_0 {
+                                        if let &Opcode::Iconst = pattern10_0 {
                                             let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
                                             if let Some(pattern13_0) =
                                                 C::imm12_from_u64(ctx, pattern12_0)
@@ -5556,9 +5548,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         opcode: ref pattern10_0,
                                         args: ref pattern10_1,
                                     } => {
-                                        if let &Opcode::Ishl = &pattern10_0 {
+                                        if let &Opcode::Ishl = pattern10_0 {
                                             let (pattern12_0, pattern12_1) =
-                                                C::unpack_value_array_2(ctx, &pattern10_1);
+                                                C::unpack_value_array_2(ctx, pattern10_1);
                                             if let Some(pattern13_0) = C::def_inst(ctx, pattern12_1)
                                             {
                                                 let pattern14_0 = C::inst_data(ctx, pattern13_0);
@@ -5567,7 +5559,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     imm: pattern15_1,
                                                 } = &pattern14_0
                                                 {
-                                                    if let &Opcode::Iconst = &pattern15_0 {
+                                                    if let &Opcode::Iconst = pattern15_0 {
                                                         let closure17 = || {
                                                             return Some(pattern3_0);
                                                         };
@@ -5622,8 +5614,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Imul => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 181.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5634,8 +5625,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Udiv => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 393.
                             let expr0_0: Type = I64;
                             let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
@@ -5645,8 +5635,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Sdiv => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
                                 let pattern9_0 = C::inst_data(ctx, pattern8_0);
                                 if let &InstructionData::UnaryImm {
@@ -5654,7 +5643,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Iconst = &pattern10_0 {
+                                    if let &Opcode::Iconst = pattern10_0 {
                                         if let Some(pattern12_0) =
                                             C::safe_divisor_from_imm64(ctx, pattern10_1)
                                         {
@@ -5685,8 +5674,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr5_0);
                         }
                         &Opcode::Urem => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 469.
                             let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_zext64(ctx, pattern7_1)?;
@@ -5697,8 +5685,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr5_0);
                         }
                         &Opcode::Srem => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 478.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_sext64(ctx, pattern7_1)?;
@@ -5715,7 +5702,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Ineg => {
                             // Rule at src/isa/aarch64/lower.isle line 171.
                             let expr0_0 = C::zero_reg(ctx);
@@ -5732,9 +5719,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     args: ref pattern9_1,
                                 } = &pattern8_0
                                 {
-                                    if let &Opcode::Ishl = &pattern9_0 {
+                                    if let &Opcode::Ishl = pattern9_0 {
                                         let (pattern11_0, pattern11_1) =
-                                            C::unpack_value_array_2(ctx, &pattern9_1);
+                                            C::unpack_value_array_2(ctx, pattern9_1);
                                         if let Some(pattern12_0) = C::def_inst(ctx, pattern11_1) {
                                             let pattern13_0 = C::inst_data(ctx, pattern12_0);
                                             if let &InstructionData::UnaryImm {
@@ -5742,7 +5729,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 imm: pattern14_1,
                                             } = &pattern13_0
                                             {
-                                                if let &Opcode::Iconst = &pattern14_0 {
+                                                if let &Opcode::Iconst = pattern14_0 {
                                                     let closure16 = || {
                                                         return Some(pattern3_0);
                                                     };
@@ -5793,7 +5780,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern9_2,
                                 } = &pattern8_0
                                 {
-                                    if let &Opcode::Extractlane = &pattern9_0 {
+                                    if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
                                         // Rule at src/isa/aarch64/lower.isle line 496.
@@ -5837,7 +5824,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     imm: pattern9_2,
                                 } = &pattern8_0
                                 {
-                                    if let &Opcode::Extractlane = &pattern9_0 {
+                                    if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
                                         // Rule at src/isa/aarch64/lower.isle line 528.
@@ -5880,10 +5867,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::UaddSat => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 150.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5893,8 +5879,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::SaddSat => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 155.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5904,8 +5889,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::UsubSat => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 160.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5915,8 +5899,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::SsubSat => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 165.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5926,8 +5909,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Band => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 614.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5937,8 +5919,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Bor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 627.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5948,8 +5929,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Bxor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 640.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5959,8 +5939,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::BandNot => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/aarch64/lower.isle line 653.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5970,9 +5949,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Ishl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 717.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 718.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vec_dup(ctx, expr1_0, &expr0_0)?;
@@ -5982,9 +5960,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr5_0);
                         }
                         &Opcode::Ushr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 779.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 780.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0: Type = I32;
                             let expr2_0 = C::zero_reg(ctx);
@@ -5997,9 +5974,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr8_0);
                         }
                         &Opcode::Sshr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 830.
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
+                            // Rule at src/isa/aarch64/lower.isle line 832.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0: Type = I32;
                             let expr2_0 = C::zero_reg(ctx);
@@ -6018,7 +5994,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Ineg => {
                             // Rule at src/isa/aarch64/lower.isle line 175.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
@@ -6047,8 +6023,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     args: ref pattern6_1,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Imul = &pattern6_0 {
-                        let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, &pattern6_1);
+                    if let &Opcode::Imul = pattern6_0 {
+                        let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, pattern6_1);
                         // Rule at src/isa/aarch64/lower.isle line 214.
                         let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -6075,7 +6051,7 @@ pub fn constructor_put_nonzero_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Valu
             imm: pattern4_1,
         } = &pattern3_0
         {
-            if let &Opcode::Iconst = &pattern4_0 {
+            if let &Opcode::Iconst = pattern4_0 {
                 if let Some(pattern6_0) = C::nonzero_u64_from_imm64(ctx, pattern4_1) {
                     // Rule at src/isa/aarch64/lower.isle line 403.
                     let expr0_0 = constructor_imm(ctx, pattern1_0, pattern6_0)?;
@@ -6101,7 +6077,7 @@ pub fn constructor_put_nonzero_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Valu
             imm: pattern4_1,
         } = &pattern3_0
         {
-            if let &Opcode::Iconst = &pattern4_0 {
+            if let &Opcode::Iconst = pattern4_0 {
                 if let Some(pattern6_0) = C::nonzero_u64_from_imm64(ctx, pattern4_1) {
                     // Rule at src/isa/aarch64/lower.isle line 451.
                     let expr0_0 = constructor_imm(ctx, pattern1_0, pattern6_0)?;
@@ -6154,8 +6130,9 @@ pub fn constructor_lower_shl128<C: Context>(
     let expr26_0 = constructor_csel(ctx, &expr24_0, expr25_0, expr5_0)?;
     let expr27_0 = Cond::Ne;
     let expr28_0 = constructor_csel(ctx, &expr27_0, expr5_0, expr18_0)?;
-    let expr29_0 = constructor_with_flags_2(ctx, &expr23_0, &expr26_0, &expr28_0)?;
-    return Some(expr29_0);
+    let expr29_0 = constructor_consumes_flags_concat(ctx, &expr26_0, &expr28_0)?;
+    let expr30_0 = constructor_with_flags(ctx, &expr23_0, &expr29_0)?;
+    return Some(expr30_0);
 }
 
 // Generated as internal constructor for term do_shift.
@@ -6177,13 +6154,13 @@ pub fn constructor_do_shift<C: Context>(
             imm: pattern6_1,
         } = &pattern5_0
         {
-            if let &Opcode::Iconst = &pattern6_0 {
+            if let &Opcode::Iconst = pattern6_0 {
                 let closure8 = || {
                     return Some(pattern1_0);
                 };
                 if let Some(pattern8_0) = closure8() {
                     if let Some(pattern9_0) = C::imm_shift_from_imm64(ctx, pattern6_1, pattern8_0) {
-                        // Rule at src/isa/aarch64/lower.isle line 761.
+                        // Rule at src/isa/aarch64/lower.isle line 762.
                         let expr0_0 = constructor_alu_rr_imm_shift(
                             ctx, pattern0_0, pattern1_0, pattern2_0, pattern9_0,
                         )?;
@@ -6198,7 +6175,7 @@ pub fn constructor_do_shift<C: Context>(
     if pattern1_0 == I32 {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 752.
+        // Rule at src/isa/aarch64/lower.isle line 753.
         let expr0_0: Type = I32;
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0: usize = 0;
@@ -6209,7 +6186,7 @@ pub fn constructor_do_shift<C: Context>(
     if pattern1_0 == I64 {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 753.
+        // Rule at src/isa/aarch64/lower.isle line 754.
         let expr0_0: Type = I64;
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0: usize = 0;
@@ -6220,7 +6197,7 @@ pub fn constructor_do_shift<C: Context>(
     if let Some(pattern2_0) = C::fits_in_16(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 741.
+        // Rule at src/isa/aarch64/lower.isle line 742.
         let expr0_0 = C::put_in_regs(ctx, pattern4_0);
         let expr1_0: usize = 0;
         let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -6242,7 +6219,7 @@ pub fn constructor_lower_ushr128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 796.
+    // Rule at src/isa/aarch64/lower.isle line 797.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6272,8 +6249,9 @@ pub fn constructor_lower_ushr128<C: Context>(
     let expr26_0 = Cond::Ne;
     let expr27_0 = C::zero_reg(ctx);
     let expr28_0 = constructor_csel(ctx, &expr26_0, expr27_0, expr7_0)?;
-    let expr29_0 = constructor_with_flags_2(ctx, &expr23_0, &expr25_0, &expr28_0)?;
-    return Some(expr29_0);
+    let expr29_0 = constructor_consumes_flags_concat(ctx, &expr25_0, &expr28_0)?;
+    let expr30_0 = constructor_with_flags(ctx, &expr23_0, &expr29_0)?;
+    return Some(expr30_0);
 }
 
 // Generated as internal constructor for term lower_sshr128.
@@ -6284,7 +6262,7 @@ pub fn constructor_lower_sshr128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 848.
+    // Rule at src/isa/aarch64/lower.isle line 850.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6317,8 +6295,9 @@ pub fn constructor_lower_sshr128<C: Context>(
     let expr29_0 = constructor_csel(ctx, &expr28_0, expr7_0, expr22_0)?;
     let expr30_0 = Cond::Ne;
     let expr31_0 = constructor_csel(ctx, &expr30_0, expr20_0, expr7_0)?;
-    let expr32_0 = constructor_with_flags_2(ctx, &expr27_0, &expr29_0, &expr31_0)?;
-    return Some(expr32_0);
+    let expr32_0 = constructor_consumes_flags_concat(ctx, &expr29_0, &expr31_0)?;
+    let expr33_0 = constructor_with_flags(ctx, &expr27_0, &expr32_0)?;
+    return Some(expr33_0);
 }
 
 // Generated as internal constructor for term small_rotr.
@@ -6331,7 +6310,7 @@ pub fn constructor_small_rotr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/lower.isle line 960.
+    // Rule at src/isa/aarch64/lower.isle line 963.
     let expr0_0: Type = I32;
     let expr1_0 = C::rotr_mask(ctx, pattern0_0);
     let expr2_0 = constructor_and_imm(ctx, expr0_0, pattern2_0, expr1_0)?;
@@ -6361,7 +6340,7 @@ pub fn constructor_small_rotr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/lower.isle line 983.
+    // Rule at src/isa/aarch64/lower.isle line 986.
     let expr0_0: Type = I32;
     let expr1_0 = constructor_lsr_imm(ctx, expr0_0, pattern1_0, pattern2_0)?;
     let expr2_0: Type = I32;
@@ -6375,7 +6354,7 @@ pub fn constructor_small_rotr_imm<C: Context>(
 // Generated as internal constructor for term lower_clz128.
 pub fn constructor_lower_clz128<C: Context>(ctx: &mut C, arg0: ValueRegs) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/lower.isle line 1059.
+    // Rule at src/isa/aarch64/lower.isle line 1062.
     let expr0_0: usize = 1;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0 = constructor_clz64(ctx, expr1_0)?;

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
@@ -1666,12 +1666,8 @@ pub fn constructor_cmp64_imm<C: Context>(
         rn: pattern0_0,
         imm12: pattern1_0,
     };
-    let expr4_0 = C::zero_reg(ctx);
-    let expr5_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
-        inst: expr3_0,
-        result: expr4_0,
-    };
-    return Some(expr5_0);
+    let expr4_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr3_0 };
+    return Some(expr4_0);
 }
 
 // Generated as internal constructor for term sbc_paired.

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1427,9 +1427,8 @@
 ;; Helper for emitting `MInst.RxSBGTest` instructions.
 (decl rxsbg_test (RxSBGOp Reg Reg u8 u8 i8) ProducesFlags)
 (rule (rxsbg_test op src1 src2 start_bit end_bit rotate_amt)
-      (ProducesFlags.ProducesFlags (MInst.RxSBGTest op src1 src2
-                                    start_bit end_bit rotate_amt)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect
+            (MInst.RxSBGTest op src1 src2 start_bit end_bit rotate_amt)))
 
 ;; Helper for emitting `MInst.UnaryRR` instructions.
 (decl unary_rr (Type UnaryOp Reg) Reg)
@@ -1441,32 +1440,27 @@
 ;; Helper for emitting `MInst.CmpRR` instructions.
 (decl cmp_rr (CmpOp Reg Reg) ProducesFlags)
 (rule (cmp_rr op src1 src2)
-      (ProducesFlags.ProducesFlags (MInst.CmpRR op src1 src2)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.CmpRR op src1 src2)))
 
 ;; Helper for emitting `MInst.CmpRX` instructions.
 (decl cmp_rx (CmpOp Reg MemArg) ProducesFlags)
 (rule (cmp_rx op src mem)
-      (ProducesFlags.ProducesFlags (MInst.CmpRX op src mem)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.CmpRX op src mem)))
 
 ;; Helper for emitting `MInst.CmpRSImm16` instructions.
 (decl cmp_rsimm16 (CmpOp Reg i16) ProducesFlags)
 (rule (cmp_rsimm16 op src imm)
-      (ProducesFlags.ProducesFlags (MInst.CmpRSImm16 op src imm)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.CmpRSImm16 op src imm)))
 
 ;; Helper for emitting `MInst.CmpRSImm32` instructions.
 (decl cmp_rsimm32 (CmpOp Reg i32) ProducesFlags)
 (rule (cmp_rsimm32 op src imm)
-      (ProducesFlags.ProducesFlags (MInst.CmpRSImm32 op src imm)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.CmpRSImm32 op src imm)))
 
 ;; Helper for emitting `MInst.CmpRUImm32` instructions.
 (decl cmp_ruimm32 (CmpOp Reg u32) ProducesFlags)
 (rule (cmp_ruimm32 op src imm)
-      (ProducesFlags.ProducesFlags (MInst.CmpRUImm32 op src imm)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.CmpRUImm32 op src imm)))
 
 ;; Helper for emitting `MInst.AtomicRmw` instructions.
 (decl atomic_rmw_impl (Type ALUOp Reg MemArg) Reg)
@@ -1615,21 +1609,19 @@
 ;; Helper for emitting `MInst.FpuCmp32` instructions.
 (decl fpu_cmp32 (Reg Reg) ProducesFlags)
 (rule (fpu_cmp32 src1 src2)
-      (ProducesFlags.ProducesFlags (MInst.FpuCmp32 src1 src2)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.FpuCmp32 src1 src2)))
 
 ;; Helper for emitting `MInst.FpuCmp64` instructions.
 (decl fpu_cmp64 (Reg Reg) ProducesFlags)
 (rule (fpu_cmp64 src1 src2)
-      (ProducesFlags.ProducesFlags (MInst.FpuCmp64 src1 src2)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.FpuCmp64 src1 src2)))
 
 ;; Helper for emitting `MInst.FpuToInt` instructions.
 (decl fpu_to_int (Type FpuToIntOp Reg) ProducesFlags)
 (rule (fpu_to_int ty op src)
       (let ((dst WritableReg (temp_writable_reg ty)))
-        (ProducesFlags.ProducesFlags (MInst.FpuToInt op dst src)
-                                     (writable_reg_to_reg dst))))
+        (ProducesFlags.ProducesFlagsReturnsReg (MInst.FpuToInt op dst src)
+                                               (writable_reg_to_reg dst))))
 
 ;; Helper for emitting `MInst.IntToFpu` instructions.
 (decl int_to_fpu (Type IntToFpuOp Reg) Reg)
@@ -1751,7 +1743,7 @@
 
 ;; Emit a `ProducesFlags` instruction when the flags are not actually needed.
 (decl drop_flags (ProducesFlags) Reg)
-(rule (drop_flags (ProducesFlags.ProducesFlags inst result))
+(rule (drop_flags (ProducesFlags.ProducesFlagsReturnsReg inst result))
       (let ((_ Unit (emit inst)))
         result))
 
@@ -1834,7 +1826,7 @@
 
 ;; Push instructions to break out of the loop if condition is met.
 (decl push_break_if (VecMInstBuilder ProducesFlags Cond) Reg)
-(rule (push_break_if ib (ProducesFlags.ProducesFlags inst result) cond)
+(rule (push_break_if ib (ProducesFlags.ProducesFlagsReturnsReg inst result) cond)
       (let ((_1 Unit (inst_builder_push ib inst))
             (_2 Unit (inst_builder_push ib (MInst.CondBreak cond))))
         result))
@@ -2215,11 +2207,11 @@
 ;; Conditionally move immediate value into destination register.  (Non-SSA form.)
 (decl emit_cmov_imm (Type WritableReg Cond i16) ConsumesFlags)
 (rule (emit_cmov_imm (gpr32_ty _ty) dst cond imm)
-      (ConsumesFlags.ConsumesFlags (MInst.CMov32SImm16 dst cond imm)
-                                   (writable_reg_to_reg dst)))
+      (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov32SImm16 dst cond imm)
+                                             (writable_reg_to_reg dst)))
 (rule (emit_cmov_imm (gpr64_ty _ty) dst cond imm)
-      (ConsumesFlags.ConsumesFlags (MInst.CMov64SImm16 dst cond imm)
-                                   (writable_reg_to_reg dst)))
+      (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov64SImm16 dst cond imm)
+                                             (writable_reg_to_reg dst)))
 
 ;; Conditionally select between immediate and source register.
 (decl cmov_imm (Type Cond i16 Reg) ConsumesFlags)
@@ -2233,7 +2225,7 @@
 (rule (cmov_imm_regpair_lo ty producer cond imm src)
       (let ((dst WritableRegPair (copy_writable_regpair src))
             (consumer ConsumesFlags (emit_cmov_imm ty (writable_regpair_lo dst) cond imm))
-            (_ Reg (with_flags_1 producer consumer)))
+            (_ Reg (with_flags_reg producer consumer)))
         (writable_regpair_to_regpair dst)))
 
 ;; Conditionally modify the high word of a register pair.
@@ -2242,23 +2234,23 @@
 (rule (cmov_imm_regpair_hi ty producer cond imm src)
       (let ((dst WritableRegPair (copy_writable_regpair src))
             (consumer ConsumesFlags (emit_cmov_imm ty (writable_regpair_hi dst) cond imm))
-            (_ Reg (with_flags_1 producer consumer)))
+            (_ Reg (with_flags_reg producer consumer)))
         (writable_regpair_to_regpair dst)))
 
 ;; Conditionally select between two source registers.  (Non-SSA form.)
 (decl emit_cmov_reg (Type WritableReg Cond Reg) ConsumesFlags)
 (rule (emit_cmov_reg (gpr32_ty _ty) dst cond src)
-      (ConsumesFlags.ConsumesFlags (MInst.CMov32 dst cond src)
-                                   (writable_reg_to_reg dst)))
+      (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov32 dst cond src)
+                                             (writable_reg_to_reg dst)))
 (rule (emit_cmov_reg (gpr64_ty _ty) dst cond src)
-      (ConsumesFlags.ConsumesFlags (MInst.CMov64 dst cond src)
-                                   (writable_reg_to_reg dst)))
+      (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov64 dst cond src)
+                                             (writable_reg_to_reg dst)))
 (rule (emit_cmov_reg $F32 dst cond src)
-      (ConsumesFlags.ConsumesFlags (MInst.FpuCMov32 dst cond src)
-                                   (writable_reg_to_reg dst)))
+      (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.FpuCMov32 dst cond src)
+                                             (writable_reg_to_reg dst)))
 (rule (emit_cmov_reg $F64 dst cond src)
-      (ConsumesFlags.ConsumesFlags (MInst.FpuCMov64 dst cond src)
-                                   (writable_reg_to_reg dst)))
+      (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.FpuCMov64 dst cond src)
+                                             (writable_reg_to_reg dst)))
 
 ;; Conditionally select between two source registers.
 (decl cmov_reg (Type Cond Reg Reg) ConsumesFlags)
@@ -2270,7 +2262,7 @@
 ;; Helpers for generating conditional traps ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl trap_if (ProducesFlags Cond TrapCode) Reg)
-(rule (trap_if (ProducesFlags.ProducesFlags inst result) cond trap_code)
+(rule (trap_if (ProducesFlags.ProducesFlagsReturnsReg inst result) cond trap_code)
       (let ((_1 Unit (emit inst))
             (_2 Unit (emit (MInst.TrapIf cond trap_code))))
         result))
@@ -2332,9 +2324,9 @@
 ;; instruction in between the producer and consumer.  (This use is only valid
 ;; if that unrelated instruction does not modify the condition code.)
 (decl emit_producer (ProducesFlags) Unit)
-(rule (emit_producer (ProducesFlags.ProducesFlags insn _)) (emit insn))
+(rule (emit_producer (ProducesFlags.ProducesFlagsSideEffect insn)) (emit insn))
 (decl emit_consumer (ConsumesFlags) Unit)
-(rule (emit_consumer (ConsumesFlags.ConsumesFlags insn _)) (emit insn))
+(rule (emit_consumer (ConsumesFlags.ConsumesFlagsReturnsReg insn _)) (emit insn))
 
 ;; Use a boolean condition to select between two registers.
 (decl select_bool_reg (Type ProducesBool Reg Reg) Reg)

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1826,10 +1826,10 @@
 
 ;; Push instructions to break out of the loop if condition is met.
 (decl push_break_if (VecMInstBuilder ProducesFlags Cond) Reg)
-(rule (push_break_if ib (ProducesFlags.ProducesFlagsReturnsReg inst result) cond)
+(rule (push_break_if ib (ProducesFlags.ProducesFlagsSideEffect inst) cond)
       (let ((_1 Unit (inst_builder_push ib inst))
             (_2 Unit (inst_builder_push ib (MInst.CondBreak cond))))
-        result))
+        (invalid_reg)))
 
 ;; Emit a `MInst.Loop` instruction holding a loop body instruction sequence.
 (decl emit_loop (VecMInstBuilder Cond) Unit)
@@ -2266,6 +2266,10 @@
       (let ((_1 Unit (emit inst))
             (_2 Unit (emit (MInst.TrapIf cond trap_code))))
         result))
+(rule (trap_if (ProducesFlags.ProducesFlagsSideEffect inst) cond trap_code)
+      (let ((_1 Unit (emit inst))
+            (_2 Unit (emit (MInst.TrapIf cond trap_code))))
+        (invalid_reg)))
 
 (decl icmps_reg_and_trap (Type Reg Reg Cond TrapCode) Reg)
 (rule (icmps_reg_and_trap ty src1 src2 cond trap_code)

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -1102,9 +1102,9 @@
             ;; result expected by Cranelift semantics.  The only exception
             ;; it the case where the input was a NaN.  We explicitly check
             ;; for that and force the output to 0 in that case.
-            (sat Reg (with_flags_1 (fcmp_reg src_ty src src)
-                                   (cmov_imm dst_ty
-                                     (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
+            (sat Reg (with_flags_reg (fcmp_reg src_ty src src)
+                                     (cmov_imm dst_ty
+                                               (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
         (value_reg sat)))
 
 
@@ -1119,9 +1119,9 @@
             ;; result expected by Cranelift semantics.  The only exception
             ;; it the case where the input was a NaN.  We explicitly check
             ;; for that and force the output to 0 in that case.
-            (sat Reg (with_flags_1 (fcmp_reg src_ty src src)
-                                   (cmov_imm dst_ty
-                                     (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
+            (sat Reg (with_flags_reg (fcmp_reg src_ty src src)
+                                     (cmov_imm dst_ty
+                                               (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
         (value_reg sat)))
 
 

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 73285cd431346d53
-src/isa/s390x/inst.isle 87a2d7c0c69d0324
-src/isa/s390x/lower.isle 3c124e26bc411983
+src/prelude.isle 980b300b3ec3e338
+src/isa/s390x/inst.isle c25f5c0061d14a19
+src/isa/s390x/lower.isle 59264a7442cf6e1c

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle 980b300b3ec3e338
-src/isa/s390x/inst.isle c25f5c0061d14a19
+src/isa/s390x/inst.isle b0f53fcf0cdadde1
 src/isa/s390x/lower.isle 59264a7442cf6e1c

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
@@ -142,16 +142,30 @@ pub enum SideEffectNoResult {
     Inst { inst: MInst },
 }
 
-/// Internal type ProducesFlags: defined at src/prelude.isle line 327.
+/// Internal type ProducesFlags: defined at src/prelude.isle line 330.
 #[derive(Clone, Debug)]
 pub enum ProducesFlags {
-    ProducesFlags { inst: MInst, result: Reg },
+    ProducesFlagsSideEffect { inst: MInst },
+    ProducesFlagsReturnsReg { inst: MInst, result: Reg },
+    ProducesFlagsReturnsResultWithConsumer { inst: MInst, result: Reg },
 }
 
-/// Internal type ConsumesFlags: defined at src/prelude.isle line 330.
+/// Internal type ConsumesFlags: defined at src/prelude.isle line 341.
 #[derive(Clone, Debug)]
 pub enum ConsumesFlags {
-    ConsumesFlags { inst: MInst, result: Reg },
+    ConsumesFlagsReturnsResultWithProducer {
+        inst: MInst,
+        result: Reg,
+    },
+    ConsumesFlagsReturnsReg {
+        inst: MInst,
+        result: Reg,
+    },
+    ConsumesFlagsTwiceReturnsValueRegs {
+        inst1: MInst,
+        inst2: MInst,
+        result: ValueRegs,
+    },
 }
 
 /// Internal type MInst: defined at src/isa/s390x/inst.isle line 2.
@@ -866,7 +880,7 @@ pub enum RegPair {
     RegPair { hi: Reg, lo: Reg },
 }
 
-/// Internal type ProducesBool: defined at src/isa/s390x/inst.isle line 2320.
+/// Internal type ProducesBool: defined at src/isa/s390x/inst.isle line 2312.
 #[derive(Clone, Debug)]
 pub enum ProducesBool {
     ProducesBool { producer: ProducesFlags, cond: Cond },
@@ -902,7 +916,7 @@ pub fn constructor_value_regs_none<C: Context>(
     } = pattern0_0
     {
         // Rule at src/prelude.isle line 313.
-        let expr0_0 = C::emit(ctx, &pattern1_0);
+        let expr0_0 = C::emit(ctx, pattern1_0);
         let expr1_0 = C::value_regs_invalid(ctx);
         return Some(expr1_0);
     }
@@ -920,9 +934,40 @@ pub fn constructor_safepoint<C: Context>(
     } = pattern0_0
     {
         // Rule at src/prelude.isle line 319.
-        let expr0_0 = C::emit_safepoint(ctx, &pattern1_0);
+        let expr0_0 = C::emit_safepoint(ctx, pattern1_0);
         let expr1_0 = C::value_regs_invalid(ctx);
         return Some(expr1_0);
+    }
+    return None;
+}
+
+// Generated as internal constructor for term consumes_flags_concat.
+pub fn constructor_consumes_flags_concat<C: Context>(
+    ctx: &mut C,
+    arg0: &ConsumesFlags,
+    arg1: &ConsumesFlags,
+) -> Option<ConsumesFlags> {
+    let pattern0_0 = arg0;
+    if let &ConsumesFlags::ConsumesFlagsReturnsReg {
+        inst: ref pattern1_0,
+        result: pattern1_1,
+    } = pattern0_0
+    {
+        let pattern2_0 = arg1;
+        if let &ConsumesFlags::ConsumesFlagsReturnsReg {
+            inst: ref pattern3_0,
+            result: pattern3_1,
+        } = pattern2_0
+        {
+            // Rule at src/prelude.isle line 353.
+            let expr0_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
+            let expr1_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
+                inst1: pattern1_0.clone(),
+                inst2: pattern3_0.clone(),
+                result: expr0_0,
+            };
+            return Some(expr1_0);
+        }
     }
     return None;
 }
@@ -934,89 +979,71 @@ pub fn constructor_with_flags<C: Context>(
     arg1: &ConsumesFlags,
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
-        inst: ref pattern1_0,
-        result: pattern1_1,
-    } = pattern0_0
-    {
-        let pattern2_0 = arg1;
-        if let &ConsumesFlags::ConsumesFlags {
-            inst: ref pattern3_0,
-            result: pattern3_1,
-        } = pattern2_0
-        {
-            // Rule at src/prelude.isle line 340.
-            let expr0_0 = C::emit(ctx, &pattern1_0);
-            let expr1_0 = C::emit(ctx, &pattern3_0);
-            let expr2_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
-            return Some(expr2_0);
+    match pattern0_0 {
+        &ProducesFlags::ProducesFlagsSideEffect {
+            inst: ref pattern1_0,
+        } => {
+            let pattern2_0 = arg1;
+            match pattern2_0 {
+                &ConsumesFlags::ConsumesFlagsReturnsReg {
+                    inst: ref pattern3_0,
+                    result: pattern3_1,
+                } => {
+                    // Rule at src/prelude.isle line 378.
+                    let expr0_0 = C::emit(ctx, pattern1_0);
+                    let expr1_0 = C::emit(ctx, pattern3_0);
+                    let expr2_0 = C::value_reg(ctx, pattern3_1);
+                    return Some(expr2_0);
+                }
+                &ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
+                    inst1: ref pattern3_0,
+                    inst2: ref pattern3_1,
+                    result: pattern3_2,
+                } => {
+                    // Rule at src/prelude.isle line 384.
+                    let expr0_0 = C::emit(ctx, pattern1_0);
+                    let expr1_0 = C::emit(ctx, pattern3_1);
+                    let expr2_0 = C::emit(ctx, pattern3_0);
+                    return Some(pattern3_2);
+                }
+                _ => {}
+            }
         }
+        &ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
+            inst: ref pattern1_0,
+            result: pattern1_1,
+        } => {
+            let pattern2_0 = arg1;
+            if let &ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
+                inst: ref pattern3_0,
+                result: pattern3_1,
+            } = pattern2_0
+            {
+                // Rule at src/prelude.isle line 372.
+                let expr0_0 = C::emit(ctx, pattern1_0);
+                let expr1_0 = C::emit(ctx, pattern3_0);
+                let expr2_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
+                return Some(expr2_0);
+            }
+        }
+        _ => {}
     }
     return None;
 }
 
-// Generated as internal constructor for term with_flags_1.
-pub fn constructor_with_flags_1<C: Context>(
+// Generated as internal constructor for term with_flags_reg.
+pub fn constructor_with_flags_reg<C: Context>(
     ctx: &mut C,
     arg0: &ProducesFlags,
     arg1: &ConsumesFlags,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
-        inst: ref pattern1_0,
-        result: pattern1_1,
-    } = pattern0_0
-    {
-        let pattern2_0 = arg1;
-        if let &ConsumesFlags::ConsumesFlags {
-            inst: ref pattern3_0,
-            result: pattern3_1,
-        } = pattern2_0
-        {
-            // Rule at src/prelude.isle line 348.
-            let expr0_0 = C::emit(ctx, &pattern1_0);
-            let expr1_0 = C::emit(ctx, &pattern3_0);
-            return Some(pattern3_1);
-        }
-    }
-    return None;
-}
-
-// Generated as internal constructor for term with_flags_2.
-pub fn constructor_with_flags_2<C: Context>(
-    ctx: &mut C,
-    arg0: &ProducesFlags,
-    arg1: &ConsumesFlags,
-    arg2: &ConsumesFlags,
-) -> Option<ValueRegs> {
-    let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
-        inst: ref pattern1_0,
-        result: pattern1_1,
-    } = pattern0_0
-    {
-        let pattern2_0 = arg1;
-        if let &ConsumesFlags::ConsumesFlags {
-            inst: ref pattern3_0,
-            result: pattern3_1,
-        } = pattern2_0
-        {
-            let pattern4_0 = arg2;
-            if let &ConsumesFlags::ConsumesFlags {
-                inst: ref pattern5_0,
-                result: pattern5_1,
-            } = pattern4_0
-            {
-                // Rule at src/prelude.isle line 358.
-                let expr0_0 = C::emit(ctx, &pattern1_0);
-                let expr1_0 = C::emit(ctx, &pattern5_0);
-                let expr2_0 = C::emit(ctx, &pattern3_0);
-                let expr3_0 = C::value_regs(ctx, pattern3_1, pattern5_1);
-                return Some(expr3_0);
-            }
-        }
-    }
-    return None;
+    let pattern1_0 = arg1;
+    // Rule at src/prelude.isle line 397.
+    let expr0_0 = constructor_with_flags(ctx, pattern0_0, pattern1_0)?;
+    let expr1_0: usize = 0;
+    let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
+    return Some(expr2_0);
 }
 
 // Generated as internal constructor for term mask_amt_reg.
@@ -1057,7 +1084,7 @@ pub fn constructor_lower_address<C: Context>(
                 opcode: ref pattern4_0,
                 global_value: pattern4_1,
             } => {
-                if let &Opcode::SymbolValue = &pattern4_0 {
+                if let &Opcode::SymbolValue = pattern4_0 {
                     if let Some((pattern6_0, pattern6_1, pattern6_2)) =
                         C::symbol_value_data(ctx, pattern4_1)
                     {
@@ -1085,8 +1112,8 @@ pub fn constructor_lower_address<C: Context>(
                 opcode: ref pattern4_0,
                 args: ref pattern4_1,
             } => {
-                if let &Opcode::Iadd = &pattern4_0 {
-                    let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                if let &Opcode::Iadd = pattern4_0 {
+                    let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                     let pattern7_0 = arg2;
                     let pattern8_0 = C::i64_from_offset(ctx, pattern7_0);
                     if pattern8_0 == 0 {
@@ -1138,7 +1165,7 @@ pub fn constructor_sink_load<C: Context>(ctx: &mut C, arg0: Inst) -> Option<MemA
         offset: pattern2_3,
     } = &pattern1_0
     {
-        if let &Opcode::Load = &pattern2_0 {
+        if let &Opcode::Load = pattern2_0 {
             // Rule at src/isa/s390x/inst.isle line 1233.
             let expr0_0 = C::sink_inst(ctx, pattern0_0);
             let expr1_0 = constructor_lower_address(ctx, pattern2_2, pattern2_1, pattern2_3)?;
@@ -1159,7 +1186,7 @@ pub fn constructor_sink_sload16<C: Context>(ctx: &mut C, arg0: Inst) -> Option<M
         offset: pattern2_3,
     } = &pattern1_0
     {
-        if let &Opcode::Sload16 = &pattern2_0 {
+        if let &Opcode::Sload16 = pattern2_0 {
             // Rule at src/isa/s390x/inst.isle line 1240.
             let expr0_0 = C::sink_inst(ctx, pattern0_0);
             let expr1_0 = constructor_lower_address(ctx, pattern2_2, pattern2_1, pattern2_3)?;
@@ -1180,7 +1207,7 @@ pub fn constructor_sink_sload32<C: Context>(ctx: &mut C, arg0: Inst) -> Option<M
         offset: pattern2_3,
     } = &pattern1_0
     {
-        if let &Opcode::Sload32 = &pattern2_0 {
+        if let &Opcode::Sload32 = pattern2_0 {
             // Rule at src/isa/s390x/inst.isle line 1247.
             let expr0_0 = C::sink_inst(ctx, pattern0_0);
             let expr1_0 = constructor_lower_address(ctx, pattern2_2, pattern2_1, pattern2_3)?;
@@ -1201,7 +1228,7 @@ pub fn constructor_sink_uload16<C: Context>(ctx: &mut C, arg0: Inst) -> Option<M
         offset: pattern2_3,
     } = &pattern1_0
     {
-        if let &Opcode::Uload16 = &pattern2_0 {
+        if let &Opcode::Uload16 = pattern2_0 {
             // Rule at src/isa/s390x/inst.isle line 1254.
             let expr0_0 = C::sink_inst(ctx, pattern0_0);
             let expr1_0 = constructor_lower_address(ctx, pattern2_2, pattern2_1, pattern2_3)?;
@@ -1222,7 +1249,7 @@ pub fn constructor_sink_uload32<C: Context>(ctx: &mut C, arg0: Inst) -> Option<M
         offset: pattern2_3,
     } = &pattern1_0
     {
-        if let &Opcode::Uload32 = &pattern2_0 {
+        if let &Opcode::Uload32 = pattern2_0 {
             // Rule at src/isa/s390x/inst.isle line 1261.
             let expr0_0 = C::sink_inst(ctx, pattern0_0);
             let expr1_0 = constructor_lower_address(ctx, pattern2_2, pattern2_1, pattern2_3)?;
@@ -1718,12 +1745,8 @@ pub fn constructor_rxsbg_test<C: Context>(
         end_bit: pattern4_0,
         rotate_amt: pattern5_0,
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term unary_rr.
@@ -1736,7 +1759,7 @@ pub fn constructor_unary_rr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1436.
+    // Rule at src/isa/s390x/inst.isle line 1435.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::UnaryRR {
         op: pattern1_0.clone(),
@@ -1758,18 +1781,14 @@ pub fn constructor_cmp_rr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1443.
+    // Rule at src/isa/s390x/inst.isle line 1442.
     let expr0_0 = MInst::CmpRR {
         op: pattern0_0.clone(),
         rn: pattern1_0,
         rm: pattern2_0,
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term cmp_rx.
@@ -1782,18 +1801,14 @@ pub fn constructor_cmp_rx<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1449.
+    // Rule at src/isa/s390x/inst.isle line 1447.
     let expr0_0 = MInst::CmpRX {
         op: pattern0_0.clone(),
         rn: pattern1_0,
         mem: pattern2_0.clone(),
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term cmp_rsimm16.
@@ -1806,18 +1821,14 @@ pub fn constructor_cmp_rsimm16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1455.
+    // Rule at src/isa/s390x/inst.isle line 1452.
     let expr0_0 = MInst::CmpRSImm16 {
         op: pattern0_0.clone(),
         rn: pattern1_0,
         imm: pattern2_0,
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term cmp_rsimm32.
@@ -1830,18 +1841,14 @@ pub fn constructor_cmp_rsimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1461.
+    // Rule at src/isa/s390x/inst.isle line 1457.
     let expr0_0 = MInst::CmpRSImm32 {
         op: pattern0_0.clone(),
         rn: pattern1_0,
         imm: pattern2_0,
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term cmp_ruimm32.
@@ -1854,18 +1861,14 @@ pub fn constructor_cmp_ruimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1467.
+    // Rule at src/isa/s390x/inst.isle line 1462.
     let expr0_0 = MInst::CmpRUImm32 {
         op: pattern0_0.clone(),
         rn: pattern1_0,
         imm: pattern2_0,
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term atomic_rmw_impl.
@@ -1880,7 +1883,7 @@ pub fn constructor_atomic_rmw_impl<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 1473.
+    // Rule at src/isa/s390x/inst.isle line 1467.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::AtomicRmw {
         alu_op: pattern1_0.clone(),
@@ -1903,7 +1906,7 @@ pub fn constructor_atomic_cas32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1480.
+    // Rule at src/isa/s390x/inst.isle line 1474.
     let expr0_0: Type = I32;
     let expr1_0 = constructor_copy_writable_reg(ctx, expr0_0, pattern0_0)?;
     let expr2_0 = MInst::AtomicCas32 {
@@ -1926,7 +1929,7 @@ pub fn constructor_atomic_cas64<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1487.
+    // Rule at src/isa/s390x/inst.isle line 1481.
     let expr0_0: Type = I64;
     let expr1_0 = constructor_copy_writable_reg(ctx, expr0_0, pattern0_0)?;
     let expr2_0 = MInst::AtomicCas64 {
@@ -1941,7 +1944,7 @@ pub fn constructor_atomic_cas64<C: Context>(
 
 // Generated as internal constructor for term fence_impl.
 pub fn constructor_fence_impl<C: Context>(ctx: &mut C) -> Option<SideEffectNoResult> {
-    // Rule at src/isa/s390x/inst.isle line 1494.
+    // Rule at src/isa/s390x/inst.isle line 1488.
     let expr0_0 = MInst::Fence;
     let expr1_0 = SideEffectNoResult::Inst { inst: expr0_0 };
     return Some(expr1_0);
@@ -1950,7 +1953,7 @@ pub fn constructor_fence_impl<C: Context>(ctx: &mut C) -> Option<SideEffectNoRes
 // Generated as internal constructor for term load32.
 pub fn constructor_load32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1499.
+    // Rule at src/isa/s390x/inst.isle line 1493.
     let expr0_0: Type = I32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::Load32 {
@@ -1965,7 +1968,7 @@ pub fn constructor_load32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg>
 // Generated as internal constructor for term load64.
 pub fn constructor_load64<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1506.
+    // Rule at src/isa/s390x/inst.isle line 1500.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::Load64 {
@@ -1980,7 +1983,7 @@ pub fn constructor_load64<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg>
 // Generated as internal constructor for term loadrev16.
 pub fn constructor_loadrev16<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1513.
+    // Rule at src/isa/s390x/inst.isle line 1507.
     let expr0_0: Type = I32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::LoadRev16 {
@@ -1995,7 +1998,7 @@ pub fn constructor_loadrev16<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<R
 // Generated as internal constructor for term loadrev32.
 pub fn constructor_loadrev32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1520.
+    // Rule at src/isa/s390x/inst.isle line 1514.
     let expr0_0: Type = I32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::LoadRev32 {
@@ -2010,7 +2013,7 @@ pub fn constructor_loadrev32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<R
 // Generated as internal constructor for term loadrev64.
 pub fn constructor_loadrev64<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1527.
+    // Rule at src/isa/s390x/inst.isle line 1521.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::LoadRev64 {
@@ -2030,7 +2033,7 @@ pub fn constructor_store8<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1534.
+    // Rule at src/isa/s390x/inst.isle line 1528.
     let expr0_0 = MInst::Store8 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2047,7 +2050,7 @@ pub fn constructor_store16<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1539.
+    // Rule at src/isa/s390x/inst.isle line 1533.
     let expr0_0 = MInst::Store16 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2064,7 +2067,7 @@ pub fn constructor_store32<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1544.
+    // Rule at src/isa/s390x/inst.isle line 1538.
     let expr0_0 = MInst::Store32 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2081,7 +2084,7 @@ pub fn constructor_store64<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1549.
+    // Rule at src/isa/s390x/inst.isle line 1543.
     let expr0_0 = MInst::Store64 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2098,7 +2101,7 @@ pub fn constructor_store8_imm<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1554.
+    // Rule at src/isa/s390x/inst.isle line 1548.
     let expr0_0 = MInst::StoreImm8 {
         imm: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2115,7 +2118,7 @@ pub fn constructor_store16_imm<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1559.
+    // Rule at src/isa/s390x/inst.isle line 1553.
     let expr0_0 = MInst::StoreImm16 {
         imm: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2132,7 +2135,7 @@ pub fn constructor_store32_simm16<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1564.
+    // Rule at src/isa/s390x/inst.isle line 1558.
     let expr0_0 = MInst::StoreImm32SExt16 {
         imm: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2149,7 +2152,7 @@ pub fn constructor_store64_simm16<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1569.
+    // Rule at src/isa/s390x/inst.isle line 1563.
     let expr0_0 = MInst::StoreImm64SExt16 {
         imm: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2166,7 +2169,7 @@ pub fn constructor_storerev16<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1574.
+    // Rule at src/isa/s390x/inst.isle line 1568.
     let expr0_0 = MInst::StoreRev16 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2183,7 +2186,7 @@ pub fn constructor_storerev32<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1579.
+    // Rule at src/isa/s390x/inst.isle line 1573.
     let expr0_0 = MInst::StoreRev32 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2200,7 +2203,7 @@ pub fn constructor_storerev64<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1584.
+    // Rule at src/isa/s390x/inst.isle line 1578.
     let expr0_0 = MInst::StoreRev64 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2219,7 +2222,7 @@ pub fn constructor_fpu_rr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1589.
+    // Rule at src/isa/s390x/inst.isle line 1583.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::FpuRR {
         fpu_op: pattern1_0.clone(),
@@ -2243,7 +2246,7 @@ pub fn constructor_fpu_rrr<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 1596.
+    // Rule at src/isa/s390x/inst.isle line 1590.
     let expr0_0 = constructor_copy_writable_reg(ctx, pattern0_0, pattern2_0)?;
     let expr1_0 = MInst::FpuRRR {
         fpu_op: pattern1_0.clone(),
@@ -2269,7 +2272,7 @@ pub fn constructor_fpu_rrrr<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 1603.
+    // Rule at src/isa/s390x/inst.isle line 1597.
     let expr0_0 = constructor_copy_writable_reg(ctx, pattern0_0, pattern2_0)?;
     let expr1_0 = MInst::FpuRRRR {
         fpu_op: pattern1_0.clone(),
@@ -2292,7 +2295,7 @@ pub fn constructor_fpu_copysign<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1610.
+    // Rule at src/isa/s390x/inst.isle line 1604.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::FpuCopysign {
         rd: expr0_0,
@@ -2312,17 +2315,13 @@ pub fn constructor_fpu_cmp32<C: Context>(
 ) -> Option<ProducesFlags> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1617.
+    // Rule at src/isa/s390x/inst.isle line 1611.
     let expr0_0 = MInst::FpuCmp32 {
         rn: pattern0_0,
         rm: pattern1_0,
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term fpu_cmp64.
@@ -2333,17 +2332,13 @@ pub fn constructor_fpu_cmp64<C: Context>(
 ) -> Option<ProducesFlags> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1623.
+    // Rule at src/isa/s390x/inst.isle line 1616.
     let expr0_0 = MInst::FpuCmp64 {
         rn: pattern0_0,
         rm: pattern1_0,
     };
-    let expr1_0 = C::invalid_reg(ctx);
-    let expr2_0 = ProducesFlags::ProducesFlags {
-        inst: expr0_0,
-        result: expr1_0,
-    };
-    return Some(expr2_0);
+    let expr1_0 = ProducesFlags::ProducesFlagsSideEffect { inst: expr0_0 };
+    return Some(expr1_0);
 }
 
 // Generated as internal constructor for term fpu_to_int.
@@ -2356,7 +2351,7 @@ pub fn constructor_fpu_to_int<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1629.
+    // Rule at src/isa/s390x/inst.isle line 1621.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::FpuToInt {
         op: pattern1_0.clone(),
@@ -2364,7 +2359,7 @@ pub fn constructor_fpu_to_int<C: Context>(
         rn: pattern2_0,
     };
     let expr2_0 = C::writable_reg_to_reg(ctx, expr0_0);
-    let expr3_0 = ProducesFlags::ProducesFlags {
+    let expr3_0 = ProducesFlags::ProducesFlagsReturnsReg {
         inst: expr1_0,
         result: expr2_0,
     };
@@ -2381,7 +2376,7 @@ pub fn constructor_int_to_fpu<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1636.
+    // Rule at src/isa/s390x/inst.isle line 1628.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::IntToFpu {
         op: pattern1_0.clone(),
@@ -2403,7 +2398,7 @@ pub fn constructor_fpu_round<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1643.
+    // Rule at src/isa/s390x/inst.isle line 1635.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::FpuRound {
         op: pattern1_0.clone(),
@@ -2427,7 +2422,7 @@ pub fn constructor_fpuvec_rrr<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 1650.
+    // Rule at src/isa/s390x/inst.isle line 1642.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = MInst::FpuVecRRR {
         fpu_op: pattern1_0.clone(),
@@ -2443,7 +2438,7 @@ pub fn constructor_fpuvec_rrr<C: Context>(
 // Generated as internal constructor for term mov_to_fpr.
 pub fn constructor_mov_to_fpr<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1657.
+    // Rule at src/isa/s390x/inst.isle line 1649.
     let expr0_0: Type = F64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovToFpr {
@@ -2458,7 +2453,7 @@ pub fn constructor_mov_to_fpr<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg>
 // Generated as internal constructor for term mov_from_fpr.
 pub fn constructor_mov_from_fpr<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1664.
+    // Rule at src/isa/s390x/inst.isle line 1656.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovFromFpr {
@@ -2473,7 +2468,7 @@ pub fn constructor_mov_from_fpr<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Re
 // Generated as internal constructor for term fpu_load32.
 pub fn constructor_fpu_load32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1671.
+    // Rule at src/isa/s390x/inst.isle line 1663.
     let expr0_0: Type = F32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuLoad32 {
@@ -2488,7 +2483,7 @@ pub fn constructor_fpu_load32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<
 // Generated as internal constructor for term fpu_load64.
 pub fn constructor_fpu_load64<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1678.
+    // Rule at src/isa/s390x/inst.isle line 1670.
     let expr0_0: Type = F64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuLoad64 {
@@ -2503,7 +2498,7 @@ pub fn constructor_fpu_load64<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<
 // Generated as internal constructor for term fpu_loadrev32.
 pub fn constructor_fpu_loadrev32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1685.
+    // Rule at src/isa/s390x/inst.isle line 1677.
     let expr0_0: Type = F32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuLoadRev32 {
@@ -2518,7 +2513,7 @@ pub fn constructor_fpu_loadrev32<C: Context>(ctx: &mut C, arg0: &MemArg) -> Opti
 // Generated as internal constructor for term fpu_loadrev64.
 pub fn constructor_fpu_loadrev64<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1692.
+    // Rule at src/isa/s390x/inst.isle line 1684.
     let expr0_0: Type = F64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuLoadRev64 {
@@ -2538,7 +2533,7 @@ pub fn constructor_fpu_store32<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1699.
+    // Rule at src/isa/s390x/inst.isle line 1691.
     let expr0_0 = MInst::FpuStore32 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2555,7 +2550,7 @@ pub fn constructor_fpu_store64<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1704.
+    // Rule at src/isa/s390x/inst.isle line 1696.
     let expr0_0 = MInst::FpuStore64 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2572,7 +2567,7 @@ pub fn constructor_fpu_storerev32<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1709.
+    // Rule at src/isa/s390x/inst.isle line 1701.
     let expr0_0 = MInst::FpuStoreRev32 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2589,7 +2584,7 @@ pub fn constructor_fpu_storerev64<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1714.
+    // Rule at src/isa/s390x/inst.isle line 1706.
     let expr0_0 = MInst::FpuStoreRev64 {
         rd: pattern0_0,
         mem: pattern1_0.clone(),
@@ -2606,7 +2601,7 @@ pub fn constructor_load_ext_name_far<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1719.
+    // Rule at src/isa/s390x/inst.isle line 1711.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = C::box_external_name(ctx, pattern0_0);
@@ -2623,7 +2618,7 @@ pub fn constructor_load_ext_name_far<C: Context>(
 // Generated as internal constructor for term load_addr.
 pub fn constructor_load_addr<C: Context>(ctx: &mut C, arg0: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1727.
+    // Rule at src/isa/s390x/inst.isle line 1719.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::LoadAddr {
@@ -2641,7 +2636,7 @@ pub fn constructor_jump_impl<C: Context>(
     arg0: MachLabel,
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 1734.
+    // Rule at src/isa/s390x/inst.isle line 1726.
     let expr0_0 = MInst::Jump { dest: pattern0_0 };
     let expr1_0 = SideEffectNoResult::Inst { inst: expr0_0 };
     return Some(expr1_0);
@@ -2657,7 +2652,7 @@ pub fn constructor_cond_br<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1739.
+    // Rule at src/isa/s390x/inst.isle line 1731.
     let expr0_0 = MInst::CondBr {
         taken: pattern0_0,
         not_taken: pattern1_0,
@@ -2675,7 +2670,7 @@ pub fn constructor_oneway_cond_br<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1744.
+    // Rule at src/isa/s390x/inst.isle line 1736.
     let expr0_0 = MInst::OneWayCondBr {
         target: pattern0_0,
         cond: pattern1_0.clone(),
@@ -2692,7 +2687,7 @@ pub fn constructor_jt_sequence<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1749.
+    // Rule at src/isa/s390x/inst.isle line 1741.
     let expr0_0 = MInst::JTSequence {
         ridx: pattern0_0,
         targets: pattern1_0.clone(),
@@ -2704,13 +2699,13 @@ pub fn constructor_jt_sequence<C: Context>(
 // Generated as internal constructor for term drop_flags.
 pub fn constructor_drop_flags<C: Context>(ctx: &mut C, arg0: &ProducesFlags) -> Option<Reg> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
+    if let &ProducesFlags::ProducesFlagsReturnsReg {
         inst: ref pattern1_0,
         result: pattern1_1,
     } = pattern0_0
     {
-        // Rule at src/isa/s390x/inst.isle line 1754.
-        let expr0_0 = C::emit(ctx, &pattern1_0);
+        // Rule at src/isa/s390x/inst.isle line 1746.
+        let expr0_0 = C::emit(ctx, pattern1_0);
         return Some(pattern1_1);
     }
     return None;
@@ -2731,7 +2726,7 @@ pub fn constructor_push_alu_reg<C: Context>(
     if let Some(pattern3_0) = C::real_reg(ctx, pattern2_0) {
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 1793.
+        // Rule at src/isa/s390x/inst.isle line 1785.
         let expr0_0 = MInst::AluRRR {
             alu_op: pattern1_0.clone(),
             rd: pattern3_0,
@@ -2765,7 +2760,7 @@ pub fn constructor_push_alu_uimm32shifted<C: Context>(
         if let Some(pattern5_0) = closure5() {
             if let Some(()) = C::same_reg(ctx, pattern4_0, pattern5_0) {
                 let pattern7_0 = arg4;
-                // Rule at src/isa/s390x/inst.isle line 1799.
+                // Rule at src/isa/s390x/inst.isle line 1791.
                 let expr0_0 = MInst::AluRUImm32Shifted {
                     alu_op: pattern1_0.clone(),
                     rd: pattern3_0,
@@ -2797,7 +2792,7 @@ pub fn constructor_push_shift<C: Context>(
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
         let pattern6_0 = arg5;
-        // Rule at src/isa/s390x/inst.isle line 1805.
+        // Rule at src/isa/s390x/inst.isle line 1797.
         let expr0_0 = MInst::ShiftRR {
             shift_op: pattern1_0.clone(),
             rd: pattern3_0,
@@ -2838,7 +2833,7 @@ pub fn constructor_push_rxsbg<C: Context>(
                 let pattern8_0 = arg5;
                 let pattern9_0 = arg6;
                 let pattern10_0 = arg7;
-                // Rule at src/isa/s390x/inst.isle line 1812.
+                // Rule at src/isa/s390x/inst.isle line 1804.
                 let expr0_0 = MInst::RxSBG {
                     op: pattern1_0.clone(),
                     rd: pattern3_0,
@@ -2869,7 +2864,7 @@ pub fn constructor_push_unary<C: Context>(
     let pattern2_0 = arg2;
     if let Some(pattern3_0) = C::real_reg(ctx, pattern2_0) {
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 1819.
+        // Rule at src/isa/s390x/inst.isle line 1811.
         let expr0_0 = MInst::UnaryRR {
             op: pattern1_0.clone(),
             rd: pattern3_0,
@@ -2895,7 +2890,7 @@ pub fn constructor_push_atomic_cas32<C: Context>(
     if let Some(pattern2_0) = C::real_reg(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 1825.
+        // Rule at src/isa/s390x/inst.isle line 1817.
         let expr0_0 = MInst::AtomicCas32 {
             rd: pattern2_0,
             rn: pattern3_0,
@@ -2921,7 +2916,7 @@ pub fn constructor_push_atomic_cas64<C: Context>(
     if let Some(pattern2_0) = C::real_reg(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 1831.
+        // Rule at src/isa/s390x/inst.isle line 1823.
         let expr0_0 = MInst::AtomicCas64 {
             rd: pattern2_0,
             rn: pattern3_0,
@@ -2943,14 +2938,14 @@ pub fn constructor_push_break_if<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    if let &ProducesFlags::ProducesFlags {
+    if let &ProducesFlags::ProducesFlagsReturnsReg {
         inst: ref pattern2_0,
         result: pattern2_1,
     } = pattern1_0
     {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1837.
-        let expr0_0 = C::inst_builder_push(ctx, pattern0_0, &pattern2_0);
+        // Rule at src/isa/s390x/inst.isle line 1829.
+        let expr0_0 = C::inst_builder_push(ctx, pattern0_0, pattern2_0);
         let expr1_0 = MInst::CondBreak {
             cond: pattern3_0.clone(),
         };
@@ -2968,7 +2963,7 @@ pub fn constructor_emit_loop<C: Context>(
 ) -> Option<Unit> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1844.
+    // Rule at src/isa/s390x/inst.isle line 1836.
     let expr0_0 = C::inst_builder_finish(ctx, pattern0_0);
     let expr1_0 = MInst::Loop {
         body: expr0_0,
@@ -2989,7 +2984,7 @@ pub fn constructor_emit_mov<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1859.
+        // Rule at src/isa/s390x/inst.isle line 1851.
         let expr0_0 = MInst::FpuMove32 {
             rd: pattern2_0,
             rn: pattern3_0,
@@ -3000,7 +2995,7 @@ pub fn constructor_emit_mov<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1862.
+        // Rule at src/isa/s390x/inst.isle line 1854.
         let expr0_0 = MInst::FpuMove64 {
             rd: pattern2_0,
             rn: pattern3_0,
@@ -3011,7 +3006,7 @@ pub fn constructor_emit_mov<C: Context>(
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1853.
+        // Rule at src/isa/s390x/inst.isle line 1845.
         let expr0_0 = MInst::Mov32 {
             rd: pattern2_0,
             rm: pattern3_0,
@@ -3022,7 +3017,7 @@ pub fn constructor_emit_mov<C: Context>(
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1856.
+        // Rule at src/isa/s390x/inst.isle line 1848.
         let expr0_0 = MInst::Mov64 {
             rd: pattern2_0,
             rm: pattern3_0,
@@ -3041,7 +3036,7 @@ pub fn constructor_copy_writable_reg<C: Context>(
 ) -> Option<WritableReg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1867.
+    // Rule at src/isa/s390x/inst.isle line 1859.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = constructor_emit_mov(ctx, pattern0_0, expr0_0, pattern1_0)?;
     return Some(expr0_0);
@@ -3051,7 +3046,7 @@ pub fn constructor_copy_writable_reg<C: Context>(
 pub fn constructor_copy_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1874.
+    // Rule at src/isa/s390x/inst.isle line 1866.
     let expr0_0 = constructor_copy_writable_reg(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -3068,7 +3063,7 @@ pub fn constructor_emit_load<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1878.
+        // Rule at src/isa/s390x/inst.isle line 1870.
         let expr0_0 = MInst::Load32 {
             rd: pattern2_0,
             mem: pattern3_0.clone(),
@@ -3079,7 +3074,7 @@ pub fn constructor_emit_load<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1880.
+        // Rule at src/isa/s390x/inst.isle line 1872.
         let expr0_0 = MInst::Load64 {
             rd: pattern2_0,
             mem: pattern3_0.clone(),
@@ -3101,7 +3096,7 @@ pub fn constructor_emit_imm<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1936.
+        // Rule at src/isa/s390x/inst.isle line 1928.
         let expr0_0 = C::u64_as_u32(ctx, pattern3_0);
         let expr1_0 = MInst::LoadFpuConst32 {
             rd: pattern2_0,
@@ -3113,7 +3108,7 @@ pub fn constructor_emit_imm<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1941.
+        // Rule at src/isa/s390x/inst.isle line 1933.
         let expr0_0 = MInst::LoadFpuConst64 {
             rd: pattern2_0,
             const_data: pattern3_0,
@@ -3124,7 +3119,7 @@ pub fn constructor_emit_imm<C: Context>(
     if let Some(pattern1_0) = C::fits_in_16(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 1890.
+        // Rule at src/isa/s390x/inst.isle line 1882.
         let expr0_0 = C::u64_as_i16(ctx, pattern3_0);
         let expr1_0 = MInst::Mov32SImm16 {
             rd: pattern2_0,
@@ -3137,7 +3132,7 @@ pub fn constructor_emit_imm<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         if let Some(pattern4_0) = C::i16_from_u64(ctx, pattern3_0) {
-            // Rule at src/isa/s390x/inst.isle line 1894.
+            // Rule at src/isa/s390x/inst.isle line 1886.
             let expr0_0 = MInst::Mov32SImm16 {
                 rd: pattern2_0,
                 imm: pattern4_0,
@@ -3145,7 +3140,7 @@ pub fn constructor_emit_imm<C: Context>(
             let expr1_0 = C::emit(ctx, &expr0_0);
             return Some(expr1_0);
         }
-        // Rule at src/isa/s390x/inst.isle line 1898.
+        // Rule at src/isa/s390x/inst.isle line 1890.
         let expr0_0 = C::u64_as_u32(ctx, pattern3_0);
         let expr1_0 = MInst::Mov32Imm {
             rd: pattern2_0,
@@ -3159,14 +3154,14 @@ pub fn constructor_emit_imm<C: Context>(
         let pattern3_0 = arg2;
         if let Some(pattern4_0) = C::u64_nonzero_hipart(ctx, pattern3_0) {
             if let Some(pattern5_0) = C::u64_nonzero_lopart(ctx, pattern3_0) {
-                // Rule at src/isa/s390x/inst.isle line 1918.
+                // Rule at src/isa/s390x/inst.isle line 1910.
                 let expr0_0 = constructor_emit_imm(ctx, pattern1_0, pattern2_0, pattern4_0)?;
                 let expr1_0 = constructor_emit_insert_imm(ctx, pattern2_0, pattern5_0)?;
                 return Some(expr1_0);
             }
         }
         if let Some(pattern4_0) = C::i16_from_u64(ctx, pattern3_0) {
-            // Rule at src/isa/s390x/inst.isle line 1902.
+            // Rule at src/isa/s390x/inst.isle line 1894.
             let expr0_0 = MInst::Mov64SImm16 {
                 rd: pattern2_0,
                 imm: pattern4_0,
@@ -3175,7 +3170,7 @@ pub fn constructor_emit_imm<C: Context>(
             return Some(expr1_0);
         }
         if let Some(pattern4_0) = C::i32_from_u64(ctx, pattern3_0) {
-            // Rule at src/isa/s390x/inst.isle line 1906.
+            // Rule at src/isa/s390x/inst.isle line 1898.
             let expr0_0 = MInst::Mov64SImm32 {
                 rd: pattern2_0,
                 imm: pattern4_0,
@@ -3184,7 +3179,7 @@ pub fn constructor_emit_imm<C: Context>(
             return Some(expr1_0);
         }
         if let Some(pattern4_0) = C::uimm32shifted_from_u64(ctx, pattern3_0) {
-            // Rule at src/isa/s390x/inst.isle line 1914.
+            // Rule at src/isa/s390x/inst.isle line 1906.
             let expr0_0 = MInst::Mov64UImm32Shifted {
                 rd: pattern2_0,
                 imm: pattern4_0,
@@ -3193,7 +3188,7 @@ pub fn constructor_emit_imm<C: Context>(
             return Some(expr1_0);
         }
         if let Some(pattern4_0) = C::uimm16shifted_from_u64(ctx, pattern3_0) {
-            // Rule at src/isa/s390x/inst.isle line 1910.
+            // Rule at src/isa/s390x/inst.isle line 1902.
             let expr0_0 = MInst::Mov64UImm16Shifted {
                 rd: pattern2_0,
                 imm: pattern4_0,
@@ -3214,7 +3209,7 @@ pub fn constructor_emit_insert_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     if let Some(pattern2_0) = C::uimm32shifted_from_u64(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 1931.
+        // Rule at src/isa/s390x/inst.isle line 1923.
         let expr0_0 = MInst::Insert64UImm32Shifted {
             rd: pattern0_0,
             imm: pattern2_0,
@@ -3223,7 +3218,7 @@ pub fn constructor_emit_insert_imm<C: Context>(
         return Some(expr1_0);
     }
     if let Some(pattern2_0) = C::uimm16shifted_from_u64(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 1927.
+        // Rule at src/isa/s390x/inst.isle line 1919.
         let expr0_0 = MInst::Insert64UImm16Shifted {
             rd: pattern0_0,
             imm: pattern2_0,
@@ -3238,7 +3233,7 @@ pub fn constructor_emit_insert_imm<C: Context>(
 pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 1946.
+    // Rule at src/isa/s390x/inst.isle line 1938.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = constructor_emit_imm(ctx, pattern0_0, expr0_0, pattern1_0)?;
     let expr2_0 = C::writable_reg_to_reg(ctx, expr0_0);
@@ -3255,7 +3250,7 @@ pub fn constructor_imm_regpair_lo<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1954.
+    // Rule at src/isa/s390x/inst.isle line 1946.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern2_0)?;
     let expr1_0 = constructor_writable_regpair_lo(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_imm(ctx, pattern0_0, expr1_0, pattern1_0)?;
@@ -3273,7 +3268,7 @@ pub fn constructor_imm_regpair_hi<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1962.
+    // Rule at src/isa/s390x/inst.isle line 1954.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern2_0)?;
     let expr1_0 = constructor_writable_regpair_hi(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_imm(ctx, pattern0_0, expr1_0, pattern1_0)?;
@@ -3285,22 +3280,22 @@ pub fn constructor_imm_regpair_hi<C: Context>(
 pub fn constructor_ty_ext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<Type> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 1972.
+        // Rule at src/isa/s390x/inst.isle line 1964.
         let expr0_0: Type = I32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 1973.
+        // Rule at src/isa/s390x/inst.isle line 1965.
         let expr0_0: Type = I32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 1974.
+        // Rule at src/isa/s390x/inst.isle line 1966.
         let expr0_0: Type = I32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 1975.
+        // Rule at src/isa/s390x/inst.isle line 1967.
         let expr0_0: Type = I64;
         return Some(expr0_0);
     }
@@ -3311,22 +3306,22 @@ pub fn constructor_ty_ext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<Type>
 pub fn constructor_ty_ext64<C: Context>(ctx: &mut C, arg0: Type) -> Option<Type> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 1979.
+        // Rule at src/isa/s390x/inst.isle line 1971.
         let expr0_0: Type = I64;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 1980.
+        // Rule at src/isa/s390x/inst.isle line 1972.
         let expr0_0: Type = I64;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 1981.
+        // Rule at src/isa/s390x/inst.isle line 1973.
         let expr0_0: Type = I64;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 1982.
+        // Rule at src/isa/s390x/inst.isle line 1974.
         let expr0_0: Type = I64;
         return Some(expr0_0);
     }
@@ -3343,7 +3338,7 @@ pub fn constructor_emit_zext32_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1987.
+    // Rule at src/isa/s390x/inst.isle line 1979.
     let expr0_0: bool = false;
     let expr1_0 = C::ty_bits(ctx, pattern1_0);
     let expr2_0: u8 = 32;
@@ -3368,7 +3363,7 @@ pub fn constructor_emit_sext32_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1993.
+    // Rule at src/isa/s390x/inst.isle line 1985.
     let expr0_0: bool = true;
     let expr1_0 = C::ty_bits(ctx, pattern1_0);
     let expr2_0: u8 = 32;
@@ -3393,7 +3388,7 @@ pub fn constructor_emit_zext64_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 1999.
+    // Rule at src/isa/s390x/inst.isle line 1991.
     let expr0_0: bool = false;
     let expr1_0 = C::ty_bits(ctx, pattern1_0);
     let expr2_0: u8 = 64;
@@ -3418,7 +3413,7 @@ pub fn constructor_emit_sext64_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2005.
+    // Rule at src/isa/s390x/inst.isle line 1997.
     let expr0_0: bool = true;
     let expr1_0 = C::ty_bits(ctx, pattern1_0);
     let expr2_0: u8 = 64;
@@ -3437,7 +3432,7 @@ pub fn constructor_emit_sext64_reg<C: Context>(
 pub fn constructor_zext32_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2011.
+    // Rule at src/isa/s390x/inst.isle line 2003.
     let expr0_0: Type = I32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_zext32_reg(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3449,7 +3444,7 @@ pub fn constructor_zext32_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) ->
 pub fn constructor_sext32_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2019.
+    // Rule at src/isa/s390x/inst.isle line 2011.
     let expr0_0: Type = I32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_sext32_reg(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3461,7 +3456,7 @@ pub fn constructor_sext32_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) ->
 pub fn constructor_zext64_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2027.
+    // Rule at src/isa/s390x/inst.isle line 2019.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_zext64_reg(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3473,7 +3468,7 @@ pub fn constructor_zext64_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) ->
 pub fn constructor_sext64_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2035.
+    // Rule at src/isa/s390x/inst.isle line 2027.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_sext64_reg(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3492,7 +3487,7 @@ pub fn constructor_emit_zext32_mem<C: Context>(
     let pattern1_0 = arg1;
     if pattern1_0 == I8 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2043.
+        // Rule at src/isa/s390x/inst.isle line 2035.
         let expr0_0 = MInst::Load32ZExt8 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3502,7 +3497,7 @@ pub fn constructor_emit_zext32_mem<C: Context>(
     }
     if pattern1_0 == I16 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2044.
+        // Rule at src/isa/s390x/inst.isle line 2036.
         let expr0_0 = MInst::Load32ZExt16 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3524,7 +3519,7 @@ pub fn constructor_emit_sext32_mem<C: Context>(
     let pattern1_0 = arg1;
     if pattern1_0 == I8 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2048.
+        // Rule at src/isa/s390x/inst.isle line 2040.
         let expr0_0 = MInst::Load32SExt8 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3534,7 +3529,7 @@ pub fn constructor_emit_sext32_mem<C: Context>(
     }
     if pattern1_0 == I16 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2049.
+        // Rule at src/isa/s390x/inst.isle line 2041.
         let expr0_0 = MInst::Load32SExt16 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3556,7 +3551,7 @@ pub fn constructor_emit_zext64_mem<C: Context>(
     let pattern1_0 = arg1;
     if pattern1_0 == I8 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2053.
+        // Rule at src/isa/s390x/inst.isle line 2045.
         let expr0_0 = MInst::Load64ZExt8 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3566,7 +3561,7 @@ pub fn constructor_emit_zext64_mem<C: Context>(
     }
     if pattern1_0 == I16 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2054.
+        // Rule at src/isa/s390x/inst.isle line 2046.
         let expr0_0 = MInst::Load64ZExt16 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3576,7 +3571,7 @@ pub fn constructor_emit_zext64_mem<C: Context>(
     }
     if pattern1_0 == I32 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2055.
+        // Rule at src/isa/s390x/inst.isle line 2047.
         let expr0_0 = MInst::Load64ZExt32 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3598,7 +3593,7 @@ pub fn constructor_emit_sext64_mem<C: Context>(
     let pattern1_0 = arg1;
     if pattern1_0 == I8 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2059.
+        // Rule at src/isa/s390x/inst.isle line 2051.
         let expr0_0 = MInst::Load64SExt8 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3608,7 +3603,7 @@ pub fn constructor_emit_sext64_mem<C: Context>(
     }
     if pattern1_0 == I16 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2060.
+        // Rule at src/isa/s390x/inst.isle line 2052.
         let expr0_0 = MInst::Load64SExt16 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3618,7 +3613,7 @@ pub fn constructor_emit_sext64_mem<C: Context>(
     }
     if pattern1_0 == I32 {
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2061.
+        // Rule at src/isa/s390x/inst.isle line 2053.
         let expr0_0 = MInst::Load64SExt32 {
             rd: pattern0_0,
             mem: pattern3_0.clone(),
@@ -3633,7 +3628,7 @@ pub fn constructor_emit_sext64_mem<C: Context>(
 pub fn constructor_zext32_mem<C: Context>(ctx: &mut C, arg0: Type, arg1: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2065.
+    // Rule at src/isa/s390x/inst.isle line 2057.
     let expr0_0: Type = I32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_zext32_mem(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3645,7 +3640,7 @@ pub fn constructor_zext32_mem<C: Context>(ctx: &mut C, arg0: Type, arg1: &MemArg
 pub fn constructor_sext32_mem<C: Context>(ctx: &mut C, arg0: Type, arg1: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2072.
+    // Rule at src/isa/s390x/inst.isle line 2064.
     let expr0_0: Type = I32;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_sext32_mem(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3657,7 +3652,7 @@ pub fn constructor_sext32_mem<C: Context>(ctx: &mut C, arg0: Type, arg1: &MemArg
 pub fn constructor_zext64_mem<C: Context>(ctx: &mut C, arg0: Type, arg1: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2079.
+    // Rule at src/isa/s390x/inst.isle line 2071.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_zext64_mem(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3669,7 +3664,7 @@ pub fn constructor_zext64_mem<C: Context>(ctx: &mut C, arg0: Type, arg1: &MemArg
 pub fn constructor_sext64_mem<C: Context>(ctx: &mut C, arg0: Type, arg1: &MemArg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2086.
+    // Rule at src/isa/s390x/inst.isle line 2078.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_emit_sext64_mem(ctx, expr1_0, pattern0_0, pattern1_0)?;
@@ -3687,7 +3682,7 @@ pub fn constructor_emit_put_in_reg_zext32<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = C::value_type(ctx, pattern1_0);
     if let Some(pattern3_0) = C::u64_from_value(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2094.
+        // Rule at src/isa/s390x/inst.isle line 2086.
         let expr0_0 = constructor_ty_ext32(ctx, pattern2_0)?;
         let expr1_0 = constructor_emit_imm(ctx, expr0_0, pattern0_0, pattern3_0)?;
         return Some(expr1_0);
@@ -3702,9 +3697,9 @@ pub fn constructor_emit_put_in_reg_zext32<C: Context>(
                 offset: pattern6_3,
             } = &pattern5_0
             {
-                if let &Opcode::Load = &pattern6_0 {
+                if let &Opcode::Load = pattern6_0 {
                     if let Some(()) = C::bigendian(ctx, pattern6_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2096.
+                        // Rule at src/isa/s390x/inst.isle line 2088.
                         let expr0_0 = constructor_sink_load(ctx, pattern4_0)?;
                         let expr1_0 =
                             constructor_emit_zext32_mem(ctx, pattern0_0, pattern3_0, &expr0_0)?;
@@ -3713,13 +3708,13 @@ pub fn constructor_emit_put_in_reg_zext32<C: Context>(
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2098.
+        // Rule at src/isa/s390x/inst.isle line 2090.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_zext32_reg(ctx, pattern0_0, pattern3_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern3_0) = C::ty_32_or_64(ctx, pattern2_0) {
-        // Rule at src/isa/s390x/inst.isle line 2100.
+        // Rule at src/isa/s390x/inst.isle line 2092.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_mov(ctx, pattern3_0, pattern0_0, expr0_0)?;
         return Some(expr1_0);
@@ -3737,7 +3732,7 @@ pub fn constructor_emit_put_in_reg_sext32<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = C::value_type(ctx, pattern1_0);
     if let Some(pattern3_0) = C::u64_from_signed_value(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2105.
+        // Rule at src/isa/s390x/inst.isle line 2097.
         let expr0_0 = constructor_ty_ext32(ctx, pattern2_0)?;
         let expr1_0 = constructor_emit_imm(ctx, expr0_0, pattern0_0, pattern3_0)?;
         return Some(expr1_0);
@@ -3752,9 +3747,9 @@ pub fn constructor_emit_put_in_reg_sext32<C: Context>(
                 offset: pattern6_3,
             } = &pattern5_0
             {
-                if let &Opcode::Load = &pattern6_0 {
+                if let &Opcode::Load = pattern6_0 {
                     if let Some(()) = C::bigendian(ctx, pattern6_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2107.
+                        // Rule at src/isa/s390x/inst.isle line 2099.
                         let expr0_0 = constructor_sink_load(ctx, pattern4_0)?;
                         let expr1_0 =
                             constructor_emit_sext32_mem(ctx, pattern0_0, pattern3_0, &expr0_0)?;
@@ -3763,13 +3758,13 @@ pub fn constructor_emit_put_in_reg_sext32<C: Context>(
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2109.
+        // Rule at src/isa/s390x/inst.isle line 2101.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_sext32_reg(ctx, pattern0_0, pattern3_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern3_0) = C::ty_32_or_64(ctx, pattern2_0) {
-        // Rule at src/isa/s390x/inst.isle line 2111.
+        // Rule at src/isa/s390x/inst.isle line 2103.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_mov(ctx, pattern3_0, pattern0_0, expr0_0)?;
         return Some(expr1_0);
@@ -3787,7 +3782,7 @@ pub fn constructor_emit_put_in_reg_zext64<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = C::value_type(ctx, pattern1_0);
     if let Some(pattern3_0) = C::u64_from_value(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2116.
+        // Rule at src/isa/s390x/inst.isle line 2108.
         let expr0_0 = constructor_ty_ext64(ctx, pattern2_0)?;
         let expr1_0 = constructor_emit_imm(ctx, expr0_0, pattern0_0, pattern3_0)?;
         return Some(expr1_0);
@@ -3802,9 +3797,9 @@ pub fn constructor_emit_put_in_reg_zext64<C: Context>(
                 offset: pattern6_3,
             } = &pattern5_0
             {
-                if let &Opcode::Load = &pattern6_0 {
+                if let &Opcode::Load = pattern6_0 {
                     if let Some(()) = C::bigendian(ctx, pattern6_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2118.
+                        // Rule at src/isa/s390x/inst.isle line 2110.
                         let expr0_0 = constructor_sink_load(ctx, pattern4_0)?;
                         let expr1_0 =
                             constructor_emit_zext64_mem(ctx, pattern0_0, pattern3_0, &expr0_0)?;
@@ -3813,13 +3808,13 @@ pub fn constructor_emit_put_in_reg_zext64<C: Context>(
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2120.
+        // Rule at src/isa/s390x/inst.isle line 2112.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_zext64_reg(ctx, pattern0_0, pattern3_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern3_0) = C::gpr64_ty(ctx, pattern2_0) {
-        // Rule at src/isa/s390x/inst.isle line 2122.
+        // Rule at src/isa/s390x/inst.isle line 2114.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_mov(ctx, pattern3_0, pattern0_0, expr0_0)?;
         return Some(expr1_0);
@@ -3837,7 +3832,7 @@ pub fn constructor_emit_put_in_reg_sext64<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = C::value_type(ctx, pattern1_0);
     if let Some(pattern3_0) = C::u64_from_signed_value(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2127.
+        // Rule at src/isa/s390x/inst.isle line 2119.
         let expr0_0 = constructor_ty_ext64(ctx, pattern2_0)?;
         let expr1_0 = constructor_emit_imm(ctx, expr0_0, pattern0_0, pattern3_0)?;
         return Some(expr1_0);
@@ -3852,9 +3847,9 @@ pub fn constructor_emit_put_in_reg_sext64<C: Context>(
                 offset: pattern6_3,
             } = &pattern5_0
             {
-                if let &Opcode::Load = &pattern6_0 {
+                if let &Opcode::Load = pattern6_0 {
                     if let Some(()) = C::bigendian(ctx, pattern6_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2129.
+                        // Rule at src/isa/s390x/inst.isle line 2121.
                         let expr0_0 = constructor_sink_load(ctx, pattern4_0)?;
                         let expr1_0 =
                             constructor_emit_sext64_mem(ctx, pattern0_0, pattern3_0, &expr0_0)?;
@@ -3863,13 +3858,13 @@ pub fn constructor_emit_put_in_reg_sext64<C: Context>(
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2131.
+        // Rule at src/isa/s390x/inst.isle line 2123.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_sext64_reg(ctx, pattern0_0, pattern3_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern3_0) = C::gpr64_ty(ctx, pattern2_0) {
-        // Rule at src/isa/s390x/inst.isle line 2133.
+        // Rule at src/isa/s390x/inst.isle line 2125.
         let expr0_0 = C::put_in_reg(ctx, pattern1_0);
         let expr1_0 = constructor_emit_mov(ctx, pattern3_0, pattern0_0, expr0_0)?;
         return Some(expr1_0);
@@ -3882,7 +3877,7 @@ pub fn constructor_put_in_reg_zext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if let Some(pattern2_0) = C::u64_from_value(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2138.
+        // Rule at src/isa/s390x/inst.isle line 2130.
         let expr0_0 = constructor_ty_ext32(ctx, pattern1_0)?;
         let expr1_0 = constructor_imm(ctx, expr0_0, pattern2_0)?;
         return Some(expr1_0);
@@ -3897,9 +3892,9 @@ pub fn constructor_put_in_reg_zext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 offset: pattern5_3,
             } = &pattern4_0
             {
-                if let &Opcode::Load = &pattern5_0 {
+                if let &Opcode::Load = pattern5_0 {
                     if let Some(()) = C::bigendian(ctx, pattern5_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2140.
+                        // Rule at src/isa/s390x/inst.isle line 2132.
                         let expr0_0 = constructor_sink_load(ctx, pattern3_0)?;
                         let expr1_0 = constructor_zext32_mem(ctx, pattern2_0, &expr0_0)?;
                         return Some(expr1_0);
@@ -3907,13 +3902,13 @@ pub fn constructor_put_in_reg_zext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2142.
+        // Rule at src/isa/s390x/inst.isle line 2134.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0 = constructor_zext32_reg(ctx, pattern2_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern2_0) = C::ty_32_or_64(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2144.
+        // Rule at src/isa/s390x/inst.isle line 2136.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
@@ -3925,7 +3920,7 @@ pub fn constructor_put_in_reg_sext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if let Some(pattern2_0) = C::u64_from_signed_value(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2149.
+        // Rule at src/isa/s390x/inst.isle line 2141.
         let expr0_0 = constructor_ty_ext32(ctx, pattern1_0)?;
         let expr1_0 = constructor_imm(ctx, expr0_0, pattern2_0)?;
         return Some(expr1_0);
@@ -3940,9 +3935,9 @@ pub fn constructor_put_in_reg_sext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 offset: pattern5_3,
             } = &pattern4_0
             {
-                if let &Opcode::Load = &pattern5_0 {
+                if let &Opcode::Load = pattern5_0 {
                     if let Some(()) = C::bigendian(ctx, pattern5_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2151.
+                        // Rule at src/isa/s390x/inst.isle line 2143.
                         let expr0_0 = constructor_sink_load(ctx, pattern3_0)?;
                         let expr1_0 = constructor_sext32_mem(ctx, pattern2_0, &expr0_0)?;
                         return Some(expr1_0);
@@ -3950,13 +3945,13 @@ pub fn constructor_put_in_reg_sext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2153.
+        // Rule at src/isa/s390x/inst.isle line 2145.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0 = constructor_sext32_reg(ctx, pattern2_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern2_0) = C::ty_32_or_64(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2155.
+        // Rule at src/isa/s390x/inst.isle line 2147.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
@@ -3968,7 +3963,7 @@ pub fn constructor_put_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if let Some(pattern2_0) = C::u64_from_value(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2160.
+        // Rule at src/isa/s390x/inst.isle line 2152.
         let expr0_0 = constructor_ty_ext64(ctx, pattern1_0)?;
         let expr1_0 = constructor_imm(ctx, expr0_0, pattern2_0)?;
         return Some(expr1_0);
@@ -3983,9 +3978,9 @@ pub fn constructor_put_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 offset: pattern5_3,
             } = &pattern4_0
             {
-                if let &Opcode::Load = &pattern5_0 {
+                if let &Opcode::Load = pattern5_0 {
                     if let Some(()) = C::bigendian(ctx, pattern5_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2162.
+                        // Rule at src/isa/s390x/inst.isle line 2154.
                         let expr0_0 = constructor_sink_load(ctx, pattern3_0)?;
                         let expr1_0 = constructor_zext64_mem(ctx, pattern2_0, &expr0_0)?;
                         return Some(expr1_0);
@@ -3993,13 +3988,13 @@ pub fn constructor_put_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2164.
+        // Rule at src/isa/s390x/inst.isle line 2156.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0 = constructor_zext64_reg(ctx, pattern2_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern2_0) = C::gpr64_ty(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2166.
+        // Rule at src/isa/s390x/inst.isle line 2158.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
@@ -4011,7 +4006,7 @@ pub fn constructor_put_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if let Some(pattern2_0) = C::u64_from_signed_value(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2171.
+        // Rule at src/isa/s390x/inst.isle line 2163.
         let expr0_0 = constructor_ty_ext64(ctx, pattern1_0)?;
         let expr1_0 = constructor_imm(ctx, expr0_0, pattern2_0)?;
         return Some(expr1_0);
@@ -4026,9 +4021,9 @@ pub fn constructor_put_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 offset: pattern5_3,
             } = &pattern4_0
             {
-                if let &Opcode::Load = &pattern5_0 {
+                if let &Opcode::Load = pattern5_0 {
                     if let Some(()) = C::bigendian(ctx, pattern5_2) {
-                        // Rule at src/isa/s390x/inst.isle line 2173.
+                        // Rule at src/isa/s390x/inst.isle line 2165.
                         let expr0_0 = constructor_sink_load(ctx, pattern3_0)?;
                         let expr1_0 = constructor_sext64_mem(ctx, pattern2_0, &expr0_0)?;
                         return Some(expr1_0);
@@ -4036,13 +4031,13 @@ pub fn constructor_put_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
                 }
             }
         }
-        // Rule at src/isa/s390x/inst.isle line 2175.
+        // Rule at src/isa/s390x/inst.isle line 2167.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0 = constructor_sext64_reg(ctx, pattern2_0, expr0_0)?;
         return Some(expr1_0);
     }
     if let Some(pattern2_0) = C::gpr64_ty(ctx, pattern1_0) {
-        // Rule at src/isa/s390x/inst.isle line 2177.
+        // Rule at src/isa/s390x/inst.isle line 2169.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
@@ -4057,7 +4052,7 @@ pub fn constructor_put_in_regpair_lo_zext32<C: Context>(
 ) -> Option<RegPair> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2183.
+    // Rule at src/isa/s390x/inst.isle line 2175.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern1_0)?;
     let expr1_0 = constructor_writable_regpair_lo(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_put_in_reg_zext32(ctx, expr1_0, pattern0_0)?;
@@ -4073,7 +4068,7 @@ pub fn constructor_put_in_regpair_lo_sext32<C: Context>(
 ) -> Option<RegPair> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2191.
+    // Rule at src/isa/s390x/inst.isle line 2183.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern1_0)?;
     let expr1_0 = constructor_writable_regpair_lo(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_put_in_reg_sext32(ctx, expr1_0, pattern0_0)?;
@@ -4089,7 +4084,7 @@ pub fn constructor_put_in_regpair_lo_zext64<C: Context>(
 ) -> Option<RegPair> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2199.
+    // Rule at src/isa/s390x/inst.isle line 2191.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern1_0)?;
     let expr1_0 = constructor_writable_regpair_lo(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_put_in_reg_zext64(ctx, expr1_0, pattern0_0)?;
@@ -4105,7 +4100,7 @@ pub fn constructor_put_in_regpair_lo_sext64<C: Context>(
 ) -> Option<RegPair> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2207.
+    // Rule at src/isa/s390x/inst.isle line 2199.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern1_0)?;
     let expr1_0 = constructor_writable_regpair_lo(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_put_in_reg_sext64(ctx, expr1_0, pattern0_0)?;
@@ -4126,14 +4121,14 @@ pub fn constructor_emit_cmov_imm<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2217.
+        // Rule at src/isa/s390x/inst.isle line 2209.
         let expr0_0 = MInst::CMov32SImm16 {
             rd: pattern2_0,
             cond: pattern3_0.clone(),
             imm: pattern4_0,
         };
         let expr1_0 = C::writable_reg_to_reg(ctx, pattern2_0);
-        let expr2_0 = ConsumesFlags::ConsumesFlags {
+        let expr2_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
             inst: expr0_0,
             result: expr1_0,
         };
@@ -4143,14 +4138,14 @@ pub fn constructor_emit_cmov_imm<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2220.
+        // Rule at src/isa/s390x/inst.isle line 2212.
         let expr0_0 = MInst::CMov64SImm16 {
             rd: pattern2_0,
             cond: pattern3_0.clone(),
             imm: pattern4_0,
         };
         let expr1_0 = C::writable_reg_to_reg(ctx, pattern2_0);
-        let expr2_0 = ConsumesFlags::ConsumesFlags {
+        let expr2_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
             inst: expr0_0,
             result: expr1_0,
         };
@@ -4171,7 +4166,7 @@ pub fn constructor_cmov_imm<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 2226.
+    // Rule at src/isa/s390x/inst.isle line 2218.
     let expr0_0 = constructor_copy_writable_reg(ctx, pattern0_0, pattern3_0)?;
     let expr1_0 = constructor_emit_cmov_imm(ctx, pattern0_0, expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -4191,11 +4186,11 @@ pub fn constructor_cmov_imm_regpair_lo<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2233.
+    // Rule at src/isa/s390x/inst.isle line 2225.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern4_0)?;
     let expr1_0 = constructor_writable_regpair_lo(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_cmov_imm(ctx, pattern0_0, expr1_0, pattern2_0, pattern3_0)?;
-    let expr3_0 = constructor_with_flags_1(ctx, pattern1_0, &expr2_0)?;
+    let expr3_0 = constructor_with_flags_reg(ctx, pattern1_0, &expr2_0)?;
     let expr4_0 = constructor_writable_regpair_to_regpair(ctx, &expr0_0)?;
     return Some(expr4_0);
 }
@@ -4214,11 +4209,11 @@ pub fn constructor_cmov_imm_regpair_hi<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2242.
+    // Rule at src/isa/s390x/inst.isle line 2234.
     let expr0_0 = constructor_copy_writable_regpair(ctx, pattern4_0)?;
     let expr1_0 = constructor_writable_regpair_hi(ctx, &expr0_0)?;
     let expr2_0 = constructor_emit_cmov_imm(ctx, pattern0_0, expr1_0, pattern2_0, pattern3_0)?;
-    let expr3_0 = constructor_with_flags_1(ctx, pattern1_0, &expr2_0)?;
+    let expr3_0 = constructor_with_flags_reg(ctx, pattern1_0, &expr2_0)?;
     let expr4_0 = constructor_writable_regpair_to_regpair(ctx, &expr0_0)?;
     return Some(expr4_0);
 }
@@ -4236,14 +4231,14 @@ pub fn constructor_emit_cmov_reg<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2256.
+        // Rule at src/isa/s390x/inst.isle line 2248.
         let expr0_0 = MInst::FpuCMov32 {
             rd: pattern2_0,
             cond: pattern3_0.clone(),
             rm: pattern4_0,
         };
         let expr1_0 = C::writable_reg_to_reg(ctx, pattern2_0);
-        let expr2_0 = ConsumesFlags::ConsumesFlags {
+        let expr2_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
             inst: expr0_0,
             result: expr1_0,
         };
@@ -4253,14 +4248,14 @@ pub fn constructor_emit_cmov_reg<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2259.
+        // Rule at src/isa/s390x/inst.isle line 2251.
         let expr0_0 = MInst::FpuCMov64 {
             rd: pattern2_0,
             cond: pattern3_0.clone(),
             rm: pattern4_0,
         };
         let expr1_0 = C::writable_reg_to_reg(ctx, pattern2_0);
-        let expr2_0 = ConsumesFlags::ConsumesFlags {
+        let expr2_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
             inst: expr0_0,
             result: expr1_0,
         };
@@ -4270,14 +4265,14 @@ pub fn constructor_emit_cmov_reg<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2250.
+        // Rule at src/isa/s390x/inst.isle line 2242.
         let expr0_0 = MInst::CMov32 {
             rd: pattern2_0,
             cond: pattern3_0.clone(),
             rm: pattern4_0,
         };
         let expr1_0 = C::writable_reg_to_reg(ctx, pattern2_0);
-        let expr2_0 = ConsumesFlags::ConsumesFlags {
+        let expr2_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
             inst: expr0_0,
             result: expr1_0,
         };
@@ -4287,14 +4282,14 @@ pub fn constructor_emit_cmov_reg<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2253.
+        // Rule at src/isa/s390x/inst.isle line 2245.
         let expr0_0 = MInst::CMov64 {
             rd: pattern2_0,
             cond: pattern3_0.clone(),
             rm: pattern4_0,
         };
         let expr1_0 = C::writable_reg_to_reg(ctx, pattern2_0);
-        let expr2_0 = ConsumesFlags::ConsumesFlags {
+        let expr2_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
             inst: expr0_0,
             result: expr1_0,
         };
@@ -4315,7 +4310,7 @@ pub fn constructor_cmov_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 2265.
+    // Rule at src/isa/s390x/inst.isle line 2257.
     let expr0_0 = constructor_copy_writable_reg(ctx, pattern0_0, pattern3_0)?;
     let expr1_0 = constructor_emit_cmov_reg(ctx, pattern0_0, expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -4329,15 +4324,15 @@ pub fn constructor_trap_if<C: Context>(
     arg2: &TrapCode,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
+    if let &ProducesFlags::ProducesFlagsReturnsReg {
         inst: ref pattern1_0,
         result: pattern1_1,
     } = pattern0_0
     {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2273.
-        let expr0_0 = C::emit(ctx, &pattern1_0);
+        // Rule at src/isa/s390x/inst.isle line 2265.
+        let expr0_0 = C::emit(ctx, pattern1_0);
         let expr1_0 = MInst::TrapIf {
             cond: pattern2_0.clone(),
             trap_code: pattern3_0.clone(),
@@ -4362,7 +4357,7 @@ pub fn constructor_icmps_reg_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2279.
+    // Rule at src/isa/s390x/inst.isle line 2271.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRR {
         op: expr0_0,
@@ -4390,7 +4385,7 @@ pub fn constructor_icmps_simm16_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2285.
+    // Rule at src/isa/s390x/inst.isle line 2277.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRSImm16 {
         op: expr0_0,
@@ -4418,7 +4413,7 @@ pub fn constructor_icmpu_reg_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2291.
+    // Rule at src/isa/s390x/inst.isle line 2283.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRR {
         op: expr0_0,
@@ -4446,7 +4441,7 @@ pub fn constructor_icmpu_uimm16_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2297.
+    // Rule at src/isa/s390x/inst.isle line 2289.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRUImm16 {
         op: expr0_0,
@@ -4466,7 +4461,7 @@ pub fn constructor_trap_impl<C: Context>(
     arg0: &TrapCode,
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2303.
+    // Rule at src/isa/s390x/inst.isle line 2295.
     let expr0_0 = MInst::Trap {
         trap_code: pattern0_0.clone(),
     };
@@ -4482,7 +4477,7 @@ pub fn constructor_trap_if_impl<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2307.
+    // Rule at src/isa/s390x/inst.isle line 2299.
     let expr0_0 = MInst::TrapIf {
         cond: pattern0_0.clone(),
         trap_code: pattern1_0.clone(),
@@ -4493,7 +4488,7 @@ pub fn constructor_trap_if_impl<C: Context>(
 
 // Generated as internal constructor for term debugtrap_impl.
 pub fn constructor_debugtrap_impl<C: Context>(ctx: &mut C) -> Option<SideEffectNoResult> {
-    // Rule at src/isa/s390x/inst.isle line 2311.
+    // Rule at src/isa/s390x/inst.isle line 2303.
     let expr0_0 = MInst::Debugtrap;
     let expr1_0 = SideEffectNoResult::Inst { inst: expr0_0 };
     return Some(expr1_0);
@@ -4507,7 +4502,7 @@ pub fn constructor_bool<C: Context>(
 ) -> Option<ProducesBool> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2322.
+    // Rule at src/isa/s390x/inst.isle line 2314.
     let expr0_0 = ProducesBool::ProducesBool {
         producer: pattern0_0.clone(),
         cond: pattern1_0.clone(),
@@ -4526,9 +4521,9 @@ pub fn constructor_invert_bool<C: Context>(
         cond: ref pattern1_1,
     } = pattern0_0
     {
-        // Rule at src/isa/s390x/inst.isle line 2326.
-        let expr0_0 = C::invert_cond(ctx, &pattern1_1);
-        let expr1_0 = constructor_bool(ctx, &pattern1_0, &expr0_0)?;
+        // Rule at src/isa/s390x/inst.isle line 2318.
+        let expr0_0 = C::invert_cond(ctx, pattern1_1);
+        let expr1_0 = constructor_bool(ctx, pattern1_0, &expr0_0)?;
         return Some(expr1_0);
     }
     return None;
@@ -4537,13 +4532,12 @@ pub fn constructor_invert_bool<C: Context>(
 // Generated as internal constructor for term emit_producer.
 pub fn constructor_emit_producer<C: Context>(ctx: &mut C, arg0: &ProducesFlags) -> Option<Unit> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlags {
+    if let &ProducesFlags::ProducesFlagsSideEffect {
         inst: ref pattern1_0,
-        result: pattern1_1,
     } = pattern0_0
     {
-        // Rule at src/isa/s390x/inst.isle line 2335.
-        let expr0_0 = C::emit(ctx, &pattern1_0);
+        // Rule at src/isa/s390x/inst.isle line 2327.
+        let expr0_0 = C::emit(ctx, pattern1_0);
         return Some(expr0_0);
     }
     return None;
@@ -4552,13 +4546,13 @@ pub fn constructor_emit_producer<C: Context>(ctx: &mut C, arg0: &ProducesFlags) 
 // Generated as internal constructor for term emit_consumer.
 pub fn constructor_emit_consumer<C: Context>(ctx: &mut C, arg0: &ConsumesFlags) -> Option<Unit> {
     let pattern0_0 = arg0;
-    if let &ConsumesFlags::ConsumesFlags {
+    if let &ConsumesFlags::ConsumesFlagsReturnsReg {
         inst: ref pattern1_0,
         result: pattern1_1,
     } = pattern0_0
     {
-        // Rule at src/isa/s390x/inst.isle line 2337.
-        let expr0_0 = C::emit(ctx, &pattern1_0);
+        // Rule at src/isa/s390x/inst.isle line 2329.
+        let expr0_0 = C::emit(ctx, pattern1_0);
         return Some(expr0_0);
     }
     return None;
@@ -4581,11 +4575,11 @@ pub fn constructor_select_bool_reg<C: Context>(
     {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2341.
+        // Rule at src/isa/s390x/inst.isle line 2333.
         let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
-        let expr1_0 = constructor_emit_producer(ctx, &pattern2_0)?;
+        let expr1_0 = constructor_emit_producer(ctx, pattern2_0)?;
         let expr2_0 = constructor_emit_mov(ctx, pattern0_0, expr0_0, pattern4_0)?;
-        let expr3_0 = constructor_emit_cmov_reg(ctx, pattern0_0, expr0_0, &pattern2_1, pattern3_0)?;
+        let expr3_0 = constructor_emit_cmov_reg(ctx, pattern0_0, expr0_0, pattern2_1, pattern3_0)?;
         let expr4_0 = constructor_emit_consumer(ctx, &expr3_0)?;
         let expr5_0 = C::writable_reg_to_reg(ctx, expr0_0);
         return Some(expr5_0);
@@ -4610,11 +4604,11 @@ pub fn constructor_select_bool_imm<C: Context>(
     {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2350.
+        // Rule at src/isa/s390x/inst.isle line 2342.
         let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
-        let expr1_0 = constructor_emit_producer(ctx, &pattern2_0)?;
+        let expr1_0 = constructor_emit_producer(ctx, pattern2_0)?;
         let expr2_0 = constructor_emit_imm(ctx, pattern0_0, expr0_0, pattern4_0)?;
-        let expr3_0 = constructor_emit_cmov_imm(ctx, pattern0_0, expr0_0, &pattern2_1, pattern3_0)?;
+        let expr3_0 = constructor_emit_cmov_imm(ctx, pattern0_0, expr0_0, pattern2_1, pattern3_0)?;
         let expr4_0 = constructor_emit_consumer(ctx, &expr3_0)?;
         let expr5_0 = C::writable_reg_to_reg(ctx, expr0_0);
         return Some(expr5_0);
@@ -4631,7 +4625,7 @@ pub fn constructor_lower_bool<C: Context>(
     let pattern0_0 = arg0;
     if pattern0_0 == B1 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2360.
+        // Rule at src/isa/s390x/inst.isle line 2352.
         let expr0_0: Type = B1;
         let expr1_0: i16 = 1;
         let expr2_0: u64 = 0;
@@ -4640,7 +4634,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B8 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2361.
+        // Rule at src/isa/s390x/inst.isle line 2353.
         let expr0_0: Type = B8;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4649,7 +4643,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B16 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2362.
+        // Rule at src/isa/s390x/inst.isle line 2354.
         let expr0_0: Type = B16;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4658,7 +4652,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B32 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2363.
+        // Rule at src/isa/s390x/inst.isle line 2355.
         let expr0_0: Type = B32;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4667,7 +4661,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B64 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2364.
+        // Rule at src/isa/s390x/inst.isle line 2356.
         let expr0_0: Type = B64;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4692,9 +4686,9 @@ pub fn constructor_cond_br_bool<C: Context>(
     {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2368.
-        let expr0_0 = constructor_emit_producer(ctx, &pattern1_0)?;
-        let expr1_0 = constructor_cond_br(ctx, pattern2_0, pattern3_0, &pattern1_1)?;
+        // Rule at src/isa/s390x/inst.isle line 2360.
+        let expr0_0 = constructor_emit_producer(ctx, pattern1_0)?;
+        let expr1_0 = constructor_cond_br(ctx, pattern2_0, pattern3_0, pattern1_1)?;
         return Some(expr1_0);
     }
     return None;
@@ -4713,9 +4707,9 @@ pub fn constructor_oneway_cond_br_bool<C: Context>(
     } = pattern0_0
     {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2374.
-        let expr0_0 = constructor_emit_producer(ctx, &pattern1_0)?;
-        let expr1_0 = constructor_oneway_cond_br(ctx, pattern2_0, &pattern1_1)?;
+        // Rule at src/isa/s390x/inst.isle line 2366.
+        let expr0_0 = constructor_emit_producer(ctx, pattern1_0)?;
+        let expr1_0 = constructor_oneway_cond_br(ctx, pattern2_0, pattern1_1)?;
         return Some(expr1_0);
     }
     return None;
@@ -4734,9 +4728,9 @@ pub fn constructor_trap_if_bool<C: Context>(
     } = pattern0_0
     {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2380.
-        let expr0_0 = constructor_emit_producer(ctx, &pattern1_0)?;
-        let expr1_0 = constructor_trap_if_impl(ctx, &pattern1_1, pattern2_0)?;
+        // Rule at src/isa/s390x/inst.isle line 2372.
+        let expr0_0 = constructor_emit_producer(ctx, pattern1_0)?;
+        let expr1_0 = constructor_trap_if_impl(ctx, pattern1_1, pattern2_0)?;
         return Some(expr1_0);
     }
     return None;
@@ -4744,7 +4738,7 @@ pub fn constructor_trap_if_bool<C: Context>(
 
 // Generated as internal constructor for term casloop_val_reg.
 pub fn constructor_casloop_val_reg<C: Context>(ctx: &mut C) -> Option<WritableReg> {
-    // Rule at src/isa/s390x/inst.isle line 2394.
+    // Rule at src/isa/s390x/inst.isle line 2386.
     let expr0_0: u8 = 0;
     let expr1_0 = C::writable_gpr(ctx, expr0_0);
     return Some(expr1_0);
@@ -4752,7 +4746,7 @@ pub fn constructor_casloop_val_reg<C: Context>(ctx: &mut C) -> Option<WritableRe
 
 // Generated as internal constructor for term casloop_tmp_reg.
 pub fn constructor_casloop_tmp_reg<C: Context>(ctx: &mut C) -> Option<WritableReg> {
-    // Rule at src/isa/s390x/inst.isle line 2398.
+    // Rule at src/isa/s390x/inst.isle line 2390.
     let expr0_0: u8 = 1;
     let expr1_0 = C::writable_gpr(ctx, expr0_0);
     return Some(expr1_0);
@@ -4772,7 +4766,7 @@ pub fn constructor_casloop_emit<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2407.
+    // Rule at src/isa/s390x/inst.isle line 2399.
     let expr0_0: i64 = 0;
     let expr1_0 = C::memarg_reg_plus_off(ctx, pattern3_0, expr0_0, pattern2_0);
     let expr2_0 = constructor_ty_ext32(ctx, pattern1_0)?;
@@ -4800,13 +4794,13 @@ pub fn constructor_casloop_result<C: Context>(
         let pattern2_0 = arg1;
         if let Some(()) = C::littleendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
-            // Rule at src/isa/s390x/inst.isle line 2425.
+            // Rule at src/isa/s390x/inst.isle line 2417.
             let expr0_0 = constructor_bswap_reg(ctx, pattern1_0, pattern4_0)?;
             return Some(expr0_0);
         }
         if let Some(()) = C::bigendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
-            // Rule at src/isa/s390x/inst.isle line 2423.
+            // Rule at src/isa/s390x/inst.isle line 2415.
             let expr0_0 = constructor_copy_reg(ctx, pattern1_0, pattern4_0)?;
             return Some(expr0_0);
         }
@@ -4828,7 +4822,7 @@ pub fn constructor_casloop<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2430.
+    // Rule at src/isa/s390x/inst.isle line 2422.
     let expr0_0 = constructor_casloop_emit(
         ctx, pattern0_0, pattern1_0, pattern2_0, pattern3_0, pattern4_0,
     )?;
@@ -4839,7 +4833,7 @@ pub fn constructor_casloop<C: Context>(
 // Generated as internal constructor for term casloop_bitshift.
 pub fn constructor_casloop_bitshift<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2445.
+    // Rule at src/isa/s390x/inst.isle line 2437.
     let expr0_0: Type = I32;
     let expr1_0: u8 = 3;
     let expr2_0 = constructor_lshl_imm(ctx, expr0_0, pattern0_0, expr1_0)?;
@@ -4849,7 +4843,7 @@ pub fn constructor_casloop_bitshift<C: Context>(ctx: &mut C, arg0: Reg) -> Optio
 // Generated as internal constructor for term casloop_aligned_addr.
 pub fn constructor_casloop_aligned_addr<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2450.
+    // Rule at src/isa/s390x/inst.isle line 2442.
     let expr0_0: Type = I64;
     let expr1_0: u16 = 65532;
     let expr2_0: u8 = 0;
@@ -4873,7 +4867,7 @@ pub fn constructor_casloop_rotate_in<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2460.
+        // Rule at src/isa/s390x/inst.isle line 2452.
         let expr0_0: Type = I32;
         let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
         let expr2_0: u8 = 0;
@@ -4887,7 +4881,7 @@ pub fn constructor_casloop_rotate_in<C: Context>(
         if let Some(()) = C::littleendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2464.
+            // Rule at src/isa/s390x/inst.isle line 2456.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 16;
@@ -4899,7 +4893,7 @@ pub fn constructor_casloop_rotate_in<C: Context>(
         if let Some(()) = C::bigendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2462.
+            // Rule at src/isa/s390x/inst.isle line 2454.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 0;
@@ -4927,7 +4921,7 @@ pub fn constructor_casloop_rotate_out<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2473.
+        // Rule at src/isa/s390x/inst.isle line 2465.
         let expr0_0: Type = I32;
         let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
         let expr2_0: u8 = 0;
@@ -4943,7 +4937,7 @@ pub fn constructor_casloop_rotate_out<C: Context>(
         if let Some(()) = C::littleendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2477.
+            // Rule at src/isa/s390x/inst.isle line 2469.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 16;
@@ -4955,7 +4949,7 @@ pub fn constructor_casloop_rotate_out<C: Context>(
         if let Some(()) = C::bigendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2475.
+            // Rule at src/isa/s390x/inst.isle line 2467.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 0;
@@ -4981,7 +4975,7 @@ pub fn constructor_casloop_rotate_result<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2488.
+        // Rule at src/isa/s390x/inst.isle line 2480.
         let expr0_0: Type = I32;
         let expr1_0: u8 = 8;
         let expr2_0 = constructor_rot_imm_reg(ctx, expr0_0, pattern4_0, expr1_0, pattern3_0)?;
@@ -4992,7 +4986,7 @@ pub fn constructor_casloop_rotate_result<C: Context>(
         if let Some(()) = C::littleendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/s390x/inst.isle line 2492.
+            // Rule at src/isa/s390x/inst.isle line 2484.
             let expr0_0: Type = I32;
             let expr1_0: Type = I32;
             let expr2_0 = constructor_rot_reg(ctx, expr1_0, pattern5_0, pattern4_0)?;
@@ -5002,7 +4996,7 @@ pub fn constructor_casloop_rotate_result<C: Context>(
         if let Some(()) = C::bigendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/s390x/inst.isle line 2490.
+            // Rule at src/isa/s390x/inst.isle line 2482.
             let expr0_0: Type = I32;
             let expr1_0: u8 = 16;
             let expr2_0 = constructor_rot_imm_reg(ctx, expr0_0, pattern5_0, expr1_0, pattern4_0)?;
@@ -5028,7 +5022,7 @@ pub fn constructor_casloop_subword<C: Context>(
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
     let pattern5_0 = arg5;
-    // Rule at src/isa/s390x/inst.isle line 2497.
+    // Rule at src/isa/s390x/inst.isle line 2489.
     let expr0_0 = constructor_casloop_emit(
         ctx, pattern0_0, pattern1_0, pattern2_0, pattern3_0, pattern5_0,
     )?;
@@ -5042,7 +5036,7 @@ pub fn constructor_clz_reg<C: Context>(ctx: &mut C, arg0: i16, arg1: Reg) -> Opt
     let pattern0_0 = arg0;
     if pattern0_0 == 64 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2508.
+        // Rule at src/isa/s390x/inst.isle line 2500.
         let expr0_0 = constructor_temp_writable_regpair(ctx)?;
         let expr1_0 = MInst::Flogr { rn: pattern2_0 };
         let expr2_0 = C::emit(ctx, &expr1_0);
@@ -5050,7 +5044,7 @@ pub fn constructor_clz_reg<C: Context>(ctx: &mut C, arg0: i16, arg1: Reg) -> Opt
         return Some(expr3_0);
     }
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2517.
+    // Rule at src/isa/s390x/inst.isle line 2509.
     let expr0_0 = constructor_temp_writable_regpair(ctx)?;
     let expr1_0 = MInst::Flogr { rn: pattern1_0 };
     let expr2_0 = C::emit(ctx, &expr1_0);
@@ -5071,22 +5065,22 @@ pub fn constructor_clz_reg<C: Context>(ctx: &mut C, arg0: i16, arg1: Reg) -> Opt
 pub fn constructor_aluop_add<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2528.
+        // Rule at src/isa/s390x/inst.isle line 2520.
         let expr0_0 = ALUOp::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2529.
+        // Rule at src/isa/s390x/inst.isle line 2521.
         let expr0_0 = ALUOp::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2530.
+        // Rule at src/isa/s390x/inst.isle line 2522.
         let expr0_0 = ALUOp::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2531.
+        // Rule at src/isa/s390x/inst.isle line 2523.
         let expr0_0 = ALUOp::Add64;
         return Some(expr0_0);
     }
@@ -5097,17 +5091,17 @@ pub fn constructor_aluop_add<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUO
 pub fn constructor_aluop_add_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2534.
+        // Rule at src/isa/s390x/inst.isle line 2526.
         let expr0_0 = ALUOp::Add32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2535.
+        // Rule at src/isa/s390x/inst.isle line 2527.
         let expr0_0 = ALUOp::Add32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2536.
+        // Rule at src/isa/s390x/inst.isle line 2528.
         let expr0_0 = ALUOp::Add64Ext16;
         return Some(expr0_0);
     }
@@ -5118,7 +5112,7 @@ pub fn constructor_aluop_add_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opti
 pub fn constructor_aluop_add_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2539.
+        // Rule at src/isa/s390x/inst.isle line 2531.
         let expr0_0 = ALUOp::Add64Ext32;
         return Some(expr0_0);
     }
@@ -5135,7 +5129,7 @@ pub fn constructor_add_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2542.
+    // Rule at src/isa/s390x/inst.isle line 2534.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5151,7 +5145,7 @@ pub fn constructor_add_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2545.
+    // Rule at src/isa/s390x/inst.isle line 2537.
     let expr0_0 = constructor_aluop_add_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5167,7 +5161,7 @@ pub fn constructor_add_simm16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2548.
+    // Rule at src/isa/s390x/inst.isle line 2540.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrsimm16(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5183,7 +5177,7 @@ pub fn constructor_add_simm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2551.
+    // Rule at src/isa/s390x/inst.isle line 2543.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rsimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5199,7 +5193,7 @@ pub fn constructor_add_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2554.
+    // Rule at src/isa/s390x/inst.isle line 2546.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5215,7 +5209,7 @@ pub fn constructor_add_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2557.
+    // Rule at src/isa/s390x/inst.isle line 2549.
     let expr0_0 = constructor_aluop_add_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5231,7 +5225,7 @@ pub fn constructor_add_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2560.
+    // Rule at src/isa/s390x/inst.isle line 2552.
     let expr0_0 = constructor_aluop_add_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5241,12 +5235,12 @@ pub fn constructor_add_mem_sext32<C: Context>(
 pub fn constructor_aluop_add_logical<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2566.
+        // Rule at src/isa/s390x/inst.isle line 2558.
         let expr0_0 = ALUOp::AddLogical32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2567.
+        // Rule at src/isa/s390x/inst.isle line 2559.
         let expr0_0 = ALUOp::AddLogical64;
         return Some(expr0_0);
     }
@@ -5257,7 +5251,7 @@ pub fn constructor_aluop_add_logical<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_aluop_add_logical_zext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2570.
+        // Rule at src/isa/s390x/inst.isle line 2562.
         let expr0_0 = ALUOp::AddLogical64Ext32;
         return Some(expr0_0);
     }
@@ -5274,7 +5268,7 @@ pub fn constructor_add_logical_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2573.
+    // Rule at src/isa/s390x/inst.isle line 2565.
     let expr0_0 = constructor_aluop_add_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5290,7 +5284,7 @@ pub fn constructor_add_logical_reg_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2576.
+    // Rule at src/isa/s390x/inst.isle line 2568.
     let expr0_0 = constructor_aluop_add_logical_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5306,7 +5300,7 @@ pub fn constructor_add_logical_zimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2579.
+    // Rule at src/isa/s390x/inst.isle line 2571.
     let expr0_0 = constructor_aluop_add_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_ruimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5322,7 +5316,7 @@ pub fn constructor_add_logical_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2582.
+    // Rule at src/isa/s390x/inst.isle line 2574.
     let expr0_0 = constructor_aluop_add_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5338,7 +5332,7 @@ pub fn constructor_add_logical_mem_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2585.
+    // Rule at src/isa/s390x/inst.isle line 2577.
     let expr0_0 = constructor_aluop_add_logical_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5348,22 +5342,22 @@ pub fn constructor_add_logical_mem_zext32<C: Context>(
 pub fn constructor_aluop_sub<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2591.
+        // Rule at src/isa/s390x/inst.isle line 2583.
         let expr0_0 = ALUOp::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2592.
+        // Rule at src/isa/s390x/inst.isle line 2584.
         let expr0_0 = ALUOp::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2593.
+        // Rule at src/isa/s390x/inst.isle line 2585.
         let expr0_0 = ALUOp::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2594.
+        // Rule at src/isa/s390x/inst.isle line 2586.
         let expr0_0 = ALUOp::Sub64;
         return Some(expr0_0);
     }
@@ -5374,17 +5368,17 @@ pub fn constructor_aluop_sub<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUO
 pub fn constructor_aluop_sub_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2597.
+        // Rule at src/isa/s390x/inst.isle line 2589.
         let expr0_0 = ALUOp::Sub32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2598.
+        // Rule at src/isa/s390x/inst.isle line 2590.
         let expr0_0 = ALUOp::Sub32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2599.
+        // Rule at src/isa/s390x/inst.isle line 2591.
         let expr0_0 = ALUOp::Sub64Ext16;
         return Some(expr0_0);
     }
@@ -5395,7 +5389,7 @@ pub fn constructor_aluop_sub_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opti
 pub fn constructor_aluop_sub_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2602.
+        // Rule at src/isa/s390x/inst.isle line 2594.
         let expr0_0 = ALUOp::Sub64Ext32;
         return Some(expr0_0);
     }
@@ -5412,7 +5406,7 @@ pub fn constructor_sub_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2605.
+    // Rule at src/isa/s390x/inst.isle line 2597.
     let expr0_0 = constructor_aluop_sub(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5428,7 +5422,7 @@ pub fn constructor_sub_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2608.
+    // Rule at src/isa/s390x/inst.isle line 2600.
     let expr0_0 = constructor_aluop_sub_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5444,7 +5438,7 @@ pub fn constructor_sub_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2611.
+    // Rule at src/isa/s390x/inst.isle line 2603.
     let expr0_0 = constructor_aluop_sub(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5460,7 +5454,7 @@ pub fn constructor_sub_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2614.
+    // Rule at src/isa/s390x/inst.isle line 2606.
     let expr0_0 = constructor_aluop_sub_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5476,7 +5470,7 @@ pub fn constructor_sub_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2617.
+    // Rule at src/isa/s390x/inst.isle line 2609.
     let expr0_0 = constructor_aluop_sub_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5486,12 +5480,12 @@ pub fn constructor_sub_mem_sext32<C: Context>(
 pub fn constructor_aluop_sub_logical<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2623.
+        // Rule at src/isa/s390x/inst.isle line 2615.
         let expr0_0 = ALUOp::SubLogical32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2624.
+        // Rule at src/isa/s390x/inst.isle line 2616.
         let expr0_0 = ALUOp::SubLogical64;
         return Some(expr0_0);
     }
@@ -5502,7 +5496,7 @@ pub fn constructor_aluop_sub_logical<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_aluop_sub_logical_zext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2627.
+        // Rule at src/isa/s390x/inst.isle line 2619.
         let expr0_0 = ALUOp::SubLogical64Ext32;
         return Some(expr0_0);
     }
@@ -5519,7 +5513,7 @@ pub fn constructor_sub_logical_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2630.
+    // Rule at src/isa/s390x/inst.isle line 2622.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5535,7 +5529,7 @@ pub fn constructor_sub_logical_reg_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2633.
+    // Rule at src/isa/s390x/inst.isle line 2625.
     let expr0_0 = constructor_aluop_sub_logical_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5551,7 +5545,7 @@ pub fn constructor_sub_logical_zimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2636.
+    // Rule at src/isa/s390x/inst.isle line 2628.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_ruimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5567,7 +5561,7 @@ pub fn constructor_sub_logical_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2639.
+    // Rule at src/isa/s390x/inst.isle line 2631.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5583,7 +5577,7 @@ pub fn constructor_sub_logical_mem_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2642.
+    // Rule at src/isa/s390x/inst.isle line 2634.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5593,22 +5587,22 @@ pub fn constructor_sub_logical_mem_zext32<C: Context>(
 pub fn constructor_aluop_mul<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2648.
+        // Rule at src/isa/s390x/inst.isle line 2640.
         let expr0_0 = ALUOp::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2649.
+        // Rule at src/isa/s390x/inst.isle line 2641.
         let expr0_0 = ALUOp::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2650.
+        // Rule at src/isa/s390x/inst.isle line 2642.
         let expr0_0 = ALUOp::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2651.
+        // Rule at src/isa/s390x/inst.isle line 2643.
         let expr0_0 = ALUOp::Mul64;
         return Some(expr0_0);
     }
@@ -5619,17 +5613,17 @@ pub fn constructor_aluop_mul<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUO
 pub fn constructor_aluop_mul_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2654.
+        // Rule at src/isa/s390x/inst.isle line 2646.
         let expr0_0 = ALUOp::Mul32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2655.
+        // Rule at src/isa/s390x/inst.isle line 2647.
         let expr0_0 = ALUOp::Mul32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2656.
+        // Rule at src/isa/s390x/inst.isle line 2648.
         let expr0_0 = ALUOp::Mul64Ext16;
         return Some(expr0_0);
     }
@@ -5640,7 +5634,7 @@ pub fn constructor_aluop_mul_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opti
 pub fn constructor_aluop_mul_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2659.
+        // Rule at src/isa/s390x/inst.isle line 2651.
         let expr0_0 = ALUOp::Mul64Ext32;
         return Some(expr0_0);
     }
@@ -5657,7 +5651,7 @@ pub fn constructor_mul_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2662.
+    // Rule at src/isa/s390x/inst.isle line 2654.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5673,7 +5667,7 @@ pub fn constructor_mul_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2665.
+    // Rule at src/isa/s390x/inst.isle line 2657.
     let expr0_0 = constructor_aluop_mul_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5689,7 +5683,7 @@ pub fn constructor_mul_simm16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2668.
+    // Rule at src/isa/s390x/inst.isle line 2660.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rsimm16(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5705,7 +5699,7 @@ pub fn constructor_mul_simm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2671.
+    // Rule at src/isa/s390x/inst.isle line 2663.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rsimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5721,7 +5715,7 @@ pub fn constructor_mul_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2674.
+    // Rule at src/isa/s390x/inst.isle line 2666.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5737,7 +5731,7 @@ pub fn constructor_mul_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2677.
+    // Rule at src/isa/s390x/inst.isle line 2669.
     let expr0_0 = constructor_aluop_mul_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5753,7 +5747,7 @@ pub fn constructor_mul_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2680.
+    // Rule at src/isa/s390x/inst.isle line 2672.
     let expr0_0 = constructor_aluop_mul_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5770,14 +5764,14 @@ pub fn constructor_udivmod<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2686.
+        // Rule at src/isa/s390x/inst.isle line 2678.
         let expr0_0 = constructor_udivmod32(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2687.
+        // Rule at src/isa/s390x/inst.isle line 2679.
         let expr0_0 = constructor_udivmod64(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -5795,14 +5789,14 @@ pub fn constructor_sdivmod<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2693.
+        // Rule at src/isa/s390x/inst.isle line 2685.
         let expr0_0 = constructor_sdivmod32(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2694.
+        // Rule at src/isa/s390x/inst.isle line 2686.
         let expr0_0 = constructor_sdivmod64(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -5813,12 +5807,12 @@ pub fn constructor_sdivmod<C: Context>(
 pub fn constructor_aluop_and<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2700.
+        // Rule at src/isa/s390x/inst.isle line 2692.
         let expr0_0 = ALUOp::And32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2701.
+        // Rule at src/isa/s390x/inst.isle line 2693.
         let expr0_0 = ALUOp::And64;
         return Some(expr0_0);
     }
@@ -5835,7 +5829,7 @@ pub fn constructor_and_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2704.
+    // Rule at src/isa/s390x/inst.isle line 2696.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5851,7 +5845,7 @@ pub fn constructor_and_uimm16shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2707.
+    // Rule at src/isa/s390x/inst.isle line 2699.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm16shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5868,7 +5862,7 @@ pub fn constructor_and_uimm32shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2710.
+    // Rule at src/isa/s390x/inst.isle line 2702.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm32shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5885,7 +5879,7 @@ pub fn constructor_and_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2713.
+    // Rule at src/isa/s390x/inst.isle line 2705.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5895,12 +5889,12 @@ pub fn constructor_and_mem<C: Context>(
 pub fn constructor_aluop_or<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2719.
+        // Rule at src/isa/s390x/inst.isle line 2711.
         let expr0_0 = ALUOp::Orr32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2720.
+        // Rule at src/isa/s390x/inst.isle line 2712.
         let expr0_0 = ALUOp::Orr64;
         return Some(expr0_0);
     }
@@ -5917,7 +5911,7 @@ pub fn constructor_or_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2723.
+    // Rule at src/isa/s390x/inst.isle line 2715.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5933,7 +5927,7 @@ pub fn constructor_or_uimm16shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2726.
+    // Rule at src/isa/s390x/inst.isle line 2718.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm16shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5950,7 +5944,7 @@ pub fn constructor_or_uimm32shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2729.
+    // Rule at src/isa/s390x/inst.isle line 2721.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm32shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5967,7 +5961,7 @@ pub fn constructor_or_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2732.
+    // Rule at src/isa/s390x/inst.isle line 2724.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5977,12 +5971,12 @@ pub fn constructor_or_mem<C: Context>(
 pub fn constructor_aluop_xor<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2738.
+        // Rule at src/isa/s390x/inst.isle line 2730.
         let expr0_0 = ALUOp::Xor32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2739.
+        // Rule at src/isa/s390x/inst.isle line 2731.
         let expr0_0 = ALUOp::Xor64;
         return Some(expr0_0);
     }
@@ -5999,7 +5993,7 @@ pub fn constructor_xor_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2742.
+    // Rule at src/isa/s390x/inst.isle line 2734.
     let expr0_0 = constructor_aluop_xor(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6015,7 +6009,7 @@ pub fn constructor_xor_uimm32shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2745.
+    // Rule at src/isa/s390x/inst.isle line 2737.
     let expr0_0 = constructor_aluop_xor(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm32shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -6032,7 +6026,7 @@ pub fn constructor_xor_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2748.
+    // Rule at src/isa/s390x/inst.isle line 2740.
     let expr0_0 = constructor_aluop_xor(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6052,7 +6046,7 @@ pub fn constructor_push_xor_uimm32shifted<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2751.
+    // Rule at src/isa/s390x/inst.isle line 2743.
     let expr0_0 = constructor_aluop_xor(ctx, pattern1_0)?;
     let expr1_0 = constructor_push_alu_uimm32shifted(
         ctx, pattern0_0, &expr0_0, pattern2_0, pattern3_0, pattern4_0,
@@ -6065,7 +6059,7 @@ pub fn constructor_not_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2757.
+        // Rule at src/isa/s390x/inst.isle line 2749.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6074,7 +6068,7 @@ pub fn constructor_not_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2759.
+        // Rule at src/isa/s390x/inst.isle line 2751.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6101,7 +6095,7 @@ pub fn constructor_push_not_reg<C: Context>(
     if let Some(pattern2_0) = C::gpr32_ty(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2765.
+        // Rule at src/isa/s390x/inst.isle line 2757.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6113,7 +6107,7 @@ pub fn constructor_push_not_reg<C: Context>(
     if let Some(pattern2_0) = C::gpr64_ty(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2767.
+        // Rule at src/isa/s390x/inst.isle line 2759.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6135,12 +6129,12 @@ pub fn constructor_push_not_reg<C: Context>(
 pub fn constructor_aluop_and_not<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2775.
+        // Rule at src/isa/s390x/inst.isle line 2767.
         let expr0_0 = ALUOp::AndNot32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2776.
+        // Rule at src/isa/s390x/inst.isle line 2768.
         let expr0_0 = ALUOp::AndNot64;
         return Some(expr0_0);
     }
@@ -6157,7 +6151,7 @@ pub fn constructor_and_not_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2779.
+    // Rule at src/isa/s390x/inst.isle line 2771.
     let expr0_0 = constructor_aluop_and_not(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6167,12 +6161,12 @@ pub fn constructor_and_not_reg<C: Context>(
 pub fn constructor_aluop_or_not<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2785.
+        // Rule at src/isa/s390x/inst.isle line 2777.
         let expr0_0 = ALUOp::OrrNot32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2786.
+        // Rule at src/isa/s390x/inst.isle line 2778.
         let expr0_0 = ALUOp::OrrNot64;
         return Some(expr0_0);
     }
@@ -6189,7 +6183,7 @@ pub fn constructor_or_not_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2789.
+    // Rule at src/isa/s390x/inst.isle line 2781.
     let expr0_0 = constructor_aluop_or_not(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6199,12 +6193,12 @@ pub fn constructor_or_not_reg<C: Context>(
 pub fn constructor_aluop_xor_not<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2795.
+        // Rule at src/isa/s390x/inst.isle line 2787.
         let expr0_0 = ALUOp::XorNot32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2796.
+        // Rule at src/isa/s390x/inst.isle line 2788.
         let expr0_0 = ALUOp::XorNot64;
         return Some(expr0_0);
     }
@@ -6221,7 +6215,7 @@ pub fn constructor_xor_not_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2799.
+    // Rule at src/isa/s390x/inst.isle line 2791.
     let expr0_0 = constructor_aluop_xor_not(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6231,12 +6225,12 @@ pub fn constructor_xor_not_reg<C: Context>(
 pub fn constructor_unaryop_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2805.
+        // Rule at src/isa/s390x/inst.isle line 2797.
         let expr0_0 = UnaryOp::Abs32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2806.
+        // Rule at src/isa/s390x/inst.isle line 2798.
         let expr0_0 = UnaryOp::Abs64;
         return Some(expr0_0);
     }
@@ -6247,7 +6241,7 @@ pub fn constructor_unaryop_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<Un
 pub fn constructor_unaryop_abs_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2809.
+        // Rule at src/isa/s390x/inst.isle line 2801.
         let expr0_0 = UnaryOp::Abs64Ext32;
         return Some(expr0_0);
     }
@@ -6258,7 +6252,7 @@ pub fn constructor_unaryop_abs_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_abs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2812.
+    // Rule at src/isa/s390x/inst.isle line 2804.
     let expr0_0 = constructor_unaryop_abs(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6268,7 +6262,7 @@ pub fn constructor_abs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
 pub fn constructor_abs_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2815.
+    // Rule at src/isa/s390x/inst.isle line 2807.
     let expr0_0 = constructor_unaryop_abs_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6278,22 +6272,22 @@ pub fn constructor_abs_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg
 pub fn constructor_unaryop_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2821.
+        // Rule at src/isa/s390x/inst.isle line 2813.
         let expr0_0 = UnaryOp::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2822.
+        // Rule at src/isa/s390x/inst.isle line 2814.
         let expr0_0 = UnaryOp::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2823.
+        // Rule at src/isa/s390x/inst.isle line 2815.
         let expr0_0 = UnaryOp::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2824.
+        // Rule at src/isa/s390x/inst.isle line 2816.
         let expr0_0 = UnaryOp::Neg64;
         return Some(expr0_0);
     }
@@ -6304,7 +6298,7 @@ pub fn constructor_unaryop_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Un
 pub fn constructor_unaryop_neg_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2827.
+        // Rule at src/isa/s390x/inst.isle line 2819.
         let expr0_0 = UnaryOp::Neg64Ext32;
         return Some(expr0_0);
     }
@@ -6315,7 +6309,7 @@ pub fn constructor_unaryop_neg_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_neg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2830.
+    // Rule at src/isa/s390x/inst.isle line 2822.
     let expr0_0 = constructor_unaryop_neg(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6325,7 +6319,7 @@ pub fn constructor_neg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
 pub fn constructor_neg_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2833.
+    // Rule at src/isa/s390x/inst.isle line 2825.
     let expr0_0 = constructor_unaryop_neg_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6335,12 +6329,12 @@ pub fn constructor_neg_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg
 pub fn constructor_unaryop_bswap<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2839.
+        // Rule at src/isa/s390x/inst.isle line 2831.
         let expr0_0 = UnaryOp::BSwap32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2840.
+        // Rule at src/isa/s390x/inst.isle line 2832.
         let expr0_0 = UnaryOp::BSwap64;
         return Some(expr0_0);
     }
@@ -6351,7 +6345,7 @@ pub fn constructor_unaryop_bswap<C: Context>(ctx: &mut C, arg0: Type) -> Option<
 pub fn constructor_bswap_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2843.
+    // Rule at src/isa/s390x/inst.isle line 2835.
     let expr0_0 = constructor_unaryop_bswap(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6369,7 +6363,7 @@ pub fn constructor_push_bswap_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 2846.
+    // Rule at src/isa/s390x/inst.isle line 2838.
     let expr0_0 = constructor_unaryop_bswap(ctx, pattern1_0)?;
     let expr1_0 = constructor_push_unary(ctx, pattern0_0, &expr0_0, pattern2_0, pattern3_0)?;
     return Some(expr1_0);
@@ -6379,12 +6373,12 @@ pub fn constructor_push_bswap_reg<C: Context>(
 pub fn constructor_shiftop_rot<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2852.
+        // Rule at src/isa/s390x/inst.isle line 2844.
         let expr0_0 = ShiftOp::RotL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2853.
+        // Rule at src/isa/s390x/inst.isle line 2845.
         let expr0_0 = ShiftOp::RotL64;
         return Some(expr0_0);
     }
@@ -6401,7 +6395,7 @@ pub fn constructor_rot_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2856.
+    // Rule at src/isa/s390x/inst.isle line 2848.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6418,7 +6412,7 @@ pub fn constructor_rot_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2860.
+    // Rule at src/isa/s390x/inst.isle line 2852.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6437,7 +6431,7 @@ pub fn constructor_rot_imm_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 2864.
+    // Rule at src/isa/s390x/inst.isle line 2856.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern0_0)?;
     let expr1_0 = constructor_shift_rr(
         ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -6461,7 +6455,7 @@ pub fn constructor_push_rot_imm_reg<C: Context>(
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
     let pattern5_0 = arg5;
-    // Rule at src/isa/s390x/inst.isle line 2868.
+    // Rule at src/isa/s390x/inst.isle line 2860.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern1_0)?;
     let expr1_0 = constructor_push_shift(
         ctx, pattern0_0, &expr0_0, pattern2_0, pattern3_0, pattern4_0, pattern5_0,
@@ -6473,22 +6467,22 @@ pub fn constructor_push_rot_imm_reg<C: Context>(
 pub fn constructor_shiftop_lshl<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2875.
+        // Rule at src/isa/s390x/inst.isle line 2867.
         let expr0_0 = ShiftOp::LShL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2876.
+        // Rule at src/isa/s390x/inst.isle line 2868.
         let expr0_0 = ShiftOp::LShL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2877.
+        // Rule at src/isa/s390x/inst.isle line 2869.
         let expr0_0 = ShiftOp::LShL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2878.
+        // Rule at src/isa/s390x/inst.isle line 2870.
         let expr0_0 = ShiftOp::LShL64;
         return Some(expr0_0);
     }
@@ -6505,7 +6499,7 @@ pub fn constructor_lshl_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2881.
+    // Rule at src/isa/s390x/inst.isle line 2873.
     let expr0_0 = constructor_shiftop_lshl(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6522,7 +6516,7 @@ pub fn constructor_lshl_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2885.
+    // Rule at src/isa/s390x/inst.isle line 2877.
     let expr0_0 = constructor_shiftop_lshl(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6533,12 +6527,12 @@ pub fn constructor_lshl_imm<C: Context>(
 pub fn constructor_shiftop_lshr<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2892.
+        // Rule at src/isa/s390x/inst.isle line 2884.
         let expr0_0 = ShiftOp::LShR32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2893.
+        // Rule at src/isa/s390x/inst.isle line 2885.
         let expr0_0 = ShiftOp::LShR64;
         return Some(expr0_0);
     }
@@ -6555,7 +6549,7 @@ pub fn constructor_lshr_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2896.
+    // Rule at src/isa/s390x/inst.isle line 2888.
     let expr0_0 = constructor_shiftop_lshr(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6572,7 +6566,7 @@ pub fn constructor_lshr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2900.
+    // Rule at src/isa/s390x/inst.isle line 2892.
     let expr0_0 = constructor_shiftop_lshr(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6583,12 +6577,12 @@ pub fn constructor_lshr_imm<C: Context>(
 pub fn constructor_shiftop_ashr<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2907.
+        // Rule at src/isa/s390x/inst.isle line 2899.
         let expr0_0 = ShiftOp::AShR32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2908.
+        // Rule at src/isa/s390x/inst.isle line 2900.
         let expr0_0 = ShiftOp::AShR64;
         return Some(expr0_0);
     }
@@ -6605,7 +6599,7 @@ pub fn constructor_ashr_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2911.
+    // Rule at src/isa/s390x/inst.isle line 2903.
     let expr0_0 = constructor_shiftop_ashr(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6622,7 +6616,7 @@ pub fn constructor_ashr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2915.
+    // Rule at src/isa/s390x/inst.isle line 2907.
     let expr0_0 = constructor_shiftop_ashr(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6632,7 +6626,7 @@ pub fn constructor_ashr_imm<C: Context>(
 // Generated as internal constructor for term popcnt_byte.
 pub fn constructor_popcnt_byte<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2922.
+    // Rule at src/isa/s390x/inst.isle line 2914.
     let expr0_0: Type = I64;
     let expr1_0 = UnaryOp::PopcntByte;
     let expr2_0 = constructor_unary_rr(ctx, expr0_0, &expr1_0, pattern0_0)?;
@@ -6642,7 +6636,7 @@ pub fn constructor_popcnt_byte<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg
 // Generated as internal constructor for term popcnt_reg.
 pub fn constructor_popcnt_reg<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2925.
+    // Rule at src/isa/s390x/inst.isle line 2917.
     let expr0_0: Type = I64;
     let expr1_0 = UnaryOp::PopcntReg;
     let expr2_0 = constructor_unary_rr(ctx, expr0_0, &expr1_0, pattern0_0)?;
@@ -6660,7 +6654,7 @@ pub fn constructor_atomic_rmw_and<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2931.
+        // Rule at src/isa/s390x/inst.isle line 2923.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::And32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6669,7 +6663,7 @@ pub fn constructor_atomic_rmw_and<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2932.
+        // Rule at src/isa/s390x/inst.isle line 2924.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::And64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6689,7 +6683,7 @@ pub fn constructor_atomic_rmw_or<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2935.
+        // Rule at src/isa/s390x/inst.isle line 2927.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::Orr32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6698,7 +6692,7 @@ pub fn constructor_atomic_rmw_or<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2936.
+        // Rule at src/isa/s390x/inst.isle line 2928.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::Orr64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6718,7 +6712,7 @@ pub fn constructor_atomic_rmw_xor<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2939.
+        // Rule at src/isa/s390x/inst.isle line 2931.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::Xor32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6727,7 +6721,7 @@ pub fn constructor_atomic_rmw_xor<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2940.
+        // Rule at src/isa/s390x/inst.isle line 2932.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::Xor64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6747,7 +6741,7 @@ pub fn constructor_atomic_rmw_add<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2943.
+        // Rule at src/isa/s390x/inst.isle line 2935.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::Add32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6756,7 +6750,7 @@ pub fn constructor_atomic_rmw_add<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2944.
+        // Rule at src/isa/s390x/inst.isle line 2936.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::Add64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6778,7 +6772,7 @@ pub fn constructor_atomic_cas_impl<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2950.
+        // Rule at src/isa/s390x/inst.isle line 2942.
         let expr0_0 = constructor_atomic_cas32(ctx, pattern2_0, pattern3_0, pattern4_0)?;
         return Some(expr0_0);
     }
@@ -6786,7 +6780,7 @@ pub fn constructor_atomic_cas_impl<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2951.
+        // Rule at src/isa/s390x/inst.isle line 2943.
         let expr0_0 = constructor_atomic_cas64(ctx, pattern2_0, pattern3_0, pattern4_0)?;
         return Some(expr0_0);
     }
@@ -6808,7 +6802,7 @@ pub fn constructor_push_atomic_cas<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2954.
+        // Rule at src/isa/s390x/inst.isle line 2946.
         let expr0_0 =
             constructor_push_atomic_cas32(ctx, pattern0_0, pattern3_0, pattern4_0, pattern5_0)?;
         return Some(expr0_0);
@@ -6817,7 +6811,7 @@ pub fn constructor_push_atomic_cas<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2955.
+        // Rule at src/isa/s390x/inst.isle line 2947.
         let expr0_0 =
             constructor_push_atomic_cas64(ctx, pattern0_0, pattern3_0, pattern4_0, pattern5_0)?;
         return Some(expr0_0);
@@ -6829,12 +6823,12 @@ pub fn constructor_push_atomic_cas<C: Context>(
 pub fn constructor_fpuop2_add<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2961.
+        // Rule at src/isa/s390x/inst.isle line 2953.
         let expr0_0 = FPUOp2::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2962.
+        // Rule at src/isa/s390x/inst.isle line 2954.
         let expr0_0 = FPUOp2::Add64;
         return Some(expr0_0);
     }
@@ -6851,7 +6845,7 @@ pub fn constructor_fadd_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2965.
+    // Rule at src/isa/s390x/inst.isle line 2957.
     let expr0_0 = constructor_fpuop2_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6861,12 +6855,12 @@ pub fn constructor_fadd_reg<C: Context>(
 pub fn constructor_fpuop2_sub<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2971.
+        // Rule at src/isa/s390x/inst.isle line 2963.
         let expr0_0 = FPUOp2::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2972.
+        // Rule at src/isa/s390x/inst.isle line 2964.
         let expr0_0 = FPUOp2::Sub64;
         return Some(expr0_0);
     }
@@ -6883,7 +6877,7 @@ pub fn constructor_fsub_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2975.
+    // Rule at src/isa/s390x/inst.isle line 2967.
     let expr0_0 = constructor_fpuop2_sub(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6893,12 +6887,12 @@ pub fn constructor_fsub_reg<C: Context>(
 pub fn constructor_fpuop2_mul<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2981.
+        // Rule at src/isa/s390x/inst.isle line 2973.
         let expr0_0 = FPUOp2::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2982.
+        // Rule at src/isa/s390x/inst.isle line 2974.
         let expr0_0 = FPUOp2::Mul64;
         return Some(expr0_0);
     }
@@ -6915,7 +6909,7 @@ pub fn constructor_fmul_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2985.
+    // Rule at src/isa/s390x/inst.isle line 2977.
     let expr0_0 = constructor_fpuop2_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6925,12 +6919,12 @@ pub fn constructor_fmul_reg<C: Context>(
 pub fn constructor_fpuop2_div<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2991.
+        // Rule at src/isa/s390x/inst.isle line 2983.
         let expr0_0 = FPUOp2::Div32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2992.
+        // Rule at src/isa/s390x/inst.isle line 2984.
         let expr0_0 = FPUOp2::Div64;
         return Some(expr0_0);
     }
@@ -6947,7 +6941,7 @@ pub fn constructor_fdiv_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2995.
+    // Rule at src/isa/s390x/inst.isle line 2987.
     let expr0_0 = constructor_fpuop2_div(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6957,12 +6951,12 @@ pub fn constructor_fdiv_reg<C: Context>(
 pub fn constructor_fpuop2_min<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3001.
+        // Rule at src/isa/s390x/inst.isle line 2993.
         let expr0_0 = FPUOp2::Min32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3002.
+        // Rule at src/isa/s390x/inst.isle line 2994.
         let expr0_0 = FPUOp2::Min64;
         return Some(expr0_0);
     }
@@ -6979,7 +6973,7 @@ pub fn constructor_fmin_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3005.
+    // Rule at src/isa/s390x/inst.isle line 2997.
     let expr0_0 = constructor_fpuop2_min(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpuvec_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6989,12 +6983,12 @@ pub fn constructor_fmin_reg<C: Context>(
 pub fn constructor_fpuop2_max<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3011.
+        // Rule at src/isa/s390x/inst.isle line 3003.
         let expr0_0 = FPUOp2::Max32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3012.
+        // Rule at src/isa/s390x/inst.isle line 3004.
         let expr0_0 = FPUOp2::Max64;
         return Some(expr0_0);
     }
@@ -7011,7 +7005,7 @@ pub fn constructor_fmax_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3015.
+    // Rule at src/isa/s390x/inst.isle line 3007.
     let expr0_0 = constructor_fpuop2_max(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpuvec_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7021,12 +7015,12 @@ pub fn constructor_fmax_reg<C: Context>(
 pub fn constructor_fpuop3_fma<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp3> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3021.
+        // Rule at src/isa/s390x/inst.isle line 3013.
         let expr0_0 = FPUOp3::MAdd32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3022.
+        // Rule at src/isa/s390x/inst.isle line 3014.
         let expr0_0 = FPUOp3::MAdd64;
         return Some(expr0_0);
     }
@@ -7045,7 +7039,7 @@ pub fn constructor_fma_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 3025.
+    // Rule at src/isa/s390x/inst.isle line 3017.
     let expr0_0 = constructor_fpuop3_fma(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrrr(
         ctx, pattern0_0, &expr0_0, pattern3_0, pattern1_0, pattern2_0,
@@ -7057,12 +7051,12 @@ pub fn constructor_fma_reg<C: Context>(
 pub fn constructor_fpuop1_sqrt<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp1> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3031.
+        // Rule at src/isa/s390x/inst.isle line 3023.
         let expr0_0 = FPUOp1::Sqrt32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3032.
+        // Rule at src/isa/s390x/inst.isle line 3024.
         let expr0_0 = FPUOp1::Sqrt64;
         return Some(expr0_0);
     }
@@ -7073,7 +7067,7 @@ pub fn constructor_fpuop1_sqrt<C: Context>(ctx: &mut C, arg0: Type) -> Option<FP
 pub fn constructor_sqrt_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3035.
+    // Rule at src/isa/s390x/inst.isle line 3027.
     let expr0_0 = constructor_fpuop1_sqrt(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7083,12 +7077,12 @@ pub fn constructor_sqrt_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuop1_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp1> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3041.
+        // Rule at src/isa/s390x/inst.isle line 3033.
         let expr0_0 = FPUOp1::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3042.
+        // Rule at src/isa/s390x/inst.isle line 3034.
         let expr0_0 = FPUOp1::Neg64;
         return Some(expr0_0);
     }
@@ -7099,7 +7093,7 @@ pub fn constructor_fpuop1_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPU
 pub fn constructor_fneg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3045.
+    // Rule at src/isa/s390x/inst.isle line 3037.
     let expr0_0 = constructor_fpuop1_neg(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7109,12 +7103,12 @@ pub fn constructor_fneg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuop1_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp1> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3051.
+        // Rule at src/isa/s390x/inst.isle line 3043.
         let expr0_0 = FPUOp1::Abs32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3052.
+        // Rule at src/isa/s390x/inst.isle line 3044.
         let expr0_0 = FPUOp1::Abs64;
         return Some(expr0_0);
     }
@@ -7125,7 +7119,7 @@ pub fn constructor_fpuop1_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPU
 pub fn constructor_fabs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3055.
+    // Rule at src/isa/s390x/inst.isle line 3047.
     let expr0_0 = constructor_fpuop1_abs(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7135,12 +7129,12 @@ pub fn constructor_fabs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuroundmode_ceil<C: Context>(ctx: &mut C, arg0: Type) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3061.
+        // Rule at src/isa/s390x/inst.isle line 3053.
         let expr0_0 = FpuRoundMode::Plus32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3062.
+        // Rule at src/isa/s390x/inst.isle line 3054.
         let expr0_0 = FpuRoundMode::Plus64;
         return Some(expr0_0);
     }
@@ -7151,7 +7145,7 @@ pub fn constructor_fpuroundmode_ceil<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_ceil_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3065.
+    // Rule at src/isa/s390x/inst.isle line 3057.
     let expr0_0 = constructor_fpuroundmode_ceil(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7161,12 +7155,12 @@ pub fn constructor_ceil_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuroundmode_floor<C: Context>(ctx: &mut C, arg0: Type) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3071.
+        // Rule at src/isa/s390x/inst.isle line 3063.
         let expr0_0 = FpuRoundMode::Minus32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3072.
+        // Rule at src/isa/s390x/inst.isle line 3064.
         let expr0_0 = FpuRoundMode::Minus64;
         return Some(expr0_0);
     }
@@ -7177,7 +7171,7 @@ pub fn constructor_fpuroundmode_floor<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_floor_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3075.
+    // Rule at src/isa/s390x/inst.isle line 3067.
     let expr0_0 = constructor_fpuroundmode_floor(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7187,12 +7181,12 @@ pub fn constructor_floor_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> 
 pub fn constructor_fpuroundmode_trunc<C: Context>(ctx: &mut C, arg0: Type) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3081.
+        // Rule at src/isa/s390x/inst.isle line 3073.
         let expr0_0 = FpuRoundMode::Zero32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3082.
+        // Rule at src/isa/s390x/inst.isle line 3074.
         let expr0_0 = FpuRoundMode::Zero64;
         return Some(expr0_0);
     }
@@ -7203,7 +7197,7 @@ pub fn constructor_fpuroundmode_trunc<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_trunc_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3085.
+    // Rule at src/isa/s390x/inst.isle line 3077.
     let expr0_0 = constructor_fpuroundmode_trunc(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7216,12 +7210,12 @@ pub fn constructor_fpuroundmode_nearest<C: Context>(
 ) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3091.
+        // Rule at src/isa/s390x/inst.isle line 3083.
         let expr0_0 = FpuRoundMode::Nearest32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3092.
+        // Rule at src/isa/s390x/inst.isle line 3084.
         let expr0_0 = FpuRoundMode::Nearest64;
         return Some(expr0_0);
     }
@@ -7232,7 +7226,7 @@ pub fn constructor_fpuroundmode_nearest<C: Context>(
 pub fn constructor_nearest_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3095.
+    // Rule at src/isa/s390x/inst.isle line 3087.
     let expr0_0 = constructor_fpuroundmode_nearest(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7248,7 +7242,7 @@ pub fn constructor_fpuop1_promote<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3101.
+            // Rule at src/isa/s390x/inst.isle line 3093.
             let expr0_0 = FPUOp1::Cvt32To64;
             return Some(expr0_0);
         }
@@ -7266,7 +7260,7 @@ pub fn constructor_fpromote_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3104.
+    // Rule at src/isa/s390x/inst.isle line 3096.
     let expr0_0 = constructor_fpuop1_promote(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7282,7 +7276,7 @@ pub fn constructor_fpuop1_demote<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3111.
+            // Rule at src/isa/s390x/inst.isle line 3103.
             let expr0_0 = FPUOp1::Cvt64To32;
             return Some(expr0_0);
         }
@@ -7300,7 +7294,7 @@ pub fn constructor_fdemote_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3114.
+    // Rule at src/isa/s390x/inst.isle line 3106.
     let expr0_0 = constructor_fpuop1_demote(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7316,12 +7310,12 @@ pub fn constructor_uint_to_fpu_op<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3121.
+            // Rule at src/isa/s390x/inst.isle line 3113.
             let expr0_0 = IntToFpuOp::U32ToF32;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3123.
+            // Rule at src/isa/s390x/inst.isle line 3115.
             let expr0_0 = IntToFpuOp::U64ToF32;
             return Some(expr0_0);
         }
@@ -7329,12 +7323,12 @@ pub fn constructor_uint_to_fpu_op<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3122.
+            // Rule at src/isa/s390x/inst.isle line 3114.
             let expr0_0 = IntToFpuOp::U32ToF64;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3124.
+            // Rule at src/isa/s390x/inst.isle line 3116.
             let expr0_0 = IntToFpuOp::U64ToF64;
             return Some(expr0_0);
         }
@@ -7352,7 +7346,7 @@ pub fn constructor_fcvt_from_uint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3127.
+    // Rule at src/isa/s390x/inst.isle line 3119.
     let expr0_0 = constructor_uint_to_fpu_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_int_to_fpu(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7368,12 +7362,12 @@ pub fn constructor_sint_to_fpu_op<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3134.
+            // Rule at src/isa/s390x/inst.isle line 3126.
             let expr0_0 = IntToFpuOp::I32ToF32;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3136.
+            // Rule at src/isa/s390x/inst.isle line 3128.
             let expr0_0 = IntToFpuOp::I64ToF32;
             return Some(expr0_0);
         }
@@ -7381,12 +7375,12 @@ pub fn constructor_sint_to_fpu_op<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3135.
+            // Rule at src/isa/s390x/inst.isle line 3127.
             let expr0_0 = IntToFpuOp::I32ToF64;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3137.
+            // Rule at src/isa/s390x/inst.isle line 3129.
             let expr0_0 = IntToFpuOp::I64ToF64;
             return Some(expr0_0);
         }
@@ -7404,7 +7398,7 @@ pub fn constructor_fcvt_from_sint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3140.
+    // Rule at src/isa/s390x/inst.isle line 3132.
     let expr0_0 = constructor_sint_to_fpu_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_int_to_fpu(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7420,12 +7414,12 @@ pub fn constructor_fpu_to_uint_op<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3147.
+            // Rule at src/isa/s390x/inst.isle line 3139.
             let expr0_0 = FpuToIntOp::F32ToU32;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3148.
+            // Rule at src/isa/s390x/inst.isle line 3140.
             let expr0_0 = FpuToIntOp::F64ToU32;
             return Some(expr0_0);
         }
@@ -7433,12 +7427,12 @@ pub fn constructor_fpu_to_uint_op<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3149.
+            // Rule at src/isa/s390x/inst.isle line 3141.
             let expr0_0 = FpuToIntOp::F32ToU64;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3150.
+            // Rule at src/isa/s390x/inst.isle line 3142.
             let expr0_0 = FpuToIntOp::F64ToU64;
             return Some(expr0_0);
         }
@@ -7456,7 +7450,7 @@ pub fn constructor_fcvt_to_uint_reg_with_flags<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3153.
+    // Rule at src/isa/s390x/inst.isle line 3145.
     let expr0_0 = constructor_fpu_to_uint_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_to_int(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7472,7 +7466,7 @@ pub fn constructor_fcvt_to_uint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3157.
+    // Rule at src/isa/s390x/inst.isle line 3149.
     let expr0_0 = constructor_fcvt_to_uint_reg_with_flags(ctx, pattern0_0, pattern1_0, pattern2_0)?;
     let expr1_0 = constructor_drop_flags(ctx, &expr0_0)?;
     return Some(expr1_0);
@@ -7488,12 +7482,12 @@ pub fn constructor_fpu_to_sint_op<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3164.
+            // Rule at src/isa/s390x/inst.isle line 3156.
             let expr0_0 = FpuToIntOp::F32ToI32;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3165.
+            // Rule at src/isa/s390x/inst.isle line 3157.
             let expr0_0 = FpuToIntOp::F64ToI32;
             return Some(expr0_0);
         }
@@ -7501,12 +7495,12 @@ pub fn constructor_fpu_to_sint_op<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3166.
+            // Rule at src/isa/s390x/inst.isle line 3158.
             let expr0_0 = FpuToIntOp::F32ToI64;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3167.
+            // Rule at src/isa/s390x/inst.isle line 3159.
             let expr0_0 = FpuToIntOp::F64ToI64;
             return Some(expr0_0);
         }
@@ -7524,7 +7518,7 @@ pub fn constructor_fcvt_to_sint_reg_with_flags<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3170.
+    // Rule at src/isa/s390x/inst.isle line 3162.
     let expr0_0 = constructor_fpu_to_sint_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_to_int(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7540,7 +7534,7 @@ pub fn constructor_fcvt_to_sint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3174.
+    // Rule at src/isa/s390x/inst.isle line 3166.
     let expr0_0 = constructor_fcvt_to_sint_reg_with_flags(ctx, pattern0_0, pattern1_0, pattern2_0)?;
     let expr1_0 = constructor_drop_flags(ctx, &expr0_0)?;
     return Some(expr1_0);
@@ -7550,12 +7544,12 @@ pub fn constructor_fcvt_to_sint_reg<C: Context>(
 pub fn constructor_cmpop_cmps<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3181.
+        // Rule at src/isa/s390x/inst.isle line 3173.
         let expr0_0 = CmpOp::CmpS32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3182.
+        // Rule at src/isa/s390x/inst.isle line 3174.
         let expr0_0 = CmpOp::CmpS64;
         return Some(expr0_0);
     }
@@ -7566,12 +7560,12 @@ pub fn constructor_cmpop_cmps<C: Context>(ctx: &mut C, arg0: Type) -> Option<Cmp
 pub fn constructor_cmpop_cmps_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3185.
+        // Rule at src/isa/s390x/inst.isle line 3177.
         let expr0_0 = CmpOp::CmpS32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3186.
+        // Rule at src/isa/s390x/inst.isle line 3178.
         let expr0_0 = CmpOp::CmpS64Ext16;
         return Some(expr0_0);
     }
@@ -7582,7 +7576,7 @@ pub fn constructor_cmpop_cmps_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_cmpop_cmps_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3189.
+        // Rule at src/isa/s390x/inst.isle line 3181.
         let expr0_0 = CmpOp::CmpS64Ext32;
         return Some(expr0_0);
     }
@@ -7599,7 +7593,7 @@ pub fn constructor_icmps_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3192.
+    // Rule at src/isa/s390x/inst.isle line 3184.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7615,7 +7609,7 @@ pub fn constructor_icmps_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3195.
+    // Rule at src/isa/s390x/inst.isle line 3187.
     let expr0_0 = constructor_cmpop_cmps_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7631,7 +7625,7 @@ pub fn constructor_icmps_simm16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3198.
+    // Rule at src/isa/s390x/inst.isle line 3190.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rsimm16(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7647,7 +7641,7 @@ pub fn constructor_icmps_simm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3201.
+    // Rule at src/isa/s390x/inst.isle line 3193.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rsimm32(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7663,7 +7657,7 @@ pub fn constructor_icmps_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3204.
+    // Rule at src/isa/s390x/inst.isle line 3196.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7679,7 +7673,7 @@ pub fn constructor_icmps_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3207.
+    // Rule at src/isa/s390x/inst.isle line 3199.
     let expr0_0 = constructor_cmpop_cmps_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7695,7 +7689,7 @@ pub fn constructor_icmps_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3210.
+    // Rule at src/isa/s390x/inst.isle line 3202.
     let expr0_0 = constructor_cmpop_cmps_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7705,12 +7699,12 @@ pub fn constructor_icmps_mem_sext32<C: Context>(
 pub fn constructor_cmpop_cmpu<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3216.
+        // Rule at src/isa/s390x/inst.isle line 3208.
         let expr0_0 = CmpOp::CmpL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3217.
+        // Rule at src/isa/s390x/inst.isle line 3209.
         let expr0_0 = CmpOp::CmpL64;
         return Some(expr0_0);
     }
@@ -7721,12 +7715,12 @@ pub fn constructor_cmpop_cmpu<C: Context>(ctx: &mut C, arg0: Type) -> Option<Cmp
 pub fn constructor_cmpop_cmpu_zext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3220.
+        // Rule at src/isa/s390x/inst.isle line 3212.
         let expr0_0 = CmpOp::CmpL32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3221.
+        // Rule at src/isa/s390x/inst.isle line 3213.
         let expr0_0 = CmpOp::CmpL64Ext16;
         return Some(expr0_0);
     }
@@ -7737,7 +7731,7 @@ pub fn constructor_cmpop_cmpu_zext16<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_cmpop_cmpu_zext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3224.
+        // Rule at src/isa/s390x/inst.isle line 3216.
         let expr0_0 = CmpOp::CmpL64Ext32;
         return Some(expr0_0);
     }
@@ -7754,7 +7748,7 @@ pub fn constructor_icmpu_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3227.
+    // Rule at src/isa/s390x/inst.isle line 3219.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7770,7 +7764,7 @@ pub fn constructor_icmpu_reg_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3230.
+    // Rule at src/isa/s390x/inst.isle line 3222.
     let expr0_0 = constructor_cmpop_cmpu_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7786,7 +7780,7 @@ pub fn constructor_icmpu_uimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3233.
+    // Rule at src/isa/s390x/inst.isle line 3225.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_ruimm32(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7802,7 +7796,7 @@ pub fn constructor_icmpu_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3236.
+    // Rule at src/isa/s390x/inst.isle line 3228.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7818,7 +7812,7 @@ pub fn constructor_icmpu_mem_zext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3239.
+    // Rule at src/isa/s390x/inst.isle line 3231.
     let expr0_0 = constructor_cmpop_cmpu_zext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7834,7 +7828,7 @@ pub fn constructor_icmpu_mem_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3242.
+    // Rule at src/isa/s390x/inst.isle line 3234.
     let expr0_0 = constructor_cmpop_cmpu_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7851,14 +7845,14 @@ pub fn constructor_fcmp_reg<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 3248.
+        // Rule at src/isa/s390x/inst.isle line 3240.
         let expr0_0 = constructor_fpu_cmp32(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 3249.
+        // Rule at src/isa/s390x/inst.isle line 3241.
         let expr0_0 = constructor_fpu_cmp64(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -7873,7 +7867,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
         &InstructionData::NullAry {
             opcode: ref pattern2_0,
         } => {
-            match &pattern2_0 {
+            match pattern2_0 {
                 &Opcode::Debugtrap => {
                     // Rule at src/isa/s390x/lower.isle line 2169.
                     let expr0_0 = constructor_debugtrap_impl(ctx)?;
@@ -7899,7 +7893,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             opcode: ref pattern2_0,
             func_ref: pattern2_1,
         } => {
-            if let &Opcode::FuncAddr = &pattern2_0 {
+            if let &Opcode::FuncAddr = pattern2_0 {
                 let (pattern4_0, pattern4_1, pattern4_2) = C::func_ref_data(ctx, pattern2_1);
                 if let Some(()) = C::reloc_distance_near(ctx, pattern4_2) {
                     // Rule at src/isa/s390x/lower.isle line 1159.
@@ -7921,7 +7915,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             opcode: ref pattern2_0,
             global_value: pattern2_1,
         } => {
-            if let &Opcode::SymbolValue = &pattern2_0 {
+            if let &Opcode::SymbolValue = pattern2_0 {
                 if let Some((pattern4_0, pattern4_1, pattern4_2)) =
                     C::symbol_value_data(ctx, pattern2_1)
                 {
@@ -7949,7 +7943,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             opcode: ref pattern2_0,
             imm: pattern2_1,
         } => {
-            if let &Opcode::F32const = &pattern2_0 {
+            if let &Opcode::F32const = pattern2_0 {
                 let pattern4_0 = C::u64_from_ieee32(ctx, pattern2_1);
                 // Rule at src/isa/s390x/lower.isle line 29.
                 let expr0_0: Type = F32;
@@ -7962,7 +7956,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             opcode: ref pattern2_0,
             imm: pattern2_1,
         } => {
-            if let &Opcode::F64const = &pattern2_0 {
+            if let &Opcode::F64const = pattern2_0 {
                 let pattern4_0 = C::u64_from_ieee64(ctx, pattern2_1);
                 // Rule at src/isa/s390x/lower.isle line 35.
                 let expr0_0: Type = F64;
@@ -7975,16 +7969,16 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             opcode: ref pattern2_0,
             code: ref pattern2_1,
         } => {
-            match &pattern2_0 {
+            match pattern2_0 {
                 &Opcode::Trap => {
                     // Rule at src/isa/s390x/lower.isle line 2139.
-                    let expr0_0 = constructor_trap_impl(ctx, &pattern2_1)?;
+                    let expr0_0 = constructor_trap_impl(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::ResumableTrap => {
                     // Rule at src/isa/s390x/lower.isle line 2145.
-                    let expr0_0 = constructor_trap_impl(ctx, &pattern2_1)?;
+                    let expr0_0 = constructor_trap_impl(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
@@ -7996,8 +7990,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             args: ref pattern2_1,
             flags: pattern2_2,
         } => {
-            if let &Opcode::AtomicStore = &pattern2_0 {
-                let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, &pattern2_1);
+            if let &Opcode::AtomicStore = pattern2_0 {
+                let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, pattern2_1);
                 let pattern5_0 = C::value_type(ctx, pattern4_0);
                 if pattern5_0 == I8 {
                     // Rule at src/isa/s390x/lower.isle line 1863.
@@ -8042,9 +8036,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             flags: pattern2_2,
             offset: pattern2_3,
         } => {
-            match &pattern2_0 {
+            match pattern2_0 {
                 &Opcode::Store => {
-                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, &pattern2_1);
+                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, pattern2_1);
                     let pattern5_0 = C::value_type(ctx, pattern4_0);
                     if pattern5_0 == I8 {
                         // Rule at src/isa/s390x/lower.isle line 1354.
@@ -8163,7 +8157,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                 }
                 &Opcode::Istore8 => {
-                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, &pattern2_1);
+                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, pattern2_1);
                     // Rule at src/isa/s390x/lower.isle line 1413.
                     let expr0_0 = constructor_istore8_impl(
                         ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
@@ -8172,7 +8166,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     return Some(expr1_0);
                 }
                 &Opcode::Istore16 => {
-                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, &pattern2_1);
+                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, pattern2_1);
                     // Rule at src/isa/s390x/lower.isle line 1431.
                     let expr0_0 = constructor_istore16_impl(
                         ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
@@ -8181,7 +8175,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     return Some(expr1_0);
                 }
                 &Opcode::Istore32 => {
-                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, &pattern2_1);
+                    let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, pattern2_1);
                     // Rule at src/isa/s390x/lower.isle line 1457.
                     let expr0_0 = constructor_istore32_impl(
                         ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
@@ -8196,7 +8190,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             opcode: ref pattern2_0,
             arg: pattern2_1,
         } => {
-            match &pattern2_0 {
+            match pattern2_0 {
                 &Opcode::Copy => {
                     // Rule at src/isa/s390x/lower.isle line 53.
                     let expr0_0 = C::put_in_reg(ctx, pattern2_1);
@@ -8224,7 +8218,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             cond: ref pattern2_2,
             code: ref pattern2_3,
         } => {
-            if let &Opcode::Trapif = &pattern2_0 {
+            if let &Opcode::Trapif = pattern2_0 {
                 if let Some(pattern4_0) = C::def_inst(ctx, pattern2_1) {
                     let pattern5_0 = C::inst_data(ctx, pattern4_0);
                     if let &InstructionData::Binary {
@@ -8232,32 +8226,28 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         args: ref pattern6_1,
                     } = &pattern5_0
                     {
-                        match &pattern6_0 {
+                        match pattern6_0 {
                             &Opcode::Ifcmp => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
+                                    C::unpack_value_array_2(ctx, pattern6_1);
                                 // Rule at src/isa/s390x/lower.isle line 2181.
                                 let expr0_0: bool = false;
                                 let expr1_0 = constructor_icmp_val(
-                                    ctx,
-                                    expr0_0,
-                                    &pattern2_2,
-                                    pattern8_0,
-                                    pattern8_1,
+                                    ctx, expr0_0, pattern2_2, pattern8_0, pattern8_1,
                                 )?;
-                                let expr2_0 = constructor_trap_if_bool(ctx, &expr1_0, &pattern2_3)?;
+                                let expr2_0 = constructor_trap_if_bool(ctx, &expr1_0, pattern2_3)?;
                                 let expr3_0 = constructor_safepoint(ctx, &expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::IaddIfcout => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
-                                if let &IntCC::UnsignedGreaterThan = &pattern2_2 {
+                                    C::unpack_value_array_2(ctx, pattern6_1);
+                                if let &IntCC::UnsignedGreaterThan = pattern2_2 {
                                     // Rule at src/isa/s390x/lower.isle line 2206.
                                     let expr0_0: u8 = 3;
                                     let expr1_0 = C::mask_as_cond(ctx, expr0_0);
                                     let expr2_0 =
-                                        constructor_trap_if_impl(ctx, &expr1_0, &pattern2_3)?;
+                                        constructor_trap_if_impl(ctx, &expr1_0, pattern2_3)?;
                                     let expr3_0 = constructor_value_regs_none(ctx, &expr2_0)?;
                                     return Some(expr3_0);
                                 }
@@ -8273,26 +8263,26 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             arg: pattern2_1,
             code: ref pattern2_2,
         } => {
-            match &pattern2_0 {
+            match pattern2_0 {
                 &Opcode::Trapz => {
                     // Rule at src/isa/s390x/lower.isle line 2151.
                     let expr0_0 = constructor_value_nonzero(ctx, pattern2_1)?;
                     let expr1_0 = constructor_invert_bool(ctx, &expr0_0)?;
-                    let expr2_0 = constructor_trap_if_bool(ctx, &expr1_0, &pattern2_2)?;
+                    let expr2_0 = constructor_trap_if_bool(ctx, &expr1_0, pattern2_2)?;
                     let expr3_0 = constructor_safepoint(ctx, &expr2_0)?;
                     return Some(expr3_0);
                 }
                 &Opcode::Trapnz => {
                     // Rule at src/isa/s390x/lower.isle line 2157.
                     let expr0_0 = constructor_value_nonzero(ctx, pattern2_1)?;
-                    let expr1_0 = constructor_trap_if_bool(ctx, &expr0_0, &pattern2_2)?;
+                    let expr1_0 = constructor_trap_if_bool(ctx, &expr0_0, pattern2_2)?;
                     let expr2_0 = constructor_safepoint(ctx, &expr1_0)?;
                     return Some(expr2_0);
                 }
                 &Opcode::ResumableTrapnz => {
                     // Rule at src/isa/s390x/lower.isle line 2163.
                     let expr0_0 = constructor_value_nonzero(ctx, pattern2_1)?;
-                    let expr1_0 = constructor_trap_if_bool(ctx, &expr0_0, &pattern2_2)?;
+                    let expr1_0 = constructor_trap_if_bool(ctx, &expr0_0, pattern2_2)?;
                     let expr2_0 = constructor_safepoint(ctx, &expr1_0)?;
                     return Some(expr2_0);
                 }
@@ -8310,7 +8300,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 arg: pattern5_1,
             } = &pattern4_0
             {
-                match &pattern5_0 {
+                match pattern5_0 {
                     &Opcode::IsNull => {
                         let pattern7_0 = C::value_type(ctx, pattern5_1);
                         if pattern7_0 == R64 {
@@ -8356,7 +8346,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    if let &Opcode::Popcnt = &pattern5_0 {
+                    if let &Opcode::Popcnt = pattern5_0 {
                         // Rule at src/isa/s390x/lower.isle line 884.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = constructor_popcnt_byte(ctx, expr0_0)?;
@@ -8369,7 +8359,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                     flags: pattern5_2,
                 } => {
-                    if let &Opcode::AtomicLoad = &pattern5_0 {
+                    if let &Opcode::AtomicLoad = pattern5_0 {
                         // Rule at src/isa/s390x/lower.isle line 1826.
                         let expr0_0: Type = I8;
                         let expr1_0 = C::zero_offset(ctx);
@@ -8386,7 +8376,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    if let &Opcode::Load = &pattern5_0 {
+                    if let &Opcode::Load = pattern5_0 {
                         // Rule at src/isa/s390x/lower.isle line 1182.
                         let expr0_0: Type = I8;
                         let expr1_0 =
@@ -8407,7 +8397,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                     flags: pattern5_2,
                 } => {
-                    if let &Opcode::AtomicLoad = &pattern5_0 {
+                    if let &Opcode::AtomicLoad = pattern5_0 {
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1834.
                             let expr0_0 = C::zero_offset(ctx);
@@ -8435,7 +8425,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    if let &Opcode::Load = &pattern5_0 {
+                    if let &Opcode::Load = pattern5_0 {
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1190.
                             let expr0_0 =
@@ -8465,10 +8455,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Umulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 252.
                             let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_1)?;
@@ -8481,8 +8470,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr7_0);
                         }
                         &Opcode::Smulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 274.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_reg_sext64(ctx, pattern7_1)?;
@@ -8501,7 +8489,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    if let &Opcode::Bitcast = &pattern5_0 {
+                    if let &Opcode::Bitcast = pattern5_0 {
                         let pattern7_0 = C::value_type(ctx, pattern5_1);
                         if pattern7_0 == F32 {
                             // Rule at src/isa/s390x/lower.isle line 1145.
@@ -8520,7 +8508,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                     flags: pattern5_2,
                 } => {
-                    if let &Opcode::AtomicLoad = &pattern5_0 {
+                    if let &Opcode::AtomicLoad = pattern5_0 {
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1842.
                             let expr0_0 = C::zero_offset(ctx);
@@ -8547,7 +8535,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    if let &Opcode::Load = &pattern5_0 {
+                    if let &Opcode::Load = pattern5_0 {
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1198.
                             let expr0_0 =
@@ -8576,10 +8564,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Umulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 259.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -8591,8 +8578,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr6_0);
                         }
                         &Opcode::Smulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 281.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
@@ -8610,7 +8596,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    if let &Opcode::Bitcast = &pattern5_0 {
+                    if let &Opcode::Bitcast = pattern5_0 {
                         let pattern7_0 = C::value_type(ctx, pattern5_1);
                         if pattern7_0 == F64 {
                             // Rule at src/isa/s390x/lower.isle line 1135.
@@ -8626,7 +8612,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                     flags: pattern5_2,
                 } => {
-                    if let &Opcode::AtomicLoad = &pattern5_0 {
+                    if let &Opcode::AtomicLoad = pattern5_0 {
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1850.
                             let expr0_0 = C::zero_offset(ctx);
@@ -8653,7 +8639,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    if let &Opcode::Load = &pattern5_0 {
+                    if let &Opcode::Load = pattern5_0 {
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1206.
                             let expr0_0 =
@@ -8684,7 +8670,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 offset: pattern5_3,
             } = &pattern4_0
             {
-                if let &Opcode::Load = &pattern5_0 {
+                if let &Opcode::Load = pattern5_0 {
                     if let Some(()) = C::littleendian(ctx, pattern5_2) {
                         // Rule at src/isa/s390x/lower.isle line 1214.
                         let expr0_0 =
@@ -8711,7 +8697,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    if let &Opcode::Bitcast = &pattern5_0 {
+                    if let &Opcode::Bitcast = pattern5_0 {
                         let pattern7_0 = C::value_type(ctx, pattern5_1);
                         if pattern7_0 == I32 {
                             // Rule at src/isa/s390x/lower.isle line 1140.
@@ -8731,7 +8717,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    if let &Opcode::Load = &pattern5_0 {
+                    if let &Opcode::Load = pattern5_0 {
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1218.
                             let expr0_0 =
@@ -8752,7 +8738,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    if let &Opcode::Bitcast = &pattern5_0 {
+                    if let &Opcode::Bitcast = pattern5_0 {
                         let pattern7_0 = C::value_type(ctx, pattern5_1);
                         if pattern7_0 == I64 {
                             // Rule at src/isa/s390x/lower.isle line 1131.
@@ -8769,7 +8755,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    if let &Opcode::Load = &pattern5_0 {
+                    if let &Opcode::Load = pattern5_0 {
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1233.
                             let expr0_0 =
@@ -8788,7 +8774,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             &InstructionData::NullAry {
                 opcode: ref pattern4_0,
             } => {
-                if let &Opcode::Null = &pattern4_0 {
+                if let &Opcode::Null = pattern4_0 {
                     // Rule at src/isa/s390x/lower.isle line 41.
                     let expr0_0: u64 = 0;
                     let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
@@ -8800,7 +8786,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 opcode: ref pattern4_0,
                 imm: pattern4_1,
             } => {
-                if let &Opcode::Iconst = &pattern4_0 {
+                if let &Opcode::Iconst = pattern4_0 {
                     let pattern6_0 = C::u64_from_imm64(ctx, pattern4_1);
                     // Rule at src/isa/s390x/lower.isle line 15.
                     let expr0_0 = constructor_imm(ctx, pattern2_0, pattern6_0)?;
@@ -8813,7 +8799,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 stack_slot: pattern4_1,
                 offset: pattern4_2,
             } => {
-                if let &Opcode::StackAddr = &pattern4_0 {
+                if let &Opcode::StackAddr = pattern4_0 {
                     // Rule at src/isa/s390x/lower.isle line 1152.
                     let expr0_0 =
                         constructor_stack_addr_impl(ctx, pattern2_0, pattern4_1, pattern4_2)?;
@@ -8825,7 +8811,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 opcode: ref pattern4_0,
                 imm: pattern4_1,
             } => {
-                if let &Opcode::Bconst = &pattern4_0 {
+                if let &Opcode::Bconst = pattern4_0 {
                     if pattern4_1 == true {
                         // Rule at src/isa/s390x/lower.isle line 23.
                         let expr0_0: u64 = 1;
@@ -8846,9 +8832,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 opcode: ref pattern4_0,
                 args: ref pattern4_1,
             } => {
-                match &pattern4_0 {
+                match pattern4_0 {
                     &Opcode::Fadd => {
-                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 920.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8857,7 +8843,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Fsub => {
-                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 927.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8866,7 +8852,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Fmul => {
-                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 934.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8875,7 +8861,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Fdiv => {
-                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 941.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8884,7 +8870,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Fcopysign => {
-                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 962.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8893,7 +8879,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Fmin => {
-                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 948.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8902,7 +8888,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr3_0);
                     }
                     &Opcode::Fmax => {
-                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                        let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 955.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8918,10 +8904,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern4_1,
                 cond: ref pattern4_2,
             } => {
-                if let &Opcode::Fcmp = &pattern4_0 {
-                    let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                if let &Opcode::Fcmp = pattern4_0 {
+                    let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                     // Rule at src/isa/s390x/lower.isle line 2004.
-                    let expr0_0 = constructor_fcmp_val(ctx, &pattern4_2, pattern6_0, pattern6_1)?;
+                    let expr0_0 = constructor_fcmp_val(ctx, pattern4_2, pattern6_0, pattern6_1)?;
                     let expr1_0 = constructor_lower_bool(ctx, pattern2_0, &expr0_0)?;
                     let expr2_0 = C::value_reg(ctx, expr1_0);
                     return Some(expr2_0);
@@ -8932,12 +8918,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern4_1,
                 cond: ref pattern4_2,
             } => {
-                if let &Opcode::Icmp = &pattern4_0 {
-                    let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, &pattern4_1);
+                if let &Opcode::Icmp = pattern4_0 {
+                    let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
                     // Rule at src/isa/s390x/lower.isle line 1915.
                     let expr0_0: bool = true;
                     let expr1_0 =
-                        constructor_icmp_val(ctx, expr0_0, &pattern4_2, pattern6_0, pattern6_1)?;
+                        constructor_icmp_val(ctx, expr0_0, pattern4_2, pattern6_0, pattern6_1)?;
                     let expr2_0 = constructor_lower_bool(ctx, pattern2_0, &expr1_0)?;
                     let expr3_0 = C::value_reg(ctx, expr2_0);
                     return Some(expr3_0);
@@ -8947,10 +8933,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 opcode: ref pattern4_0,
                 args: ref pattern4_1,
             } => {
-                match &pattern4_0 {
+                match pattern4_0 {
                     &Opcode::Select => {
                         let (pattern6_0, pattern6_1, pattern6_2) =
-                            C::unpack_value_array_3(ctx, &pattern4_1);
+                            C::unpack_value_array_3(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 2046.
                         let expr0_0 = constructor_value_nonzero(ctx, pattern6_0)?;
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8963,7 +8949,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Fma => {
                         let (pattern6_0, pattern6_1, pattern6_2) =
-                            C::unpack_value_array_3(ctx, &pattern4_1);
+                            C::unpack_value_array_3(ctx, pattern4_1);
                         // Rule at src/isa/s390x/lower.isle line 969.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
@@ -8981,9 +8967,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 args: ref pattern4_1,
                 cond: ref pattern4_2,
             } => {
-                if let &Opcode::SelectifSpectreGuard = &pattern4_0 {
+                if let &Opcode::SelectifSpectreGuard = pattern4_0 {
                     let (pattern6_0, pattern6_1, pattern6_2) =
-                        C::unpack_value_array_3(ctx, &pattern4_1);
+                        C::unpack_value_array_3(ctx, pattern4_1);
                     if let Some(pattern7_0) = C::def_inst(ctx, pattern6_0) {
                         let pattern8_0 = C::inst_data(ctx, pattern7_0);
                         if let &InstructionData::Binary {
@@ -8991,15 +8977,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             args: ref pattern9_1,
                         } = &pattern8_0
                         {
-                            if let &Opcode::Ifcmp = &pattern9_0 {
+                            if let &Opcode::Ifcmp = pattern9_0 {
                                 let (pattern11_0, pattern11_1) =
-                                    C::unpack_value_array_2(ctx, &pattern9_1);
+                                    C::unpack_value_array_2(ctx, pattern9_1);
                                 // Rule at src/isa/s390x/lower.isle line 2058.
                                 let expr0_0: bool = false;
                                 let expr1_0 = constructor_icmp_val(
                                     ctx,
                                     expr0_0,
-                                    &pattern4_2,
+                                    pattern4_2,
                                     pattern11_0,
                                     pattern11_1,
                                 )?;
@@ -9019,7 +9005,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 opcode: ref pattern4_0,
                 arg: pattern4_1,
             } => {
-                match &pattern4_0 {
+                match pattern4_0 {
                     &Opcode::Sqrt => {
                         // Rule at src/isa/s390x/lower.isle line 976.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
@@ -9132,10 +9118,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         opcode: ref pattern6_0,
                         args: ref pattern6_1,
                     } => {
-                        match &pattern6_0 {
+                        match pattern6_0 {
                             &Opcode::BandNot => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
+                                    C::unpack_value_array_2(ctx, pattern6_1);
                                 // Rule at src/isa/s390x/lower.isle line 702.
                                 let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9146,7 +9132,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                             &Opcode::BorNot => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
+                                    C::unpack_value_array_2(ctx, pattern6_1);
                                 // Rule at src/isa/s390x/lower.isle line 713.
                                 let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9157,7 +9143,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                             &Opcode::BxorNot => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
+                                    C::unpack_value_array_2(ctx, pattern6_1);
                                 // Rule at src/isa/s390x/lower.isle line 724.
                                 let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9173,9 +9159,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         opcode: ref pattern6_0,
                         args: ref pattern6_1,
                     } => {
-                        if let &Opcode::Bitselect = &pattern6_0 {
+                        if let &Opcode::Bitselect = pattern6_0 {
                             let (pattern8_0, pattern8_1, pattern8_2) =
-                                C::unpack_value_array_3(ctx, &pattern6_1);
+                                C::unpack_value_array_3(ctx, pattern6_1);
                             // Rule at src/isa/s390x/lower.isle line 735.
                             let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9192,7 +9178,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         opcode: ref pattern6_0,
                         arg: pattern6_1,
                     } => {
-                        match &pattern6_0 {
+                        match pattern6_0 {
                             &Opcode::Bnot => {
                                 // Rule at src/isa/s390x/lower.isle line 625.
                                 let expr0_0 = C::put_in_reg(ctx, pattern6_1);
@@ -9223,7 +9209,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern6_1,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Popcnt = &pattern6_0 {
+                    if let &Opcode::Popcnt = pattern6_0 {
                         // Rule at src/isa/s390x/lower.isle line 898.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr1_0 = constructor_popcnt_byte(ctx, expr0_0)?;
@@ -9247,7 +9233,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern6_1,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Popcnt = &pattern6_0 {
+                    if let &Opcode::Popcnt = pattern6_0 {
                         // Rule at src/isa/s390x/lower.isle line 903.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr1_0 = constructor_popcnt_byte(ctx, expr0_0)?;
@@ -9276,7 +9262,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern6_1,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Popcnt = &pattern6_0 {
+                    if let &Opcode::Popcnt = pattern6_0 {
                         // Rule at src/isa/s390x/lower.isle line 909.
                         let expr0_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr1_0 = constructor_popcnt_byte(ctx, expr0_0)?;
@@ -9310,10 +9296,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         opcode: ref pattern6_0,
                         args: ref pattern6_1,
                     } => {
-                        match &pattern6_0 {
+                        match pattern6_0 {
                             &Opcode::BandNot => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
+                                    C::unpack_value_array_2(ctx, pattern6_1);
                                 // Rule at src/isa/s390x/lower.isle line 706.
                                 let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9325,7 +9311,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                             &Opcode::BorNot => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
+                                    C::unpack_value_array_2(ctx, pattern6_1);
                                 // Rule at src/isa/s390x/lower.isle line 717.
                                 let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9337,7 +9323,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                             &Opcode::BxorNot => {
                                 let (pattern8_0, pattern8_1) =
-                                    C::unpack_value_array_2(ctx, &pattern6_1);
+                                    C::unpack_value_array_2(ctx, pattern6_1);
                                 // Rule at src/isa/s390x/lower.isle line 728.
                                 let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9354,9 +9340,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         opcode: ref pattern6_0,
                         args: ref pattern6_1,
                     } => {
-                        if let &Opcode::Bitselect = &pattern6_0 {
+                        if let &Opcode::Bitselect = pattern6_0 {
                             let (pattern8_0, pattern8_1, pattern8_2) =
-                                C::unpack_value_array_3(ctx, &pattern6_1);
+                                C::unpack_value_array_3(ctx, pattern6_1);
                             // Rule at src/isa/s390x/lower.isle line 742.
                             let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern8_1);
@@ -9373,7 +9359,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         opcode: ref pattern6_0,
                         arg: pattern6_1,
                     } => {
-                        if let &Opcode::Bnot = &pattern6_0 {
+                        if let &Opcode::Bnot = pattern6_0 {
                             // Rule at src/isa/s390x/lower.isle line 630.
                             let expr0_0 = C::put_in_reg(ctx, pattern6_1);
                             let expr1_0 = constructor_not_reg(ctx, pattern4_0, expr0_0)?;
@@ -9395,7 +9381,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     offset: pattern6_3,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Load = &pattern6_0 {
+                    if let &Opcode::Load = pattern6_0 {
                         if let Some(()) = C::littleendian(ctx, pattern6_2) {
                             // Rule at src/isa/s390x/lower.isle line 1222.
                             let expr0_0 =
@@ -9416,7 +9402,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     offset: pattern6_3,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Load = &pattern6_0 {
+                    if let &Opcode::Load = pattern6_0 {
                         if let Some(()) = C::littleendian(ctx, pattern6_2) {
                             // Rule at src/isa/s390x/lower.isle line 1237.
                             let expr0_0 =
@@ -9439,7 +9425,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     offset: pattern6_3,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Load = &pattern6_0 {
+                    if let &Opcode::Load = pattern6_0 {
                         if let Some(()) = C::littleendian(ctx, pattern6_2) {
                             // Rule at src/isa/s390x/lower.isle line 1227.
                             let expr0_0 =
@@ -9464,7 +9450,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     offset: pattern6_3,
                 } = &pattern5_0
                 {
-                    if let &Opcode::Load = &pattern6_0 {
+                    if let &Opcode::Load = pattern6_0 {
                         if let Some(()) = C::littleendian(ctx, pattern6_2) {
                             // Rule at src/isa/s390x/lower.isle line 1242.
                             let expr0_0 =
@@ -9485,7 +9471,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 arg: pattern5_1,
             } = &pattern4_0
             {
-                if let &Opcode::Bint = &pattern5_0 {
+                if let &Opcode::Bint = pattern5_0 {
                     // Rule at src/isa/s390x/lower.isle line 796.
                     let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                     let expr1_0: u16 = 1;
@@ -9504,7 +9490,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 arg: pattern5_1,
             } = &pattern4_0
             {
-                if let &Opcode::Bint = &pattern5_0 {
+                if let &Opcode::Bint = pattern5_0 {
                     // Rule at src/isa/s390x/lower.isle line 800.
                     let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                     let expr1_0: u32 = 1;
@@ -9523,10 +9509,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Iadd => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i16_from_value(ctx, pattern7_0) {
                                 // Rule at src/isa/s390x/lower.isle line 72.
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -9550,7 +9535,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Sextend = &pattern10_0 {
+                                    if let &Opcode::Sextend = pattern10_0 {
                                         let pattern12_0 = C::value_type(ctx, pattern10_1);
                                         if pattern12_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 66.
@@ -9574,7 +9559,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     offset: pattern10_3,
                                 } = &pattern9_0
                                 {
-                                    match &pattern10_0 {
+                                    match pattern10_0 {
                                         &Opcode::Sload16 => {
                                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 94.
@@ -9616,7 +9601,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 88.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -9642,7 +9627,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 82.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -9681,7 +9666,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Sextend = &pattern10_0 {
+                                    if let &Opcode::Sextend = pattern10_0 {
                                         let pattern12_0 = C::value_type(ctx, pattern10_1);
                                         if pattern12_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 64.
@@ -9705,7 +9690,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     offset: pattern10_3,
                                 } = &pattern9_0
                                 {
-                                    match &pattern10_0 {
+                                    match pattern10_0 {
                                         &Opcode::Sload16 => {
                                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 92.
@@ -9747,7 +9732,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 86.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -9773,7 +9758,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 80.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -9797,8 +9782,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Isub => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i16_from_negated_value(ctx, pattern7_1) {
                                 // Rule at src/isa/s390x/lower.isle line 113.
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -9822,7 +9806,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Sextend = &pattern10_0 {
+                                    if let &Opcode::Sextend = pattern10_0 {
                                         let pattern12_0 = C::value_type(ctx, pattern10_1);
                                         if pattern12_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 109.
@@ -9846,7 +9830,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     offset: pattern10_3,
                                 } = &pattern9_0
                                 {
-                                    match &pattern10_0 {
+                                    match pattern10_0 {
                                         &Opcode::Sload16 => {
                                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 127.
@@ -9888,7 +9872,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 123.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -9914,7 +9898,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 119.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -9938,8 +9922,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Imul => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i16_from_value(ctx, pattern7_0) {
                                 // Rule at src/isa/s390x/lower.isle line 212.
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -9963,7 +9946,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Sextend = &pattern10_0 {
+                                    if let &Opcode::Sextend = pattern10_0 {
                                         let pattern12_0 = C::value_type(ctx, pattern10_1);
                                         if pattern12_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 206.
@@ -9987,7 +9970,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     offset: pattern10_3,
                                 } = &pattern9_0
                                 {
-                                    match &pattern10_0 {
+                                    match pattern10_0 {
                                         &Opcode::Sload16 => {
                                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 234.
@@ -10029,7 +10012,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 228.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10055,7 +10038,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 222.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10094,7 +10077,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Sextend = &pattern10_0 {
+                                    if let &Opcode::Sextend = pattern10_0 {
                                         let pattern12_0 = C::value_type(ctx, pattern10_1);
                                         if pattern12_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 204.
@@ -10118,7 +10101,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     offset: pattern10_3,
                                 } = &pattern9_0
                                 {
-                                    match &pattern10_0 {
+                                    match pattern10_0 {
                                         &Opcode::Sload16 => {
                                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 232.
@@ -10160,7 +10143,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 226.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -10186,7 +10169,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 220.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -10210,8 +10193,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Udiv => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 303.
                             let expr0_0 = constructor_zero_divisor_check_needed(ctx, pattern7_1)?;
                             let expr1_0 = constructor_ty_ext32(ctx, pattern3_0)?;
@@ -10233,8 +10215,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr12_0);
                         }
                         &Opcode::Sdiv => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 375.
                             let expr0_0 = constructor_zero_divisor_check_needed(ctx, pattern7_1)?;
                             let expr1_0 = constructor_div_overflow_check_needed(ctx, pattern7_1)?;
@@ -10256,8 +10237,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr11_0);
                         }
                         &Opcode::Urem => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 326.
                             let expr0_0 = constructor_zero_divisor_check_needed(ctx, pattern7_1)?;
                             let expr1_0: u64 = 0;
@@ -10278,8 +10258,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr11_0);
                         }
                         &Opcode::Srem => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 398.
                             let expr0_0 = constructor_zero_divisor_check_needed(ctx, pattern7_1)?;
                             let expr1_0 = constructor_div_overflow_check_needed(ctx, pattern7_1)?;
@@ -10301,8 +10280,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr11_0);
                         }
                         &Opcode::IaddIfcout => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::u32_from_value(ctx, pattern7_0) {
                                 // Rule at src/isa/s390x/lower.isle line 170.
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10319,7 +10297,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Uextend = &pattern10_0 {
+                                    if let &Opcode::Uextend = pattern10_0 {
                                         let pattern12_0 = C::value_type(ctx, pattern10_1);
                                         if pattern12_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 164.
@@ -10344,7 +10322,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     offset: pattern10_3,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Uload32 = &pattern10_0 {
+                                    if let &Opcode::Uload32 = pattern10_0 {
                                         if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                             // Rule at src/isa/s390x/lower.isle line 182.
                                             let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10371,7 +10349,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 176.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10404,7 +10382,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern10_1,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Uextend = &pattern10_0 {
+                                    if let &Opcode::Uextend = pattern10_0 {
                                         let pattern12_0 = C::value_type(ctx, pattern10_1);
                                         if pattern12_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 162.
@@ -10429,7 +10407,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     offset: pattern10_3,
                                 } = &pattern9_0
                                 {
-                                    if let &Opcode::Uload32 = &pattern10_0 {
+                                    if let &Opcode::Uload32 = pattern10_0 {
                                         if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                             // Rule at src/isa/s390x/lower.isle line 180.
                                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -10456,7 +10434,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 174.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -10482,8 +10460,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Band => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             let pattern8_0 = C::value_type(ctx, pattern7_0);
                             if let Some(pattern9_0) = C::ty_32_or_64(ctx, pattern8_0) {
                                 if let Some(pattern10_0) = C::sinkable_inst(ctx, pattern7_0) {
@@ -10495,7 +10472,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 653.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10544,7 +10521,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 651.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -10590,8 +10567,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Bor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             let pattern8_0 = C::value_type(ctx, pattern7_0);
                             if let Some(pattern9_0) = C::ty_32_or_64(ctx, pattern8_0) {
                                 if let Some(pattern10_0) = C::sinkable_inst(ctx, pattern7_0) {
@@ -10603,7 +10579,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 676.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10648,7 +10624,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 674.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -10690,8 +10666,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             let pattern8_0 = C::value_type(ctx, pattern7_0);
                             if let Some(pattern9_0) = C::ty_32_or_64(ctx, pattern8_0) {
                                 if let Some(pattern10_0) = C::sinkable_inst(ctx, pattern7_0) {
@@ -10703,7 +10678,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 695.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -10739,7 +10714,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         offset: pattern12_3,
                                     } = &pattern11_0
                                     {
-                                        if let &Opcode::Load = &pattern12_0 {
+                                        if let &Opcode::Load = pattern12_0 {
                                             if let Some(()) = C::bigendian(ctx, pattern12_2) {
                                                 // Rule at src/isa/s390x/lower.isle line 693.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
@@ -10772,8 +10747,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Ishl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i64_from_value(ctx, pattern7_1) {
                                 // Rule at src/isa/s390x/lower.isle line 482.
                                 let expr0_0 = C::mask_amt_imm(ctx, pattern3_0, pattern8_0);
@@ -10792,8 +10766,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i64_from_value(ctx, pattern7_1) {
                                 // Rule at src/isa/s390x/lower.isle line 498.
                                 let expr0_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
@@ -10813,8 +10786,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr5_0);
                         }
                         &Opcode::Sshr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i64_from_value(ctx, pattern7_1) {
                                 // Rule at src/isa/s390x/lower.isle line 515.
                                 let expr0_0 = constructor_put_in_reg_sext32(ctx, pattern7_0)?;
@@ -10840,7 +10812,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Ineg => {
                             if let Some(pattern7_0) = C::def_inst(ctx, pattern5_1) {
                                 let pattern8_0 = C::inst_data(ctx, pattern7_0);
@@ -10849,7 +10821,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern9_1,
                                 } = &pattern8_0
                                 {
-                                    if let &Opcode::Sextend = &pattern9_0 {
+                                    if let &Opcode::Sextend = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         if pattern11_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 193.
@@ -10877,7 +10849,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     arg: pattern9_1,
                                 } = &pattern8_0
                                 {
-                                    if let &Opcode::Sextend = &pattern9_0 {
+                                    if let &Opcode::Sextend = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         if pattern11_0 == I32 {
                                             // Rule at src/isa/s390x/lower.isle line 141.
@@ -10945,10 +10917,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Rotl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i64_from_value(ctx, pattern7_1) {
                                 // Rule at src/isa/s390x/lower.isle line 528.
                                 let expr0_0 = C::mask_amt_imm(ctx, pattern3_0, pattern8_0);
@@ -10966,8 +10937,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Rotr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i64_from_negated_value(ctx, pattern7_1) {
                                 // Rule at src/isa/s390x/lower.isle line 566.
                                 let expr0_0 = C::mask_amt_imm(ctx, pattern3_0, pattern8_0);
@@ -10994,10 +10964,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     op: ref pattern5_3,
                 } => {
-                    if let &Opcode::AtomicRmw = &pattern5_0 {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                    if let &Opcode::AtomicRmw = pattern5_0 {
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
-                            match &pattern5_3 {
+                            match pattern5_3 {
                                 &AtomicRmwOp::And => {
                                     // Rule at src/isa/s390x/lower.isle line 1505.
                                     let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -11047,7 +11017,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
-                            match &pattern5_3 {
+                            match pattern5_3 {
                                 &AtomicRmwOp::Add => {
                                     // Rule at src/isa/s390x/lower.isle line 1535.
                                     let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -11125,13 +11095,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr4_0 = C::writable_reg_to_reg(ctx, expr3_0);
                         let expr5_0 = constructor_casloop_tmp_reg(ctx)?;
                         let expr6_0 = constructor_atomic_rmw_body(
-                            ctx,
-                            &expr2_0,
-                            pattern3_0,
-                            pattern5_2,
-                            &pattern5_3,
-                            expr5_0,
-                            expr4_0,
+                            ctx, &expr2_0, pattern3_0, pattern5_2, pattern5_3, expr5_0, expr4_0,
                             expr0_0,
                         )?;
                         let expr7_0 = constructor_casloop(
@@ -11146,9 +11110,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     args: ref pattern5_1,
                     flags: pattern5_2,
                 } => {
-                    if let &Opcode::AtomicCas = &pattern5_0 {
+                    if let &Opcode::AtomicCas = pattern5_0 {
                         let (pattern7_0, pattern7_1, pattern7_2) =
-                            C::unpack_value_array_3(ctx, &pattern5_1);
+                            C::unpack_value_array_3(ctx, pattern5_1);
                         if let Some(()) = C::littleendian(ctx, pattern5_2) {
                             // Rule at src/isa/s390x/lower.isle line 1762.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_1);
@@ -11184,7 +11148,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::FcvtToUint => {
                             let pattern7_0 = C::value_type(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 1057.
@@ -11216,7 +11180,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr5_0: i16 = 0;
                             let expr6_0 =
                                 constructor_cmov_imm(ctx, pattern3_0, &expr4_0, expr5_0, expr1_0)?;
-                            let expr7_0 = constructor_with_flags_1(ctx, &expr2_0, &expr6_0)?;
+                            let expr7_0 = constructor_with_flags_reg(ctx, &expr2_0, &expr6_0)?;
                             let expr8_0 = C::value_reg(ctx, expr7_0);
                             return Some(expr8_0);
                         }
@@ -11251,7 +11215,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr5_0: i16 = 0;
                             let expr6_0 =
                                 constructor_cmov_imm(ctx, pattern3_0, &expr4_0, expr5_0, expr1_0)?;
-                            let expr7_0 = constructor_with_flags_1(ctx, &expr2_0, &expr6_0)?;
+                            let expr7_0 = constructor_with_flags_reg(ctx, &expr2_0, &expr6_0)?;
                             let expr8_0 = C::value_reg(ctx, expr7_0);
                             return Some(expr8_0);
                         }
@@ -11268,10 +11232,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     args: ref pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Umulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 245.
                             let expr0_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern7_1)?;
@@ -11284,8 +11247,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr7_0);
                         }
                         &Opcode::Smulhi => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             // Rule at src/isa/s390x/lower.isle line 267.
                             let expr0_0 = constructor_put_in_reg_sext32(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_reg_sext32(ctx, pattern7_1)?;
@@ -11298,8 +11260,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr7_0);
                         }
                         &Opcode::Rotl => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i64_from_value(ctx, pattern7_1) {
                                 if let Some(pattern9_0) = C::i64_from_negated_value(ctx, pattern7_1)
                                 {
@@ -11332,8 +11293,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr9_0);
                         }
                         &Opcode::Rotr => {
-                            let (pattern7_0, pattern7_1) =
-                                C::unpack_value_array_2(ctx, &pattern5_1);
+                            let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::i64_from_value(ctx, pattern7_1) {
                                 if let Some(pattern9_0) = C::i64_from_negated_value(ctx, pattern7_1)
                                 {
@@ -11374,8 +11334,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     op: ref pattern5_3,
                 } => {
-                    if let &Opcode::AtomicRmw = &pattern5_0 {
-                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, &pattern5_1);
+                    if let &Opcode::AtomicRmw = pattern5_0 {
+                        let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                         // Rule at src/isa/s390x/lower.isle line 1562.
                         let expr0_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr1_0 = C::put_in_reg(ctx, pattern7_0);
@@ -11389,13 +11349,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         )?;
                         let expr8_0 = constructor_casloop_tmp_reg(ctx)?;
                         let expr9_0 = constructor_atomic_rmw_body(
-                            ctx,
-                            &expr4_0,
-                            pattern3_0,
-                            pattern5_2,
-                            &pattern5_3,
-                            expr8_0,
-                            expr7_0,
+                            ctx, &expr4_0, pattern3_0, pattern5_2, pattern5_3, expr8_0, expr7_0,
                             expr0_0,
                         )?;
                         let expr10_0 = constructor_casloop_rotate_out(
@@ -11413,9 +11367,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     args: ref pattern5_1,
                     flags: pattern5_2,
                 } => {
-                    if let &Opcode::AtomicCas = &pattern5_0 {
+                    if let &Opcode::AtomicCas = pattern5_0 {
                         let (pattern7_0, pattern7_1, pattern7_2) =
-                            C::unpack_value_array_3(ctx, &pattern5_1);
+                            C::unpack_value_array_3(ctx, pattern5_1);
                         // Rule at src/isa/s390x/lower.isle line 1769.
                         let expr0_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr1_0 = C::put_in_reg(ctx, pattern7_2);
@@ -11453,7 +11407,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Ctz => {
                             // Rule at src/isa/s390x/lower.isle line 859.
                             let expr0_0: Type = I64;
@@ -11496,7 +11450,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Uload8 => {
                             // Rule at src/isa/s390x/lower.isle line 1251.
                             let expr0_0: Type = I8;
@@ -11574,7 +11528,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     opcode: ref pattern5_0,
                     arg: pattern5_1,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Ctz => {
                             // Rule at src/isa/s390x/lower.isle line 874.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
@@ -11614,7 +11568,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     flags: pattern5_2,
                     offset: pattern5_3,
                 } => {
-                    match &pattern5_0 {
+                    match pattern5_0 {
                         &Opcode::Uload8 => {
                             // Rule at src/isa/s390x/lower.isle line 1255.
                             let expr0_0: Type = I8;
@@ -11750,7 +11704,7 @@ pub fn constructor_lower_branch<C: Context>(
             destination: pattern2_2,
             table: pattern2_3,
         } => {
-            if let &Opcode::BrTable = &pattern2_0 {
+            if let &Opcode::BrTable = pattern2_0 {
                 let pattern4_0 = arg1;
                 // Rule at src/isa/s390x/lower.isle line 2076.
                 let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern2_1)?;
@@ -11777,7 +11731,7 @@ pub fn constructor_lower_branch<C: Context>(
             args: pattern2_1,
             destination: pattern2_2,
         } => {
-            match &pattern2_0 {
+            match pattern2_0 {
                 &Opcode::Brz => {
                     let (pattern4_0, pattern4_1) = C::unwrap_head_value_list_1(ctx, pattern2_1);
                     let pattern5_0 = arg1;
@@ -11813,7 +11767,7 @@ pub fn constructor_lower_branch<C: Context>(
             args: pattern2_1,
             destination: pattern2_2,
         } => {
-            if let &Opcode::Jump = &pattern2_0 {
+            if let &Opcode::Jump = pattern2_0 {
                 let pattern4_0 = C::value_list_slice(ctx, pattern2_1);
                 let pattern5_0 = arg1;
                 // Rule at src/isa/s390x/lower.isle line 2068.
@@ -11830,7 +11784,7 @@ pub fn constructor_lower_branch<C: Context>(
             cond: ref pattern2_2,
             destination: pattern2_3,
         } => {
-            if let &Opcode::Brif = &pattern2_0 {
+            if let &Opcode::Brif = pattern2_0 {
                 let (pattern4_0, pattern4_1) = C::unwrap_head_value_list_1(ctx, pattern2_1);
                 if let Some(pattern5_0) = C::def_inst(ctx, pattern4_0) {
                     let pattern6_0 = C::inst_data(ctx, pattern5_0);
@@ -11839,18 +11793,13 @@ pub fn constructor_lower_branch<C: Context>(
                         args: ref pattern7_1,
                     } = &pattern6_0
                     {
-                        if let &Opcode::Ifcmp = &pattern7_0 {
-                            let (pattern9_0, pattern9_1) =
-                                C::unpack_value_array_2(ctx, &pattern7_1);
+                        if let &Opcode::Ifcmp = pattern7_0 {
+                            let (pattern9_0, pattern9_1) = C::unpack_value_array_2(ctx, pattern7_1);
                             let pattern10_0 = arg1;
                             // Rule at src/isa/s390x/lower.isle line 2131.
                             let expr0_0: bool = false;
                             let expr1_0 = constructor_icmp_val(
-                                ctx,
-                                expr0_0,
-                                &pattern2_2,
-                                pattern9_0,
-                                pattern9_1,
+                                ctx, expr0_0, pattern2_2, pattern9_0, pattern9_1,
                             )?;
                             let expr2_0: u8 = 0;
                             let expr3_0 = C::vec_element(ctx, pattern10_0, expr2_0);
@@ -13208,7 +13157,7 @@ pub fn constructor_icmps_val<C: Context>(
                     offset: pattern8_3,
                 } = &pattern7_0
                 {
-                    match &pattern8_0 {
+                    match pattern8_0 {
                         &Opcode::Sload16 => {
                             if let Some(()) = C::bigendian(ctx, pattern8_2) {
                                 // Rule at src/isa/s390x/lower.isle line 1958.
@@ -13246,7 +13195,7 @@ pub fn constructor_icmps_val<C: Context>(
                         offset: pattern10_3,
                     } = &pattern9_0
                     {
-                        if let &Opcode::Load = &pattern10_0 {
+                        if let &Opcode::Load = pattern10_0 {
                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                 // Rule at src/isa/s390x/lower.isle line 1954.
                                 let expr0_0 = constructor_ty_ext32(ctx, pattern4_0)?;
@@ -13270,7 +13219,7 @@ pub fn constructor_icmps_val<C: Context>(
                         offset: pattern10_3,
                     } = &pattern9_0
                     {
-                        if let &Opcode::Load = &pattern10_0 {
+                        if let &Opcode::Load = pattern10_0 {
                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                 // Rule at src/isa/s390x/lower.isle line 1950.
                                 let expr0_0 = C::put_in_reg(ctx, pattern2_0);
@@ -13310,7 +13259,7 @@ pub fn constructor_icmps_val<C: Context>(
                 arg: pattern7_1,
             } = &pattern6_0
             {
-                if let &Opcode::Sextend = &pattern7_0 {
+                if let &Opcode::Sextend = pattern7_0 {
                     let pattern9_0 = C::value_type(ctx, pattern7_1);
                     if pattern9_0 == I32 {
                         // Rule at src/isa/s390x/lower.isle line 1940.
@@ -13355,7 +13304,7 @@ pub fn constructor_icmpu_val<C: Context>(
                     offset: pattern8_3,
                 } = &pattern7_0
                 {
-                    match &pattern8_0 {
+                    match pattern8_0 {
                         &Opcode::Uload16 => {
                             if let Some(pattern10_0) = C::def_inst(ctx, pattern8_1) {
                                 let pattern11_0 = C::inst_data(ctx, pattern10_0);
@@ -13364,7 +13313,7 @@ pub fn constructor_icmpu_val<C: Context>(
                                     global_value: pattern12_1,
                                 } = &pattern11_0
                                 {
-                                    if let &Opcode::SymbolValue = &pattern12_0 {
+                                    if let &Opcode::SymbolValue = pattern12_0 {
                                         if let Some((pattern14_0, pattern14_1, pattern14_2)) =
                                             C::symbol_value_data(ctx, pattern12_1)
                                         {
@@ -13393,7 +13342,7 @@ pub fn constructor_icmpu_val<C: Context>(
                                                             offset: pattern20_3,
                                                         } = &pattern19_0
                                                         {
-                                                            if let &Opcode::Uload16 = &pattern20_0 {
+                                                            if let &Opcode::Uload16 = pattern20_0 {
                                                                 if let Some(()) =
                                                                     C::bigendian(ctx, pattern20_2)
                                                                 {
@@ -13444,7 +13393,7 @@ pub fn constructor_icmpu_val<C: Context>(
                         offset: pattern10_3,
                     } = &pattern9_0
                     {
-                        if let &Opcode::Load = &pattern10_0 {
+                        if let &Opcode::Load = pattern10_0 {
                             if let Some(pattern12_0) = C::def_inst(ctx, pattern10_1) {
                                 let pattern13_0 = C::inst_data(ctx, pattern12_0);
                                 if let &InstructionData::UnaryGlobalValue {
@@ -13452,7 +13401,7 @@ pub fn constructor_icmpu_val<C: Context>(
                                     global_value: pattern14_1,
                                 } = &pattern13_0
                                 {
-                                    if let &Opcode::SymbolValue = &pattern14_0 {
+                                    if let &Opcode::SymbolValue = pattern14_0 {
                                         if let Some((pattern16_0, pattern16_1, pattern16_2)) =
                                             C::symbol_value_data(ctx, pattern14_1)
                                         {
@@ -13481,7 +13430,7 @@ pub fn constructor_icmpu_val<C: Context>(
                                                             offset: pattern22_3,
                                                         } = &pattern21_0
                                                         {
-                                                            if let &Opcode::Load = &pattern22_0 {
+                                                            if let &Opcode::Load = pattern22_0 {
                                                                 if let Some(()) =
                                                                     C::bigendian(ctx, pattern22_2)
                                                                 {
@@ -13521,7 +13470,7 @@ pub fn constructor_icmpu_val<C: Context>(
                         offset: pattern10_3,
                     } = &pattern9_0
                     {
-                        if let &Opcode::Load = &pattern10_0 {
+                        if let &Opcode::Load = pattern10_0 {
                             if let Some(()) = C::bigendian(ctx, pattern10_2) {
                                 // Rule at src/isa/s390x/lower.isle line 1980.
                                 let expr0_0 = C::put_in_reg(ctx, pattern2_0);
@@ -13554,7 +13503,7 @@ pub fn constructor_icmpu_val<C: Context>(
                 arg: pattern7_1,
             } = &pattern6_0
             {
-                if let &Opcode::Uextend = &pattern7_0 {
+                if let &Opcode::Uextend = pattern7_0 {
                     let pattern9_0 = C::value_type(ctx, pattern7_1);
                     if pattern9_0 == I32 {
                         // Rule at src/isa/s390x/lower.isle line 1972.
@@ -13608,10 +13557,10 @@ pub fn constructor_value_nonzero<C: Context>(ctx: &mut C, arg0: Value) -> Option
                 args: ref pattern3_1,
                 cond: ref pattern3_2,
             } => {
-                if let &Opcode::Fcmp = &pattern3_0 {
-                    let (pattern5_0, pattern5_1) = C::unpack_value_array_2(ctx, &pattern3_1);
+                if let &Opcode::Fcmp = pattern3_0 {
+                    let (pattern5_0, pattern5_1) = C::unpack_value_array_2(ctx, pattern3_1);
                     // Rule at src/isa/s390x/lower.isle line 2037.
-                    let expr0_0 = constructor_fcmp_val(ctx, &pattern3_2, pattern5_0, pattern5_1)?;
+                    let expr0_0 = constructor_fcmp_val(ctx, pattern3_2, pattern5_0, pattern5_1)?;
                     return Some(expr0_0);
                 }
             }
@@ -13620,12 +13569,12 @@ pub fn constructor_value_nonzero<C: Context>(ctx: &mut C, arg0: Value) -> Option
                 args: ref pattern3_1,
                 cond: ref pattern3_2,
             } => {
-                if let &Opcode::Icmp = &pattern3_0 {
-                    let (pattern5_0, pattern5_1) = C::unpack_value_array_2(ctx, &pattern3_1);
+                if let &Opcode::Icmp = pattern3_0 {
+                    let (pattern5_0, pattern5_1) = C::unpack_value_array_2(ctx, pattern3_1);
                     // Rule at src/isa/s390x/lower.isle line 2036.
                     let expr0_0: bool = false;
                     let expr1_0 =
-                        constructor_icmp_val(ctx, expr0_0, &pattern3_2, pattern5_0, pattern5_1)?;
+                        constructor_icmp_val(ctx, expr0_0, pattern3_2, pattern5_0, pattern5_1)?;
                     return Some(expr1_0);
                 }
             }
@@ -13633,7 +13582,7 @@ pub fn constructor_value_nonzero<C: Context>(ctx: &mut C, arg0: Value) -> Option
                 opcode: ref pattern3_0,
                 arg: pattern3_1,
             } => {
-                if let &Opcode::Bint = &pattern3_0 {
+                if let &Opcode::Bint = pattern3_0 {
                     // Rule at src/isa/s390x/lower.isle line 2035.
                     let expr0_0 = constructor_value_nonzero(ctx, pattern3_1)?;
                     return Some(expr0_0);

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
@@ -880,7 +880,7 @@ pub enum RegPair {
     RegPair { hi: Reg, lo: Reg },
 }
 
-/// Internal type ProducesBool: defined at src/isa/s390x/inst.isle line 2312.
+/// Internal type ProducesBool: defined at src/isa/s390x/inst.isle line 2316.
 #[derive(Clone, Debug)]
 pub enum ProducesBool {
     ProducesBool { producer: ProducesFlags, cond: Cond },
@@ -2938,9 +2938,8 @@ pub fn constructor_push_break_if<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    if let &ProducesFlags::ProducesFlagsReturnsReg {
+    if let &ProducesFlags::ProducesFlagsSideEffect {
         inst: ref pattern2_0,
-        result: pattern2_1,
     } = pattern1_0
     {
         let pattern3_0 = arg2;
@@ -2950,7 +2949,8 @@ pub fn constructor_push_break_if<C: Context>(
             cond: pattern3_0.clone(),
         };
         let expr2_0 = C::inst_builder_push(ctx, pattern0_0, &expr1_0);
-        return Some(pattern2_1);
+        let expr3_0 = C::invalid_reg(ctx);
+        return Some(expr3_0);
     }
     return None;
 }
@@ -4324,21 +4324,38 @@ pub fn constructor_trap_if<C: Context>(
     arg2: &TrapCode,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
-    if let &ProducesFlags::ProducesFlagsReturnsReg {
-        inst: ref pattern1_0,
-        result: pattern1_1,
-    } = pattern0_0
-    {
-        let pattern2_0 = arg1;
-        let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2265.
-        let expr0_0 = C::emit(ctx, pattern1_0);
-        let expr1_0 = MInst::TrapIf {
-            cond: pattern2_0.clone(),
-            trap_code: pattern3_0.clone(),
-        };
-        let expr2_0 = C::emit(ctx, &expr1_0);
-        return Some(pattern1_1);
+    match pattern0_0 {
+        &ProducesFlags::ProducesFlagsSideEffect {
+            inst: ref pattern1_0,
+        } => {
+            let pattern2_0 = arg1;
+            let pattern3_0 = arg2;
+            // Rule at src/isa/s390x/inst.isle line 2269.
+            let expr0_0 = C::emit(ctx, pattern1_0);
+            let expr1_0 = MInst::TrapIf {
+                cond: pattern2_0.clone(),
+                trap_code: pattern3_0.clone(),
+            };
+            let expr2_0 = C::emit(ctx, &expr1_0);
+            let expr3_0 = C::invalid_reg(ctx);
+            return Some(expr3_0);
+        }
+        &ProducesFlags::ProducesFlagsReturnsReg {
+            inst: ref pattern1_0,
+            result: pattern1_1,
+        } => {
+            let pattern2_0 = arg1;
+            let pattern3_0 = arg2;
+            // Rule at src/isa/s390x/inst.isle line 2265.
+            let expr0_0 = C::emit(ctx, pattern1_0);
+            let expr1_0 = MInst::TrapIf {
+                cond: pattern2_0.clone(),
+                trap_code: pattern3_0.clone(),
+            };
+            let expr2_0 = C::emit(ctx, &expr1_0);
+            return Some(pattern1_1);
+        }
+        _ => {}
     }
     return None;
 }
@@ -4357,7 +4374,7 @@ pub fn constructor_icmps_reg_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2271.
+    // Rule at src/isa/s390x/inst.isle line 2275.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRR {
         op: expr0_0,
@@ -4385,7 +4402,7 @@ pub fn constructor_icmps_simm16_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2277.
+    // Rule at src/isa/s390x/inst.isle line 2281.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRSImm16 {
         op: expr0_0,
@@ -4413,7 +4430,7 @@ pub fn constructor_icmpu_reg_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2283.
+    // Rule at src/isa/s390x/inst.isle line 2287.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRR {
         op: expr0_0,
@@ -4441,7 +4458,7 @@ pub fn constructor_icmpu_uimm16_and_trap<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2289.
+    // Rule at src/isa/s390x/inst.isle line 2293.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = MInst::CmpTrapRUImm16 {
         op: expr0_0,
@@ -4461,7 +4478,7 @@ pub fn constructor_trap_impl<C: Context>(
     arg0: &TrapCode,
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2295.
+    // Rule at src/isa/s390x/inst.isle line 2299.
     let expr0_0 = MInst::Trap {
         trap_code: pattern0_0.clone(),
     };
@@ -4477,7 +4494,7 @@ pub fn constructor_trap_if_impl<C: Context>(
 ) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2299.
+    // Rule at src/isa/s390x/inst.isle line 2303.
     let expr0_0 = MInst::TrapIf {
         cond: pattern0_0.clone(),
         trap_code: pattern1_0.clone(),
@@ -4488,7 +4505,7 @@ pub fn constructor_trap_if_impl<C: Context>(
 
 // Generated as internal constructor for term debugtrap_impl.
 pub fn constructor_debugtrap_impl<C: Context>(ctx: &mut C) -> Option<SideEffectNoResult> {
-    // Rule at src/isa/s390x/inst.isle line 2303.
+    // Rule at src/isa/s390x/inst.isle line 2307.
     let expr0_0 = MInst::Debugtrap;
     let expr1_0 = SideEffectNoResult::Inst { inst: expr0_0 };
     return Some(expr1_0);
@@ -4502,7 +4519,7 @@ pub fn constructor_bool<C: Context>(
 ) -> Option<ProducesBool> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2314.
+    // Rule at src/isa/s390x/inst.isle line 2318.
     let expr0_0 = ProducesBool::ProducesBool {
         producer: pattern0_0.clone(),
         cond: pattern1_0.clone(),
@@ -4521,7 +4538,7 @@ pub fn constructor_invert_bool<C: Context>(
         cond: ref pattern1_1,
     } = pattern0_0
     {
-        // Rule at src/isa/s390x/inst.isle line 2318.
+        // Rule at src/isa/s390x/inst.isle line 2322.
         let expr0_0 = C::invert_cond(ctx, pattern1_1);
         let expr1_0 = constructor_bool(ctx, pattern1_0, &expr0_0)?;
         return Some(expr1_0);
@@ -4536,7 +4553,7 @@ pub fn constructor_emit_producer<C: Context>(ctx: &mut C, arg0: &ProducesFlags) 
         inst: ref pattern1_0,
     } = pattern0_0
     {
-        // Rule at src/isa/s390x/inst.isle line 2327.
+        // Rule at src/isa/s390x/inst.isle line 2331.
         let expr0_0 = C::emit(ctx, pattern1_0);
         return Some(expr0_0);
     }
@@ -4551,7 +4568,7 @@ pub fn constructor_emit_consumer<C: Context>(ctx: &mut C, arg0: &ConsumesFlags) 
         result: pattern1_1,
     } = pattern0_0
     {
-        // Rule at src/isa/s390x/inst.isle line 2329.
+        // Rule at src/isa/s390x/inst.isle line 2333.
         let expr0_0 = C::emit(ctx, pattern1_0);
         return Some(expr0_0);
     }
@@ -4575,7 +4592,7 @@ pub fn constructor_select_bool_reg<C: Context>(
     {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2333.
+        // Rule at src/isa/s390x/inst.isle line 2337.
         let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
         let expr1_0 = constructor_emit_producer(ctx, pattern2_0)?;
         let expr2_0 = constructor_emit_mov(ctx, pattern0_0, expr0_0, pattern4_0)?;
@@ -4604,7 +4621,7 @@ pub fn constructor_select_bool_imm<C: Context>(
     {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2342.
+        // Rule at src/isa/s390x/inst.isle line 2346.
         let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
         let expr1_0 = constructor_emit_producer(ctx, pattern2_0)?;
         let expr2_0 = constructor_emit_imm(ctx, pattern0_0, expr0_0, pattern4_0)?;
@@ -4625,7 +4642,7 @@ pub fn constructor_lower_bool<C: Context>(
     let pattern0_0 = arg0;
     if pattern0_0 == B1 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2352.
+        // Rule at src/isa/s390x/inst.isle line 2356.
         let expr0_0: Type = B1;
         let expr1_0: i16 = 1;
         let expr2_0: u64 = 0;
@@ -4634,7 +4651,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B8 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2353.
+        // Rule at src/isa/s390x/inst.isle line 2357.
         let expr0_0: Type = B8;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4643,7 +4660,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B16 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2354.
+        // Rule at src/isa/s390x/inst.isle line 2358.
         let expr0_0: Type = B16;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4652,7 +4669,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B32 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2355.
+        // Rule at src/isa/s390x/inst.isle line 2359.
         let expr0_0: Type = B32;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4661,7 +4678,7 @@ pub fn constructor_lower_bool<C: Context>(
     }
     if pattern0_0 == B64 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2356.
+        // Rule at src/isa/s390x/inst.isle line 2360.
         let expr0_0: Type = B64;
         let expr1_0: i16 = -1;
         let expr2_0: u64 = 0;
@@ -4686,7 +4703,7 @@ pub fn constructor_cond_br_bool<C: Context>(
     {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2360.
+        // Rule at src/isa/s390x/inst.isle line 2364.
         let expr0_0 = constructor_emit_producer(ctx, pattern1_0)?;
         let expr1_0 = constructor_cond_br(ctx, pattern2_0, pattern3_0, pattern1_1)?;
         return Some(expr1_0);
@@ -4707,7 +4724,7 @@ pub fn constructor_oneway_cond_br_bool<C: Context>(
     } = pattern0_0
     {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2366.
+        // Rule at src/isa/s390x/inst.isle line 2370.
         let expr0_0 = constructor_emit_producer(ctx, pattern1_0)?;
         let expr1_0 = constructor_oneway_cond_br(ctx, pattern2_0, pattern1_1)?;
         return Some(expr1_0);
@@ -4728,7 +4745,7 @@ pub fn constructor_trap_if_bool<C: Context>(
     } = pattern0_0
     {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2372.
+        // Rule at src/isa/s390x/inst.isle line 2376.
         let expr0_0 = constructor_emit_producer(ctx, pattern1_0)?;
         let expr1_0 = constructor_trap_if_impl(ctx, pattern1_1, pattern2_0)?;
         return Some(expr1_0);
@@ -4738,7 +4755,7 @@ pub fn constructor_trap_if_bool<C: Context>(
 
 // Generated as internal constructor for term casloop_val_reg.
 pub fn constructor_casloop_val_reg<C: Context>(ctx: &mut C) -> Option<WritableReg> {
-    // Rule at src/isa/s390x/inst.isle line 2386.
+    // Rule at src/isa/s390x/inst.isle line 2390.
     let expr0_0: u8 = 0;
     let expr1_0 = C::writable_gpr(ctx, expr0_0);
     return Some(expr1_0);
@@ -4746,7 +4763,7 @@ pub fn constructor_casloop_val_reg<C: Context>(ctx: &mut C) -> Option<WritableRe
 
 // Generated as internal constructor for term casloop_tmp_reg.
 pub fn constructor_casloop_tmp_reg<C: Context>(ctx: &mut C) -> Option<WritableReg> {
-    // Rule at src/isa/s390x/inst.isle line 2390.
+    // Rule at src/isa/s390x/inst.isle line 2394.
     let expr0_0: u8 = 1;
     let expr1_0 = C::writable_gpr(ctx, expr0_0);
     return Some(expr1_0);
@@ -4766,7 +4783,7 @@ pub fn constructor_casloop_emit<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2399.
+    // Rule at src/isa/s390x/inst.isle line 2403.
     let expr0_0: i64 = 0;
     let expr1_0 = C::memarg_reg_plus_off(ctx, pattern3_0, expr0_0, pattern2_0);
     let expr2_0 = constructor_ty_ext32(ctx, pattern1_0)?;
@@ -4794,13 +4811,13 @@ pub fn constructor_casloop_result<C: Context>(
         let pattern2_0 = arg1;
         if let Some(()) = C::littleendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
-            // Rule at src/isa/s390x/inst.isle line 2417.
+            // Rule at src/isa/s390x/inst.isle line 2421.
             let expr0_0 = constructor_bswap_reg(ctx, pattern1_0, pattern4_0)?;
             return Some(expr0_0);
         }
         if let Some(()) = C::bigendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
-            // Rule at src/isa/s390x/inst.isle line 2415.
+            // Rule at src/isa/s390x/inst.isle line 2419.
             let expr0_0 = constructor_copy_reg(ctx, pattern1_0, pattern4_0)?;
             return Some(expr0_0);
         }
@@ -4822,7 +4839,7 @@ pub fn constructor_casloop<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2422.
+    // Rule at src/isa/s390x/inst.isle line 2426.
     let expr0_0 = constructor_casloop_emit(
         ctx, pattern0_0, pattern1_0, pattern2_0, pattern3_0, pattern4_0,
     )?;
@@ -4833,7 +4850,7 @@ pub fn constructor_casloop<C: Context>(
 // Generated as internal constructor for term casloop_bitshift.
 pub fn constructor_casloop_bitshift<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2437.
+    // Rule at src/isa/s390x/inst.isle line 2441.
     let expr0_0: Type = I32;
     let expr1_0: u8 = 3;
     let expr2_0 = constructor_lshl_imm(ctx, expr0_0, pattern0_0, expr1_0)?;
@@ -4843,7 +4860,7 @@ pub fn constructor_casloop_bitshift<C: Context>(ctx: &mut C, arg0: Reg) -> Optio
 // Generated as internal constructor for term casloop_aligned_addr.
 pub fn constructor_casloop_aligned_addr<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2442.
+    // Rule at src/isa/s390x/inst.isle line 2446.
     let expr0_0: Type = I64;
     let expr1_0: u16 = 65532;
     let expr2_0: u8 = 0;
@@ -4867,7 +4884,7 @@ pub fn constructor_casloop_rotate_in<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2452.
+        // Rule at src/isa/s390x/inst.isle line 2456.
         let expr0_0: Type = I32;
         let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
         let expr2_0: u8 = 0;
@@ -4881,7 +4898,7 @@ pub fn constructor_casloop_rotate_in<C: Context>(
         if let Some(()) = C::littleendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2456.
+            // Rule at src/isa/s390x/inst.isle line 2460.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 16;
@@ -4893,7 +4910,7 @@ pub fn constructor_casloop_rotate_in<C: Context>(
         if let Some(()) = C::bigendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2454.
+            // Rule at src/isa/s390x/inst.isle line 2458.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 0;
@@ -4921,7 +4938,7 @@ pub fn constructor_casloop_rotate_out<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2465.
+        // Rule at src/isa/s390x/inst.isle line 2469.
         let expr0_0: Type = I32;
         let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
         let expr2_0: u8 = 0;
@@ -4937,7 +4954,7 @@ pub fn constructor_casloop_rotate_out<C: Context>(
         if let Some(()) = C::littleendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2469.
+            // Rule at src/isa/s390x/inst.isle line 2473.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 16;
@@ -4949,7 +4966,7 @@ pub fn constructor_casloop_rotate_out<C: Context>(
         if let Some(()) = C::bigendian(ctx, pattern3_0) {
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/s390x/inst.isle line 2467.
+            // Rule at src/isa/s390x/inst.isle line 2471.
             let expr0_0: Type = I32;
             let expr1_0 = constructor_casloop_tmp_reg(ctx)?;
             let expr2_0: u8 = 0;
@@ -4975,7 +4992,7 @@ pub fn constructor_casloop_rotate_result<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2480.
+        // Rule at src/isa/s390x/inst.isle line 2484.
         let expr0_0: Type = I32;
         let expr1_0: u8 = 8;
         let expr2_0 = constructor_rot_imm_reg(ctx, expr0_0, pattern4_0, expr1_0, pattern3_0)?;
@@ -4986,7 +5003,7 @@ pub fn constructor_casloop_rotate_result<C: Context>(
         if let Some(()) = C::littleendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/s390x/inst.isle line 2484.
+            // Rule at src/isa/s390x/inst.isle line 2488.
             let expr0_0: Type = I32;
             let expr1_0: Type = I32;
             let expr2_0 = constructor_rot_reg(ctx, expr1_0, pattern5_0, pattern4_0)?;
@@ -4996,7 +5013,7 @@ pub fn constructor_casloop_rotate_result<C: Context>(
         if let Some(()) = C::bigendian(ctx, pattern2_0) {
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/s390x/inst.isle line 2482.
+            // Rule at src/isa/s390x/inst.isle line 2486.
             let expr0_0: Type = I32;
             let expr1_0: u8 = 16;
             let expr2_0 = constructor_rot_imm_reg(ctx, expr0_0, pattern5_0, expr1_0, pattern4_0)?;
@@ -5022,7 +5039,7 @@ pub fn constructor_casloop_subword<C: Context>(
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
     let pattern5_0 = arg5;
-    // Rule at src/isa/s390x/inst.isle line 2489.
+    // Rule at src/isa/s390x/inst.isle line 2493.
     let expr0_0 = constructor_casloop_emit(
         ctx, pattern0_0, pattern1_0, pattern2_0, pattern3_0, pattern5_0,
     )?;
@@ -5036,7 +5053,7 @@ pub fn constructor_clz_reg<C: Context>(ctx: &mut C, arg0: i16, arg1: Reg) -> Opt
     let pattern0_0 = arg0;
     if pattern0_0 == 64 {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2500.
+        // Rule at src/isa/s390x/inst.isle line 2504.
         let expr0_0 = constructor_temp_writable_regpair(ctx)?;
         let expr1_0 = MInst::Flogr { rn: pattern2_0 };
         let expr2_0 = C::emit(ctx, &expr1_0);
@@ -5044,7 +5061,7 @@ pub fn constructor_clz_reg<C: Context>(ctx: &mut C, arg0: i16, arg1: Reg) -> Opt
         return Some(expr3_0);
     }
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2509.
+    // Rule at src/isa/s390x/inst.isle line 2513.
     let expr0_0 = constructor_temp_writable_regpair(ctx)?;
     let expr1_0 = MInst::Flogr { rn: pattern1_0 };
     let expr2_0 = C::emit(ctx, &expr1_0);
@@ -5065,22 +5082,22 @@ pub fn constructor_clz_reg<C: Context>(ctx: &mut C, arg0: i16, arg1: Reg) -> Opt
 pub fn constructor_aluop_add<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2520.
+        // Rule at src/isa/s390x/inst.isle line 2524.
         let expr0_0 = ALUOp::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2521.
+        // Rule at src/isa/s390x/inst.isle line 2525.
         let expr0_0 = ALUOp::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2522.
+        // Rule at src/isa/s390x/inst.isle line 2526.
         let expr0_0 = ALUOp::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2523.
+        // Rule at src/isa/s390x/inst.isle line 2527.
         let expr0_0 = ALUOp::Add64;
         return Some(expr0_0);
     }
@@ -5091,17 +5108,17 @@ pub fn constructor_aluop_add<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUO
 pub fn constructor_aluop_add_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2526.
+        // Rule at src/isa/s390x/inst.isle line 2530.
         let expr0_0 = ALUOp::Add32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2527.
+        // Rule at src/isa/s390x/inst.isle line 2531.
         let expr0_0 = ALUOp::Add32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2528.
+        // Rule at src/isa/s390x/inst.isle line 2532.
         let expr0_0 = ALUOp::Add64Ext16;
         return Some(expr0_0);
     }
@@ -5112,7 +5129,7 @@ pub fn constructor_aluop_add_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opti
 pub fn constructor_aluop_add_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2531.
+        // Rule at src/isa/s390x/inst.isle line 2535.
         let expr0_0 = ALUOp::Add64Ext32;
         return Some(expr0_0);
     }
@@ -5129,7 +5146,7 @@ pub fn constructor_add_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2534.
+    // Rule at src/isa/s390x/inst.isle line 2538.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5145,7 +5162,7 @@ pub fn constructor_add_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2537.
+    // Rule at src/isa/s390x/inst.isle line 2541.
     let expr0_0 = constructor_aluop_add_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5161,7 +5178,7 @@ pub fn constructor_add_simm16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2540.
+    // Rule at src/isa/s390x/inst.isle line 2544.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrsimm16(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5177,7 +5194,7 @@ pub fn constructor_add_simm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2543.
+    // Rule at src/isa/s390x/inst.isle line 2547.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rsimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5193,7 +5210,7 @@ pub fn constructor_add_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2546.
+    // Rule at src/isa/s390x/inst.isle line 2550.
     let expr0_0 = constructor_aluop_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5209,7 +5226,7 @@ pub fn constructor_add_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2549.
+    // Rule at src/isa/s390x/inst.isle line 2553.
     let expr0_0 = constructor_aluop_add_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5225,7 +5242,7 @@ pub fn constructor_add_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2552.
+    // Rule at src/isa/s390x/inst.isle line 2556.
     let expr0_0 = constructor_aluop_add_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5235,12 +5252,12 @@ pub fn constructor_add_mem_sext32<C: Context>(
 pub fn constructor_aluop_add_logical<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2558.
+        // Rule at src/isa/s390x/inst.isle line 2562.
         let expr0_0 = ALUOp::AddLogical32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2559.
+        // Rule at src/isa/s390x/inst.isle line 2563.
         let expr0_0 = ALUOp::AddLogical64;
         return Some(expr0_0);
     }
@@ -5251,7 +5268,7 @@ pub fn constructor_aluop_add_logical<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_aluop_add_logical_zext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2562.
+        // Rule at src/isa/s390x/inst.isle line 2566.
         let expr0_0 = ALUOp::AddLogical64Ext32;
         return Some(expr0_0);
     }
@@ -5268,7 +5285,7 @@ pub fn constructor_add_logical_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2565.
+    // Rule at src/isa/s390x/inst.isle line 2569.
     let expr0_0 = constructor_aluop_add_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5284,7 +5301,7 @@ pub fn constructor_add_logical_reg_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2568.
+    // Rule at src/isa/s390x/inst.isle line 2572.
     let expr0_0 = constructor_aluop_add_logical_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5300,7 +5317,7 @@ pub fn constructor_add_logical_zimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2571.
+    // Rule at src/isa/s390x/inst.isle line 2575.
     let expr0_0 = constructor_aluop_add_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_ruimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5316,7 +5333,7 @@ pub fn constructor_add_logical_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2574.
+    // Rule at src/isa/s390x/inst.isle line 2578.
     let expr0_0 = constructor_aluop_add_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5332,7 +5349,7 @@ pub fn constructor_add_logical_mem_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2577.
+    // Rule at src/isa/s390x/inst.isle line 2581.
     let expr0_0 = constructor_aluop_add_logical_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5342,22 +5359,22 @@ pub fn constructor_add_logical_mem_zext32<C: Context>(
 pub fn constructor_aluop_sub<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2583.
+        // Rule at src/isa/s390x/inst.isle line 2587.
         let expr0_0 = ALUOp::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2584.
+        // Rule at src/isa/s390x/inst.isle line 2588.
         let expr0_0 = ALUOp::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2585.
+        // Rule at src/isa/s390x/inst.isle line 2589.
         let expr0_0 = ALUOp::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2586.
+        // Rule at src/isa/s390x/inst.isle line 2590.
         let expr0_0 = ALUOp::Sub64;
         return Some(expr0_0);
     }
@@ -5368,17 +5385,17 @@ pub fn constructor_aluop_sub<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUO
 pub fn constructor_aluop_sub_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2589.
+        // Rule at src/isa/s390x/inst.isle line 2593.
         let expr0_0 = ALUOp::Sub32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2590.
+        // Rule at src/isa/s390x/inst.isle line 2594.
         let expr0_0 = ALUOp::Sub32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2591.
+        // Rule at src/isa/s390x/inst.isle line 2595.
         let expr0_0 = ALUOp::Sub64Ext16;
         return Some(expr0_0);
     }
@@ -5389,7 +5406,7 @@ pub fn constructor_aluop_sub_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opti
 pub fn constructor_aluop_sub_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2594.
+        // Rule at src/isa/s390x/inst.isle line 2598.
         let expr0_0 = ALUOp::Sub64Ext32;
         return Some(expr0_0);
     }
@@ -5406,7 +5423,7 @@ pub fn constructor_sub_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2597.
+    // Rule at src/isa/s390x/inst.isle line 2601.
     let expr0_0 = constructor_aluop_sub(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5422,7 +5439,7 @@ pub fn constructor_sub_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2600.
+    // Rule at src/isa/s390x/inst.isle line 2604.
     let expr0_0 = constructor_aluop_sub_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5438,7 +5455,7 @@ pub fn constructor_sub_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2603.
+    // Rule at src/isa/s390x/inst.isle line 2607.
     let expr0_0 = constructor_aluop_sub(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5454,7 +5471,7 @@ pub fn constructor_sub_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2606.
+    // Rule at src/isa/s390x/inst.isle line 2610.
     let expr0_0 = constructor_aluop_sub_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5470,7 +5487,7 @@ pub fn constructor_sub_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2609.
+    // Rule at src/isa/s390x/inst.isle line 2613.
     let expr0_0 = constructor_aluop_sub_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5480,12 +5497,12 @@ pub fn constructor_sub_mem_sext32<C: Context>(
 pub fn constructor_aluop_sub_logical<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2615.
+        // Rule at src/isa/s390x/inst.isle line 2619.
         let expr0_0 = ALUOp::SubLogical32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2616.
+        // Rule at src/isa/s390x/inst.isle line 2620.
         let expr0_0 = ALUOp::SubLogical64;
         return Some(expr0_0);
     }
@@ -5496,7 +5513,7 @@ pub fn constructor_aluop_sub_logical<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_aluop_sub_logical_zext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2619.
+        // Rule at src/isa/s390x/inst.isle line 2623.
         let expr0_0 = ALUOp::SubLogical64Ext32;
         return Some(expr0_0);
     }
@@ -5513,7 +5530,7 @@ pub fn constructor_sub_logical_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2622.
+    // Rule at src/isa/s390x/inst.isle line 2626.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5529,7 +5546,7 @@ pub fn constructor_sub_logical_reg_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2625.
+    // Rule at src/isa/s390x/inst.isle line 2629.
     let expr0_0 = constructor_aluop_sub_logical_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5545,7 +5562,7 @@ pub fn constructor_sub_logical_zimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2628.
+    // Rule at src/isa/s390x/inst.isle line 2632.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_ruimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5561,7 +5578,7 @@ pub fn constructor_sub_logical_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2631.
+    // Rule at src/isa/s390x/inst.isle line 2635.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5577,7 +5594,7 @@ pub fn constructor_sub_logical_mem_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2634.
+    // Rule at src/isa/s390x/inst.isle line 2638.
     let expr0_0 = constructor_aluop_sub_logical(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5587,22 +5604,22 @@ pub fn constructor_sub_logical_mem_zext32<C: Context>(
 pub fn constructor_aluop_mul<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2640.
+        // Rule at src/isa/s390x/inst.isle line 2644.
         let expr0_0 = ALUOp::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2641.
+        // Rule at src/isa/s390x/inst.isle line 2645.
         let expr0_0 = ALUOp::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2642.
+        // Rule at src/isa/s390x/inst.isle line 2646.
         let expr0_0 = ALUOp::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2643.
+        // Rule at src/isa/s390x/inst.isle line 2647.
         let expr0_0 = ALUOp::Mul64;
         return Some(expr0_0);
     }
@@ -5613,17 +5630,17 @@ pub fn constructor_aluop_mul<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUO
 pub fn constructor_aluop_mul_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2646.
+        // Rule at src/isa/s390x/inst.isle line 2650.
         let expr0_0 = ALUOp::Mul32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2647.
+        // Rule at src/isa/s390x/inst.isle line 2651.
         let expr0_0 = ALUOp::Mul32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2648.
+        // Rule at src/isa/s390x/inst.isle line 2652.
         let expr0_0 = ALUOp::Mul64Ext16;
         return Some(expr0_0);
     }
@@ -5634,7 +5651,7 @@ pub fn constructor_aluop_mul_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opti
 pub fn constructor_aluop_mul_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2651.
+        // Rule at src/isa/s390x/inst.isle line 2655.
         let expr0_0 = ALUOp::Mul64Ext32;
         return Some(expr0_0);
     }
@@ -5651,7 +5668,7 @@ pub fn constructor_mul_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2654.
+    // Rule at src/isa/s390x/inst.isle line 2658.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5667,7 +5684,7 @@ pub fn constructor_mul_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2657.
+    // Rule at src/isa/s390x/inst.isle line 2661.
     let expr0_0 = constructor_aluop_mul_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5683,7 +5700,7 @@ pub fn constructor_mul_simm16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2660.
+    // Rule at src/isa/s390x/inst.isle line 2664.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rsimm16(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5699,7 +5716,7 @@ pub fn constructor_mul_simm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2663.
+    // Rule at src/isa/s390x/inst.isle line 2667.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rsimm32(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5715,7 +5732,7 @@ pub fn constructor_mul_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2666.
+    // Rule at src/isa/s390x/inst.isle line 2670.
     let expr0_0 = constructor_aluop_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5731,7 +5748,7 @@ pub fn constructor_mul_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2669.
+    // Rule at src/isa/s390x/inst.isle line 2673.
     let expr0_0 = constructor_aluop_mul_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5747,7 +5764,7 @@ pub fn constructor_mul_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2672.
+    // Rule at src/isa/s390x/inst.isle line 2676.
     let expr0_0 = constructor_aluop_mul_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5764,14 +5781,14 @@ pub fn constructor_udivmod<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2678.
+        // Rule at src/isa/s390x/inst.isle line 2682.
         let expr0_0 = constructor_udivmod32(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2679.
+        // Rule at src/isa/s390x/inst.isle line 2683.
         let expr0_0 = constructor_udivmod64(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -5789,14 +5806,14 @@ pub fn constructor_sdivmod<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2685.
+        // Rule at src/isa/s390x/inst.isle line 2689.
         let expr0_0 = constructor_sdivmod32(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2686.
+        // Rule at src/isa/s390x/inst.isle line 2690.
         let expr0_0 = constructor_sdivmod64(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -5807,12 +5824,12 @@ pub fn constructor_sdivmod<C: Context>(
 pub fn constructor_aluop_and<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2692.
+        // Rule at src/isa/s390x/inst.isle line 2696.
         let expr0_0 = ALUOp::And32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2693.
+        // Rule at src/isa/s390x/inst.isle line 2697.
         let expr0_0 = ALUOp::And64;
         return Some(expr0_0);
     }
@@ -5829,7 +5846,7 @@ pub fn constructor_and_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2696.
+    // Rule at src/isa/s390x/inst.isle line 2700.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5845,7 +5862,7 @@ pub fn constructor_and_uimm16shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2699.
+    // Rule at src/isa/s390x/inst.isle line 2703.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm16shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5862,7 +5879,7 @@ pub fn constructor_and_uimm32shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2702.
+    // Rule at src/isa/s390x/inst.isle line 2706.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm32shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5879,7 +5896,7 @@ pub fn constructor_and_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2705.
+    // Rule at src/isa/s390x/inst.isle line 2709.
     let expr0_0 = constructor_aluop_and(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5889,12 +5906,12 @@ pub fn constructor_and_mem<C: Context>(
 pub fn constructor_aluop_or<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2711.
+        // Rule at src/isa/s390x/inst.isle line 2715.
         let expr0_0 = ALUOp::Orr32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2712.
+        // Rule at src/isa/s390x/inst.isle line 2716.
         let expr0_0 = ALUOp::Orr64;
         return Some(expr0_0);
     }
@@ -5911,7 +5928,7 @@ pub fn constructor_or_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2715.
+    // Rule at src/isa/s390x/inst.isle line 2719.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5927,7 +5944,7 @@ pub fn constructor_or_uimm16shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2718.
+    // Rule at src/isa/s390x/inst.isle line 2722.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm16shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5944,7 +5961,7 @@ pub fn constructor_or_uimm32shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2721.
+    // Rule at src/isa/s390x/inst.isle line 2725.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm32shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -5961,7 +5978,7 @@ pub fn constructor_or_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2724.
+    // Rule at src/isa/s390x/inst.isle line 2728.
     let expr0_0 = constructor_aluop_or(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -5971,12 +5988,12 @@ pub fn constructor_or_mem<C: Context>(
 pub fn constructor_aluop_xor<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2730.
+        // Rule at src/isa/s390x/inst.isle line 2734.
         let expr0_0 = ALUOp::Xor32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2731.
+        // Rule at src/isa/s390x/inst.isle line 2735.
         let expr0_0 = ALUOp::Xor64;
         return Some(expr0_0);
     }
@@ -5993,7 +6010,7 @@ pub fn constructor_xor_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2734.
+    // Rule at src/isa/s390x/inst.isle line 2738.
     let expr0_0 = constructor_aluop_xor(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6009,7 +6026,7 @@ pub fn constructor_xor_uimm32shifted<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2737.
+    // Rule at src/isa/s390x/inst.isle line 2741.
     let expr0_0 = constructor_aluop_xor(ctx, pattern0_0)?;
     let expr1_0 =
         constructor_alu_ruimm32shifted(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
@@ -6026,7 +6043,7 @@ pub fn constructor_xor_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2740.
+    // Rule at src/isa/s390x/inst.isle line 2744.
     let expr0_0 = constructor_aluop_xor(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rx(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6046,7 +6063,7 @@ pub fn constructor_push_xor_uimm32shifted<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/s390x/inst.isle line 2743.
+    // Rule at src/isa/s390x/inst.isle line 2747.
     let expr0_0 = constructor_aluop_xor(ctx, pattern1_0)?;
     let expr1_0 = constructor_push_alu_uimm32shifted(
         ctx, pattern0_0, &expr0_0, pattern2_0, pattern3_0, pattern4_0,
@@ -6059,7 +6076,7 @@ pub fn constructor_not_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2749.
+        // Rule at src/isa/s390x/inst.isle line 2753.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6068,7 +6085,7 @@ pub fn constructor_not_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
         let pattern2_0 = arg1;
-        // Rule at src/isa/s390x/inst.isle line 2751.
+        // Rule at src/isa/s390x/inst.isle line 2755.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6095,7 +6112,7 @@ pub fn constructor_push_not_reg<C: Context>(
     if let Some(pattern2_0) = C::gpr32_ty(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2757.
+        // Rule at src/isa/s390x/inst.isle line 2761.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6107,7 +6124,7 @@ pub fn constructor_push_not_reg<C: Context>(
     if let Some(pattern2_0) = C::gpr64_ty(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2759.
+        // Rule at src/isa/s390x/inst.isle line 2763.
         let expr0_0: u32 = 4294967295;
         let expr1_0: u8 = 0;
         let expr2_0 = C::uimm32shifted(ctx, expr0_0, expr1_0);
@@ -6129,12 +6146,12 @@ pub fn constructor_push_not_reg<C: Context>(
 pub fn constructor_aluop_and_not<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2767.
+        // Rule at src/isa/s390x/inst.isle line 2771.
         let expr0_0 = ALUOp::AndNot32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2768.
+        // Rule at src/isa/s390x/inst.isle line 2772.
         let expr0_0 = ALUOp::AndNot64;
         return Some(expr0_0);
     }
@@ -6151,7 +6168,7 @@ pub fn constructor_and_not_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2771.
+    // Rule at src/isa/s390x/inst.isle line 2775.
     let expr0_0 = constructor_aluop_and_not(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6161,12 +6178,12 @@ pub fn constructor_and_not_reg<C: Context>(
 pub fn constructor_aluop_or_not<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2777.
+        // Rule at src/isa/s390x/inst.isle line 2781.
         let expr0_0 = ALUOp::OrrNot32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2778.
+        // Rule at src/isa/s390x/inst.isle line 2782.
         let expr0_0 = ALUOp::OrrNot64;
         return Some(expr0_0);
     }
@@ -6183,7 +6200,7 @@ pub fn constructor_or_not_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2781.
+    // Rule at src/isa/s390x/inst.isle line 2785.
     let expr0_0 = constructor_aluop_or_not(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6193,12 +6210,12 @@ pub fn constructor_or_not_reg<C: Context>(
 pub fn constructor_aluop_xor_not<C: Context>(ctx: &mut C, arg0: Type) -> Option<ALUOp> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::gpr32_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2787.
+        // Rule at src/isa/s390x/inst.isle line 2791.
         let expr0_0 = ALUOp::XorNot32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::gpr64_ty(ctx, pattern0_0) {
-        // Rule at src/isa/s390x/inst.isle line 2788.
+        // Rule at src/isa/s390x/inst.isle line 2792.
         let expr0_0 = ALUOp::XorNot64;
         return Some(expr0_0);
     }
@@ -6215,7 +6232,7 @@ pub fn constructor_xor_not_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2791.
+    // Rule at src/isa/s390x/inst.isle line 2795.
     let expr0_0 = constructor_aluop_xor_not(ctx, pattern0_0)?;
     let expr1_0 = constructor_alu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6225,12 +6242,12 @@ pub fn constructor_xor_not_reg<C: Context>(
 pub fn constructor_unaryop_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2797.
+        // Rule at src/isa/s390x/inst.isle line 2801.
         let expr0_0 = UnaryOp::Abs32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2798.
+        // Rule at src/isa/s390x/inst.isle line 2802.
         let expr0_0 = UnaryOp::Abs64;
         return Some(expr0_0);
     }
@@ -6241,7 +6258,7 @@ pub fn constructor_unaryop_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<Un
 pub fn constructor_unaryop_abs_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2801.
+        // Rule at src/isa/s390x/inst.isle line 2805.
         let expr0_0 = UnaryOp::Abs64Ext32;
         return Some(expr0_0);
     }
@@ -6252,7 +6269,7 @@ pub fn constructor_unaryop_abs_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_abs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2804.
+    // Rule at src/isa/s390x/inst.isle line 2808.
     let expr0_0 = constructor_unaryop_abs(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6262,7 +6279,7 @@ pub fn constructor_abs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
 pub fn constructor_abs_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2807.
+    // Rule at src/isa/s390x/inst.isle line 2811.
     let expr0_0 = constructor_unaryop_abs_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6272,22 +6289,22 @@ pub fn constructor_abs_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg
 pub fn constructor_unaryop_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2813.
+        // Rule at src/isa/s390x/inst.isle line 2817.
         let expr0_0 = UnaryOp::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2814.
+        // Rule at src/isa/s390x/inst.isle line 2818.
         let expr0_0 = UnaryOp::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2815.
+        // Rule at src/isa/s390x/inst.isle line 2819.
         let expr0_0 = UnaryOp::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2816.
+        // Rule at src/isa/s390x/inst.isle line 2820.
         let expr0_0 = UnaryOp::Neg64;
         return Some(expr0_0);
     }
@@ -6298,7 +6315,7 @@ pub fn constructor_unaryop_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Un
 pub fn constructor_unaryop_neg_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2819.
+        // Rule at src/isa/s390x/inst.isle line 2823.
         let expr0_0 = UnaryOp::Neg64Ext32;
         return Some(expr0_0);
     }
@@ -6309,7 +6326,7 @@ pub fn constructor_unaryop_neg_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_neg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2822.
+    // Rule at src/isa/s390x/inst.isle line 2826.
     let expr0_0 = constructor_unaryop_neg(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6319,7 +6336,7 @@ pub fn constructor_neg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
 pub fn constructor_neg_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2825.
+    // Rule at src/isa/s390x/inst.isle line 2829.
     let expr0_0 = constructor_unaryop_neg_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6329,12 +6346,12 @@ pub fn constructor_neg_reg_sext32<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg
 pub fn constructor_unaryop_bswap<C: Context>(ctx: &mut C, arg0: Type) -> Option<UnaryOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2831.
+        // Rule at src/isa/s390x/inst.isle line 2835.
         let expr0_0 = UnaryOp::BSwap32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2832.
+        // Rule at src/isa/s390x/inst.isle line 2836.
         let expr0_0 = UnaryOp::BSwap64;
         return Some(expr0_0);
     }
@@ -6345,7 +6362,7 @@ pub fn constructor_unaryop_bswap<C: Context>(ctx: &mut C, arg0: Type) -> Option<
 pub fn constructor_bswap_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 2835.
+    // Rule at src/isa/s390x/inst.isle line 2839.
     let expr0_0 = constructor_unaryop_bswap(ctx, pattern0_0)?;
     let expr1_0 = constructor_unary_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -6363,7 +6380,7 @@ pub fn constructor_push_bswap_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 2838.
+    // Rule at src/isa/s390x/inst.isle line 2842.
     let expr0_0 = constructor_unaryop_bswap(ctx, pattern1_0)?;
     let expr1_0 = constructor_push_unary(ctx, pattern0_0, &expr0_0, pattern2_0, pattern3_0)?;
     return Some(expr1_0);
@@ -6373,12 +6390,12 @@ pub fn constructor_push_bswap_reg<C: Context>(
 pub fn constructor_shiftop_rot<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2844.
+        // Rule at src/isa/s390x/inst.isle line 2848.
         let expr0_0 = ShiftOp::RotL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2845.
+        // Rule at src/isa/s390x/inst.isle line 2849.
         let expr0_0 = ShiftOp::RotL64;
         return Some(expr0_0);
     }
@@ -6395,7 +6412,7 @@ pub fn constructor_rot_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2848.
+    // Rule at src/isa/s390x/inst.isle line 2852.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6412,7 +6429,7 @@ pub fn constructor_rot_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2852.
+    // Rule at src/isa/s390x/inst.isle line 2856.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6431,7 +6448,7 @@ pub fn constructor_rot_imm_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 2856.
+    // Rule at src/isa/s390x/inst.isle line 2860.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern0_0)?;
     let expr1_0 = constructor_shift_rr(
         ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -6455,7 +6472,7 @@ pub fn constructor_push_rot_imm_reg<C: Context>(
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
     let pattern5_0 = arg5;
-    // Rule at src/isa/s390x/inst.isle line 2860.
+    // Rule at src/isa/s390x/inst.isle line 2864.
     let expr0_0 = constructor_shiftop_rot(ctx, pattern1_0)?;
     let expr1_0 = constructor_push_shift(
         ctx, pattern0_0, &expr0_0, pattern2_0, pattern3_0, pattern4_0, pattern5_0,
@@ -6467,22 +6484,22 @@ pub fn constructor_push_rot_imm_reg<C: Context>(
 pub fn constructor_shiftop_lshl<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I8 {
-        // Rule at src/isa/s390x/inst.isle line 2867.
+        // Rule at src/isa/s390x/inst.isle line 2871.
         let expr0_0 = ShiftOp::LShL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I16 {
-        // Rule at src/isa/s390x/inst.isle line 2868.
+        // Rule at src/isa/s390x/inst.isle line 2872.
         let expr0_0 = ShiftOp::LShL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2869.
+        // Rule at src/isa/s390x/inst.isle line 2873.
         let expr0_0 = ShiftOp::LShL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2870.
+        // Rule at src/isa/s390x/inst.isle line 2874.
         let expr0_0 = ShiftOp::LShL64;
         return Some(expr0_0);
     }
@@ -6499,7 +6516,7 @@ pub fn constructor_lshl_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2873.
+    // Rule at src/isa/s390x/inst.isle line 2877.
     let expr0_0 = constructor_shiftop_lshl(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6516,7 +6533,7 @@ pub fn constructor_lshl_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2877.
+    // Rule at src/isa/s390x/inst.isle line 2881.
     let expr0_0 = constructor_shiftop_lshl(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6527,12 +6544,12 @@ pub fn constructor_lshl_imm<C: Context>(
 pub fn constructor_shiftop_lshr<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2884.
+        // Rule at src/isa/s390x/inst.isle line 2888.
         let expr0_0 = ShiftOp::LShR32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2885.
+        // Rule at src/isa/s390x/inst.isle line 2889.
         let expr0_0 = ShiftOp::LShR64;
         return Some(expr0_0);
     }
@@ -6549,7 +6566,7 @@ pub fn constructor_lshr_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2888.
+    // Rule at src/isa/s390x/inst.isle line 2892.
     let expr0_0 = constructor_shiftop_lshr(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6566,7 +6583,7 @@ pub fn constructor_lshr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2892.
+    // Rule at src/isa/s390x/inst.isle line 2896.
     let expr0_0 = constructor_shiftop_lshr(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6577,12 +6594,12 @@ pub fn constructor_lshr_imm<C: Context>(
 pub fn constructor_shiftop_ashr<C: Context>(ctx: &mut C, arg0: Type) -> Option<ShiftOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 2899.
+        // Rule at src/isa/s390x/inst.isle line 2903.
         let expr0_0 = ShiftOp::AShR32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 2900.
+        // Rule at src/isa/s390x/inst.isle line 2904.
         let expr0_0 = ShiftOp::AShR64;
         return Some(expr0_0);
     }
@@ -6599,7 +6616,7 @@ pub fn constructor_ashr_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2903.
+    // Rule at src/isa/s390x/inst.isle line 2907.
     let expr0_0 = constructor_shiftop_ashr(ctx, pattern0_0)?;
     let expr1_0: u8 = 0;
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, expr1_0, pattern2_0)?;
@@ -6616,7 +6633,7 @@ pub fn constructor_ashr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2907.
+    // Rule at src/isa/s390x/inst.isle line 2911.
     let expr0_0 = constructor_shiftop_ashr(ctx, pattern0_0)?;
     let expr1_0 = C::zero_reg(ctx);
     let expr2_0 = constructor_shift_rr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0, expr1_0)?;
@@ -6626,7 +6643,7 @@ pub fn constructor_ashr_imm<C: Context>(
 // Generated as internal constructor for term popcnt_byte.
 pub fn constructor_popcnt_byte<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2914.
+    // Rule at src/isa/s390x/inst.isle line 2918.
     let expr0_0: Type = I64;
     let expr1_0 = UnaryOp::PopcntByte;
     let expr2_0 = constructor_unary_rr(ctx, expr0_0, &expr1_0, pattern0_0)?;
@@ -6636,7 +6653,7 @@ pub fn constructor_popcnt_byte<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg
 // Generated as internal constructor for term popcnt_reg.
 pub fn constructor_popcnt_reg<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/s390x/inst.isle line 2917.
+    // Rule at src/isa/s390x/inst.isle line 2921.
     let expr0_0: Type = I64;
     let expr1_0 = UnaryOp::PopcntReg;
     let expr2_0 = constructor_unary_rr(ctx, expr0_0, &expr1_0, pattern0_0)?;
@@ -6654,7 +6671,7 @@ pub fn constructor_atomic_rmw_and<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2923.
+        // Rule at src/isa/s390x/inst.isle line 2927.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::And32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6663,7 +6680,7 @@ pub fn constructor_atomic_rmw_and<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2924.
+        // Rule at src/isa/s390x/inst.isle line 2928.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::And64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6683,7 +6700,7 @@ pub fn constructor_atomic_rmw_or<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2927.
+        // Rule at src/isa/s390x/inst.isle line 2931.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::Orr32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6692,7 +6709,7 @@ pub fn constructor_atomic_rmw_or<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2928.
+        // Rule at src/isa/s390x/inst.isle line 2932.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::Orr64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6712,7 +6729,7 @@ pub fn constructor_atomic_rmw_xor<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2931.
+        // Rule at src/isa/s390x/inst.isle line 2935.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::Xor32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6721,7 +6738,7 @@ pub fn constructor_atomic_rmw_xor<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2932.
+        // Rule at src/isa/s390x/inst.isle line 2936.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::Xor64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6741,7 +6758,7 @@ pub fn constructor_atomic_rmw_add<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2935.
+        // Rule at src/isa/s390x/inst.isle line 2939.
         let expr0_0: Type = I32;
         let expr1_0 = ALUOp::Add32;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6750,7 +6767,7 @@ pub fn constructor_atomic_rmw_add<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 2936.
+        // Rule at src/isa/s390x/inst.isle line 2940.
         let expr0_0: Type = I64;
         let expr1_0 = ALUOp::Add64;
         let expr2_0 = constructor_atomic_rmw_impl(ctx, expr0_0, &expr1_0, pattern2_0, pattern3_0)?;
@@ -6772,7 +6789,7 @@ pub fn constructor_atomic_cas_impl<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2942.
+        // Rule at src/isa/s390x/inst.isle line 2946.
         let expr0_0 = constructor_atomic_cas32(ctx, pattern2_0, pattern3_0, pattern4_0)?;
         return Some(expr0_0);
     }
@@ -6780,7 +6797,7 @@ pub fn constructor_atomic_cas_impl<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/s390x/inst.isle line 2943.
+        // Rule at src/isa/s390x/inst.isle line 2947.
         let expr0_0 = constructor_atomic_cas64(ctx, pattern2_0, pattern3_0, pattern4_0)?;
         return Some(expr0_0);
     }
@@ -6802,7 +6819,7 @@ pub fn constructor_push_atomic_cas<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2946.
+        // Rule at src/isa/s390x/inst.isle line 2950.
         let expr0_0 =
             constructor_push_atomic_cas32(ctx, pattern0_0, pattern3_0, pattern4_0, pattern5_0)?;
         return Some(expr0_0);
@@ -6811,7 +6828,7 @@ pub fn constructor_push_atomic_cas<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/s390x/inst.isle line 2947.
+        // Rule at src/isa/s390x/inst.isle line 2951.
         let expr0_0 =
             constructor_push_atomic_cas64(ctx, pattern0_0, pattern3_0, pattern4_0, pattern5_0)?;
         return Some(expr0_0);
@@ -6823,12 +6840,12 @@ pub fn constructor_push_atomic_cas<C: Context>(
 pub fn constructor_fpuop2_add<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2953.
+        // Rule at src/isa/s390x/inst.isle line 2957.
         let expr0_0 = FPUOp2::Add32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2954.
+        // Rule at src/isa/s390x/inst.isle line 2958.
         let expr0_0 = FPUOp2::Add64;
         return Some(expr0_0);
     }
@@ -6845,7 +6862,7 @@ pub fn constructor_fadd_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2957.
+    // Rule at src/isa/s390x/inst.isle line 2961.
     let expr0_0 = constructor_fpuop2_add(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6855,12 +6872,12 @@ pub fn constructor_fadd_reg<C: Context>(
 pub fn constructor_fpuop2_sub<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2963.
+        // Rule at src/isa/s390x/inst.isle line 2967.
         let expr0_0 = FPUOp2::Sub32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2964.
+        // Rule at src/isa/s390x/inst.isle line 2968.
         let expr0_0 = FPUOp2::Sub64;
         return Some(expr0_0);
     }
@@ -6877,7 +6894,7 @@ pub fn constructor_fsub_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2967.
+    // Rule at src/isa/s390x/inst.isle line 2971.
     let expr0_0 = constructor_fpuop2_sub(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6887,12 +6904,12 @@ pub fn constructor_fsub_reg<C: Context>(
 pub fn constructor_fpuop2_mul<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2973.
+        // Rule at src/isa/s390x/inst.isle line 2977.
         let expr0_0 = FPUOp2::Mul32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2974.
+        // Rule at src/isa/s390x/inst.isle line 2978.
         let expr0_0 = FPUOp2::Mul64;
         return Some(expr0_0);
     }
@@ -6909,7 +6926,7 @@ pub fn constructor_fmul_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2977.
+    // Rule at src/isa/s390x/inst.isle line 2981.
     let expr0_0 = constructor_fpuop2_mul(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6919,12 +6936,12 @@ pub fn constructor_fmul_reg<C: Context>(
 pub fn constructor_fpuop2_div<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2983.
+        // Rule at src/isa/s390x/inst.isle line 2987.
         let expr0_0 = FPUOp2::Div32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2984.
+        // Rule at src/isa/s390x/inst.isle line 2988.
         let expr0_0 = FPUOp2::Div64;
         return Some(expr0_0);
     }
@@ -6941,7 +6958,7 @@ pub fn constructor_fdiv_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2987.
+    // Rule at src/isa/s390x/inst.isle line 2991.
     let expr0_0 = constructor_fpuop2_div(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6951,12 +6968,12 @@ pub fn constructor_fdiv_reg<C: Context>(
 pub fn constructor_fpuop2_min<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 2993.
+        // Rule at src/isa/s390x/inst.isle line 2997.
         let expr0_0 = FPUOp2::Min32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 2994.
+        // Rule at src/isa/s390x/inst.isle line 2998.
         let expr0_0 = FPUOp2::Min64;
         return Some(expr0_0);
     }
@@ -6973,7 +6990,7 @@ pub fn constructor_fmin_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 2997.
+    // Rule at src/isa/s390x/inst.isle line 3001.
     let expr0_0 = constructor_fpuop2_min(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpuvec_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -6983,12 +7000,12 @@ pub fn constructor_fmin_reg<C: Context>(
 pub fn constructor_fpuop2_max<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp2> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3003.
+        // Rule at src/isa/s390x/inst.isle line 3007.
         let expr0_0 = FPUOp2::Max32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3004.
+        // Rule at src/isa/s390x/inst.isle line 3008.
         let expr0_0 = FPUOp2::Max64;
         return Some(expr0_0);
     }
@@ -7005,7 +7022,7 @@ pub fn constructor_fmax_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3007.
+    // Rule at src/isa/s390x/inst.isle line 3011.
     let expr0_0 = constructor_fpuop2_max(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpuvec_rrr(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7015,12 +7032,12 @@ pub fn constructor_fmax_reg<C: Context>(
 pub fn constructor_fpuop3_fma<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp3> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3013.
+        // Rule at src/isa/s390x/inst.isle line 3017.
         let expr0_0 = FPUOp3::MAdd32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3014.
+        // Rule at src/isa/s390x/inst.isle line 3018.
         let expr0_0 = FPUOp3::MAdd64;
         return Some(expr0_0);
     }
@@ -7039,7 +7056,7 @@ pub fn constructor_fma_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/s390x/inst.isle line 3017.
+    // Rule at src/isa/s390x/inst.isle line 3021.
     let expr0_0 = constructor_fpuop3_fma(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rrrr(
         ctx, pattern0_0, &expr0_0, pattern3_0, pattern1_0, pattern2_0,
@@ -7051,12 +7068,12 @@ pub fn constructor_fma_reg<C: Context>(
 pub fn constructor_fpuop1_sqrt<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp1> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3023.
+        // Rule at src/isa/s390x/inst.isle line 3027.
         let expr0_0 = FPUOp1::Sqrt32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3024.
+        // Rule at src/isa/s390x/inst.isle line 3028.
         let expr0_0 = FPUOp1::Sqrt64;
         return Some(expr0_0);
     }
@@ -7067,7 +7084,7 @@ pub fn constructor_fpuop1_sqrt<C: Context>(ctx: &mut C, arg0: Type) -> Option<FP
 pub fn constructor_sqrt_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3027.
+    // Rule at src/isa/s390x/inst.isle line 3031.
     let expr0_0 = constructor_fpuop1_sqrt(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7077,12 +7094,12 @@ pub fn constructor_sqrt_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuop1_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp1> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3033.
+        // Rule at src/isa/s390x/inst.isle line 3037.
         let expr0_0 = FPUOp1::Neg32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3034.
+        // Rule at src/isa/s390x/inst.isle line 3038.
         let expr0_0 = FPUOp1::Neg64;
         return Some(expr0_0);
     }
@@ -7093,7 +7110,7 @@ pub fn constructor_fpuop1_neg<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPU
 pub fn constructor_fneg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3037.
+    // Rule at src/isa/s390x/inst.isle line 3041.
     let expr0_0 = constructor_fpuop1_neg(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7103,12 +7120,12 @@ pub fn constructor_fneg_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuop1_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPUOp1> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3043.
+        // Rule at src/isa/s390x/inst.isle line 3047.
         let expr0_0 = FPUOp1::Abs32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3044.
+        // Rule at src/isa/s390x/inst.isle line 3048.
         let expr0_0 = FPUOp1::Abs64;
         return Some(expr0_0);
     }
@@ -7119,7 +7136,7 @@ pub fn constructor_fpuop1_abs<C: Context>(ctx: &mut C, arg0: Type) -> Option<FPU
 pub fn constructor_fabs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3047.
+    // Rule at src/isa/s390x/inst.isle line 3051.
     let expr0_0 = constructor_fpuop1_abs(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7129,12 +7146,12 @@ pub fn constructor_fabs_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuroundmode_ceil<C: Context>(ctx: &mut C, arg0: Type) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3053.
+        // Rule at src/isa/s390x/inst.isle line 3057.
         let expr0_0 = FpuRoundMode::Plus32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3054.
+        // Rule at src/isa/s390x/inst.isle line 3058.
         let expr0_0 = FpuRoundMode::Plus64;
         return Some(expr0_0);
     }
@@ -7145,7 +7162,7 @@ pub fn constructor_fpuroundmode_ceil<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_ceil_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3057.
+    // Rule at src/isa/s390x/inst.isle line 3061.
     let expr0_0 = constructor_fpuroundmode_ceil(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7155,12 +7172,12 @@ pub fn constructor_ceil_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> O
 pub fn constructor_fpuroundmode_floor<C: Context>(ctx: &mut C, arg0: Type) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3063.
+        // Rule at src/isa/s390x/inst.isle line 3067.
         let expr0_0 = FpuRoundMode::Minus32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3064.
+        // Rule at src/isa/s390x/inst.isle line 3068.
         let expr0_0 = FpuRoundMode::Minus64;
         return Some(expr0_0);
     }
@@ -7171,7 +7188,7 @@ pub fn constructor_fpuroundmode_floor<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_floor_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3067.
+    // Rule at src/isa/s390x/inst.isle line 3071.
     let expr0_0 = constructor_fpuroundmode_floor(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7181,12 +7198,12 @@ pub fn constructor_floor_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> 
 pub fn constructor_fpuroundmode_trunc<C: Context>(ctx: &mut C, arg0: Type) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3073.
+        // Rule at src/isa/s390x/inst.isle line 3077.
         let expr0_0 = FpuRoundMode::Zero32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3074.
+        // Rule at src/isa/s390x/inst.isle line 3078.
         let expr0_0 = FpuRoundMode::Zero64;
         return Some(expr0_0);
     }
@@ -7197,7 +7214,7 @@ pub fn constructor_fpuroundmode_trunc<C: Context>(ctx: &mut C, arg0: Type) -> Op
 pub fn constructor_trunc_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3077.
+    // Rule at src/isa/s390x/inst.isle line 3081.
     let expr0_0 = constructor_fpuroundmode_trunc(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7210,12 +7227,12 @@ pub fn constructor_fpuroundmode_nearest<C: Context>(
 ) -> Option<FpuRoundMode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32 {
-        // Rule at src/isa/s390x/inst.isle line 3083.
+        // Rule at src/isa/s390x/inst.isle line 3087.
         let expr0_0 = FpuRoundMode::Nearest32;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
-        // Rule at src/isa/s390x/inst.isle line 3084.
+        // Rule at src/isa/s390x/inst.isle line 3088.
         let expr0_0 = FpuRoundMode::Nearest64;
         return Some(expr0_0);
     }
@@ -7226,7 +7243,7 @@ pub fn constructor_fpuroundmode_nearest<C: Context>(
 pub fn constructor_nearest_reg<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/s390x/inst.isle line 3087.
+    // Rule at src/isa/s390x/inst.isle line 3091.
     let expr0_0 = constructor_fpuroundmode_nearest(ctx, pattern0_0)?;
     let expr1_0 = constructor_fpu_round(ctx, pattern0_0, &expr0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -7242,7 +7259,7 @@ pub fn constructor_fpuop1_promote<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3093.
+            // Rule at src/isa/s390x/inst.isle line 3097.
             let expr0_0 = FPUOp1::Cvt32To64;
             return Some(expr0_0);
         }
@@ -7260,7 +7277,7 @@ pub fn constructor_fpromote_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3096.
+    // Rule at src/isa/s390x/inst.isle line 3100.
     let expr0_0 = constructor_fpuop1_promote(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7276,7 +7293,7 @@ pub fn constructor_fpuop1_demote<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3103.
+            // Rule at src/isa/s390x/inst.isle line 3107.
             let expr0_0 = FPUOp1::Cvt64To32;
             return Some(expr0_0);
         }
@@ -7294,7 +7311,7 @@ pub fn constructor_fdemote_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3106.
+    // Rule at src/isa/s390x/inst.isle line 3110.
     let expr0_0 = constructor_fpuop1_demote(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_rr(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7310,12 +7327,12 @@ pub fn constructor_uint_to_fpu_op<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3113.
+            // Rule at src/isa/s390x/inst.isle line 3117.
             let expr0_0 = IntToFpuOp::U32ToF32;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3115.
+            // Rule at src/isa/s390x/inst.isle line 3119.
             let expr0_0 = IntToFpuOp::U64ToF32;
             return Some(expr0_0);
         }
@@ -7323,12 +7340,12 @@ pub fn constructor_uint_to_fpu_op<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3114.
+            // Rule at src/isa/s390x/inst.isle line 3118.
             let expr0_0 = IntToFpuOp::U32ToF64;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3116.
+            // Rule at src/isa/s390x/inst.isle line 3120.
             let expr0_0 = IntToFpuOp::U64ToF64;
             return Some(expr0_0);
         }
@@ -7346,7 +7363,7 @@ pub fn constructor_fcvt_from_uint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3119.
+    // Rule at src/isa/s390x/inst.isle line 3123.
     let expr0_0 = constructor_uint_to_fpu_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_int_to_fpu(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7362,12 +7379,12 @@ pub fn constructor_sint_to_fpu_op<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3126.
+            // Rule at src/isa/s390x/inst.isle line 3130.
             let expr0_0 = IntToFpuOp::I32ToF32;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3128.
+            // Rule at src/isa/s390x/inst.isle line 3132.
             let expr0_0 = IntToFpuOp::I64ToF32;
             return Some(expr0_0);
         }
@@ -7375,12 +7392,12 @@ pub fn constructor_sint_to_fpu_op<C: Context>(
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         if pattern2_0 == I32 {
-            // Rule at src/isa/s390x/inst.isle line 3127.
+            // Rule at src/isa/s390x/inst.isle line 3131.
             let expr0_0 = IntToFpuOp::I32ToF64;
             return Some(expr0_0);
         }
         if pattern2_0 == I64 {
-            // Rule at src/isa/s390x/inst.isle line 3129.
+            // Rule at src/isa/s390x/inst.isle line 3133.
             let expr0_0 = IntToFpuOp::I64ToF64;
             return Some(expr0_0);
         }
@@ -7398,7 +7415,7 @@ pub fn constructor_fcvt_from_sint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3132.
+    // Rule at src/isa/s390x/inst.isle line 3136.
     let expr0_0 = constructor_sint_to_fpu_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_int_to_fpu(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7414,12 +7431,12 @@ pub fn constructor_fpu_to_uint_op<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3139.
+            // Rule at src/isa/s390x/inst.isle line 3143.
             let expr0_0 = FpuToIntOp::F32ToU32;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3140.
+            // Rule at src/isa/s390x/inst.isle line 3144.
             let expr0_0 = FpuToIntOp::F64ToU32;
             return Some(expr0_0);
         }
@@ -7427,12 +7444,12 @@ pub fn constructor_fpu_to_uint_op<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3141.
+            // Rule at src/isa/s390x/inst.isle line 3145.
             let expr0_0 = FpuToIntOp::F32ToU64;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3142.
+            // Rule at src/isa/s390x/inst.isle line 3146.
             let expr0_0 = FpuToIntOp::F64ToU64;
             return Some(expr0_0);
         }
@@ -7450,7 +7467,7 @@ pub fn constructor_fcvt_to_uint_reg_with_flags<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3145.
+    // Rule at src/isa/s390x/inst.isle line 3149.
     let expr0_0 = constructor_fpu_to_uint_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_to_int(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7466,7 +7483,7 @@ pub fn constructor_fcvt_to_uint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3149.
+    // Rule at src/isa/s390x/inst.isle line 3153.
     let expr0_0 = constructor_fcvt_to_uint_reg_with_flags(ctx, pattern0_0, pattern1_0, pattern2_0)?;
     let expr1_0 = constructor_drop_flags(ctx, &expr0_0)?;
     return Some(expr1_0);
@@ -7482,12 +7499,12 @@ pub fn constructor_fpu_to_sint_op<C: Context>(
     if pattern0_0 == I32 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3156.
+            // Rule at src/isa/s390x/inst.isle line 3160.
             let expr0_0 = FpuToIntOp::F32ToI32;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3157.
+            // Rule at src/isa/s390x/inst.isle line 3161.
             let expr0_0 = FpuToIntOp::F64ToI32;
             return Some(expr0_0);
         }
@@ -7495,12 +7512,12 @@ pub fn constructor_fpu_to_sint_op<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         if pattern2_0 == F32 {
-            // Rule at src/isa/s390x/inst.isle line 3158.
+            // Rule at src/isa/s390x/inst.isle line 3162.
             let expr0_0 = FpuToIntOp::F32ToI64;
             return Some(expr0_0);
         }
         if pattern2_0 == F64 {
-            // Rule at src/isa/s390x/inst.isle line 3159.
+            // Rule at src/isa/s390x/inst.isle line 3163.
             let expr0_0 = FpuToIntOp::F64ToI64;
             return Some(expr0_0);
         }
@@ -7518,7 +7535,7 @@ pub fn constructor_fcvt_to_sint_reg_with_flags<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3162.
+    // Rule at src/isa/s390x/inst.isle line 3166.
     let expr0_0 = constructor_fpu_to_sint_op(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_fpu_to_int(ctx, pattern0_0, &expr0_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7534,7 +7551,7 @@ pub fn constructor_fcvt_to_sint_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3166.
+    // Rule at src/isa/s390x/inst.isle line 3170.
     let expr0_0 = constructor_fcvt_to_sint_reg_with_flags(ctx, pattern0_0, pattern1_0, pattern2_0)?;
     let expr1_0 = constructor_drop_flags(ctx, &expr0_0)?;
     return Some(expr1_0);
@@ -7544,12 +7561,12 @@ pub fn constructor_fcvt_to_sint_reg<C: Context>(
 pub fn constructor_cmpop_cmps<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3173.
+        // Rule at src/isa/s390x/inst.isle line 3177.
         let expr0_0 = CmpOp::CmpS32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3174.
+        // Rule at src/isa/s390x/inst.isle line 3178.
         let expr0_0 = CmpOp::CmpS64;
         return Some(expr0_0);
     }
@@ -7560,12 +7577,12 @@ pub fn constructor_cmpop_cmps<C: Context>(ctx: &mut C, arg0: Type) -> Option<Cmp
 pub fn constructor_cmpop_cmps_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3177.
+        // Rule at src/isa/s390x/inst.isle line 3181.
         let expr0_0 = CmpOp::CmpS32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3178.
+        // Rule at src/isa/s390x/inst.isle line 3182.
         let expr0_0 = CmpOp::CmpS64Ext16;
         return Some(expr0_0);
     }
@@ -7576,7 +7593,7 @@ pub fn constructor_cmpop_cmps_sext16<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_cmpop_cmps_sext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3181.
+        // Rule at src/isa/s390x/inst.isle line 3185.
         let expr0_0 = CmpOp::CmpS64Ext32;
         return Some(expr0_0);
     }
@@ -7593,7 +7610,7 @@ pub fn constructor_icmps_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3184.
+    // Rule at src/isa/s390x/inst.isle line 3188.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7609,7 +7626,7 @@ pub fn constructor_icmps_reg_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3187.
+    // Rule at src/isa/s390x/inst.isle line 3191.
     let expr0_0 = constructor_cmpop_cmps_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7625,7 +7642,7 @@ pub fn constructor_icmps_simm16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3190.
+    // Rule at src/isa/s390x/inst.isle line 3194.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rsimm16(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7641,7 +7658,7 @@ pub fn constructor_icmps_simm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3193.
+    // Rule at src/isa/s390x/inst.isle line 3197.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rsimm32(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7657,7 +7674,7 @@ pub fn constructor_icmps_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3196.
+    // Rule at src/isa/s390x/inst.isle line 3200.
     let expr0_0 = constructor_cmpop_cmps(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7673,7 +7690,7 @@ pub fn constructor_icmps_mem_sext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3199.
+    // Rule at src/isa/s390x/inst.isle line 3203.
     let expr0_0 = constructor_cmpop_cmps_sext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7689,7 +7706,7 @@ pub fn constructor_icmps_mem_sext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3202.
+    // Rule at src/isa/s390x/inst.isle line 3206.
     let expr0_0 = constructor_cmpop_cmps_sext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7699,12 +7716,12 @@ pub fn constructor_icmps_mem_sext32<C: Context>(
 pub fn constructor_cmpop_cmpu<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3208.
+        // Rule at src/isa/s390x/inst.isle line 3212.
         let expr0_0 = CmpOp::CmpL32;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3209.
+        // Rule at src/isa/s390x/inst.isle line 3213.
         let expr0_0 = CmpOp::CmpL64;
         return Some(expr0_0);
     }
@@ -7715,12 +7732,12 @@ pub fn constructor_cmpop_cmpu<C: Context>(ctx: &mut C, arg0: Type) -> Option<Cmp
 pub fn constructor_cmpop_cmpu_zext16<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I32 {
-        // Rule at src/isa/s390x/inst.isle line 3212.
+        // Rule at src/isa/s390x/inst.isle line 3216.
         let expr0_0 = CmpOp::CmpL32Ext16;
         return Some(expr0_0);
     }
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3213.
+        // Rule at src/isa/s390x/inst.isle line 3217.
         let expr0_0 = CmpOp::CmpL64Ext16;
         return Some(expr0_0);
     }
@@ -7731,7 +7748,7 @@ pub fn constructor_cmpop_cmpu_zext16<C: Context>(ctx: &mut C, arg0: Type) -> Opt
 pub fn constructor_cmpop_cmpu_zext32<C: Context>(ctx: &mut C, arg0: Type) -> Option<CmpOp> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/s390x/inst.isle line 3216.
+        // Rule at src/isa/s390x/inst.isle line 3220.
         let expr0_0 = CmpOp::CmpL64Ext32;
         return Some(expr0_0);
     }
@@ -7748,7 +7765,7 @@ pub fn constructor_icmpu_reg<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3219.
+    // Rule at src/isa/s390x/inst.isle line 3223.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7764,7 +7781,7 @@ pub fn constructor_icmpu_reg_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3222.
+    // Rule at src/isa/s390x/inst.isle line 3226.
     let expr0_0 = constructor_cmpop_cmpu_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rr(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7780,7 +7797,7 @@ pub fn constructor_icmpu_uimm32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3225.
+    // Rule at src/isa/s390x/inst.isle line 3229.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_ruimm32(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7796,7 +7813,7 @@ pub fn constructor_icmpu_mem<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3228.
+    // Rule at src/isa/s390x/inst.isle line 3232.
     let expr0_0 = constructor_cmpop_cmpu(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7812,7 +7829,7 @@ pub fn constructor_icmpu_mem_zext16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3231.
+    // Rule at src/isa/s390x/inst.isle line 3235.
     let expr0_0 = constructor_cmpop_cmpu_zext16(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7828,7 +7845,7 @@ pub fn constructor_icmpu_mem_zext32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/s390x/inst.isle line 3234.
+    // Rule at src/isa/s390x/inst.isle line 3238.
     let expr0_0 = constructor_cmpop_cmpu_zext32(ctx, pattern0_0)?;
     let expr1_0 = constructor_cmp_rx(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -7845,14 +7862,14 @@ pub fn constructor_fcmp_reg<C: Context>(
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 3240.
+        // Rule at src/isa/s390x/inst.isle line 3244.
         let expr0_0 = constructor_fpu_cmp32(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/s390x/inst.isle line 3241.
+        // Rule at src/isa/s390x/inst.isle line 3245.
         let expr0_0 = constructor_fpu_cmp64(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -149,14 +149,40 @@
        (Setcc (cc CC)
               (dst WritableGpr))
 
-       ;; Integer conditional move.
-       ;;
-       ;; Overwrites the destination register.
+       ;; =========================================
+       ;; Conditional moves.
+
+       ;; GPR conditional move; overwrites the destination register.
        (Cmove (size OperandSize)
               (cc CC)
               (consequent GprMem)
               (alternative Gpr)
               (dst WritableGpr))
+
+       ;; GPR conditional move with the `OR` of two conditions; overwrites
+       ;; the destination register.
+       (CmoveOr (size OperandSize)
+              (cc1 CC)
+              (cc2 CC)
+              (consequent GprMem)
+              (alternative Gpr)
+              (dst WritableGpr))
+
+       ;; XMM conditional move; overwrites the destination register.
+       (XmmCmove (size OperandSize)
+              (cc CC)
+              (consequent XmmMem)
+              (alternative Xmm)
+              (dst WritableXmm))
+
+       ;; XMM conditional move with the `OR` of two conditions; overwrites
+       ;; the destination register.
+       (XmmCmoveOr (size OperandSize)
+              (cc1 CC)
+              (cc2 CC)
+              (consequent XmmMem)
+              (alternative Xmm)
+              (dst WritableXmm))
 
        ;; =========================================
        ;; Stack manipulation.
@@ -274,14 +300,6 @@
                      (is_min bool)
                      (lhs Xmm)
                      (rhs_dst WritableXmm))
-
-       ;; XMM (scalar) conditional move.
-       ;;
-       ;; Overwrites the destination register if cc is set.
-       (XmmCmove (size OperandSize)
-                 (cc CC)
-                 (src XmmMem)
-                 (dst WritableXmm))
 
        ;; Float comparisons/tests: cmp (b w l q) (reg addr imm) reg.
        (XmmCmpRmR (op SseOpcode)
@@ -1027,6 +1045,17 @@
 (decl xmm0 () WritableXmm)
 (extern constructor xmm0 xmm0)
 
+;;;; Helpers for determining the register class of a value type ;;;;;;;;;;;;;;;;
+
+(decl is_xmm_type (Type) Type)
+(extern extractor is_xmm_type is_xmm_type)
+
+(decl is_gpr_type (Type) Type)
+(extern extractor is_gpr_type is_gpr_type)
+
+(decl is_single_register_type (Type) Type)
+(extern extractor is_single_register_type is_single_register_type)
+
 ;;;; Helpers for Querying Enabled ISA Extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl avx512vl_enabled () Type)
@@ -1256,26 +1285,28 @@
                  src2))
 
 ;; Helper for creating `add` instructions whose flags are also used.
-(decl add_with_flags (Type Gpr GprMemImm) ProducesFlags)
-(rule (add_with_flags ty src1 src2)
+(decl add_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
+(rule (add_with_flags_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
-        (ProducesFlags.ProducesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                                                    (AluRmiROpcode.Add)
-                                                    src1
-                                                    src2
-                                                    dst)
-                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
+        (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
+         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
+                        (AluRmiROpcode.Add)
+                        src1
+                        src2
+                        dst)
+         (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for creating `adc` instructions.
-(decl adc (Type Gpr GprMemImm) ConsumesFlags)
-(rule (adc ty src1 src2)
+(decl adc_paired (Type Gpr GprMemImm) ConsumesFlags)
+(rule (adc_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
-        (ConsumesFlags.ConsumesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                                                    (AluRmiROpcode.Adc)
-                                                    src1
-                                                    src2
-                                                    dst)
-                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
+        (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
+         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
+                        (AluRmiROpcode.Adc)
+                        src1
+                        src2
+                        dst)
+         (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for emitting `sub` instructions.
 (decl sub (Type Gpr GprMemImm) Gpr)
@@ -1286,26 +1317,28 @@
                  src2))
 
 ;; Helper for creating `sub` instructions whose flags are also used.
-(decl sub_with_flags (Type Gpr GprMemImm) ProducesFlags)
-(rule (sub_with_flags ty src1 src2)
+(decl sub_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
+(rule (sub_with_flags_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
-        (ProducesFlags.ProducesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                                                    (AluRmiROpcode.Sub)
-                                                    src1
-                                                    src2
-                                                    dst)
-                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
+        (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
+         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
+                        (AluRmiROpcode.Sub)
+                        src1
+                        src2
+                        dst)
+         (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for creating `sbb` instructions.
-(decl sbb (Type Gpr GprMemImm) ConsumesFlags)
-(rule (sbb ty src1 src2)
+(decl sbb_paired (Type Gpr GprMemImm) ConsumesFlags)
+(rule (sbb_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
-        (ConsumesFlags.ConsumesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                                                    (AluRmiROpcode.Sbb)
-                                                    src1
-                                                    src2
-                                                    dst)
-                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
+        (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
+         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
+                        (AluRmiROpcode.Sbb)
+                        src1
+                        src2
+                        dst)
+         (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for creating `mul` instructions.
 (decl mul (Type Gpr GprMemImm) Gpr)
@@ -1456,29 +1489,128 @@
 ;; Helper for creating `MInst.CmpRmiR` instructions.
 (decl cmp_rmi_r (OperandSize CmpOpcode GprMemImm Gpr) ProducesFlags)
 (rule (cmp_rmi_r size opcode src1 src2)
-      (ProducesFlags.ProducesFlags (MInst.CmpRmiR size
-                                                  opcode
-                                                  src1
-                                                  src2)
-                                   (invalid_reg)))
+      (ProducesFlags.ProducesFlagsSideEffect
+       (MInst.CmpRmiR size
+                      opcode
+                      src1
+                      src2)))
 
 ;; Helper for creating `cmp` instructions.
 (decl cmp (OperandSize GprMemImm Gpr) ProducesFlags)
 (rule (cmp size src1 src2)
       (cmp_rmi_r size (CmpOpcode.Cmp) src1 src2))
 
+;; Helper for creating `MInst.XmmCmpRmR` instructions.
+(decl xmm_cmp_rm_r (SseOpcode XmmMem Xmm) ProducesFlags)
+(rule (xmm_cmp_rm_r opcode src1 src2)
+      (ProducesFlags.ProducesFlagsSideEffect
+       (MInst.XmmCmpRmR opcode src1 src2)))
+
+;; Helper for creating `fpcmp` instructions (cannot use `fcmp` as it is taken by
+;; `clif.isle`).
+(decl fpcmp (Value Value) ProducesFlags)
+(rule (fpcmp src1 @ (value_type $F32) src2)
+      (xmm_cmp_rm_r (SseOpcode.Ucomiss) (put_in_xmm_mem src1) (put_in_xmm src2)))
+(rule (fpcmp src1 @ (value_type $F64) src2)
+      (xmm_cmp_rm_r (SseOpcode.Ucomisd) (put_in_xmm_mem src1) (put_in_xmm src2)))
+
 ;; Helper for creating `test` instructions.
 (decl test (OperandSize GprMemImm Gpr) ProducesFlags)
 (rule (test size src1 src2)
       (cmp_rmi_r size (CmpOpcode.Test) src1 src2))
 
-;; Helper for creating `MInst.Cmove` instructions.
+;; Helper for creating `cmove` instructions. Note that these instructions do not
+;; always result in a single emitted x86 instruction; e.g., XmmCmove uses jumps
+;; to conditionally move the selected value into an XMM register.
 (decl cmove (Type CC GprMem Gpr) ConsumesFlags)
 (rule (cmove ty cc consequent alternative)
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty)))
-        (ConsumesFlags.ConsumesFlags (MInst.Cmove size cc consequent alternative dst)
-                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
+        (ConsumesFlags.ConsumesFlagsReturnsReg
+         (MInst.Cmove size cc consequent alternative dst)
+         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+
+(decl cmove_xmm (Type CC XmmMem Xmm) ConsumesFlags)
+(rule (cmove_xmm ty cc consequent alternative)
+      (let ((dst WritableXmm (temp_writable_xmm))
+            (size OperandSize (operand_size_of_type_32_64 ty)))
+        (ConsumesFlags.ConsumesFlagsReturnsReg
+         (MInst.XmmCmove size cc consequent alternative dst)
+         (xmm_to_reg (writable_xmm_to_xmm dst)))))
+
+;; Helper for creating `cmove` instructions directly from values. This allows us
+;; to special-case the `I128` types and default to the `cmove` helper otherwise.
+;; It also eliminates some `put_in_reg*` boilerplate in the lowering ISLE code.
+(decl cmove_from_values (Type CC Value Value) ConsumesFlags)
+(rule (cmove_from_values $I128 cc consequent alternative)
+      (let ((cons ValueRegs (put_in_regs consequent))
+            (alt ValueRegs (put_in_regs alternative))
+            (dst1 WritableGpr (temp_writable_gpr))
+            (dst2 WritableGpr (temp_writable_gpr))
+            (size OperandSize (OperandSize.Size64))
+            (lower_cmove MInst (MInst.Cmove
+                                size cc
+                                (gpr_to_gpr_mem (value_regs_get_gpr cons 0))
+                                (value_regs_get_gpr alt 0) dst1))
+            (upper_cmove MInst (MInst.Cmove
+                                size cc
+                                (gpr_to_gpr_mem (value_regs_get_gpr cons 1))
+                                (value_regs_get_gpr alt 1) dst2)))
+        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
+         lower_cmove
+         upper_cmove
+         (value_regs
+          (gpr_to_reg (writable_gpr_to_gpr dst1))
+          (gpr_to_reg (writable_gpr_to_gpr dst2))))))
+
+(rule (cmove_from_values (is_gpr_type (is_single_register_type ty)) cc consequent alternative)
+      (cmove ty cc (put_in_gpr_mem consequent) (put_in_gpr alternative)))
+
+(rule (cmove_from_values (is_xmm_type (is_single_register_type ty)) cc consequent alternative)
+      (cmove_xmm ty cc (put_in_xmm_mem consequent) (put_in_xmm alternative)))
+
+;; Helper for creating `cmove` instructions with the logical OR of multiple
+;; flags. Note that these instructions will always result in more than one
+;; emitted x86 instruction.
+(decl cmove_or (Type CC CC GprMem Gpr) ConsumesFlags)
+(rule (cmove_or ty cc1 cc2 consequent alternative)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (size OperandSize (operand_size_of_type_32_64 ty)))
+        (ConsumesFlags.ConsumesFlagsReturnsReg
+         (MInst.CmoveOr size cc1 cc2 consequent alternative dst)
+         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+
+(decl cmove_or_xmm (Type CC CC XmmMem Xmm) ConsumesFlags)
+(rule (cmove_or_xmm ty cc1 cc2 consequent alternative)
+      (let ((dst WritableXmm (temp_writable_xmm))
+            (size OperandSize (operand_size_of_type_32_64 ty)))
+        (ConsumesFlags.ConsumesFlagsReturnsReg
+         (MInst.XmmCmoveOr size cc1 cc2 consequent alternative dst)
+         (xmm_to_reg (writable_xmm_to_xmm dst)))))
+
+;; Helper for creating `cmove_or` instructions directly from values. This allows
+;; us to special-case the `I128` types and default to the `cmove_or` helper
+;; otherwise.
+(decl cmove_or_from_values (Type CC CC Value Value) ConsumesFlags)
+(rule (cmove_or_from_values $I128 cc1 cc2 consequent alternative)
+      (let ((cons ValueRegs (put_in_regs consequent))
+            (alt ValueRegs (put_in_regs alternative))
+            (dst1 WritableGpr (temp_writable_gpr))
+            (dst2 WritableGpr (temp_writable_gpr))
+            (size OperandSize (OperandSize.Size64))
+            (lower_cmove MInst (MInst.CmoveOr size cc1 cc2 (gpr_to_gpr_mem (value_regs_get_gpr cons 0)) (value_regs_get_gpr alt 0) dst1))
+            (upper_cmove MInst (MInst.CmoveOr size cc1 cc2 (gpr_to_gpr_mem (value_regs_get_gpr cons 1)) (value_regs_get_gpr alt 1) dst2)))
+        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
+         lower_cmove
+         upper_cmove
+         (value_regs (gpr_to_reg (writable_gpr_to_gpr dst1))
+                     (gpr_to_reg (writable_gpr_to_gpr dst2))))))
+
+(rule (cmove_or_from_values (is_gpr_type (is_single_register_type ty)) cc1 cc2 consequent alternative)
+      (cmove_or ty cc1 cc2 (put_in_gpr_mem consequent) (put_in_gpr alternative)))
+
+(rule (cmove_or_from_values (is_xmm_type (is_single_register_type ty)) cc1 cc2 consequent alternative)
+      (cmove_or_xmm ty cc1 cc2 (put_in_xmm_mem consequent) (put_in_xmm alternative)))
 
 ;; Helper for creating `MInst.MovzxRmR` instructions.
 (decl movzx (Type ExtMode GprMem) Gpr)

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -124,8 +124,8 @@
               (y_lo Gpr (value_regs_get_gpr y_regs 0))
               (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do an add followed by an add-with-carry.
-          (with_flags (add_with_flags $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
-                      (adc $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
+          (with_flags (add_with_flags_paired $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+                      (adc_paired $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
 
 ;;;; Rules for `sadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -225,8 +225,8 @@
       (let ((y_regs ValueRegs (put_in_regs y))
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-        (with_flags (add_with_flags $I64 y_lo x)
-                    (adc $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
+        (with_flags (add_with_flags_paired $I64 y_lo x)
+                    (adc_paired $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
 
 ;; Otherwise, put the immediate into a register.
 (rule (lower (has_type $I128 (iadd_imm y (u64_from_imm64 x))))
@@ -234,8 +234,8 @@
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1))
             (x_lo Gpr (gpr_new (imm $I64 x))))
-        (with_flags (add_with_flags $I64 y_lo (gpr_to_gpr_mem_imm x_lo))
-                    (adc $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
+        (with_flags (add_with_flags_paired $I64 y_lo (gpr_to_gpr_mem_imm x_lo))
+                    (adc_paired $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -293,8 +293,8 @@
               (y_lo Gpr (value_regs_get_gpr y_regs 0))
               (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do a sub followed by an sub-with-borrow.
-          (with_flags (sub_with_flags $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
-                      (sbb $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
+          (with_flags (sub_with_flags_paired $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+                      (sbb_paired $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
 
 ;;;; Rules for `ssub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -562,7 +562,7 @@
                                                   (gpr_to_gpr_mem_imm amt)))))
             (zero Gpr (gpr_new (imm $I64 0)))
             ;; Nullify the carry if we are shifting in by a multiple of 128.
-            (carry_ Gpr (gpr_new (with_flags_1 (test (OperandSize.Size64)
+            (carry_ Gpr (gpr_new (with_flags_reg (test (OperandSize.Size64)
                                                      (gpr_mem_imm_new (RegMemImm.Imm 127))
                                                      amt)
                                                (cmove $I64
@@ -574,11 +574,10 @@
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the low bits are zero and the high bits are our
         ;; low bits.
-        (with_flags_2 (test (OperandSize.Size64)
-                            (gpr_mem_imm_new (RegMemImm.Imm 64))
-                            amt)
-                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted) zero)
-                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted_) lo_shifted))))
+        (with_flags (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 64)) amt)
+                    (consumes_flags_concat
+                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted) zero)
+                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted_) lo_shifted)))))
 
 (rule (lower (has_type $I128 (ishl src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
@@ -674,23 +673,17 @@
                                                   (gpr_new (imm $I64 64))
                                                   (gpr_to_gpr_mem_imm amt)))))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (gpr_new (with_flags_1 (test (OperandSize.Size64)
-                                                     (gpr_mem_imm_new (RegMemImm.Imm 127))
-                                                     amt)
-                                               (cmove $I64
-                                                      (CC.Z)
-                                                      (gpr_to_gpr_mem (gpr_new (imm $I64 0)))
-                                                      carry))))
+            (carry_ Gpr (gpr_new (with_flags_reg (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 127)) amt)
+                                        (cmove $I64 (CC.Z) (gpr_to_gpr_mem (gpr_new (imm $I64 0))) carry))))
             ;; Add the carry bits into the lo.
             (lo_shifted_ Gpr (or $I64 carry_ (gpr_to_gpr_mem_imm lo_shifted))))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are zero and the lo bits are what
         ;; would otherwise be our hi bits.
-        (with_flags_2 (test (OperandSize.Size64)
-                            (gpr_mem_imm_new (RegMemImm.Imm 64))
-                            amt)
-                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
-                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) (gpr_new (imm $I64 0))))))
+        (with_flags (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 64)) amt)
+                    (consumes_flags_concat
+                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
+                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) (gpr_new (imm $I64 0)))))))
 
 (rule (lower (has_type $I128 (ushr src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
@@ -787,13 +780,8 @@
                                                   (gpr_new (imm $I64 64))
                                                   (gpr_to_gpr_mem_imm amt)))))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (gpr_new (with_flags_1 (test (OperandSize.Size64)
-                                                     (gpr_mem_imm_new (RegMemImm.Imm 127))
-                                                     amt)
-                                               (cmove $I64
-                                                      (CC.Z)
-                                                      (gpr_to_gpr_mem (gpr_new (imm $I64 0)))
-                                                      carry))))
+            (carry_ Gpr (gpr_new (with_flags_reg (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 127)) amt)
+                                    (cmove $I64 (CC.Z) (gpr_to_gpr_mem (gpr_new (imm $I64 0))) carry))))
             ;; Add the carry into the low half.
             (lo_shifted_ Gpr (or $I64 lo_shifted (gpr_to_gpr_mem_imm carry_)))
             ;; Get all sign bits.
@@ -801,11 +789,10 @@
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are all sign bits and the lo bits are
         ;; what would otherwise be our hi bits.
-        (with_flags_2 (test (OperandSize.Size64)
-                            (gpr_mem_imm_new (RegMemImm.Imm 64))
-                            amt)
-                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
-                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) sign_bits))))
+        (with_flags (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 64)) amt)
+                    (consumes_flags_concat
+                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
+                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) sign_bits)))))
 
 (rule (lower (has_type $I128 (sshr src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
@@ -1468,7 +1455,7 @@
       (let ((x_reg Gpr (put_in_gpr x))
             (y_reg Gpr (put_in_gpr y))
             (size OperandSize (raw_operand_size_of_type ty)))
-           (value_reg (with_flags_1 (cmp size (gpr_to_gpr_mem_imm x_reg) y_reg)
+           (value_reg (with_flags_reg (cmp size (gpr_to_gpr_mem_imm x_reg) y_reg)
                                     (cmove ty cc (gpr_to_gpr_mem y_reg) x_reg)))))
 
 (rule (lower (has_type (fits_in_64 ty) (umin x y)))
@@ -1536,3 +1523,90 @@
 
 (rule (lower (resumable_trap code))
       (safepoint (ud2 code)))
+
+;;;; Rules for `select` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; CLIF `select` instructions receive a testable argument (i.e. boolean or
+;; integer) that determines which of the other two arguments is selected as
+;; output. Since Cranelift booleans are typically generated by a comparison, the
+;; lowerings in this section "look upwards in the tree" to emit the proper
+;; sequence of "selection" instructions.
+;;
+;; The following rules--for selecting on a floating-point comparison--emit a
+;; `UCOMIS*` instruction and then a conditional move, `cmove`. Note that for
+;; values contained in XMM registers, `cmove` and `cmove_or` may in fact emit a
+;; jump sequence, not `CMOV`. The `cmove` instruction operates on the flags set
+;; by `UCOMIS*`; the key to understanding these is the UCOMIS* documentation
+;; (see Intel's Software Developer's Manual, volume 2, chapter 4):
+;;  - unordered assigns    Z = 1, P = 1, C = 1
+;;  - greater than assigns Z = 0, P = 0, C = 0
+;;  - less than assigns    Z = 0, P = 0, C = 1
+;;  - equal assigns        Z = 1, P = 0, C = 0
+;;
+;; Note that prefixing the flag with `N` means "not," so that `CC.P -> P = 1`
+;; and `CC.NP -> P = 0`. Also, x86 uses mnemonics for certain combinations of
+;; flags; e.g.:
+;;  - `CC.B -> C = 1` (below)
+;;  - `CC.NB -> C = 0` (not below)
+;;  - `CC.BE -> C = 1 OR Z = 1` (below or equal)
+;;  - `CC.NBE -> C = 0 AND Z = 0` (not below or equal)
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.Ordered) a b)) x y)))
+      (with_flags (fpcmp b a) (cmove_from_values ty (CC.NP) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.Unordered) a b)) x y)))
+      (with_flags (fpcmp b a) (cmove_from_values ty (CC.P) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.GreaterThan) a b)) x y)))
+      (with_flags (fpcmp b a) (cmove_from_values ty (CC.NBE) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.GreaterThanOrEqual) a b)) x y)))
+      (with_flags (fpcmp b a) (cmove_from_values ty (CC.NB) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.UnorderedOrLessThan) a b)) x y)))
+      (with_flags (fpcmp b a) (cmove_from_values ty (CC.B) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.UnorderedOrLessThanOrEqual) a b)) x y)))
+      (with_flags (fpcmp b a) (cmove_from_values ty (CC.BE) x y)))
+
+;; Certain FloatCC variants are implemented by flipping the operands of the
+;; comparison (e.g., "greater than" is lowered the same as "less than" but the
+;; comparison is reversed). This allows us to use a single flag for the `cmove`,
+;; which involves fewer instructions than `cmove_or`.
+;;
+;; But why flip at all, you may ask? Can't we just use `CC.B` (i.e., below) for
+;; `FloatCC.LessThan`? Recall that in these floating-point lowerings, values may
+;; be unordered and we must we want to express that `FloatCC.LessThan` is `LT`,
+;; not `LT | UNO`. By flipping the operands AND inverting the comparison (e.g.,
+;; to `CC.NBE`), we also avoid these unordered cases.
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.LessThan) a b)) x y)))
+      (with_flags (fpcmp a b) (cmove_from_values ty (CC.NBE) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.LessThanOrEqual) a b)) x y)))
+      (with_flags (fpcmp a b) (cmove_from_values ty (CC.NB) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.UnorderedOrGreaterThan) a b)) x y)))
+      (with_flags (fpcmp a b) (cmove_from_values ty (CC.B) x y)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.UnorderedOrGreaterThanOrEqual) a b)) x y)))
+      (with_flags (fpcmp a b) (cmove_from_values ty (CC.BE) x y)))
+
+;; `FloatCC.Equal` and `FloatCC.NotEqual` can only be implemented with multiple
+;; flag checks. Recall from the flag assignment chart above that equality, e.g.,
+;; will assign `Z = 1`. But so does an unordered comparison: `Z = 1, P = 1, C =
+;; 1`. In order to avoid semantics like `EQ | UNO` for equality, we must ensure
+;; that the values are actually ordered, checking that `P = 0` (note that the
+;; `C` flag is irrelevant here). Since we cannot find a single instruction that
+;; implements a `Z = 1 AND P = 0` check, we invert the flag checks (i.e., `Z = 1
+;; AND P = 0` becomes `Z = 0 OR P = 1`) and also flip the select operands, `x`
+;; and `y`. The same argument applies to `FloatCC.NotEqual`.
+;;
+;; More details about the CLIF semantics for `fcmp` are available at
+;; https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/trait.InstBuilder.html#method.fcmp.
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.Equal) a b)) x y)))
+      (with_flags (fpcmp a b) (cmove_or_from_values ty (CC.NZ) (CC.P) y x)))
+
+(rule (lower (has_type ty (select (def_inst (fcmp (FloatCC.NotEqual) a b)) x y)))
+      (with_flags (fpcmp a b) (cmove_or_from_values ty (CC.NZ) (CC.P) x y)))

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -6,11 +6,11 @@ use generated_code::MInst;
 use regalloc::Writable;
 
 // Types that the generated ISLE code uses via `use super::*`.
-use super::{is_mergeable_load, lower_to_amode, Reg};
+use super::{is_int_or_ref_ty, is_mergeable_load, lower_to_amode, Reg};
 use crate::{
     ir::{
-        immediates::*, types::*, Inst, InstructionData, Opcode, TrapCode, Value, ValueLabel,
-        ValueList,
+        condcodes::FloatCC, immediates::*, types::*, Inst, InstructionData, Opcode, TrapCode,
+        Value, ValueLabel, ValueList,
     },
     isa::{
         settings::Flags,
@@ -439,6 +439,32 @@ where
     #[inline]
     fn imm8_to_imm8_gpr(&mut self, imm: u8) -> Imm8Gpr {
         Imm8Gpr::new(Imm8Reg::Imm8 { imm }).unwrap()
+    }
+
+    fn is_gpr_type(&mut self, ty: Type) -> Option<Type> {
+        if is_int_or_ref_ty(ty) || ty == I128 || ty == B128 {
+            Some(ty)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn is_xmm_type(&mut self, ty: Type) -> Option<Type> {
+        if ty == F32 || ty == F64 || (ty.is_vector() && ty.bits() == 128) {
+            Some(ty)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn is_single_register_type(&mut self, ty: Type) -> Option<Type> {
+        if ty != I128 {
+            Some(ty)
+        } else {
+            None
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 73285cd431346d53
-src/isa/x64/inst.isle 301db31d5f1118ae
-src/isa/x64/lower.isle cdc94aec26c0bc5b
+src/prelude.isle 980b300b3ec3e338
+src/isa/x64/inst.isle ac88a0ae153ed210
+src/isa/x64/lower.isle 1ebdd4469355e2cf

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -324,47 +324,79 @@
 
 ;; Newtype wrapper around `MInst` for instructions that are used for their
 ;; effect on flags.
-(type ProducesFlags (enum (ProducesFlags (inst MInst) (result Reg))))
+;;
+;; Variant determines how result is given when combined with a
+;; ConsumesFlags. See `with_flags` below for more.
+(type ProducesFlags (enum
+                     (ProducesFlagsSideEffect (inst MInst))
+                     ;; Not directly combinable with a ConsumesFlags;
+                     ;; used in s390x and unwrapped directly by `trapif`.
+                     (ProducesFlagsReturnsReg (inst MInst) (result Reg))
+                     (ProducesFlagsReturnsResultWithConsumer (inst MInst) (result Reg))))
 
 ;; Newtype wrapper around `MInst` for instructions that consume flags.
-(type ConsumesFlags (enum (ConsumesFlags (inst MInst) (result Reg))))
+;;
+;; Variant determines how result is given when combined with a
+;; ProducesFlags. See `with_flags` below for more.
+(type ConsumesFlags (enum
+                     (ConsumesFlagsReturnsResultWithProducer (inst MInst) (result Reg))
+                     (ConsumesFlagsReturnsReg (inst MInst) (result Reg))
+                     (ConsumesFlagsTwiceReturnsValueRegs (inst1 MInst)
+                                                         (inst2 MInst)
+                                                         (result ValueRegs))))
+
+
+;; Helper for combining two flags-consumer instructions that return a
+;; single Reg, giving a ConsumesFlags that returns both values in a
+;; ValueRegs.
+(decl consumes_flags_concat (ConsumesFlags ConsumesFlags) ConsumesFlags)
+(rule (consumes_flags_concat (ConsumesFlags.ConsumesFlagsReturnsReg inst1 reg1)
+                             (ConsumesFlags.ConsumesFlagsReturnsReg inst2 reg2))
+      (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
+       inst1
+       inst2
+       (value_regs reg1 reg2)))
 
 ;; Combine flags-producing and -consuming instructions together, ensuring that
 ;; they are emitted back-to-back and no other instructions can be emitted
 ;; between them and potentially clobber the flags.
 ;;
-;; Returns a `ValueRegs` where the first register is the result of the
-;; `ProducesFlags` instruction and the second is the result of the
-;; `ConsumesFlags` instruction.
+;; Returns a `ValueRegs` according to the specific combination of ProducesFlags and ConsumesFlags modes:
+;; - SideEffect + ReturnsReg --> ValueReg with one Reg from consumer
+;; - SideEffect + ReturnsValueRegs --> ValueReg as given from consumer
+;; - ReturnsResultWithProducer + ReturnsResultWithConsumer --> ValueReg with low part from producer, high part from consumer
+;;
+;; See `with_flags_reg` below for a variant that extracts out just the lower Reg.
 (decl with_flags (ProducesFlags ConsumesFlags) ValueRegs)
-(rule (with_flags (ProducesFlags.ProducesFlags producer_inst producer_result)
-                  (ConsumesFlags.ConsumesFlags consumer_inst consumer_result))
+
+(rule (with_flags (ProducesFlags.ProducesFlagsReturnsResultWithConsumer producer_inst producer_result)
+                  (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer consumer_inst consumer_result))
       (let ((_x Unit (emit producer_inst))
             (_y Unit (emit consumer_inst)))
         (value_regs producer_result consumer_result)))
 
-;; Like `with_flags` but returns only the result of the consumer operation.
-(decl with_flags_1 (ProducesFlags ConsumesFlags) Reg)
-(rule (with_flags_1 (ProducesFlags.ProducesFlags producer_inst _producer_result)
-                    (ConsumesFlags.ConsumesFlags consumer_inst consumer_result))
+(rule (with_flags (ProducesFlags.ProducesFlagsSideEffect producer_inst)
+                  (ConsumesFlags.ConsumesFlagsReturnsReg consumer_inst consumer_result))
       (let ((_x Unit (emit producer_inst))
             (_y Unit (emit consumer_inst)))
-        consumer_result))
+        (value_reg consumer_result)))
 
-;; Like `with_flags` but allows two consumers of the same flags. The result is a
-;; `ValueRegs` containing the first consumer's result and then the second
-;; consumer's result.
-(decl with_flags_2 (ProducesFlags ConsumesFlags ConsumesFlags) ValueRegs)
-(rule (with_flags_2 (ProducesFlags.ProducesFlags producer_inst _producer_result)
-                    (ConsumesFlags.ConsumesFlags consumer_inst_1 consumer_result_1)
-                    (ConsumesFlags.ConsumesFlags consumer_inst_2 consumer_result_2))
+(rule (with_flags (ProducesFlags.ProducesFlagsSideEffect producer_inst)
+                  (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs consumer_inst_1
+                                                                    consumer_inst_2
+                                                                    consumer_result))
       (let ((_x Unit (emit producer_inst))
             ;; Note that the order of emission here is swapped, as this seems
             ;; to generate better register allocation for now with fewer
             ;; `mov` instructions.
             (_y Unit (emit consumer_inst_2))
             (_z Unit (emit consumer_inst_1)))
-        (value_regs consumer_result_1 consumer_result_2)))
+        consumer_result))
+
+(decl with_flags_reg (ProducesFlags ConsumesFlags) Reg)
+(rule (with_flags_reg p c)
+      (let ((v ValueRegs (with_flags p c)))
+        (value_regs_get v 0)))
 
 ;;;; Helpers for Working with TrapCode ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -43,7 +43,7 @@ block0(v0: f64, v1: i64):
 ;   Entry block: 0
 ; Block 0:
 ;   (original IR block: block0)
-;   (instruction range: 0 .. 17)
+;   (instruction range: 0 .. 16)
 ;   Inst 0:   pushq   %rbp
 ;   Inst 1:   movq    %rsp, %rbp
 ;   Inst 2:   movsd   0(%rdi), %xmm1
@@ -52,14 +52,12 @@ block0(v0: f64, v1: i64):
 ;   Inst 5:   setz    %sil
 ;   Inst 6:   andl    %edi, %esi
 ;   Inst 7:   andq    $1, %rsi
-;   Inst 8:   ucomisd %xmm1, %xmm0
+;   Inst 8:   ucomisd %xmm0, %xmm1
 ;   Inst 9:   movaps  %xmm0, %xmm1
-;   Inst 10:   jnp $next; movsd %xmm0, %xmm1; $next: 
-;   Inst 11:   jz $next; movsd %xmm0, %xmm1; $next: 
-;   Inst 12:   movq    %rsi, %rax
-;   Inst 13:   movaps  %xmm1, %xmm0
-;   Inst 14:   movq    %rbp, %rsp
-;   Inst 15:   popq    %rbp
-;   Inst 16:   ret
+;   Inst 10:   jz $check; movsd %xmm0, %xmm1; $check: jnp $next; movsd %xmm0, %xmm1; $next
+;   Inst 11:   movq    %rsi, %rax
+;   Inst 12:   movaps  %xmm1, %xmm0
+;   Inst 13:   movq    %rbp, %rsp
+;   Inst 14:   popq    %rbp
+;   Inst 15:   ret
 ; }}
-

--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -1,0 +1,80 @@
+test interpret
+test run
+target x86_64
+
+function %select_eq_f32(f32, f32) -> i32 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp eq v0, v1
+    v3 = iconst.i32 1
+    v4 = iconst.i32 0
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_eq_f32(0x42.42, 0x42.42) == 1
+; run: %select_eq_f32(0x42.42, 0.0) == 0
+; run: %select_eq_f32(0x42.42, NaN) == 0
+
+function %select_ne_f64(f64, f64) -> i32 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp ne v0, v1
+    v3 = iconst.i32 1
+    v4 = iconst.i32 0
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_ne_f64(0x42.42, 0x42.42) == 0
+; run: %select_ne_f64(0x42.42, 0.0) == 1
+; run: %select_ne_f64(NaN, NaN) == 1
+
+function %select_gt_f64(f64, f64) -> b1 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp gt v0, v1
+    v3 = bconst.b1 true
+    v4 = bconst.b1 false
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_gt_f64(0x42.42, 0.0) == true
+; run: %select_gt_f64(0.0, 0.0) == false
+; run: %select_gt_f64(0x0.0, 0x42.42) == false
+; run: %select_gt_f64(NaN, 0x42.42) == false
+
+function %select_ge_f64(f64, f64) -> i64 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp ge v0, v1
+    v3 = iconst.i64 1
+    v4 = iconst.i64 0
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_ge_f64(0x42.42, 0.0) == 1
+; run: %select_ge_f64(0.0, 0.0) == 1
+; run: %select_ge_f64(0x0.0, 0x42.42) == 0
+; run: %select_ge_f64(0x0.0, NaN) == 0
+
+function %select_le_f32(f32, f32) -> f32 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp le v0, v1
+    v3 = f32const 0x1.0
+    v4 = f32const 0x0.0
+    v5 = select v2, v3, v4
+    return v5
+}
+; runx: %select_le_f32(0x42.42, 0.0) == 0x0.0
+; run: %select_le_f32(0.0, 0.0) == 0x1.0
+; run: %select_le_f32(0x0.0, 0x42.42) == 0x1.0
+; run: %select_le_f32(0x0.0, NaN) == 0x0.0
+
+function %select_uno_f32(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp uno v0, v1
+    v3 = iconst.i8 1
+    v4 = iconst.i8 0
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_uno_f32(0x42.42, 0.0) == 0
+; run: %select_uno_f32(0.0, 0.0) == 0
+; run: %select_uno_f32(0x0.0, 0x42.42) == 0
+; run: %select_uno_f32(0x0.0, NaN) == 1
+; run: %select_uno_f32(-NaN, 0x42.42) == 1

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -460,7 +460,7 @@ impl<'a> Codegen<'a> {
                 };
                 let valuename = self.value_binder(&value, /* is_ref = */ true, ty);
                 let fieldname = &self.typeenv.syms[field.name.index()];
-                self.define_val(&value, ctx, /* is_ref = */ false, field.ty);
+                self.define_val(&value, ctx, /* is_ref = */ true, field.ty);
                 format!("{}: {}", fieldname, valuename)
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
This change ports CLIF's `select` instruction to ISLE for x64.