### PR TITLE
Update memfd support with a runtime toggle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ default = [
   "wasmtime/parallel-compilation",
   "wasi-nn",
   "pooling-allocator",
+  "memfd",
 ]
 jitdump = ["wasmtime/jitdump"]
 vtune = ["wasmtime/vtune"]

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -61,6 +61,7 @@ pub struct WasmtimeConfig {
     pub(crate) consume_fuel: bool,
     memory_config: MemoryConfig,
     force_jump_veneers: bool,
+    memfd: bool,
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, Hash, PartialEq)]
@@ -99,7 +100,8 @@ impl Config {
             .cranelift_nan_canonicalization(self.wasmtime.canonicalize_nans)
             .cranelift_opt_level(self.wasmtime.opt_level.to_wasmtime())
             .interruptable(self.wasmtime.interruptable)
-            .consume_fuel(self.wasmtime.consume_fuel);
+            .consume_fuel(self.wasmtime.consume_fuel)
+            .memfd(self.wasmtime.memfd);
 
         // If the wasm-smith-generated module use nan canonicalization then we
         // don't need to enable it, but if it doesn't enable it already then we

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -51,7 +51,16 @@ wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ['async', 'cache', 'wat', 'jitdump', 'parallel-compilation', 'cranelift', 'pooling-allocator']
+default = [
+  'async',
+  'cache',
+  'wat',
+  'jitdump',
+  'parallel-compilation',
+  'cranelift',
+  'pooling-allocator',
+  'memfd',
+]
 
 # An on-by-default feature enabling runtime compilation of WebAssembly modules
 # with the Cranelift compiler. Cranelift is the default compilation backend of

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -275,6 +275,21 @@
 //!   all architectures for both the JIT compiler and the `wasmtime compile` CLI
 //!   command.
 //!
+//! * `pooling-allocator` - Enabled by default, this feature adds support for
+//!   the pooling allocation strategy enabled via
+//!   [`Config::allocation_strategy`]. The pooling allocator can enable more
+//!   efficient reuse of resources for high-concurrency and
+//!   high-instantiation-count scenarios.
+//!
+//! * `memfd` - Enabled by default, this feature builds in support for a
+//!   Linux-specific feature of creating a `memfd` where applicable for a
+//!   [`Module`]'s initial memory. This makes instantiation much faster by
+//!   `mmap`-ing the initial memory image into place instead of copying memory
+//!   into place, allowing sharing pages that end up only getting read and
+//!   otherwise using copy-on-write for efficient initialization of memory. Note
+//!   that this is simply compile-time support and this must also be enabled at
+//!   run-time via [`Config::memfd`].
+//!
 //! ## Examples
 //!
 //! In addition to the examples below be sure to check out the [online embedding

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -724,6 +724,9 @@ impl Module {
     }
 
     pub(crate) fn memfds(&self) -> Result<Option<&Arc<ModuleMemFds>>> {
+        if !self.engine().config().memfd {
+            return Ok(None);
+        }
         Ok(self
             .inner
             .memfds


### PR DESCRIPTION
This commit updates the `memfd` support in Wasmtime to have a runtime
toggle as to whether it's used or not. The compile-time feature gating
`memfd` support is now also re-enabled by default, but the new runtime
switch is still disabled-by-default.

Additionally this commit updates our fuzz oracle to turn on/off the
memfd flag to re-enable fuzzing with memfd on oss-fuzz.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
