### PR TITLE
ISLE: Allow emitting safepoint insns

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -152,14 +152,17 @@ where
                         let imm =
                             MoveWideConst::maybe_with_shift(((!imm16) & 0xffff) as u16, i * 16)
                                 .unwrap();
-                        self.emitted_insts.push(MInst::MovN { rd, imm, size });
+                        self.emitted_insts
+                            .push((MInst::MovN { rd, imm, size }, false));
                     } else {
                         let imm = MoveWideConst::maybe_with_shift(imm16 as u16, i * 16).unwrap();
-                        self.emitted_insts.push(MInst::MovZ { rd, imm, size });
+                        self.emitted_insts
+                            .push((MInst::MovZ { rd, imm, size }, false));
                     }
                 } else {
                     let imm = MoveWideConst::maybe_with_shift(imm16 as u16, i * 16).unwrap();
-                    self.emitted_insts.push(MInst::MovK { rd, imm, size });
+                    self.emitted_insts
+                        .push((MInst::MovK { rd, imm, size }, false));
                 }
             }
         }
@@ -200,7 +203,7 @@ where
     }
 
     fn emit(&mut self, inst: &MInst) -> Unit {
-        self.emitted_insts.push(inst.clone());
+        self.emitted_insts.push((inst.clone(), false));
     }
 
     fn cond_br_zero(&mut self, reg: Reg) -> CondBrKind {

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -470,6 +470,6 @@ where
 
     #[inline]
     fn emit(&mut self, inst: &MInst) -> Unit {
-        self.emitted_insts.push(inst.clone());
+        self.emitted_insts.push((inst.clone(), false));
     }
 }

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -227,7 +227,7 @@ where
 
     fn emit(&mut self, inst: &MInst) -> Unit {
         for inst in inst.clone().mov_mitosis() {
-            self.emitted_insts.push(inst);
+            self.emitted_insts.push((inst, false));
         }
     }
 


### PR DESCRIPTION
Change the implementation of emitted_insts in IsleContext from
a plain vector of instructions into a vector of tuples, where
the second element is a boolean that indicates whether this
instruction should be emitted as a safepoint.

This allows targets to emit safepoint insns via ISLE.

@cfallin @fitzgen 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
