### PR TITLE
Don't copy `VMBuiltinFunctionsArray` into each `VMContext`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -281,10 +281,15 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         let mut mem_flags = ir::MemFlags::trusted();
         mem_flags.set_readonly();
 
+        // Load the base of the array of builtin functions
+        let array_offset = i32::try_from(self.offsets.vmctx_builtin_functions()).unwrap();
+        let array_addr = pos.ins().load(pointer_type, mem_flags, base, array_offset);
+
         // Load the callee address.
-        let body_offset =
-            i32::try_from(self.offsets.vmctx_builtin_function(callee_func_idx)).unwrap();
-        let func_addr = pos.ins().load(pointer_type, mem_flags, base, body_offset);
+        let body_offset = i32::try_from(callee_func_idx.index() * pointer_type.bytes()).unwrap();
+        let func_addr = pos
+            .ins()
+            .load(pointer_type, mem_flags, array_addr, body_offset);
 
         (base, func_addr)
     }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -16,12 +16,12 @@
 //      memories: [VMMemoryDefinition; module.num_defined_memories],
 //      globals: [VMGlobalDefinition; module.num_defined_globals],
 //      anyfuncs: [VMCallerCheckedAnyfunc; module.num_imported_functions + module.num_defined_functions],
-//      builtins: VMBuiltinFunctionsArray,
+//      builtins: *mut VMBuiltinFunctionsArray,
 // }
 
 use crate::{
-    BuiltinFunctionIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex,
-    GlobalIndex, MemoryIndex, Module, TableIndex, TypeIndex,
+    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GlobalIndex, MemoryIndex,
+    Module, TableIndex, TypeIndex,
 };
 use more_asserts::assert_lt;
 use std::convert::TryFrom;
@@ -287,11 +287,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             .unwrap();
         ret.size = ret
             .builtin_functions
-            .checked_add(
-                BuiltinFunctionIndex::builtin_functions_total_number()
-                    .checked_mul(u32::from(ret.pointer_size()))
-                    .unwrap(),
-            )
+            .checked_add(u32::from(ret.pointer_size()))
             .unwrap();
 
         return ret;
@@ -597,7 +593,7 @@ impl<P: PtrSize> VMOffsets<P> {
 
     /// The offset of the builtin functions array.
     #[inline]
-    pub fn vmctx_builtin_functions_begin(&self) -> u32 {
+    pub fn vmctx_builtin_functions(&self) -> u32 {
         self.builtin_functions
     }
 
@@ -738,12 +734,6 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_vmglobal_import_from(&self, index: GlobalIndex) -> u32 {
         self.vmctx_vmglobal_import(index) + u32::from(self.vmglobal_import_from())
-    }
-
-    /// Return the offset to builtin function in `VMBuiltinFunctionsArray` index `index`.
-    #[inline]
-    pub fn vmctx_builtin_function(&self, index: BuiltinFunctionIndex) -> u32 {
-        self.vmctx_builtin_functions_begin() + index.index() * u32::from(self.pointer_size())
     }
 }
 

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -481,10 +481,8 @@ unsafe fn initialize_vmcontext(instance: &mut Instance, req: InstanceAllocationR
     }
 
     // Initialize the built-in functions
-    ptr::write(
-        instance.vmctx_plus_offset(instance.offsets.vmctx_builtin_functions_begin()),
-        VMBuiltinFunctionsArray::initialized(),
-    );
+    *instance.vmctx_plus_offset(instance.offsets.vmctx_builtin_functions()) =
+        VMBuiltinFunctionsArray::new();
 
     // Initialize the imports
     debug_assert_eq!(req.imports.functions.len(), module.num_imported_funcs);

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -482,7 +482,7 @@ unsafe fn initialize_vmcontext(instance: &mut Instance, req: InstanceAllocationR
 
     // Initialize the built-in functions
     *instance.vmctx_plus_offset(instance.offsets.vmctx_builtin_functions()) =
-        VMBuiltinFunctionsArray::new();
+        &VMBuiltinFunctionsArray::INIT;
 
     // Initialize the imports
     debug_assert_eq!(req.imports.functions.len(), module.num_imported_funcs);

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -615,13 +615,9 @@ macro_rules! define_builtin_array {
         }
 
         impl VMBuiltinFunctionsArray {
-            pub fn new() -> &'static Self {
-                static INIT: VMBuiltinFunctionsArray =
-                VMBuiltinFunctionsArray {
-                    $($name: crate::libcalls::$name,)*
-                };
-                &INIT
-            }
+            pub const INIT: VMBuiltinFunctionsArray = VMBuiltinFunctionsArray {
+                $($name: crate::libcalls::$name,)*
+            };
         }
     };
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -9,7 +9,6 @@ use std::marker;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::u32;
-use wasmtime_environ::BuiltinFunctionIndex;
 
 /// An imported function.
 #[derive(Debug, Copy, Clone)]
@@ -594,65 +593,46 @@ mod test_vmcaller_checked_anyfunc {
     }
 }
 
-/// An array that stores addresses of builtin functions. We translate code
-/// to use indirect calls. This way, we don't have to patch the code.
-#[repr(C)]
-pub struct VMBuiltinFunctionsArray {
-    ptrs: [usize; Self::len()],
-}
+macro_rules! define_builtin_array {
+    (
+        $(
+            $( #[$attr:meta] )*
+            $name:ident( $( $param:ident ),* ) -> ( $( $result:ident ),* );
+        )*
+    ) => {
+        /// An array that stores addresses of builtin functions. We translate code
+        /// to use indirect calls. This way, we don't have to patch the code.
+        #[repr(C)]
+        #[allow(unused_parens)]
+        pub struct VMBuiltinFunctionsArray {
+            $(
+                $name: unsafe extern "C" fn(
+                    $(define_builtin_array!(@ty $param)),*
+                ) -> (
+                    $(define_builtin_array!(@ty $result)),*
+                ),
+            )*
+        }
 
-impl VMBuiltinFunctionsArray {
-    pub const fn len() -> usize {
-        BuiltinFunctionIndex::builtin_functions_total_number() as usize
-    }
-
-    pub fn initialized() -> Self {
-        use crate::libcalls::*;
-
-        let mut ptrs = [0; Self::len()];
-
-        ptrs[BuiltinFunctionIndex::memory32_grow().index() as usize] =
-            wasmtime_memory32_grow as usize;
-        ptrs[BuiltinFunctionIndex::table_copy().index() as usize] = wasmtime_table_copy as usize;
-        ptrs[BuiltinFunctionIndex::table_grow_funcref().index() as usize] =
-            wasmtime_table_grow as usize;
-        ptrs[BuiltinFunctionIndex::table_grow_externref().index() as usize] =
-            wasmtime_table_grow as usize;
-        ptrs[BuiltinFunctionIndex::table_init().index() as usize] = wasmtime_table_init as usize;
-        ptrs[BuiltinFunctionIndex::elem_drop().index() as usize] = wasmtime_elem_drop as usize;
-        ptrs[BuiltinFunctionIndex::memory_copy().index() as usize] = wasmtime_memory_copy as usize;
-        ptrs[BuiltinFunctionIndex::memory_fill().index() as usize] = wasmtime_memory_fill as usize;
-        ptrs[BuiltinFunctionIndex::memory_init().index() as usize] = wasmtime_memory_init as usize;
-        ptrs[BuiltinFunctionIndex::data_drop().index() as usize] = wasmtime_data_drop as usize;
-        ptrs[BuiltinFunctionIndex::drop_externref().index() as usize] =
-            wasmtime_drop_externref as usize;
-        ptrs[BuiltinFunctionIndex::activations_table_insert_with_gc().index() as usize] =
-            wasmtime_activations_table_insert_with_gc as usize;
-        ptrs[BuiltinFunctionIndex::externref_global_get().index() as usize] =
-            wasmtime_externref_global_get as usize;
-        ptrs[BuiltinFunctionIndex::externref_global_set().index() as usize] =
-            wasmtime_externref_global_set as usize;
-        ptrs[BuiltinFunctionIndex::table_fill_externref().index() as usize] =
-            wasmtime_table_fill as usize;
-        ptrs[BuiltinFunctionIndex::table_fill_funcref().index() as usize] =
-            wasmtime_table_fill as usize;
-        ptrs[BuiltinFunctionIndex::memory_atomic_notify().index() as usize] =
-            wasmtime_memory_atomic_notify as usize;
-        ptrs[BuiltinFunctionIndex::memory_atomic_wait32().index() as usize] =
-            wasmtime_memory_atomic_wait32 as usize;
-        ptrs[BuiltinFunctionIndex::memory_atomic_wait64().index() as usize] =
-            wasmtime_memory_atomic_wait64 as usize;
-        ptrs[BuiltinFunctionIndex::out_of_gas().index() as usize] = wasmtime_out_of_gas as usize;
-        ptrs[BuiltinFunctionIndex::new_epoch().index() as usize] = wasmtime_new_epoch as usize;
-
-        if cfg!(debug_assertions) {
-            for i in 0..ptrs.len() {
-                debug_assert!(ptrs[i] != 0, "index {} is not initialized", i);
+        impl VMBuiltinFunctionsArray {
+            pub fn new() -> &'static Self {
+                static INIT: VMBuiltinFunctionsArray =
+                VMBuiltinFunctionsArray {
+                    $($name: crate::libcalls::$name,)*
+                };
+                &INIT
             }
         }
-        Self { ptrs }
-    }
+    };
+
+    (@ty i32) => (u32);
+    (@ty i64) => (u64);
+    (@ty reference) => (*mut u8);
+    (@ty pointer) => (*mut u8);
+    (@ty vmctx) => (*mut VMContext);
 }
+
+wasmtime_environ::foreach_builtin_function!(define_builtin_array);
 
 /// The storage for a WebAssembly invocation argument
 ///


### PR DESCRIPTION
This is another PR along the lines of "let's squeeze all possible
performance we can out of instantiation". Before this PR we would copy,
by value, the contents of `VMBuiltinFunctionsArray` into each
`VMContext` allocated. This array of function pointers is modestly-sized
but growing over time as we add various intrinsics. Additionally it's
the exact same for all `VMContext` allocations.

This PR attempts to speed up instantiation slightly by instead storing
an indirection to the function array. This means that calling a builtin
intrinsic is a tad bit slower since it requires two loads instead of one
(one to get the base pointer, another to get the actual address).
Otherwise though `VMContext` initialization is now simply setting one
pointer instead of doing a `memcpy` from one location to another.

With some macro-magic this commit also replaces the previous
implementation with one that's more `const`-friendly which also gets us
compile-time type-checks of libcalls as well as compile-time
verification that all libcalls are defined.

Overall, as with #3739, the win is very modest here. Locally I measured
a speedup from 1.9us to 1.7us taken to instantiate an empty module with
one function. While small at these scales it's still a 10% improvement!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
