### PR TITLE
Use is-terminal instead of atty.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.18",
  "libc",
  "winapi",
 ]
@@ -269,9 +269,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c920cce6be66349c19b15f149741ac63a99c62c001eac873011cdea38801e7"
+checksum = "96fbe6525273163d9cfea432d3f3e4edc3a52ec571f5d8ffd7ea0f95f3f3a6e9"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2737eb174c9482c865789a428bfbddfdf284317d466ebbc637eee2e1242bfaa"
+checksum = "f1fc128b736b17903e7cdfa753073bdf27e0c6fce26bc098205128550bfc2eac"
 dependencies = [
  "ambient-authority",
  "errno",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14abeb7657b6740639c7e33534633412643ddc96aa24143e9fe531ab56a23bb"
+checksum = "2d30bc2b78678712bab13bc0260cf6f909c40240ac9f4d0fd53a26c606665195"
 dependencies = [
  "ambient-authority",
  "rand 0.8.3",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9ba199282865f3e3c3e7afc6907a3a27896435e24209e035c8a24d4fbcf43a"
+checksum = "b2b8c96d0db4735e144eeb51e04fb4d6cb2477c47d023822e84a98e5cdf77881"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c472ee35e2073a74a3d882c21745e7db2d573825e2e0a754dbffaeef97f4458"
+checksum = "8b2cc4af777567ad4932df16056906a0bc0c7a7b1e6d7b94e5f7e6cfc648758a"
 dependencies = [
  "cap-std",
  "rand 0.8.3",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbb6ba1f840b5b22fedaa6956ddf2e1e77604e986e23f7238c8ba509ce0bb9f"
+checksum = "8ad739b69f94a64b4e72840ec720ae8f65cc99a72ed979cc196def5821ead5d6"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -1185,9 +1185,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ebf75299c070b6b4da3c9da0be01fee7388fb919fd4e6bad5b4f94923d08f1"
+checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
 dependencies = [
  "io-lifetimes",
  "rustix",
@@ -1320,6 +1320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab7905ea95c6d9af62940f9d7dd9596d54c334ae2c15300c482051292d5637f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.12.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9132d2d6504f4e348b8e16787f01613b4d0e587458641a40e727304416ac8d"
+checksum = "d0c937cc9891c12eaa8c63ad347e4a288364b1328b924886970b47a14ab8f8f8"
 dependencies = [
  "io-lifetimes",
  "winapi",
@@ -1404,10 +1413,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
+checksum = "768dbad422f45f69c8f5ce59c0802e2681aa3e751c5db8217901607bb2bc24dd"
 dependencies = [
+ "libc",
  "winapi",
 ]
 
@@ -1416,6 +1426,18 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+
+[[package]]
+name = "is-terminal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c89a757e762896bdbdfadf2860d0f8b0cea5e363d8cf3e7bdfeb63d1d976352"
+dependencies = [
+ "hermit-abi 0.2.0",
+ "io-lifetimes",
+ "rustix",
+ "winapi",
+]
 
 [[package]]
 name = "is_ci"
@@ -1526,9 +1548,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1559,9 +1581,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.36"
+version = "0.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
+checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
 
 [[package]]
 name = "lock_api"
@@ -1807,7 +1829,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.18",
  "libc",
 ]
 
@@ -2456,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f93a06380ac0b4210538cbb392381faca6f7eba0bedd6c61f2a52514896560"
+checksum = "817cc66bf0c10bfaf7d5291ad6cf9ff7b3428bc76472a6521fce328f6d6c041b"
 dependencies = [
  "bitflags",
  "errno",
@@ -2746,16 +2768,15 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc4f831d868c8fe30ef417d6d6cba0cd8c95688a179c2bb0ce339aee44ffdab"
+checksum = "1e09bb3fb4e02ec4b87e182ea9718fadbc0fa3e50085b40a9af9690572b67f9e"
 dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
  "cap-std",
  "io-lifetimes",
- "rustc_version",
  "rustix",
  "winapi",
  "winx",
@@ -3129,7 +3150,6 @@ version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "atty",
  "cap-fs-ext",
  "cap-rand",
  "cap-std",
@@ -3137,6 +3157,7 @@ dependencies = [
  "fs-set-times",
  "io-extras",
  "io-lifetimes",
+ "is-terminal",
  "lazy_static",
  "rustix",
  "system-interface",
@@ -3788,9 +3809,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54de2ce52a3e5839e129c7859e2b1f581769bbef57c0a2a09a12a5a3a5b3c2a"
+checksum = "08d5973cb8cd94a77d03ad7e23bbe14889cb29805da1cec0e4aff75e21aebded"
 dependencies = [
  "bitflags",
  "io-lifetimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ wasmparser = "0.81.0"
 lazy_static = "1.4.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.22.0"
+cap-std = "0.24.0"
 
 [dev-dependencies]
 wat = "1.0"

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -29,7 +29,7 @@ wat = { version = "1.0.36", optional = true }
 # Optional dependencies for the `wasi` feature
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.22.0", optional = true }
+cap-std = { version = "0.24.0", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache']

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -24,7 +24,7 @@ zstd = { version = "0.9", default-features = false }
 winapi = "0.3.7"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [dev-dependencies]
 filetime = "0.2.7"

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 links = "wasmtime-fiber-shims"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4.8"
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [features]
 jitdump = []

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.38"
 mach = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi", "handleapi"] }

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.37"
-cap-std = "0.22.0"
+cap-std = "0.24.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,12 +22,12 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "=0.33.0" }
 tracing = "0.1.19"
-cap-std = "0.22.0"
-cap-rand = "0.22.0"
+cap-std = "0.24.0"
+cap-rand = "0.24.0"
 bitflags = "1.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,23 +15,23 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "=0.33.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.22.0"
-cap-fs-ext = "0.22.0"
-cap-time-ext = "0.22.0"
-cap-rand = "0.22.0"
-fs-set-times = "0.14.1"
-system-interface = { version = "0.17.0", features = ["cap_std_impls"] }
+cap-std = "0.24.0"
+cap-fs-ext = "0.24.0"
+cap-time-ext = "0.24.0"
+cap-rand = "0.24.0"
+fs-set-times = "0.15.0"
+system-interface = { version = "0.20.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
-io-lifetimes = { version = "0.4.4", default-features = false }
+io-lifetimes = { version = "0.5.0", default-features = false }
+is-terminal = "0.1.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
 lazy_static = "1.4"
-atty = "0.2.14"
-io-extras = "0.12.0"
+io-extras = "0.13.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/crates/wasi-common/cap-std-sync/src/file.rs
+++ b/crates/wasi-common/cap-std-sync/src/file.rs
@@ -1,5 +1,6 @@
 use cap_fs_ext::MetadataExt;
 use fs_set_times::{SetTimes, SystemTimeSpec};
+use is_terminal::IsTerminal;
 use std::any::Any;
 use std::convert::TryInto;
 use std::io;
@@ -125,14 +126,7 @@ impl WasiFile for File {
         Ok(self.0.num_ready_bytes()?)
     }
     fn isatty(&self) -> bool {
-        #[cfg(unix)]
-        {
-            rustix::io::isatty(&self.0)
-        }
-        #[cfg(windows)]
-        {
-            false
-        }
+        self.0.is_terminal()
     }
     async fn readable(&self) -> Result<(), Error> {
         Err(Error::badf())

--- a/crates/wasi-common/cap-std-sync/src/stdio.rs
+++ b/crates/wasi-common/cap-std-sync/src/stdio.rs
@@ -1,6 +1,7 @@
 use crate::file::convert_systimespec;
 use fs_set_times::SetTimes;
 use io_lifetimes::AsFilelike;
+use is_terminal::IsTerminal;
 use std::any::Any;
 use std::convert::TryInto;
 use std::fs::File;
@@ -111,14 +112,7 @@ impl WasiFile for Stdin {
         Ok(self.0.num_ready_bytes()?)
     }
     fn isatty(&self) -> bool {
-        #[cfg(unix)]
-        {
-            rustix::io::isatty(&self.0)
-        }
-        #[cfg(not(unix))]
-        {
-            atty::is(atty::Stream::Stdin)
-        }
+        self.0.is_terminal()
     }
     async fn readable(&self) -> Result<(), Error> {
         Err(Error::badf())
@@ -242,14 +236,7 @@ macro_rules! wasi_file_write_impl {
                 Ok(0)
             }
             fn isatty(&self) -> bool {
-                #[cfg(unix)]
-                {
-                    rustix::io::isatty(&self.0)
-                }
-                #[cfg(not(unix))]
-                {
-                    atty::is(atty::Stream::$ident)
-                }
+                self.0.is_terminal()
             }
             async fn readable(&self) -> Result<(), Error> {
                 Err(Error::badf())

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,20 +15,20 @@ wasi-common = { path = "../", version = "=0.33.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "=0.33.0" }
 wiggle = { path = "../../wiggle", version = "=0.33.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.22.0"
+cap-std = "0.24.0"
 anyhow = "1"
-io-lifetimes = { version = "0.4.4", default-features = false }
+io-lifetimes = { version = "0.5.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.31.0"
+rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
 lazy_static = "1.4"
-io-extras = "0.12.0"
+io-extras = "0.13.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.22.0"
+cap-tempfile = "0.24.0"


### PR DESCRIPTION
Following up on #3696, use the new is-terminal crate to test for a tty
rather than having platform-specific logic in Wasmtime. The is-terminal
crate has a platform-independent API which takes a handle.

This also updates the tree to cap-std 0.24 etc., to avoid depending on
multiple versions of io-lifetimes at once, as enforced by the cargo deny
check.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
