### PR TITLE
Add epoch-based interruption for cooperative async timeslicing.

### DIFF
--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -45,6 +45,8 @@ macro_rules! foreach_builtin_function {
             memory_atomic_wait64(vmctx, i32, pointer, i64, i64) -> (i32);
             /// Invoked when fuel has run out while executing a function.
             out_of_gas(vmctx) -> ();
+            /// Invoked when we reach a new epoch.
+            new_epoch(vmctx) -> (i64);
         }
     };
 }

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -36,6 +36,9 @@ pub struct Tunables {
     /// will be consumed every time a wasm instruction is executed.
     pub consume_fuel: bool,
 
+    /// Whether or not we use epoch-based interruption.
+    pub epoch_interruption: bool,
+
     /// Whether or not to treat the static memory bound as the maximum for unbounded heaps.
     pub static_memory_bound_is_maximum: bool,
 
@@ -88,6 +91,7 @@ impl Default for Tunables {
             parse_wasm_debuginfo: true,
             interruptable: false,
             consume_fuel: false,
+            epoch_interruption: false,
             static_memory_bound_is_maximum: false,
             guard_before_linear_memory: true,
             generate_address_map: true,

--- a/crates/misc/run-examples/src/main.rs
+++ b/crates/misc/run-examples/src/main.rs
@@ -73,8 +73,8 @@ fn main() -> anyhow::Result<()> {
                 format!("examples/{}.{}", example, extension)
             };
 
-            if extension == &"cc" && !std::path::Path::new(&file).exists() {
-                // cc files are optional so we can skip them.
+            if !std::path::Path::new(&file).exists() {
+                // C and C++ files are optional so we can skip them.
                 continue;
             }
 

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -21,6 +21,7 @@ use std::convert::TryFrom;
 use std::hash::Hash;
 use std::ops::Range;
 use std::ptr::NonNull;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::{mem, ptr, slice};
 use wasmtime_environ::{
@@ -201,6 +202,11 @@ impl Instance {
     /// Return a pointer to the interrupts structure
     pub fn interrupts(&self) -> *mut *const VMInterrupts {
         unsafe { self.vmctx_plus_offset(self.offsets.vmctx_interrupts()) }
+    }
+
+    /// Return a pointer to the global epoch counter used by this instance.
+    pub fn epoch_ptr(&self) -> *mut *const AtomicU64 {
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_epoch_ptr()) }
     }
 
     /// Return a pointer to the `VMExternRefActivationsTable`.

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -463,6 +463,7 @@ fn initialize_instance(
 unsafe fn initialize_vmcontext(instance: &mut Instance, req: InstanceAllocationRequest) {
     if let Some(store) = req.store.as_raw() {
         *instance.interrupts() = (*store).vminterrupts();
+        *instance.epoch_ptr() = (*store).epoch_ptr();
         *instance.externref_activations_table() = (*store).externref_activations_table().0;
         instance.set_store(store);
     }

--- a/crates/runtime/src/instance/allocator/pooling/uffd.rs
+++ b/crates/runtime/src/instance/allocator/pooling/uffd.rs
@@ -438,6 +438,7 @@ mod test {
         Imports, InstanceAllocationRequest, InstanceLimits, ModuleLimits,
         PoolingAllocationStrategy, Store, StorePtr, VMSharedSignatureIndex,
     };
+    use std::sync::atomic::AtomicU64;
     use std::sync::Arc;
     use wasmtime_environ::{Memory, MemoryPlan, MemoryStyle, Module, PrimaryMap, Tunables};
 
@@ -545,6 +546,12 @@ mod test {
                 fn table_grow_failed(&mut self, _error: &anyhow::Error) {}
                 fn out_of_gas(&mut self) -> Result<(), anyhow::Error> {
                     Ok(())
+                }
+                fn epoch_ptr(&self) -> *const AtomicU64 {
+                    std::ptr::null()
+                }
+                fn new_epoch(&mut self) -> Result<u64, anyhow::Error> {
+                    Ok(0)
                 }
             }
             struct MockModuleInfo;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -20,6 +20,8 @@
     )
 )]
 
+use std::sync::atomic::AtomicU64;
+
 use anyhow::Error;
 
 mod export;
@@ -84,6 +86,11 @@ pub unsafe trait Store {
     /// in the `VMContext`.
     fn vminterrupts(&self) -> *mut VMInterrupts;
 
+    /// Returns a pointer to the global epoch counter.
+    ///
+    /// Used to configure the `VMContext` on initialization.
+    fn epoch_ptr(&self) -> *const AtomicU64;
+
     /// Returns the externref management structures necessary for this store.
     ///
     /// The first element returned is the table in which externrefs are stored
@@ -119,4 +126,8 @@ pub unsafe trait Store {
     /// is returned that's raised as a trap. Otherwise wasm execution will
     /// continue as normal.
     fn out_of_gas(&mut self) -> Result<(), Error>;
+    /// Callback invoked whenever an instance observes a new epoch
+    /// number. Cannot fail; cooperative epoch-based yielding is
+    /// completely semantically transparent. Returns the new deadline.
+    fn new_epoch(&mut self) -> Result<u64, Error>;
 }

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -557,3 +557,11 @@ pub unsafe extern "C" fn wasmtime_out_of_gas(vmctx: *mut VMContext) {
         Err(err) => crate::traphandlers::raise_user_trap(err),
     }
 }
+
+/// Hook for when an instance observes that the epoch has changed.
+pub unsafe extern "C" fn wasmtime_new_epoch(vmctx: *mut VMContext) -> u64 {
+    match (*(*vmctx).instance().store()).new_epoch() {
+        Ok(new_deadline) => new_deadline,
+        Err(err) => crate::traphandlers::raise_user_trap(err),
+    }
+}

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -596,6 +596,7 @@ impl<'a> SerializedModule<'a> {
             parse_wasm_debuginfo,
             interruptable,
             consume_fuel,
+            epoch_interruption,
             static_memory_bound_is_maximum,
             guard_before_linear_memory,
 
@@ -636,6 +637,11 @@ impl<'a> SerializedModule<'a> {
         )?;
         Self::check_bool(interruptable, other.interruptable, "interruption support")?;
         Self::check_bool(consume_fuel, other.consume_fuel, "fuel support")?;
+        Self::check_bool(
+            epoch_interruption,
+            other.epoch_interruption,
+            "epoch interruption",
+        )?;
         Self::check_bool(
             static_memory_bound_is_maximum,
             other.static_memory_bound_is_maximum,

--- a/examples/epochs.rs
+++ b/examples/epochs.rs
@@ -1,0 +1,48 @@
+//! Example of interrupting a WebAssembly function's runtime via epoch
+//! changes ("epoch interruption") in a synchronous context.  To see
+//! an example of setup for asynchronous usage, see
+//! `tests/all/epoch_interruption.rs`
+
+use anyhow::Error;
+use std::sync::Arc;
+use wasmtime::{Config, Engine, Instance, Module, Store};
+
+fn main() -> Result<(), Error> {
+    // Set up an engine configured with epoch interruption enabled.
+    let mut config = Config::new();
+    config.epoch_interruption(true);
+    let engine = Arc::new(Engine::new(&config)?);
+
+    let mut store = Store::new(&engine, ());
+    // Configure the store to trap on reaching the epoch deadline.
+    // This is the default, but we do it explicitly here to
+    // demonstrate.
+    store.epoch_deadline_trap();
+    // Configure the store to have an initial epoch deadline one tick
+    // in the future.
+    store.set_epoch_deadline(1);
+
+    // Reuse the fibonacci function from the Fuel example. This is a
+    // long-running function that we will want to interrupt.
+    let module = Module::from_file(store.engine(), "examples/fuel.wat")?;
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    // Start a thread that will bump the epoch after 1 second.
+    let engine_clone = engine.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        engine_clone.increment_epoch();
+    });
+
+    // Invoke `fibonacci` with a large argument such that a normal
+    // invocation would take many seconds to complete.
+    let fibonacci = instance.get_typed_func::<i32, i32, _>(&mut store, "fibonacci")?;
+    match fibonacci.call(&mut store, 100) {
+        Ok(_) => panic!("Somehow we computed recursive fib(100) in less than a second!"),
+        Err(_) => {
+            println!("Trapped out of fib(100) after epoch increment");
+        }
+    };
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,12 @@ struct CommonOptions {
     #[structopt(long)]
     consume_fuel: bool,
 
+    /// Executing wasm code will yield when a global epoch counter
+    /// changes, allowing for async operation without blocking the
+    /// executor.
+    #[structopt(long)]
+    epoch_interruption: bool,
+
     /// Disables the on-by-default address map from native code to wasm code.
     #[structopt(long)]
     disable_address_map: bool,
@@ -315,6 +321,7 @@ impl CommonOptions {
         }
 
         config.consume_fuel(self.consume_fuel);
+        config.epoch_interruption(self.epoch_interruption);
         config.generate_address_map(!self.disable_address_map);
         config.paged_memory_initialization(self.paged_memory_initialization);
 

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -1,0 +1,421 @@
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use wasmtime::*;
+
+fn dummy_waker() -> Waker {
+    return unsafe { Waker::from_raw(clone(5 as *const _)) };
+
+    unsafe fn clone(ptr: *const ()) -> RawWaker {
+        assert_eq!(ptr as usize, 5);
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+        RawWaker::new(ptr, &VTABLE)
+    }
+
+    unsafe fn wake(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn wake_by_ref(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+
+    unsafe fn drop(ptr: *const ()) {
+        assert_eq!(ptr as usize, 5);
+    }
+}
+
+fn build_engine() -> Arc<Engine> {
+    let mut config = Config::new();
+    config.async_support(true);
+    config.epoch_interruption(true);
+    Arc::new(Engine::new(&config).unwrap())
+}
+
+fn make_env(engine: &Engine) -> Linker<()> {
+    let mut linker = Linker::new(engine);
+    let engine = engine.clone();
+
+    linker
+        .func_new(
+            "",
+            "bump_epoch",
+            FuncType::new(None, None),
+            move |_caller, _params, _results| {
+                engine.increment_epoch();
+                Ok(())
+            },
+        )
+        .unwrap();
+
+    linker
+}
+
+/// Run a test with the given wasm, giving an initial deadline of
+/// `initial` ticks in the future, and either configuring the wasm to
+/// yield and set a deadline `delta` ticks in the future if `delta` is
+/// `Some(..)` or trapping if `delta` is `None`.
+///
+/// Returns `Some(yields)` if function completed normally, giving the
+/// number of yields that occured, or `None` if a trap occurred.
+fn run_and_count_yields_or_trap<F: Fn(Arc<Engine>)>(
+    wasm: &str,
+    initial: u64,
+    delta: Option<u64>,
+    setup_func: F,
+) -> Option<usize> {
+    let engine = build_engine();
+    let linker = make_env(&engine);
+    let module = Module::new(&engine, wasm).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = linker.instantiate(&mut store, &module).unwrap();
+    let f = instance.get_func(&mut store, "run").unwrap();
+
+    store.set_epoch_deadline(initial);
+    match delta {
+        Some(delta) => {
+            store.epoch_deadline_async_yield_and_update(delta);
+        }
+        None => {
+            store.epoch_deadline_trap();
+        }
+    }
+
+    let engine_clone = engine.clone();
+    setup_func(engine_clone);
+
+    let mut future = Box::pin(f.call_async(&mut store, &[], &mut []));
+    let mut yields = 0;
+    loop {
+        match future
+            .as_mut()
+            .poll(&mut Context::from_waker(&dummy_waker()))
+        {
+            Poll::Pending => {
+                yields += 1;
+            }
+            Poll::Ready(Ok(..)) => {
+                break;
+            }
+            Poll::Ready(Err(e)) => match e.downcast::<wasmtime::Trap>() {
+                Ok(_) => {
+                    return None;
+                }
+                e => {
+                    e.unwrap();
+                }
+            },
+        }
+    }
+
+    Some(yields)
+}
+
+#[test]
+fn epoch_yield_at_func_entry() {
+    // Should yield at start of call to func $subfunc.
+    assert_eq!(
+        Some(1),
+        run_and_count_yields_or_trap(
+            "
+            (module
+                (import \"\" \"bump_epoch\" (func $bump))
+                (func (export \"run\")
+                    call $bump  ;; bump epoch
+                    call $subfunc) ;; call func; will notice new epoch and yield
+                (func $subfunc))
+            ",
+            1,
+            Some(1),
+            |_| {},
+        )
+    );
+}
+
+#[test]
+fn epoch_yield_at_loop_header() {
+    // Should yield at top of loop, once per five iters.
+    assert_eq!(
+        Some(2),
+        run_and_count_yields_or_trap(
+            "
+            (module
+                (import \"\" \"bump_epoch\" (func $bump))
+                (func (export \"run\")
+                    (local $i i32)
+                    (local.set $i (i32.const 10))
+                    (loop $l
+                        call $bump
+                        (br_if $l (local.tee $i (i32.sub (local.get $i) (i32.const 1)))))))
+            ",
+            0,
+            Some(5),
+            |_| {},
+        )
+    );
+}
+
+#[test]
+fn epoch_yield_immediate() {
+    // We should see one yield immediately when the initial deadline
+    // is zero.
+    assert_eq!(
+        Some(1),
+        run_and_count_yields_or_trap(
+            "
+            (module
+                (import \"\" \"bump_epoch\" (func $bump))
+                (func (export \"run\")))
+            ",
+            0,
+            Some(1),
+            |_| {},
+        )
+    );
+}
+
+#[test]
+fn epoch_yield_only_once() {
+    // We should yield from the subfunction, and then when we return
+    // to the outer function and hit another loop header, we should
+    // not yield again (the double-check block will reload the correct
+    // epoch).
+    assert_eq!(
+        Some(1),
+        run_and_count_yields_or_trap(
+            "
+            (module
+                (import \"\" \"bump_epoch\" (func $bump))
+                (func (export \"run\")
+                  (local $i i32)
+                  (call $subfunc)
+                  (local.set $i (i32.const 0))
+                  (loop $l
+                    (br_if $l (i32.eq (i32.const 10)
+                                      (local.tee $i (i32.add (i32.const 1) (local.get $i)))))))
+                (func $subfunc
+                  (call $bump)))
+            ",
+            1,
+            Some(1),
+            |_| {},
+        )
+    );
+}
+
+#[test]
+fn epoch_interrupt_infinite_loop() {
+    assert_eq!(
+        None,
+        run_and_count_yields_or_trap(
+            "
+            (module
+                (import \"\" \"bump_epoch\" (func $bump))
+                (func (export \"run\")
+                  (loop $l
+                    (br $l))))
+            ",
+            1,
+            None,
+            |engine| {
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    engine.increment_epoch();
+                });
+            },
+        )
+    );
+}
+
+#[test]
+fn epoch_interrupt_function_entries() {
+    assert_eq!(
+        None,
+        run_and_count_yields_or_trap(
+            "
+            (module
+                (import \"\" \"bump_epoch\" (func $bump))
+                (func (export \"run\")
+                  call $f1
+                  call $f1
+                  call $f1
+                  call $f1
+                  call $f1
+                  call $f1
+                  call $f1
+                  call $f1
+                  call $f1
+                  call $f1)
+                (func $f1
+                  call $f2
+                  call $f2
+                  call $f2
+                  call $f2
+                  call $f2
+                  call $f2
+                  call $f2
+                  call $f2
+                  call $f2
+                  call $f2)
+                (func $f2
+                  call $f3
+                  call $f3
+                  call $f3
+                  call $f3
+                  call $f3
+                  call $f3
+                  call $f3
+                  call $f3
+                  call $f3
+                  call $f3)
+                (func $f3
+                  call $f4
+                  call $f4
+                  call $f4
+                  call $f4
+                  call $f4
+                  call $f4
+                  call $f4
+                  call $f4
+                  call $f4
+                  call $f4)
+                (func $f4
+                  call $f5
+                  call $f5
+                  call $f5
+                  call $f5
+                  call $f5
+                  call $f5
+                  call $f5
+                  call $f5
+                  call $f5
+                  call $f5)
+                (func $f5
+                  call $f6
+                  call $f6
+                  call $f6
+                  call $f6
+                  call $f6
+                  call $f6
+                  call $f6
+                  call $f6
+                  call $f6
+                  call $f6)
+                (func $f6
+                  call $f7
+                  call $f7
+                  call $f7
+                  call $f7
+                  call $f7
+                  call $f7
+                  call $f7
+                  call $f7
+                  call $f7
+                  call $f7)
+                (func $f7
+                  call $f8
+                  call $f8
+                  call $f8
+                  call $f8
+                  call $f8
+                  call $f8
+                  call $f8
+                  call $f8
+                  call $f8
+                  call $f8)
+                (func $f8
+                  call $f9
+                  call $f9
+                  call $f9
+                  call $f9
+                  call $f9
+                  call $f9
+                  call $f9
+                  call $f9
+                  call $f9
+                  call $f9)
+                (func $f9))
+            ",
+            1,
+            None,
+            |engine| {
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    engine.increment_epoch();
+                });
+            },
+        )
+    );
+}
+
+#[test]
+fn drop_future_on_epoch_yield() {
+    let wasm = "
+    (module
+      (import \"\" \"bump_epoch\" (func $bump))
+      (import \"\" \"im_alive\" (func $im_alive))
+      (import \"\" \"oops\" (func $oops))
+      (func (export \"run\")
+        (call $im_alive)
+        (call $bump)
+        (call $subfunc)  ;; subfunc entry to do epoch check
+        (call $oops))
+      (func $subfunc))
+    ";
+
+    let engine = build_engine();
+    let mut linker = make_env(&engine);
+
+    // Create a few helpers for the Wasm to call.
+    let alive_flag = Arc::new(AtomicBool::new(false));
+    let alive_flag_clone = alive_flag.clone();
+    linker
+        .func_new(
+            "",
+            "oops",
+            FuncType::new(None, None),
+            move |_caller, _params, _results| {
+                panic!("Should not have reached this point!");
+            },
+        )
+        .unwrap();
+    linker
+        .func_new(
+            "",
+            "im_alive",
+            FuncType::new(None, None),
+            move |_caller, _params, _results| {
+                alive_flag_clone.store(true, Ordering::Release);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+    let module = Module::new(&engine, wasm).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = linker.instantiate(&mut store, &module).unwrap();
+    let f = instance.get_func(&mut store, "run").unwrap();
+
+    store.set_epoch_deadline(1);
+    store.epoch_deadline_async_yield_and_update(1);
+
+    let mut future = Box::pin(f.call_async(&mut store, &[], &mut []));
+    match future
+        .as_mut()
+        .poll(&mut Context::from_waker(&dummy_waker()))
+    {
+        Poll::Pending => {
+            // OK: expected yield.
+        }
+        Poll::Ready(Ok(..)) => {
+            panic!("Shoulud not have returned");
+        }
+        Poll::Ready(e) => {
+            e.unwrap();
+        }
+    }
+
+    drop(future);
+    assert_eq!(true, alive_flag.load(Ordering::Acquire));
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -3,6 +3,7 @@ mod call_hook;
 mod cli_tests;
 mod custom_signal_handler;
 mod debug;
+mod epoch_interruption;
 mod externals;
 mod fuel;
 mod func;


### PR DESCRIPTION
(Builds on #3698)

This PR introduces a new way of performing cooperative timeslicing that
is intended to replace the "fuel" mechanism. The tradeoff is that this
mechanism interrupts with less precision: not at deterministic points
where fuel runs out, but rather when the Engine enters a new epoch. The
generated code instrumentation is substantially faster, however, because
it does not need to do as much work as when tracking fuel; it only loads
the global "epoch counter" and does a compare-and-branch at backedges
and function prologues.

This change has been measured as ~twice as fast as fuel-based
timeslicing for some workloads, especially control-flow-intensive
workloads such as the SpiderMonkey JS interpreter on Wasm/WASI.

The intended interface is that the embedder of the `Engine` performs an
`engine.increment_epoch()` call periodically, e.g. once per millisecond.
An async invocation of a Wasm guest on a `Store` can specify a number of
epoch-ticks that are allowed before an async yield back to the
executor's event loop. (The initial amount and automatic "refills" are
configured on the `Store`, just as for fuel.) This call does only
signal-safe work (it increments an `AtomicU64`) so could be invoked from
a periodic signal, or from a thread that wakes up once per period.