### PR TITLE
Fuzz using precompiled modules on CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2816,13 +2825,13 @@ checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -3584,6 +3593,7 @@ dependencies = [
  "env_logger 0.8.3",
  "log",
  "rayon",
+ "tempfile",
  "v8",
  "wasm-encoder",
  "wasm-smith",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,6 +13,7 @@ arbitrary = { version = "1.0.0", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
+tempfile = "3.3.0"
 wasmparser = "0.82"
 wasmprinter = "0.2.32"
 wasmtime = { path = "../wasmtime" }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -143,7 +143,7 @@ pub fn instantiate(wasm: &[u8], known_valid: bool, config: &generators::Config, 
     }
 
     log_wasm(wasm);
-    let module = match Module::new(store.engine(), wasm) {
+    let module = match config.compile(store.engine(), wasm) {
         Ok(module) => module,
         Err(_) if !known_valid => return,
         Err(e) => panic!("failed to compile module: {:?}", e),
@@ -222,7 +222,7 @@ pub fn differential_execution(
         log::debug!("fuzz config: {:?}", fuzz_config);
 
         let mut store = fuzz_config.to_store();
-        let module = Module::new(store.engine(), &wasm).unwrap();
+        let module = fuzz_config.compile(store.engine(), &wasm).unwrap();
 
         // TODO: we should implement tracing versions of these dummy imports
         // that record a trace of the order that imported functions were called
@@ -432,7 +432,7 @@ pub fn table_ops(mut fuzz_config: generators::Config, ops: generators::table_ops
 
         let wasm = ops.to_wasm_binary();
         log_wasm(&wasm);
-        let module = match Module::new(store.engine(), &wasm) {
+        let module = match fuzz_config.compile(store.engine(), &wasm) {
             Ok(m) => m,
             Err(_) => return,
         };
@@ -736,7 +736,9 @@ fn differential_store(
     fuzz_config: &generators::Config,
 ) -> (Module, Store<StoreLimits>) {
     let store = fuzz_config.to_store();
-    let module = Module::new(store.engine(), &wasm).expect("Wasmtime can compile module");
+    let module = fuzz_config
+        .compile(store.engine(), wasm)
+        .expect("Wasmtime can compile module");
     (module, store)
 }
 


### PR DESCRIPTION
In working on #3787 I see now that our coverage of loading precompiled
files specifically is somewhat lacking, so this adds a config option to
the fuzzers where, if enabled, will round-trip all compiled modules
through the filesystem to test out the mmapped-file case.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
