### PR TITLE
Fix a typo in `cranelift-frontend`'s docs

### DIFF
--- a/cranelift/frontend/src/variable.rs
+++ b/cranelift/frontend/src/variable.rs
@@ -11,7 +11,7 @@
 use core::u32;
 use cranelift_codegen::entity::EntityRef;
 
-///! An opaque reference to a variable.
+/// An opaque reference to a variable.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Variable(u32);
 


### PR DESCRIPTION
This just fixes a small typo in the documentation of `Variable` I found.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
