### PR TITLE
Pooling allocator: Default for allocation policy should use memfd feature, not memfd-allocator.

### DIFF
--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -259,14 +259,12 @@ pub enum PoolingAllocationStrategy {
 }
 
 impl Default for PoolingAllocationStrategy {
-    #[cfg(feature = "memfd-allocator")]
     fn default() -> Self {
-        Self::ReuseAffinity
-    }
-
-    #[cfg(not(feature = "memfd-allocator"))]
-    fn default() -> Self {
-        Self::NextAvailable
+        if cfg!(memfd) {
+            Self::ReuseAffinity
+        } else {
+            Self::NextAvailable
+        }
     }
 }
 


### PR DESCRIPTION
Thanks to @peterheune for noticing this!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
