### PR TITLE
Try to fix CI for Rust 1.58

### DIFF
--- a/crates/misc/run-examples/src/main.rs
+++ b/crates/misc/run-examples/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> anyhow::Result<()> {
                     .arg("ole32.lib")
                     .arg("bcrypt.lib");
                 if is_dir {
-                    "main.exe".to_string()
+                    "./main.exe".to_string()
                 } else {
                     format!("./{}.exe", example)
                 }


### PR DESCRIPTION
PATH lookup for WIndows command execution was tweaked slightly to not
search the cwd, so let's see if this fixes things...

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
