### PR TITLE
ISLE: emit traps as safepoints on x64

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1461,9 +1461,9 @@
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (trap code))
-      (value_regs_none (ud2 code)))
+      (safepoint (ud2 code)))
 
 ;;;; Rules for `resumable_trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (resumable_trap code))
-      (value_regs_none (ud2 code)))
+      (safepoint (ud2 code)))

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -233,8 +233,12 @@ where
         }
     }
 
-    fn emit_safepoint(&mut self, _inst: &MInst) -> Unit {
-        unimplemented!();
+    fn emit_safepoint(&mut self, inst: &MInst) -> Unit {
+        use crate::machinst::MachInst;
+        for inst in inst.clone().mov_mitosis() {
+            let is_safepoint = !inst.is_move().is_some();
+            self.emitted_insts.push((inst, is_safepoint));
+        }
     }
 
     #[inline]

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle 6aaf8ce0f5a5c2ec
 src/isa/x64/inst.isle 7513533d16948249
-src/isa/x64/lower.isle ccda13e9fe83c89a
+src/isa/x64/lower.isle 976ac116c5fcfa16

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
@@ -2993,13 +2993,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 &Opcode::Trap => {
                     // Rule at src/isa/x64/lower.isle line 1463.
                     let expr0_0 = constructor_ud2(ctx, &pattern2_1)?;
-                    let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                    let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::ResumableTrap => {
                     // Rule at src/isa/x64/lower.isle line 1468.
                     let expr0_0 = constructor_ud2(ctx, &pattern2_1)?;
-                    let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                    let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 _ => {}


### PR DESCRIPTION
This adds support for emitting safepoints from ISLE on x64 and makes traps safepoints, just like they used to be before they were ported to ISLE in 658c5d33c.

This doesn't actually affect Wasmtime at all, since Wasmtime never uses resumable traps, and we unwind the stack for regular traps, meaning that we never inspect the safepoint's spill slots. But maybe other Cranelift users rely on traps being safepoints, so best to keep the old behavior given that we don't have a strong reason to change it.