### PR TITLE
Add the instance allocation strategy to generated fuzzing configs. 

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -97,22 +97,26 @@ impl ModuleLimits {
 
 impl<'a> Arbitrary<'a> for ModuleLimits {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        const MAXIMUM: u32 = 1000;
+        const MAX_IMPORTS: u32 = 1000;
+        const MAX_TYPES: u32 = 1000;
+        const MAX_FUNCTIONS: u32 = 1000;
         const MAX_TABLES: u32 = 10;
         const MAX_MEMORIES: u32 = 10;
+        const MAX_GLOBALS: u32 = 1000;
+        const MAX_ELEMENTS: u32 = 1000;
         const MAX_MEMORY_PAGES: u64 = 65536;
 
         Ok(Self {
-            imported_functions: u.int_in_range(0..=MAXIMUM)?,
-            imported_tables: u.int_in_range(0..=MAXIMUM)?,
-            imported_memories: u.int_in_range(0..=MAXIMUM)?,
-            imported_globals: u.int_in_range(0..=MAXIMUM)?,
-            types: u.int_in_range(0..=MAXIMUM)?,
-            functions: u.int_in_range(0..=MAXIMUM)?,
+            imported_functions: u.int_in_range(0..=MAX_IMPORTS)?,
+            imported_tables: u.int_in_range(0..=MAX_IMPORTS)?,
+            imported_memories: u.int_in_range(0..=MAX_IMPORTS)?,
+            imported_globals: u.int_in_range(0..=MAX_IMPORTS)?,
+            types: u.int_in_range(0..=MAX_TYPES)?,
+            functions: u.int_in_range(0..=MAX_FUNCTIONS)?,
             tables: u.int_in_range(0..=MAX_TABLES)?,
             memories: u.int_in_range(0..=MAX_MEMORIES)?,
-            globals: u.int_in_range(0..=MAXIMUM)?,
-            table_elements: u.int_in_range(0..=MAXIMUM)?,
+            globals: u.int_in_range(0..=MAX_GLOBALS)?,
+            table_elements: u.int_in_range(0..=MAX_ELEMENTS)?,
             memory_pages: u.int_in_range(0..=MAX_MEMORY_PAGES)?,
         })
     }
@@ -132,10 +136,10 @@ impl InstanceLimits {
 
 impl<'a> Arbitrary<'a> for InstanceLimits {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        const MAXIMUM: u32 = 100;
+        const MAX_COUNT: u32 = 100;
 
         Ok(Self {
-            count: u.int_in_range(1..=MAXIMUM)?,
+            count: u.int_in_range(1..=MAX_COUNT)?,
         })
     }
 }

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -229,6 +229,10 @@ impl<'a> Arbitrary<'a> for Config {
             cfg.max_memories = limits.memories as usize;
             cfg.max_tables = limits.tables as usize;
             cfg.max_memory_pages = limits.memory_pages;
+
+            // Force no aliases in any generated modules as they might count against the
+            // import limits above.
+            cfg.max_aliases = 0;
         }
 
         // Constrain memory limits to 32-bit values

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -14,6 +14,7 @@ pub mod dummy;
 
 use crate::generators;
 use anyhow::Context;
+use arbitrary::Arbitrary;
 use log::{debug, warn};
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::{Arc, Condvar, Mutex};
@@ -142,27 +143,107 @@ pub fn instantiate(wasm: &[u8], known_valid: bool, config: &generators::Config, 
         Timeout::None => {}
     }
 
-    log_wasm(wasm);
-    let module = match config.compile(store.engine(), wasm) {
-        Ok(module) => module,
-        Err(_) if !known_valid => return,
+    if let Some(module) = compile_module(store.engine(), wasm, known_valid, config) {
+        instantiate_with_dummy(&mut store, &module);
+    }
+}
+
+/// Represents supported commands to the `instantiate_many` function.
+#[derive(Arbitrary, Debug)]
+pub enum Command {
+    /// Instantiates a module.
+    ///
+    /// The value is the index of the module to instantiate.
+    ///
+    /// The module instantiated will be this value modulo the number of modules provided to `instantiate_many`.
+    Instantiate(usize),
+    /// Terminates a "running" instance.
+    ///
+    /// The value is the index of the instance to terminate.
+    ///
+    /// The instance terminated will be this value modulo the number of currently running
+    /// instances.
+    ///
+    /// If no instances are running, the command will be ignored.
+    Terminate(usize),
+}
+
+/// Instantiates many instances from the given modules.
+///
+/// The engine will be configured using the provided config.
+///
+/// The modules are expected to *not* have start functions as no timeouts are configured.
+pub fn instantiate_many(
+    modules: &[Vec<u8>],
+    known_valid: bool,
+    config: &generators::Config,
+    commands: &[Command],
+) {
+    assert!(!config.module_config.config.allow_start_export);
+
+    let engine = Engine::new(&config.to_wasmtime()).unwrap();
+
+    let modules = modules
+        .iter()
+        .filter_map(|bytes| compile_module(&engine, bytes, known_valid, config))
+        .collect::<Vec<_>>();
+
+    // If no modules were valid, we're done
+    if modules.is_empty() {
+        return;
+    }
+
+    // This stores every `Store` where a successful instantiation takes place
+    let mut stores = Vec::new();
+
+    for command in commands {
+        match command {
+            Command::Instantiate(index) => {
+                let module = &modules[*index % modules.len()];
+                let mut store = Store::new(&engine, StoreLimits::new());
+                config.configure_store(&mut store);
+
+                if instantiate_with_dummy(&mut store, module).is_some() {
+                    stores.push(Some(store));
+                }
+            }
+            Command::Terminate(index) => {
+                if stores.is_empty() {
+                    continue;
+                }
+
+                stores.swap_remove(*index % stores.len());
+            }
+        }
+    }
+}
+
+fn compile_module(
+    engine: &Engine,
+    bytes: &[u8],
+    known_valid: bool,
+    config: &generators::Config,
+) -> Option<Module> {
+    log_wasm(bytes);
+    match config.compile(engine, bytes) {
+        Ok(module) => Some(module),
+        Err(_) if !known_valid => None,
         Err(e) => {
             if let generators::InstanceAllocationStrategy::Pooling { .. } =
                 &config.wasmtime.strategy
             {
                 // When using the pooling allocator, accept failures to compile when arbitrary
-                // limits have been exceeded.
+                // table element limits have been exceeded as there is currently no way
+                // to constrain the generated module table types.
                 let string = e.to_string();
-                if string.contains("exceeds the limit of") {
-                    return;
+                if string.contains("minimum element size") {
+                    return None;
                 }
             }
 
             panic!("failed to compile module: {:?}", e);
         }
-    };
-
-    instantiate_with_dummy(&mut store, &module);
+    }
 }
 
 fn instantiate_with_dummy(store: &mut Store<StoreLimits>, module: &Module) -> Option<Instance> {
@@ -201,8 +282,13 @@ fn instantiate_with_dummy(store: &mut Store<StoreLimits>, module: &Module) -> Op
         return None;
     }
 
+    // Also allow failures to instantiate as a result of hitting instance limits
+    if string.contains("concurrent instances has been reached") {
+        return None;
+    }
+
     // Everything else should be a bug in the fuzzer or a bug in wasmtime
-    panic!("failed to instantiate {:?}", e);
+    panic!("failed to instantiate: {:?}", e);
 }
 
 /// Instantiate the given Wasm module with each `Config` and call all of its

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -91,3 +91,9 @@ name = "cranelift-fuzzgen-verify"
 path = "fuzz_targets/cranelift-fuzzgen-verify.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "instantiate-many"
+path = "fuzz_targets/instantiate-many.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/instantiate-many.rs
+++ b/fuzz/fuzz_targets/instantiate-many.rs
@@ -1,0 +1,54 @@
+//! This fuzz target is used to test multiple concurrent instantiations from
+//! multiple modules.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{Result, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use wasmtime_fuzzing::{generators, oracles};
+
+const MAX_MODULES: usize = 5;
+
+fuzz_target!(|data: &[u8]| {
+    // errors in `run` have to do with not enough input in `data`, which we
+    // ignore here since it doesn't affect how we'd like to fuzz.
+    drop(run(data));
+});
+
+fn run(data: &[u8]) -> Result<()> {
+    let mut u = Unstructured::new(data);
+    let mut config: generators::Config = u.arbitrary()?;
+
+    // Don't generate start functions
+    // No wasm code execution is necessary for this fuzz target and thus we don't
+    // use timeouts or ensure that the generated wasm code will terminate.
+    config.module_config.config.allow_start_export = false;
+
+    // Create the modules to instantiate
+    let modules = (0..u.int_in_range(1..=MAX_MODULES)?)
+        .map(|_| Ok(config.module_config.generate(&mut u)?.to_bytes()))
+        .collect::<Result<Vec<_>>>()?;
+
+    let max_instances = match &config.wasmtime.strategy {
+        generators::InstanceAllocationStrategy::OnDemand => u.int_in_range(1..=100)?,
+        generators::InstanceAllocationStrategy::Pooling {
+            instance_limits, ..
+        } => instance_limits.count,
+    };
+
+    // Front-load with instantiation commands
+    let mut commands: Vec<oracles::Command> = (0..u.int_in_range(1..=max_instances)?)
+        .map(|_| Ok(oracles::Command::Instantiate(u.arbitrary()?)))
+        .collect::<Result<_>>()?;
+
+    // Then add some more arbitrary commands
+    commands.extend(
+        (0..u.int_in_range(0..=2 * max_instances)?)
+            .map(|_| u.arbitrary())
+            .collect::<Result<Vec<_>>>()?,
+    );
+
+    oracles::instantiate_many(&modules, true, &config, &commands);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support for generating configs with arbitrary instance
allocation strategies.

With this, the pooling allocator will be fuzzed as part of the existing fuzz
targets and also with the new `instantiate-many` fuzz target.