### PR TITLE
Agenda item 03-17

### DIFF
--- a/meetings/wasmtime/2022/wasmtime-03-17.md
+++ b/meetings/wasmtime/2022/wasmtime-03-17.md
@@ -11,7 +11,7 @@
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Other agenda items
-    1. _Submit a PR to add your item here_
+    1. Conrad Watt: verified Wasm interpreter as fuzzing oracle
 
 ## Notes
 


### PR DESCRIPTION
A while ago, it was [observed](https://github.com/WebAssembly/spec/pull/1354) that the official reference interpreter has performance issues which limit its usefulness as a fuzzing oracle. I currently maintain a [fork of the reference interpreter](https://github.com/conrad-watt/spec/tree/conrad-new-interpreter/interpreter) which uses a more efficient representation of Wasm's runtime state, avoiding the quadratic behaviour above. The core of this interpreter is a generated from and verified against my [mechanisation of Wasm's semantics](https://vtss.doc.ic.ac.uk/publications/Watt2021Two.html).

I've been speaking to @cfallin, @alexcrichton, @abrown, and @fitzgen about the feasibility of using this interpreter as a fuzzing oracle, and they suggested I bring this idea up for wider discussion in a Wasmtime meeting.