### PR TITLE
ISLE: Fix clif.isle InstructionData entries

### DIFF
--- a/cranelift/codegen/src/clif.isle
+++ b/cranelift/codegen/src/clif.isle
@@ -349,7 +349,7 @@
         (BranchIcmp (opcode Opcode) (args ValueList) (cond IntCC) (destination Block))
         (BranchInt (opcode Opcode) (args ValueList) (cond IntCC) (destination Block))
         (BranchTable (opcode Opcode) (arg Value) (destination Block) (table JumpTable))
-        (Call (opcode Opcode) (func_ref FuncRef))
+        (Call (opcode Opcode) (args ValueList) (func_ref FuncRef))
         (CallIndirect (opcode Opcode) (args ValueList) (sig_ref SigRef))
         (CondTrap (opcode Opcode) (arg Value) (code TrapCode))
         (FloatCompare (opcode Opcode) (args ValueArray2) (cond FloatCC))
@@ -362,11 +362,11 @@
         (IntCond (opcode Opcode) (arg Value) (cond IntCC))
         (IntCondTrap (opcode Opcode) (arg Value) (cond IntCC) (code TrapCode))
         (IntSelect (opcode Opcode) (args ValueArray3) (cond IntCC))
-        (Jump (opcode Opcode) (destination Block))
+        (Jump (opcode Opcode) (args ValueList) (destination Block))
         (Load (opcode Opcode) (arg Value) (flags MemFlags) (offset Offset32))
-        (LoadComplex (opcode Opcode) (flags MemFlags) (offset Offset32))
+        (LoadComplex (opcode Opcode) (args ValueList) (flags MemFlags) (offset Offset32))
         (LoadNoOffset (opcode Opcode) (arg Value) (flags MemFlags))
-        (MultiAry (opcode Opcode))
+        (MultiAry (opcode Opcode) (args ValueList))
         (NullAry (opcode Opcode))
         (Shuffle (opcode Opcode) (args ValueArray2) (imm Immediate))
         (StackLoad (opcode Opcode) (stack_slot StackSlot) (offset Offset32))
@@ -393,7 +393,7 @@
 (decl jump (Block ValueSlice) Inst)
 (extractor
     (jump block args)
-    (inst_data (InstructionData.Jump (Opcode.Jump) block))
+    (inst_data (InstructionData.Jump (Opcode.Jump) (value_list_slice args) block))
 )
 
 (decl brz (Value Block ValueSlice) Inst)
@@ -483,19 +483,19 @@
 (decl return (ValueSlice) Inst)
 (extractor
     (return rvals)
-    (inst_data (InstructionData.MultiAry (Opcode.Return)))
+    (inst_data (InstructionData.MultiAry (Opcode.Return) (value_list_slice rvals)))
 )
 
 (decl fallthrough_return (ValueSlice) Inst)
 (extractor
     (fallthrough_return rvals)
-    (inst_data (InstructionData.MultiAry (Opcode.FallthroughReturn)))
+    (inst_data (InstructionData.MultiAry (Opcode.FallthroughReturn) (value_list_slice rvals)))
 )
 
 (decl call (FuncRef ValueSlice) Inst)
 (extractor
     (call FN args)
-    (inst_data (InstructionData.Call (Opcode.Call) FN))
+    (inst_data (InstructionData.Call (Opcode.Call) (value_list_slice args) FN))
 )
 
 (decl call_indirect (SigRef Value ValueSlice) Inst)
@@ -597,7 +597,7 @@
 (decl load_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (load_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.LoadComplex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.LoadComplex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl store (MemFlags Value Value Offset32) Inst)
@@ -621,7 +621,7 @@
 (decl uload8_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (uload8_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Uload8Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Uload8Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl sload8 (MemFlags Value Offset32) Inst)
@@ -633,7 +633,7 @@
 (decl sload8_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (sload8_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Sload8Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Sload8Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl istore8 (MemFlags Value Value Offset32) Inst)
@@ -657,7 +657,7 @@
 (decl uload16_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (uload16_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Uload16Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Uload16Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl sload16 (MemFlags Value Offset32) Inst)
@@ -669,7 +669,7 @@
 (decl sload16_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (sload16_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Sload16Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Sload16Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl istore16 (MemFlags Value Value Offset32) Inst)
@@ -693,7 +693,7 @@
 (decl uload32_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (uload32_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Uload32Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Uload32Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl sload32 (MemFlags Value Offset32) Inst)
@@ -705,7 +705,7 @@
 (decl sload32_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (sload32_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Sload32Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Sload32Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl istore32 (MemFlags Value Value Offset32) Inst)
@@ -729,7 +729,7 @@
 (decl uload8x8_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (uload8x8_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Uload8x8Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Uload8x8Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl sload8x8 (MemFlags Value Offset32) Inst)
@@ -741,7 +741,7 @@
 (decl sload8x8_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (sload8x8_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Sload8x8Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Sload8x8Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl uload16x4 (MemFlags Value Offset32) Inst)
@@ -753,7 +753,7 @@
 (decl uload16x4_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (uload16x4_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Uload16x4Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Uload16x4Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl sload16x4 (MemFlags Value Offset32) Inst)
@@ -765,7 +765,7 @@
 (decl sload16x4_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (sload16x4_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Sload16x4Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Sload16x4Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl uload32x2 (MemFlags Value Offset32) Inst)
@@ -777,7 +777,7 @@
 (decl uload32x2_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (uload32x2_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Uload32x2Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Uload32x2Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl sload32x2 (MemFlags Value Offset32) Inst)
@@ -789,7 +789,7 @@
 (decl sload32x2_complex (MemFlags ValueSlice Offset32) Inst)
 (extractor
     (sload32x2_complex MemFlags args Offset)
-    (inst_data (InstructionData.LoadComplex (Opcode.Sload32x2Complex) MemFlags Offset))
+    (inst_data (InstructionData.LoadComplex (Opcode.Sload32x2Complex) (value_list_slice args) MemFlags Offset))
 )
 
 (decl stack_load (StackSlot Offset32) Inst)

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
-src/clif.isle f176ef3bba99365
+src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle 51d2aef2566c1c96
 src/isa/aarch64/inst.isle f946561093de4ff5
 src/isa/aarch64/lower.isle 2d2e1e076a0c8a23

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
-src/clif.isle f176ef3bba99365
+src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle 51d2aef2566c1c96
 src/isa/s390x/inst.isle 63cf833b5cfd727d
 src/isa/s390x/lower.isle a0e21a567040bc33

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
-src/clif.isle f176ef3bba99365
+src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle 51d2aef2566c1c96
 src/isa/x64/inst.isle 61004acbb1289816
 src/isa/x64/lower.isle 82db7f7d47ac7809


### PR DESCRIPTION
Attempt to match a Jump instruction in ISLE will currently lead to the
generated files not compiling.  This is because the definition of the
InstructionData enum in clif.isle does not match the actual type used
in Rust code.

Specifically, clif.isle erroneously omits the ValueList variable-length
argument entry if the format does not use a typevar operand.  This is
the case for Jump and a few other formats.  The problem is caused by
a bug in the gen_isle routine in meta/src/gen_inst.rs.

CC @cfallin @fitzgen 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
