### PR TITLE
Added 'add_fuel' command line option

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -164,6 +164,10 @@ impl RunCommand {
         let engine = Engine::new(&config)?;
         let mut store = Store::new(&engine, Host::default());
 
+        if self.common.consume_fuel {
+            store.add_fuel(self.common.add_fuel).unwrap();
+        }
+
         let preopen_sockets = self.compute_preopen_sockets()?;
 
         // Make wasi available by default.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -164,18 +164,10 @@ impl RunCommand {
         let engine = Engine::new(&config)?;
         let mut store = Store::new(&engine, Host::default());
 
-        // if consume fuel has been flagged, we want to instantiate the
-        // store with the set amount of fuel from the 'add_fuel' option
-        if self.common.consume_fuel {
-            store.add_fuel(self.common.add_fuel)?;
-        }
-
-        // warn the user if 'add_fuel' is set - is not 0 - and 'consume_fuel' is not
-        if self.common.add_fuel != 0 && !self.common.consume_fuel {
-            eprintln!(
-                "warning: using `--add-fuel` without '--consume-fuel' flag\
-            being set. This currently won't do anything."
-            );
+        // if fuel has been configured, we want to set the fuel amount 
+        // of the store to the amount of fuel configured
+        if let Some(fuel) = self.common.fuel {
+            store.add_fuel(fuel)?;
         }
 
         let preopen_sockets = self.compute_preopen_sockets()?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -164,7 +164,7 @@ impl RunCommand {
         let engine = Engine::new(&config)?;
         let mut store = Store::new(&engine, Host::default());
 
-        // if fuel has been configured, we want to set the fuel amount 
+        // if fuel has been configured, we want to set the fuel amount
         // of the store to the amount of fuel configured
         if let Some(fuel) = self.common.fuel {
             store.add_fuel(fuel)?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -171,9 +171,11 @@ impl RunCommand {
         }
 
         // warn the user if 'add_fuel' is set - is not 0 - and 'consume_fuel' is not
-        if self.common.add_fuel != 0 && !self.common.consume_fuel{
-            eprintln!("warning: using `--add-fuel` without '--consume-fuel' flag\
-            being set. This currently won't do anything.");
+        if self.common.add_fuel != 0 && !self.common.consume_fuel {
+            eprintln!(
+                "warning: using `--add-fuel` without '--consume-fuel' flag\
+            being set. This currently won't do anything."
+            );
         }
 
         let preopen_sockets = self.compute_preopen_sockets()?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -164,6 +164,8 @@ impl RunCommand {
         let engine = Engine::new(&config)?;
         let mut store = Store::new(&engine, Host::default());
 
+        // if consume fuel has been flagged, we want to instantiate the
+        // store with the set amount of fuel from the 'add_fuel' option
         if self.common.consume_fuel {
             store.add_fuel(self.common.add_fuel).unwrap();
         }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -164,8 +164,8 @@ impl RunCommand {
         let engine = Engine::new(&config)?;
         let mut store = Store::new(&engine, Host::default());
 
-        // if fuel has been configured, we want to set the fuel amount
-        // of the store to the amount of fuel configured
+        // If fuel has been configured, we want to add the configured
+        // fuel amount to this store.
         if let Some(fuel) = self.common.fuel {
             store.add_fuel(fuel)?;
         }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -167,7 +167,13 @@ impl RunCommand {
         // if consume fuel has been flagged, we want to instantiate the
         // store with the set amount of fuel from the 'add_fuel' option
         if self.common.consume_fuel {
-            store.add_fuel(self.common.add_fuel).unwrap();
+            store.add_fuel(self.common.add_fuel)?;
+        }
+
+        // warn the user if 'add_fuel' is set - is not 0 - and 'consume_fuel' is not
+        if self.common.add_fuel != 0 && !self.common.consume_fuel{
+            eprintln!("warning: using `--add-fuel` without '--consume-fuel' flag\
+            being set. This currently won't do anything.");
         }
 
         let preopen_sockets = self.compute_preopen_sockets()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,8 +239,8 @@ struct CommonOptions {
     consume_fuel: bool,
 
     /// Amount of fuel to be consumed if "consume_fuel" is checked
-    #[structopt(long),  default_value = 0]
-    add_fuel: Option<u64>,
+    #[structopt(long, default_value = "0")]
+    add_fuel: u64,
 
     /// Executing wasm code will yield when a global epoch counter
     /// changes, allowing for async operation without blocking the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,13 +234,8 @@ struct CommonOptions {
     #[structopt(long)]
     enable_cranelift_nan_canonicalization: bool,
 
-    /// Executing wasm code will consume fuel, limiting its execution.
     #[structopt(long)]
-    consume_fuel: bool,
-
-    /// Amount of fuel to be consumed if "consume_fuel" is checked
-    #[structopt(long, default_value = "0")]
-    add_fuel: u64,
+    fuel: Option<u64>,
 
     /// Executing wasm code will yield when a global epoch counter
     /// changes, allowing for async operation without blocking the
@@ -332,7 +327,11 @@ impl CommonOptions {
             config.dynamic_memory_guard_size(size);
         }
 
-        config.consume_fuel(self.consume_fuel);
+        // if fuel has been configured, set the `consume fuel` flag on the config
+        if self.fuel.is_some() {
+            config.consume_fuel(true);
+        }        
+
         config.epoch_interruption(self.epoch_interruption);
         config.generate_address_map(!self.disable_address_map);
         config.paged_memory_initialization(self.paged_memory_initialization);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,10 @@ struct CommonOptions {
     #[structopt(long)]
     consume_fuel: bool,
 
+    /// Amount of fuel to be consumed if "consume_fuel" is checked
+    #[structopt(long)]
+    add_fuel: Option<u64>,
+
     /// Executing wasm code will yield when a global epoch counter
     /// changes, allowing for async operation without blocking the
     /// executor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ impl CommonOptions {
         // if fuel has been configured, set the `consume fuel` flag on the config
         if self.fuel.is_some() {
             config.consume_fuel(true);
-        }        
+        }
 
         config.epoch_interruption(self.epoch_interruption);
         config.generate_address_map(!self.disable_address_map);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ struct CommonOptions {
     consume_fuel: bool,
 
     /// Amount of fuel to be consumed if "consume_fuel" is checked
-    #[structopt(long)]
+    #[structopt(long),  default_value = 0]
     add_fuel: Option<u64>,
 
     /// Executing wasm code will yield when a global epoch counter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,7 @@ impl CommonOptions {
             config.dynamic_memory_guard_size(size);
         }
 
-        // if fuel has been configured, set the `consume fuel` flag on the config
+        // If fuel has been configured, set the `consume fuel` flag on the config.
         if self.fuel.is_some() {
             config.consume_fuel(true);
         }


### PR DESCRIPTION
Relatively new to both Rust and Wasmtime, so trying to just pick up a small first issue here. 

PR to try a solution to Issue #3717 

Currently just adds a "add_fuel" config option to the wasmtime API. I was taking a look and I think I might need to update this default value when the interpreter is instantiated: 

```
    pub fn new(state: InterpreterState<'a>) -> Self {
        Self { state, fuel: None }
    }
```

to 
```
    pub fn new(state: InterpreterState<'a>, fuel: Option<u64> = None) -> Self {
        Self { state, fuel: fuel }
    }
```

Don't currently have any test cases for the specific command line option just yet. Just wanted to check if I was on the right track. 

CC: @fitzgen 
