### PR TITLE
[RFC] ISLE: Lowering of multi-output instructions

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2,7 +2,7 @@
 
 ;; The main lowering constructor term: takes a clif `Inst` and returns the
 ;; register(s) within which the lowered instruction's result values live.
-(decl lower (Inst) ValueRegs)
+(decl lower (Inst) InstOutput)
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 8bf92e18323e7041
+src/prelude.isle 957023853b23dacb
 src/isa/aarch64/inst.isle 3678d0a37bdb4cff
-src/isa/aarch64/lower.isle 1bc1f817a4721801
+src/isa/aarch64/lower.isle 90accbfcadaea46d

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
@@ -25,6 +25,12 @@ pub trait Context {
     fn value_reg(&mut self, arg0: Reg) -> ValueRegs;
     fn value_regs(&mut self, arg0: Reg, arg1: Reg) -> ValueRegs;
     fn value_regs_invalid(&mut self) -> ValueRegs;
+    fn output_none(&mut self) -> InstOutput;
+    fn output(&mut self, arg0: ValueRegs) -> InstOutput;
+    fn output_pair(&mut self, arg0: ValueRegs, arg1: ValueRegs) -> InstOutput;
+    fn output_builder_new(&mut self) -> InstOutputBuilder;
+    fn output_builder_push(&mut self, arg0: &InstOutputBuilder, arg1: ValueRegs) -> Unit;
+    fn output_builder_finish(&mut self, arg0: &InstOutputBuilder) -> InstOutput;
     fn temp_writable_reg(&mut self, arg0: Type) -> WritableReg;
     fn invalid_reg(&mut self) -> Reg;
     fn put_in_reg(&mut self, arg0: Value) -> Reg;
@@ -102,13 +108,13 @@ pub trait Context {
     fn rotr_opposite_amount(&mut self, arg0: Type, arg1: ImmShift) -> ImmShift;
 }
 
-/// Internal type SideEffectNoResult: defined at src/prelude.isle line 308.
+/// Internal type SideEffectNoResult: defined at src/prelude.isle line 345.
 #[derive(Clone, Debug)]
 pub enum SideEffectNoResult {
     Inst { inst: MInst },
 }
 
-/// Internal type ProducesFlags: defined at src/prelude.isle line 330.
+/// Internal type ProducesFlags: defined at src/prelude.isle line 367.
 #[derive(Clone, Debug)]
 pub enum ProducesFlags {
     ProducesFlagsSideEffect { inst: MInst },
@@ -116,7 +122,7 @@ pub enum ProducesFlags {
     ProducesFlagsReturnsResultWithConsumer { inst: MInst, result: Reg },
 }
 
-/// Internal type ConsumesFlags: defined at src/prelude.isle line 341.
+/// Internal type ConsumesFlags: defined at src/prelude.isle line 378.
 #[derive(Clone, Debug)]
 pub enum ConsumesFlags {
     ConsumesFlagsReturnsResultWithProducer {
@@ -995,10 +1001,28 @@ pub enum AtomicRMWOp {
     Umin,
 }
 
+// Generated as internal constructor for term output_reg.
+pub fn constructor_output_reg<C: Context>(ctx: &mut C, arg0: Reg) -> Option<InstOutput> {
+    let pattern0_0 = arg0;
+    // Rule at src/prelude.isle line 86.
+    let expr0_0 = C::value_reg(ctx, pattern0_0);
+    let expr1_0 = C::output(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term output_value.
+pub fn constructor_output_value<C: Context>(ctx: &mut C, arg0: Value) -> Option<InstOutput> {
+    let pattern0_0 = arg0;
+    // Rule at src/prelude.isle line 90.
+    let expr0_0 = C::put_in_regs(ctx, pattern0_0);
+    let expr1_0 = C::output(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
 // Generated as internal constructor for term temp_reg.
 pub fn constructor_temp_reg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/prelude.isle line 73.
+    // Rule at src/prelude.isle line 110.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -1007,26 +1031,26 @@ pub fn constructor_temp_reg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Reg> 
 // Generated as internal constructor for term lo_reg.
 pub fn constructor_lo_reg<C: Context>(ctx: &mut C, arg0: Value) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/prelude.isle line 108.
+    // Rule at src/prelude.isle line 145.
     let expr0_0 = C::put_in_regs(ctx, pattern0_0);
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term value_regs_none.
-pub fn constructor_value_regs_none<C: Context>(
+// Generated as internal constructor for term side_effect.
+pub fn constructor_side_effect<C: Context>(
     ctx: &mut C,
     arg0: &SideEffectNoResult,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     if let &SideEffectNoResult::Inst {
         inst: ref pattern1_0,
     } = pattern0_0
     {
-        // Rule at src/prelude.isle line 313.
+        // Rule at src/prelude.isle line 350.
         let expr0_0 = C::emit(ctx, pattern1_0);
-        let expr1_0 = C::value_regs_invalid(ctx);
+        let expr1_0 = C::output_none(ctx);
         return Some(expr1_0);
     }
     return None;
@@ -1036,15 +1060,15 @@ pub fn constructor_value_regs_none<C: Context>(
 pub fn constructor_safepoint<C: Context>(
     ctx: &mut C,
     arg0: &SideEffectNoResult,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     if let &SideEffectNoResult::Inst {
         inst: ref pattern1_0,
     } = pattern0_0
     {
-        // Rule at src/prelude.isle line 319.
+        // Rule at src/prelude.isle line 356.
         let expr0_0 = C::emit_safepoint(ctx, pattern1_0);
-        let expr1_0 = C::value_regs_invalid(ctx);
+        let expr1_0 = C::output_none(ctx);
         return Some(expr1_0);
     }
     return None;
@@ -1068,7 +1092,7 @@ pub fn constructor_consumes_flags_concat<C: Context>(
             result: pattern3_1,
         } = pattern2_0
         {
-            // Rule at src/prelude.isle line 353.
+            // Rule at src/prelude.isle line 390.
             let expr0_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
             let expr1_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
                 inst1: pattern1_0.clone(),
@@ -1098,7 +1122,7 @@ pub fn constructor_with_flags<C: Context>(
                     inst: ref pattern3_0,
                     result: pattern3_1,
                 } => {
-                    // Rule at src/prelude.isle line 378.
+                    // Rule at src/prelude.isle line 415.
                     let expr0_0 = C::emit(ctx, pattern1_0);
                     let expr1_0 = C::emit(ctx, pattern3_0);
                     let expr2_0 = C::value_reg(ctx, pattern3_1);
@@ -1109,7 +1133,7 @@ pub fn constructor_with_flags<C: Context>(
                     inst2: ref pattern3_1,
                     result: pattern3_2,
                 } => {
-                    // Rule at src/prelude.isle line 384.
+                    // Rule at src/prelude.isle line 421.
                     let expr0_0 = C::emit(ctx, pattern1_0);
                     let expr1_0 = C::emit(ctx, pattern3_1);
                     let expr2_0 = C::emit(ctx, pattern3_0);
@@ -1128,7 +1152,7 @@ pub fn constructor_with_flags<C: Context>(
                 result: pattern3_1,
             } = pattern2_0
             {
-                // Rule at src/prelude.isle line 372.
+                // Rule at src/prelude.isle line 409.
                 let expr0_0 = C::emit(ctx, pattern1_0);
                 let expr1_0 = C::emit(ctx, pattern3_0);
                 let expr2_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
@@ -1148,7 +1172,7 @@ pub fn constructor_with_flags_reg<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/prelude.isle line 397.
+    // Rule at src/prelude.isle line 434.
     let expr0_0 = constructor_with_flags(ctx, pattern0_0, pattern1_0)?;
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -3409,7 +3433,7 @@ pub fn constructor_i128_alu_bitop<C: Context>(
 }
 
 // Generated as internal constructor for term lower.
-pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueRegs> {
+pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::first_result(ctx, pattern0_0) {
         let pattern2_0 = C::value_type(ctx, pattern1_0);
@@ -3430,7 +3454,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr4_0: u8 = 24;
                         let expr5_0 = C::imm_shift_from_u8(ctx, expr4_0);
                         let expr6_0 = constructor_lsr_imm(ctx, expr0_0, expr3_0, expr5_0)?;
-                        let expr7_0 = C::value_reg(ctx, expr6_0);
+                        let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                         return Some(expr7_0);
                     }
                     &Opcode::Clz => {
@@ -3442,7 +3466,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr4_0: u8 = 24;
                         let expr5_0 = C::u8_into_imm12(ctx, expr4_0);
                         let expr6_0 = constructor_sub_imm(ctx, expr0_0, expr3_0, expr5_0)?;
-                        let expr7_0 = C::value_reg(ctx, expr6_0);
+                        let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                         return Some(expr7_0);
                     }
                     &Opcode::Cls => {
@@ -3454,7 +3478,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr4_0: u8 = 24;
                         let expr5_0 = C::u8_into_imm12(ctx, expr4_0);
                         let expr6_0 = constructor_sub_imm(ctx, expr0_0, expr3_0, expr5_0)?;
-                        let expr7_0 = C::value_reg(ctx, expr6_0);
+                        let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                         return Some(expr7_0);
                     }
                     &Opcode::Ctz => {
@@ -3469,7 +3493,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr7_0 = C::u64_into_imm_logic(ctx, expr5_0, expr6_0);
                         let expr8_0 = constructor_orr_imm(ctx, expr1_0, expr4_0, expr7_0)?;
                         let expr9_0 = constructor_a64_clz(ctx, expr0_0, expr8_0)?;
-                        let expr10_0 = C::value_reg(ctx, expr9_0);
+                        let expr10_0 = constructor_output_reg(ctx, expr9_0)?;
                         return Some(expr10_0);
                     }
                     &Opcode::Popcnt => {
@@ -3482,7 +3506,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr5_0: u8 = 0;
                         let expr6_0 = VectorSize::Size8x16;
                         let expr7_0 = constructor_mov_from_vec(ctx, expr4_0, expr5_0, &expr6_0)?;
-                        let expr8_0 = C::value_reg(ctx, expr7_0);
+                        let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                         return Some(expr8_0);
                     }
                     _ => {}
@@ -3506,7 +3530,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr4_0: u8 = 16;
                         let expr5_0 = C::imm_shift_from_u8(ctx, expr4_0);
                         let expr6_0 = constructor_lsr_imm(ctx, expr0_0, expr3_0, expr5_0)?;
-                        let expr7_0 = C::value_reg(ctx, expr6_0);
+                        let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                         return Some(expr7_0);
                     }
                     &Opcode::Clz => {
@@ -3518,7 +3542,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr4_0: u8 = 16;
                         let expr5_0 = C::u8_into_imm12(ctx, expr4_0);
                         let expr6_0 = constructor_sub_imm(ctx, expr0_0, expr3_0, expr5_0)?;
-                        let expr7_0 = C::value_reg(ctx, expr6_0);
+                        let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                         return Some(expr7_0);
                     }
                     &Opcode::Cls => {
@@ -3530,7 +3554,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr4_0: u8 = 16;
                         let expr5_0 = C::u8_into_imm12(ctx, expr4_0);
                         let expr6_0 = constructor_sub_imm(ctx, expr0_0, expr3_0, expr5_0)?;
-                        let expr7_0 = C::value_reg(ctx, expr6_0);
+                        let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                         return Some(expr7_0);
                     }
                     &Opcode::Ctz => {
@@ -3545,7 +3569,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr7_0 = C::u64_into_imm_logic(ctx, expr5_0, expr6_0);
                         let expr8_0 = constructor_orr_imm(ctx, expr1_0, expr4_0, expr7_0)?;
                         let expr9_0 = constructor_a64_clz(ctx, expr0_0, expr8_0)?;
-                        let expr10_0 = C::value_reg(ctx, expr9_0);
+                        let expr10_0 = constructor_output_reg(ctx, expr9_0)?;
                         return Some(expr10_0);
                     }
                     &Opcode::Popcnt => {
@@ -3560,7 +3584,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr7_0: u8 = 0;
                         let expr8_0 = VectorSize::Size8x16;
                         let expr9_0 = constructor_mov_from_vec(ctx, expr6_0, expr7_0, &expr8_0)?;
-                        let expr10_0 = C::value_reg(ctx, expr9_0);
+                        let expr10_0 = constructor_output_reg(ctx, expr9_0)?;
                         return Some(expr10_0);
                     }
                     _ => {}
@@ -3604,7 +3628,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr4_0 = constructor_a64_rotr_imm(
                                                     ctx, expr0_0, expr1_0, expr3_0,
                                                 )?;
-                                                let expr5_0 = C::value_reg(ctx, expr4_0);
+                                                let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                                                 return Some(expr5_0);
                                             }
                                         }
@@ -3619,7 +3643,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: Type = I32;
                             let expr5_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr6_0 = constructor_a64_rotr(ctx, expr4_0, expr5_0, expr3_0)?;
-                            let expr7_0 = C::value_reg(ctx, expr6_0);
+                            let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                             return Some(expr7_0);
                         }
                         &Opcode::Rotr => {
@@ -3651,7 +3675,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr1_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -3663,7 +3687,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr3_0 = constructor_a64_rotr(ctx, expr0_0, expr1_0, expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -3685,7 +3709,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr7_0: u8 = 0;
                         let expr8_0 = VectorSize::Size8x16;
                         let expr9_0 = constructor_mov_from_vec(ctx, expr6_0, expr7_0, &expr8_0)?;
-                        let expr10_0 = C::value_reg(ctx, expr9_0);
+                        let expr10_0 = constructor_output_reg(ctx, expr9_0)?;
                         return Some(expr10_0);
                     }
                 }
@@ -3707,7 +3731,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr3_0 = constructor_umulh(ctx, expr0_0, expr1_0, expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Smulhi => {
@@ -3717,7 +3741,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr3_0 = constructor_smulh(ctx, expr0_0, expr1_0, expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Band => {
@@ -3728,7 +3752,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bor => {
@@ -3739,7 +3763,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
@@ -3750,7 +3774,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::BandNot => {
@@ -3761,7 +3785,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_alu_rs_imm_logic(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::BorNot => {
@@ -3772,7 +3796,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_alu_rs_imm_logic(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::BxorNot => {
@@ -3783,7 +3807,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_alu_rs_imm_logic(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Rotl => {
@@ -3815,7 +3839,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr4_0 = constructor_a64_rotr_imm(
                                                     ctx, expr0_0, expr1_0, expr3_0,
                                                 )?;
-                                                let expr5_0 = C::value_reg(ctx, expr4_0);
+                                                let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                                                 return Some(expr5_0);
                                             }
                                         }
@@ -3830,7 +3854,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: Type = I64;
                             let expr5_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr6_0 = constructor_a64_rotr(ctx, expr4_0, expr5_0, expr3_0)?;
-                            let expr7_0 = C::value_reg(ctx, expr6_0);
+                            let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                             return Some(expr7_0);
                         }
                         &Opcode::Rotr => {
@@ -3862,7 +3886,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr1_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -3874,7 +3898,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr3_0 = constructor_a64_rotr(ctx, expr0_0, expr1_0, expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Ishl => {
@@ -3885,7 +3909,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr3_0 =
                                 constructor_do_shift(ctx, &expr0_0, expr1_0, expr2_0, pattern7_1)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
@@ -3896,7 +3920,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr3_0 =
                                 constructor_do_shift(ctx, &expr0_0, expr1_0, expr2_0, pattern7_1)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Sshr => {
@@ -3907,7 +3931,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                             let expr3_0 =
                                 constructor_do_shift(ctx, &expr0_0, expr1_0, expr2_0, pattern7_1)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -3929,7 +3953,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr7_0: u8 = 0;
                         let expr8_0 = VectorSize::Size8x16;
                         let expr9_0 = constructor_mov_from_vec(ctx, expr6_0, expr7_0, &expr8_0)?;
-                        let expr10_0 = C::value_reg(ctx, expr9_0);
+                        let expr10_0 = constructor_output_reg(ctx, expr9_0)?;
                         return Some(expr10_0);
                     }
                 }
@@ -3963,7 +3987,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr12_0: Type = I64;
                             let expr13_0 = constructor_adc_paired(ctx, expr12_0, expr4_0, expr9_0)?;
                             let expr14_0 = constructor_with_flags(ctx, &expr11_0, &expr13_0)?;
-                            return Some(expr14_0);
+                            let expr15_0 = C::output(ctx, expr14_0);
+                            return Some(expr15_0);
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -3984,7 +4009,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr12_0: Type = I64;
                             let expr13_0 = constructor_sbc_paired(ctx, expr12_0, expr4_0, expr9_0)?;
                             let expr14_0 = constructor_with_flags(ctx, &expr11_0, &expr13_0)?;
-                            return Some(expr14_0);
+                            let expr15_0 = C::output(ctx, expr14_0);
+                            return Some(expr15_0);
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4006,7 +4032,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr14_0 = C::zero_reg(ctx);
                             let expr15_0 = constructor_madd64(ctx, expr2_0, expr7_0, expr14_0)?;
                             let expr16_0 = C::value_regs(ctx, expr15_0, expr13_0);
-                            return Some(expr16_0);
+                            let expr17_0 = C::output(ctx, expr16_0);
+                            return Some(expr17_0);
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4016,7 +4043,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_i128_alu_bitop(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4026,7 +4054,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_i128_alu_bitop(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4036,7 +4065,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_i128_alu_bitop(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::BandNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4046,7 +4076,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_i128_alu_bitop(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::BorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4056,7 +4087,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_i128_alu_bitop(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::BxorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4066,7 +4098,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_i128_alu_bitop(
                                 ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::Rotl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4095,7 +4128,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr21_0 = C::value_regs_get(ctx, expr10_0, expr20_0);
                             let expr22_0 = constructor_orr(ctx, expr17_0, expr19_0, expr21_0)?;
                             let expr23_0 = C::value_regs(ctx, expr16_0, expr22_0);
-                            return Some(expr23_0);
+                            let expr24_0 = C::output(ctx, expr23_0);
+                            return Some(expr24_0);
                         }
                         &Opcode::Rotr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4124,7 +4158,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr21_0 = C::value_regs_get(ctx, expr10_0, expr20_0);
                             let expr22_0 = constructor_orr(ctx, expr17_0, expr19_0, expr21_0)?;
                             let expr23_0 = C::value_regs(ctx, expr22_0, expr16_0);
-                            return Some(expr23_0);
+                            let expr24_0 = C::output(ctx, expr23_0);
+                            return Some(expr24_0);
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4134,7 +4169,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0: usize = 0;
                             let expr3_0 = C::value_regs_get(ctx, expr1_0, expr2_0);
                             let expr4_0 = constructor_lower_shl128(ctx, expr0_0, expr3_0)?;
-                            return Some(expr4_0);
+                            let expr5_0 = C::output(ctx, expr4_0);
+                            return Some(expr5_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4144,7 +4180,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0: usize = 0;
                             let expr3_0 = C::value_regs_get(ctx, expr1_0, expr2_0);
                             let expr4_0 = constructor_lower_ushr128(ctx, expr0_0, expr3_0)?;
-                            return Some(expr4_0);
+                            let expr5_0 = C::output(ctx, expr4_0);
+                            return Some(expr5_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -4154,7 +4191,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0: usize = 0;
                             let expr3_0 = C::value_regs_get(ctx, expr1_0, expr2_0);
                             let expr4_0 = constructor_lower_sshr128(ctx, expr0_0, expr3_0)?;
-                            return Some(expr4_0);
+                            let expr5_0 = C::output(ctx, expr4_0);
+                            return Some(expr5_0);
                         }
                         _ => {}
                     }
@@ -4178,7 +4216,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr9_0 = C::zero_reg(ctx);
                             let expr10_0 = constructor_orr_not(ctx, expr8_0, expr9_0, expr4_0)?;
                             let expr11_0 = C::value_regs(ctx, expr7_0, expr10_0);
-                            return Some(expr11_0);
+                            let expr12_0 = C::output(ctx, expr11_0);
+                            return Some(expr12_0);
                         }
                         &Opcode::Bitrev => {
                             // Rule at src/isa/aarch64/lower.isle line 983.
@@ -4192,13 +4231,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr7_0 = C::value_regs_get(ctx, expr0_0, expr6_0);
                             let expr8_0 = constructor_rbit(ctx, expr5_0, expr7_0)?;
                             let expr9_0 = C::value_regs(ctx, expr8_0, expr4_0);
-                            return Some(expr9_0);
+                            let expr10_0 = C::output(ctx, expr9_0);
+                            return Some(expr10_0);
                         }
                         &Opcode::Clz => {
                             // Rule at src/isa/aarch64/lower.isle line 1001.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0 = constructor_lower_clz128(ctx, expr0_0)?;
-                            return Some(expr1_0);
+                            let expr2_0 = C::output(ctx, expr1_0);
+                            return Some(expr2_0);
                         }
                         &Opcode::Cls => {
                             // Rule at src/isa/aarch64/lower.isle line 1057.
@@ -4231,7 +4272,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr26_0: u64 = 0;
                             let expr27_0 = constructor_imm(ctx, expr25_0, expr26_0)?;
                             let expr28_0 = C::value_regs(ctx, expr24_0, expr27_0);
-                            return Some(expr28_0);
+                            let expr29_0 = C::output(ctx, expr28_0);
+                            return Some(expr29_0);
                         }
                         &Opcode::Ctz => {
                             // Rule at src/isa/aarch64/lower.isle line 1031.
@@ -4246,7 +4288,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr8_0 = constructor_rbit(ctx, expr5_0, expr7_0)?;
                             let expr9_0 = C::value_regs(ctx, expr8_0, expr4_0);
                             let expr10_0 = constructor_lower_clz128(ctx, expr9_0)?;
-                            return Some(expr10_0);
+                            let expr11_0 = C::output(ctx, expr10_0);
+                            return Some(expr11_0);
                         }
                         &Opcode::Popcnt => {
                             // Rule at src/isa/aarch64/lower.isle line 1117.
@@ -4273,7 +4316,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr18_0: u64 = 0;
                             let expr19_0 = constructor_imm(ctx, expr17_0, expr18_0)?;
                             let expr20_0 = C::value_regs(ctx, expr16_0, expr19_0);
-                            return Some(expr20_0);
+                            let expr21_0 = C::output(ctx, expr20_0);
+                            return Some(expr21_0);
                         }
                         &Opcode::Uextend => {
                             if let Some(pattern7_0) = C::def_inst(ctx, pattern5_1) {
@@ -4300,7 +4344,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         let expr4_0: u64 = 0;
                                         let expr5_0 = constructor_imm(ctx, expr3_0, expr4_0)?;
                                         let expr6_0 = C::value_regs(ctx, expr2_0, expr5_0);
-                                        return Some(expr6_0);
+                                        let expr7_0 = C::output(ctx, expr6_0);
+                                        return Some(expr7_0);
                                     }
                                 }
                             }
@@ -4310,7 +4355,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0: u64 = 0;
                             let expr3_0 = constructor_imm(ctx, expr1_0, expr2_0)?;
                             let expr4_0 = C::value_regs(ctx, expr0_0, expr3_0);
-                            return Some(expr4_0);
+                            let expr5_0 = C::output(ctx, expr4_0);
+                            return Some(expr5_0);
                         }
                         &Opcode::Sextend => {
                             if let Some(pattern7_0) = C::def_inst(ctx, pattern5_1) {
@@ -4341,7 +4387,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 ctx, expr3_0, expr2_0, expr5_0,
                                             )?;
                                             let expr7_0 = C::value_regs(ctx, expr2_0, expr6_0);
-                                            return Some(expr7_0);
+                                            let expr8_0 = C::output(ctx, expr7_0);
+                                            return Some(expr8_0);
                                         }
                                         if let Some(()) = C::not_i64x2(ctx, pattern11_0) {
                                             let pattern13_0 = C::u8_from_uimm8(ctx, pattern9_2);
@@ -4365,7 +4412,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 ctx, expr5_0, expr4_0, expr7_0,
                                             )?;
                                             let expr9_0 = C::value_regs(ctx, expr4_0, expr8_0);
-                                            return Some(expr9_0);
+                                            let expr10_0 = C::output(ctx, expr9_0);
+                                            return Some(expr10_0);
                                         }
                                     }
                                 }
@@ -4377,7 +4425,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr3_0 = C::imm_shift_from_u8(ctx, expr2_0);
                             let expr4_0 = constructor_asr_imm(ctx, expr1_0, expr0_0, expr3_0)?;
                             let expr5_0 = C::value_regs(ctx, expr0_0, expr4_0);
-                            return Some(expr5_0);
+                            let expr6_0 = C::output(ctx, expr5_0);
+                            return Some(expr6_0);
                         }
                         _ => {}
                     }
@@ -4397,7 +4446,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                     let expr1_0 = VectorSize::Size8x16;
                     let expr2_0 = constructor_vec_cnt(ctx, expr0_0, &expr1_0)?;
-                    let expr3_0 = C::value_reg(ctx, expr2_0);
+                    let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                     return Some(expr3_0);
                 }
             }
@@ -4442,7 +4491,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_smull8(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4473,7 +4523,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_smull8(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4504,7 +4555,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_umull8(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4535,7 +4587,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_umull8(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4590,7 +4643,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_smull16(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4621,7 +4675,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_smull16(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4652,7 +4707,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_umull16(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4683,7 +4739,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_umull16(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4738,7 +4795,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_smull32(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4769,7 +4827,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_smull32(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4800,7 +4859,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_umull32(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4831,7 +4891,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                         let expr3_0 = constructor_umull32(
                                                             ctx, expr0_0, expr1_0, expr2_0,
                                                         )?;
-                                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                        let expr4_0 =
+                                                            constructor_output_reg(ctx, expr3_0)?;
                                                         return Some(expr4_0);
                                                     }
                                                 }
@@ -4860,7 +4921,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr13_0 = constructor_shll32(ctx, expr9_0, expr12_0)?;
                     let expr14_0: bool = false;
                     let expr15_0 = constructor_umlal32(ctx, expr13_0, expr11_0, expr7_0, expr14_0)?;
-                    let expr16_0 = C::value_reg(ctx, expr15_0);
+                    let expr16_0 = constructor_output_reg(ctx, expr15_0)?;
                     return Some(expr16_0);
                 }
             }
@@ -4874,7 +4935,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     // Rule at src/isa/aarch64/lower.isle line 22.
                     let expr0_0: u64 = 0;
                     let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
-                    let expr2_0 = C::value_reg(ctx, expr1_0);
+                    let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                     return Some(expr2_0);
                 }
             }
@@ -4886,7 +4947,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let pattern6_0 = C::u64_from_imm64(ctx, pattern4_1);
                     // Rule at src/isa/aarch64/lower.isle line 9.
                     let expr0_0 = constructor_imm(ctx, pattern2_0, pattern6_0)?;
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
+                    let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                     return Some(expr1_0);
                 }
             }
@@ -4899,14 +4960,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         // Rule at src/isa/aarch64/lower.isle line 17.
                         let expr0_0: u64 = 1;
                         let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     if pattern4_1 == false {
                         // Rule at src/isa/aarch64/lower.isle line 14.
                         let expr0_0: u64 = 0;
                         let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                 }
@@ -4920,21 +4981,21 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         // Rule at src/isa/aarch64/lower.isle line 989.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_rbit(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Clz => {
                         // Rule at src/isa/aarch64/lower.isle line 1004.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_a64_clz(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Cls => {
                         // Rule at src/isa/aarch64/lower.isle line 1071.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_a64_cls(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Ctz => {
@@ -4942,7 +5003,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_rbit(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = constructor_a64_clz(ctx, pattern2_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     _ => {}
@@ -4965,7 +5026,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr2_0 = constructor_vector_size(ctx, pattern2_0)?;
                         let expr3_0 = constructor_add_vec(ctx, expr0_0, expr1_0, &expr2_0)?;
-                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                        let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                     &Opcode::Isub => {
@@ -4975,7 +5036,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr2_0 = constructor_vector_size(ctx, pattern2_0)?;
                         let expr3_0 = constructor_sub_vec(ctx, expr0_0, expr1_0, &expr2_0)?;
-                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                        let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                     _ => {}
@@ -5015,7 +5076,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_small_rotr_imm(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -5029,7 +5090,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr3_0 = constructor_sub(ctx, expr0_0, expr1_0, expr2_0)?;
                         let expr4_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr5_0 = constructor_small_rotr(ctx, pattern3_0, expr4_0, expr3_0)?;
-                        let expr6_0 = C::value_reg(ctx, expr5_0);
+                        let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                         return Some(expr6_0);
                     }
                     &Opcode::Rotr => {
@@ -5058,7 +5119,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 expr0_0,
                                                 pattern13_0,
                                             )?;
-                                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                             return Some(expr2_0);
                                         }
                                     }
@@ -5069,7 +5130,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr2_0 = constructor_small_rotr(ctx, pattern3_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     _ => {}
@@ -5095,7 +5156,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr5_0 = C::ty_bits(ctx, pattern3_0);
                         let expr6_0 = C::imm_shift_from_u8(ctx, expr5_0);
                         let expr7_0 = constructor_lsr_imm(ctx, expr4_0, expr3_0, expr6_0)?;
-                        let expr8_0 = C::value_reg(ctx, expr7_0);
+                        let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                         return Some(expr8_0);
                     }
                     &Opcode::Smulhi => {
@@ -5109,7 +5170,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr5_0 = C::ty_bits(ctx, pattern3_0);
                         let expr6_0 = C::imm_shift_from_u8(ctx, expr5_0);
                         let expr7_0 = constructor_asr_imm(ctx, expr4_0, expr3_0, expr6_0)?;
-                        let expr8_0 = C::value_reg(ctx, expr7_0);
+                        let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                         return Some(expr8_0);
                     }
                     &Opcode::Band => {
@@ -5119,7 +5180,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
                         )?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Bor => {
@@ -5129,7 +5190,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
                         )?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Bxor => {
@@ -5139,7 +5200,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
                         )?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::BandNot => {
@@ -5149,7 +5210,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_alu_rs_imm_logic(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
                         )?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::BorNot => {
@@ -5159,7 +5220,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_alu_rs_imm_logic(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
                         )?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::BxorNot => {
@@ -5170,7 +5231,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr2_0 = constructor_alu_rs_imm_logic(
                             ctx, &expr0_0, expr1_0, pattern7_0, pattern7_1,
                         )?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Ishl => {
@@ -5180,7 +5241,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                         let expr2_0 =
                             constructor_do_shift(ctx, &expr0_0, pattern3_0, expr1_0, pattern7_1)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Ushr => {
@@ -5190,7 +5251,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr2_0 =
                             constructor_do_shift(ctx, &expr0_0, pattern3_0, expr1_0, pattern7_1)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Sshr => {
@@ -5200,7 +5261,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_put_in_reg_sext32(ctx, pattern7_0)?;
                         let expr2_0 =
                             constructor_do_shift(ctx, &expr0_0, pattern3_0, expr1_0, pattern7_1)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     _ => {}
@@ -5237,7 +5298,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr0_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                                 return Some(expr2_0);
                                             }
                                             if let Some(pattern13_0) =
@@ -5251,7 +5312,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr0_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                                 return Some(expr2_0);
                                             }
                                         }
@@ -5271,7 +5332,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr3_0 = constructor_madd(
                                                     ctx, pattern3_0, expr0_0, expr1_0, expr2_0,
                                                 )?;
-                                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                                 return Some(expr4_0);
                                             }
                                             &Opcode::Ishl => {
@@ -5316,7 +5377,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             pattern18_0,
                                                                         )?;
                                                                     let expr3_0 =
-                                                                        C::value_reg(ctx, expr2_0);
+                                                                        constructor_output_reg(
+                                                                            ctx, expr2_0,
+                                                                        )?;
                                                                     return Some(expr3_0);
                                                                 }
                                                             }
@@ -5336,7 +5399,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
                                 let expr1_0 =
                                     constructor_add_extend(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
@@ -5359,7 +5422,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr0_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                                 return Some(expr2_0);
                                             }
                                             if let Some(pattern13_0) =
@@ -5373,7 +5436,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr0_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                                 return Some(expr2_0);
                                             }
                                         }
@@ -5393,7 +5456,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr3_0 = constructor_madd(
                                                     ctx, pattern3_0, expr0_0, expr1_0, expr2_0,
                                                 )?;
-                                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                                 return Some(expr4_0);
                                             }
                                             &Opcode::Ishl => {
@@ -5438,7 +5501,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             pattern18_0,
                                                                         )?;
                                                                     let expr3_0 =
-                                                                        C::value_reg(ctx, expr2_0);
+                                                                        constructor_output_reg(
+                                                                            ctx, expr2_0,
+                                                                        )?;
                                                                     return Some(expr3_0);
                                                                 }
                                                             }
@@ -5458,14 +5523,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_add_extend(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             // Rule at src/isa/aarch64/lower.isle line 30.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Isub => {
@@ -5490,7 +5555,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr0_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                                 return Some(expr2_0);
                                             }
                                             if let Some(pattern13_0) =
@@ -5504,7 +5569,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     expr0_0,
                                                     pattern13_0,
                                                 )?;
-                                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                                 return Some(expr2_0);
                                             }
                                         }
@@ -5550,7 +5615,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                         pattern18_0,
                                                                     )?;
                                                                 let expr3_0 =
-                                                                    C::value_reg(ctx, expr2_0);
+                                                                    constructor_output_reg(
+                                                                        ctx, expr2_0,
+                                                                    )?;
                                                                 return Some(expr3_0);
                                                             }
                                                         }
@@ -5568,14 +5635,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_sub_extend(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             // Rule at src/isa/aarch64/lower.isle line 101.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Imul => {
@@ -5586,7 +5653,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = C::zero_reg(ctx);
                             let expr3_0 =
                                 constructor_madd(ctx, pattern3_0, expr0_0, expr1_0, expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Udiv => {
@@ -5596,7 +5663,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr2_0 = constructor_put_nonzero_in_reg_zext64(ctx, pattern7_1)?;
                             let expr3_0 = constructor_a64_udiv(ctx, expr0_0, expr1_0, expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Sdiv => {
@@ -5621,7 +5688,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr3_0 = constructor_a64_sdiv(
                                                 ctx, expr0_0, expr1_0, expr2_0,
                                             )?;
-                                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                             return Some(expr4_0);
                                         }
                                     }
@@ -5635,7 +5702,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             )?;
                             let expr3_0: Type = I64;
                             let expr4_0 = constructor_a64_sdiv(ctx, expr3_0, expr2_0, expr1_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         &Opcode::Urem => {
@@ -5646,7 +5713,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0: Type = I64;
                             let expr3_0 = constructor_a64_udiv(ctx, expr2_0, expr0_0, expr1_0)?;
                             let expr4_0 = constructor_msub64(ctx, expr3_0, expr1_0, expr0_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         &Opcode::Srem => {
@@ -5657,7 +5724,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0: Type = I64;
                             let expr3_0 = constructor_a64_sdiv(ctx, expr2_0, expr0_0, expr1_0)?;
                             let expr4_0 = constructor_msub64(ctx, expr3_0, expr1_0, expr0_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         _ => {}
@@ -5673,7 +5740,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::zero_reg(ctx);
                             let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bnot => {
@@ -5718,8 +5785,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                     expr1_0,
                                                                     pattern17_0,
                                                                 )?;
-                                                            let expr3_0 =
-                                                                C::value_reg(ctx, expr2_0);
+                                                            let expr3_0 = constructor_output_reg(
+                                                                ctx, expr2_0,
+                                                            )?;
                                                             return Some(expr3_0);
                                                         }
                                                     }
@@ -5733,7 +5801,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::zero_reg(ctx);
                             let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr2_0 = constructor_orr_not(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Uextend => {
@@ -5757,7 +5825,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             pattern12_0,
                                             &expr1_0,
                                         )?;
-                                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                         return Some(expr3_0);
                                     }
                                 }
@@ -5767,7 +5835,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 // Rule at src/isa/aarch64/lower.isle line 488.
                                 let expr0_0 = C::sink_atomic_load(ctx, &pattern8_0);
                                 let expr1_0 = constructor_load_acquire(ctx, pattern7_0, expr0_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             // Rule at src/isa/aarch64/lower.isle line 476.
@@ -5777,7 +5845,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr3_0 = C::ty_bits(ctx, pattern3_0);
                             let expr4_0 =
                                 constructor_extend(ctx, expr0_0, expr1_0, expr2_0, expr3_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         &Opcode::Sextend => {
@@ -5803,7 +5871,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             &expr1_0,
                                             &expr2_0,
                                         )?;
-                                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                                        let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                         return Some(expr4_0);
                                     }
                                 }
@@ -5816,7 +5884,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr3_0 = C::ty_bits(ctx, pattern3_0);
                             let expr4_0 =
                                 constructor_extend(ctx, expr0_0, expr1_0, expr2_0, expr3_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         _ => {}
@@ -5840,7 +5908,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_uqadd(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::SaddSat => {
@@ -5850,7 +5918,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_sqadd(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::UsubSat => {
@@ -5860,7 +5928,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_uqsub(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::SsubSat => {
@@ -5870,7 +5938,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_sqsub(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Band => {
@@ -5880,7 +5948,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_and_vec(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Bor => {
@@ -5890,7 +5958,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_orr_vec(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Bxor => {
@@ -5900,7 +5968,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_eor_vec(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::BandNot => {
@@ -5910,7 +5978,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr3_0 = constructor_bic_vec(ctx, expr0_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Ishl => {
@@ -5921,7 +5989,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_vec_dup(ctx, expr1_0, &expr0_0)?;
                             let expr3_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr4_0 = constructor_sshl(ctx, expr3_0, expr2_0, &expr0_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         &Opcode::Ushr => {
@@ -5935,7 +6003,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr5_0 = constructor_vec_dup(ctx, expr4_0, &expr0_0)?;
                             let expr6_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr7_0 = constructor_ushl(ctx, expr6_0, expr5_0, &expr0_0)?;
-                            let expr8_0 = C::value_reg(ctx, expr7_0);
+                            let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
                         &Opcode::Sshr => {
@@ -5949,7 +6017,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr5_0 = constructor_vec_dup(ctx, expr4_0, &expr0_0)?;
                             let expr6_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr7_0 = constructor_sshl(ctx, expr6_0, expr5_0, &expr0_0)?;
-                            let expr8_0 = C::value_reg(ctx, expr7_0);
+                            let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
                         _ => {}
@@ -5965,7 +6033,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr2_0 = constructor_neg(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bnot => {
@@ -5973,7 +6041,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr2_0 = constructor_not(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         _ => {}
@@ -5995,7 +6063,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = C::put_in_reg(ctx, pattern8_1);
                         let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
                         let expr3_0 = constructor_mul(ctx, expr0_0, expr1_0, &expr2_0)?;
-                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                        let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                 }

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -2,12 +2,12 @@
 
 ;; The main lowering constructor term: takes a clif `Inst` and returns the
 ;; register(s) within which the lowered instruction's result values live.
-(decl lower (Inst) ValueRegs)
+(decl lower (Inst) InstOutput)
 
 ;; A variant of the main lowering constructor term, used for branches.
 ;; The only difference is that it gets an extra argument holding a vector
 ;; of branch targets to be used.
-(decl lower_branch (Inst VecMachLabel) ValueRegs)
+(decl lower_branch (Inst VecMachLabel) InstOutput)
 
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -148,39 +148,39 @@
 ;; containing the carry result, but we do not support the `iflags` mechanism.
 ;; However, the only actual use case is where `iadd_ifcout` feeds into `trapif`,
 ;; which is implemented by explicitly matching on the flags producer.  So we can
-;; get away with just allocating a second temp so that the reg-renaming code
+;; get away with just using an invalid second output, and the reg-renaming code
 ;; does the right thing, for now.
-(decl value_regs_ifcout (Reg) ValueRegs)
-(rule (value_regs_ifcout reg)
-      (value_regs reg (writable_reg_to_reg (temp_writable_reg $I64))))
+(decl output_ifcout (Reg) InstOutput)
+(rule (output_ifcout reg)
+      (output_pair reg (value_regs_invalid)))
 
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x y)))
-      (value_regs_ifcout (add_logical_reg ty x y)))
+      (output_ifcout (add_logical_reg ty x y)))
 
 ;; Add a register and a zero-extended register.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (zext32_value y))))
-      (value_regs_ifcout (add_logical_reg_zext32 ty x y)))
+      (output_ifcout (add_logical_reg_zext32 ty x y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (zext32_value x) y)))
-      (value_regs_ifcout (add_logical_reg_zext32 ty y x)))
+      (output_ifcout (add_logical_reg_zext32 ty y x)))
 
 ;; Add a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (u32_from_value y))))
-      (value_regs_ifcout (add_logical_zimm32 ty x y)))
+      (output_ifcout (add_logical_zimm32 ty x y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (u32_from_value x) y)))
-      (value_regs_ifcout (add_logical_zimm32 ty y x)))
+      (output_ifcout (add_logical_zimm32 ty y x)))
 
 ;; Add a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (sinkable_load_32_64 y))))
-      (value_regs_ifcout (add_logical_mem ty x (sink_load y))))
+      (output_ifcout (add_logical_mem ty x (sink_load y))))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (sinkable_load_32_64 x) y)))
-      (value_regs_ifcout (add_logical_mem ty y (sink_load x))))
+      (output_ifcout (add_logical_mem ty y (sink_load x))))
 
 ;; Add a register and zero-extended memory.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (sinkable_uload32 y))))
-      (value_regs_ifcout (add_logical_mem_zext32 ty x (sink_uload32 y))))
+      (output_ifcout (add_logical_mem_zext32 ty x (sink_uload32 y))))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (sinkable_uload32 x) y)))
-      (value_regs_ifcout (add_logical_mem_zext32 ty y (sink_uload32 x))))
+      (output_ifcout (add_logical_mem_zext32 ty y (sink_uload32 x))))
 
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1352,66 +1352,66 @@
 
 ;; Store 8-bit integer type, main lowering entry point.
 (rule (lower (store flags val @ (value_type $I8) addr offset))
-      (value_regs_none (istore8_impl flags val addr offset)))
+      (side_effect (istore8_impl flags val addr offset)))
 
 ;; Store 16-bit integer type, main lowering entry point.
 (rule (lower (store flags val @ (value_type $I16) addr offset))
-      (value_regs_none (istore16_impl flags val addr offset)))
+      (side_effect (istore16_impl flags val addr offset)))
 
 ;; Store 32-bit integer type, main lowering entry point.
 (rule (lower (store flags val @ (value_type $I32) addr offset))
-      (value_regs_none (istore32_impl flags val addr offset)))
+      (side_effect (istore32_impl flags val addr offset)))
 
 ;; Store 64-bit integer type, main lowering entry point.
 (rule (lower (store flags val @ (value_type $I64) addr offset))
-      (value_regs_none (istore64_impl flags val addr offset)))
+      (side_effect (istore64_impl flags val addr offset)))
 
 ;; Store 64-bit reference type, main lowering entry point.
 (rule (lower (store flags val @ (value_type $R64) addr offset))
-      (value_regs_none (istore64_impl flags val addr offset)))
+      (side_effect (istore64_impl flags val addr offset)))
 
 ;; Store 32-bit big-endian floating-point type.
 (rule (lower (store flags @ (bigendian)
                     val @ (value_type $F32) addr offset))
-      (value_regs_none (fpu_store32 (put_in_reg val)
-                                    (lower_address flags addr offset))))
+      (side_effect (fpu_store32 (put_in_reg val)
+                                (lower_address flags addr offset))))
 
 ;; Store 32-bit little-endian floating-point type (z15 instruction).
 (rule (lower (store flags @ (littleendian)
                     val @ (value_type (and $F32 (vxrs_ext2_enabled))) addr offset))
-      (value_regs_none (fpu_storerev32 (put_in_reg val)
-                                       (lower_address flags addr offset))))
+      (side_effect (fpu_storerev32 (put_in_reg val)
+                                   (lower_address flags addr offset))))
 
 ;; Store 32-bit little-endian floating-point type (via GPR on z14).
 (rule (lower (store flags @ (littleendian)
                     val @ (value_type (and $F32 (vxrs_ext2_disabled))) addr offset))
       (let ((gpr Reg (lshr_imm $I64 (mov_from_fpr (put_in_reg val)) 32)))
-        (value_regs_none (storerev32 gpr (lower_address flags addr offset)))))
+        (side_effect (storerev32 gpr (lower_address flags addr offset)))))
 
 ;; Store 64-bit big-endian floating-point type.
 (rule (lower (store flags @ (bigendian)
                     val @ (value_type $F64) addr offset))
-      (value_regs_none (fpu_store64 (put_in_reg val)
-                                    (lower_address flags addr offset))))
+      (side_effect (fpu_store64 (put_in_reg val)
+                                (lower_address flags addr offset))))
 
 ;; Store 64-bit little-endian floating-point type (z15 instruction).
 (rule (lower (store flags @ (littleendian)
                     val @ (value_type (and $F64 (vxrs_ext2_enabled))) addr offset))
-      (value_regs_none (fpu_storerev64 (put_in_reg val)
-                                       (lower_address flags addr offset))))
+      (side_effect (fpu_storerev64 (put_in_reg val)
+                                   (lower_address flags addr offset))))
 
 ;; Store 64-bit little-endian floating-point type (via GPR on z14).
 (rule (lower (store flags @ (littleendian)
                     val @ (value_type (and $F64 (vxrs_ext2_disabled))) addr offset))
       (let ((gpr Reg (mov_from_fpr (put_in_reg val))))
-        (value_regs_none (storerev64 gpr (lower_address flags addr offset)))))
+        (side_effect (storerev64 gpr (lower_address flags addr offset)))))
 
 
 ;;;; Rules for 8-bit integer stores ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Main `istore8` lowering entry point, dispatching to the helper.
 (rule (lower (istore8 flags val addr offset))
-      (value_regs_none (istore8_impl flags val addr offset)))
+      (side_effect (istore8_impl flags val addr offset)))
 
 ;; Helper to store 8-bit integer types.
 (decl istore8_impl (MemFlags Value Value Offset32) SideEffectNoResult)
@@ -1429,7 +1429,7 @@
 
 ;; Main `istore16` lowering entry point, dispatching to the helper.
 (rule (lower (istore16 flags val addr offset))
-      (value_regs_none (istore16_impl flags val addr offset)))
+      (side_effect (istore16_impl flags val addr offset)))
 
 ;; Helper to store 16-bit integer types.
 (decl istore16_impl (MemFlags Value Value Offset32) SideEffectNoResult)
@@ -1455,7 +1455,7 @@
 
 ;; Main `istore32` lowering entry point, dispatching to the helper.
 (rule (lower (istore32 flags val addr offset))
-      (value_regs_none (istore32_impl flags val addr offset)))
+      (side_effect (istore32_impl flags val addr offset)))
 
 ;; Helper to store 32-bit integer types.
 (decl istore32_impl (MemFlags Value Value Offset32) SideEffectNoResult)
@@ -1854,10 +1854,10 @@
 ;;;; Rules for `atomic_store` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Atomic stores can be implemented via regular stores followed by a fence.
-(decl atomic_store_impl (SideEffectNoResult) ValueRegs)
+(decl atomic_store_impl (SideEffectNoResult) InstOutput)
 (rule (atomic_store_impl store)
-      (let ((_ ValueRegs (value_regs_none store)))
-         (value_regs_none (fence_impl))))
+      (let ((_ InstOutput (side_effect store)))
+         (side_effect (fence_impl))))
 
 ;; 8-bit atomic store.
 (rule (lower (atomic_store flags val @ (value_type $I8) addr))
@@ -1880,7 +1880,7 @@
 
 ;; Fence to ensure sequential consistency.
 (rule (lower (fence))
-      (value_regs_none (fence_impl)))
+      (side_effect (fence_impl)))
 
 
 ;;;; Rules for `icmp` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2066,7 +2066,7 @@
 ;; Unconditional branch.  The target is found as first (and only) element in
 ;; the list of the current block's branch targets passed as `targets`.
 (rule (lower_branch (jump _ _) targets)
-      (value_regs_none (jump_impl (vec_element targets 0))))
+      (side_effect (jump_impl (vec_element targets 0))))
 
 
 ;;;; Rules for `br_table` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2082,8 +2082,8 @@
             (cond ProducesBool
               (bool (icmpu_uimm32 $I64 idx (vec_length_minus1 targets))
                     (intcc_as_cond (IntCC.UnsignedGreaterThanOrEqual))))
-            (_ ValueRegs (value_regs_none (oneway_cond_br_bool cond
-                                            (vec_element targets 0)))))
+            (_ InstOutput (side_effect (oneway_cond_br_bool cond
+                                         (vec_element targets 0)))))
         ;; Scale the index by the element size, and then emit the
         ;; compound instruction that does:
         ;;
@@ -2098,7 +2098,7 @@
         ;; PC-rel offset to the jumptable would be incorrect.
         ;; (The alternative is to introduce a relocation pass
         ;; for inlined jumptables, which is much worse, IMHO.)
-        (value_regs_none (jt_sequence (lshl_imm $I64 idx 2) targets))))
+        (side_effect (jt_sequence (lshl_imm $I64 idx 2) targets))))
 
 
 ;;;; Rules for `brz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2107,9 +2107,9 @@
 ;; - element 0: target if the condition is true (i.e. value is zero)
 ;; - element 1: target if the condition is false (i.e. value is nonzero)
 (rule (lower_branch (brz val_cond _ _) targets)
-      (value_regs_none (cond_br_bool (invert_bool (value_nonzero val_cond))
-                                     (vec_element targets 0)
-                                     (vec_element targets 1))))
+      (side_effect (cond_br_bool (invert_bool (value_nonzero val_cond))
+                                 (vec_element targets 0)
+                                 (vec_element targets 1))))
 
 
 ;;;; Rules for `brnz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2118,9 +2118,9 @@
 ;; - element 0: target if the condition is true (i.e. value is nonzero)
 ;; - element 1: target if the condition is false (i.e. value is zero)
 (rule (lower_branch (brnz val_cond _ _) targets)
-      (value_regs_none (cond_br_bool (value_nonzero val_cond)
-                                     (vec_element targets 0)
-                                     (vec_element targets 1))))
+      (side_effect (cond_br_bool (value_nonzero val_cond)
+                                 (vec_element targets 0)
+                                 (vec_element targets 1))))
 
 
 ;;;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2129,9 +2129,9 @@
 ;; generated by common code here.  Others will fail to lower.
 
 (rule (lower_branch (brif int_cc (ifcmp x y) _ _) targets)
-      (value_regs_none (cond_br_bool (icmp_val $false int_cc x y)
-                                     (vec_element targets 0)
-                                     (vec_element targets 1))))
+      (side_effect (cond_br_bool (icmp_val $false int_cc x y)
+                                 (vec_element targets 0)
+                                 (vec_element targets 1))))
 
 
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2167,7 +2167,7 @@
 ;;;; Rules for `debugtrap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (debugtrap))
-      (value_regs_none (debugtrap_impl)))
+      (side_effect (debugtrap_impl)))
 
 
 ;;;; Rules for `trapif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2205,6 +2205,6 @@
 
 (rule (lower (trapif (IntCC.UnsignedGreaterThan)
                      (iadd_ifcout x y) trap_code))
-      (value_regs_none (trap_if_impl (mask_as_cond 3) trap_code)))
+      (side_effect (trap_if_impl (mask_as_cond 3) trap_code)))
 
 

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 8bf92e18323e7041
+src/prelude.isle 957023853b23dacb
 src/isa/s390x/inst.isle d91a16074ab186a8
-src/isa/s390x/lower.isle 5626c0ef61594d61
+src/isa/s390x/lower.isle 1cc5a12adc8c75f9

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
@@ -25,6 +25,12 @@ pub trait Context {
     fn value_reg(&mut self, arg0: Reg) -> ValueRegs;
     fn value_regs(&mut self, arg0: Reg, arg1: Reg) -> ValueRegs;
     fn value_regs_invalid(&mut self) -> ValueRegs;
+    fn output_none(&mut self) -> InstOutput;
+    fn output(&mut self, arg0: ValueRegs) -> InstOutput;
+    fn output_pair(&mut self, arg0: ValueRegs, arg1: ValueRegs) -> InstOutput;
+    fn output_builder_new(&mut self) -> InstOutputBuilder;
+    fn output_builder_push(&mut self, arg0: &InstOutputBuilder, arg1: ValueRegs) -> Unit;
+    fn output_builder_finish(&mut self, arg0: &InstOutputBuilder) -> InstOutput;
     fn temp_writable_reg(&mut self, arg0: Type) -> WritableReg;
     fn invalid_reg(&mut self) -> Reg;
     fn put_in_reg(&mut self, arg0: Value) -> Reg;
@@ -136,13 +142,13 @@ pub trait Context {
     fn same_reg(&mut self, arg0: Reg, arg1: WritableReg) -> Option<()>;
 }
 
-/// Internal type SideEffectNoResult: defined at src/prelude.isle line 308.
+/// Internal type SideEffectNoResult: defined at src/prelude.isle line 345.
 #[derive(Clone, Debug)]
 pub enum SideEffectNoResult {
     Inst { inst: MInst },
 }
 
-/// Internal type ProducesFlags: defined at src/prelude.isle line 330.
+/// Internal type ProducesFlags: defined at src/prelude.isle line 367.
 #[derive(Clone, Debug)]
 pub enum ProducesFlags {
     ProducesFlagsSideEffect { inst: MInst },
@@ -150,7 +156,7 @@ pub enum ProducesFlags {
     ProducesFlagsReturnsResultWithConsumer { inst: MInst, result: Reg },
 }
 
-/// Internal type ConsumesFlags: defined at src/prelude.isle line 341.
+/// Internal type ConsumesFlags: defined at src/prelude.isle line 378.
 #[derive(Clone, Debug)]
 pub enum ConsumesFlags {
     ConsumesFlagsReturnsResultWithProducer {
@@ -886,10 +892,28 @@ pub enum ProducesBool {
     ProducesBool { producer: ProducesFlags, cond: Cond },
 }
 
+// Generated as internal constructor for term output_reg.
+pub fn constructor_output_reg<C: Context>(ctx: &mut C, arg0: Reg) -> Option<InstOutput> {
+    let pattern0_0 = arg0;
+    // Rule at src/prelude.isle line 86.
+    let expr0_0 = C::value_reg(ctx, pattern0_0);
+    let expr1_0 = C::output(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term output_value.
+pub fn constructor_output_value<C: Context>(ctx: &mut C, arg0: Value) -> Option<InstOutput> {
+    let pattern0_0 = arg0;
+    // Rule at src/prelude.isle line 90.
+    let expr0_0 = C::put_in_regs(ctx, pattern0_0);
+    let expr1_0 = C::output(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
 // Generated as internal constructor for term temp_reg.
 pub fn constructor_temp_reg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/prelude.isle line 73.
+    // Rule at src/prelude.isle line 110.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -898,26 +922,26 @@ pub fn constructor_temp_reg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Reg> 
 // Generated as internal constructor for term lo_reg.
 pub fn constructor_lo_reg<C: Context>(ctx: &mut C, arg0: Value) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/prelude.isle line 108.
+    // Rule at src/prelude.isle line 145.
     let expr0_0 = C::put_in_regs(ctx, pattern0_0);
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term value_regs_none.
-pub fn constructor_value_regs_none<C: Context>(
+// Generated as internal constructor for term side_effect.
+pub fn constructor_side_effect<C: Context>(
     ctx: &mut C,
     arg0: &SideEffectNoResult,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     if let &SideEffectNoResult::Inst {
         inst: ref pattern1_0,
     } = pattern0_0
     {
-        // Rule at src/prelude.isle line 313.
+        // Rule at src/prelude.isle line 350.
         let expr0_0 = C::emit(ctx, pattern1_0);
-        let expr1_0 = C::value_regs_invalid(ctx);
+        let expr1_0 = C::output_none(ctx);
         return Some(expr1_0);
     }
     return None;
@@ -927,15 +951,15 @@ pub fn constructor_value_regs_none<C: Context>(
 pub fn constructor_safepoint<C: Context>(
     ctx: &mut C,
     arg0: &SideEffectNoResult,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     if let &SideEffectNoResult::Inst {
         inst: ref pattern1_0,
     } = pattern0_0
     {
-        // Rule at src/prelude.isle line 319.
+        // Rule at src/prelude.isle line 356.
         let expr0_0 = C::emit_safepoint(ctx, pattern1_0);
-        let expr1_0 = C::value_regs_invalid(ctx);
+        let expr1_0 = C::output_none(ctx);
         return Some(expr1_0);
     }
     return None;
@@ -959,7 +983,7 @@ pub fn constructor_consumes_flags_concat<C: Context>(
             result: pattern3_1,
         } = pattern2_0
         {
-            // Rule at src/prelude.isle line 353.
+            // Rule at src/prelude.isle line 390.
             let expr0_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
             let expr1_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
                 inst1: pattern1_0.clone(),
@@ -989,7 +1013,7 @@ pub fn constructor_with_flags<C: Context>(
                     inst: ref pattern3_0,
                     result: pattern3_1,
                 } => {
-                    // Rule at src/prelude.isle line 378.
+                    // Rule at src/prelude.isle line 415.
                     let expr0_0 = C::emit(ctx, pattern1_0);
                     let expr1_0 = C::emit(ctx, pattern3_0);
                     let expr2_0 = C::value_reg(ctx, pattern3_1);
@@ -1000,7 +1024,7 @@ pub fn constructor_with_flags<C: Context>(
                     inst2: ref pattern3_1,
                     result: pattern3_2,
                 } => {
-                    // Rule at src/prelude.isle line 384.
+                    // Rule at src/prelude.isle line 421.
                     let expr0_0 = C::emit(ctx, pattern1_0);
                     let expr1_0 = C::emit(ctx, pattern3_1);
                     let expr2_0 = C::emit(ctx, pattern3_0);
@@ -1019,7 +1043,7 @@ pub fn constructor_with_flags<C: Context>(
                 result: pattern3_1,
             } = pattern2_0
             {
-                // Rule at src/prelude.isle line 372.
+                // Rule at src/prelude.isle line 409.
                 let expr0_0 = C::emit(ctx, pattern1_0);
                 let expr1_0 = C::emit(ctx, pattern3_0);
                 let expr2_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
@@ -1039,7 +1063,7 @@ pub fn constructor_with_flags_reg<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/prelude.isle line 397.
+    // Rule at src/prelude.isle line 434.
     let expr0_0 = constructor_with_flags(ctx, pattern0_0, pattern1_0)?;
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -7877,7 +7901,7 @@ pub fn constructor_fcmp_reg<C: Context>(
 }
 
 // Generated as internal constructor for term lower.
-pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueRegs> {
+pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     let pattern1_0 = C::inst_data(ctx, pattern0_0);
     match &pattern1_0 {
@@ -7888,19 +7912,19 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 &Opcode::Debugtrap => {
                     // Rule at src/isa/s390x/lower.isle line 2169.
                     let expr0_0 = constructor_debugtrap_impl(ctx)?;
-                    let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                    let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::Nop => {
                     // Rule at src/isa/s390x/lower.isle line 47.
                     let expr0_0 = C::invalid_reg(ctx);
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
+                    let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::Fence => {
                     // Rule at src/isa/s390x/lower.isle line 1882.
                     let expr0_0 = constructor_fence_impl(ctx)?;
-                    let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                    let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 _ => {}
@@ -7918,13 +7942,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr1_0 = C::memflags_trusted(ctx);
                     let expr2_0 = C::memarg_symbol(ctx, pattern4_1, expr0_0, expr1_0);
                     let expr3_0 = constructor_load_addr(ctx, &expr2_0)?;
-                    let expr4_0 = C::value_reg(ctx, expr3_0);
+                    let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                     return Some(expr4_0);
                 }
                 // Rule at src/isa/s390x/lower.isle line 1163.
                 let expr0_0: i64 = 0;
                 let expr1_0 = constructor_load_ext_name_far(ctx, pattern4_1, expr0_0)?;
-                let expr2_0 = C::value_reg(ctx, expr1_0);
+                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                 return Some(expr2_0);
             }
         }
@@ -7945,13 +7969,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::memflags_trusted(ctx);
                             let expr1_0 = C::memarg_symbol(ctx, pattern4_0, pattern7_0, expr0_0);
                             let expr2_0 = constructor_load_addr(ctx, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                     }
                     // Rule at src/isa/s390x/lower.isle line 1175.
                     let expr0_0 = constructor_load_ext_name_far(ctx, pattern4_0, pattern4_2)?;
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
+                    let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                     return Some(expr1_0);
                 }
             }
@@ -7965,7 +7989,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 // Rule at src/isa/s390x/lower.isle line 29.
                 let expr0_0: Type = F32;
                 let expr1_0 = constructor_imm(ctx, expr0_0, pattern4_0)?;
-                let expr2_0 = C::value_reg(ctx, expr1_0);
+                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                 return Some(expr2_0);
             }
         }
@@ -7978,7 +8002,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 // Rule at src/isa/s390x/lower.isle line 35.
                 let expr0_0: Type = F64;
                 let expr1_0 = constructor_imm(ctx, expr0_0, pattern4_0)?;
-                let expr2_0 = C::value_reg(ctx, expr1_0);
+                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                 return Some(expr2_0);
             }
         }
@@ -8062,7 +8086,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = constructor_istore8_impl(
                             ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                         )?;
-                        let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                        let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                         return Some(expr1_0);
                     }
                     if pattern5_0 == I16 {
@@ -8070,7 +8094,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = constructor_istore16_impl(
                             ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                         )?;
-                        let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                        let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                         return Some(expr1_0);
                     }
                     if pattern5_0 == I32 {
@@ -8078,7 +8102,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = constructor_istore32_impl(
                             ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                         )?;
-                        let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                        let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                         return Some(expr1_0);
                     }
                     if pattern5_0 == I64 {
@@ -8086,7 +8110,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = constructor_istore64_impl(
                             ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                         )?;
-                        let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                        let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                         return Some(expr1_0);
                     }
                     if pattern5_0 == R64 {
@@ -8094,7 +8118,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = constructor_istore64_impl(
                             ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                         )?;
-                        let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                        let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                         return Some(expr1_0);
                     }
                     if pattern5_0 == F32 {
@@ -8104,7 +8128,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern2_2, pattern4_1, pattern2_3)?;
                             let expr2_0 = constructor_fpu_store32(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_regs_none(ctx, &expr2_0)?;
+                            let expr3_0 = constructor_side_effect(ctx, &expr2_0)?;
                             return Some(expr3_0);
                         }
                         if let Some(()) = C::vxrs_ext2_enabled(ctx, pattern5_0) {
@@ -8115,7 +8139,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern2_2, pattern4_1, pattern2_3,
                                 )?;
                                 let expr2_0 = constructor_fpu_storerev32(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_regs_none(ctx, &expr2_0)?;
+                                let expr3_0 = constructor_side_effect(ctx, &expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -8131,7 +8155,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern2_2, pattern4_1, pattern2_3,
                                 )?;
                                 let expr6_0 = constructor_storerev32(ctx, expr4_0, &expr5_0)?;
-                                let expr7_0 = constructor_value_regs_none(ctx, &expr6_0)?;
+                                let expr7_0 = constructor_side_effect(ctx, &expr6_0)?;
                                 return Some(expr7_0);
                             }
                         }
@@ -8143,7 +8167,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern2_2, pattern4_1, pattern2_3)?;
                             let expr2_0 = constructor_fpu_store64(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_regs_none(ctx, &expr2_0)?;
+                            let expr3_0 = constructor_side_effect(ctx, &expr2_0)?;
                             return Some(expr3_0);
                         }
                         if let Some(()) = C::vxrs_ext2_enabled(ctx, pattern5_0) {
@@ -8154,7 +8178,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern2_2, pattern4_1, pattern2_3,
                                 )?;
                                 let expr2_0 = constructor_fpu_storerev64(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_regs_none(ctx, &expr2_0)?;
+                                let expr3_0 = constructor_side_effect(ctx, &expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -8167,7 +8191,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern2_2, pattern4_1, pattern2_3,
                                 )?;
                                 let expr3_0 = constructor_storerev64(ctx, expr1_0, &expr2_0)?;
-                                let expr4_0 = constructor_value_regs_none(ctx, &expr3_0)?;
+                                let expr4_0 = constructor_side_effect(ctx, &expr3_0)?;
                                 return Some(expr4_0);
                             }
                         }
@@ -8179,7 +8203,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr0_0 = constructor_istore8_impl(
                         ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                     )?;
-                    let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                    let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::Istore16 => {
@@ -8188,7 +8212,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr0_0 = constructor_istore16_impl(
                         ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                     )?;
-                    let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                    let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::Istore32 => {
@@ -8197,7 +8221,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr0_0 = constructor_istore32_impl(
                         ctx, pattern2_2, pattern4_0, pattern4_1, pattern2_3,
                     )?;
-                    let expr1_0 = constructor_value_regs_none(ctx, &expr0_0)?;
+                    let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 _ => {}
@@ -8210,17 +8234,17 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             match pattern2_0 {
                 &Opcode::Copy => {
                     // Rule at src/isa/s390x/lower.isle line 53.
-                    let expr0_0 = C::put_in_regs(ctx, pattern2_1);
+                    let expr0_0 = constructor_output_value(ctx, pattern2_1)?;
                     return Some(expr0_0);
                 }
                 &Opcode::Breduce => {
                     // Rule at src/isa/s390x/lower.isle line 752.
-                    let expr0_0 = C::put_in_regs(ctx, pattern2_1);
+                    let expr0_0 = constructor_output_value(ctx, pattern2_1)?;
                     return Some(expr0_0);
                 }
                 &Opcode::Ireduce => {
                     // Rule at src/isa/s390x/lower.isle line 596.
-                    let expr0_0 = C::put_in_regs(ctx, pattern2_1);
+                    let expr0_0 = constructor_output_value(ctx, pattern2_1)?;
                     return Some(expr0_0);
                 }
                 _ => {}
@@ -8262,7 +8286,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     let expr1_0 = C::mask_as_cond(ctx, expr0_0);
                                     let expr2_0 =
                                         constructor_trap_if_impl(ctx, &expr1_0, pattern2_3)?;
-                                    let expr3_0 = constructor_value_regs_none(ctx, &expr2_0)?;
+                                    let expr3_0 = constructor_side_effect(ctx, &expr2_0)?;
                                     return Some(expr3_0);
                                 }
                             }
@@ -8328,7 +8352,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr6_0 = C::intcc_as_cond(ctx, &expr5_0);
                             let expr7_0 = constructor_bool(ctx, &expr4_0, &expr6_0)?;
                             let expr8_0 = constructor_lower_bool(ctx, expr0_0, &expr7_0)?;
-                            let expr9_0 = C::value_reg(ctx, expr8_0);
+                            let expr9_0 = constructor_output_reg(ctx, expr8_0)?;
                             return Some(expr9_0);
                         }
                     }
@@ -8345,7 +8369,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr6_0 = C::intcc_as_cond(ctx, &expr5_0);
                             let expr7_0 = constructor_bool(ctx, &expr4_0, &expr6_0)?;
                             let expr8_0 = constructor_lower_bool(ctx, expr0_0, &expr7_0)?;
-                            let expr9_0 = C::value_reg(ctx, expr8_0);
+                            let expr9_0 = constructor_output_reg(ctx, expr8_0)?;
                             return Some(expr9_0);
                         }
                     }
@@ -8364,7 +8388,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         // Rule at src/isa/s390x/lower.isle line 884.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = constructor_popcnt_byte(ctx, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                 }
@@ -8380,7 +8404,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr2_0 =
                             constructor_lower_address(ctx, pattern5_2, pattern5_1, expr1_0)?;
                         let expr3_0 = constructor_zext32_mem(ctx, expr0_0, &expr2_0)?;
-                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                        let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                 }
@@ -8396,7 +8420,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 =
                             constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                         let expr2_0 = constructor_zext32_mem(ctx, expr0_0, &expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                 }
@@ -8418,7 +8442,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, expr0_0)?;
                             let expr2_0 = constructor_loadrev16(ctx, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -8428,7 +8452,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, expr1_0)?;
                             let expr3_0 = constructor_zext32_mem(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                     }
@@ -8445,7 +8469,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr1_0 = constructor_loadrev16(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -8454,7 +8478,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr2_0 = constructor_zext32_mem(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                     }
@@ -8480,7 +8504,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: Type = I64;
                             let expr5_0: u8 = 32;
                             let expr6_0 = constructor_lshr_imm(ctx, expr4_0, expr3_0, expr5_0)?;
-                            let expr7_0 = C::value_reg(ctx, expr6_0);
+                            let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                             return Some(expr7_0);
                         }
                         &Opcode::Smulhi => {
@@ -8493,7 +8517,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: Type = I64;
                             let expr5_0: u8 = 32;
                             let expr6_0 = constructor_ashr_imm(ctx, expr4_0, expr3_0, expr5_0)?;
-                            let expr7_0 = C::value_reg(ctx, expr6_0);
+                            let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                             return Some(expr7_0);
                         }
                         _ => {}
@@ -8512,7 +8536,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_mov_from_fpr(ctx, expr1_0)?;
                             let expr3_0: u8 = 32;
                             let expr4_0 = constructor_lshr_imm(ctx, expr0_0, expr2_0, expr3_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                     }
@@ -8529,7 +8553,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, expr0_0)?;
                             let expr2_0 = constructor_loadrev32(ctx, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -8538,7 +8562,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, expr0_0)?;
                             let expr2_0 = constructor_load32(ctx, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                     }
@@ -8555,7 +8579,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr1_0 = constructor_loadrev32(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -8563,7 +8587,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr1_0 = constructor_load32(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -8588,7 +8612,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr3_0: Type = I64;
                             let expr4_0 = constructor_regpair_hi(ctx, &expr2_0)?;
                             let expr5_0 = constructor_copy_reg(ctx, expr3_0, expr4_0)?;
-                            let expr6_0 = C::value_reg(ctx, expr5_0);
+                            let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Smulhi => {
@@ -8600,7 +8624,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr3_0: Type = I64;
                             let expr4_0 = constructor_regpair_hi(ctx, &expr2_0)?;
                             let expr5_0 = constructor_copy_reg(ctx, expr3_0, expr4_0)?;
-                            let expr6_0 = C::value_reg(ctx, expr5_0);
+                            let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         _ => {}
@@ -8616,7 +8640,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             // Rule at src/isa/s390x/lower.isle line 1135.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_mov_from_fpr(ctx, expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -8633,7 +8657,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, expr0_0)?;
                             let expr2_0 = constructor_loadrev64(ctx, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -8642,7 +8666,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, expr0_0)?;
                             let expr2_0 = constructor_load64(ctx, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                     }
@@ -8659,7 +8683,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr1_0 = constructor_loadrev64(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -8667,7 +8691,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr1_0 = constructor_load64(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -8690,7 +8714,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 =
                             constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                         let expr1_0 = constructor_loadrev64(ctx, &expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -8698,7 +8722,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 =
                             constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                         let expr1_0 = constructor_load64(ctx, &expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                 }
@@ -8720,7 +8744,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0: u8 = 32;
                             let expr3_0 = constructor_lshl_imm(ctx, expr0_0, expr1_0, expr2_0)?;
                             let expr4_0 = constructor_mov_to_fpr(ctx, expr3_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                     }
@@ -8737,7 +8761,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr1_0 = constructor_fpu_load32(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -8758,7 +8782,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             // Rule at src/isa/s390x/lower.isle line 1131.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_mov_to_fpr(ctx, expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -8775,7 +8799,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr1_0 = constructor_fpu_load64(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -8792,7 +8816,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     // Rule at src/isa/s390x/lower.isle line 41.
                     let expr0_0: u64 = 0;
                     let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
-                    let expr2_0 = C::value_reg(ctx, expr1_0);
+                    let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                     return Some(expr2_0);
                 }
             }
@@ -8804,7 +8828,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let pattern6_0 = C::u64_from_imm64(ctx, pattern4_1);
                     // Rule at src/isa/s390x/lower.isle line 15.
                     let expr0_0 = constructor_imm(ctx, pattern2_0, pattern6_0)?;
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
+                    let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                     return Some(expr1_0);
                 }
             }
@@ -8817,7 +8841,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     // Rule at src/isa/s390x/lower.isle line 1152.
                     let expr0_0 =
                         constructor_stack_addr_impl(ctx, pattern2_0, pattern4_1, pattern4_2)?;
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
+                    let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                     return Some(expr1_0);
                 }
             }
@@ -8830,14 +8854,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         // Rule at src/isa/s390x/lower.isle line 23.
                         let expr0_0: u64 = 1;
                         let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     if pattern4_1 == false {
                         // Rule at src/isa/s390x/lower.isle line 21.
                         let expr0_0: u64 = 0;
                         let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                 }
@@ -8853,7 +8877,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr2_0 = constructor_fadd_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Fsub => {
@@ -8862,7 +8886,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr2_0 = constructor_fsub_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Fmul => {
@@ -8871,7 +8895,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr2_0 = constructor_fmul_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Fdiv => {
@@ -8880,7 +8904,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr2_0 = constructor_fdiv_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Fcopysign => {
@@ -8889,7 +8913,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr2_0 = constructor_fpu_copysign(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Fmin => {
@@ -8898,7 +8922,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr2_0 = constructor_fmin_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::Fmax => {
@@ -8907,7 +8931,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern6_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern6_1);
                         let expr2_0 = constructor_fmax_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     _ => {}
@@ -8923,7 +8947,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     // Rule at src/isa/s390x/lower.isle line 2004.
                     let expr0_0 = constructor_fcmp_val(ctx, pattern4_2, pattern6_0, pattern6_1)?;
                     let expr1_0 = constructor_lower_bool(ctx, pattern2_0, &expr0_0)?;
-                    let expr2_0 = C::value_reg(ctx, expr1_0);
+                    let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                     return Some(expr2_0);
                 }
             }
@@ -8939,7 +8963,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr1_0 =
                         constructor_icmp_val(ctx, expr0_0, pattern4_2, pattern6_0, pattern6_1)?;
                     let expr2_0 = constructor_lower_bool(ctx, pattern2_0, &expr1_0)?;
-                    let expr3_0 = C::value_reg(ctx, expr2_0);
+                    let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                     return Some(expr3_0);
                 }
             }
@@ -8958,7 +8982,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr3_0 = constructor_select_bool_reg(
                             ctx, pattern2_0, &expr0_0, expr1_0, expr2_0,
                         )?;
-                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                        let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                     &Opcode::Fma => {
@@ -8970,7 +8994,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr2_0 = C::put_in_reg(ctx, pattern6_2);
                         let expr3_0 =
                             constructor_fma_reg(ctx, pattern2_0, expr0_0, expr1_0, expr2_0)?;
-                        let expr4_0 = C::value_reg(ctx, expr3_0);
+                        let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                     _ => {}
@@ -9008,7 +9032,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr4_0 = constructor_select_bool_reg(
                                     ctx, pattern2_0, &expr1_0, expr2_0, expr3_0,
                                 )?;
-                                let expr5_0 = C::value_reg(ctx, expr4_0);
+                                let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                                 return Some(expr5_0);
                             }
                         }
@@ -9024,61 +9048,61 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         // Rule at src/isa/s390x/lower.isle line 976.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_sqrt_reg(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Fneg => {
                         // Rule at src/isa/s390x/lower.isle line 983.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_fneg_reg(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Fabs => {
                         // Rule at src/isa/s390x/lower.isle line 990.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_fabs_reg(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Ceil => {
                         // Rule at src/isa/s390x/lower.isle line 997.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_ceil_reg(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Floor => {
                         // Rule at src/isa/s390x/lower.isle line 1004.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_floor_reg(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Trunc => {
                         // Rule at src/isa/s390x/lower.isle line 1011.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_trunc_reg(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Nearest => {
                         // Rule at src/isa/s390x/lower.isle line 1018.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_nearest_reg(ctx, pattern2_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Bextend => {
                         // Rule at src/isa/s390x/lower.isle line 760.
                         let expr0_0 = constructor_cast_bool(ctx, pattern2_0, pattern4_1)?;
-                        let expr1_0 = C::value_reg(ctx, expr0_0);
+                        let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                         return Some(expr1_0);
                     }
                     &Opcode::Bmask => {
                         // Rule at src/isa/s390x/lower.isle line 762.
                         let expr0_0 = constructor_cast_bool(ctx, pattern2_0, pattern4_1)?;
-                        let expr1_0 = C::value_reg(ctx, expr0_0);
+                        let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                         return Some(expr1_0);
                     }
                     &Opcode::Fpromote => {
@@ -9087,7 +9111,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 =
                             constructor_fpromote_reg(ctx, pattern2_0, pattern6_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Fdemote => {
@@ -9096,7 +9120,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 =
                             constructor_fdemote_reg(ctx, pattern2_0, pattern6_0, expr0_0)?;
-                        let expr2_0 = C::value_reg(ctx, expr1_0);
+                        let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::FcvtFromUint => {
@@ -9106,7 +9130,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern4_1)?;
                         let expr2_0 =
                             constructor_fcvt_from_uint_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     &Opcode::FcvtFromSint => {
@@ -9116,7 +9140,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr1_0 = constructor_put_in_reg_sext32(ctx, pattern4_1)?;
                         let expr2_0 =
                             constructor_fcvt_from_sint_reg(ctx, pattern2_0, expr0_0, expr1_0)?;
-                        let expr3_0 = C::value_reg(ctx, expr2_0);
+                        let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
                     _ => {}
@@ -9141,7 +9165,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
                                 let expr2_0 =
                                     constructor_and_not_reg(ctx, pattern4_0, expr0_0, expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::BorNot => {
@@ -9152,7 +9176,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
                                 let expr2_0 =
                                     constructor_or_not_reg(ctx, pattern4_0, expr0_0, expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::BxorNot => {
@@ -9163,7 +9187,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::put_in_reg(ctx, pattern8_1);
                                 let expr2_0 =
                                     constructor_xor_not_reg(ctx, pattern4_0, expr0_0, expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             _ => {}
@@ -9184,7 +9208,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0 =
                                 constructor_and_not_reg(ctx, pattern4_0, expr3_0, expr0_0)?;
                             let expr5_0 = constructor_or_reg(ctx, pattern4_0, expr4_0, expr2_0)?;
-                            let expr6_0 = C::value_reg(ctx, expr5_0);
+                            let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                     }
@@ -9198,14 +9222,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern6_1);
                                 let expr1_0 =
                                     constructor_or_not_reg(ctx, pattern4_0, expr0_0, expr0_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             &Opcode::Popcnt => {
                                 // Rule at src/isa/s390x/lower.isle line 889.
                                 let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern6_1)?;
                                 let expr1_0 = constructor_popcnt_reg(ctx, expr0_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             _ => {}
@@ -9235,7 +9259,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr7_0: Type = I32;
                         let expr8_0: u8 = 8;
                         let expr9_0 = constructor_lshr_imm(ctx, expr7_0, expr6_0, expr8_0)?;
-                        let expr10_0 = C::value_reg(ctx, expr9_0);
+                        let expr10_0 = constructor_output_reg(ctx, expr9_0)?;
                         return Some(expr10_0);
                     }
                 }
@@ -9264,7 +9288,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr12_0: Type = I32;
                         let expr13_0: u8 = 24;
                         let expr14_0 = constructor_lshr_imm(ctx, expr12_0, expr11_0, expr13_0)?;
-                        let expr15_0 = C::value_reg(ctx, expr14_0);
+                        let expr15_0 = constructor_output_reg(ctx, expr14_0)?;
                         return Some(expr15_0);
                     }
                 }
@@ -9298,7 +9322,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr17_0: Type = I64;
                         let expr18_0: u8 = 56;
                         let expr19_0 = constructor_lshr_imm(ctx, expr17_0, expr16_0, expr18_0)?;
-                        let expr20_0 = C::value_reg(ctx, expr19_0);
+                        let expr20_0 = constructor_output_reg(ctx, expr19_0)?;
                         return Some(expr20_0);
                     }
                 }
@@ -9320,7 +9344,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr2_0 =
                                     constructor_and_reg(ctx, pattern4_0, expr0_0, expr1_0)?;
                                 let expr3_0 = constructor_not_reg(ctx, pattern4_0, expr2_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             &Opcode::BorNot => {
@@ -9332,7 +9356,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr2_0 =
                                     constructor_or_reg(ctx, pattern4_0, expr0_0, expr1_0)?;
                                 let expr3_0 = constructor_not_reg(ctx, pattern4_0, expr2_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             &Opcode::BxorNot => {
@@ -9344,7 +9368,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr2_0 =
                                     constructor_xor_reg(ctx, pattern4_0, expr0_0, expr1_0)?;
                                 let expr3_0 = constructor_not_reg(ctx, pattern4_0, expr2_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             _ => {}
@@ -9365,7 +9389,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0 = constructor_and_reg(ctx, pattern4_0, expr3_0, expr0_0)?;
                             let expr5_0 = constructor_not_reg(ctx, pattern4_0, expr4_0)?;
                             let expr6_0 = constructor_or_reg(ctx, pattern4_0, expr5_0, expr2_0)?;
-                            let expr7_0 = C::value_reg(ctx, expr6_0);
+                            let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                             return Some(expr7_0);
                         }
                     }
@@ -9377,7 +9401,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             // Rule at src/isa/s390x/lower.isle line 630.
                             let expr0_0 = C::put_in_reg(ctx, pattern6_1);
                             let expr1_0 = constructor_not_reg(ctx, pattern4_0, expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -9401,7 +9425,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern6_2, pattern6_1, pattern6_3)?;
                             let expr1_0 = constructor_fpu_loadrev32(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -9422,7 +9446,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 =
                                 constructor_lower_address(ctx, pattern6_2, pattern6_1, pattern6_3)?;
                             let expr1_0 = constructor_fpu_loadrev64(ctx, &expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -9449,7 +9473,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr3_0: u8 = 32;
                             let expr4_0 = constructor_lshl_imm(ctx, expr2_0, expr1_0, expr3_0)?;
                             let expr5_0 = constructor_mov_to_fpr(ctx, expr4_0)?;
-                            let expr6_0 = C::value_reg(ctx, expr5_0);
+                            let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                     }
@@ -9471,7 +9495,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 constructor_lower_address(ctx, pattern6_2, pattern6_1, pattern6_3)?;
                             let expr1_0 = constructor_loadrev64(ctx, &expr0_0)?;
                             let expr2_0 = constructor_mov_to_fpr(ctx, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                     }
@@ -9492,7 +9516,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr2_0: u8 = 0;
                     let expr3_0 = C::uimm16shifted(ctx, expr1_0, expr2_0);
                     let expr4_0 = constructor_and_uimm16shifted(ctx, pattern3_0, expr0_0, expr3_0)?;
-                    let expr5_0 = C::value_reg(ctx, expr4_0);
+                    let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                     return Some(expr5_0);
                 }
             }
@@ -9511,7 +9535,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr2_0: u8 = 0;
                     let expr3_0 = C::uimm32shifted(ctx, expr1_0, expr2_0);
                     let expr4_0 = constructor_and_uimm32shifted(ctx, pattern3_0, expr0_0, expr3_0)?;
-                    let expr5_0 = C::value_reg(ctx, expr4_0);
+                    let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                     return Some(expr5_0);
                 }
             }
@@ -9531,7 +9555,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
                                 let expr1_0 =
                                     constructor_add_simm16(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::i32_from_value(ctx, pattern7_0) {
@@ -9539,7 +9563,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
                                 let expr1_0 =
                                     constructor_add_simm32(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_0) {
@@ -9558,7 +9582,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_add_reg_sext32(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -9583,7 +9607,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9596,7 +9620,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem_sext32(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9624,7 +9648,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9650,7 +9674,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9662,7 +9686,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_add_simm16(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::i32_from_value(ctx, pattern7_1) {
@@ -9670,7 +9694,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_add_simm32(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
@@ -9689,7 +9713,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_add_reg_sext32(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -9714,7 +9738,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9727,7 +9751,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem_sext32(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9755,7 +9779,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9781,7 +9805,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_add_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9792,7 +9816,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_add_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Isub => {
@@ -9802,7 +9826,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_add_simm16(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::i32_from_negated_value(ctx, pattern7_1) {
@@ -9810,7 +9834,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_add_simm32(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
@@ -9829,7 +9853,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_sub_reg_sext32(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -9854,7 +9878,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_sub_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9867,7 +9891,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_sub_mem_sext32(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9895,7 +9919,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_sub_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9921,7 +9945,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_sub_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -9932,7 +9956,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_sub_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Imul => {
@@ -9942,7 +9966,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
                                 let expr1_0 =
                                     constructor_mul_simm16(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::i32_from_value(ctx, pattern7_0) {
@@ -9950,7 +9974,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_1);
                                 let expr1_0 =
                                     constructor_mul_simm32(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_0) {
@@ -9969,7 +9993,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_mul_reg_sext32(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -9994,7 +10018,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10007,7 +10031,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem_sext32(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10035,7 +10059,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10061,7 +10085,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10073,7 +10097,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_mul_simm16(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::i32_from_value(ctx, pattern7_1) {
@@ -10081,7 +10105,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_mul_simm32(ctx, pattern3_0, expr0_0, pattern8_0)?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
@@ -10100,7 +10124,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_mul_reg_sext32(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -10125,7 +10149,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10138,7 +10162,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem_sext32(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10166,7 +10190,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem_sext16(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10192,7 +10216,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_mul_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10203,7 +10227,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_mul_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Udiv => {
@@ -10225,7 +10249,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr9_0 = constructor_udivmod(ctx, expr7_0, &expr5_0, expr6_0)?;
                             let expr10_0 = constructor_regpair_lo(ctx, &expr9_0)?;
                             let expr11_0 = constructor_copy_reg(ctx, pattern3_0, expr10_0)?;
-                            let expr12_0 = C::value_reg(ctx, expr11_0);
+                            let expr12_0 = constructor_output_reg(ctx, expr11_0)?;
                             return Some(expr12_0);
                         }
                         &Opcode::Sdiv => {
@@ -10247,7 +10271,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr8_0 = constructor_sdivmod(ctx, expr5_0, &expr3_0, expr4_0)?;
                             let expr9_0 = constructor_regpair_lo(ctx, &expr8_0)?;
                             let expr10_0 = constructor_copy_reg(ctx, pattern3_0, expr9_0)?;
-                            let expr11_0 = C::value_reg(ctx, expr10_0);
+                            let expr11_0 = constructor_output_reg(ctx, expr10_0)?;
                             return Some(expr11_0);
                         }
                         &Opcode::Urem => {
@@ -10268,7 +10292,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr8_0 = constructor_udivmod(ctx, expr6_0, &expr4_0, expr5_0)?;
                             let expr9_0 = constructor_regpair_hi(ctx, &expr8_0)?;
                             let expr10_0 = constructor_copy_reg(ctx, pattern3_0, expr9_0)?;
-                            let expr11_0 = C::value_reg(ctx, expr10_0);
+                            let expr11_0 = constructor_output_reg(ctx, expr10_0)?;
                             return Some(expr11_0);
                         }
                         &Opcode::Srem => {
@@ -10290,7 +10314,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr8_0 = constructor_sdivmod(ctx, expr5_0, &expr7_0, expr4_0)?;
                             let expr9_0 = constructor_regpair_hi(ctx, &expr8_0)?;
                             let expr10_0 = constructor_copy_reg(ctx, pattern3_0, expr9_0)?;
-                            let expr11_0 = C::value_reg(ctx, expr10_0);
+                            let expr11_0 = constructor_output_reg(ctx, expr10_0)?;
                             return Some(expr11_0);
                         }
                         &Opcode::IaddIfcout => {
@@ -10301,7 +10325,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_add_logical_zimm32(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = constructor_value_regs_ifcout(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_ifcout(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_0) {
@@ -10320,8 +10344,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_add_logical_reg_zext32(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 =
-                                                constructor_value_regs_ifcout(ctx, expr2_0)?;
+                                            let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -10345,8 +10368,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_add_logical_mem_zext32(
                                                 ctx, pattern3_0, expr0_0, &expr1_0,
                                             )?;
-                                            let expr3_0 =
-                                                constructor_value_regs_ifcout(ctx, expr2_0)?;
+                                            let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -10373,7 +10395,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
                                                 let expr3_0 =
-                                                    constructor_value_regs_ifcout(ctx, expr2_0)?;
+                                                    constructor_output_ifcout(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10386,7 +10408,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_add_logical_zimm32(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = constructor_value_regs_ifcout(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_ifcout(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::def_inst(ctx, pattern7_1) {
@@ -10405,8 +10427,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_add_logical_reg_zext32(
                                                 ctx, pattern3_0, expr0_0, expr1_0,
                                             )?;
-                                            let expr3_0 =
-                                                constructor_value_regs_ifcout(ctx, expr2_0)?;
+                                            let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -10430,8 +10451,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr2_0 = constructor_add_logical_mem_zext32(
                                                 ctx, pattern3_0, expr0_0, &expr1_0,
                                             )?;
-                                            let expr3_0 =
-                                                constructor_value_regs_ifcout(ctx, expr2_0)?;
+                                            let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                             return Some(expr3_0);
                                         }
                                     }
@@ -10458,7 +10478,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
                                                 let expr3_0 =
-                                                    constructor_value_regs_ifcout(ctx, expr2_0)?;
+                                                    constructor_output_ifcout(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10470,7 +10490,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 =
                                 constructor_add_logical_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = constructor_value_regs_ifcout(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Band => {
@@ -10495,7 +10515,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_and_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10510,7 +10530,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_and_uimm32shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) =
@@ -10521,7 +10541,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_and_uimm16shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             let pattern8_0 = C::value_type(ctx, pattern7_1);
@@ -10544,7 +10564,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_and_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10559,7 +10579,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_and_uimm32shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) =
@@ -10570,14 +10590,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_and_uimm16shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 637.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_and_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bor => {
@@ -10602,7 +10622,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_or_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10615,7 +10635,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_or_uimm32shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::uimm16shifted_from_value(ctx, pattern7_0) {
@@ -10624,7 +10644,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_or_uimm16shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             let pattern8_0 = C::value_type(ctx, pattern7_1);
@@ -10647,7 +10667,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_or_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10660,7 +10680,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_or_uimm32shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::uimm16shifted_from_value(ctx, pattern7_1) {
@@ -10669,14 +10689,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_or_uimm16shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 660.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_or_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
@@ -10701,7 +10721,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_xor_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10714,7 +10734,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_xor_uimm32shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             let pattern8_0 = C::value_type(ctx, pattern7_1);
@@ -10737,7 +10757,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 let expr2_0 = constructor_xor_mem(
                                                     ctx, pattern3_0, expr0_0, &expr1_0,
                                                 )?;
-                                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                                 return Some(expr3_0);
                                             }
                                         }
@@ -10750,14 +10770,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_xor_uimm32shifted(
                                     ctx, pattern3_0, expr0_0, pattern8_0,
                                 )?;
-                                let expr2_0 = C::value_reg(ctx, expr1_0);
+                                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 683.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_xor_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Ishl => {
@@ -10768,7 +10788,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr2_0 =
                                     constructor_lshl_imm(ctx, pattern3_0, expr1_0, expr0_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 477.
@@ -10776,7 +10796,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = constructor_mask_amt_reg(ctx, pattern3_0, expr0_0)?;
                             let expr2_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr3_0 = constructor_lshl_reg(ctx, pattern3_0, expr2_0, expr1_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
@@ -10787,7 +10807,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::mask_amt_imm(ctx, pattern3_0, pattern8_0);
                                 let expr2_0 = constructor_ty_ext32(ctx, pattern3_0)?;
                                 let expr3_0 = constructor_lshr_imm(ctx, expr2_0, expr0_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 491.
@@ -10796,7 +10816,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_mask_amt_reg(ctx, pattern3_0, expr1_0)?;
                             let expr3_0 = constructor_ty_ext32(ctx, pattern3_0)?;
                             let expr4_0 = constructor_lshr_reg(ctx, expr3_0, expr0_0, expr2_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         &Opcode::Sshr => {
@@ -10807,7 +10827,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::mask_amt_imm(ctx, pattern3_0, pattern8_0);
                                 let expr2_0 = constructor_ty_ext32(ctx, pattern3_0)?;
                                 let expr3_0 = constructor_ashr_imm(ctx, expr2_0, expr0_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 508.
@@ -10816,7 +10836,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_mask_amt_reg(ctx, pattern3_0, expr1_0)?;
                             let expr3_0 = constructor_ty_ext32(ctx, pattern3_0)?;
                             let expr4_0 = constructor_ashr_reg(ctx, expr3_0, expr0_0, expr2_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         _ => {}
@@ -10843,7 +10863,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr1_0 = constructor_neg_reg_sext32(
                                                 ctx, pattern3_0, expr0_0,
                                             )?;
-                                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                             return Some(expr2_0);
                                         }
                                     }
@@ -10852,7 +10872,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             // Rule at src/isa/s390x/lower.isle line 189.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_neg_reg(ctx, pattern3_0, expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         &Opcode::Iabs => {
@@ -10871,7 +10891,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             let expr1_0 = constructor_abs_reg_sext32(
                                                 ctx, pattern3_0, expr0_0,
                                             )?;
-                                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                             return Some(expr2_0);
                                         }
                                     }
@@ -10881,7 +10901,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr0_0 = constructor_ty_ext32(ctx, pattern3_0)?;
                             let expr1_0 = constructor_put_in_reg_sext32(ctx, pattern5_1)?;
                             let expr2_0 = constructor_abs_reg(ctx, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Clz => {
@@ -10891,7 +10911,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr2_0 = constructor_clz_reg(ctx, expr1_0, expr0_0)?;
                             let expr3_0 = constructor_regpair_hi(ctx, &expr2_0)?;
                             let expr4_0 = constructor_clz_offset(ctx, pattern3_0, expr3_0)?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                         &Opcode::Cls => {
@@ -10906,7 +10926,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr7_0 = constructor_clz_reg(ctx, expr6_0, expr5_0)?;
                             let expr8_0 = constructor_regpair_hi(ctx, &expr7_0)?;
                             let expr9_0 = constructor_clz_offset(ctx, pattern3_0, expr8_0)?;
-                            let expr10_0 = C::value_reg(ctx, expr9_0);
+                            let expr10_0 = constructor_output_reg(ctx, expr9_0)?;
                             return Some(expr10_0);
                         }
                         &Opcode::Bint => {
@@ -10915,7 +10935,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0: u64 = 1;
                             let expr2_0 = constructor_imm(ctx, pattern3_0, expr1_0)?;
                             let expr3_0 = constructor_and_reg(ctx, pattern3_0, expr0_0, expr2_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -10940,14 +10960,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr2_0 =
                                     constructor_rot_imm(ctx, pattern3_0, expr1_0, expr0_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 524.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_rot_reg(ctx, pattern3_0, expr0_0, expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Rotr => {
@@ -10958,7 +10978,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr2_0 =
                                     constructor_rot_imm(ctx, pattern3_0, expr1_0, expr0_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/s390x/lower.isle line 560.
@@ -10966,7 +10986,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 = constructor_neg_reg(ctx, pattern3_0, expr0_0)?;
                             let expr2_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr3_0 = constructor_rot_reg(ctx, pattern3_0, expr2_0, expr1_0)?;
-                            let expr4_0 = C::value_reg(ctx, expr3_0);
+                            let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -10994,7 +11014,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         ctx, pattern3_0, expr1_0, &expr3_0,
                                     )?;
                                     let expr5_0 = constructor_bswap_reg(ctx, pattern3_0, expr4_0)?;
-                                    let expr6_0 = C::value_reg(ctx, expr5_0);
+                                    let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                                     return Some(expr6_0);
                                 }
                                 &AtomicRmwOp::Or => {
@@ -11009,7 +11029,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         ctx, pattern3_0, expr1_0, &expr3_0,
                                     )?;
                                     let expr5_0 = constructor_bswap_reg(ctx, pattern3_0, expr4_0)?;
-                                    let expr6_0 = C::value_reg(ctx, expr5_0);
+                                    let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                                     return Some(expr6_0);
                                 }
                                 &AtomicRmwOp::Xor => {
@@ -11024,7 +11044,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         ctx, pattern3_0, expr1_0, &expr3_0,
                                     )?;
                                     let expr5_0 = constructor_bswap_reg(ctx, pattern3_0, expr4_0)?;
-                                    let expr6_0 = C::value_reg(ctx, expr5_0);
+                                    let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
                                     return Some(expr6_0);
                                 }
                                 _ => {}
@@ -11042,7 +11062,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     let expr3_0 = constructor_atomic_rmw_add(
                                         ctx, pattern3_0, expr0_0, &expr2_0,
                                     )?;
-                                    let expr4_0 = C::value_reg(ctx, expr3_0);
+                                    let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                     return Some(expr4_0);
                                 }
                                 &AtomicRmwOp::And => {
@@ -11055,7 +11075,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     let expr3_0 = constructor_atomic_rmw_and(
                                         ctx, pattern3_0, expr0_0, &expr2_0,
                                     )?;
-                                    let expr4_0 = C::value_reg(ctx, expr3_0);
+                                    let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                     return Some(expr4_0);
                                 }
                                 &AtomicRmwOp::Or => {
@@ -11068,7 +11088,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     let expr3_0 = constructor_atomic_rmw_or(
                                         ctx, pattern3_0, expr0_0, &expr2_0,
                                     )?;
-                                    let expr4_0 = C::value_reg(ctx, expr3_0);
+                                    let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                     return Some(expr4_0);
                                 }
                                 &AtomicRmwOp::Sub => {
@@ -11082,7 +11102,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     let expr4_0 = constructor_atomic_rmw_add(
                                         ctx, pattern3_0, expr1_0, &expr3_0,
                                     )?;
-                                    let expr5_0 = C::value_reg(ctx, expr4_0);
+                                    let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                                     return Some(expr5_0);
                                 }
                                 &AtomicRmwOp::Xor => {
@@ -11095,7 +11115,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     let expr3_0 = constructor_atomic_rmw_xor(
                                         ctx, pattern3_0, expr0_0, &expr2_0,
                                     )?;
-                                    let expr4_0 = C::value_reg(ctx, expr3_0);
+                                    let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                     return Some(expr4_0);
                                 }
                                 _ => {}
@@ -11115,7 +11135,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr7_0 = constructor_casloop(
                             ctx, &expr2_0, pattern3_0, pattern5_2, expr1_0, expr6_0,
                         )?;
-                        let expr8_0 = C::value_reg(ctx, expr7_0);
+                        let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                         return Some(expr8_0);
                     }
                 }
@@ -11140,7 +11160,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 ctx, pattern3_0, expr1_0, expr3_0, &expr5_0,
                             )?;
                             let expr7_0 = constructor_bswap_reg(ctx, pattern3_0, expr6_0)?;
-                            let expr8_0 = C::value_reg(ctx, expr7_0);
+                            let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
                         if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -11153,7 +11173,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0 = constructor_atomic_cas_impl(
                                 ctx, pattern3_0, expr0_0, expr1_0, &expr3_0,
                             )?;
-                            let expr5_0 = C::value_reg(ctx, expr4_0);
+                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
                             return Some(expr5_0);
                         }
                     }
@@ -11179,7 +11199,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr8_0 = C::floatcc_as_cond(ctx, &expr7_0);
                             let expr9_0 = C::trap_code_integer_overflow(ctx);
                             let expr10_0 = constructor_trap_if(ctx, &expr6_0, &expr8_0, &expr9_0)?;
-                            let expr11_0 = C::value_reg(ctx, expr10_0);
+                            let expr11_0 = constructor_output_reg(ctx, expr10_0)?;
                             return Some(expr11_0);
                         }
                         &Opcode::FcvtToUintSat => {
@@ -11195,7 +11215,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr6_0 =
                                 constructor_cmov_imm(ctx, pattern3_0, &expr4_0, expr5_0, expr1_0)?;
                             let expr7_0 = constructor_with_flags_reg(ctx, &expr2_0, &expr6_0)?;
-                            let expr8_0 = C::value_reg(ctx, expr7_0);
+                            let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
                         &Opcode::FcvtToSint => {
@@ -11214,7 +11234,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr8_0 = C::floatcc_as_cond(ctx, &expr7_0);
                             let expr9_0 = C::trap_code_integer_overflow(ctx);
                             let expr10_0 = constructor_trap_if(ctx, &expr6_0, &expr8_0, &expr9_0)?;
-                            let expr11_0 = C::value_reg(ctx, expr10_0);
+                            let expr11_0 = constructor_output_reg(ctx, expr10_0)?;
                             return Some(expr11_0);
                         }
                         &Opcode::FcvtToSintSat => {
@@ -11230,7 +11250,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr6_0 =
                                 constructor_cmov_imm(ctx, pattern3_0, &expr4_0, expr5_0, expr1_0)?;
                             let expr7_0 = constructor_with_flags_reg(ctx, &expr2_0, &expr6_0)?;
-                            let expr8_0 = C::value_reg(ctx, expr7_0);
+                            let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
                         _ => {}
@@ -11257,7 +11277,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: Type = I32;
                             let expr5_0 = C::ty_bits(ctx, pattern3_0);
                             let expr6_0 = constructor_lshr_imm(ctx, expr4_0, expr3_0, expr5_0)?;
-                            let expr7_0 = C::value_reg(ctx, expr6_0);
+                            let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                             return Some(expr7_0);
                         }
                         &Opcode::Smulhi => {
@@ -11270,7 +11290,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: Type = I32;
                             let expr5_0 = C::ty_bits(ctx, pattern3_0);
                             let expr6_0 = constructor_ashr_imm(ctx, expr4_0, expr3_0, expr5_0)?;
-                            let expr7_0 = C::value_reg(ctx, expr6_0);
+                            let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                             return Some(expr7_0);
                         }
                         &Opcode::Rotl => {
@@ -11289,7 +11309,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         constructor_lshr_imm(ctx, expr1_0, expr0_0, expr3_0)?;
                                     let expr6_0 =
                                         constructor_or_reg(ctx, pattern3_0, expr4_0, expr5_0)?;
-                                    let expr7_0 = C::value_reg(ctx, expr6_0);
+                                    let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                                     return Some(expr7_0);
                                 }
                             }
@@ -11303,7 +11323,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr6_0 = constructor_lshl_reg(ctx, expr1_0, expr0_0, expr4_0)?;
                             let expr7_0 = constructor_lshr_reg(ctx, expr1_0, expr0_0, expr5_0)?;
                             let expr8_0 = constructor_or_reg(ctx, pattern3_0, expr6_0, expr7_0)?;
-                            let expr9_0 = C::value_reg(ctx, expr8_0);
+                            let expr9_0 = constructor_output_reg(ctx, expr8_0)?;
                             return Some(expr9_0);
                         }
                         &Opcode::Rotr => {
@@ -11322,7 +11342,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         constructor_lshr_imm(ctx, expr1_0, expr0_0, expr2_0)?;
                                     let expr6_0 =
                                         constructor_or_reg(ctx, pattern3_0, expr4_0, expr5_0)?;
-                                    let expr7_0 = C::value_reg(ctx, expr6_0);
+                                    let expr7_0 = constructor_output_reg(ctx, expr6_0)?;
                                     return Some(expr7_0);
                                 }
                             }
@@ -11336,7 +11356,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr6_0 = constructor_lshl_reg(ctx, expr1_0, expr0_0, expr5_0)?;
                             let expr7_0 = constructor_lshr_reg(ctx, expr1_0, expr0_0, expr4_0)?;
                             let expr8_0 = constructor_or_reg(ctx, pattern3_0, expr6_0, expr7_0)?;
-                            let expr9_0 = C::value_reg(ctx, expr8_0);
+                            let expr9_0 = constructor_output_reg(ctx, expr8_0)?;
                             return Some(expr9_0);
                         }
                         _ => {}
@@ -11372,7 +11392,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr11_0 = constructor_casloop_subword(
                             ctx, &expr4_0, pattern3_0, pattern5_2, expr3_0, expr2_0, expr10_0,
                         )?;
-                        let expr12_0 = C::value_reg(ctx, expr11_0);
+                        let expr12_0 = constructor_output_reg(ctx, expr11_0)?;
                         return Some(expr12_0);
                     }
                 }
@@ -11407,7 +11427,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr12_0 = constructor_casloop_subword(
                             ctx, &expr5_0, pattern3_0, pattern5_2, expr4_0, expr3_0, expr11_0,
                         )?;
-                        let expr13_0 = C::value_reg(ctx, expr12_0);
+                        let expr13_0 = constructor_output_reg(ctx, expr12_0)?;
                         return Some(expr13_0);
                     }
                 }
@@ -11440,19 +11460,19 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr12_0 = constructor_regpair_hi(ctx, &expr9_0)?;
                             let expr13_0 =
                                 constructor_sub_reg(ctx, pattern3_0, expr11_0, expr12_0)?;
-                            let expr14_0 = C::value_reg(ctx, expr13_0);
+                            let expr14_0 = constructor_output_reg(ctx, expr13_0)?;
                             return Some(expr14_0);
                         }
                         &Opcode::Uextend => {
                             // Rule at src/isa/s390x/lower.isle line 603.
                             let expr0_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
-                            let expr1_0 = C::value_reg(ctx, expr0_0);
+                            let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                             return Some(expr1_0);
                         }
                         &Opcode::Sextend => {
                             // Rule at src/isa/s390x/lower.isle line 614.
                             let expr0_0 = constructor_put_in_reg_sext32(ctx, pattern5_1)?;
-                            let expr1_0 = C::value_reg(ctx, expr0_0);
+                            let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                             return Some(expr1_0);
                         }
                         _ => {}
@@ -11471,7 +11491,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr2_0 = constructor_zext32_mem(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Sload8 => {
@@ -11480,7 +11500,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr2_0 = constructor_sext32_mem(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Uload16 => {
@@ -11492,7 +11512,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_loadrev16(ctx, &expr0_0)?;
                                 let expr2_0: Type = I16;
                                 let expr3_0 = constructor_zext32_reg(ctx, expr2_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -11502,7 +11522,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern5_2, pattern5_1, pattern5_3,
                                 )?;
                                 let expr2_0 = constructor_zext32_mem(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -11515,7 +11535,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_loadrev16(ctx, &expr0_0)?;
                                 let expr2_0: Type = I16;
                                 let expr3_0 = constructor_sext32_reg(ctx, expr2_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -11525,7 +11545,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern5_2, pattern5_1, pattern5_3,
                                 )?;
                                 let expr2_0 = constructor_sext32_mem(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -11558,19 +11578,19 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr10_0 = constructor_imm(ctx, expr8_0, expr9_0)?;
                             let expr11_0 = constructor_regpair_hi(ctx, &expr6_0)?;
                             let expr12_0 = constructor_sub_reg(ctx, expr7_0, expr10_0, expr11_0)?;
-                            let expr13_0 = C::value_reg(ctx, expr12_0);
+                            let expr13_0 = constructor_output_reg(ctx, expr12_0)?;
                             return Some(expr13_0);
                         }
                         &Opcode::Uextend => {
                             // Rule at src/isa/s390x/lower.isle line 607.
                             let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern5_1)?;
-                            let expr1_0 = C::value_reg(ctx, expr0_0);
+                            let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                             return Some(expr1_0);
                         }
                         &Opcode::Sextend => {
                             // Rule at src/isa/s390x/lower.isle line 618.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern5_1)?;
-                            let expr1_0 = C::value_reg(ctx, expr0_0);
+                            let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                             return Some(expr1_0);
                         }
                         _ => {}
@@ -11589,7 +11609,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr2_0 = constructor_zext64_mem(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Sload8 => {
@@ -11598,7 +11618,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr1_0 =
                                 constructor_lower_address(ctx, pattern5_2, pattern5_1, pattern5_3)?;
                             let expr2_0 = constructor_sext64_mem(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = C::value_reg(ctx, expr2_0);
+                            let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Uload16 => {
@@ -11610,7 +11630,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_loadrev16(ctx, &expr0_0)?;
                                 let expr2_0: Type = I16;
                                 let expr3_0 = constructor_zext64_reg(ctx, expr2_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -11620,7 +11640,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern5_2, pattern5_1, pattern5_3,
                                 )?;
                                 let expr2_0 = constructor_zext64_mem(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -11633,7 +11653,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_loadrev16(ctx, &expr0_0)?;
                                 let expr2_0: Type = I16;
                                 let expr3_0 = constructor_sext64_reg(ctx, expr2_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -11643,7 +11663,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern5_2, pattern5_1, pattern5_3,
                                 )?;
                                 let expr2_0 = constructor_sext64_mem(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -11656,7 +11676,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_loadrev32(ctx, &expr0_0)?;
                                 let expr2_0: Type = I32;
                                 let expr3_0 = constructor_zext64_reg(ctx, expr2_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -11666,7 +11686,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern5_2, pattern5_1, pattern5_3,
                                 )?;
                                 let expr2_0 = constructor_zext64_mem(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -11679,7 +11699,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 = constructor_loadrev32(ctx, &expr0_0)?;
                                 let expr2_0: Type = I32;
                                 let expr3_0 = constructor_sext64_reg(ctx, expr2_0, expr1_0)?;
-                                let expr4_0 = C::value_reg(ctx, expr3_0);
+                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             if let Some(()) = C::bigendian(ctx, pattern5_2) {
@@ -11689,7 +11709,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     ctx, pattern5_2, pattern5_1, pattern5_3,
                                 )?;
                                 let expr2_0 = constructor_sext64_mem(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = C::value_reg(ctx, expr2_0);
+                                let expr3_0 = constructor_output_reg(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                         }
@@ -11708,7 +11728,7 @@ pub fn constructor_lower_branch<C: Context>(
     ctx: &mut C,
     arg0: Inst,
     arg1: &VecMachLabel,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     let pattern1_0 = C::inst_data(ctx, pattern0_0);
     match &pattern1_0 {
@@ -11731,12 +11751,12 @@ pub fn constructor_lower_branch<C: Context>(
                 let expr7_0: u8 = 0;
                 let expr8_0 = C::vec_element(ctx, pattern4_0, expr7_0);
                 let expr9_0 = constructor_oneway_cond_br_bool(ctx, &expr6_0, expr8_0)?;
-                let expr10_0 = constructor_value_regs_none(ctx, &expr9_0)?;
+                let expr10_0 = constructor_side_effect(ctx, &expr9_0)?;
                 let expr11_0: Type = I64;
                 let expr12_0: u8 = 2;
                 let expr13_0 = constructor_lshl_imm(ctx, expr11_0, expr0_0, expr12_0)?;
                 let expr14_0 = constructor_jt_sequence(ctx, expr13_0, pattern4_0)?;
-                let expr15_0 = constructor_value_regs_none(ctx, &expr14_0)?;
+                let expr15_0 = constructor_side_effect(ctx, &expr14_0)?;
                 return Some(expr15_0);
             }
         }
@@ -11757,7 +11777,7 @@ pub fn constructor_lower_branch<C: Context>(
                     let expr4_0: u8 = 1;
                     let expr5_0 = C::vec_element(ctx, pattern5_0, expr4_0);
                     let expr6_0 = constructor_cond_br_bool(ctx, &expr1_0, expr3_0, expr5_0)?;
-                    let expr7_0 = constructor_value_regs_none(ctx, &expr6_0)?;
+                    let expr7_0 = constructor_side_effect(ctx, &expr6_0)?;
                     return Some(expr7_0);
                 }
                 &Opcode::Brnz => {
@@ -11770,7 +11790,7 @@ pub fn constructor_lower_branch<C: Context>(
                     let expr3_0: u8 = 1;
                     let expr4_0 = C::vec_element(ctx, pattern5_0, expr3_0);
                     let expr5_0 = constructor_cond_br_bool(ctx, &expr0_0, expr2_0, expr4_0)?;
-                    let expr6_0 = constructor_value_regs_none(ctx, &expr5_0)?;
+                    let expr6_0 = constructor_side_effect(ctx, &expr5_0)?;
                     return Some(expr6_0);
                 }
                 _ => {}
@@ -11788,7 +11808,7 @@ pub fn constructor_lower_branch<C: Context>(
                 let expr0_0: u8 = 0;
                 let expr1_0 = C::vec_element(ctx, pattern5_0, expr0_0);
                 let expr2_0 = constructor_jump_impl(ctx, expr1_0)?;
-                let expr3_0 = constructor_value_regs_none(ctx, &expr2_0)?;
+                let expr3_0 = constructor_side_effect(ctx, &expr2_0)?;
                 return Some(expr3_0);
             }
         }
@@ -11821,7 +11841,7 @@ pub fn constructor_lower_branch<C: Context>(
                             let expr5_0 = C::vec_element(ctx, pattern10_0, expr4_0);
                             let expr6_0 =
                                 constructor_cond_br_bool(ctx, &expr1_0, expr3_0, expr5_0)?;
-                            let expr7_0 = constructor_value_regs_none(ctx, &expr6_0)?;
+                            let expr7_0 = constructor_side_effect(ctx, &expr6_0)?;
                             return Some(expr7_0);
                         }
                     }
@@ -11833,15 +11853,14 @@ pub fn constructor_lower_branch<C: Context>(
     return None;
 }
 
-// Generated as internal constructor for term value_regs_ifcout.
-pub fn constructor_value_regs_ifcout<C: Context>(ctx: &mut C, arg0: Reg) -> Option<ValueRegs> {
+// Generated as internal constructor for term output_ifcout.
+pub fn constructor_output_ifcout<C: Context>(ctx: &mut C, arg0: Reg) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     // Rule at src/isa/s390x/lower.isle line 154.
-    let expr0_0: Type = I64;
-    let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
-    let expr2_0 = C::writable_reg_to_reg(ctx, expr1_0);
-    let expr3_0 = C::value_regs(ctx, pattern0_0, expr2_0);
-    return Some(expr3_0);
+    let expr0_0 = C::value_reg(ctx, pattern0_0);
+    let expr1_0 = C::value_regs_invalid(ctx);
+    let expr2_0 = C::output_pair(ctx, expr0_0, expr1_0);
+    return Some(expr2_0);
 }
 
 // Generated as internal constructor for term zero_divisor_check_needed.
@@ -13109,12 +13128,12 @@ pub fn constructor_atomic_cas_body<C: Context>(
 pub fn constructor_atomic_store_impl<C: Context>(
     ctx: &mut C,
     arg0: &SideEffectNoResult,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     // Rule at src/isa/s390x/lower.isle line 1858.
-    let expr0_0 = constructor_value_regs_none(ctx, pattern0_0)?;
+    let expr0_0 = constructor_side_effect(ctx, pattern0_0)?;
     let expr1_0 = constructor_fence_impl(ctx)?;
-    let expr2_0 = constructor_value_regs_none(ctx, &expr1_0)?;
+    let expr2_0 = constructor_side_effect(ctx, &expr1_0)?;
     return Some(expr2_0);
 }
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1009,20 +1009,20 @@
 (rule (put_in_xmm_mem_imm val)
       (xmm_mem_imm_new (put_in_reg_mem_imm val)))
 
-;; Construct a `ValueRegs` out of a single GPR register.
-(decl value_gpr (Gpr) ValueRegs)
-(rule (value_gpr x)
-      (value_reg (gpr_to_reg x)))
+;; Construct an `InstOutput` out of a single GPR register.
+(decl output_gpr (Gpr) InstOutput)
+(rule (output_gpr x)
+      (output_reg (gpr_to_reg x)))
 
 ;; Construct a `ValueRegs` out of two GPR registers.
 (decl value_gprs (Gpr Gpr) ValueRegs)
 (rule (value_gprs x y)
       (value_regs (gpr_to_reg x) (gpr_to_reg y)))
 
-;; Construct a `ValueRegs` out of a single XMM register.
-(decl value_xmm (Xmm) ValueRegs)
-(rule (value_xmm x)
-      (value_reg (xmm_to_reg x)))
+;; Construct an `InstOutput` out of a single XMM register.
+(decl output_xmm (Xmm) InstOutput)
+(rule (output_xmm x)
+      (output_reg (xmm_to_reg x)))
 
 ;; Get the `n`th reg in a `ValueRegs` and construct a GPR from it.
 ;;
@@ -2223,7 +2223,7 @@
 
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(convert Gpr ValueRegs value_gpr)
+(convert Gpr InstOutput output_gpr)
 (convert Value Gpr put_in_gpr)
 (convert Value GprMem put_in_gpr_mem)
 (convert Value GprMemImm put_in_gpr_mem_imm)
@@ -2242,7 +2242,7 @@
 (convert WritableGpr WritableReg writable_gpr_to_reg)
 (convert WritableGpr Reg writable_gpr_to_r_reg)
 
-(convert Xmm ValueRegs value_xmm)
+(convert Xmm InstOutput output_xmm)
 (convert Value Xmm put_in_xmm)
 (convert Value XmmMem put_in_xmm_mem)
 (convert Value XmmMemImm put_in_xmm_mem_imm)

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2,7 +2,7 @@
 
 ;; The main lowering constructor term: takes a clif `Inst` and returns the
 ;; register(s) within which the lowered instruction's result values live.
-(decl lower (Inst) ValueRegs)
+(decl lower (Inst) InstOutput)
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -148,48 +148,39 @@
 ;; replace this with a bool carry flag, and all consumers of `iflags`
 ;; remain in the handwritten pattern-matching code and explicitly
 ;; match on the flags producer. So we can get away with just
-;; allocating a second temp so that the reg-renaming code does the
+;; using an invalid second output, and the reg-renaming code does the
 ;; right thing, for now. For safety, we assert elsewhere that no one
 ;; actually uses the register assigned to the SSA `iflags`-typed
 ;; `Value`.
 
-(decl unused_iflags () Gpr)
-(rule (unused_iflags)
-      (temp_writable_gpr))
+(decl output_ifcout (Reg) InstOutput)
+(rule (output_ifcout reg)
+      (output_pair reg (value_regs_invalid)))
 
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x y)))
-      (value_gprs (add ty x y)
-                  (unused_iflags)))
+      (output_ifcout (add ty x y)))
 
 ;; Add a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (simm32_from_value y))))
-      (value_gprs (add ty x y)
-                  (unused_iflags)))
+      (output_ifcout (add ty x y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (simm32_from_value x) y)))
-      (value_gprs (add ty y x)
-                  (unused_iflags)))
+      (output_ifcout (add ty y x)))
 
 ;; Add a register and memory.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (sinkable_load y))))
-      (value_gprs (add ty
-                       x
-                       (sink_load_to_gpr_mem_imm y))
-                  (unused_iflags)))
+      (output_ifcout (add ty x (sink_load_to_gpr_mem_imm y))))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (sinkable_load x) y)))
-      (value_gprs (add ty
-                       y
-                       (sink_load_to_gpr_mem_imm x))
-                  (unused_iflags)))
+      (output_ifcout (add ty y (sink_load_to_gpr_mem_imm x))))
 
 ;; (No `iadd_ifcout` for `i128`.)
 

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 8bf92e18323e7041
-src/isa/x64/inst.isle 1948445a25530d71
-src/isa/x64/lower.isle d1ee574941be387
+src/prelude.isle 957023853b23dacb
+src/isa/x64/inst.isle 5ee89205e6e9a46b
+src/isa/x64/lower.isle 348a808ea5de4cdb

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
@@ -25,6 +25,12 @@ pub trait Context {
     fn value_reg(&mut self, arg0: Reg) -> ValueRegs;
     fn value_regs(&mut self, arg0: Reg, arg1: Reg) -> ValueRegs;
     fn value_regs_invalid(&mut self) -> ValueRegs;
+    fn output_none(&mut self) -> InstOutput;
+    fn output(&mut self, arg0: ValueRegs) -> InstOutput;
+    fn output_pair(&mut self, arg0: ValueRegs, arg1: ValueRegs) -> InstOutput;
+    fn output_builder_new(&mut self) -> InstOutputBuilder;
+    fn output_builder_push(&mut self, arg0: &InstOutputBuilder, arg1: ValueRegs) -> Unit;
+    fn output_builder_finish(&mut self, arg0: &InstOutputBuilder) -> InstOutput;
     fn temp_writable_reg(&mut self, arg0: Type) -> WritableReg;
     fn invalid_reg(&mut self) -> Reg;
     fn put_in_reg(&mut self, arg0: Value) -> Reg;
@@ -127,13 +133,13 @@ pub trait Context {
     fn sse_insertps_lane_imm(&mut self, arg0: u8) -> u8;
 }
 
-/// Internal type SideEffectNoResult: defined at src/prelude.isle line 308.
+/// Internal type SideEffectNoResult: defined at src/prelude.isle line 345.
 #[derive(Clone, Debug)]
 pub enum SideEffectNoResult {
     Inst { inst: MInst },
 }
 
-/// Internal type ProducesFlags: defined at src/prelude.isle line 330.
+/// Internal type ProducesFlags: defined at src/prelude.isle line 367.
 #[derive(Clone, Debug)]
 pub enum ProducesFlags {
     ProducesFlagsSideEffect { inst: MInst },
@@ -141,7 +147,7 @@ pub enum ProducesFlags {
     ProducesFlagsReturnsResultWithConsumer { inst: MInst, result: Reg },
 }
 
-/// Internal type ConsumesFlags: defined at src/prelude.isle line 341.
+/// Internal type ConsumesFlags: defined at src/prelude.isle line 378.
 #[derive(Clone, Debug)]
 pub enum ConsumesFlags {
     ConsumesFlagsReturnsResultWithProducer {
@@ -494,10 +500,28 @@ pub enum ExtendKind {
     Zero,
 }
 
+// Generated as internal constructor for term output_reg.
+pub fn constructor_output_reg<C: Context>(ctx: &mut C, arg0: Reg) -> Option<InstOutput> {
+    let pattern0_0 = arg0;
+    // Rule at src/prelude.isle line 86.
+    let expr0_0 = C::value_reg(ctx, pattern0_0);
+    let expr1_0 = C::output(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term output_value.
+pub fn constructor_output_value<C: Context>(ctx: &mut C, arg0: Value) -> Option<InstOutput> {
+    let pattern0_0 = arg0;
+    // Rule at src/prelude.isle line 90.
+    let expr0_0 = C::put_in_regs(ctx, pattern0_0);
+    let expr1_0 = C::output(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
 // Generated as internal constructor for term temp_reg.
 pub fn constructor_temp_reg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/prelude.isle line 73.
+    // Rule at src/prelude.isle line 110.
     let expr0_0 = C::temp_writable_reg(ctx, pattern0_0);
     let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -506,26 +530,26 @@ pub fn constructor_temp_reg<C: Context>(ctx: &mut C, arg0: Type) -> Option<Reg> 
 // Generated as internal constructor for term lo_reg.
 pub fn constructor_lo_reg<C: Context>(ctx: &mut C, arg0: Value) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/prelude.isle line 108.
+    // Rule at src/prelude.isle line 145.
     let expr0_0 = C::put_in_regs(ctx, pattern0_0);
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term value_regs_none.
-pub fn constructor_value_regs_none<C: Context>(
+// Generated as internal constructor for term side_effect.
+pub fn constructor_side_effect<C: Context>(
     ctx: &mut C,
     arg0: &SideEffectNoResult,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     if let &SideEffectNoResult::Inst {
         inst: ref pattern1_0,
     } = pattern0_0
     {
-        // Rule at src/prelude.isle line 313.
+        // Rule at src/prelude.isle line 350.
         let expr0_0 = C::emit(ctx, pattern1_0);
-        let expr1_0 = C::value_regs_invalid(ctx);
+        let expr1_0 = C::output_none(ctx);
         return Some(expr1_0);
     }
     return None;
@@ -535,15 +559,15 @@ pub fn constructor_value_regs_none<C: Context>(
 pub fn constructor_safepoint<C: Context>(
     ctx: &mut C,
     arg0: &SideEffectNoResult,
-) -> Option<ValueRegs> {
+) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     if let &SideEffectNoResult::Inst {
         inst: ref pattern1_0,
     } = pattern0_0
     {
-        // Rule at src/prelude.isle line 319.
+        // Rule at src/prelude.isle line 356.
         let expr0_0 = C::emit_safepoint(ctx, pattern1_0);
-        let expr1_0 = C::value_regs_invalid(ctx);
+        let expr1_0 = C::output_none(ctx);
         return Some(expr1_0);
     }
     return None;
@@ -567,7 +591,7 @@ pub fn constructor_consumes_flags_concat<C: Context>(
             result: pattern3_1,
         } = pattern2_0
         {
-            // Rule at src/prelude.isle line 353.
+            // Rule at src/prelude.isle line 390.
             let expr0_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
             let expr1_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
                 inst1: pattern1_0.clone(),
@@ -597,7 +621,7 @@ pub fn constructor_with_flags<C: Context>(
                     inst: ref pattern3_0,
                     result: pattern3_1,
                 } => {
-                    // Rule at src/prelude.isle line 378.
+                    // Rule at src/prelude.isle line 415.
                     let expr0_0 = C::emit(ctx, pattern1_0);
                     let expr1_0 = C::emit(ctx, pattern3_0);
                     let expr2_0 = C::value_reg(ctx, pattern3_1);
@@ -608,7 +632,7 @@ pub fn constructor_with_flags<C: Context>(
                     inst2: ref pattern3_1,
                     result: pattern3_2,
                 } => {
-                    // Rule at src/prelude.isle line 384.
+                    // Rule at src/prelude.isle line 421.
                     let expr0_0 = C::emit(ctx, pattern1_0);
                     let expr1_0 = C::emit(ctx, pattern3_1);
                     let expr2_0 = C::emit(ctx, pattern3_0);
@@ -627,7 +651,7 @@ pub fn constructor_with_flags<C: Context>(
                 result: pattern3_1,
             } = pattern2_0
             {
-                // Rule at src/prelude.isle line 372.
+                // Rule at src/prelude.isle line 409.
                 let expr0_0 = C::emit(ctx, pattern1_0);
                 let expr1_0 = C::emit(ctx, pattern3_0);
                 let expr2_0 = C::value_regs(ctx, pattern1_1, pattern3_1);
@@ -647,7 +671,7 @@ pub fn constructor_with_flags_reg<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/prelude.isle line 397.
+    // Rule at src/prelude.isle line 434.
     let expr0_0 = constructor_with_flags(ctx, pattern0_0, pattern1_0)?;
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -746,12 +770,12 @@ pub fn constructor_put_in_xmm_mem_imm<C: Context>(ctx: &mut C, arg0: Value) -> O
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term value_gpr.
-pub fn constructor_value_gpr<C: Context>(ctx: &mut C, arg0: Gpr) -> Option<ValueRegs> {
+// Generated as internal constructor for term output_gpr.
+pub fn constructor_output_gpr<C: Context>(ctx: &mut C, arg0: Gpr) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     // Rule at src/isa/x64/inst.isle line 1014.
     let expr0_0 = C::gpr_to_reg(ctx, pattern0_0);
-    let expr1_0 = C::value_reg(ctx, expr0_0);
+    let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
     return Some(expr1_0);
 }
 
@@ -766,12 +790,12 @@ pub fn constructor_value_gprs<C: Context>(ctx: &mut C, arg0: Gpr, arg1: Gpr) -> 
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term value_xmm.
-pub fn constructor_value_xmm<C: Context>(ctx: &mut C, arg0: Xmm) -> Option<ValueRegs> {
+// Generated as internal constructor for term output_xmm.
+pub fn constructor_output_xmm<C: Context>(ctx: &mut C, arg0: Xmm) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     // Rule at src/isa/x64/inst.isle line 1024.
     let expr0_0 = C::xmm_to_reg(ctx, pattern0_0);
-    let expr1_0 = C::value_reg(ctx, expr0_0);
+    let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
     return Some(expr1_0);
 }
 
@@ -3442,7 +3466,7 @@ pub fn constructor_synthetic_amode_to_xmm_mem<C: Context>(
 }
 
 // Generated as internal constructor for term lower.
-pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueRegs> {
+pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutput> {
     let pattern0_0 = arg0;
     let pattern1_0 = C::inst_data(ctx, pattern0_0);
     match &pattern1_0 {
@@ -3455,7 +3479,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 // Rule at src/isa/x64/lower.isle line 46.
                 let expr0_0: Type = F32;
                 let expr1_0 = constructor_imm(ctx, expr0_0, pattern4_0)?;
-                let expr2_0 = C::value_reg(ctx, expr1_0);
+                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                 return Some(expr2_0);
             }
         }
@@ -3468,7 +3492,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 // Rule at src/isa/x64/lower.isle line 51.
                 let expr0_0: Type = F64;
                 let expr1_0 = constructor_imm(ctx, expr0_0, pattern4_0)?;
-                let expr2_0 = C::value_reg(ctx, expr1_0);
+                let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                 return Some(expr2_0);
             }
         }
@@ -3478,13 +3502,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
         } => {
             match pattern2_0 {
                 &Opcode::Trap => {
-                    // Rule at src/isa/x64/lower.isle line 1444.
+                    // Rule at src/isa/x64/lower.isle line 1435.
                     let expr0_0 = constructor_ud2(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::ResumableTrap => {
-                    // Rule at src/isa/x64/lower.isle line 1449.
+                    // Rule at src/isa/x64/lower.isle line 1440.
                     let expr0_0 = constructor_ud2(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
@@ -3501,12 +3525,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, pattern2_1);
                 let pattern5_0 = C::value_type(ctx, pattern4_0);
                 let pattern6_0 = C::u8_from_uimm8(ctx, pattern2_2);
-                // Rule at src/isa/x64/lower.isle line 1311.
+                // Rule at src/isa/x64/lower.isle line 1302.
                 let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                 let expr1_0 = C::put_in_reg_mem(ctx, pattern4_1);
                 let expr2_0 =
                     constructor_vec_insert_lane(ctx, pattern5_0, expr0_0, &expr1_0, pattern6_0)?;
-                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                 return Some(expr3_0);
             }
         }
@@ -3531,7 +3555,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: u64 = 0;
                             let expr5_0 = constructor_imm(ctx, expr3_0, expr4_0)?;
                             let expr6_0 = C::value_regs(ctx, expr2_0, expr5_0);
-                            return Some(expr6_0);
+                            let expr7_0 = C::output(ctx, expr6_0);
+                            return Some(expr7_0);
                         }
                         if pattern5_1 == false {
                             // Rule at src/isa/x64/lower.isle line 34.
@@ -3542,7 +3567,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr4_0: u64 = 0;
                             let expr5_0 = constructor_imm(ctx, expr3_0, expr4_0)?;
                             let expr6_0 = C::value_regs(ctx, expr2_0, expr5_0);
-                            return Some(expr6_0);
+                            let expr7_0 = C::output(ctx, expr6_0);
+                            return Some(expr7_0);
                         }
                     }
                 }
@@ -3553,7 +3579,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 353.
+                            // Rule at src/isa/x64/lower.isle line 344.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3564,11 +3590,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr7_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
                             let expr8_0 = constructor_x64_and(ctx, expr6_0, expr2_0, &expr7_0)?;
                             let expr9_0 = constructor_value_gprs(ctx, expr8_0, expr4_0)?;
-                            return Some(expr9_0);
+                            let expr10_0 = C::output(ctx, expr9_0);
+                            return Some(expr10_0);
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 419.
+                            // Rule at src/isa/x64/lower.isle line 410.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3579,11 +3606,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr7_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
                             let expr8_0 = constructor_or(ctx, expr6_0, expr2_0, &expr7_0)?;
                             let expr9_0 = constructor_value_gprs(ctx, expr8_0, expr4_0)?;
-                            return Some(expr9_0);
+                            let expr10_0 = C::output(ctx, expr9_0);
+                            return Some(expr10_0);
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 477.
+                            // Rule at src/isa/x64/lower.isle line 468.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3594,7 +3622,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr7_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
                             let expr8_0 = constructor_xor(ctx, expr6_0, expr2_0, &expr7_0)?;
                             let expr9_0 = constructor_value_gprs(ctx, expr8_0, expr4_0)?;
-                            return Some(expr9_0);
+                            let expr10_0 = C::output(ctx, expr9_0);
+                            return Some(expr10_0);
                         }
                         _ => {}
                     }
@@ -3604,9 +3633,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Bnot = pattern5_0 {
-                        // Rule at src/isa/x64/lower.isle line 1278.
+                        // Rule at src/isa/x64/lower.isle line 1269.
                         let expr0_0 = constructor_i128_not(ctx, pattern5_1)?;
-                        return Some(expr0_0);
+                        let expr1_0 = C::output(ctx, expr0_0);
+                        return Some(expr1_0);
                     }
                 }
                 _ => {}
@@ -3628,7 +3658,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr3_0: u64 = 0;
                         let expr4_0 = constructor_imm(ctx, expr2_0, expr3_0)?;
                         let expr5_0 = C::value_regs(ctx, expr1_0, expr4_0);
-                        return Some(expr5_0);
+                        let expr6_0 = C::output(ctx, expr5_0);
+                        return Some(expr6_0);
                     }
                 }
                 &InstructionData::Binary {
@@ -3659,11 +3690,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr15_0 =
                                 constructor_adc_paired(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0 = constructor_with_flags(ctx, &expr12_0, &expr15_0)?;
-                            return Some(expr16_0);
+                            let expr17_0 = C::output(ctx, expr16_0);
+                            return Some(expr17_0);
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 266.
+                            // Rule at src/isa/x64/lower.isle line 257.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3684,11 +3716,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr15_0 =
                                 constructor_sbb_paired(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0 = constructor_with_flags(ctx, &expr12_0, &expr15_0)?;
-                            return Some(expr16_0);
+                            let expr17_0 = C::output(ctx, expr16_0);
+                            return Some(expr17_0);
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 966.
+                            // Rule at src/isa/x64/lower.isle line 957.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3719,11 +3752,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr27_0 = C::gpr_to_gpr_mem_imm(ctx, expr25_0);
                             let expr28_0 = constructor_add(ctx, expr26_0, expr18_0, &expr27_0)?;
                             let expr29_0 = constructor_value_gprs(ctx, expr23_0, expr28_0)?;
-                            return Some(expr29_0);
+                            let expr30_0 = C::output(ctx, expr29_0);
+                            return Some(expr30_0);
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 343.
+                            // Rule at src/isa/x64/lower.isle line 334.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3741,19 +3775,21 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr14_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
                             let expr15_0 = constructor_x64_and(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0 = constructor_value_gprs(ctx, expr12_0, expr15_0)?;
-                            return Some(expr16_0);
+                            let expr17_0 = C::output(ctx, expr16_0);
+                            return Some(expr17_0);
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 416.
+                            // Rule at src/isa/x64/lower.isle line 407.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0 = constructor_or_i128(ctx, expr0_0, expr1_0)?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 467.
+                            // Rule at src/isa/x64/lower.isle line 458.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3771,11 +3807,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr14_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
                             let expr15_0 = constructor_xor(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0 = constructor_value_gprs(ctx, expr12_0, expr15_0)?;
-                            return Some(expr16_0);
+                            let expr17_0 = C::output(ctx, expr16_0);
+                            return Some(expr17_0);
                         }
                         &Opcode::Rotl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 839.
+                            // Rule at src/isa/x64/lower.isle line 830.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr2_0 = constructor_shl_i128(ctx, expr0_0, expr1_0)?;
@@ -3788,11 +3825,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr9_0 = constructor_sub(ctx, expr3_0, expr7_0, &expr8_0)?;
                             let expr10_0 = constructor_shr_i128(ctx, expr0_0, expr9_0)?;
                             let expr11_0 = constructor_or_i128(ctx, expr2_0, expr10_0)?;
-                            return Some(expr11_0);
+                            let expr12_0 = C::output(ctx, expr11_0);
+                            return Some(expr12_0);
                         }
                         &Opcode::Rotr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 879.
+                            // Rule at src/isa/x64/lower.isle line 870.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr2_0 = constructor_shr_i128(ctx, expr0_0, expr1_0)?;
@@ -3805,31 +3843,35 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr9_0 = constructor_sub(ctx, expr3_0, expr7_0, &expr8_0)?;
                             let expr10_0 = constructor_shl_i128(ctx, expr0_0, expr9_0)?;
                             let expr11_0 = constructor_or_i128(ctx, expr2_0, expr10_0)?;
-                            return Some(expr11_0);
+                            let expr12_0 = C::output(ctx, expr11_0);
+                            return Some(expr12_0);
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 531.
+                            // Rule at src/isa/x64/lower.isle line 522.
                             let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr1_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr2_0 = constructor_shl_i128(ctx, expr1_0, expr0_0)?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 632.
+                            // Rule at src/isa/x64/lower.isle line 623.
                             let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr1_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr2_0 = constructor_shr_i128(ctx, expr1_0, expr0_0)?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 737.
+                            // Rule at src/isa/x64/lower.isle line 728.
                             let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr1_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr2_0 = constructor_sar_i128(ctx, expr1_0, expr0_0)?;
-                            return Some(expr2_0);
+                            let expr3_0 = C::output(ctx, expr2_0);
+                            return Some(expr3_0);
                         }
                         _ => {}
                     }
@@ -3839,9 +3881,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Bnot = pattern5_0 {
-                        // Rule at src/isa/x64/lower.isle line 1275.
+                        // Rule at src/isa/x64/lower.isle line 1266.
                         let expr0_0 = constructor_i128_not(ctx, pattern5_1)?;
-                        return Some(expr0_0);
+                        let expr1_0 = C::output(ctx, expr0_0);
+                        return Some(expr1_0);
                     }
                 }
                 &InstructionData::BinaryImm64 {
@@ -3851,7 +3894,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     if let &Opcode::IaddImm = pattern5_0 {
                         let pattern7_0 = C::u64_from_imm64(ctx, pattern5_2);
-                        // Rule at src/isa/x64/lower.isle line 219.
+                        // Rule at src/isa/x64/lower.isle line 210.
                         let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                         let expr1_0: usize = 0;
                         let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3870,7 +3913,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr14_0 = C::gpr_mem_imm_new(ctx, &expr13_0);
                         let expr15_0 = constructor_adc_paired(ctx, expr11_0, expr4_0, &expr14_0)?;
                         let expr16_0 = constructor_with_flags(ctx, &expr10_0, &expr15_0)?;
-                        return Some(expr16_0);
+                        let expr17_0 = C::output(ctx, expr16_0);
+                        return Some(expr17_0);
                     }
                 }
                 _ => {}
@@ -3886,43 +3930,43 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1411.
+                            // Rule at src/isa/x64/lower.isle line 1402.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminsb(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1433.
+                            // Rule at src/isa/x64/lower.isle line 1424.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminub(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1400.
+                            // Rule at src/isa/x64/lower.isle line 1391.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxsb(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1422.
+                            // Rule at src/isa/x64/lower.isle line 1413.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxub(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 543.
+                            // Rule at src/isa/x64/lower.isle line 534.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -3936,12 +3980,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr10_0 = RegMem::Reg { reg: expr8_0 };
                             let expr11_0 = C::reg_mem_to_xmm_mem(ctx, &expr10_0);
                             let expr12_0 = constructor_sse_and(ctx, expr9_0, expr3_0, &expr11_0)?;
-                            let expr13_0 = constructor_value_xmm(ctx, expr12_0)?;
+                            let expr13_0 = constructor_output_xmm(ctx, expr12_0)?;
                             return Some(expr13_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 642.
+                            // Rule at src/isa/x64/lower.isle line 633.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -3955,13 +3999,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr10_0 = RegMem::Reg { reg: expr8_0 };
                             let expr11_0 = C::reg_mem_to_xmm_mem(ctx, &expr10_0);
                             let expr12_0 = constructor_sse_and(ctx, expr9_0, expr3_0, &expr11_0)?;
-                            let expr13_0 = constructor_value_xmm(ctx, expr12_0)?;
+                            let expr13_0 = constructor_output_xmm(ctx, expr12_0)?;
                             return Some(expr13_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             let pattern8_0 = C::value_type(ctx, pattern7_1);
-                            // Rule at src/isa/x64/lower.isle line 758.
+                            // Rule at src/isa/x64/lower.isle line 749.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                             let expr2_0 = constructor_punpcklbw(ctx, expr0_0, &expr1_0)?;
@@ -3974,7 +4018,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr8_0 = constructor_psraw(ctx, expr4_0, &expr6_0)?;
                             let expr9_0 = C::xmm_to_xmm_mem(ctx, expr8_0);
                             let expr10_0 = constructor_packsswb(ctx, expr7_0, &expr9_0)?;
-                            let expr11_0 = constructor_value_xmm(ctx, expr10_0)?;
+                            let expr11_0 = constructor_output_xmm(ctx, expr10_0)?;
                             return Some(expr11_0);
                         }
                         _ => {}
@@ -3986,21 +4030,21 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 898.
+                            // Rule at src/isa/x64/lower.isle line 889.
                             let expr0_0: Type = I8X16;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr5_0 = constructor_psubb(ctx, expr3_0, &expr4_0)?;
-                            let expr6_0 = constructor_value_xmm(ctx, expr5_0)?;
+                            let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1219.
+                            // Rule at src/isa/x64/lower.isle line 1210.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr1_0 = constructor_pabsb(ctx, &expr0_0)?;
-                            let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
+                            let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         _ => {}
@@ -4019,68 +4063,68 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1414.
+                            // Rule at src/isa/x64/lower.isle line 1405.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminsw(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1436.
+                            // Rule at src/isa/x64/lower.isle line 1427.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminuw(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1403.
+                            // Rule at src/isa/x64/lower.isle line 1394.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxsw(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1425.
+                            // Rule at src/isa/x64/lower.isle line 1416.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxuw(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 585.
+                            // Rule at src/isa/x64/lower.isle line 576.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psllw(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 687.
+                            // Rule at src/isa/x64/lower.isle line 678.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psrlw(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 785.
+                            // Rule at src/isa/x64/lower.isle line 776.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psraw(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -4092,21 +4136,21 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 901.
+                            // Rule at src/isa/x64/lower.isle line 892.
                             let expr0_0: Type = I16X8;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr5_0 = constructor_psubw(ctx, expr3_0, &expr4_0)?;
-                            let expr6_0 = constructor_value_xmm(ctx, expr5_0)?;
+                            let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1222.
+                            // Rule at src/isa/x64/lower.isle line 1213.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr1_0 = constructor_pabsw(ctx, &expr0_0)?;
-                            let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
+                            let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         _ => {}
@@ -4125,68 +4169,68 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1417.
+                            // Rule at src/isa/x64/lower.isle line 1408.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminsd(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1439.
+                            // Rule at src/isa/x64/lower.isle line 1430.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminud(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1406.
+                            // Rule at src/isa/x64/lower.isle line 1397.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxsd(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1428.
+                            // Rule at src/isa/x64/lower.isle line 1419.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxud(ctx, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 588.
+                            // Rule at src/isa/x64/lower.isle line 579.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_pslld(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 690.
+                            // Rule at src/isa/x64/lower.isle line 681.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psrld(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 788.
+                            // Rule at src/isa/x64/lower.isle line 779.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psrad(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -4198,21 +4242,21 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 904.
+                            // Rule at src/isa/x64/lower.isle line 895.
                             let expr0_0: Type = I32X4;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr5_0 = constructor_psubd(ctx, expr3_0, &expr4_0)?;
-                            let expr6_0 = constructor_value_xmm(ctx, expr5_0)?;
+                            let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1225.
+                            // Rule at src/isa/x64/lower.isle line 1216.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr1_0 = constructor_pabsd(ctx, &expr0_0)?;
-                            let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
+                            let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         _ => {}
@@ -4231,27 +4275,27 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 591.
+                            // Rule at src/isa/x64/lower.isle line 582.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psllq(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 693.
+                            // Rule at src/isa/x64/lower.isle line 684.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psrlq(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 799.
+                            // Rule at src/isa/x64/lower.isle line 790.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0: Type = I64;
                             let expr2_0: u8 = 0;
@@ -4269,7 +4313,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr14_0 = C::gpr_to_gpr_mem(ctx, expr12_0);
                             let expr15_0 =
                                 constructor_make_i64x2_from_lanes(ctx, &expr13_0, &expr14_0)?;
-                            let expr16_0 = constructor_value_xmm(ctx, expr15_0)?;
+                            let expr16_0 = constructor_output_xmm(ctx, expr15_0)?;
                             return Some(expr16_0);
                         }
                         _ => {}
@@ -4281,18 +4325,18 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 907.
+                            // Rule at src/isa/x64/lower.isle line 898.
                             let expr0_0: Type = I64X2;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr5_0 = constructor_psubq(ctx, expr3_0, &expr4_0)?;
-                            let expr6_0 = constructor_value_xmm(ctx, expr5_0)?;
+                            let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1239.
+                            // Rule at src/isa/x64/lower.isle line 1230.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                             let expr1_0: Type = I64X2;
                             let expr2_0: u64 = 0;
@@ -4302,7 +4346,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             let expr6_0 = constructor_psubq(ctx, expr4_0, &expr5_0)?;
                             let expr7_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                             let expr8_0 = constructor_blendvpd(ctx, expr6_0, &expr7_0, expr6_0)?;
-                            let expr9_0 = constructor_value_xmm(ctx, expr8_0)?;
+                            let expr9_0 = constructor_output_xmm(ctx, expr8_0)?;
                             return Some(expr9_0);
                         }
                         _ => {}
@@ -4319,7 +4363,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } = &pattern4_0
             {
                 if let &Opcode::Fabs = pattern5_0 {
-                    // Rule at src/isa/x64/lower.isle line 1247.
+                    // Rule at src/isa/x64/lower.isle line 1238.
                     let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                     let expr1_0: Type = F32X4;
                     let expr2_0 = constructor_vector_all_ones(ctx, expr1_0)?;
@@ -4329,7 +4373,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr6_0 = constructor_psrld(ctx, expr2_0, &expr5_0)?;
                     let expr7_0 = C::xmm_to_xmm_mem(ctx, expr6_0);
                     let expr8_0 = constructor_andps(ctx, expr0_0, &expr7_0)?;
-                    let expr9_0 = constructor_value_xmm(ctx, expr8_0)?;
+                    let expr9_0 = constructor_output_xmm(ctx, expr8_0)?;
                     return Some(expr9_0);
                 }
             }
@@ -4342,7 +4386,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } = &pattern4_0
             {
                 if let &Opcode::Fabs = pattern5_0 {
-                    // Rule at src/isa/x64/lower.isle line 1253.
+                    // Rule at src/isa/x64/lower.isle line 1244.
                     let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                     let expr1_0: Type = F64X2;
                     let expr2_0 = constructor_vector_all_ones(ctx, expr1_0)?;
@@ -4352,7 +4396,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     let expr6_0 = constructor_psrlq(ctx, expr2_0, &expr5_0)?;
                     let expr7_0 = C::xmm_to_xmm_mem(ctx, expr6_0);
                     let expr8_0 = constructor_andpd(ctx, expr0_0, &expr7_0)?;
-                    let expr9_0 = constructor_value_xmm(ctx, expr8_0)?;
+                    let expr9_0 = constructor_output_xmm(ctx, expr8_0)?;
                     return Some(expr9_0);
                 }
             }
@@ -4366,7 +4410,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     // Rule at src/isa/x64/lower.isle line 56.
                     let expr0_0: u64 = 0;
                     let expr1_0 = constructor_imm(ctx, pattern2_0, expr0_0)?;
-                    let expr2_0 = C::value_reg(ctx, expr1_0);
+                    let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                     return Some(expr2_0);
                 }
             }
@@ -4376,11 +4420,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } => {
                 if let &Opcode::BandNot = pattern4_0 {
                     let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
-                    // Rule at src/isa/x64/lower.isle line 1214.
+                    // Rule at src/isa/x64/lower.isle line 1205.
                     let expr0_0 = constructor_put_in_xmm(ctx, pattern6_1)?;
                     let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern6_0)?;
                     let expr2_0 = constructor_sse_and_not(ctx, pattern2_0, expr0_0, &expr1_0)?;
-                    let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                    let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                     return Some(expr3_0);
                 }
             }
@@ -4404,7 +4448,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     C::unpack_value_array_2(ctx, pattern9_1);
                                 match pattern9_2 {
                                     &FloatCC::Equal => {
-                                        // Rule at src/isa/x64/lower.isle line 1533.
+                                        // Rule at src/isa/x64/lower.isle line 1524.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NZ;
@@ -4415,10 +4459,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr4_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr3_0)?;
-                                        return Some(expr4_0);
+                                        let expr5_0 = C::output(ctx, expr4_0);
+                                        return Some(expr5_0);
                                     }
                                     &FloatCC::GreaterThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1485.
+                                        // Rule at src/isa/x64/lower.isle line 1476.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NBE;
@@ -4427,10 +4472,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::GreaterThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1488.
+                                        // Rule at src/isa/x64/lower.isle line 1479.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NB;
@@ -4439,10 +4485,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::LessThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1508.
+                                        // Rule at src/isa/x64/lower.isle line 1499.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NBE;
@@ -4451,10 +4498,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::LessThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1511.
+                                        // Rule at src/isa/x64/lower.isle line 1502.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NB;
@@ -4463,10 +4511,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::NotEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1536.
+                                        // Rule at src/isa/x64/lower.isle line 1527.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NZ;
@@ -4477,10 +4526,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr4_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr3_0)?;
-                                        return Some(expr4_0);
+                                        let expr5_0 = C::output(ctx, expr4_0);
+                                        return Some(expr5_0);
                                     }
                                     &FloatCC::Ordered => {
-                                        // Rule at src/isa/x64/lower.isle line 1479.
+                                        // Rule at src/isa/x64/lower.isle line 1470.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NP;
@@ -4489,10 +4539,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::Unordered => {
-                                        // Rule at src/isa/x64/lower.isle line 1482.
+                                        // Rule at src/isa/x64/lower.isle line 1473.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::P;
@@ -4501,10 +4552,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::UnorderedOrGreaterThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1514.
+                                        // Rule at src/isa/x64/lower.isle line 1505.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::B;
@@ -4513,10 +4565,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::UnorderedOrGreaterThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1517.
+                                        // Rule at src/isa/x64/lower.isle line 1508.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::BE;
@@ -4525,10 +4578,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::UnorderedOrLessThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1491.
+                                        // Rule at src/isa/x64/lower.isle line 1482.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::B;
@@ -4537,10 +4591,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     &FloatCC::UnorderedOrLessThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1494.
+                                        // Rule at src/isa/x64/lower.isle line 1485.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::BE;
@@ -4549,7 +4604,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         )?;
                                         let expr3_0 =
                                             constructor_with_flags(ctx, &expr0_0, &expr2_0)?;
-                                        return Some(expr3_0);
+                                        let expr4_0 = C::output(ctx, expr3_0);
+                                        return Some(expr4_0);
                                     }
                                     _ => {}
                                 }
@@ -4574,11 +4630,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 if let &Opcode::Imul = pattern9_0 {
                                     let (pattern11_0, pattern11_1) =
                                         C::unpack_value_array_2(ctx, pattern9_1);
-                                    // Rule at src/isa/x64/lower.isle line 1001.
+                                    // Rule at src/isa/x64/lower.isle line 992.
                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern11_0)?;
                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern11_1)?;
                                     let expr2_0 = constructor_vpmullq(ctx, &expr0_0, expr1_0)?;
-                                    let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                    let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                     return Some(expr3_0);
                                 }
                             }
@@ -4595,10 +4651,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     } = &pattern6_0
                     {
                         if let &Opcode::Iabs = pattern7_0 {
-                            // Rule at src/isa/x64/lower.isle line 1229.
+                            // Rule at src/isa/x64/lower.isle line 1220.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr1_0 = constructor_vpabsq(ctx, &expr0_0)?;
-                            let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
+                            let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -4618,11 +4674,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::AvgRound => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 912.
+                                // Rule at src/isa/x64/lower.isle line 903.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pavgb(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::UaddSat => {
@@ -4632,7 +4688,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddusb(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::SaddSat => {
@@ -4642,27 +4698,27 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddsb(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::UsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 291.
+                                // Rule at src/isa/x64/lower.isle line 282.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubusb(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::SsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 281.
+                                // Rule at src/isa/x64/lower.isle line 272.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubsb(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Iadd => {
@@ -4672,17 +4728,17 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddb(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 249.
+                                // Rule at src/isa/x64/lower.isle line 240.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubb(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             _ => {}
@@ -4702,11 +4758,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::AvgRound => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 916.
+                                // Rule at src/isa/x64/lower.isle line 907.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pavgw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::UaddSat => {
@@ -4716,7 +4772,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddusw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::SaddSat => {
@@ -4726,27 +4782,27 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddsw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::UsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 295.
+                                // Rule at src/isa/x64/lower.isle line 286.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubusw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::SsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 285.
+                                // Rule at src/isa/x64/lower.isle line 276.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubsw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Iadd => {
@@ -4756,17 +4812,17 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 253.
+                                // Rule at src/isa/x64/lower.isle line 244.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Imul => {
@@ -4815,14 +4871,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1089.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1080.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_pmovsxbw(ctx, &expr0_0)?;
                                                                                     let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
                                                                                     let expr3_0 = constructor_pmovsxbw(ctx, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
                                                                                     let expr5_0 = constructor_pmullw(ctx, expr1_0, &expr4_0)?;
-                                                                                    let expr6_0 = constructor_value_xmm(ctx, expr5_0)?;
+                                                                                    let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                                                                                     return Some(
                                                                                         expr6_0,
                                                                                     );
@@ -4871,7 +4927,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1049.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1040.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                                                                                     let expr2_0: u8 = 8;
@@ -4888,7 +4944,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr13_0 = constructor_pmovsxbw(ctx, &expr12_0)?;
                                                                                     let expr14_0 = C::xmm_to_xmm_mem(ctx, expr13_0);
                                                                                     let expr15_0 = constructor_pmullw(ctx, expr6_0, &expr14_0)?;
-                                                                                    let expr16_0 = constructor_value_xmm(ctx, expr15_0)?;
+                                                                                    let expr16_0 = constructor_output_xmm(ctx, expr15_0)?;
                                                                                     return Some(
                                                                                         expr16_0,
                                                                                     );
@@ -4937,14 +4993,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1165.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1156.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_pmovzxbw(ctx, &expr0_0)?;
                                                                                     let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
                                                                                     let expr3_0 = constructor_pmovzxbw(ctx, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
                                                                                     let expr5_0 = constructor_pmullw(ctx, expr1_0, &expr4_0)?;
-                                                                                    let expr6_0 = constructor_value_xmm(ctx, expr5_0)?;
+                                                                                    let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                                                                                     return Some(
                                                                                         expr6_0,
                                                                                     );
@@ -4993,7 +5049,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1125.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1116.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                                                                                     let expr2_0: u8 = 8;
@@ -5010,7 +5066,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr13_0 = constructor_pmovzxbw(ctx, &expr12_0)?;
                                                                                     let expr14_0 = C::xmm_to_xmm_mem(ctx, expr13_0);
                                                                                     let expr15_0 = constructor_pmullw(ctx, expr6_0, &expr14_0)?;
-                                                                                    let expr16_0 = constructor_value_xmm(ctx, expr15_0)?;
+                                                                                    let expr16_0 = constructor_output_xmm(ctx, expr15_0)?;
                                                                                     return Some(
                                                                                         expr16_0,
                                                                                     );
@@ -5028,11 +5084,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         }
                                     }
                                 }
-                                // Rule at src/isa/x64/lower.isle line 993.
+                                // Rule at src/isa/x64/lower.isle line 984.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pmullw(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             _ => {}
@@ -5056,17 +5112,17 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddd(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 257.
+                                // Rule at src/isa/x64/lower.isle line 248.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubd(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Imul => {
@@ -5115,7 +5171,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1099.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1090.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5124,7 +5180,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr5_0 = constructor_pmulhw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
                                                                                     let expr7_0 = constructor_punpcklwd(ctx, expr3_0, &expr6_0)?;
-                                                                                    let expr8_0 = constructor_value_xmm(ctx, expr7_0)?;
+                                                                                    let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
                                                                                     );
@@ -5173,7 +5229,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1063.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1054.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5182,7 +5238,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr5_0 = constructor_pmulhw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
                                                                                     let expr7_0 = constructor_punpckhwd(ctx, expr3_0, &expr6_0)?;
-                                                                                    let expr8_0 = constructor_value_xmm(ctx, expr7_0)?;
+                                                                                    let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
                                                                                     );
@@ -5231,7 +5287,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1175.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1166.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5240,7 +5296,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr5_0 = constructor_pmulhuw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
                                                                                     let expr7_0 = constructor_punpcklwd(ctx, expr3_0, &expr6_0)?;
-                                                                                    let expr8_0 = constructor_value_xmm(ctx, expr7_0)?;
+                                                                                    let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
                                                                                     );
@@ -5289,7 +5345,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1139.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1130.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5298,7 +5354,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr5_0 = constructor_pmulhuw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
                                                                                     let expr7_0 = constructor_punpckhwd(ctx, expr3_0, &expr6_0)?;
-                                                                                    let expr8_0 = constructor_value_xmm(ctx, expr7_0)?;
+                                                                                    let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
                                                                                     );
@@ -5316,11 +5372,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         }
                                     }
                                 }
-                                // Rule at src/isa/x64/lower.isle line 996.
+                                // Rule at src/isa/x64/lower.isle line 987.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pmulld(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             _ => {}
@@ -5344,17 +5400,17 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddq(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 261.
+                                // Rule at src/isa/x64/lower.isle line 252.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubq(ctx, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             &Opcode::Imul => {
@@ -5403,7 +5459,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1111.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1102.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 80;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5414,7 +5470,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
                                                                                     let expr9_0 = constructor_pmuldq(ctx, expr3_0, &expr8_0)?;
-                                                                                    let expr10_0 = constructor_value_xmm(ctx, expr9_0)?;
+                                                                                    let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
                                                                                     );
@@ -5463,7 +5519,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1075.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1066.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 250;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5474,7 +5530,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
                                                                                     let expr9_0 = constructor_pmuldq(ctx, expr3_0, &expr8_0)?;
-                                                                                    let expr10_0 = constructor_value_xmm(ctx, expr9_0)?;
+                                                                                    let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
                                                                                     );
@@ -5523,7 +5579,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1187.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1178.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 80;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5534,7 +5590,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
                                                                                     let expr9_0 = constructor_pmuludq(ctx, expr3_0, &expr8_0)?;
-                                                                                    let expr10_0 = constructor_value_xmm(ctx, expr9_0)?;
+                                                                                    let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
                                                                                     );
@@ -5583,7 +5639,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1151.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1142.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 250;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5594,7 +5650,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                                     let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
                                                                                     let expr9_0 = constructor_pmuludq(ctx, expr3_0, &expr8_0)?;
-                                                                                    let expr10_0 = constructor_value_xmm(ctx, expr9_0)?;
+                                                                                    let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
                                                                                     );
@@ -5612,7 +5668,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         }
                                     }
                                 }
-                                // Rule at src/isa/x64/lower.isle line 1027.
+                                // Rule at src/isa/x64/lower.isle line 1018.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm(ctx, pattern9_1)?;
                                 let expr2_0: u32 = 32;
@@ -5637,7 +5693,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr21_0 = constructor_pmuludq(ctx, expr0_0, &expr20_0)?;
                                 let expr22_0 = C::xmm_to_xmm_mem(ctx, expr19_0);
                                 let expr23_0 = constructor_paddq(ctx, expr21_0, &expr22_0)?;
-                                let expr24_0 = constructor_value_xmm(ctx, expr23_0)?;
+                                let expr24_0 = constructor_output_xmm(ctx, expr23_0)?;
                                 return Some(expr24_0);
                             }
                             _ => {}
@@ -5654,29 +5710,29 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 337.
+                            // Rule at src/isa/x64/lower.isle line 328.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sse_and(ctx, pattern2_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 401.
+                            // Rule at src/isa/x64/lower.isle line 392.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sse_or(ctx, pattern2_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 462.
+                            // Rule at src/isa/x64/lower.isle line 453.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sse_xor(ctx, pattern2_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_xmm(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         _ => {}
@@ -5690,7 +5746,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::Bitselect => {
                             let (pattern7_0, pattern7_1, pattern7_2) =
                                 C::unpack_value_array_3(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1288.
+                            // Rule at src/isa/x64/lower.isle line 1279.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr2_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
@@ -5700,20 +5756,20 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 constructor_sse_and_not(ctx, pattern2_0, expr0_0, &expr4_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
                             let expr7_0 = constructor_sse_or(ctx, pattern2_0, expr5_0, &expr6_0)?;
-                            let expr8_0 = constructor_value_xmm(ctx, expr7_0)?;
+                            let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
                         &Opcode::Vselect => {
                             let (pattern7_0, pattern7_1, pattern7_2) =
                                 C::unpack_value_array_3(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1302.
+                            // Rule at src/isa/x64/lower.isle line 1293.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_put_in_xmm(ctx, pattern7_2)?;
                             let expr3_0 = constructor_sse_blend(
                                 ctx, pattern2_0, &expr0_0, &expr1_0, expr2_0,
                             )?;
-                            let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -5724,12 +5780,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Bnot = pattern5_0 {
-                        // Rule at src/isa/x64/lower.isle line 1283.
+                        // Rule at src/isa/x64/lower.isle line 1274.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                         let expr1_0 = constructor_vector_all_ones(ctx, pattern2_0)?;
                         let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
                         let expr3_0 = constructor_sse_xor(ctx, pattern2_0, expr0_0, &expr2_0)?;
-                        let expr4_0 = constructor_value_xmm(ctx, expr3_0)?;
+                        let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                 }
@@ -5747,7 +5803,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let pattern7_0 = C::u64_from_imm64(ctx, pattern5_1);
                         // Rule at src/isa/x64/lower.isle line 10.
                         let expr0_0 = constructor_imm(ctx, pattern3_0, pattern7_0)?;
-                        let expr1_0 = C::value_reg(ctx, expr0_0);
+                        let expr1_0 = constructor_output_reg(ctx, expr0_0)?;
                         return Some(expr1_0);
                     }
                 }
@@ -5760,14 +5816,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             // Rule at src/isa/x64/lower.isle line 28.
                             let expr0_0: u64 = 1;
                             let expr1_0 = constructor_imm(ctx, pattern3_0, expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         if pattern5_1 == false {
                             // Rule at src/isa/x64/lower.isle line 24.
                             let expr0_0: u64 = 0;
                             let expr1_0 = constructor_imm(ctx, pattern3_0, expr0_0)?;
-                            let expr2_0 = C::value_reg(ctx, expr1_0);
+                            let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                     }
@@ -5779,39 +5835,43 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1392.
+                            // Rule at src/isa/x64/lower.isle line 1383.
                             let expr0_0 = CC::L;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr1_0);
+                            let expr2_0 = C::output(ctx, expr1_0);
+                            return Some(expr2_0);
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1386.
+                            // Rule at src/isa/x64/lower.isle line 1377.
                             let expr0_0 = CC::B;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr1_0);
+                            let expr2_0 = C::output(ctx, expr1_0);
+                            return Some(expr2_0);
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1395.
+                            // Rule at src/isa/x64/lower.isle line 1386.
                             let expr0_0 = CC::NL;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr1_0);
+                            let expr2_0 = C::output(ctx, expr1_0);
+                            return Some(expr2_0);
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1389.
+                            // Rule at src/isa/x64/lower.isle line 1380.
                             let expr0_0 = CC::NB;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
                             )?;
-                            return Some(expr1_0);
+                            let expr2_0 = C::output(ctx, expr1_0);
+                            return Some(expr2_0);
                         }
                         &Opcode::Iadd => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
@@ -5820,7 +5880,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
@@ -5829,7 +5889,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
@@ -5837,7 +5897,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
@@ -5846,293 +5906,293 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/x64/lower.isle line 64.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 237.
+                                // Rule at src/isa/x64/lower.isle line 228.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sub(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 242.
+                                // Rule at src/isa/x64/lower.isle line 233.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 232.
+                            // Rule at src/isa/x64/lower.isle line 223.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 934.
+                                // Rule at src/isa/x64/lower.isle line 925.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 946.
+                                // Rule at src/isa/x64/lower.isle line 937.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 930.
+                                // Rule at src/isa/x64/lower.isle line 921.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 940.
+                                // Rule at src/isa/x64/lower.isle line 931.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 925.
+                            // Rule at src/isa/x64/lower.isle line 916.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::IaddIfcout => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 173.
+                                // Rule at src/isa/x64/lower.isle line 171.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_unused_iflags(ctx)?;
-                                let expr3_0 = constructor_value_gprs(ctx, expr1_0, expr2_0)?;
+                                let expr2_0 = C::gpr_to_reg(ctx, expr1_0);
+                                let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 187.
+                                // Rule at src/isa/x64/lower.isle line 181.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_unused_iflags(ctx)?;
-                                let expr4_0 = constructor_value_gprs(ctx, expr2_0, expr3_0)?;
+                                let expr3_0 = C::gpr_to_reg(ctx, expr2_0);
+                                let expr4_0 = constructor_output_ifcout(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 168.
+                                // Rule at src/isa/x64/lower.isle line 167.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_unused_iflags(ctx)?;
-                                let expr3_0 = constructor_value_gprs(ctx, expr1_0, expr2_0)?;
+                                let expr2_0 = C::gpr_to_reg(ctx, expr1_0);
+                                let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 180.
+                                // Rule at src/isa/x64/lower.isle line 177.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_unused_iflags(ctx)?;
-                                let expr4_0 = constructor_value_gprs(ctx, expr2_0, expr3_0)?;
+                                let expr3_0 = C::gpr_to_reg(ctx, expr2_0);
+                                let expr4_0 = constructor_output_ifcout(ctx, expr3_0)?;
                                 return Some(expr4_0);
                             }
                             // Rule at src/isa/x64/lower.isle line 161.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_unused_iflags(ctx)?;
-                            let expr4_0 = constructor_value_gprs(ctx, expr2_0, expr3_0)?;
+                            let expr3_0 = C::gpr_to_reg(ctx, expr2_0);
+                            let expr4_0 = constructor_output_ifcout(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 326.
+                                // Rule at src/isa/x64/lower.isle line 317.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_x64_and(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 314.
+                                // Rule at src/isa/x64/lower.isle line 305.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 =
                                     constructor_x64_and(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 322.
+                                // Rule at src/isa/x64/lower.isle line 313.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_x64_and(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 309.
+                                // Rule at src/isa/x64/lower.isle line 300.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 =
                                     constructor_x64_and(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 304.
+                            // Rule at src/isa/x64/lower.isle line 295.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_x64_and(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 390.
+                                // Rule at src/isa/x64/lower.isle line 381.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 379.
+                                // Rule at src/isa/x64/lower.isle line 370.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 386.
+                                // Rule at src/isa/x64/lower.isle line 377.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 374.
+                                // Rule at src/isa/x64/lower.isle line 365.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 369.
+                            // Rule at src/isa/x64/lower.isle line 360.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 456.
+                                // Rule at src/isa/x64/lower.isle line 447.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 445.
+                                // Rule at src/isa/x64/lower.isle line 436.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 452.
+                                // Rule at src/isa/x64/lower.isle line 443.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
-                                let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                                let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 440.
+                                // Rule at src/isa/x64/lower.isle line 431.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
                                 let expr2_0 = constructor_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 435.
+                            // Rule at src/isa/x64/lower.isle line 426.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 492.
+                            // Rule at src/isa/x64/lower.isle line 483.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, pattern3_0);
                             let expr2_0 = constructor_shl(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 598.
+                            // Rule at src/isa/x64/lower.isle line 589.
                             let expr0_0 = ExtendKind::Zero;
                             let expr1_0 =
                                 constructor_extend_to_gpr(ctx, pattern7_0, pattern3_0, &expr0_0)?;
                             let expr2_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, pattern3_0);
                             let expr3_0 = constructor_shr(ctx, pattern3_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_gpr(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 700.
+                            // Rule at src/isa/x64/lower.isle line 691.
                             let expr0_0 = ExtendKind::Sign;
                             let expr1_0 =
                                 constructor_extend_to_gpr(ctx, pattern7_0, pattern3_0, &expr0_0)?;
                             let expr2_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, pattern3_0);
                             let expr3_0 = constructor_sar(ctx, pattern3_0, expr1_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_gpr(ctx, expr3_0)?;
+                            let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
                         _ => {}
@@ -6144,17 +6204,17 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 893.
+                            // Rule at src/isa/x64/lower.isle line 884.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
                             let expr1_0 = constructor_neg(ctx, pattern3_0, expr0_0)?;
-                            let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                            let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         &Opcode::Bnot => {
-                            // Rule at src/isa/x64/lower.isle line 1262.
+                            // Rule at src/isa/x64/lower.isle line 1253.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
                             let expr1_0 = constructor_not(ctx, pattern3_0, expr0_0)?;
-                            let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
+                            let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         _ => {}
@@ -6167,12 +6227,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     if let &Opcode::IaddImm = pattern5_0 {
                         let pattern7_0 = C::u64_from_imm64(ctx, pattern5_2);
-                        // Rule at src/isa/x64/lower.isle line 205.
+                        // Rule at src/isa/x64/lower.isle line 196.
                         let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
                         let expr1_0 = constructor_imm(ctx, pattern3_0, pattern7_0)?;
                         let expr2_0 = constructor_reg_to_gpr_mem_imm(ctx, expr1_0)?;
                         let expr3_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr2_0)?;
-                        let expr4_0 = constructor_value_gpr(ctx, expr3_0)?;
+                        let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                 }
@@ -6198,23 +6258,23 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 832.
+                                    // Rule at src/isa/x64/lower.isle line 823.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
                                     let expr2_0 =
                                         constructor_x64_rotl(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                    let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                    let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                     return Some(expr3_0);
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 826.
+                        // Rule at src/isa/x64/lower.isle line 817.
                         let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                         let expr2_0 = C::gpr_to_imm8_gpr(ctx, expr0_0);
                         let expr3_0 = constructor_x64_rotl(ctx, pattern3_0, expr1_0, &expr2_0)?;
-                        let expr4_0 = constructor_value_gpr(ctx, expr3_0)?;
+                        let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                     &Opcode::Rotr => {
@@ -6228,23 +6288,23 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 872.
+                                    // Rule at src/isa/x64/lower.isle line 863.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
                                     let expr2_0 =
                                         constructor_x64_rotr(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                    let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                    let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                     return Some(expr3_0);
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 866.
+                        // Rule at src/isa/x64/lower.isle line 857.
                         let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                         let expr2_0 = C::gpr_to_imm8_gpr(ctx, expr0_0);
                         let expr3_0 = constructor_x64_rotr(ctx, pattern3_0, expr1_0, &expr2_0)?;
-                        let expr4_0 = constructor_value_gpr(ctx, expr3_0)?;
+                        let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
                     _ => {}
@@ -6270,18 +6330,18 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 818.
+                                    // Rule at src/isa/x64/lower.isle line 809.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
                                     let expr2_0 =
                                         constructor_x64_rotl(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                    let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                    let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                     return Some(expr3_0);
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 814.
+                        // Rule at src/isa/x64/lower.isle line 805.
                         let expr0_0: Type = I32;
                         let expr1_0 = ExtendKind::Zero;
                         let expr2_0 =
@@ -6289,7 +6349,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr3_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                         let expr4_0 = C::gpr_to_imm8_gpr(ctx, expr2_0);
                         let expr5_0 = constructor_x64_rotl(ctx, pattern3_0, expr3_0, &expr4_0)?;
-                        let expr6_0 = constructor_value_gpr(ctx, expr5_0)?;
+                        let expr6_0 = constructor_output_gpr(ctx, expr5_0)?;
                         return Some(expr6_0);
                     }
                     &Opcode::Rotr => {
@@ -6303,18 +6363,18 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 858.
+                                    // Rule at src/isa/x64/lower.isle line 849.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
                                     let expr2_0 =
                                         constructor_x64_rotr(ctx, pattern3_0, expr0_0, &expr1_0)?;
-                                    let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                                    let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                     return Some(expr3_0);
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 854.
+                        // Rule at src/isa/x64/lower.isle line 845.
                         let expr0_0: Type = I32;
                         let expr1_0 = ExtendKind::Zero;
                         let expr2_0 =
@@ -6322,7 +6382,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         let expr3_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                         let expr4_0 = C::gpr_to_imm8_gpr(ctx, expr2_0);
                         let expr5_0 = constructor_x64_rotr(ctx, pattern3_0, expr3_0, &expr4_0)?;
-                        let expr6_0 = constructor_value_gpr(ctx, expr5_0)?;
+                        let expr6_0 = constructor_output_gpr(ctx, expr5_0)?;
                         return Some(expr6_0);
                     }
                     _ => {}
@@ -6333,12 +6393,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
     return None;
 }
 
-// Generated as internal constructor for term unused_iflags.
-pub fn constructor_unused_iflags<C: Context>(ctx: &mut C) -> Option<Gpr> {
+// Generated as internal constructor for term output_ifcout.
+pub fn constructor_output_ifcout<C: Context>(ctx: &mut C, arg0: Reg) -> Option<InstOutput> {
+    let pattern0_0 = arg0;
     // Rule at src/isa/x64/lower.isle line 157.
-    let expr0_0 = C::temp_writable_gpr(ctx);
-    let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    return Some(expr1_0);
+    let expr0_0 = C::value_reg(ctx, pattern0_0);
+    let expr1_0 = C::value_regs_invalid(ctx);
+    let expr2_0 = C::output_pair(ctx, expr0_0, expr1_0);
+    return Some(expr2_0);
 }
 
 // Generated as internal constructor for term sse_and.
@@ -6352,21 +6414,21 @@ pub fn constructor_sse_and<C: Context>(
     if pattern0_0 == F32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 333.
+        // Rule at src/isa/x64/lower.isle line 324.
         let expr0_0 = constructor_andps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 334.
+        // Rule at src/isa/x64/lower.isle line 325.
         let expr0_0 = constructor_andpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 335.
+        // Rule at src/isa/x64/lower.isle line 326.
         let expr0_0 = constructor_pand(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -6384,21 +6446,21 @@ pub fn constructor_sse_or<C: Context>(
     if pattern0_0 == F32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 397.
+        // Rule at src/isa/x64/lower.isle line 388.
         let expr0_0 = constructor_orps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 398.
+        // Rule at src/isa/x64/lower.isle line 389.
         let expr0_0 = constructor_orpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 399.
+        // Rule at src/isa/x64/lower.isle line 390.
         let expr0_0 = constructor_por(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -6413,7 +6475,7 @@ pub fn constructor_or_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 408.
+    // Rule at src/isa/x64/lower.isle line 399.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6440,7 +6502,7 @@ pub fn constructor_shl_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 498.
+    // Rule at src/isa/x64/lower.isle line 489.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6505,12 +6567,12 @@ pub fn constructor_ishl_i8x16_mask<C: Context>(
     let pattern0_0 = arg0;
     match pattern0_0 {
         &RegMemImm::Imm { simm32: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 561.
+            // Rule at src/isa/x64/lower.isle line 552.
             let expr0_0 = C::ishl_i8x16_mask_for_const(ctx, pattern1_0);
             return Some(expr0_0);
         }
         &RegMemImm::Reg { reg: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 570.
+            // Rule at src/isa/x64/lower.isle line 561.
             let expr0_0 = C::ishl_i8x16_mask_table(ctx);
             let expr1_0 = constructor_lea(ctx, &expr0_0)?;
             let expr2_0: Type = I64;
@@ -6527,7 +6589,7 @@ pub fn constructor_ishl_i8x16_mask<C: Context>(
         &RegMemImm::Mem {
             addr: ref pattern1_0,
         } => {
-            // Rule at src/isa/x64/lower.isle line 580.
+            // Rule at src/isa/x64/lower.isle line 571.
             let expr0_0: Type = I64;
             let expr1_0 = ExtKind::None;
             let expr2_0 = constructor_x64_load(ctx, expr0_0, pattern1_0, &expr1_0)?;
@@ -6548,7 +6610,7 @@ pub fn constructor_shr_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 605.
+    // Rule at src/isa/x64/lower.isle line 596.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6616,12 +6678,12 @@ pub fn constructor_ushr_i8x16_mask<C: Context>(
     let pattern0_0 = arg0;
     match pattern0_0 {
         &RegMemImm::Imm { simm32: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 662.
+            // Rule at src/isa/x64/lower.isle line 653.
             let expr0_0 = C::ushr_i8x16_mask_for_const(ctx, pattern1_0);
             return Some(expr0_0);
         }
         &RegMemImm::Reg { reg: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 671.
+            // Rule at src/isa/x64/lower.isle line 662.
             let expr0_0 = C::ushr_i8x16_mask_table(ctx);
             let expr1_0 = constructor_lea(ctx, &expr0_0)?;
             let expr2_0: Type = I64;
@@ -6638,7 +6700,7 @@ pub fn constructor_ushr_i8x16_mask<C: Context>(
         &RegMemImm::Mem {
             addr: ref pattern1_0,
         } => {
-            // Rule at src/isa/x64/lower.isle line 682.
+            // Rule at src/isa/x64/lower.isle line 673.
             let expr0_0: Type = I64;
             let expr1_0 = ExtKind::None;
             let expr2_0 = constructor_x64_load(ctx, expr0_0, pattern1_0, &expr1_0)?;
@@ -6659,7 +6721,7 @@ pub fn constructor_sar_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 707.
+    // Rule at src/isa/x64/lower.isle line 698.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6729,7 +6791,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
     let pattern1_0 = arg1;
     match pattern1_0 {
         &RegMemImm::Imm { simm32: pattern2_0 } => {
-            // Rule at src/isa/x64/lower.isle line 771.
+            // Rule at src/isa/x64/lower.isle line 762.
             let expr0_0: u32 = 8;
             let expr1_0 = C::u32_add(ctx, pattern2_0, expr0_0);
             let expr2_0 = RegMemImm::Imm { simm32: expr1_0 };
@@ -6737,7 +6799,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
             return Some(expr3_0);
         }
         &RegMemImm::Reg { reg: pattern2_0 } => {
-            // Rule at src/isa/x64/lower.isle line 773.
+            // Rule at src/isa/x64/lower.isle line 764.
             let expr0_0 = C::gpr_new(ctx, pattern2_0);
             let expr1_0: u32 = 8;
             let expr2_0 = RegMemImm::Imm { simm32: expr1_0 };
@@ -6751,7 +6813,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
         &RegMemImm::Mem {
             addr: ref pattern2_0,
         } => {
-            // Rule at src/isa/x64/lower.isle line 777.
+            // Rule at src/isa/x64/lower.isle line 768.
             let expr0_0: u64 = 8;
             let expr1_0 = constructor_imm(ctx, pattern0_0, expr0_0)?;
             let expr2_0 = C::gpr_new(ctx, expr1_0);
@@ -6778,21 +6840,21 @@ pub fn constructor_sse_and_not<C: Context>(
     if pattern0_0 == F32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 1203.
+        // Rule at src/isa/x64/lower.isle line 1194.
         let expr0_0 = constructor_andnps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 1204.
+        // Rule at src/isa/x64/lower.isle line 1195.
         let expr0_0 = constructor_andnpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 1205.
+        // Rule at src/isa/x64/lower.isle line 1196.
         let expr0_0 = constructor_pandn(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -6802,7 +6864,7 @@ pub fn constructor_sse_and_not<C: Context>(
 // Generated as internal constructor for term i128_not.
 pub fn constructor_i128_not<C: Context>(ctx: &mut C, arg0: Value) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/lower.isle line 1268.
+    // Rule at src/isa/x64/lower.isle line 1259.
     let expr0_0 = C::put_in_regs(ctx, pattern0_0);
     let expr1_0: usize = 0;
     let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -6829,7 +6891,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1322.
+        // Rule at src/isa/x64/lower.isle line 1313.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = constructor_pinsrb(ctx, pattern2_0, &expr0_0, pattern4_0)?;
         return Some(expr1_0);
@@ -6838,7 +6900,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1326.
+        // Rule at src/isa/x64/lower.isle line 1317.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = constructor_pinsrw(ctx, pattern2_0, &expr0_0, pattern4_0)?;
         return Some(expr1_0);
@@ -6847,7 +6909,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1330.
+        // Rule at src/isa/x64/lower.isle line 1321.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = OperandSize::Size32;
         let expr2_0 = constructor_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
@@ -6857,7 +6919,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1334.
+        // Rule at src/isa/x64/lower.isle line 1325.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = OperandSize::Size64;
         let expr2_0 = constructor_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
@@ -6867,7 +6929,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1338.
+        // Rule at src/isa/x64/lower.isle line 1329.
         let expr0_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
         let expr1_0 = C::sse_insertps_lane_imm(ctx, pattern4_0);
         let expr2_0 = constructor_insertps(ctx, pattern2_0, &expr0_0, expr1_0)?;
@@ -6879,7 +6941,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         if let &RegMem::Reg { reg: pattern4_0 } = pattern3_0 {
             let pattern5_0 = arg3;
             if pattern5_0 == 0 {
-                // Rule at src/isa/x64/lower.isle line 1360.
+                // Rule at src/isa/x64/lower.isle line 1351.
                 let expr0_0 = constructor_reg_to_xmm_mem(ctx, pattern4_0)?;
                 let expr1_0 = constructor_movsd(ctx, pattern2_0, &expr0_0)?;
                 return Some(expr1_0);
@@ -6887,7 +6949,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         }
         let pattern4_0 = arg3;
         if pattern4_0 == 0 {
-            // Rule at src/isa/x64/lower.isle line 1362.
+            // Rule at src/isa/x64/lower.isle line 1353.
             let expr0_0 = SseOpcode::Movsd;
             let expr1_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
             let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
@@ -6896,7 +6958,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
             return Some(expr4_0);
         }
         if pattern4_0 == 1 {
-            // Rule at src/isa/x64/lower.isle line 1371.
+            // Rule at src/isa/x64/lower.isle line 1362.
             let expr0_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
             let expr1_0 = constructor_movlhps(ctx, pattern2_0, &expr0_0)?;
             return Some(expr1_0);
@@ -6918,7 +6980,7 @@ pub fn constructor_cmp_and_choose<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1379.
+        // Rule at src/isa/x64/lower.isle line 1370.
         let expr0_0 = constructor_put_in_gpr(ctx, pattern3_0)?;
         let expr1_0 = constructor_put_in_gpr(ctx, pattern4_0)?;
         let expr2_0 = C::raw_operand_size_of_type(ctx, pattern1_0);

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -1,9 +1,10 @@
-use crate::ir::{Inst, Value};
+use crate::ir::{types, Inst, Value};
 use crate::machinst::{get_output_reg, InsnOutput, LowerCtx, MachInst, RegRenamer};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use regalloc::{Reg, Writable};
 use smallvec::SmallVec;
+use std::cell::Cell;
 
 pub use super::MachLabel;
 pub use crate::ir::{ExternalName, FuncRef, GlobalValue, SigRef};
@@ -18,6 +19,8 @@ pub type WritableReg = Writable<Reg>;
 pub type VecReg = Vec<Reg>;
 pub type VecWritableReg = Vec<WritableReg>;
 pub type ValueRegs = crate::machinst::ValueRegs<Reg>;
+pub type InstOutput = SmallVec<[ValueRegs; 2]>;
+pub type InstOutputBuilder = Cell<InstOutput>;
 pub type VecMachLabel = Vec<MachLabel>;
 pub type BoxExternalName = Box<ExternalName>;
 
@@ -62,6 +65,38 @@ macro_rules! isle_prelude_methods {
         #[inline]
         fn value_regs_invalid(&mut self) -> ValueRegs {
             ValueRegs::invalid()
+        }
+
+        #[inline]
+        fn output_none(&mut self) -> InstOutput {
+            smallvec::smallvec![]
+        }
+
+        #[inline]
+        fn output(&mut self, regs: ValueRegs) -> InstOutput {
+            smallvec::smallvec![regs]
+        }
+
+        #[inline]
+        fn output_pair(&mut self, r1: ValueRegs, r2: ValueRegs) -> InstOutput {
+            smallvec::smallvec![r1, r2]
+        }
+
+        #[inline]
+        fn output_builder_new(&mut self) -> InstOutputBuilder {
+            std::cell::Cell::new(InstOutput::new())
+        }
+
+        #[inline]
+        fn output_builder_push(&mut self, builder: &InstOutputBuilder, regs: ValueRegs) -> Unit {
+            let mut vec = builder.take();
+            vec.push(regs);
+            builder.set(vec);
+        }
+
+        #[inline]
+        fn output_builder_finish(&mut self, builder: &InstOutputBuilder) -> InstOutput {
+            builder.take()
         }
 
         #[inline]
@@ -363,7 +398,7 @@ pub(crate) fn lower_common<C, F, I, IF, const N: usize>(
 where
     C: LowerCtx,
     [(C::I, bool); N]: smallvec::Array<Item = (C::I, bool)>,
-    IF: Fn(&mut IsleContext<'_, C, F, I, N>, Inst) -> Option<ValueRegs>,
+    IF: Fn(&mut IsleContext<'_, C, F, I, N>, Inst) -> Option<InstOutput>,
 {
     // TODO: reuse the ISLE context across lowerings so we can reuse its
     // internal heap allocations.
@@ -375,22 +410,17 @@ where
     };
 
     let temp_regs = isle_lower(&mut isle_ctx, inst).ok_or(())?;
-    let mut temp_regs = temp_regs.regs().iter();
 
     #[cfg(debug_assertions)]
     {
-        let all_dsts_len = outputs
-            .iter()
-            .map(|out| get_output_reg(isle_ctx.lower_ctx, *out).len())
-            .sum();
         debug_assert_eq!(
             temp_regs.len(),
-            all_dsts_len,
-            "the number of temporary registers and destination registers do \
+            outputs.len(),
+            "the number of temporary values and destination values do \
          not match ({} != {}); ensure the correct registers are being \
          returned.",
             temp_regs.len(),
-            all_dsts_len,
+            outputs.len(),
         );
     }
 
@@ -399,12 +429,22 @@ where
     // registers they were assigned when their value was used as an operand in
     // earlier lowerings.
     let mut renamer = RegRenamer::default();
-    for output in outputs {
-        let dsts = get_output_reg(isle_ctx.lower_ctx, *output);
-        let ty = isle_ctx.lower_ctx.output_ty(output.insn, output.output);
-        let (_, tys) = <C::I>::rc_for_type(ty).unwrap();
-        for ((temp, dst), ty) in temp_regs.by_ref().zip(dsts.regs()).zip(tys) {
-            renamer.add_rename(*temp, dst.to_reg(), *ty);
+    for i in 0..outputs.len() {
+        let regs = temp_regs[i];
+        let dsts = get_output_reg(isle_ctx.lower_ctx, outputs[i]);
+        let ty = isle_ctx
+            .lower_ctx
+            .output_ty(outputs[i].insn, outputs[i].output);
+        if ty == types::IFLAGS || ty == types::FFLAGS {
+            // Flags values do not occupy any registers.
+            assert!(regs.len() == 0);
+        } else {
+            let (_, tys) = <C::I>::rc_for_type(ty).unwrap();
+            assert!(regs.len() == tys.len());
+            assert!(regs.len() == dsts.len());
+            for ((dst, temp), ty) in dsts.regs().iter().zip(regs.regs().iter()).zip(tys) {
+                renamer.add_rename(*temp, dst.to_reg(), *ty);
+            }
         }
     }
     for (inst, _) in isle_ctx.emitted_insts.iter_mut() {

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -38,6 +38,11 @@
 (type ValueList (primitive ValueList))
 (type ValueRegs (primitive ValueRegs))
 
+;; Instruction lowering result: a vector of `ValueRegs`.
+(type InstOutput (primitive InstOutput))
+;; (Mutable) builder to incrementally construct an `InstOutput`.
+(type InstOutputBuilder extern (enum))
+
 (decl u32_add (u32 u32) u32)
 (extern constructor u32_add u32_add)
 
@@ -63,6 +68,38 @@
 ;; Construct an empty `ValueRegs` containing only invalid register sentinels.
 (decl value_regs_invalid () ValueRegs)
 (extern constructor value_regs_invalid value_regs_invalid)
+
+;; Construct an empty `InstOutput`.
+(decl output_none () InstOutput)
+(extern constructor output_none output_none)
+
+;; Construct a single-element `InstOutput`.
+(decl output (ValueRegs) InstOutput)
+(extern constructor output output)
+
+;; Construct a two-element `InstOutput`.
+(decl output_pair (ValueRegs ValueRegs) InstOutput)
+(extern constructor output_pair output_pair)
+
+;; Construct a single-element `InstOutput` from a single register.
+(decl output_reg (Reg) InstOutput)
+(rule (output_reg reg) (output (value_reg reg)))
+
+;; Construct a single-element `InstOutput` from a value.
+(decl output_value (Value) InstOutput)
+(rule (output_value val) (output (put_in_regs val)))
+
+;; Initially empty `InstOutput` builder.
+(decl output_builder_new () InstOutputBuilder)
+(extern constructor output_builder_new output_builder_new)
+
+;; Append a `ValueRegs` to an `InstOutput` under construction.
+(decl output_builder_push (InstOutputBuilder ValueRegs) Unit)
+(extern constructor output_builder_push output_builder_push)
+
+;; Finish building an `InstOutput` incrementally.
+(decl output_builder_finish (InstOutputBuilder) InstOutput)
+(extern constructor output_builder_finish output_builder_finish)
 
 ;; Get a temporary register for writing.
 (decl temp_writable_reg (Type) WritableReg)
@@ -307,18 +344,18 @@
 
 (type SideEffectNoResult (enum (Inst (inst MInst))))
 
-;; Create an empty `ValueRegs`, but do emit the given side-effectful
+;; Create an empty `InstOutput`, but do emit the given side-effectful
 ;; instruction.
-(decl value_regs_none (SideEffectNoResult) ValueRegs)
-(rule (value_regs_none (SideEffectNoResult.Inst inst))
+(decl side_effect (SideEffectNoResult) InstOutput)
+(rule (side_effect (SideEffectNoResult.Inst inst))
       (let ((_ Unit (emit inst)))
-        (value_regs_invalid)))
+        (output_none)))
 
 ;; Similarly, but emit the side-effectful instruction as a safepoint.
-(decl safepoint (SideEffectNoResult) ValueRegs)
+(decl safepoint (SideEffectNoResult) InstOutput)
 (rule (safepoint (SideEffectNoResult.Inst inst))
       (let ((_ Unit (emit_safepoint inst)))
-        (value_regs_invalid)))
+        (output_none)))
 
 ;;;; Helpers for Working with Flags ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -438,3 +475,6 @@
 (convert Value Reg put_in_reg)
 (convert Value ValueRegs put_in_regs)
 (convert WritableReg Reg writable_reg_to_reg)
+(convert ValueRegs InstOutput output)
+(convert Reg InstOutput output_reg)
+(convert Value InstOutput output_value)


### PR DESCRIPTION
This changes the output of the `lower` constructor from a
`ValueRegs` to a new `InstOutput` type, which is a vector
of `ValueRegs`.

Code in `lower_common` is updated to use this new type to
handle instructions with multiple outputs.  All back-ends
are updated to use the new type.

CC @cfallin @fitzgen - this is an attempt to address https://github.com/bytecodealliance/wasmtime/issues/3747

I like the way `lower_common` now looks better, and handling of `iadd_ifcount` seems improved.  However, the current implementation requires a large number of changes to all back ends, which is not ideal.   Note that if we end up implementing the suggestion https://github.com/bytecodealliance/wasmtime/issues/3753, we can avoid most of those changes simply by installing a default conversion from a `ValueRegs` to a (singleton) `InstOutput`.

Not sure if the terminology `InstOutput` is the best possible -- other suggestions appreciated!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
