### PR TITLE
Change how uffd is configured with Wasmtime

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -39,6 +39,14 @@ pub enum InstanceAllocationStrategy {
     Pooling {
         /// The allocation strategy to use.
         strategy: PoolingAllocationStrategy,
+        /// Whether or not to use a Linux-specific feature of "userfaultfd" to
+        /// lazily initialize linear memories instead of immediately
+        /// initializating linear memories on instantiation.
+        ///
+        /// Note that this flag is enabled by default via
+        /// [`InstanceAllocationStrategy::pooling`] if the `uffd` crate feature
+        /// is enabled and the target os is Linux.
+        uffd: bool,
         /// The module limits to use.
         module_limits: ModuleLimits,
         /// The instance limits to use.
@@ -54,6 +62,15 @@ impl InstanceAllocationStrategy {
             strategy: PoolingAllocationStrategy::default(),
             module_limits: ModuleLimits::default(),
             instance_limits: InstanceLimits::default(),
+            uffd: cfg!(feature = "uffd") && cfg!(target_os = "linux"),
+        }
+    }
+
+    pub(crate) fn uffd_enabled(&self) -> bool {
+        match self {
+            #[cfg(feature = "pooling-allocator")]
+            InstanceAllocationStrategy::Pooling { uffd, .. } => *uffd,
+            _ => false,
         }
     }
 }
@@ -103,7 +120,6 @@ pub struct Config {
     pub(crate) async_support: bool,
     pub(crate) module_version: ModuleVersionStrategy,
     pub(crate) parallel_compilation: bool,
-    pub(crate) paged_memory_initialization: bool,
 }
 
 impl Config {
@@ -127,8 +143,6 @@ impl Config {
             async_support: false,
             module_version: ModuleVersionStrategy::default(),
             parallel_compilation: true,
-            // Default to paged memory initialization when using uffd on linux
-            paged_memory_initialization: cfg!(all(target_os = "linux", feature = "uffd")),
         };
         #[cfg(compiler)]
         {
@@ -837,30 +851,20 @@ impl Config {
     /// [`Config::static_memory_maximum_size`] and
     /// [`Config::static_memory_guard_size`] options will be used to configure
     /// the virtual memory allocations of linear memories.
-    pub fn allocation_strategy(&mut self, strategy: InstanceAllocationStrategy) -> &mut Self {
+    pub fn allocation_strategy(
+        &mut self,
+        strategy: InstanceAllocationStrategy,
+    ) -> Result<&mut Self> {
+        if strategy.uffd_enabled() {
+            if !cfg!(feature = "uffd") {
+                bail!("uffd requested at runtime but support is not compiled in");
+            }
+            if !cfg!(target_os = "linux") {
+                bail!("uffd can only be enabled on Linux");
+            }
+        }
         self.allocation_strategy = strategy;
-        self
-    }
-
-    /// Sets whether or not an attempt is made to initialize linear memories by page.
-    ///
-    /// This setting is `false` by default and Wasmtime initializes linear memories
-    /// by copying individual data segments from the compiled module.
-    ///
-    /// Setting this to `true` will cause compilation to attempt to organize the
-    /// data segments into WebAssembly pages and linear memories are initialized by
-    /// copying each page rather than individual data segments.
-    ///
-    /// Modules that import a memory or have data segments that use a global base
-    /// will continue to be initialized by copying each data segment individually.
-    ///
-    /// When combined with the `uffd` feature on Linux, this will allow Wasmtime
-    /// to delay initialization of a linear memory page until it is accessed
-    /// for the first time during WebAssembly execution; this may improve
-    /// instantiation performance as a result.
-    pub fn paged_memory_initialization(&mut self, value: bool) -> &mut Self {
-        self.paged_memory_initialization = value;
-        self
+        Ok(self)
     }
 
     /// Configures the maximum size, in bytes, where a linear memory is
@@ -1196,6 +1200,10 @@ impl Config {
             )?)),
         }
     }
+
+    pub(crate) fn uffd_enabled(&self) -> bool {
+        self.allocation_strategy.uffd_enabled()
+    }
 }
 
 #[cfg(compiler)]
@@ -1238,7 +1246,6 @@ impl Clone for Config {
             async_stack_size: self.async_stack_size,
             module_version: self.module_version.clone(),
             parallel_compilation: self.parallel_compilation,
-            paged_memory_initialization: self.paged_memory_initialization,
         }
     }
 }

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -403,9 +403,12 @@ impl Module {
                     .compiler()
                     .emit_obj(&translation, &types, funcs, tunables, &mut obj)?;
 
-            // If configured, attempt to use paged memory initialization
-            // instead of the default mode of memory initialization
-            if engine.config().paged_memory_initialization {
+            // If uffd is configured, attempt to use paged memory
+            // initialization instead of the default mode of memory
+            // initialization. This organization of memory initialization is the
+            // benefit of uffd which allows skipping memory initialization
+            // entirely on module instantiation.
+            if engine.config().uffd_enabled() {
                 translation.try_paged_init();
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,11 +245,6 @@ struct CommonOptions {
     /// Disables the on-by-default address map from native code to wasm code.
     #[structopt(long)]
     disable_address_map: bool,
-
-    /// Switches memory initialization to happen in a paged fashion instead of
-    /// the data segments specified in the original wasm module.
-    #[structopt(long)]
-    paged_memory_initialization: bool,
 }
 
 impl CommonOptions {
@@ -323,7 +318,6 @@ impl CommonOptions {
         config.consume_fuel(self.consume_fuel);
         config.epoch_interruption(self.epoch_interruption);
         config.generate_address_map(!self.disable_address_map);
-        config.paged_memory_initialization(self.paged_memory_initialization);
 
         Ok(config)
     }


### PR DESCRIPTION
This commit updates how the `uffd` feature of Wasmtime is enabled and
used. Previously to use `uffd` users needed to do a few things:

* Enable the pooling allocator
* Enable paged memory initialization
* Enable the `uffd` feature at compile time

If any one of these were omitted, however, then `uffd` was silently not
used or otherwise wasn't beneficial (e.g. forgetting paged memory
initialization means that memories would be all initialized
immediately).

This commit changes this configuration to instead have consumers
explicitly request `uffd` as part of enabling the pooling allocation
strategy. This makes it clear that `uffd` is only enabled for the
pooling allocator, and requests to enable it when the feature isn't
compiled in (or is the wrong platform) can return an error indicating
what happened.

This does sort of effectively revert #3245 which allows enabling paged
memory initialization independent of uffd, but at this time I can't
quite remember what the motivation was for that PR so I'm hoping that
this can jog a memory!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
