### PR TITLE
Use a much lower memory page limit for pooling allocator fuzzing.

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -105,7 +105,7 @@ impl<'a> Arbitrary<'a> for ModuleLimits {
         const MAX_MEMORIES: u32 = 10;
         const MAX_GLOBALS: u32 = 1000;
         const MAX_ELEMENTS: u32 = 1000;
-        const MAX_MEMORY_PAGES: u64 = 0x10000;
+        const MAX_MEMORY_PAGES: u64 = 160; // 10 MiB
 
         Ok(Self {
             imported_functions: u.int_in_range(0..=MAX_IMPORTS)?,


### PR DESCRIPTION
This PR makes it such that the pooling allocator will be configured with a
much lower upper bound for memory pages, which will greatly reduce the
likelihood that the fuzzer memory limits will be hit from having too many
memories from too many instances committed.
