### PR TITLE
Pooling allocator: make backend (mmap, uffd, memfd) runtime-configurable.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,7 @@ jobs:
     - run: cargo check -p wasmtime --no-default-features --features async
     - run: cargo check -p wasmtime --no-default-features --features uffd
     - run: cargo check -p wasmtime --no-default-features --features pooling-allocator
+    - run: cargo check -p wasmtime --no-default-features --features memfd-allocator
     - run: cargo check -p wasmtime --no-default-features --features cranelift
     - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache
 
@@ -310,11 +311,13 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-    # Test uffd functionality on Linux
+    # Test Linux-specific functionality
     - run: |
         cargo test --features uffd -p wasmtime-runtime instance::allocator::pooling
         cargo test --features uffd -p wasmtime-cli pooling_allocator
         cargo test --features uffd -p wasmtime-cli wast::Cranelift
+        cargo test --features memfd-allocator -p wasmtime-cli pooling_allocator
+        cargo test --features memfd-allocator -p wasmtime-cli wast::Cranelift
       if: matrix.os == 'ubuntu-latest' && matrix.target == ''
       env:
         RUST_BACKTRACE: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -316,8 +316,24 @@ jobs:
         cargo test --features uffd -p wasmtime-runtime instance::allocator::pooling
         cargo test --features uffd -p wasmtime-cli pooling_allocator
         cargo test --features uffd -p wasmtime-cli wast::Cranelift
+        cargo test --features memfd-allocator -p wasmtime-runtime instance::allocator::pooling
         cargo test --features memfd-allocator -p wasmtime-cli pooling_allocator
         cargo test --features memfd-allocator -p wasmtime-cli wast::Cranelift
+        cargo test --features memfd-allocator,wasmtime-runtime/default-mmap-backend -p wasmtime-runtime instance::allocator::pooling
+        cargo test --features memfd-allocator,wasmtime-runtime/default-mmap-backend -p wasmtime-cli pooling_allocator
+        cargo test --features memfd-allocator,wasmtime-runtime/default-mmap-backend -p wasmtime-cli wast::Cranelift
+        cargo test --features uffd,wasmtime-runtime/default-mmap-backend -p wasmtime-runtime instance::allocator::pooling
+        cargo test --features uffd,wasmtime-runtime/default-mmap-backend -p wasmtime-cli pooling_allocator
+        cargo test --features uffd,wasmtime-runtime/default-mmap-backend -p wasmtime-cli wast::Cranelift
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-mmap-backend -p wasmtime-runtime instance::allocator::pooling
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-mmap-backend -p wasmtime-cli pooling_allocator
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-mmap-backend -p wasmtime-cli wast::Cranelift
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-uffd-backend -p wasmtime-runtime instance::allocator::pooling
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-uffd-backend -p wasmtime-cli pooling_allocator
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-uffd-backend -p wasmtime-cli wast::Cranelift
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-memfd-backend -p wasmtime-runtime instance::allocator::pooling
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-memfd-backend -p wasmtime-cli pooling_allocator
+        cargo test --features uffd,memfd-allocator,wasmtime-runtime/default-memfd-backend -p wasmtime-cli wast::Cranelift
       if: matrix.os == 'ubuntu-latest' && matrix.target == ''
       env:
         RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memfd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6627dc657574b49d6ad27105ed671822be56e0d2547d413bfbf3e8d8fa92e7a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memmap2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,6 +3596,7 @@ dependencies = [
  "libc",
  "log",
  "mach",
+ "memfd",
  "memoffset",
  "more-asserts",
  "rand 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,8 @@ vtune = ["wasmtime/vtune"]
 wasi-crypto = ["wasmtime-wasi-crypto"]
 wasi-nn = ["wasmtime-wasi-nn"]
 uffd = ["wasmtime/uffd"]
+pooling-allocator = ["wasmtime/pooling-allocator"]
+memfd-allocator = ["pooling-allocator", "wasmtime/memfd-allocator"]
 all-arch = ["wasmtime/all-arch"]
 posix-signals-on-macos = ["wasmtime/posix-signals-on-macos"]
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -37,6 +37,7 @@ winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingap
 
 [target.'cfg(target_os = "linux")'.dependencies]
 userfaultfd = { version = "0.4.1", optional = true }
+memfd = { version = "0.4.1", optional = true }
 
 [build-dependencies]
 cc = "1.0"
@@ -59,3 +60,5 @@ uffd = ["userfaultfd", "pooling-allocator"]
 # It is useful for applications that do not bind their own exception ports and
 # need portable signal handling.
 posix-signals-on-macos = []
+
+memfd-allocator = ["pooling-allocator", "memfd"]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -62,3 +62,12 @@ uffd = ["userfaultfd", "pooling-allocator"]
 posix-signals-on-macos = []
 
 memfd-allocator = ["pooling-allocator", "memfd"]
+
+# For testing only: make the uffd backend the default.
+default-uffd-backend = ["uffd"]
+
+# For testing only: make the memfd backend the default.
+default-memfd-backend = ["memfd-allocator"]
+
+# For testing only: make the mmap backend the default.
+default-mmap-backend = []

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -33,7 +33,8 @@ pub use self::pooling::MemFdSlot;
 
 #[cfg(feature = "pooling-allocator")]
 pub use self::pooling::{
-    InstanceLimits, ModuleLimits, PoolingAllocationStrategy, PoolingInstanceAllocator,
+    InstanceLimits, ModuleLimits, PoolingAllocationStrategy, PoolingBackend,
+    PoolingInstanceAllocator,
 };
 
 /// Represents a request for a new runtime instance.

--- a/crates/runtime/src/instance/allocator/pooling/linux.rs
+++ b/crates/runtime/src/instance/allocator/pooling/linux.rs
@@ -1,3 +1,4 @@
+use crate::PoolingBackend;
 use anyhow::{Context, Result};
 
 fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
@@ -19,7 +20,7 @@ fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn commit_memory_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     if len == 0 {
         return Ok(());
     }
@@ -31,26 +32,26 @@ pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
     }
 }
 
-pub fn decommit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_memory_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, true)
 }
 
-pub fn commit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+pub fn commit_table_pages(_backend: PoolingBackend, _addr: *mut u8, _len: usize) -> Result<()> {
     // A no-op as table pages remain READ|WRITE
     Ok(())
 }
 
-pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_table_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }
 
 #[cfg(feature = "async")]
-pub fn commit_stack_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+pub fn commit_stack_pages(_backend: PoolingBackend, _addr: *mut u8, _len: usize) -> Result<()> {
     // A no-op as stack pages remain READ|WRITE
     Ok(())
 }
 
 #[cfg(feature = "async")]
-pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_stack_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }

--- a/crates/runtime/src/instance/allocator/pooling/unix.rs
+++ b/crates/runtime/src/instance/allocator/pooling/unix.rs
@@ -1,3 +1,4 @@
+use crate::PoolingBackend;
 use anyhow::{Context, Result};
 
 fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
@@ -26,7 +27,7 @@ fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn commit_memory_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     if len == 0 {
         return Ok(());
     }
@@ -38,26 +39,26 @@ pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
     }
 }
 
-pub fn decommit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_memory_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, true)
 }
 
-pub fn commit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+pub fn commit_table_pages(_backend: PoolingBackend, _addr: *mut u8, _len: usize) -> Result<()> {
     // A no-op as table pages remain READ|WRITE
     Ok(())
 }
 
-pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_table_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }
 
 #[cfg(feature = "async")]
-pub fn commit_stack_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+pub fn commit_stack_pages(_backend: PoolingBackend, _addr: *mut u8, _len: usize) -> Result<()> {
     // A no-op as stack pages remain READ|WRITE
     Ok(())
 }
 
 #[cfg(feature = "async")]
-pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_stack_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len, false)
 }

--- a/crates/runtime/src/instance/allocator/pooling/windows.rs
+++ b/crates/runtime/src/instance/allocator/pooling/windows.rs
@@ -1,3 +1,4 @@
+use crate::PoolingBackend;
 use anyhow::{bail, Result};
 use winapi::um::memoryapi::{VirtualAlloc, VirtualFree};
 use winapi::um::winnt::{MEM_COMMIT, MEM_DECOMMIT, PAGE_READWRITE};
@@ -30,18 +31,18 @@ pub fn decommit(addr: *mut u8, len: usize) -> Result<()> {
     Ok(())
 }
 
-pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn commit_memory_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     commit(addr, len)
 }
 
-pub fn decommit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_memory_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len)
 }
 
-pub fn commit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn commit_table_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     commit(addr, len)
 }
 
-pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_table_pages(_backend: PoolingBackend, addr: *mut u8, len: usize) -> Result<()> {
     decommit(addr, len)
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -19,6 +19,7 @@
         clippy::use_self
     )
 )]
+#![cfg_attr(feature = "memfd-allocator", allow(dead_code))]
 
 use std::sync::atomic::AtomicU64;
 
@@ -62,6 +63,14 @@ pub use crate::vmcontext::{
     VMGlobalImport, VMInterrupts, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport,
     VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMTrampoline, ValRaw,
 };
+
+mod module_id;
+pub use module_id::{CompiledModuleId, CompiledModuleIdAllocator};
+
+#[cfg(feature = "memfd-allocator")]
+mod memfd;
+#[cfg(feature = "memfd-allocator")]
+pub use crate::memfd::{MemFdRegistry, ModuleMemFds};
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -48,7 +48,8 @@ pub use crate::instance::{
 };
 #[cfg(feature = "pooling-allocator")]
 pub use crate::instance::{
-    InstanceLimits, ModuleLimits, PoolingAllocationStrategy, PoolingInstanceAllocator,
+    InstanceLimits, ModuleLimits, PoolingAllocationStrategy, PoolingBackend,
+    PoolingInstanceAllocator,
 };
 pub use crate::jit_int::GdbJitImageRegistration;
 pub use crate::memory::{DefaultMemoryCreator, Memory, RuntimeLinearMemory, RuntimeMemoryCreator};

--- a/crates/runtime/src/memfd.rs
+++ b/crates/runtime/src/memfd.rs
@@ -1,0 +1,279 @@
+//! memfd support.
+
+use crate::module_id::CompiledModuleId;
+use anyhow::Result;
+use memfd::{Memfd, MemfdOptions};
+use rustix::fs::FileExt;
+use std::convert::TryFrom;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::{Arc, Mutex},
+};
+use wasmtime_environ::{
+    DefinedMemoryIndex, MemoryInitialization, MemoryInitializer, MemoryPlan, Module, PrimaryMap,
+};
+
+/// A registry of MemFD images.
+pub struct MemFdRegistry {
+    memfds: Mutex<HashMap<CompiledModuleId, Arc<ModuleMemFds>>>,
+}
+
+/// MemFDs containing backing images for certain memories in a module.
+pub struct ModuleMemFds {
+    memories: PrimaryMap<DefinedMemoryIndex, Option<Arc<MemoryMemFd>>>,
+}
+
+const MAX_MEMFD_IMAGE_SIZE: u64 = 1024 * 1024 * 1024; // limit to 1GiB.
+
+impl ModuleMemFds {
+    pub(crate) fn get_memory_image(
+        &self,
+        defined_index: DefinedMemoryIndex,
+    ) -> Option<&Arc<MemoryMemFd>> {
+        self.memories[defined_index].as_ref()
+    }
+}
+
+/// One backing image for one memory.
+#[derive(Debug)]
+pub(crate) struct MemoryMemFd {
+    pub(crate) fd: Memfd,
+    /// Length of image. Note that initial memory size may be larger;
+    /// leading and trailing zeroes are truncated (handled by
+    /// anonymous backing memfd).
+    pub(crate) len: usize,
+    /// Image starts this many bytes into heap space. Note that the
+    /// memfd's offsets are always equal to the heap offsets, so we
+    /// map at an offset into the fd as well. (This simplifies
+    /// construction.)
+    pub(crate) offset: usize,
+}
+
+fn unsupported_initializer(segment: &MemoryInitializer, plan: &MemoryPlan) -> bool {
+    // If the segment has a base that is dynamically determined
+    // (by a global value, which may be a function of an imported
+    // module, for example), then we cannot build a single static
+    // image that is used for every instantiation. So we skip this
+    // memory entirely.
+    if segment.base.is_some() {
+        return true;
+    }
+
+    // Cannot be out-of-bounds. If there is a *possibility* it may
+    // be, then we just fall back on ordinary initialization.
+    if plan.initializer_possibly_out_of_bounds(segment) {
+        return true;
+    }
+
+    // Must fit in our max size.
+    let end = segment.end().expect("must have statically-known end");
+    if end > MAX_MEMFD_IMAGE_SIZE {
+        return true;
+    }
+
+    false
+}
+
+impl MemFdRegistry {
+    /// Create a new MemFD image registry.
+    pub fn new() -> Self {
+        Self {
+            memfds: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get or create MemFD images for a module's memories.
+    pub fn get_or_create(
+        &self,
+        id: CompiledModuleId,
+        module: &Module,
+        wasm_data: &[u8],
+    ) -> Result<Arc<ModuleMemFds>> {
+        // Lock once and check the hashmap; take a clone of the Arc
+        // right away and return it if present.
+        if let Some(memfds) = self.memfds.lock().unwrap().get(&id) {
+            return Ok(memfds.clone());
+        }
+
+        // If not, construct the payload (bundle of MemFds) and try
+        // inserting. If we raced with another instantiation, drop the
+        // thing that we built and just return the one that won
+        // insertion.
+        let memfds = Self::build_memfds(module, wasm_data)?;
+        match self.memfds.lock().unwrap().entry(id) {
+            Entry::Vacant(v) => {
+                v.insert(memfds.clone());
+                Ok(memfds)
+            }
+            Entry::Occupied(o) => {
+                drop(memfds);
+                Ok(o.get().clone())
+            }
+        }
+    }
+
+    /// Remove any cached memfd images for the given module, if present.
+    pub fn remove(&self, id: CompiledModuleId) {
+        self.memfds.lock().unwrap().remove(&id);
+    }
+
+    fn build_memfds(module: &Module, wasm_data: &[u8]) -> Result<Arc<ModuleMemFds>> {
+        let page_size = region::page::size() as u64;
+        let num_defined_memories = module.memory_plans.len() - module.num_imported_memories;
+
+        // Allocate a memfd file initially for every memory. We'll
+        // release those and set `excluded_memories` for those that we
+        // determine during initializer processing we cannot support a
+        // static image (e.g. due to dynamically-located segments).
+        let mut memfds: PrimaryMap<DefinedMemoryIndex, Option<Memfd>> = PrimaryMap::default();
+        let mut sizes: PrimaryMap<DefinedMemoryIndex, u64> = PrimaryMap::default();
+        let mut excluded_memories: PrimaryMap<DefinedMemoryIndex, bool> = PrimaryMap::new();
+
+        for _ in 0..num_defined_memories {
+            memfds.push(None);
+            sizes.push(0);
+            excluded_memories.push(false);
+        }
+
+        fn create_memfd() -> Result<Memfd> {
+            // Create the memfd. It needs a name, but the
+            // documentation for `memfd_create()` says that names can
+            // be duplicated with no issues.
+            MemfdOptions::new()
+                .allow_sealing(true)
+                .create("wasm-memory-image")
+                .map_err(|e| e.into())
+        }
+        let round_up_page = |len: u64| (len + page_size - 1) & !(page_size - 1);
+
+        match &module.memory_initialization {
+            &MemoryInitialization::Segmented(ref segments) => {
+                for (i, segment) in segments.iter().enumerate() {
+                    let defined_memory = match module.defined_memory_index(segment.memory_index) {
+                        Some(defined_memory) => defined_memory,
+                        None => continue,
+                    };
+                    if excluded_memories[defined_memory] {
+                        continue;
+                    }
+
+                    if unsupported_initializer(segment, &module.memory_plans[segment.memory_index])
+                    {
+                        memfds[defined_memory] = None;
+                        excluded_memories[defined_memory] = true;
+                        continue;
+                    }
+
+                    if memfds[defined_memory].is_none() {
+                        memfds[defined_memory] = Some(create_memfd()?);
+                    }
+                    let memfd = memfds[defined_memory].as_mut().unwrap();
+
+                    let end = round_up_page(segment.end().expect("must have statically-known end"));
+                    if end > sizes[defined_memory] {
+                        sizes[defined_memory] = end;
+                        memfd.as_file().set_len(end)?;
+                    }
+
+                    let base = segments[i].offset;
+                    let data = &wasm_data[segment.data.start as usize..segment.data.end as usize];
+                    memfd.as_file().write_at(data, base)?;
+                }
+            }
+            &MemoryInitialization::Paged { ref map, .. } => {
+                for (defined_memory, pages) in map {
+                    let top = pages
+                        .iter()
+                        .map(|(base, range)| *base + range.len() as u64)
+                        .max()
+                        .unwrap_or(0);
+
+                    let memfd = create_memfd()?;
+                    memfd.as_file().set_len(top)?;
+
+                    for (base, range) in pages {
+                        let data = &wasm_data[range.start as usize..range.end as usize];
+                        memfd.as_file().write_at(data, *base)?;
+                    }
+
+                    memfds[defined_memory] = Some(memfd);
+                    sizes[defined_memory] = top;
+                }
+            }
+        }
+
+        // Now finalize each memory.
+        let mut memories: PrimaryMap<DefinedMemoryIndex, Option<Arc<MemoryMemFd>>> =
+            PrimaryMap::default();
+        for (defined_memory, maybe_memfd) in memfds {
+            let memfd = match maybe_memfd {
+                Some(memfd) => memfd,
+                None => {
+                    memories.push(None);
+                    continue;
+                }
+            };
+            let size = sizes[defined_memory];
+
+            // Find leading and trailing zero data so that the mmap
+            // can precisely map only the nonzero data; anon-mmap zero
+            // memory is faster for anything that doesn't actually
+            // have content.
+            let mut page_data = vec![0; page_size as usize];
+            let mut page_is_nonzero = |page| {
+                let offset = page_size * page;
+                memfd.as_file().read_at(&mut page_data[..], offset).unwrap();
+                page_data.iter().any(|byte| *byte != 0)
+            };
+            let n_pages = size / page_size;
+
+            let mut offset = 0;
+            for page in 0..n_pages {
+                if page_is_nonzero(page) {
+                    break;
+                }
+                offset += page_size;
+            }
+            let len = if offset == size {
+                0
+            } else {
+                let mut len = 0;
+                for page in (0..n_pages).rev() {
+                    if page_is_nonzero(page) {
+                        len = (page + 1) * page_size - offset;
+                        break;
+                    }
+                }
+                len
+            };
+
+            // Seal the memfd's data and length.
+            //
+            // This is a defense-in-depth security mitigation. The
+            // memfd will serve as the starting point for the heap of
+            // every instance of this module. If anything were to
+            // write to this, it could affect every execution. The
+            // memfd object itself is owned by the machinery here and
+            // not exposed elsewhere, but it is still an ambient open
+            // file descriptor at the syscall level, so some other
+            // vulnerability that allowed writes to arbitrary fds
+            // could modify it. Or we could have some issue with the
+            // way that we map it into each instance. To be
+            // extra-super-sure that it never changes, and because
+            // this costs very little, we use the kernel's "seal" API
+            // to make the memfd image permanently read-only.
+            memfd.add_seal(memfd::FileSeal::SealGrow)?;
+            memfd.add_seal(memfd::FileSeal::SealShrink)?;
+            memfd.add_seal(memfd::FileSeal::SealWrite)?;
+            memfd.add_seal(memfd::FileSeal::SealSeal)?;
+
+            memories.push(Some(Arc::new(MemoryMemFd {
+                fd: memfd,
+                offset: usize::try_from(offset).unwrap(),
+                len: usize::try_from(len).unwrap(),
+            })));
+        }
+
+        Ok(Arc::new(ModuleMemFds { memories }))
+    }
+}

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -2,6 +2,8 @@
 //!
 //! `RuntimeLinearMemory` is to WebAssembly linear memories what `Table` is to WebAssembly tables.
 
+#[cfg(feature = "memfd-allocator")]
+use crate::instance::MemFdSlot;
 use crate::mmap::Mmap;
 use crate::vmcontext::VMMemoryDefinition;
 use crate::Store;
@@ -208,7 +210,12 @@ pub enum Memory {
         /// A callback which makes portions of `base` accessible for when memory
         /// is grown. Otherwise it's expected that accesses to `base` will
         /// fault.
-        make_accessible: fn(*mut u8, usize) -> Result<()>,
+        make_accessible: Option<fn(*mut u8, usize) -> Result<()>>,
+
+        /// The MemFdSlot, if any, for this memory. Owned here and
+        /// returned to the pooling allocator when termination occurs.
+        #[cfg(feature = "memfd-allocator")]
+        memfd_slot: Option<MemFdSlot>,
 
         /// Stores the pages in the linear memory that have faulted as guard pages when using the `uffd` feature.
         /// These pages need their protection level reset before the memory can grow.
@@ -220,6 +227,9 @@ pub enum Memory {
     /// to this instance.
     Dynamic(Box<dyn RuntimeLinearMemory>),
 }
+
+unsafe impl Send for Memory {}
+unsafe impl Sync for Memory {}
 
 impl Memory {
     /// Create a new dynamic (movable) memory instance for the specified plan.
@@ -253,9 +263,34 @@ impl Memory {
         Ok(Memory::Static {
             base,
             size: minimum,
-            make_accessible,
+            make_accessible: Some(make_accessible),
             #[cfg(all(feature = "uffd", target_os = "linux"))]
             guard_page_faults: Vec::new(),
+            #[cfg(feature = "memfd-allocator")]
+            memfd_slot: None,
+        })
+    }
+
+    /// Create a new static (immovable) memory instance backed by a MemFD.
+    #[cfg(feature = "memfd-allocator")]
+    pub fn new_memfd(
+        plan: &MemoryPlan,
+        base: &'static mut [u8],
+        memfd_slot: MemFdSlot,
+        store: &mut dyn Store,
+    ) -> Result<Self> {
+        let (minimum, maximum) = Self::limit_new(plan, store)?;
+
+        let base = match maximum {
+            Some(max) if max < base.len() => &mut base[..max],
+            _ => base,
+        };
+
+        Ok(Memory::Static {
+            base,
+            size: minimum,
+            make_accessible: None,
+            memfd_slot: Some(memfd_slot),
         })
     }
 
@@ -373,6 +408,29 @@ impl Memory {
         }
     }
 
+    /// Returns whether or not this memory is backed by a MemFD
+    /// image. Note that this is testing whether there is actually an
+    /// *image* mapped, not just whether the MemFD mechanism is being
+    /// used. The distinction is important because if we are not using
+    /// a prevalidated and prepared image, we need to fall back to
+    /// ordinary initialization code.
+    #[cfg(feature = "memfd-allocator")]
+    pub(crate) fn is_memfd_with_image(&self) -> bool {
+        match self {
+            Memory::Static {
+                memfd_slot: Some(ref slot),
+                ..
+            } => slot.image.is_some(),
+            _ => false,
+        }
+    }
+
+    /// Returns whether or not this memory is backed by a MemFD image.
+    #[cfg(not(feature = "memfd-allocator"))]
+    pub(crate) fn is_memfd_with_image(&self) -> bool {
+        false
+    }
+
     /// Grow memory by the specified amount of wasm pages.
     ///
     /// Returns `None` if memory can't be grown by the specified amount
@@ -443,12 +501,34 @@ impl Memory {
         }
 
         match self {
+            #[cfg(feature = "memfd-allocator")]
+            Memory::Static {
+                base,
+                size,
+                memfd_slot: Some(ref mut memfd_slot),
+                ..
+            } => {
+                // Never exceed static memory size
+                if new_byte_size > base.len() {
+                    store.memory_grow_failed(&format_err!("static memory size exceeded"));
+                    return Ok(None);
+                }
+
+                if let Err(e) = memfd_slot.set_heap_limit(new_byte_size) {
+                    store.memory_grow_failed(&e);
+                    return Ok(None);
+                }
+                *size = new_byte_size;
+            }
             Memory::Static {
                 base,
                 size,
                 make_accessible,
                 ..
             } => {
+                let make_accessible = make_accessible
+                    .expect("make_accessible must be Some if this is not a MemFD memory");
+
                 // Never exceed static memory size
                 if new_byte_size > base.len() {
                     store.memory_grow_failed(&format_err!("static memory size exceeded"));
@@ -540,7 +620,9 @@ impl Default for Memory {
         Memory::Static {
             base: &mut [],
             size: 0,
-            make_accessible: |_, _| unreachable!(),
+            make_accessible: Some(|_, _| unreachable!()),
+            #[cfg(feature = "memfd-allocator")]
+            memfd_slot: None,
             #[cfg(all(feature = "uffd", target_os = "linux"))]
             guard_page_faults: Vec::new(),
         }

--- a/crates/runtime/src/module_id.rs
+++ b/crates/runtime/src/module_id.rs
@@ -1,0 +1,28 @@
+//! Unique IDs for modules in the runtime.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A unique identifier (within an engine or similar) for a compiled
+/// module.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CompiledModuleId(u64);
+
+/// An allocator for compiled module IDs.
+pub struct CompiledModuleIdAllocator {
+    next: AtomicU64,
+}
+
+impl CompiledModuleIdAllocator {
+    /// Create a compiled-module ID allocator.
+    pub fn new() -> Self {
+        Self {
+            next: AtomicU64::new(1),
+        }
+    }
+
+    /// Allocate a new ID.
+    pub fn alloc(&self) -> CompiledModuleId {
+        let id = self.next.fetch_add(1, Ordering::Relaxed);
+        CompiledModuleId(id)
+    }
+}

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -51,9 +51,17 @@ pub unsafe fn platform_init() {
         register(&mut PREV_SIGFPE, libc::SIGFPE);
     }
 
-    // On ARM, handle Unaligned Accesses.
-    // On Darwin, guard page accesses are raised as SIGBUS.
-    if cfg!(target_arch = "arm") || cfg!(target_os = "macos") || cfg!(target_os = "freebsd") {
+    // Sometimes we need to handle SIGBUS too:
+    // - On ARM, handle Unaligned Accesses.
+    // - On Darwin, guard page accesses are raised as SIGBUS.
+    // - With the MemFD allocator, heap growth is controlled by
+    //   ftruncate'ing an mmap'd file, and so out-of-bounds accesses
+    //   are raised as SIGBUS.
+    if cfg!(target_arch = "arm")
+        || cfg!(target_os = "macos")
+        || cfg!(target_os = "freebsd")
+        || cfg!(feature = "memfd-allocator")
+    {
         register(&mut PREV_SIGBUS, libc::SIGBUS);
     }
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -89,3 +89,5 @@ all-arch = ["wasmtime-cranelift/all-arch"]
 # It is useful for applications that do not bind their own exception ports and
 # need portable signal handling.
 posix-signals-on-macos = ["wasmtime-runtime/posix-signals-on-macos"]
+
+memfd-allocator = ["wasmtime-runtime/memfd-allocator", "pooling-allocator"]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -90,4 +90,5 @@ all-arch = ["wasmtime-cranelift/all-arch"]
 # need portable signal handling.
 posix-signals-on-macos = ["wasmtime-runtime/posix-signals-on-macos"]
 
+# Enables use of memfd and CoW for efficient instance memories on Linux.
 memfd-allocator = ["wasmtime-runtime/memfd-allocator", "pooling-allocator"]

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -43,6 +43,8 @@ pub enum InstanceAllocationStrategy {
         module_limits: ModuleLimits,
         /// The instance limits to use.
         instance_limits: InstanceLimits,
+        /// The backend (memory allocation strategy) to use.
+        backend: PoolingBackend,
     },
 }
 
@@ -54,6 +56,7 @@ impl InstanceAllocationStrategy {
             strategy: PoolingAllocationStrategy::default(),
             module_limits: ModuleLimits::default(),
             instance_limits: InstanceLimits::default(),
+            backend: PoolingBackend::default(),
         }
     }
 }
@@ -1161,10 +1164,12 @@ impl Config {
                 strategy,
                 module_limits,
                 instance_limits,
+                backend,
             } => Ok(Box::new(wasmtime_runtime::PoolingInstanceAllocator::new(
                 strategy.into(),
                 module_limits.into(),
                 instance_limits.into(),
+                backend.into(),
                 stack_size,
                 &self.tunables,
             )?)),

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -274,7 +274,12 @@ impl<'a> SerializedModule<'a> {
     pub fn into_module(self, engine: &Engine) -> Result<Module> {
         let (main_module, modules, types, upvars) = self.into_parts(engine)?;
         let modules = engine.run_maybe_parallel(modules, |(i, m)| {
-            CompiledModule::from_artifacts(i, m, &*engine.config().profiler)
+            CompiledModule::from_artifacts(
+                i,
+                m,
+                &*engine.config().profiler,
+                engine.unique_id_allocator(),
+            )
         })?;
 
         Module::from_parts(engine, modules, main_module, Arc::new(types), &upvars)

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -421,11 +421,14 @@ impl<T> Store<T> {
                     shared_signatures: None.into(),
                     imports: Default::default(),
                     module: Arc::new(wasmtime_environ::Module::default()),
+                    #[cfg(feature = "memfd-allocator")]
+                    memfds: None,
                     store: StorePtr::empty(),
                     wasm_data: &[],
                 })
                 .expect("failed to allocate default callee")
         };
+
         let mut inner = Box::new(StoreInner {
             inner: StoreOpaque {
                 _marker: marker::PhantomPinned,

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -41,6 +41,8 @@ fn create_handle(
         let handle = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0).allocate(
             InstanceAllocationRequest {
                 module: Arc::new(module),
+                #[cfg(feature = "memfd-allocator")]
+                memfds: None,
                 functions,
                 image_base: 0,
                 imports,

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -161,6 +161,8 @@ pub unsafe fn create_raw_function(
     Ok(
         OnDemandInstanceAllocator::default().allocate(InstanceAllocationRequest {
             module: Arc::new(module),
+            #[cfg(feature = "memfd-allocator")]
+            memfds: None,
             functions: &functions,
             image_base: (*func).as_ptr() as usize,
             imports: Imports::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use wasmtime::{Config, ProfilingStrategy};
 #[cfg(feature = "pooling-allocator")]
-use wasmtime::{InstanceLimits, ModuleLimits, PoolingAllocationStrategy};
+use wasmtime::{InstanceLimits, ModuleLimits, PoolingAllocationStrategy, PoolingBackend};
 
 fn pick_profiling_strategy(jitdump: bool, vtune: bool) -> Result<ProfilingStrategy> {
     Ok(match (jitdump, vtune) {
@@ -346,6 +346,7 @@ impl CommonOptions {
                     strategy: PoolingAllocationStrategy::NextAvailable,
                     module_limits,
                     instance_limits,
+                    backend: PoolingBackend::default(),
                 });
             }
         }

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -431,6 +431,7 @@ fn async_with_pooling_stacks() {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -460,6 +461,7 @@ fn async_host_func_with_pooling_stacks() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);

--- a/tests/all/instance.rs
+++ b/tests/all/instance.rs
@@ -71,6 +71,7 @@ fn linear_memory_limits() -> Result<()> {
                 ..ModuleLimits::default()
             },
             instance_limits: InstanceLimits::default(),
+            backend: PoolingBackend::default(),
         },
     ))?)?;
     return Ok(());

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -362,6 +362,7 @@ fn test_pooling_allocator_initial_limits_exceeded() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        backend: PoolingBackend::default(),
     });
 
     let engine = Engine::new(&config)?;
@@ -735,6 +736,7 @@ fn custom_limiter_detect_grow_failure() -> Result<()> {
         instance_limits: InstanceLimits {
             ..Default::default()
         },
+        backend: PoolingBackend::default(),
     });
     let engine = Engine::new(&config).unwrap();
     let linker = Linker::new(&engine);
@@ -847,6 +849,7 @@ async fn custom_limiter_async_detect_grow_failure() -> Result<()> {
         instance_limits: InstanceLimits {
             ..Default::default()
         },
+        backend: PoolingBackend::default(),
     });
     let engine = Engine::new(&config).unwrap();
     let linker = Linker::new(&engine);

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -198,6 +198,7 @@ fn guards_present_pooling() -> Result<()> {
             ..ModuleLimits::default()
         },
         instance_limits: InstanceLimits { count: 2 },
+        backend: PoolingBackend::default(),
     });
     let engine = Engine::new(&config)?;
 

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -13,6 +13,7 @@ fn successful_instantiation() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -39,6 +40,7 @@ fn memory_limit() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(65536);
@@ -110,6 +112,7 @@ fn memory_init() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        backend: PoolingBackend::default(),
     });
 
     let engine = Engine::new(&config)?;
@@ -146,6 +149,7 @@ fn memory_guard_page_trap() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        backend: PoolingBackend::default(),
     });
 
     let engine = Engine::new(&config)?;
@@ -202,6 +206,7 @@ fn memory_zeroed() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -245,6 +250,7 @@ fn table_limit() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -325,6 +331,7 @@ fn table_init() -> Result<()> {
             count: 1,
             ..Default::default()
         },
+        backend: PoolingBackend::default(),
     });
 
     let engine = Engine::new(&config)?;
@@ -375,6 +382,7 @@ fn table_zeroed() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 1 },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -421,6 +429,7 @@ fn instantiation_limit() -> Result<()> {
         instance_limits: InstanceLimits {
             count: INSTANCE_LIMIT,
         },
+        backend: PoolingBackend::default(),
     });
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
@@ -471,6 +480,7 @@ fn preserve_data_segments() -> Result<()> {
             ..Default::default()
         },
         instance_limits: InstanceLimits { count: 2 },
+        backend: PoolingBackend::default(),
     });
     let engine = Engine::new(&config)?;
     let m = Module::new(

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::{Condvar, Mutex};
 use wasmtime::{
     Config, Engine, InstanceAllocationStrategy, InstanceLimits, ModuleLimits,
-    PoolingAllocationStrategy, Store, Strategy,
+    PoolingAllocationStrategy, PoolingBackend, Store, Strategy,
 };
 use wasmtime_wast::WastContext;
 
@@ -91,6 +91,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
                 count: 450,
                 ..Default::default()
             },
+            backend: PoolingBackend::default(),
         });
         Some(lock_pooling())
     } else {


### PR DESCRIPTION
(Stacked on top of #3697)

Currently, the pooling allocator makes heavy use of compile-time
features to determine its runtime behavior and allocation strategy. This
makes testing harder, and makes runtime configuration from higher levels
of the system impossible.
    
This PR passes a `PoolingBackend` value down from the configuration
plumbing and into the pooling allocator, and uses its value to
dynamically choose a backend instead. This is mostly a matter of lots of
plumbing and conditionals.
    
The most complex part of this PR is actually the testing and feature
setup. We still want the memfd and uffd backends to be optional -- i.e.,
one should be able to build a wasmtime binary without them included.
This implies not including the enum options in the config enum, and
everything down from there.
    
In order to test all possible situations, we actually need to test four
builds -- with neither uffd nor memfd, with just one, or with both. We
also want to test that everything works when different backends are
specified, and the simplest way to do this is just to run the whole test
suite with the default backend set to each possible option. Hence we run
tests with both backends included and the default set three different
ways; with one backend included and the default set to that or the
allback mmap backend; etc.
    
I'm not sure that this is actually the simplest option -- it may, in the
end, be simpler to entirely remove uffd, if we eventually determine that
memfd supersedes it, and then unconditionally include memfd support on
Linux. But it was suggested here [1] to opt for a dynamic approach, so
this PR explores what that would look like!
    
[1] https://github.com/bytecodealliance/wasmtime/pull/3697#discussion_r792246996
