### PR TITLE
cranelift: Use `emit` helper function on aarch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -152,17 +152,14 @@ where
                         let imm =
                             MoveWideConst::maybe_with_shift(((!imm16) & 0xffff) as u16, i * 16)
                                 .unwrap();
-                        self.emitted_insts
-                            .push((MInst::MovN { rd, imm, size }, false));
+                        self.emit(&MInst::MovN { rd, imm, size });
                     } else {
                         let imm = MoveWideConst::maybe_with_shift(imm16 as u16, i * 16).unwrap();
-                        self.emitted_insts
-                            .push((MInst::MovZ { rd, imm, size }, false));
+                        self.emit(&MInst::MovZ { rd, imm, size });
                     }
                 } else {
                     let imm = MoveWideConst::maybe_with_shift(imm16 as u16, i * 16).unwrap();
-                    self.emitted_insts
-                        .push((MInst::MovK { rd, imm, size }, false));
+                    self.emit(&MInst::MovK { rd, imm, size });
                 }
             }
         }


### PR DESCRIPTION
...instead of pushing to the `emitted_insts` vec directly.

cc @uweigand 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
