### PR TITLE
docs: render the `fcmp` tables as code

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3035,12 +3035,14 @@ pub(crate) fn define(
         Two IEEE 754-2008 floating point numbers, `x` and `y`, relate to each
         other in exactly one of four ways:
 
+        ```text
         == ==========================================
         UN Unordered when one or both numbers is NaN.
         EQ When `x = y`. (And `0.0 = -0.0`).
         LT When `x < y`.
         GT When `x > y`.
         == ==========================================
+        ```
 
         The 14 `floatcc` condition codes each correspond to a subset of
         the four relations, except for the empty set which would always be
@@ -3049,6 +3051,7 @@ pub(crate) fn define(
         The condition codes are divided into 7 'ordered' conditions which don't
         include UN, and 7 unordered conditions which all include UN.
 
+        ```text
         +-------+------------+---------+------------+-------------------------+
         |Ordered             |Unordered             |Condition                |
         +=======+============+=========+============+=========================+
@@ -3066,6 +3069,7 @@ pub(crate) fn define(
         +-------+------------+---------+------------+-------------------------+
         |ge     |GT | EQ     |uge      |UN | GT | EQ|Greater than or equal    |
         +-------+------------+---------+------------+-------------------------+
+        ```
 
         The standard C comparison operators, `<, <=, >, >=`, are all ordered,
         so they are false if either operand is NaN. The C equality operator,
@@ -3073,6 +3077,7 @@ pub(crate) fn define(
         inverse it is *unordered*. They map to the `floatcc` condition
         codes as follows:
 
+        ```text
         ==== ====== ============
         C    `Cond` Subset
         ==== ====== ============
@@ -3083,6 +3088,7 @@ pub(crate) fn define(
         `>`  gt     GT
         `>=` ge     GT | EQ
         ==== ====== ============
+        ```
 
         This subset of condition codes also corresponds to the WebAssembly
         floating point comparisons of the same name.


### PR DESCRIPTION
Looking at [the `fcmp`
documentation](https://docs.rs/cranelift-codegen/0.80.0/cranelift_codegen/ir/trait.InstBuilder.html#method.fcmp)--generated
from Cranelift's instruction definitions, the charts explaining the
logic for the various conditions is unreadable. Since rendering those charts
as plain text is problematic, this change wraps them as code sections
for a consistent layout.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
