### PR TITLE
Make VMOffset calculation more readable

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -299,7 +299,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     /// reference count.
     ///
     /// The new reference count is returned.
-    fn mutate_extenref_ref_count(
+    fn mutate_externref_ref_count(
         &mut self,
         builder: &mut FunctionBuilder,
         externref: ir::Value,
@@ -1036,7 +1036,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 // * store the reference into the bump table at `*next`,
                 // * and finally increment the `next` bump finger.
                 builder.switch_to_block(no_gc_block);
-                self.mutate_extenref_ref_count(builder, elem, 1);
+                self.mutate_externref_ref_count(builder, elem, 1);
                 builder.ins().store(ir::MemFlags::trusted(), elem, next, 0);
 
                 let new_next = builder
@@ -1159,7 +1159,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                     .brnz(value_is_null, check_current_elem_block, &[]);
                 builder.ins().jump(inc_ref_count_block, &[]);
                 builder.switch_to_block(inc_ref_count_block);
-                self.mutate_extenref_ref_count(builder, value, 1);
+                self.mutate_externref_ref_count(builder, value, 1);
                 builder.ins().jump(check_current_elem_block, &[]);
 
                 // Grab the current element from the table, and store the new
@@ -1193,7 +1193,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 builder.ins().jump(continue_block, &[]);
 
                 builder.switch_to_block(dec_ref_count_block);
-                let prev_ref_count = self.mutate_extenref_ref_count(builder, current_elem, -1);
+                let prev_ref_count = self.mutate_externref_ref_count(builder, current_elem, -1);
                 let one = builder.ins().iconst(pointer_type, 1);
                 builder
                     .ins()

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -204,7 +204,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
         macro_rules! fields {
             (size($field:ident) = $size:expr, $($rest:tt)*) => {
                 ret.$field = next_field_offset;
-                next_field_offset = cadd(next_field_offset, $size);
+                next_field_offset = cadd(next_field_offset, u32::from($size));
                 fields!($($rest)*);
             };
             (align($align:literal), $($rest:tt)*) => {
@@ -215,12 +215,12 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
         }
 
         fields! {
-            size(interrupts) = u32::from(ret.ptr.size()),
-            size(epoch_ptr) = u32::from(ret.ptr.size()),
-            size(externref_activations_table) = u32::from(ret.ptr.size()),
-            size(store) = u32::from(ret.ptr.size() * 2),
-            size(builtin_functions) = u32::from(ret.pointer_size()),
-            size(signature_ids) = u32::from(ret.ptr.size()),
+            size(interrupts) = ret.ptr.size(),
+            size(epoch_ptr) = ret.ptr.size(),
+            size(externref_activations_table) = ret.ptr.size(),
+            size(store) = ret.ptr.size() * 2,
+            size(builtin_functions) = ret.pointer_size(),
+            size(signature_ids) = ret.ptr.size(),
             size(imported_functions)
                 = cmul(ret.num_imported_functions, ret.size_of_vmfunction_import()),
             size(imported_tables)

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -185,8 +185,6 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             size: 0,
         };
 
-        // Use a local variable instead of ret.size to prevent unnecessary loads and stores.
-        // LLVM is not able to optimize accesses of ret.size away most of the time.
         let mut next_field_offset = 0;
 
         // Convenience functions for checked addition and multiplication.

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -7,6 +7,7 @@
 //      interrupts: *const VMInterrupts,
 //      externref_activations_table: *mut VMExternRefActivationsTable,
 //      store: *mut dyn Store,
+//      builtins: *mut VMBuiltinFunctionsArray,
 //      signature_ids: *const VMSharedSignatureIndex,
 //      imported_functions: [VMFunctionImport; module.num_imported_functions],
 //      imported_tables: [VMTableImport; module.num_imported_tables],
@@ -16,7 +17,6 @@
 //      memories: [VMMemoryDefinition; module.num_defined_memories],
 //      globals: [VMGlobalDefinition; module.num_defined_globals],
 //      anyfuncs: [VMCallerCheckedAnyfunc; module.num_imported_functions + module.num_defined_functions],
-//      builtins: *mut VMBuiltinFunctionsArray,
 // }
 
 use crate::{
@@ -74,6 +74,7 @@ pub struct VMOffsets<P> {
     epoch_ptr: u32,
     externref_activations_table: u32,
     store: u32,
+    builtin_functions: u32,
     signature_ids: u32,
     imported_functions: u32,
     imported_tables: u32,
@@ -83,7 +84,6 @@ pub struct VMOffsets<P> {
     defined_memories: u32,
     defined_globals: u32,
     defined_anyfuncs: u32,
-    builtin_functions: u32,
     size: u32,
 }
 
@@ -172,6 +172,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             epoch_ptr: 0,
             externref_activations_table: 0,
             store: 0,
+            builtin_functions: 0,
             signature_ids: 0,
             imported_functions: 0,
             imported_tables: 0,
@@ -181,7 +182,6 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             defined_memories: 0,
             defined_globals: 0,
             defined_anyfuncs: 0,
-            builtin_functions: 0,
             size: 0,
         };
 
@@ -204,6 +204,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
         field!(epoch_ptr = .; size = u32::from(ret.ptr.size()));
         field!(externref_activations_table = .; size = u32::from(ret.ptr.size()));
         field!(store = .; size = u32::from(ret.ptr.size() * 2));
+        field!(builtin_functions = .; size = u32::from(ret.pointer_size()));
         field!(signature_ids = .; size = u32::from(ret.ptr.size()));
         field!(imported_functions = .; size = ret.num_imported_functions
             .checked_mul(u32::from(ret.size_of_vmfunction_import()))
@@ -231,7 +232,6 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             .unwrap()
             .checked_mul(u32::from(ret.size_of_vmcaller_checked_anyfunc()))
             .unwrap());
-        field!(builtin_functions = .; size = u32::from(ret.pointer_size()));
 
         ret.size = next_field_offset;
 


### PR DESCRIPTION
This should reduce the risk of making a mistake when changing it. Also fixes a typo and moves `builtin_functions` earlier in the `VMContext` to make it's offset known at compile time.