### PR TITLE
implement `--add-fuel` option for `wasmtime` CLI to configure amount of fuel

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -115,6 +115,13 @@ WASMTIME_CONFIG_PROP(void, interruptable, bool)
 WASMTIME_CONFIG_PROP(void, consume_fuel, bool)
 
 /**
+ * \brief Configures how much "fuel" is allocated for WebAssembly execution.
+ *
+ * This setting is `0` by default.
+ */
+WASMTIME_CONFIG_PROP(void, fuel_amount, uint64_t)
+
+/**
  * \brief Configures the maximum stack size, in bytes, that JIT code can use.
  *
  * This setting is 2MB by default. Configuring this setting will limit the
@@ -271,4 +278,3 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_config_cache_config_load(wasm_config_
 #endif
 
 #endif // WASMTIME_CONFIG_H
-

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -36,6 +36,9 @@ pub struct Tunables {
     /// will be consumed every time a wasm instruction is executed.
     pub consume_fuel: bool,
 
+    /// How much fuel the generated code is allowed to use.
+    pub fuel_amount: u64,
+
     /// Whether or not we use epoch-based interruption.
     pub epoch_interruption: bool,
 
@@ -91,6 +94,7 @@ impl Default for Tunables {
             parse_wasm_debuginfo: true,
             interruptable: false,
             consume_fuel: false,
+            fuel_amount: 0,
             epoch_interruption: false,
             static_memory_bound_is_maximum: false,
             guard_before_linear_memory: true,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -334,13 +334,25 @@ impl Config {
     ///
     /// Note that a [`Store`] starts with no fuel, so if you enable this option
     /// you'll have to be sure to pour some fuel into [`Store`] before
-    /// executing some code.
+    /// executing some code. You can do this by calling [`Config::fuel_amount`].
     ///
     /// By default this option is `false`.
     ///
     /// [`Store`]: crate::Store
     pub fn consume_fuel(&mut self, enable: bool) -> &mut Self {
         self.tunables.consume_fuel = enable;
+        self
+    }
+
+    /// Configures how much "fuel" is placed into a [`Store`] for WebAssembly
+    /// execution.
+    ///
+    /// This option is a counterpart to [`Config::consume_fuel`].
+    ///
+    /// By default this option is `0`.
+    ///
+    pub fn fuel_amount(&mut self, amount: u64) -> &mut Self {
+        self.tunables.fuel_amount = amount;
         self
     }
 

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -608,6 +608,7 @@ impl<'a> SerializedModule<'a> {
             parse_wasm_debuginfo,
             interruptable,
             consume_fuel,
+            fuel_amount,
             epoch_interruption,
             static_memory_bound_is_maximum,
             guard_before_linear_memory,
@@ -636,6 +637,11 @@ impl<'a> SerializedModule<'a> {
             dynamic_memory_offset_guard_size,
             other.dynamic_memory_offset_guard_size,
             "dynamic memory guard size",
+        )?;
+        Self::check_int(
+            fuel_amount,
+            other.fuel_amount,
+            "fuel amount guard size",
         )?;
         Self::check_bool(
             generate_native_debuginfo,

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -465,6 +465,10 @@ impl<T> Store<T> {
             data: ManuallyDrop::new(data),
         });
 
+        if inner.engine().config().tunables.consume_fuel {
+            inner.add_fuel(engine.config().tunables.fuel_amount).unwrap();
+        }
+
         // Once we've actually allocated the store itself we can configure the
         // trait object pointer of the default callee. Note the erasure of the
         // lifetime here into `'static`, so in general usage of this trait

--- a/examples/fuel.c
+++ b/examples/fuel.c
@@ -31,6 +31,7 @@ int main() {
   wasm_config_t *config = wasm_config_new();
   assert(config != NULL);
   wasmtime_config_consume_fuel_set(config, true);
+  wasmtime_config_fuel_amount_set(config, 10000);
 
   // Create an *engine*, which is a compilation context, with our configured options.
   wasm_engine_t *engine = wasm_engine_new_with_config(config);
@@ -38,10 +39,6 @@ int main() {
   wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
   assert(store != NULL);
   wasmtime_context_t *context = wasmtime_store_context(store);
-
-  error = wasmtime_context_add_fuel(context, 10000);
-  if (error != NULL)
-    exit_with_error("failed to add fuel", error, NULL);
 
   // Load our input file to parse it next
   FILE* file = fopen("examples/fuel.wat", "r");

--- a/examples/fuel.rs
+++ b/examples/fuel.rs
@@ -8,9 +8,9 @@ use wasmtime::*;
 fn main() -> Result<()> {
     let mut config = Config::new();
     config.consume_fuel(true);
+    config.fuel_amount(10_000);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
-    store.add_fuel(10_000)?;
     let module = Module::from_file(store.engine(), "examples/fuel.wat")?;
     let instance = Instance::new(&mut store, &module, &[])?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,10 @@ struct CommonOptions {
     #[structopt(long)]
     consume_fuel: bool,
 
+    /// How much fuel the wasm code is allowed to consume.
+    #[structopt(long, default_value = "0")]
+    add_fuel: u64,
+
     /// Executing wasm code will yield when a global epoch counter
     /// changes, allowing for async operation without blocking the
     /// executor.
@@ -328,6 +332,7 @@ impl CommonOptions {
             config.dynamic_memory_guard_size(size);
         }
 
+        config.fuel_amount(self.add_fuel);
         config.consume_fuel(self.consume_fuel);
         config.epoch_interruption(self.epoch_interruption);
         config.generate_address_map(!self.disable_address_map);
@@ -741,6 +746,16 @@ mod test {
                 wasi_nn: false,
                 wasi_crypto: false
             }
+        );
+    }
+
+    #[test]
+    fn test_add_fuel() {
+        let options =
+            CommonOptions::from_iter_safe(vec!["foo", "--add-fuel=100"]).unwrap();
+        assert_eq!(
+            options.add_fuel,
+            100
         );
     }
 }


### PR DESCRIPTION
This flag is expected to be used with the `--consume-fuel` flag.

The way this has been implemented is by:
1. adding a `fuel_amount` u64 field to the `Tunables` struct with a default
   value of 0.
2. adding a `Config::fuel_amount` method, which sets `fuel_amount` on it's
   `tunables` field.
3. updating `Store::new` to call `StoreOpaque::add_fuel` if `consume_fuel` is
   true.

The `fuel` examples to use the new `Config::fuel_amount` instead of calling
`Store::add_fuel` directly

I've only added a test for the CLI flag and nothing else as I could not locate 
tests for Tunables, Config, or Store.

This should resolve https://github.com/bytecodealliance/wasmtime/issues/3779
