### PR TITLE
s390x: Codegen fixes and preparation for ISLE migration

### DIFF
--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -501,8 +501,7 @@ impl ABIMachineSpec for S390xMachineDeps {
             insts.push(Inst::StoreMultiple64 {
                 rt: gpr(first_clobbered_gpr as u8),
                 rt2: gpr(15),
-                addr_reg: stack_reg(),
-                addr_off: SImm20::maybe_from_i64(offset).unwrap(),
+                mem: MemArg::reg_plus_off(stack_reg(), offset, MemFlags::trusted()),
             });
         }
         if flags.unwind_info() {
@@ -606,8 +605,7 @@ impl ABIMachineSpec for S390xMachineDeps {
             insts.push(Inst::LoadMultiple64 {
                 rt: writable_gpr(first_clobbered_gpr as u8),
                 rt2: writable_gpr(15),
-                addr_reg: stack_reg(),
-                addr_off: SImm20::maybe_from_i64(offset).unwrap(),
+                mem: MemArg::reg_plus_off(stack_reg(), offset, MemFlags::trusted()),
             });
         }
 

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -1,4 +1,4 @@
-use crate::ir::MemFlags;
+use crate::ir::{MemFlags, TrapCode};
 use crate::isa::s390x::inst::*;
 use crate::isa::s390x::settings as s390x_settings;
 use crate::settings;
@@ -2062,352 +2062,352 @@ fn test_s390x_binemit() {
             shift_op: ShiftOp::RotL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB450000801D",
-        "rll %r4, %r5, -524288",
+        "EB450000001D",
+        "rll %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::RotL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7F1D",
-        "rll %r4, %r5, 524287",
+        "EB45003F001D",
+        "rll %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::RotL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB456000801D",
-        "rll %r4, %r5, -524288(%r6)",
+        "EB456000001D",
+        "rll %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::RotL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7F1D",
-        "rll %r4, %r5, 524287(%r6)",
+        "EB45603F001D",
+        "rll %r4, %r5, 63(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::RotL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB450000801C",
-        "rllg %r4, %r5, -524288",
+        "EB450000001C",
+        "rllg %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::RotL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7F1C",
-        "rllg %r4, %r5, 524287",
+        "EB45003F001C",
+        "rllg %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::RotL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB456000801C",
-        "rllg %r4, %r5, -524288(%r6)",
+        "EB456000001C",
+        "rllg %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::RotL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7F1C",
-        "rllg %r4, %r5, 524287(%r6)",
+        "EB45603F001C",
+        "rllg %r4, %r5, 63(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB45000080DF",
-        "sllk %r4, %r5, -524288",
+        "EB45000000DF",
+        "sllk %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7FDF",
-        "sllk %r4, %r5, 524287",
+        "EB45003F00DF",
+        "sllk %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB45600080DF",
-        "sllk %r4, %r5, -524288(%r6)",
+        "EB45600000DF",
+        "sllk %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7FDF",
-        "sllk %r4, %r5, 524287(%r6)",
+        "EB45603F00DF",
+        "sllk %r4, %r5, 63(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB450000800D",
-        "sllg %r4, %r5, -524288",
+        "EB450000000D",
+        "sllg %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7F0D",
-        "sllg %r4, %r5, 524287",
+        "EB45003F000D",
+        "sllg %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB456000800D",
-        "sllg %r4, %r5, -524288(%r6)",
+        "EB456000000D",
+        "sllg %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShL64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7F0D",
-        "sllg %r4, %r5, 524287(%r6)",
+        "EB45603F000D",
+        "sllg %r4, %r5, 63(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB45000080DE",
-        "srlk %r4, %r5, -524288",
+        "EB45000000DE",
+        "srlk %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7FDE",
-        "srlk %r4, %r5, 524287",
+        "EB45003F00DE",
+        "srlk %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB45600080DE",
-        "srlk %r4, %r5, -524288(%r6)",
+        "EB45600000DE",
+        "srlk %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7FDE",
-        "srlk %r4, %r5, 524287(%r6)",
+        "EB45603F00DE",
+        "srlk %r4, %r5, 63(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB450000800C",
-        "srlg %r4, %r5, -524288",
+        "EB450000000C",
+        "srlg %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7F0C",
-        "srlg %r4, %r5, 524287",
+        "EB45003F000C",
+        "srlg %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB456000800C",
-        "srlg %r4, %r5, -524288(%r6)",
+        "EB456000000C",
+        "srlg %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::LShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7F0C",
-        "srlg %r4, %r5, 524287(%r6)",
+        "EB45603F000C",
+        "srlg %r4, %r5, 63(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB45000080DC",
-        "srak %r4, %r5, -524288",
+        "EB45000000DC",
+        "srak %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7FDC",
-        "srak %r4, %r5, 524287",
+        "EB45003F00DC",
+        "srak %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB45600080DC",
-        "srak %r4, %r5, -524288(%r6)",
+        "EB45600000DC",
+        "srak %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR32,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7FDC",
-        "srak %r4, %r5, 524287(%r6)",
+        "EB45603F00DC",
+        "srak %r4, %r5, 63(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: None,
+            shift_imm: 0,
+            shift_reg: zero_reg(),
         },
-        "EB450000800A",
-        "srag %r4, %r5, -524288",
+        "EB450000000A",
+        "srag %r4, %r5, 0",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: None,
+            shift_imm: 63,
+            shift_reg: zero_reg(),
         },
-        "EB450FFF7F0A",
-        "srag %r4, %r5, 524287",
+        "EB45003F000A",
+        "srag %r4, %r5, 63",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(-524288).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 0,
+            shift_reg: gpr(6),
         },
-        "EB456000800A",
-        "srag %r4, %r5, -524288(%r6)",
+        "EB456000000A",
+        "srag %r4, %r5, 0(%r6)",
     ));
     insns.push((
         Inst::ShiftRR {
             shift_op: ShiftOp::AShR64,
             rd: writable_gpr(4),
             rn: gpr(5),
-            shift_imm: SImm20::maybe_from_i64(524287).unwrap(),
-            shift_reg: Some(gpr(6)),
+            shift_imm: 63,
+            shift_reg: gpr(6),
         },
-        "EB456FFF7F0A",
-        "srag %r4, %r5, 524287(%r6)",
+        "EB45603F000A",
+        "srag %r4, %r5, 63(%r6)",
     ));
 
     insns.push((
@@ -5718,8 +5718,12 @@ fn test_s390x_binemit() {
         Inst::LoadMultiple64 {
             rt: writable_gpr(8),
             rt2: writable_gpr(12),
-            addr_reg: gpr(15),
-            addr_off: SImm20::maybe_from_i64(-524288).unwrap(),
+            mem: MemArg::BXD20 {
+                base: gpr(15),
+                index: zero_reg(),
+                disp: SImm20::maybe_from_i64(-524288).unwrap(),
+                flags: MemFlags::trusted(),
+            },
         },
         "EB8CF0008004",
         "lmg %r8, %r12, -524288(%r15)",
@@ -5728,8 +5732,12 @@ fn test_s390x_binemit() {
         Inst::LoadMultiple64 {
             rt: writable_gpr(8),
             rt2: writable_gpr(12),
-            addr_reg: gpr(15),
-            addr_off: SImm20::maybe_from_i64(524287).unwrap(),
+            mem: MemArg::BXD20 {
+                base: gpr(15),
+                index: zero_reg(),
+                disp: SImm20::maybe_from_i64(524287).unwrap(),
+                flags: MemFlags::trusted(),
+            },
         },
         "EB8CFFFF7F04",
         "lmg %r8, %r12, 524287(%r15)",
@@ -5739,8 +5747,12 @@ fn test_s390x_binemit() {
         Inst::StoreMultiple64 {
             rt: gpr(8),
             rt2: gpr(12),
-            addr_reg: gpr(15),
-            addr_off: SImm20::maybe_from_i64(-524288).unwrap(),
+            mem: MemArg::BXD20 {
+                base: gpr(15),
+                index: zero_reg(),
+                disp: SImm20::maybe_from_i64(-524288).unwrap(),
+                flags: MemFlags::trusted(),
+            },
         },
         "EB8CF0008024",
         "stmg %r8, %r12, -524288(%r15)",
@@ -5749,8 +5761,12 @@ fn test_s390x_binemit() {
         Inst::StoreMultiple64 {
             rt: gpr(8),
             rt2: gpr(12),
-            addr_reg: gpr(15),
-            addr_off: SImm20::maybe_from_i64(524287).unwrap(),
+            mem: MemArg::BXD20 {
+                base: gpr(15),
+                index: zero_reg(),
+                disp: SImm20::maybe_from_i64(524287).unwrap(),
+                flags: MemFlags::trusted(),
+            },
         },
         "EB8CFFFF7F24",
         "stmg %r8, %r12, 524287(%r15)",
@@ -7964,7 +7980,7 @@ fn test_s390x_binemit() {
     insns.push((
         Inst::LoadFpuConst32 {
             rd: writable_fpr(8),
-            const_data: 1.0,
+            const_data: 1.0_f32.to_bits(),
         },
         "A71500043F80000078801000",
         "bras %r1, 8 ; data.f32 1 ; le %f8, 0(%r1)",
@@ -7972,7 +7988,7 @@ fn test_s390x_binemit() {
     insns.push((
         Inst::LoadFpuConst64 {
             rd: writable_fpr(8),
-            const_data: 1.0,
+            const_data: 1.0_f64.to_bits(),
         },
         "A71500063FF000000000000068801000",
         "bras %r1, 12 ; data.f64 1 ; ld %f8, 0(%r1)",

--- a/cranelift/filetests/filetests/isa/s390x/bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops.clif
@@ -93,7 +93,7 @@ block0(v0: i64):
 }
 
 ; check:  srag %r3, %r2, 63
-; nextln: xgr %r3, %r2
+; nextln: xgrk %r2, %r3, %r2
 ; nextln: flogr %r0, %r2
 ; nextln: lgr %r2, %r0
 ; nextln: br %r14
@@ -106,7 +106,7 @@ block0(v0: i32):
 
 ; check:  lgfr %r2, %r2
 ; nextln: srag %r3, %r2, 63
-; nextln: xgr %r3, %r2
+; nextln: xgrk %r2, %r3, %r2
 ; nextln: flogr %r0, %r2
 ; nextln: lr %r2, %r0
 ; nextln: ahi %r2, -32
@@ -120,7 +120,7 @@ block0(v0: i16):
 
 ; check:  lghr %r2, %r2
 ; nextln: srag %r3, %r2, 63
-; nextln: xgr %r3, %r2
+; nextln: xgrk %r2, %r3, %r2
 ; nextln: flogr %r0, %r2
 ; nextln: lr %r2, %r0
 ; nextln: ahi %r2, -48
@@ -134,7 +134,7 @@ block0(v0: i8):
 
 ; check:  lgbr %r2, %r2
 ; nextln: srag %r3, %r2, 63
-; nextln: xgr %r3, %r2
+; nextln: xgrk %r2, %r3, %r2
 ; nextln: flogr %r0, %r2
 ; nextln: lr %r2, %r0
 ; nextln: ahi %r2, -56

--- a/cranelift/filetests/filetests/isa/s390x/icmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp.clif
@@ -418,6 +418,19 @@ block0(v0: i64):
 ; nextln: lochil %r2, 1
 ; nextln: br %r14
 
+function %icmp_ult_i64_mem_ext16(i64, i64) -> b1 {
+block0(v0: i64, v1: i64):
+  v2 = uload16.i64 v1
+  v3 = icmp.i64 ult v0, v2
+  return v3
+}
+
+; check:  llgh %r3, 0(%r3)
+; check:  clgr %r2, %r3
+; nextln: lhi %r2, 0
+; nextln: lochil %r2, 1
+; nextln: br %r14
+
 function %icmp_ult_i64_sym_ext16(i64) -> b1 {
   gv0 = symbol colocated %sym
 block0(v0: i64):
@@ -489,6 +502,19 @@ block0(v0: i32):
 }
 
 ; check:  clrl %r2, %sym + 0
+; nextln: lhi %r2, 0
+; nextln: lochil %r2, 1
+; nextln: br %r14
+
+function %icmp_ult_i32_mem_ext16(i32, i64) -> b1 {
+block0(v0: i32, v1: i64):
+  v2 = uload16.i32 v1
+  v3 = icmp.i32 ult v0, v2
+  return v3
+}
+
+; check:  llh %r3, 0(%r3)
+; check:  clr %r2, %r3
 ; nextln: lhi %r2, 0
 ; nextln: lochil %r2, 1
 ; nextln: br %r14

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -251,10 +251,8 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-; FIXME: check shift count ?
-
 ; check:  llhr %r2, %r2
-; nextln: nill %r3, 31
+; nextln: nill %r3, 15
 ; nextln: srlk %r2, %r2, 0(%r3)
 ; nextln: br %r14
 
@@ -276,7 +274,7 @@ block0(v0: i8, v1: i8):
 }
 
 ; check:  llcr %r2, %r2
-; nextln: nill %r3, 31
+; nextln: nill %r3, 7
 ; nextln: srlk %r2, %r2, 0(%r3)
 ; nextln: br %r14
 
@@ -339,7 +337,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-; check:  nill %r3, 31
+; check:  nill %r3, 15
 ; nextln: sllk %r2, %r2, 0(%r3)
 ; nextln: br %r14
 
@@ -359,7 +357,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
-; check:  nill %r3, 31
+; check:  nill %r3, 7
 ; nextln: sllk %r2, %r2, 0(%r3)
 ; nextln: br %r14
 
@@ -422,7 +420,7 @@ block0(v0: i16, v1: i16):
 }
 
 ; check:  lhr %r2, %r2
-; nextln: nill %r3, 31
+; nextln: nill %r3, 15
 ; nextln: srak %r2, %r2, 0(%r3)
 ; nextln: br %r14
 
@@ -444,7 +442,7 @@ block0(v0: i8, v1: i8):
 }
 
 ; check:  lbr %r2, %r2
-; nextln: nill %r3, 31
+; nextln: nill %r3, 7
 ; nextln: srak %r2, %r2, 0(%r3)
 ; nextln: br %r14
 


### PR DESCRIPTION
In preparing the back-end to move to ISLE, I detected a
number of codegen bugs in the existing code, which are
fixed here:

- Fix internal compiler error with uload16/icmp corner case.
- Fix broken Cls lowering.
- Correctly mask shift count for i8/i16 shifts.

In addition, I made several changes to operand encodings
in various MInst patterns.  These should not have any
functional effect, but will make the ISLE migration easier:

- Encode floating-point constants as u32/u64 in MInst patterns.
- Encode shift amounts as u8 and Reg in ShiftOp pattern.
- Use MemArg in LoadMultiple64 and StoreMultiple64 patterns.

CC @cfallin 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
