### PR TITLE
fix #3749: returns count should count the returns, not the params.

### DIFF
--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -97,7 +97,10 @@ impl WasmFuncType {
     #[inline]
     pub fn new(params: Box<[WasmType]>, returns: Box<[WasmType]>) -> Self {
         let externref_params_count = params.iter().filter(|p| **p == WasmType::ExternRef).count();
-        let externref_returns_count = params.iter().filter(|r| **r == WasmType::ExternRef).count();
+        let externref_returns_count = returns
+            .iter()
+            .filter(|r| **r == WasmType::ExternRef)
+            .count();
         WasmFuncType {
             params,
             externref_params_count,


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
