### PR TITLE
Add CLI options for preopened listen sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
 
 [[package]]
+name = "listenfd"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e514e2cb8a9624701346ea3e694c1766d76778e343e537d873c1c366e79a7"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3483,7 @@ dependencies = [
  "humantime 2.1.0",
  "lazy_static",
  "libc",
+ "listenfd",
  "memchr",
  "more-asserts",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rayon = "1.5.0"
 humantime = "2.0.0"
 wasmparser = "0.82.0"
 lazy_static = "1.4.0"
+listenfd = "0.3.5"
 
 [target.'cfg(unix)'.dependencies]
 rustix = "0.33.0"


### PR DESCRIPTION
As a follow up for https://github.com/bytecodealliance/wasmtime/pull/3711, this implements CLI options to insert pre-opened sockets.

`--listenfd` : Inherit environment variables and file descriptors following the systemd listen fd specification (UNIX only)

`--tcplisten <SOCKET ADDRESS>`: Grant access to the given TCP listen socket

### TODO

* [ ] Write test cases

### EXAMPLES

```
$ git clone --branch wasi https://github.com/haraldh/mio.git
$ cd mio
$ cargo +nightly build --target wasm32-wasi --example tcp_server --features="os-poll net" 
$ wasmtime run --tcplisten 127.0.0.1:9000 --env 'LISTEN_FDS=1' target/wasm32-wasi/debug/examples/tcp_server.wasm 
Using preopened socket FD 3
You can connect to the server using `nc`:
 $ nc <IP> <PORT>
You'll see our welcome message and anything you type will be printed here.
^Z
[1]+  Stopped                 wasmtime run --tcplisten 127.0.0.1:9000 --env 'LISTEN_FDS=1' target/wasm32-wasi/debug/examples/tcp_server.wasm
$ bg
$ echo Hello | nc 127.0.0.1 9000
Accepted connection from: 0.0.0.0:0
Hello world!
Received data: Hello
Connection closed
$ fg
$ ^C
```
