### PR TITLE
Add copy-on-write based instance reuse mechanism

### DIFF
--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -666,7 +666,7 @@ impl OnDemandInstanceAllocator {
         &self,
         module: &Module,
         store: &mut StorePtr,
-        memory_source: &MemorySource,
+        memory_source: MemorySource,
     ) -> Result<PrimaryMap<DefinedMemoryIndex, Memory>, InstantiationError> {
         let creator = self
             .mem_creator
@@ -726,7 +726,7 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
         &self,
         mut req: InstanceAllocationRequest,
     ) -> Result<InstanceHandle, InstantiationError> {
-        let memories = self.create_memories(&req.module, &mut req.store, &req.memory_source)?;
+        let memories = self.create_memories(&req.module, &mut req.store, req.memory_source)?;
         let tables = Self::create_tables(&req.module, &mut req.store)?;
 
         let host_state = std::mem::replace(&mut req.host_state, Box::new(()));

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -9,7 +9,7 @@
 
 use super::{
     initialize_instance, initialize_vmcontext, InstanceAllocationRequest, InstanceAllocator,
-    InstanceHandle, InstantiationError, MemorySource,
+    InstanceHandle, InstantiationError,
 };
 use crate::{instance::Instance, Memory, Mmap, Table, VMContext};
 use anyhow::{anyhow, bail, Context, Result};
@@ -422,8 +422,8 @@ impl InstancePool {
     ) -> Result<InstanceHandle, InstantiationError> {
         #[cfg(target_os = "linux")]
         match req.memory_source {
-            MemorySource::FromCreator => {}
-            MemorySource::CopyOnWriteInitialize => {
+            super::MemorySource::FromCreatorx => {}
+            super::MemorySource::CopyOnWriteInitialize => {
                 return Err(InstantiationError::IncompatibleAllocationStrategy);
             }
         }

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -422,7 +422,7 @@ impl InstancePool {
     ) -> Result<InstanceHandle, InstantiationError> {
         #[cfg(target_os = "linux")]
         match req.memory_source {
-            super::MemorySource::FromCreatorx => {}
+            super::MemorySource::FromCreator => {}
             super::MemorySource::CopyOnWriteInitialize => {
                 return Err(InstantiationError::IncompatibleAllocationStrategy);
             }

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -32,6 +32,7 @@
 
 use super::{InstancePool, MemoryPool};
 use crate::instance::Instance;
+use crate::MemorySource;
 use anyhow::{bail, Context, Result};
 use rustix::io::{madvise, Advice};
 use std::thread;
@@ -582,6 +583,7 @@ mod test {
                                 host_state: Box::new(()),
                                 store: StorePtr::new(&mut mock_store),
                                 wasm_data: &[],
+                                memory_source: MemorySource::FromCreator,
                             },
                         )
                         .expect("instance should allocate"),

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -32,7 +32,6 @@
 
 use super::{InstancePool, MemoryPool};
 use crate::instance::Instance;
-use crate::MemorySource;
 use anyhow::{bail, Context, Result};
 use rustix::io::{madvise, Advice};
 use std::thread;
@@ -436,7 +435,7 @@ impl Drop for PageFaultHandler {
 mod test {
     use super::*;
     use crate::{
-        Imports, InstanceAllocationRequest, InstanceLimits, ModuleLimits,
+        Imports, InstanceAllocationRequest, InstanceLimits, MemorySource, ModuleLimits,
         PoolingAllocationStrategy, Store, StorePtr, VMSharedSignatureIndex,
     };
     use std::sync::Arc;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -41,7 +41,7 @@ pub use crate::externref::*;
 pub use crate::imports::Imports;
 pub use crate::instance::{
     InstanceAllocationRequest, InstanceAllocator, InstanceHandle, InstantiationError, LinkError,
-    OnDemandInstanceAllocator, StorePtr,
+    MemorySource, OnDemandInstanceAllocator, StorePtr,
 };
 #[cfg(feature = "pooling-allocator")]
 pub use crate::instance::{

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -353,10 +353,10 @@ impl Mmap {
         use std::io::{Read, Seek};
         const PAGE_SIZE: usize = 4096;
 
-        assert_eq!(rustix::process::page_size(), 4096);
+        assert_eq!(rustix::process::page_size(), PAGE_SIZE);
 
-        assert_eq!(accessible_offset % 4096, 0);
-        assert_eq!(accessible % 4096, 0);
+        assert_eq!(accessible_offset % PAGE_SIZE, 0);
+        assert_eq!(accessible % PAGE_SIZE, 0);
 
         let mut page_last_index = 0;
         let mut page_first_index = None;

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -407,7 +407,7 @@ impl Mmap {
             assert!(data_offset + data_length <= self.len);
             Ok((data_offset, data_length))
         } else {
-            Ok((0, 0))
+            Ok((accessible_offset, 0))
         }
     }
 
@@ -700,6 +700,7 @@ fn test_populated_range() -> Result<()> {
 
     let mut mmap = Mmap::with_at_least(pages(16))?;
     assert_eq!(mmap.populated_range(0, pages(16))?, (0, 0));
+    assert_eq!(mmap.populated_range(pages(1), pages(15))?, (pages(1), 0));
 
     mmap.as_mut_slice()[last_byte_of_page(1)] = 1;
     assert_eq!(mmap.populated_range(0, pages(16))?, (pages(1), pages(1)));

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -91,7 +91,7 @@ use std::ptr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use wasmtime_runtime::{
-    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, ModuleInfo,
+    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, MemorySource, ModuleInfo,
     OnDemandInstanceAllocator, SignalHandler, StorePtr, VMCallerCheckedAnyfunc, VMContext,
     VMExternRef, VMExternRefActivationsTable, VMInterrupts, VMSharedSignatureIndex, VMTrampoline,
 };
@@ -409,6 +409,7 @@ impl<T> Store<T> {
                     module: Arc::new(wasmtime_environ::Module::default()),
                     store: StorePtr::empty(),
                     wasm_data: &[],
+                    memory_source: MemorySource::FromCreator,
                 })
                 .expect("failed to allocate default callee")
         };

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -18,8 +18,8 @@ use std::any::Any;
 use std::sync::Arc;
 use wasmtime_environ::{EntityIndex, GlobalIndex, MemoryIndex, Module, TableIndex};
 use wasmtime_runtime::{
-    Imports, InstanceAllocationRequest, InstanceAllocator, OnDemandInstanceAllocator, StorePtr,
-    VMFunctionImport, VMSharedSignatureIndex,
+    Imports, InstanceAllocationRequest, InstanceAllocator, MemorySource, OnDemandInstanceAllocator,
+    StorePtr, VMFunctionImport, VMSharedSignatureIndex,
 };
 
 fn create_handle(
@@ -48,6 +48,7 @@ fn create_handle(
                 host_state,
                 store: StorePtr::new(store.traitobj()),
                 wasm_data: &[],
+                memory_source: MemorySource::FromCreator,
             },
         )?;
 

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use wasmtime_environ::{EntityIndex, Module, ModuleType, PrimaryMap, SignatureIndex};
 use wasmtime_jit::{CodeMemory, MmapVec};
 use wasmtime_runtime::{
-    Imports, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
+    Imports, InstanceAllocationRequest, InstanceAllocator, InstanceHandle, MemorySource,
     OnDemandInstanceAllocator, StorePtr, VMContext, VMFunctionBody, VMSharedSignatureIndex,
     VMTrampoline,
 };
@@ -134,6 +134,7 @@ pub unsafe fn create_raw_function(
             host_state,
             store: StorePtr::empty(),
             wasm_data: &[],
+            memory_source: MemorySource::FromCreator,
         })?,
     )
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -25,6 +25,8 @@ mod module_serialize;
 mod name;
 mod pooling_allocator;
 mod relocs;
+#[cfg(target_os = "linux")]
+mod reusable;
 mod stack_overflow;
 mod store;
 mod table;

--- a/tests/all/reusable.rs
+++ b/tests/all/reusable.rs
@@ -28,15 +28,21 @@ fn clears_memory_on_reset(config: &Config) -> Result<()> {
             (func $read_memory (result i32)
               (i32.load offset=1024 (i32.const 0))
             )
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
     let instance = instance_pre.instantiate_reusable(&mut store)?;
 
-    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
-    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
+    let read_memory = instance
+        .get_func(&mut store, "read_memory")
+        .unwrap()
+        .typed::<(), i32, _>(&store)?;
+    let write_memory = instance
+        .get_func(&mut store, "write_memory")
+        .unwrap()
+        .typed::<(), (), _>(&store)?;
 
     // Modify the memory and make sure it's actually modified.
     assert_eq!(read_memory.call(&mut store, ())?, 0);
@@ -92,16 +98,25 @@ fn restores_original_data_segment_on_reset(config: &Config) -> Result<()> {
             (func $read_memory (result i32)
               (i32.load offset=1024 (i32.const 0))
             )
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
     let instance = instance_pre.instantiate_reusable(&mut store)?;
 
-    let grow_memory = instance.get_func(&mut store, "grow_memory").unwrap().typed::<i32, i32, _>(&store)?;
-    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
-    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
+    let grow_memory = instance
+        .get_func(&mut store, "grow_memory")
+        .unwrap()
+        .typed::<i32, i32, _>(&store)?;
+    let read_memory = instance
+        .get_func(&mut store, "read_memory")
+        .unwrap()
+        .typed::<(), i32, _>(&store)?;
+    let write_memory = instance
+        .get_func(&mut store, "write_memory")
+        .unwrap()
+        .typed::<(), (), _>(&store)?;
 
     // Modify the memory and make sure it's actually modified.
     assert_eq!(read_memory.call(&mut store, ())?, 65);
@@ -166,21 +181,44 @@ fn restores_memory_size_on_reset_after_grow(config: &Config) -> Result<()> {
             (func $read_memory (result i32)
               (i32.load offset=65536 (i32.const 0))
             )
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
     let instance = instance_pre.instantiate_reusable(&mut store)?;
 
-    let grow_memory = instance.get_func(&mut store, "grow_memory").unwrap().typed::<i32, i32, _>(&store)?;
-    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
-    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
+    let grow_memory = instance
+        .get_func(&mut store, "grow_memory")
+        .unwrap()
+        .typed::<i32, i32, _>(&store)?;
+    let write_memory = instance
+        .get_func(&mut store, "write_memory")
+        .unwrap()
+        .typed::<(), (), _>(&store)?;
+    let read_memory = instance
+        .get_func(&mut store, "read_memory")
+        .unwrap()
+        .typed::<(), i32, _>(&store)?;
 
     // The memory should initially be one WASM page big.
     assert_eq!(grow_memory.call(&mut store, 0)?, 1);
-    assert_eq!(read_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
-    assert_eq!(write_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
+    assert_eq!(
+        read_memory
+            .call(&mut store, ())
+            .unwrap_err()
+            .trap_code()
+            .unwrap(),
+        TrapCode::MemoryOutOfBounds
+    );
+    assert_eq!(
+        write_memory
+            .call(&mut store, ())
+            .unwrap_err()
+            .trap_code()
+            .unwrap(),
+        TrapCode::MemoryOutOfBounds
+    );
 
     // ...then we grow it, which should make it accessible.
     assert_eq!(grow_memory.call(&mut store, 1)?, 1);
@@ -197,8 +235,22 @@ fn restores_memory_size_on_reset_after_grow(config: &Config) -> Result<()> {
 
     // Make sure that the memory size was reset, and that it isn't actually accessible.
     assert_eq!(grow_memory.call(&mut store, 0)?, 1);
-    assert_eq!(read_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
-    assert_eq!(write_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
+    assert_eq!(
+        read_memory
+            .call(&mut store, ())
+            .unwrap_err()
+            .trap_code()
+            .unwrap(),
+        TrapCode::MemoryOutOfBounds
+    );
+    assert_eq!(
+        write_memory
+            .call(&mut store, ())
+            .unwrap_err()
+            .trap_code()
+            .unwrap(),
+        TrapCode::MemoryOutOfBounds
+    );
 
     // Now we can grow it again.
     assert_eq!(grow_memory.call(&mut store, 1)?, 1);
@@ -250,14 +302,17 @@ fn restores_table_on_reset() -> Result<()> {
             (func $return_200 (result i32)
               (i32.const 200)
             )
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
     let instance = instance_pre.instantiate_reusable(&mut store)?;
 
-    let call_table = instance.get_func(&mut store, "call_table").unwrap().typed::<(), i32, _>(&store)?;
+    let call_table = instance
+        .get_func(&mut store, "call_table")
+        .unwrap()
+        .typed::<(), i32, _>(&store)?;
     let return_200 = instance.get_func(&mut store, "return_200").unwrap();
     let table = instance.get_table(&mut store, "table").unwrap();
 
@@ -305,15 +360,21 @@ fn snapshot_is_taken_after_start() -> Result<()> {
                 (i32.const 5)
               )
             )
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
     let instance = instance_pre.instantiate_reusable(&mut store)?;
 
-    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
-    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
+    let read_memory = instance
+        .get_func(&mut store, "read_memory")
+        .unwrap()
+        .typed::<(), i32, _>(&store)?;
+    let write_memory = instance
+        .get_func(&mut store, "write_memory")
+        .unwrap()
+        .typed::<(), (), _>(&store)?;
 
     // Make sure the start function was actually run.
     assert_eq!(read_memory.call(&mut store, ())?, 5);
@@ -347,15 +408,21 @@ fn globals_are_restored_on_reset() -> Result<()> {
             (func $read_global (result i32)
               (global.get $1)
             )
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
     let instance = instance_pre.instantiate_reusable(&mut store)?;
 
-    let read_global = instance.get_func(&mut store, "read_global").unwrap().typed::<(), i32, _>(&store)?;
-    let write_global = instance.get_func(&mut store, "write_global").unwrap().typed::<(), (), _>(&store)?;
+    let read_global = instance
+        .get_func(&mut store, "read_global")
+        .unwrap()
+        .typed::<(), i32, _>(&store)?;
+    let write_global = instance
+        .get_func(&mut store, "write_global")
+        .unwrap()
+        .typed::<(), (), _>(&store)?;
 
     // Make sure the global was properly initialized.
     assert_eq!(read_global.call(&mut store, ())?, 123);
@@ -376,10 +443,7 @@ fn non_reusable_instance_cannot_be_reset() -> Result<()> {
     let engine = Engine::default();
     let linker = Linker::new(&engine);
 
-    let module = Module::new(
-        &engine,
-        r#"(module)"#
-    )?;
+    let module = Module::new(&engine, r#"(module)"#)?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
@@ -396,16 +460,13 @@ fn reusable_instances_are_not_compatible_with_instance_pooling_strategy() -> Res
     config.allocation_strategy(InstanceAllocationStrategy::Pooling {
         strategy: Default::default(),
         module_limits: Default::default(),
-        instance_limits: Default::default()
+        instance_limits: Default::default(),
     });
 
     let engine = Engine::new(&config)?;
     let linker = Linker::new(&engine);
 
-    let module = Module::new(
-        &engine,
-        r#"(module)"#
-    )?;
+    let module = Module::new(&engine, r#"(module)"#)?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
@@ -423,7 +484,7 @@ unsafe impl MemoryCreator for DummyMemoryCreator {
         _minimum: usize,
         _maximum: Option<usize>,
         _reserved_size_in_bytes: Option<usize>,
-        _guard_size_in_bytes: usize
+        _guard_size_in_bytes: usize,
     ) -> Result<Box<dyn LinearMemory>, String> {
         unimplemented!();
     }
@@ -447,14 +508,17 @@ fn reusable_instances_do_not_use_a_custom_memory_creator() -> Result<()> {
                (local.get $0)
               )
             )
-           )"#
+           )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
     let instance_pre = linker.instantiate_pre(&mut store, &module)?;
     let instance = instance_pre.instantiate_reusable(&mut store)?;
 
-    let grow_memory = instance.get_func(&mut store, "grow_memory").unwrap().typed::<i32, i32, _>(&store)?;
+    let grow_memory = instance
+        .get_func(&mut store, "grow_memory")
+        .unwrap()
+        .typed::<i32, i32, _>(&store)?;
 
     assert_eq!(grow_memory.call(&mut store, 1)?, 1);
     assert_eq!(grow_memory.call(&mut store, 1)?, 2);
@@ -473,7 +537,7 @@ fn incompatible_with_imported_memories() -> Result<()> {
         &engine,
         r#"(module
             (import "env" "memory" (memory $memoryimport 1))
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());
@@ -497,7 +561,7 @@ fn incompatible_with_imported_tables() -> Result<()> {
         &engine,
         r#"(module
             (import "env" "table" (table $tableimport 1 2 funcref))
-        )"#
+        )"#,
     )?;
 
     let mut store = Store::new(&engine, ());

--- a/tests/all/reusable.rs
+++ b/tests/all/reusable.rs
@@ -1,0 +1,513 @@
+use anyhow::Result;
+use std::sync::Arc;
+use wasmtime::*;
+
+fn dynamic_memory_config() -> Config {
+    let mut config = Config::new();
+    config.static_memory_maximum_size(0);
+    config.dynamic_memory_reserved_for_growth(0);
+    config
+}
+
+fn clears_memory_on_reset(config: &Config) -> Result<()> {
+    let engine = Engine::new(&config)?;
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (memory $0 1)
+            (export "write_memory" (func $write_memory))
+            (export "read_memory" (func $read_memory))
+            (func $write_memory
+              (i32.store offset=1024
+                (i32.const 0)
+                (i32.const 10)
+              )
+            )
+            (func $read_memory (result i32)
+              (i32.load offset=1024 (i32.const 0))
+            )
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate_reusable(&mut store)?;
+
+    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
+    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
+
+    // Modify the memory and make sure it's actually modified.
+    assert_eq!(read_memory.call(&mut store, ())?, 0);
+    write_memory.call(&mut store, ())?;
+    assert_eq!(read_memory.call(&mut store, ())?, 10);
+
+    // Reset the instance and make sure the memory was actually cleared.
+    instance.reset(&mut store)?;
+    assert_eq!(read_memory.call(&mut store, ())?, 0);
+
+    // Do it all over again to make sure the instance can be reset multiple times.
+    write_memory.call(&mut store, ())?;
+    assert_eq!(read_memory.call(&mut store, ())?, 10);
+    instance.reset(&mut store)?;
+    assert_eq!(read_memory.call(&mut store, ())?, 0);
+
+    Ok(())
+}
+
+#[test]
+fn clears_memory_on_reset_static_memory() -> Result<()> {
+    clears_memory_on_reset(&Config::new())
+}
+
+#[test]
+fn clears_memory_on_reset_dynamic_memory() -> Result<()> {
+    clears_memory_on_reset(&dynamic_memory_config())
+}
+
+fn restores_original_data_segment_on_reset(config: &Config) -> Result<()> {
+    let engine = Engine::new(&config)?;
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (memory $0 1)
+            (data $.data (i32.const 1024) "A\00\00\00")
+            (export "write_memory" (func $write_memory))
+            (export "grow_memory" (func $grow_memory))
+            (export "read_memory" (func $read_memory))
+            (func $write_memory
+              (i32.store offset=1024
+                (i32.const 0)
+                (i32.const 66)
+              )
+            )
+            (func $grow_memory (param $0 i32) (result i32)
+              (memory.grow
+               (local.get $0)
+              )
+            )
+            (func $read_memory (result i32)
+              (i32.load offset=1024 (i32.const 0))
+            )
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate_reusable(&mut store)?;
+
+    let grow_memory = instance.get_func(&mut store, "grow_memory").unwrap().typed::<i32, i32, _>(&store)?;
+    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
+    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
+
+    // Modify the memory and make sure it's actually modified.
+    assert_eq!(read_memory.call(&mut store, ())?, 65);
+    write_memory.call(&mut store, ())?;
+    assert_eq!(read_memory.call(&mut store, ())?, 66);
+
+    // Reset the memory and make sure it was actually reset to its initial value.
+    instance.reset(&mut store)?;
+    assert_eq!(read_memory.call(&mut store, ())?, 65);
+
+    // Do it all over again to make sure the instance can be reset multiple times.
+    write_memory.call(&mut store, ())?;
+    assert_eq!(read_memory.call(&mut store, ())?, 66);
+    instance.reset(&mut store)?;
+    assert_eq!(read_memory.call(&mut store, ())?, 65);
+
+    // Do it once again, but this time grow the memory after writing to it.
+    //
+    // If the memory is dynamic this will reallocate it from scratch somewhere
+    // else in memory, so we want to make sure that it still can be reset.
+    write_memory.call(&mut store, ())?;
+    assert_eq!(grow_memory.call(&mut store, 1)?, 1);
+    assert_eq!(read_memory.call(&mut store, ())?, 66);
+    instance.reset(&mut store)?;
+    assert_eq!(read_memory.call(&mut store, ())?, 65);
+
+    Ok(())
+}
+
+#[test]
+fn restores_original_data_segment_on_reset_static_memory() -> Result<()> {
+    restores_original_data_segment_on_reset(&Config::new())
+}
+
+#[test]
+fn restores_original_data_segment_on_reset_dynamic_memory() -> Result<()> {
+    restores_original_data_segment_on_reset(&dynamic_memory_config())
+}
+
+fn restores_memory_size_on_reset_after_grow(config: &Config) -> Result<()> {
+    let engine = Engine::new(&config)?;
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (memory $0 1)
+            (export "write_memory" (func $write_memory))
+            (export "grow_memory" (func $grow_memory))
+            (export "read_memory" (func $read_memory))
+            (func $write_memory
+              (i32.store offset=65536
+                (i32.const 0)
+                (i32.const 10)
+              )
+            )
+            (func $grow_memory (param $0 i32) (result i32)
+              (memory.grow
+               (local.get $0)
+              )
+            )
+            (func $read_memory (result i32)
+              (i32.load offset=65536 (i32.const 0))
+            )
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate_reusable(&mut store)?;
+
+    let grow_memory = instance.get_func(&mut store, "grow_memory").unwrap().typed::<i32, i32, _>(&store)?;
+    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
+    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
+
+    // The memory should initially be one WASM page big.
+    assert_eq!(grow_memory.call(&mut store, 0)?, 1);
+    assert_eq!(read_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
+    assert_eq!(write_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
+
+    // ...then we grow it, which should make it accessible.
+    assert_eq!(grow_memory.call(&mut store, 1)?, 1);
+
+    // Make sure that we can access it and that it's actually zero'd.
+    assert_eq!(read_memory.call(&mut store, ())?, 0);
+
+    // Now we can dirty it.
+    write_memory.call(&mut store, ())?;
+    assert_eq!(read_memory.call(&mut store, ())?, 10);
+
+    // Then we reset it to its initial state (both its size and its contents).
+    instance.reset(&mut store)?;
+
+    // Make sure that the memory size was reset, and that it isn't actually accessible.
+    assert_eq!(grow_memory.call(&mut store, 0)?, 1);
+    assert_eq!(read_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
+    assert_eq!(write_memory.call(&mut store, ()).unwrap_err().trap_code().unwrap(), TrapCode::MemoryOutOfBounds);
+
+    // Now we can grow it again.
+    assert_eq!(grow_memory.call(&mut store, 1)?, 1);
+
+    // Let's make sure the old value doesn't linger (that is - that the memory wasn't simply only made unaccessible).
+    assert_eq!(read_memory.call(&mut store, ())?, 0);
+
+    // Now make sure we can write to it again and read the value back.
+    write_memory.call(&mut store, ())?;
+    assert_eq!(read_memory.call(&mut store, ())?, 10);
+
+    Ok(())
+}
+
+#[test]
+fn restores_memory_size_on_reset_after_grow_static_memory() -> Result<()> {
+    restores_memory_size_on_reset_after_grow(&Config::new())
+}
+
+#[test]
+fn restores_memory_size_on_reset_after_grow_dynamic_memory() -> Result<()> {
+    restores_memory_size_on_reset_after_grow(&dynamic_memory_config())
+}
+
+#[test]
+fn restores_table_on_reset() -> Result<()> {
+    let engine = Engine::default();
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (type $none_=>_i32 (func (result i32)))
+            (memory $0 1)
+            (table $table 1 2 funcref)
+            (export "return_100" (func $return_100))
+            (export "return_200" (func $return_200))
+            (export "call_table" (func $call_table))
+            (export "table" (table $table))
+            (elem (i32.const 0) $return_100)
+            (func $call_table (result i32)
+              (call_indirect (type $none_=>_i32)
+                (i32.const 0)
+              )
+            )
+            (func $return_100 (result i32)
+              (i32.const 100)
+            )
+            (func $return_200 (result i32)
+              (i32.const 200)
+            )
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate_reusable(&mut store)?;
+
+    let call_table = instance.get_func(&mut store, "call_table").unwrap().typed::<(), i32, _>(&store)?;
+    let return_200 = instance.get_func(&mut store, "return_200").unwrap();
+    let table = instance.get_table(&mut store, "table").unwrap();
+
+    // Sanity checks on the initial state.
+    assert_eq!(call_table.call(&mut store, ())?, 100);
+    assert_eq!(table.size(&mut store), 1);
+
+    // Replace the function in the table, and grow the table.
+    table.set(&mut store, 0, return_200.into())?;
+    assert_eq!(call_table.call(&mut store, ())?, 200);
+    assert_eq!(table.grow(&mut store, 1, return_200.into())?, 1);
+
+    // Reset the instance, and make sure the table was restored (both its size and its contents).
+    instance.reset(&mut store)?;
+    assert_eq!(call_table.call(&mut store, ())?, 100);
+    assert_eq!(table.size(&mut store), 1);
+
+    Ok(())
+}
+
+#[test]
+fn snapshot_is_taken_after_start() -> Result<()> {
+    let engine = Engine::default();
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (memory $0 1)
+            (export "write_memory" (func $write_memory))
+            (export "read_memory" (func $read_memory))
+            (start $start)
+            (func $write_memory
+              (i32.store offset=1024
+                (i32.const 0)
+                (i32.const 10)
+              )
+            )
+            (func $read_memory (result i32)
+              (i32.load offset=1024 (i32.const 0))
+            )
+            (func $start
+              (i32.store offset=1024
+                (i32.const 0)
+                (i32.const 5)
+              )
+            )
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate_reusable(&mut store)?;
+
+    let read_memory = instance.get_func(&mut store, "read_memory").unwrap().typed::<(), i32, _>(&store)?;
+    let write_memory = instance.get_func(&mut store, "write_memory").unwrap().typed::<(), (), _>(&store)?;
+
+    // Make sure the start function was actually run.
+    assert_eq!(read_memory.call(&mut store, ())?, 5);
+
+    // Overwrite the memory.
+    write_memory.call(&mut store, ())?;
+    assert_eq!(read_memory.call(&mut store, ())?, 10);
+
+    // Reset the memory and make sure it was restored to what the start function wrote.
+    instance.reset(&mut store)?;
+    assert_eq!(read_memory.call(&mut store, ())?, 5);
+
+    Ok(())
+}
+
+#[test]
+fn globals_are_restored_on_reset() -> Result<()> {
+    let engine = Engine::default();
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (memory $0 1)
+            (global $1 (mut i32) (i32.const 123))
+            (export "write_global" (func $write_global))
+            (export "read_global" (func $read_global))
+            (func $write_global
+              (global.set $1 (i32.const 124))
+            )
+            (func $read_global (result i32)
+              (global.get $1)
+            )
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate_reusable(&mut store)?;
+
+    let read_global = instance.get_func(&mut store, "read_global").unwrap().typed::<(), i32, _>(&store)?;
+    let write_global = instance.get_func(&mut store, "write_global").unwrap().typed::<(), (), _>(&store)?;
+
+    // Make sure the global was properly initialized.
+    assert_eq!(read_global.call(&mut store, ())?, 123);
+
+    // Overwrite the global.
+    write_global.call(&mut store, ())?;
+    assert_eq!(read_global.call(&mut store, ())?, 124);
+
+    // Reset the instance and make sure the global was also restored.
+    instance.reset(&mut store)?;
+    assert_eq!(read_global.call(&mut store, ())?, 123);
+
+    Ok(())
+}
+
+#[test]
+fn non_reusable_instance_cannot_be_reset() -> Result<()> {
+    let engine = Engine::default();
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module)"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate(&mut store)?;
+
+    assert!(instance.reset(&mut store).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn reusable_instances_are_not_compatible_with_instance_pooling_strategy() -> Result<()> {
+    let mut config = Config::new();
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling {
+        strategy: Default::default(),
+        module_limits: Default::default(),
+        instance_limits: Default::default()
+    });
+
+    let engine = Engine::new(&config)?;
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module)"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    assert!(instance_pre.instantiate_reusable(&mut store).is_err());
+
+    Ok(())
+}
+
+struct DummyMemoryCreator;
+
+unsafe impl MemoryCreator for DummyMemoryCreator {
+    fn new_memory(
+        &self,
+        _ty: MemoryType,
+        _minimum: usize,
+        _maximum: Option<usize>,
+        _reserved_size_in_bytes: Option<usize>,
+        _guard_size_in_bytes: usize
+    ) -> Result<Box<dyn LinearMemory>, String> {
+        unimplemented!();
+    }
+}
+
+#[test]
+fn reusable_instances_do_not_use_a_custom_memory_creator() -> Result<()> {
+    let mut config = Config::new();
+    config.with_host_memory(Arc::new(DummyMemoryCreator));
+
+    let engine = Engine::new(&config)?;
+    let linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (memory $0 1)
+            (export "grow_memory" (func $grow_memory))
+            (func $grow_memory (param $0 i32) (result i32)
+              (memory.grow
+               (local.get $0)
+              )
+            )
+           )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance = instance_pre.instantiate_reusable(&mut store)?;
+
+    let grow_memory = instance.get_func(&mut store, "grow_memory").unwrap().typed::<i32, i32, _>(&store)?;
+
+    assert_eq!(grow_memory.call(&mut store, 1)?, 1);
+    assert_eq!(grow_memory.call(&mut store, 1)?, 2);
+
+    instance.reset(&mut store)?;
+
+    Ok(())
+}
+
+#[test]
+fn incompatible_with_imported_memories() -> Result<()> {
+    let engine = Engine::default();
+    let mut linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (import "env" "memory" (memory $memoryimport 1))
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let memory_ty = MemoryType::new(1, None);
+    let memory = Memory::new(&mut store, memory_ty)?;
+    linker.define("env", "memory", memory)?;
+
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    assert!(instance_pre.instantiate(&mut store).is_ok());
+    assert!(instance_pre.instantiate_reusable(&mut store).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn incompatible_with_imported_tables() -> Result<()> {
+    let engine = Engine::default();
+    let mut linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (import "env" "table" (table $tableimport 1 2 funcref))
+        )"#
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let table_ty = TableType::new(ValType::FuncRef, 1, Some(2));
+    let table = Table::new(&mut store, table_ty, Val::FuncRef(None))?;
+    linker.define("env", "table", table)?;
+
+    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    assert!(instance_pre.instantiate(&mut store).is_ok());
+    assert!(instance_pre.instantiate_reusable(&mut store).is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds a new copy-on-write based instance reuse mechanism on Linux.

## Usage

The general idea is - you instantiate your instance once, and then you can reset its state back to how it was when it was initially instantiated.

```rust
    // Initialize a new instance. This is done only once.
    let mut store = Store::new(&engine, ());
    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
    let instance = instance_pre.instantiate_reusable(&mut store)?;

    loop {
        // Call methods, modify memory, modify the table, etc.
        use_instance(instance, &mut store)?;
    
        // Reset the instance to its initial state.
        instance.reset(&mut store)?;
    }
```

## How does it work?

After the instance is instantiated a snapshot of its state is taken. Tables and globals are simply cloned into a spare `Vec`, while the memory is copied into an `memfd` and remapped inplace in a copy-on-write fashion. Then when `reset` is called the tables and the globals are restored by simply copying them back over, and the memory is reset using `madvise(MADV_DONTNEED)` which either clears the memory (for those pages which are not mapped to the `memfd`) or restores the original contents (for those pages which *are* mapped to the `memfd`).

## Benchmarks

In our benchmarks this is currently the fastest way to call into a WASM module assuming you rarely need to instantiate it from scratch.

![call_empty_function](https://user-images.githubusercontent.com/246574/149503025-f3d56896-5181-4fa0-8b26-ea9ba03fbeb2.png)

![dirty_1mb_of_memory](https://user-images.githubusercontent.com/246574/149503033-0c7c48ad-64e4-4bb0-a0d4-dfaf2223cd9c.png)

Legend:
- `instance_pooling_with_uffd`: create a fresh instance with `InstanceAllocationStrategy::Pooling` strategy *with* `uffd` turned on
- `instance_pooling_without_uffd`: create a fresh instance with `InstanceAllocationStrategy::Pooling` strategy *without* `uffd` turned on
- `recreate_instance`: create a fresh instance with `InstanceAllocationStrategy::OnDemand` strategy
- `native_instance_reuse`: this PR
- `interpreted`: just for our own reference; an instance created through the [`wasmi`](https://github.com/paritytech/wasmi) crate
- `legacy_instance_reuse`: just for our own reference; this is what we're currently using - it is an instance spawned with `InstanceAllocationStrategy::OnDemand` strategy and then reused after manually clearing its memory and restoring its data segments and globals

The two of the benchmarks shown here are:
- `call_empty_function`: an empty function is called in a loop, resetting (or recreating) the instance after each call
- `dirty_1mb_of_memory`: a function which dirties 1MB of memory and then returns is called in a loop, resetting (or recreating) the instance after each call

The measurements are *only* for the main thread; thread count on the bottom signifies how many other threads were running in the background doing exactly the same thing as the main thread, e.g. for 4 threads there was 1 thread (the main thread) being benchmarked while other 3 threads were running in the background.

For your reference the benchmarks used to generate these graphs can be found here:

`https://github.com/koute/substrate/tree/master_wasmtime_benchmarks`

Which can be run like this after cloning the repository:

```
$ cd substrate/client/executor/benches

# `instance_pooling_with_uffd`
$ FORCE_WASMTIME_INSTANCE_POOLING=1 rustup run nightly-2021-11-01-x86_64-unknown-linux-gnu cargo bench --features wasmtime,sc-executor-wasmtime/uffd --bench bench -- with_recreate_instance

# `instance_pooling_without_uffd`
$ FORCE_WASMTIME_INSTANCE_POOLING=1 rustup run nightly-2021-11-01-x86_64-unknown-linux-gnu cargo bench --features wasmtime --bench bench -- with_recreate_instance

# `recreate_instance`
FORCE_WASMTIME_INSTANCE_POOLING=0 rustup run nightly-2021-11-01-x86_64-unknown-linux-gnu cargo bench --features wasmtime --bench bench -- with_recreate_instance

# `native_instance_reuse`
rustup run nightly-2021-11-01-x86_64-unknown-linux-gnu cargo bench --features wasmtime --bench bench -- native_instance_reuse
```

(The rustc version is just for reference as to what I used. Also please forgive the hacky way the benchmarks have to be launched for instance pooling; we don't intend to keep this codepath, so I quckly hacked it in only for the benchmarks.)

The benchmarks were run on the following machine:

AMD Threadripper 3970x (32-core)
64GB of RAM
Linux 5.14.16

## Possible future work (missing features)

- Add support for other OSes (this is Linux-only for now)
- Add support for imported memories (this only supports modules which do *not* import memory)
- Add support for taking snapshots at an arbitrary points in time (it always takes a snapshot right after instantiation)
- Add the ability to customize what is restored on reset (it always resets everything)
- Add address-space pooling to make the initial initialization faster (for cases where new modules are frequently instantiated from scratch)
