### PR TITLE
Make memfd image creation lazy (on first instantiation).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"
@@ -3377,6 +3377,7 @@ dependencies = [
  "libc",
  "log",
  "object",
+ "once_cell",
  "paste",
  "psm",
  "rayon",

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -37,6 +37,7 @@ lazy_static = "1.4"
 rayon = { version = "1.0", optional = true }
 object = { version = "0.27", default-features = false, features = ['read_core', 'elf'] }
 async-trait = { version = "0.1.51", optional = true }
+once_cell = "1.9"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -690,6 +690,9 @@ impl<'a> Instantiator<'a> {
         // properly referenced while in use by the store.
         store.modules_mut().register(&self.cur.module);
 
+        // Initialize any memfd images now.
+        let memfds = self.cur.module.memfds()?;
+
         unsafe {
             // The first thing we do is issue an instance allocation request
             // to the instance allocator. This, on success, will give us an
@@ -708,7 +711,7 @@ impl<'a> Instantiator<'a> {
                     .allocate(InstanceAllocationRequest {
                         module: compiled_module.module(),
                         unique_id: Some(compiled_module.unique_id()),
-                        memfds: self.cur.module.memfds(),
+                        memfds,
                         image_base: compiled_module.code().as_ptr() as usize,
                         functions: compiled_module.functions(),
                         imports: self.cur.build(),


### PR DESCRIPTION
As a followup to the recent memfd allocator work, this PR makes the
memfd image creation occur on the first instantiation, rather than
immediately when the `Module` is loaded.

This shaves off a potentially surprising cost spike that would have
otherwise occurred: prior to the memfd work, no allocator eagerly read
the module's initial heap state into RAM. The behavior should now more
closely resemble what happened before (and the improvements in overall
instantiation time and performance, as compared to either eager init
with pure-mmap memory or user-mode pagefault handling with uffd,
remain).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
