### PR TITLE
Fix MemFd's allocated memory for dynamic memories

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -405,6 +405,7 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
 ///
 /// Ensures that spec tests pass regardless of the `Config`.
 pub fn spectest(mut fuzz_config: generators::Config, test: generators::SpecTest) {
+    crate::init_fuzzing();
     fuzz_config.module_config.set_spectest_compliant();
     log::debug!("running {:?} with {:?}", test.file, fuzz_config);
     let mut wast_context = WastContext::new(fuzz_config.to_store());

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -159,7 +159,11 @@ impl MmapMemory {
         let memfd = match memfd_image {
             Some(image) => {
                 let base = unsafe { mmap.as_mut_ptr().add(pre_guard_bytes) };
-                let mut memfd_slot = MemFdSlot::create(base.cast(), minimum, alloc_bytes);
+                let mut memfd_slot = MemFdSlot::create(
+                    base.cast(),
+                    minimum,
+                    alloc_bytes + extra_to_reserve_on_growth,
+                );
                 memfd_slot.instantiate(minimum, Some(image))?;
                 // On drop, we will unmap our mmap'd range that this
                 // memfd_slot was mapped on top of, so there is no


### PR DESCRIPTION
This fixes a bug in the memfd-related management of a linear memory
where for dynamic memories memfd wasn't informed of the extra room that
the dynamic memory could grow into, only the actual size of linear
memory, which ended up tripping an assert once the memory was grown. The
fix here is pretty simple which is to factor in this extra space when
passing the allocation size to the creation of the `MemFdSlot`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
