### PR TITLE
Cranelift: Pass the ISA-specific compilation flags to the ABI implementations

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -619,7 +619,10 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
     }
 
-    fn gen_debug_frame_info(flags: &settings::Flags) -> SmallInstVec<Inst> {
+    fn gen_debug_frame_info(
+        flags: &settings::Flags,
+        _isa_flags: &Vec<settings::Value>,
+    ) -> SmallInstVec<Inst> {
         let mut insts = SmallVec::new();
         if flags.unwind_info() {
             insts.push(Inst::Unwind {

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -57,7 +57,7 @@ impl AArch64Backend {
         flags: shared_settings::Flags,
     ) -> CodegenResult<VCode<inst::Inst>> {
         let emit_info = EmitInfo::new(flags.clone());
-        let abi = Box::new(abi::AArch64ABICallee::new(func, flags)?);
+        let abi = Box::new(abi::AArch64ABICallee::new(func, flags, self.isa_flags())?);
         compile::compile::<AArch64Backend>(func, self, abi, &self.reg_universe, emit_info)
     }
 }

--- a/cranelift/codegen/src/isa/arm32/mod.rs
+++ b/cranelift/codegen/src/isa/arm32/mod.rs
@@ -48,7 +48,7 @@ impl Arm32Backend {
         // This performs lowering to VCode, register-allocates the code, computes
         // block layout and finalizes branches. The result is ready for binary emission.
         let emit_info = EmitInfo::new(flags.clone());
-        let abi = Box::new(abi::Arm32ABICallee::new(func, flags)?);
+        let abi = Box::new(abi::Arm32ABICallee::new(func, flags, self.isa_flags())?);
         compile::compile::<Arm32Backend>(func, self, abi, &self.reg_universe, emit_info)
     }
 }

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -60,7 +60,7 @@ impl S390xBackend {
         flags: shared_settings::Flags,
     ) -> CodegenResult<VCode<inst::Inst>> {
         let emit_info = EmitInfo::new(flags.clone(), self.isa_flags.clone());
-        let abi = Box::new(abi::S390xABICallee::new(func, flags)?);
+        let abi = Box::new(abi::S390xABICallee::new(func, flags, self.isa_flags())?);
         compile::compile::<S390xBackend>(func, self, abi, &self.reg_universe, emit_info)
     }
 }

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -49,7 +49,7 @@ impl X64Backend {
         // This performs lowering to VCode, register-allocates the code, computes
         // block layout and finalizes branches. The result is ready for binary emission.
         let emit_info = EmitInfo::new(flags.clone(), self.x64_flags.clone());
-        let abi = Box::new(abi::X64ABICallee::new(&func, flags)?);
+        let abi = Box::new(abi::X64ABICallee::new(&func, flags, self.isa_flags())?);
         compile::compile::<Self>(&func, self, abi, &self.reg_universe, emit_info)
     }
 }


### PR DESCRIPTION
These changes have been extracted from PR #3606. There are various cases in which function prologues and epilogues need to be modified depending on ISA specifics such as supported extensions, e.g. any prototyping work for bytecodealliance/rfcs#19, so this PR adds the necessary plumbing to the generic ABI implementation.