### PR TITLE
Further minor optimizations to instantiation

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1556,13 +1556,23 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 let sig_id_type = Type::int(u16::from(sig_id_size) * 8).unwrap();
                 let vmctx = self.vmctx(builder.func);
                 let base = builder.ins().global_value(pointer_type, vmctx);
-                let offset =
-                    i32::try_from(self.offsets.vmctx_vmshared_signature_id(ty_index)).unwrap();
 
                 // Load the caller ID.
                 let mut mem_flags = ir::MemFlags::trusted();
                 mem_flags.set_readonly();
-                let caller_sig_id = builder.ins().load(sig_id_type, mem_flags, base, offset);
+                let signatures = builder.ins().load(
+                    pointer_type,
+                    mem_flags,
+                    base,
+                    i32::try_from(self.offsets.vmctx_signature_ids_array()).unwrap(),
+                );
+                let sig_index = self.module.types[ty_index].unwrap_function();
+                let caller_sig_id = builder.ins().load(
+                    sig_id_type,
+                    mem_flags,
+                    signatures,
+                    i32::try_from(sig_index.as_u32() * sig_id_type.bytes()).unwrap(),
+                );
 
                 // Load the callee ID.
                 let mem_flags = ir::MemFlags::trusted();

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -1037,7 +1037,6 @@ mod tests {
 
         let offsets = wasmtime_environ::VMOffsets::from(wasmtime_environ::VMOffsetsFields {
             ptr: 8,
-            num_signature_ids: 0,
             num_imported_functions: 0,
             num_imported_tables: 0,
             num_imported_memories: 0,
@@ -1064,7 +1063,6 @@ mod tests {
 
         let offsets = wasmtime_environ::VMOffsets::from(wasmtime_environ::VMOffsetsFields {
             ptr: 8,
-            num_signature_ids: 0,
             num_imported_functions: 0,
             num_imported_tables: 0,
             num_imported_memories: 0,
@@ -1091,7 +1089,6 @@ mod tests {
 
         let offsets = wasmtime_environ::VMOffsets::from(wasmtime_environ::VMOffsetsFields {
             ptr: 8,
-            num_signature_ids: 0,
             num_imported_functions: 0,
             num_imported_tables: 0,
             num_imported_memories: 0,

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -460,25 +460,25 @@ unsafe fn initialize_vmcontext(instance: &mut Instance, req: InstanceAllocationR
 
     // Initialize the imports
     debug_assert_eq!(req.imports.functions.len(), module.num_imported_funcs);
-    ptr::copy(
+    ptr::copy_nonoverlapping(
         req.imports.functions.as_ptr(),
         instance.vmctx_plus_offset(instance.offsets.vmctx_imported_functions_begin()),
         req.imports.functions.len(),
     );
     debug_assert_eq!(req.imports.tables.len(), module.num_imported_tables);
-    ptr::copy(
+    ptr::copy_nonoverlapping(
         req.imports.tables.as_ptr(),
         instance.vmctx_plus_offset(instance.offsets.vmctx_imported_tables_begin()),
         req.imports.tables.len(),
     );
     debug_assert_eq!(req.imports.memories.len(), module.num_imported_memories);
-    ptr::copy(
+    ptr::copy_nonoverlapping(
         req.imports.memories.as_ptr(),
         instance.vmctx_plus_offset(instance.offsets.vmctx_imported_memories_begin()),
         req.imports.memories.len(),
     );
     debug_assert_eq!(req.imports.globals.len(), module.num_imported_globals);
-    ptr::copy(
+    ptr::copy_nonoverlapping(
         req.imports.globals.as_ptr(),
         instance.vmctx_plus_offset(instance.offsets.vmctx_imported_globals_begin()),
         req.imports.globals.len(),

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -299,7 +299,6 @@ impl InstancePool {
         // Calculate the maximum size of an Instance structure given the limits
         let offsets = VMOffsets::from(VMOffsetsFields {
             ptr: HostPtr,
-            num_signature_ids: module_limits.types,
             num_imported_functions: module_limits.imported_functions,
             num_imported_tables: module_limits.imported_tables,
             num_imported_memories: module_limits.imported_memories,

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -1452,6 +1452,9 @@ mod test {
             fn wasm_data(&self) -> &[u8] {
                 &[]
             }
+            fn signature_ids(&self) -> &[VMSharedSignatureIndex] {
+                &[]
+            }
         }
 
         Arc::new(RuntimeInfo(module))

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -190,4 +190,8 @@ pub trait ModuleRuntimeInfo: Send + Sync + 'static {
 
     /// A slice pointing to all data that is referenced by this instance.
     fn wasm_data(&self) -> &[u8];
+
+    /// Returns an array, indexed by `SignatureIndex` of all
+    /// `VMSharedSignatureIndex` entries corresponding to the `SignatureIndex`.
+    fn signature_ids(&self) -> &[VMSharedSignatureIndex];
 }

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -188,7 +188,10 @@ pub(crate) struct FuncData {
     // optimized use cases (e.g. `TypedFunc`) it's not actually needed or it's
     // only needed rarely. To handle that this is an optionally-contained field
     // which is lazily loaded into as part of `Func::call`.
-    ty: Option<FuncType>,
+    //
+    // Also note that this is intentionally placed behind a poiner to keep it
+    // small as `FuncData` instances are often inserted into a `Store`.
+    ty: Option<Box<FuncType>>,
 }
 
 /// The three ways that a function can be created and referenced from within a
@@ -216,7 +219,12 @@ enum FuncKind {
     /// `Func::new` or similar APIs. The `HostFunc` internally owns the
     /// `InstanceHandle` and that will get dropped when this `HostFunc` itself
     /// is dropped.
-    Host(HostFunc),
+    ///
+    /// Note that this is intentionally placed behind a `Box` to minimize the
+    /// size of this enum since the most common variant for high-peformance
+    /// situations is `SharedHost` and `StoreOwned`, so this ideally isn't
+    /// larger than those two.
+    Host(Box<HostFunc>),
 }
 
 macro_rules! for_each_function_signature {
@@ -711,7 +719,7 @@ impl Func {
         // this time.
         if store.store_data()[self.0].ty.is_none() {
             let ty = self.load_ty(store);
-            store.store_data_mut()[self.0].ty = Some(ty);
+            store.store_data_mut()[self.0].ty = Some(Box::new(ty));
         }
 
         (store.store_data()[self.0].ty.as_ref().unwrap(), store)
@@ -2091,7 +2099,7 @@ impl HostFunc {
     /// Same as [`HostFunc::to_func`], different ownership.
     unsafe fn into_func(self, store: &mut StoreOpaque) -> Func {
         self.validate_store(store);
-        Func::from_func_kind(FuncKind::Host(self), store)
+        Func::from_func_kind(FuncKind::Host(Box::new(self)), store)
     }
 
     fn validate_store(&self, store: &mut StoreOpaque) {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -1055,6 +1055,10 @@ impl wasmtime_runtime::ModuleRuntimeInfo for ModuleInner {
     fn wasm_data(&self) -> &[u8] {
         self.module.wasm_data()
     }
+
+    fn signature_ids(&self) -> &[VMSharedSignatureIndex] {
+        self.signatures.as_module_map().values().as_slice()
+    }
 }
 
 /// A barebones implementation of ModuleRuntimeInfo that is useful for
@@ -1143,5 +1147,12 @@ impl wasmtime_runtime::ModuleRuntimeInfo for BareModuleInfo {
 
     fn wasm_data(&self) -> &[u8] {
         &[]
+    }
+
+    fn signature_ids(&self) -> &[VMSharedSignatureIndex] {
+        match &self.one_signature {
+            Some((_, id)) => std::slice::from_ref(id),
+            None => &[],
+        }
     }
 }

--- a/crates/wasmtime/src/store/data.rs
+++ b/crates/wasmtime/src/store/data.rs
@@ -103,6 +103,10 @@ impl StoreData {
     pub(crate) fn funcs(&self) -> impl Iterator<Item = &crate::func::FuncData> {
         self.funcs.iter()
     }
+
+    pub(crate) fn reserve_funcs(&mut self, count: usize) {
+        self.funcs.reserve(count);
+    }
 }
 
 impl<T> Index<Stored<T>> for StoreData


### PR DESCRIPTION
I've been poring over profiles of instantiation recently and this is the final batch (for now at least) of optimizations of low-ish hanging fruit for speeding up instantiation. At this level the fruit is starting to appear significantly higher in the tree and at least for me this is basically at the limit of what I think makes sense to optimize for now. In the `instantiation.rs` benchmark the `WasiCtx::new` call is starting to become a pretty nontrivial portion of the entire benchmark which while we could make faster shows just how fast instantiation is at this point.

Each optimization is split out to a separate commit below, but at a high level the optimizations implemented here are:

* The `FuncData` type is shrunk to avoid extraneous movement of hundreds of bytes per-instantiation.
* Type information is no longer stored inline in `VMContext` but rather externally in `Module` to provide constant-time instantiation.
* Space for functions being inserted into a store is now pre-reserved to minimize reallocations and memory movement during the instantiation process.

Each improvement here is relatively modest but overall this improves the instantiation of spidermonkey/rustpython modules by 20-25%, dropping them to 3.5 and 3.9us on my machine.

The [remaining profile](https://share.firefox.dev/3Bb0ieI) I'm having a tough time finding what else to move out of the way and optimize. One of the highest parts of the profile now is all the `Arc<T>` reference count management, but doing something different there would be a pretty major overhaul I think and honestly this feels like a great problem to have. There's probably some minor tweaks we can make to data structures in `Store<T>` to make them more optimal, but as things go it feels like we're in a pretty good place as-is.