### PR TITLE
cranelift: Use GPR newtypes extensively in x64 lowering

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -16,9 +16,9 @@
        ;; Integer arithmetic/bit-twiddling.
        (AluRmiR (size OperandSize) ;; 4 or 8
                 (op AluRmiROpcode)
-                (src1 Reg)
-                (src2 RegMemImm)
-                (dst WritableReg))
+                (src1 Gpr)
+                (src2 GprMemImm)
+                (dst WritableGpr))
 
        ;; Instructions on general-purpose registers that only read src and
        ;; defines dst (dst is not modified). `bsr`, etc.
@@ -40,19 +40,19 @@
        ;; Integer quotient and remainder: (div idiv) $rax $rdx (reg addr)
        (Div (size OperandSize) ;; 1, 2, 4, or 8
             (signed bool)
-            (divisor RegMem)
-            (dividend Reg)
-            (dst_quotient WritableReg)
-            (dst_remainder WritableReg))
+            (divisor GprMem)
+            (dividend Gpr)
+            (dst_quotient WritableGpr)
+            (dst_remainder WritableGpr))
 
        ;; The high (and low) bits of a (un)signed multiply: `RDX:RAX := RAX *
        ;; rhs`.
        (MulHi (size OperandSize)
               (signed bool)
-              (src1 Reg)
-              (src2 RegMem)
-              (dst_lo WritableReg)
-              (dst_hi WritableReg))
+              (src1 Gpr)
+              (src2 GprMem)
+              (dst_lo WritableGpr)
+              (dst_hi WritableGpr))
 
        ;; A synthetic sequence to implement the right inline checks for
        ;; remainder and division, assuming the dividend is in %rax.
@@ -69,32 +69,32 @@
        ;; regalloc failures where %rdx is live before its first def!
        (CheckedDivOrRemSeq (kind DivOrRemKind)
                            (size OperandSize)
-                           (dividend Reg)
+                           (dividend Gpr)
                            ;; The divisor operand. Note it's marked as modified
                            ;; so that it gets assigned a register different from
                            ;; the temporary.
-                           (divisor WritableReg)
-                           (dst_quotient WritableReg)
-                           (dst_remainder WritableReg)
-                           (tmp OptionWritableReg))
+                           (divisor WritableGpr)
+                           (dst_quotient WritableGpr)
+                           (dst_remainder WritableGpr)
+                           (tmp OptionWritableGpr))
 
        ;; Do a sign-extend based on the sign of the value in rax into rdx: (cwd
        ;; cdq cqo) or al into ah: (cbw)
        (SignExtendData (size OperandSize) ;; 1, 2, 4, or 8
-                       (src Reg)
-                       (dst WritableReg))
+                       (src Gpr)
+                       (dst WritableGpr))
 
        ;; Constant materialization: (imm32 imm64) reg.
        ;;
        ;; Either: movl $imm32, %reg32 or movabsq $imm64, %reg32.
        (Imm (dst_size OperandSize) ;; 4 or 8
             (simm64 u64)
-            (dst WritableReg))
+            (dst WritableGpr))
 
        ;; GPR to GPR move: mov (64 32) reg reg.
        (MovRR (size OperandSize) ;; 4 or 8
-              (src Reg)
-              (dst WritableReg))
+              (src Gpr)
+              (dst WritableGpr))
 
        ;; Zero-extended loads, except for 64 bits: movz (bl bq wl wq lq) addr
        ;; reg.
@@ -103,12 +103,12 @@
        ;; zero-extend rule makes it unnecessary. For that case we emit the
        ;; equivalent "movl AM, reg32".
        (MovzxRmR (ext_mode ExtMode)
-                 (src RegMem)
-                 (dst WritableReg))
+                 (src GprMem)
+                 (dst WritableGpr))
 
        ;; A plain 64-bit integer load, since MovZX_RM_R can't represent that.
        (Mov64MR (src SyntheticAmode)
-                (dst WritableReg))
+                (dst WritableGpr))
 
        ;; Loads the memory address of addr into dst.
        (LoadEffectiveAddress (addr SyntheticAmode)
@@ -116,22 +116,22 @@
 
        ;; Sign-extended loads and moves: movs (bl bq wl wq lq) addr reg.
        (MovsxRmR (ext_mode ExtMode)
-                 (src RegMem)
-                 (dst WritableReg))
+                 (src GprMem)
+                 (dst WritableGpr))
 
        ;; Integer stores: mov (b w l q) reg addr.
        (MovRM (size OperandSize) ;; 1, 2, 4, or 8
-              (src Reg)
+              (src Gpr)
               (dst SyntheticAmode))
 
        ;; Arithmetic shifts: (shl shr sar) (b w l q) imm reg.
        (ShiftR (size OperandSize) ;; 1, 2, 4, or 8
                (kind ShiftKind)
-               (src Reg)
-               ;; shift count: `Imm8Reg::Imm8(0 .. #bits-in-type - 1)` or
-               ;; `Imm8Reg::Reg(r)` where `r` get's move mitosis'd into `%cl`.
-               (num_bits Imm8Reg)
-               (dst WritableReg))
+               (src Gpr)
+               ;; shift count: `Imm8Gpr::Imm8(0 .. #bits-in-type - 1)` or
+               ;; `Imm8Reg::Gpr(r)` where `r` get's move mitosis'd into `%cl`.
+               (num_bits Imm8Gpr)
+               (dst WritableGpr))
 
        ;; Arithmetic SIMD shifts.
        (XmmRmiReg (opcode SseOpcode)
@@ -142,30 +142,30 @@
        ;; Integer comparisons/tests: cmp or test (b w l q) (reg addr imm) reg.
        (CmpRmiR (size OperandSize) ;; 1, 2, 4, or 8
                 (opcode CmpOpcode)
-                (src RegMemImm)
-                (dst Reg))
+                (src GprMemImm)
+                (dst Gpr))
 
        ;; Materializes the requested condition code in the destinaton reg.
        (Setcc (cc CC)
-              (dst WritableReg))
+              (dst WritableGpr))
 
        ;; Integer conditional move.
        ;;
        ;; Overwrites the destination register.
        (Cmove (size OperandSize)
               (cc CC)
-              (consequent RegMem)
-              (alternative Reg)
-              (dst WritableReg))
+              (consequent GprMem)
+              (alternative Gpr)
+              (dst WritableGpr))
 
        ;; =========================================
        ;; Stack manipulation.
 
        ;; pushq (reg addr imm)
-       (Push64 (src RegMemImm))
+       (Push64 (src GprMemImm))
 
        ;; popq reg
-       (Pop64 (dst WritableReg))
+       (Pop64 (dst WritableGpr))
 
        ;; =========================================
        ;; Floating-point operations.
@@ -221,7 +221,7 @@
        ;; XMM (scalar) unary op (from integer to float reg): movd, movq,
        ;; cvtsi2s{s,d}
        (GprToXmm (op SseOpcode)
-                 (src RegMem)
+                 (src GprMem)
                  (dst WritableXmm)
                  (src_size OperandSize))
 
@@ -272,21 +272,21 @@
        ;; registers.
        (XmmMinMaxSeq (size OperandSize)
                      (is_min bool)
-                     (lhs Reg)
-                     (rhs_dst WritableReg))
+                     (lhs Xmm)
+                     (rhs_dst WritableXmm))
 
        ;; XMM (scalar) conditional move.
        ;;
        ;; Overwrites the destination register if cc is set.
        (XmmCmove (size OperandSize)
                  (cc CC)
-                 (src RegMem)
-                 (dst WritableReg))
+                 (src XmmMem)
+                 (dst WritableXmm))
 
        ;; Float comparisons/tests: cmp (b w l q) (reg addr imm) reg.
        (XmmCmpRmR (op SseOpcode)
-                  (src RegMem)
-                  (dst Reg))
+                  (src XmmMem)
+                  (dst Xmm))
 
        ;; A binary XMM instruction with an 8-bit immediate: e.g. cmp (ps pd) imm
        ;; (reg addr) reg
@@ -780,8 +780,8 @@
 ;; As a side effect, this marks the value as used.
 ;;
 ;; This is used when lowering various shifts and rotates.
-(decl put_masked_in_imm8_reg (Value Type) Imm8Reg)
-(extern constructor put_masked_in_imm8_reg put_masked_in_imm8_reg)
+(decl put_masked_in_imm8_gpr (Value Type) Imm8Gpr)
+(extern constructor put_masked_in_imm8_gpr put_masked_in_imm8_gpr)
 
 (type CC extern
       (enum O
@@ -825,13 +825,20 @@
 
 (type Gpr (primitive Gpr))
 (type WritableGpr (primitive WritableGpr))
+(type OptionWritableGpr (primitive OptionWritableGpr))
 (type GprMem extern (enum))
 (type GprMemImm extern (enum))
+(type Imm8Gpr extern (enum))
 
 (type Xmm (primitive Xmm))
 (type WritableXmm (primitive WritableXmm))
+(type OptionWritableXmm (primitive OptionWritableXmm))
 (type XmmMem extern (enum))
 (type XmmMemImm extern (enum))
+
+;; Convert an `Imm8Reg` into an `Imm8Gpr`.
+(decl imm8_reg_to_imm8_gpr (Imm8Reg) Imm8Gpr)
+(extern constructor imm8_reg_to_imm8_gpr imm8_reg_to_imm8_gpr)
 
 ;; Convert a `WritableGpr` to a `WritableReg`.
 (decl writable_gpr_to_reg (WritableGpr) WritableReg)
@@ -856,6 +863,14 @@
 ;; Convert an `Gpr` to a `Reg`.
 (decl gpr_to_reg (Gpr) Reg)
 (extern constructor gpr_to_reg gpr_to_reg)
+
+;; Convert an `Gpr` to a `GprMem`.
+(decl gpr_to_gpr_mem (Gpr) GprMem)
+(extern constructor gpr_to_gpr_mem gpr_to_gpr_mem)
+
+;; Convert an `Gpr` to a `GprMemImm`.
+(decl gpr_to_gpr_mem_imm (Gpr) GprMemImm)
+(extern constructor gpr_to_gpr_mem_imm gpr_to_gpr_mem_imm)
 
 ;; Convert an `Xmm` to a `Reg`.
 (decl xmm_to_reg (Xmm) Reg)
@@ -984,6 +999,25 @@
 (rule (value_xmm x)
       (value_reg (xmm_to_reg x)))
 
+;; Get the `n`th reg in a `ValueRegs` and construct a GPR from it.
+;;
+;; Asserts that the register is a GPR.
+(decl value_regs_get_gpr (ValueRegs usize) Gpr)
+(rule (value_regs_get_gpr regs n)
+      (gpr_new (value_regs_get regs n)))
+
+;; Convert a `Gpr` to an `Imm8Gpr`.
+(decl gpr_to_imm8_gpr (Gpr) Imm8Gpr)
+(extern constructor gpr_to_imm8_gpr gpr_to_imm8_gpr)
+
+;; Convert an 8-bit immediate into an `Imm8Gpr`.
+(decl imm8_to_imm8_gpr (u8) Imm8Gpr)
+(extern constructor imm8_to_imm8_gpr imm8_to_imm8_gpr)
+
+;; Get the low half of the given `Value` as a GPR.
+(decl lo_gpr (Value) Gpr)
+(rule (lo_gpr regs) (gpr_new (lo_reg regs)))
+
 ;;;; Helpers for Getting Particular Physical Registers ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; These should only be used for legalization purposes, when we can't otherwise
@@ -1014,15 +1048,15 @@
 ;; `Imm8Reg.Imm8`. This is used for shifts and rotates, so that we don't try and
 ;; shift/rotate more bits than the type has available, per Cranelift's
 ;; semantics.
-(decl const_to_type_masked_imm8 (u64 Type) Imm8Reg)
+(decl const_to_type_masked_imm8 (u64 Type) Imm8Gpr)
 (extern constructor const_to_type_masked_imm8 const_to_type_masked_imm8)
 
-;; Extract a constant `RegMemImm.Imm` from a value operand.
-(decl simm32_from_value (RegMemImm) Value)
+;; Extract a constant `GprMemImm.Imm` from a value operand.
+(decl simm32_from_value (GprMemImm) Value)
 (extern extractor simm32_from_value simm32_from_value)
 
 ;; Extract a constant `RegMemImm.Imm` from an `Imm64` immediate.
-(decl simm32_from_imm64 (RegMemImm) Imm64)
+(decl simm32_from_imm64 (GprMemImm) Imm64)
 (extern extractor simm32_from_imm64 simm32_from_imm64)
 
 ;; A load that can be sunk into another operation.
@@ -1041,6 +1075,10 @@
 (decl sink_load (SinkableLoad) RegMemImm)
 (extern constructor sink_load sink_load)
 
+(decl sink_load_to_gpr_mem_imm (SinkableLoad) GprMemImm)
+(rule (sink_load_to_gpr_mem_imm load)
+      (gpr_mem_imm_new (sink_load load)))
+
 ;;;; Helpers for Sign/Zero Extending ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (type ExtKind extern
@@ -1057,13 +1095,13 @@
 (extern constructor ext_mode ext_mode)
 
 ;; Put the given value into a register, but extended as the given type.
-(decl extend_to_reg (Value Type ExtendKind) Reg)
+(decl extend_to_gpr (Value Type ExtendKind) Gpr)
 
 ;; If the value is already of the requested type, no extending is necessary.
-(rule (extend_to_reg (and val (value_type ty)) =ty _kind)
-      (put_in_reg val))
+(rule (extend_to_gpr (and val (value_type ty)) =ty _kind)
+      (put_in_gpr val))
 
-(rule (extend_to_reg (and val (value_type from_ty))
+(rule (extend_to_gpr (and val (value_type from_ty))
                      to_ty
                      kind)
       (let ((from_bits u16 (ty_bits_u16 from_ty))
@@ -1073,10 +1111,10 @@
         (extend kind
                 to_ty
                 (ext_mode from_bits to_bits)
-                (put_in_reg_mem val))))
+                (put_in_gpr_mem val))))
 
-;; Do a sign or zero extension of the given `RegMem`.
-(decl extend (ExtendKind Type ExtMode RegMem) Reg)
+;; Do a sign or zero extension of the given `GprMem`.
+(decl extend (ExtendKind Type ExtMode GprMem) Gpr)
 
 ;; Zero extending uses `movzx`.
 (rule (extend (ExtendKind.Zero) ty mode src)
@@ -1166,14 +1204,14 @@
 (decl x64_load (Type SyntheticAmode ExtKind) Reg)
 
 (rule (x64_load (fits_in_32 ty) addr (ExtKind.SignExtend))
-      (movsx ty
-             (ext_mode (ty_bytes ty) 8)
-             (synthetic_amode_to_reg_mem addr)))
+      (gpr_to_reg (movsx ty
+                         (ext_mode (ty_bytes ty) 8)
+                         (reg_mem_to_gpr_mem (synthetic_amode_to_reg_mem addr)))))
 
 (rule (x64_load $I64 addr _ext_kind)
-      (let ((dst WritableReg (temp_writable_reg $I64))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.Mov64MR addr dst))))
-        (writable_reg_to_reg dst)))
+        (gpr_to_reg (writable_gpr_to_gpr dst))))
 
 (rule (x64_load $F32 addr _ext_kind)
       (xmm_to_reg (xmm_unary_rm_r (SseOpcode.Movss)
@@ -1202,15 +1240,15 @@
 ;; only gets defined the once.
 
 ;; Helper for emitting `MInst.AluRmiR` instructions.
-(decl alu_rmi_r (Type AluRmiROpcode Reg RegMemImm) Reg)
+(decl alu_rmi_r (Type AluRmiROpcode Gpr GprMemImm) Gpr)
 (rule (alu_rmi_r ty opcode src1 src2)
-      (let ((dst WritableReg (temp_writable_reg ty))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.AluRmiR size opcode src1 src2 dst))))
-        (writable_reg_to_reg dst)))
+        (writable_gpr_to_gpr dst)))
 
 ;; Helper for emitting `add` instructions.
-(decl add (Type Reg RegMemImm) Reg)
+(decl add (Type Gpr GprMemImm) Gpr)
 (rule (add ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Add)
@@ -1218,29 +1256,29 @@
                  src2))
 
 ;; Helper for creating `add` instructions whose flags are also used.
-(decl add_with_flags (Type Reg RegMemImm) ProducesFlags)
+(decl add_with_flags (Type Gpr GprMemImm) ProducesFlags)
 (rule (add_with_flags ty src1 src2)
-      (let ((dst WritableReg (temp_writable_reg ty)))
+      (let ((dst WritableGpr (temp_writable_gpr)))
         (ProducesFlags.ProducesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
                                                     (AluRmiROpcode.Add)
                                                     src1
                                                     src2
                                                     dst)
-                                     (writable_reg_to_reg dst))))
+                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for creating `adc` instructions.
-(decl adc (Type Reg RegMemImm) ConsumesFlags)
+(decl adc (Type Gpr GprMemImm) ConsumesFlags)
 (rule (adc ty src1 src2)
-      (let ((dst WritableReg (temp_writable_reg ty)))
+      (let ((dst WritableGpr (temp_writable_gpr)))
         (ConsumesFlags.ConsumesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
                                                     (AluRmiROpcode.Adc)
                                                     src1
                                                     src2
                                                     dst)
-                                     (writable_reg_to_reg dst))))
+                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for emitting `sub` instructions.
-(decl sub (Type Reg RegMemImm) Reg)
+(decl sub (Type Gpr GprMemImm) Gpr)
 (rule (sub ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Sub)
@@ -1248,29 +1286,29 @@
                  src2))
 
 ;; Helper for creating `sub` instructions whose flags are also used.
-(decl sub_with_flags (Type Reg RegMemImm) ProducesFlags)
+(decl sub_with_flags (Type Gpr GprMemImm) ProducesFlags)
 (rule (sub_with_flags ty src1 src2)
-      (let ((dst WritableReg (temp_writable_reg ty)))
+      (let ((dst WritableGpr (temp_writable_gpr)))
         (ProducesFlags.ProducesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
                                                     (AluRmiROpcode.Sub)
                                                     src1
                                                     src2
                                                     dst)
-                                     (writable_reg_to_reg dst))))
+                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for creating `sbb` instructions.
-(decl sbb (Type Reg RegMemImm) ConsumesFlags)
+(decl sbb (Type Gpr GprMemImm) ConsumesFlags)
 (rule (sbb ty src1 src2)
-      (let ((dst WritableReg (temp_writable_reg ty)))
+      (let ((dst WritableGpr (temp_writable_gpr)))
         (ConsumesFlags.ConsumesFlags (MInst.AluRmiR (operand_size_of_type_32_64 ty)
                                                     (AluRmiROpcode.Sbb)
                                                     src1
                                                     src2
                                                     dst)
-                                     (writable_reg_to_reg dst))))
+                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for creating `mul` instructions.
-(decl mul (Type Reg RegMemImm) Reg)
+(decl mul (Type Gpr GprMemImm) Gpr)
 (rule (mul ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Mul)
@@ -1278,10 +1316,7 @@
                  src2))
 
 ;; Helper for emitting `and` instructions.
-;;
-;; Use `m_` prefix (short for "mach inst") to disambiguate with the ISLE-builtin
-;; `and` operator.
-(decl x64_and (Type Reg RegMemImm) Reg)
+(decl x64_and (Type Gpr GprMemImm) Gpr)
 (rule (x64_and ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.And)
@@ -1289,7 +1324,7 @@
                  src2))
 
 ;; Helper for emitting `or` instructions.
-(decl or (Type Reg RegMemImm) Reg)
+(decl or (Type Gpr GprMemImm) Gpr)
 (rule (or ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Or)
@@ -1297,7 +1332,7 @@
                  src2))
 
 ;; Helper for emitting `xor` instructions.
-(decl xor (Type Reg RegMemImm) Reg)
+(decl xor (Type Gpr GprMemImm) Gpr)
 (rule (xor ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Xor)
@@ -1309,10 +1344,10 @@
 
 ;; Integer immediates.
 (rule (imm (fits_in_64 ty) simm64)
-      (let ((dst WritableReg (temp_writable_reg ty))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.Imm size simm64 dst))))
-        (writable_reg_to_reg dst)))
+        (gpr_to_reg (writable_gpr_to_gpr dst))))
 
 ;; `f32` immediates.
 (rule (imm $F32 bits)
@@ -1332,21 +1367,21 @@
 ;; Special case for when a 64-bit immediate fits into 32-bits. We can use a
 ;; 32-bit move that zero-extends the value, which has a smaller encoding.
 (rule (imm $I64 (nonzero_u64_fits_in_u32 x))
-      (let ((dst WritableReg (temp_writable_reg $I64))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.Imm (OperandSize.Size32) x dst))))
-        (writable_reg_to_reg dst)))
+        (gpr_to_reg (writable_gpr_to_gpr dst))))
 
 ;; Special case for integer zero immediates: turn them into an `xor r, r`.
 (rule (imm (fits_in_64 ty) 0)
-      (let ((wr WritableReg (temp_writable_reg ty))
-            (r Reg (writable_reg_to_reg wr))
+      (let ((wgpr WritableGpr (temp_writable_gpr))
+            (g Gpr (writable_gpr_to_gpr wgpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.AluRmiR size
                                          (AluRmiROpcode.Xor)
-                                         r
-                                         (RegMemImm.Reg r)
-                                         wr))))
-        r))
+                                         g
+                                         (gpr_to_gpr_mem_imm g)
+                                         wgpr))))
+        (gpr_to_reg g)))
 
 ;; Special case for zero immediates with vector types, they turn into an xor
 ;; specific to the vector type.
@@ -1384,44 +1419,42 @@
 ;; TODO: use cmpeqpd for all 1s
 
 ;; Helper for creating `MInst.ShifR` instructions.
-(decl shift_r (Type ShiftKind Reg Imm8Reg) Reg)
+(decl shift_r (Type ShiftKind Gpr Imm8Gpr) Gpr)
 (rule (shift_r ty kind src1 src2)
-      (let ((dst WritableReg (temp_writable_reg ty))
+      (let ((dst WritableGpr (temp_writable_gpr))
             ;; Use actual 8/16-bit instructions when appropriate: we
             ;; rely on their shift-amount-masking semantics.
             (size OperandSize (raw_operand_size_of_type ty))
             (_ Unit (emit (MInst.ShiftR size kind src1 src2 dst))))
-        (writable_reg_to_reg dst)))
+        (writable_gpr_to_gpr dst)))
 
-;; Helper for creating `rotl` instructions (prefixed with "m_", short for "mach
-;; inst", to disambiguate this from clif's `rotl`).
-(decl x64_rotl (Type Reg Imm8Reg) Reg)
+;; Helper for creating `rotl` instructions.
+(decl x64_rotl (Type Gpr Imm8Gpr) Gpr)
 (rule (x64_rotl ty src1 src2)
       (shift_r ty (ShiftKind.RotateLeft) src1 src2))
 
-;; Helper for creating `rotr` instructions (prefixed with "m_", short for "mach
-;; inst", to disambiguate this from clif's `rotr`).
-(decl x64_rotr (Type Reg Imm8Reg) Reg)
+;; Helper for creating `rotr` instructions.
+(decl x64_rotr (Type Gpr Imm8Gpr) Gpr)
 (rule (x64_rotr ty src1 src2)
       (shift_r ty (ShiftKind.RotateRight) src1 src2))
 
 ;; Helper for creating `shl` instructions.
-(decl shl (Type Reg Imm8Reg) Reg)
+(decl shl (Type Gpr Imm8Gpr) Gpr)
 (rule (shl ty src1 src2)
       (shift_r ty (ShiftKind.ShiftLeft) src1 src2))
 
 ;; Helper for creating logical shift-right instructions.
-(decl shr (Type Reg Imm8Reg) Reg)
+(decl shr (Type Gpr Imm8Gpr) Gpr)
 (rule (shr ty src1 src2)
       (shift_r ty (ShiftKind.ShiftRightLogical) src1 src2))
 
 ;; Helper for creating arithmetic shift-right instructions.
-(decl sar (Type Reg Imm8Reg) Reg)
+(decl sar (Type Gpr Imm8Gpr) Gpr)
 (rule (sar ty src1 src2)
       (shift_r ty (ShiftKind.ShiftRightArithmetic) src1 src2))
 
 ;; Helper for creating `MInst.CmpRmiR` instructions.
-(decl cmp_rmi_r (OperandSize CmpOpcode RegMemImm Reg) ProducesFlags)
+(decl cmp_rmi_r (OperandSize CmpOpcode GprMemImm Gpr) ProducesFlags)
 (rule (cmp_rmi_r size opcode src1 src2)
       (ProducesFlags.ProducesFlags (MInst.CmpRmiR size
                                                   opcode
@@ -1430,36 +1463,36 @@
                                    (invalid_reg)))
 
 ;; Helper for creating `cmp` instructions.
-(decl cmp (OperandSize RegMemImm Reg) ProducesFlags)
+(decl cmp (OperandSize GprMemImm Gpr) ProducesFlags)
 (rule (cmp size src1 src2)
       (cmp_rmi_r size (CmpOpcode.Cmp) src1 src2))
 
 ;; Helper for creating `test` instructions.
-(decl test (OperandSize RegMemImm Reg) ProducesFlags)
+(decl test (OperandSize GprMemImm Gpr) ProducesFlags)
 (rule (test size src1 src2)
       (cmp_rmi_r size (CmpOpcode.Test) src1 src2))
 
 ;; Helper for creating `MInst.Cmove` instructions.
-(decl cmove (Type CC RegMem Reg) ConsumesFlags)
+(decl cmove (Type CC GprMem Gpr) ConsumesFlags)
 (rule (cmove ty cc consequent alternative)
-      (let ((dst WritableReg (temp_writable_reg ty))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty)))
         (ConsumesFlags.ConsumesFlags (MInst.Cmove size cc consequent alternative dst)
-                                     (writable_reg_to_reg dst))))
+                                     (gpr_to_reg (writable_gpr_to_gpr dst)))))
 
 ;; Helper for creating `MInst.MovzxRmR` instructions.
-(decl movzx (Type ExtMode RegMem) Reg)
+(decl movzx (Type ExtMode GprMem) Gpr)
 (rule (movzx ty mode src)
-      (let ((dst WritableReg (temp_writable_reg ty))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.MovzxRmR mode src dst))))
-        (writable_reg_to_reg dst)))
+        (writable_gpr_to_gpr dst)))
 
 ;; Helper for creating `MInst.MovsxRmR` instructions.
-(decl movsx (Type ExtMode RegMem) Reg)
+(decl movsx (Type ExtMode GprMem) Gpr)
 (rule (movsx ty mode src)
-      (let ((dst WritableReg (temp_writable_reg ty))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.MovsxRmR mode src dst))))
-        (writable_reg_to_reg dst)))
+        (writable_gpr_to_gpr dst)))
 
 ;; Helper for creating `MInst.XmmRmR` instructions.
 (decl xmm_rm_r (Type SseOpcode Xmm XmmMem) Xmm)
@@ -1926,10 +1959,10 @@
 ;; Helper for creating `MInst.MulHi` instructions.
 ;;
 ;; Returns the (lo, hi) register halves of the multiplication.
-(decl mul_hi (Type bool Reg RegMem) ValueRegs)
+(decl mul_hi (Type bool Gpr GprMem) ValueRegs)
 (rule (mul_hi ty signed src1 src2)
-      (let ((dst_lo WritableReg (temp_writable_reg ty))
-            (dst_hi WritableReg (temp_writable_reg ty))
+      (let ((dst_lo WritableGpr (temp_writable_gpr))
+            (dst_hi WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.MulHi size
                                        signed
@@ -1937,12 +1970,12 @@
                                        src2
                                        dst_lo
                                        dst_hi))))
-        (value_regs (writable_reg_to_reg dst_lo)
-                    (writable_reg_to_reg dst_hi))))
+        (value_gprs (writable_gpr_to_gpr dst_lo)
+                    (writable_gpr_to_gpr dst_hi))))
 
 ;; Helper for creating `mul` instructions that return both the lower and
 ;; (unsigned) higher halves of the result.
-(decl mulhi_u (Type Reg RegMem) ValueRegs)
+(decl mulhi_u (Type Gpr GprMem) ValueRegs)
 (rule (mulhi_u ty src1 src2)
       (mul_hi ty $false src1 src2))
 
@@ -2026,7 +2059,7 @@
 (decl gpr_to_xmm (SseOpcode GprMem OperandSize) Xmm)
 (rule (gpr_to_xmm op src size)
       (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.GprToXmm op (gpr_mem_to_reg_mem src) dst size))))
+            (_ Unit (emit (MInst.GprToXmm op src dst size))))
         (writable_xmm_to_xmm dst)))
 
 ;; Helper for creating `not` instructions.

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -63,33 +63,33 @@
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x y)))
-      (value_reg (add ty
-                      (put_in_reg x)
-                      (RegMemImm.Reg (put_in_reg y)))))
+      (value_gpr (add ty
+                      (put_in_gpr x)
+                      (gpr_to_gpr_mem_imm (put_in_gpr y)))))
 
 ;; Add a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x (simm32_from_value y))))
-      (value_reg (add ty (put_in_reg x) y)))
+      (value_gpr (add ty (put_in_gpr x) y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd (simm32_from_value x) y)))
-      (value_reg (add ty (put_in_reg y) x)))
+      (value_gpr (add ty (put_in_gpr y) x)))
 
 ;; Add a register and memory.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x (sinkable_load y))))
-      (value_reg (add ty
-                      (put_in_reg x)
-                      (sink_load y))))
+      (value_gpr (add ty
+                      (put_in_gpr x)
+                      (sink_load_to_gpr_mem_imm y))))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd (sinkable_load x) y)))
-      (value_reg (add ty
-                      (put_in_reg y)
-                      (sink_load x))))
+      (value_gpr (add ty
+                      (put_in_gpr y)
+                      (sink_load_to_gpr_mem_imm x))))
 
 ;; SSE.
 
@@ -117,15 +117,15 @@
 (rule (lower (has_type $I128 (iadd x y)))
       ;; Get the high/low registers for `x`.
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1)))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1)))
         ;; Get the high/low registers for `y`.
         (let ((y_regs ValueRegs (put_in_regs y))
-              (y_lo Reg (value_regs_get y_regs 0))
-              (y_hi Reg (value_regs_get y_regs 1)))
+              (y_lo Gpr (value_regs_get_gpr y_regs 0))
+              (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do an add followed by an add-with-carry.
-          (with_flags (add_with_flags $I64 x_lo (RegMemImm.Reg y_lo))
-                      (adc $I64 x_hi (RegMemImm.Reg y_hi))))))
+          (with_flags (add_with_flags $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+                      (adc $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
 
 ;;;; Rules for `sadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -166,42 +166,42 @@
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x y)))
-      (let ((unused_iflags Reg (writable_reg_to_reg (temp_writable_reg $I64))))
-        (value_regs (add ty
-                         (put_in_reg x)
-                         (RegMemImm.Reg (put_in_reg y)))
-                    unused_iflags)))
+      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
+        (value_gprs (add ty
+                        (put_in_gpr x)
+                        (put_in_gpr_mem_imm y))
+                   unused_iflags)))
 
 ;; Add a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (simm32_from_value y))))
-      (let ((unused_iflags Reg (writable_reg_to_reg (temp_writable_reg $I64))))
-        (value_regs (add ty (put_in_reg x) y)
+      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
+        (value_gprs (add ty (put_in_gpr x) y)
                     unused_iflags)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (simm32_from_value x) y)))
-      (let ((unused_iflags Reg (writable_reg_to_reg (temp_writable_reg $I64))))
-        (value_regs (add ty (put_in_reg y) x)
+      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
+        (value_gprs (add ty (put_in_gpr y) x)
                     unused_iflags)))
 
 ;; Add a register and memory.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (sinkable_load y))))
-      (let ((unused_iflags Reg (writable_reg_to_reg (temp_writable_reg $I64))))
-        (value_regs (add ty
-                         (put_in_reg x)
-                         (sink_load y))
+      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
+        (value_gprs (add ty
+                         (put_in_gpr x)
+                         (sink_load_to_gpr_mem_imm y))
                     unused_iflags)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (sinkable_load x) y)))
-      (let ((unused_iflags Reg (writable_reg_to_reg (temp_writable_reg $I64))))
-        (value_regs (add ty
-                         (put_in_reg y)
-                         (sink_load x))
+      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
+        (value_gprs (add ty
+                         (put_in_gpr y)
+                         (sink_load_to_gpr_mem_imm x))
                     unused_iflags)))
 
 ;; (No `iadd_ifcout` for `i128`.)
@@ -212,30 +212,30 @@
 
 ;; When the immediate fits in a `RegMemImm.Imm`, use that.
 (rule (lower (has_type (fits_in_64 ty) (iadd_imm y (simm32_from_imm64 x))))
-      (value_reg (add ty (put_in_reg y) x)))
+      (value_gpr (add ty (put_in_gpr y) x)))
 
 ;; Otherwise, put the immediate into a register.
 (rule (lower (has_type (fits_in_64 ty) (iadd_imm y (u64_from_imm64 x))))
-      (value_reg (add ty (put_in_reg y) (RegMemImm.Reg (imm ty x)))))
+      (value_gpr (add ty (put_in_gpr y) (gpr_to_gpr_mem_imm (gpr_new (imm ty x))))))
 
 ;; `i128`
 
 ;; When the immediate fits in a `RegMemImm.Imm`, use that.
 (rule (lower (has_type $I128 (iadd_imm y (simm32_from_imm64 x))))
       (let ((y_regs ValueRegs (put_in_regs y))
-            (y_lo Reg (value_regs_get y_regs 0))
-            (y_hi Reg (value_regs_get y_regs 1)))
+            (y_lo Gpr (value_regs_get_gpr y_regs 0))
+            (y_hi Gpr (value_regs_get_gpr y_regs 1)))
         (with_flags (add_with_flags $I64 y_lo x)
-                    (adc $I64 y_hi (RegMemImm.Imm 0)))))
+                    (adc $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
 
 ;; Otherwise, put the immediate into a register.
 (rule (lower (has_type $I128 (iadd_imm y (u64_from_imm64 x))))
       (let ((y_regs ValueRegs (put_in_regs y))
-            (y_lo Reg (value_regs_get y_regs 0))
-            (y_hi Reg (value_regs_get y_regs 1))
-            (x_lo Reg (imm $I64 x)))
-        (with_flags (add_with_flags $I64 y_lo (RegMemImm.Reg x_lo))
-                    (adc $I64 y_hi (RegMemImm.Imm 0)))))
+            (y_lo Gpr (value_regs_get_gpr y_regs 0))
+            (y_hi Gpr (value_regs_get_gpr y_regs 1))
+            (x_lo Gpr (gpr_new (imm $I64 x))))
+        (with_flags (add_with_flags $I64 y_lo (gpr_to_gpr_mem_imm x_lo))
+                    (adc $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -244,21 +244,21 @@
 ;; Sub two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x y)))
-      (value_reg (sub ty
-                      (put_in_reg x)
-                      (RegMemImm.Reg (put_in_reg y)))))
+      (value_gpr (sub ty
+                      (put_in_gpr x)
+                      (put_in_gpr_mem_imm y))))
 
 ;; Sub a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x (simm32_from_value y))))
-      (value_reg (sub ty (put_in_reg x) y)))
+      (value_gpr (sub ty (put_in_gpr x) y)))
 
 ;; Sub a register and memory.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x (sinkable_load y))))
-      (value_reg (sub ty
-                      (put_in_reg x)
-                      (sink_load y))))
+      (value_gpr (sub ty
+                      (put_in_gpr x)
+                      (sink_load_to_gpr_mem_imm y))))
 
 ;; SSE.
 
@@ -286,15 +286,15 @@
 (rule (lower (has_type $I128 (isub x y)))
       ;; Get the high/low registers for `x`.
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1)))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1)))
         ;; Get the high/low registers for `y`.
         (let ((y_regs ValueRegs (put_in_regs y))
-              (y_lo Reg (value_regs_get y_regs 0))
-              (y_hi Reg (value_regs_get y_regs 1)))
+              (y_lo Gpr (value_regs_get_gpr y_regs 0))
+              (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do a sub followed by an sub-with-borrow.
-          (with_flags (sub_with_flags $I64 x_lo (RegMemImm.Reg y_lo))
-                      (sbb $I64 x_hi (RegMemImm.Reg y_hi))))))
+          (with_flags (sub_with_flags $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+                      (sbb $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
 
 ;;;; Rules for `ssub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -326,36 +326,36 @@
 
 ;; And two registers.
 (rule (lower (has_type (fits_in_64 ty) (band x y)))
-      (value_reg (x64_and ty
-                          (put_in_reg x)
-                          (RegMemImm.Reg (put_in_reg y)))))
+      (value_gpr (x64_and ty
+                          (put_in_gpr x)
+                          (put_in_gpr_mem_imm y))))
 
 ;; And with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band x (sinkable_load y))))
-      (value_reg (x64_and ty
-                          (put_in_reg x)
-                          (sink_load y))))
+      (value_gpr (x64_and ty
+                          (put_in_gpr x)
+                          (sink_load_to_gpr_mem_imm y))))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band (sinkable_load x) y)))
-      (value_reg (x64_and ty
-                          (put_in_reg y)
-                          (sink_load x))))
+      (value_gpr (x64_and ty
+                          (put_in_gpr y)
+                          (sink_load_to_gpr_mem_imm x))))
 
 ;; And with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band x (simm32_from_value y))))
-      (value_reg (x64_and ty
-                          (put_in_reg x)
+      (value_gpr (x64_and ty
+                          (put_in_gpr x)
                           y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band (simm32_from_value x) y)))
-      (value_reg (x64_and ty
-                          (put_in_reg y)
+      (value_gpr (x64_and ty
+                          (put_in_gpr y)
                           x)))
 
 ;; SSE.
@@ -375,23 +375,23 @@
 
 (rule (lower (has_type $I128 (band x y)))
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1))
             (y_regs ValueRegs (put_in_regs y))
-            (y_lo Reg (value_regs_get y_regs 0))
-            (y_hi Reg (value_regs_get y_regs 1)))
-        (value_regs (x64_and $I64 x_lo (RegMemImm.Reg y_lo))
-                    (x64_and $I64 x_hi (RegMemImm.Reg y_hi)))))
+            (y_lo Gpr (value_regs_get_gpr y_regs 0))
+            (y_hi Gpr (value_regs_get_gpr y_regs 1)))
+        (value_gprs (x64_and $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+                    (x64_and $I64 x_hi (gpr_to_gpr_mem_imm y_hi)))))
 
 (rule (lower (has_type $B128 (band x y)))
       ;; Booleans are always `0` or `1`, so we only need to do the `and` on the
       ;; low half. The high half is always zero but, rather than generate a new
       ;; zero, we just reuse `x`'s high half which is already zero.
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1))
-            (y_lo Reg (lo_reg y)))
-        (value_regs (x64_and $I64 x_lo (RegMemImm.Reg y_lo))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1))
+            (y_lo Gpr (lo_gpr y)))
+        (value_gprs (x64_and $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
                     x_hi)))
 
 ;;;; Rules for `bor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -400,36 +400,36 @@
 
 ;; Or two registers.
 (rule (lower (has_type (fits_in_64 ty) (bor x y)))
-      (value_reg (or ty
-                     (put_in_reg x)
-                     (RegMemImm.Reg (put_in_reg y)))))
+      (value_gpr (or ty
+                     (put_in_gpr x)
+                     (put_in_gpr_mem_imm y))))
 
 ;; Or with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor x (sinkable_load y))))
-      (value_reg (or ty
-                     (put_in_reg x)
-                     (sink_load y))))
+      (value_gpr (or ty
+                     (put_in_gpr x)
+                     (sink_load_to_gpr_mem_imm y))))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor (sinkable_load x) y)))
-      (value_reg (or ty
-                     (put_in_reg y)
-                     (sink_load x))))
+      (value_gpr (or ty
+                     (put_in_gpr y)
+                     (sink_load_to_gpr_mem_imm x))))
 
 ;; Or with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor x (simm32_from_value y))))
-      (value_reg (or ty
-                     (put_in_reg x)
+      (value_gpr (or ty
+                     (put_in_gpr x)
                      y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor (simm32_from_value x) y)))
-      (value_reg (or ty
-                     (put_in_reg y)
+      (value_gpr (or ty
+                     (put_in_gpr y)
                      x)))
 
 ;; SSE.
@@ -449,12 +449,12 @@
 
 (decl or_i128 (ValueRegs ValueRegs) ValueRegs)
 (rule (or_i128 x y)
-      (let ((x_lo Reg (value_regs_get x 0))
-            (x_hi Reg (value_regs_get x 1))
-            (y_lo Reg (value_regs_get y 0))
-            (y_hi Reg (value_regs_get y 1)))
-        (value_regs (or $I64 x_lo (RegMemImm.Reg y_lo))
-                    (or $I64 x_hi (RegMemImm.Reg y_hi)))))
+      (let ((x_lo Gpr (value_regs_get_gpr x 0))
+            (x_hi Gpr (value_regs_get_gpr x 1))
+            (y_lo Gpr (value_regs_get_gpr y 0))
+            (y_hi Gpr (value_regs_get_gpr y 1)))
+        (value_gprs (or $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+                    (or $I64 x_hi (gpr_to_gpr_mem_imm y_hi)))))
 
 (rule (lower (has_type $I128 (bor x y)))
       (or_i128 (put_in_regs x) (put_in_regs y)))
@@ -464,10 +464,10 @@
       ;; low half. The high half is always zero but, rather than generate a new
       ;; zero, we just reuse `x`'s high half which is already zero.
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1))
-            (y_lo Reg (lo_reg y)))
-        (value_regs (or $I64 x_lo (RegMemImm.Reg y_lo))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1))
+            (y_lo Gpr (lo_gpr y)))
+        (value_gprs (or $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
                     x_hi)))
 
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -476,36 +476,36 @@
 
 ;; Xor two registers.
 (rule (lower (has_type (fits_in_64 ty) (bxor x y)))
-      (value_reg (xor ty
-                      (put_in_reg x)
-                      (RegMemImm.Reg (put_in_reg y)))))
+      (value_gpr (xor ty
+                      (put_in_gpr x)
+                      (put_in_gpr_mem_imm y))))
 
 ;; Xor with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor x (sinkable_load y))))
-      (value_reg (xor ty
-                      (put_in_reg x)
-                      (sink_load y))))
+      (value_gpr (xor ty
+                      (put_in_gpr x)
+                      (sink_load_to_gpr_mem_imm y))))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor (sinkable_load x) y)))
-      (value_reg (xor ty
-                      (put_in_reg y)
-                      (sink_load x))))
+      (value_gpr (xor ty
+                      (put_in_gpr y)
+                      (sink_load_to_gpr_mem_imm x))))
 
 ;; Xor with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor x (simm32_from_value y))))
-      (value_reg (xor ty
-                      (put_in_reg x)
+      (value_gpr (xor ty
+                      (put_in_gpr x)
                       y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor (simm32_from_value x) y)))
-      (value_reg (xor ty
-                      (put_in_reg y)
+      (value_gpr (xor ty
+                      (put_in_gpr y)
                       x)))
 
 ;; SSE.
@@ -517,23 +517,23 @@
 
 (rule (lower (has_type $I128 (bxor x y)))
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1))
             (y_regs ValueRegs (put_in_regs y))
-            (y_lo Reg (value_regs_get y_regs 0))
-            (y_hi Reg (value_regs_get y_regs 1)))
-        (value_regs (xor $I64 x_lo (RegMemImm.Reg y_lo))
-                    (xor $I64 x_hi (RegMemImm.Reg y_hi)))))
+            (y_lo Gpr (value_regs_get_gpr y_regs 0))
+            (y_hi Gpr (value_regs_get_gpr y_regs 1)))
+        (value_gprs (xor $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+                    (xor $I64 x_hi (gpr_to_gpr_mem_imm y_hi)))))
 
 (rule (lower (has_type $B128 (bxor x y)))
       ;; Booleans are always `0` or `1`, so we only need to do the `xor` on the
       ;; low half. The high half is always zero but, rather than generate a new
       ;; zero, we just reuse `x`'s high half which is already zero.
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1))
-            (y_lo Reg (lo_reg y)))
-        (value_regs (xor $I64 x_lo (RegMemImm.Reg y_lo))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1))
+            (y_lo Gpr (lo_gpr y)))
+        (value_gprs (xor $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
                     x_hi)))
 
 ;;;; Rules for `ishl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -541,38 +541,49 @@
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (ishl src amt)))
-      (value_reg (shl ty (put_in_reg src) (put_masked_in_imm8_reg amt ty))))
+      (value_gpr (shl ty (put_in_gpr src) (put_masked_in_imm8_gpr amt ty))))
 
 ;; `i128`.
 
-(decl shl_i128 (ValueRegs Reg) ValueRegs)
+(decl shl_i128 (ValueRegs Gpr) ValueRegs)
 (rule (shl_i128 src amt)
       ;; Unpack the registers that make up the 128-bit value being shifted.
-      (let ((src_lo Reg (value_regs_get src 0))
-            (src_hi Reg (value_regs_get src 1))
+      (let ((src_lo Gpr (value_regs_get_gpr src 0))
+            (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do two 64-bit shifts.
-            (lo_shifted Reg (shl $I64 src_lo (Imm8Reg.Reg amt)))
-            (hi_shifted Reg (shl $I64 src_hi (Imm8Reg.Reg amt)))
+            (lo_shifted Gpr (shl $I64 src_lo (gpr_to_imm8_gpr amt)))
+            (hi_shifted Gpr (shl $I64 src_hi (gpr_to_imm8_gpr amt)))
             ;; `src_lo >> (64 - amt)` are the bits to carry over from the lo
             ;; into the hi.
-            (carry Reg (shr $I64 src_lo (Imm8Reg.Reg (sub $I64 (imm $I64 64) (RegMemImm.Reg amt)))))
-            (zero Reg (imm $I64 0))
+            (carry Gpr (shr $I64
+                            src_lo
+                            (gpr_to_imm8_gpr (sub $I64
+                                                  (gpr_new (imm $I64 64))
+                                                  (gpr_to_gpr_mem_imm amt)))))
+            (zero Gpr (gpr_new (imm $I64 0)))
             ;; Nullify the carry if we are shifting in by a multiple of 128.
-            (carry_ Reg (with_flags_1 (test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
-                                      (cmove $I64 (CC.Z) (RegMem.Reg zero) carry)))
+            (carry_ Gpr (gpr_new (with_flags_1 (test (OperandSize.Size64)
+                                                     (gpr_mem_imm_new (RegMemImm.Imm 127))
+                                                     amt)
+                                               (cmove $I64
+                                                      (CC.Z)
+                                                      (gpr_to_gpr_mem zero)
+                                                      carry))))
             ;; Add the carry into the high half.
-            (hi_shifted_ Reg (or $I64 carry_ (RegMemImm.Reg hi_shifted))))
+            (hi_shifted_ Gpr (or $I64 carry_ (gpr_to_gpr_mem_imm hi_shifted))))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the low bits are zero and the high bits are our
         ;; low bits.
-        (with_flags_2 (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
-                      (cmove $I64 (CC.Z) (RegMem.Reg lo_shifted) zero)
-                      (cmove $I64 (CC.Z) (RegMem.Reg hi_shifted_) lo_shifted))))
+        (with_flags_2 (test (OperandSize.Size64)
+                            (gpr_mem_imm_new (RegMemImm.Imm 64))
+                            amt)
+                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted) zero)
+                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted_) lo_shifted))))
 
 (rule (lower (has_type $I128 (ishl src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
       ;; amount to the value's bit width.
-      (let ((amt_ Reg (lo_reg amt)))
+      (let ((amt_ Gpr (lo_gpr amt)))
         (shl_i128 (put_in_regs src) amt_)))
 
 ;; SSE.
@@ -613,10 +624,12 @@
 (rule (ishl_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ishl_i8x16_mask_table))
             (base_mask_addr Gpr (lea mask_table))
-            (mask_offset Reg (shl $I64 amt (Imm8Reg.Imm8 4))))
+            (mask_offset Gpr (shl $I64
+                                  (gpr_new amt)
+                                  (imm8_to_imm8_gpr 4))))
         (amode_to_synthetic_amode (amode_imm_reg_reg_shift 0
                                                            base_mask_addr
-                                                           (gpr_new mask_offset)
+                                                           mask_offset
                                                            0))))
 (rule (ishl_i8x16_mask (RegMemImm.Mem amt))
       (ishl_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))
@@ -640,38 +653,49 @@
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (ushr src amt)))
-      (let ((src_ Reg (extend_to_reg src ty (ExtendKind.Zero))))
-        (value_reg (shr ty src_ (put_masked_in_imm8_reg amt ty)))))
+      (let ((src_ Gpr (extend_to_gpr src ty (ExtendKind.Zero))))
+        (value_gpr (shr ty src_ (put_masked_in_imm8_gpr amt ty)))))
 
 ;; `i128`.
 
-(decl shr_i128 (ValueRegs Reg) ValueRegs)
+(decl shr_i128 (ValueRegs Gpr) ValueRegs)
 (rule (shr_i128 src amt)
       ;; Unpack the lo/hi halves of `src`.
-      (let ((src_lo Reg (value_regs_get src 0))
-            (src_hi Reg (value_regs_get src 1))
+      (let ((src_lo Gpr (value_regs_get_gpr src 0))
+            (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do a shift on each half.
-            (lo_shifted Reg (shr $I64 src_lo (Imm8Reg.Reg amt)))
-            (hi_shifted Reg (shr $I64 src_hi (Imm8Reg.Reg amt)))
+            (lo_shifted Gpr (shr $I64 src_lo (gpr_to_imm8_gpr amt)))
+            (hi_shifted Gpr (shr $I64 src_hi (gpr_to_imm8_gpr amt)))
             ;; `src_hi << (64 - amt)` are the bits to carry over from the hi
             ;; into the lo.
-            (carry Reg (shl $I64 src_hi (Imm8Reg.Reg (sub $I64 (imm $I64 64) (RegMemImm.Reg amt)))))
+            (carry Gpr (shl $I64
+                            src_hi
+                            (gpr_to_imm8_gpr (sub $I64
+                                                  (gpr_new (imm $I64 64))
+                                                  (gpr_to_gpr_mem_imm amt)))))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Reg (with_flags_1 (test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
-                                      (cmove $I64 (CC.Z) (RegMem.Reg (imm $I64 0)) carry)))
+            (carry_ Gpr (gpr_new (with_flags_1 (test (OperandSize.Size64)
+                                                     (gpr_mem_imm_new (RegMemImm.Imm 127))
+                                                     amt)
+                                               (cmove $I64
+                                                      (CC.Z)
+                                                      (gpr_to_gpr_mem (gpr_new (imm $I64 0)))
+                                                      carry))))
             ;; Add the carry bits into the lo.
-            (lo_shifted_ Reg (or $I64 carry_ (RegMemImm.Reg lo_shifted))))
+            (lo_shifted_ Gpr (or $I64 carry_ (gpr_to_gpr_mem_imm lo_shifted))))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are zero and the lo bits are what
         ;; would otherwise be our hi bits.
-        (with_flags_2 (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
-                      (cmove $I64 (CC.Z) (RegMem.Reg lo_shifted_) hi_shifted)
-                      (cmove $I64 (CC.Z) (RegMem.Reg hi_shifted) (imm $I64 0)))))
+        (with_flags_2 (test (OperandSize.Size64)
+                            (gpr_mem_imm_new (RegMemImm.Imm 64))
+                            amt)
+                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
+                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) (gpr_new (imm $I64 0))))))
 
 (rule (lower (has_type $I128 (ushr src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
       ;; amount to the value's bit width.
-      (let ((amt_ Reg (lo_reg amt)))
+      (let ((amt_ Gpr (lo_gpr amt)))
         (shr_i128 (put_in_regs src) amt_)))
 
 ;; SSE.
@@ -712,10 +736,12 @@
 (rule (ushr_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ushr_i8x16_mask_table))
             (base_mask_addr Gpr (lea mask_table))
-            (mask_offset Reg (shl $I64 amt (Imm8Reg.Imm8 4))))
+            (mask_offset Gpr (shl $I64
+                                  (gpr_new amt)
+                                  (imm8_to_imm8_gpr 4))))
         (amode_to_synthetic_amode (amode_imm_reg_reg_shift 0
                                                            base_mask_addr
-                                                           (gpr_new mask_offset)
+                                                           mask_offset
                                                            0))))
 (rule (ushr_i8x16_mask (RegMemImm.Mem amt))
       (ushr_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))
@@ -739,41 +765,52 @@
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (sshr src amt)))
-      (let ((src_ Reg (extend_to_reg src ty (ExtendKind.Sign))))
-        (value_reg (sar ty src_ (put_masked_in_imm8_reg amt ty)))))
+      (let ((src_ Gpr (extend_to_gpr src ty (ExtendKind.Sign))))
+        (value_gpr (sar ty src_ (put_masked_in_imm8_gpr amt ty)))))
 
 ;; `i128`.
 
-(decl sar_i128 (ValueRegs Reg) ValueRegs)
+(decl sar_i128 (ValueRegs Gpr) ValueRegs)
 (rule (sar_i128 src amt)
       ;; Unpack the low/high halves of `src`.
-      (let ((src_lo Reg (value_regs_get src 0))
-            (src_hi Reg (value_regs_get src 1))
+      (let ((src_lo Gpr (value_regs_get_gpr src 0))
+            (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do a shift of each half. NB: the low half uses an unsigned shift
             ;; because its MSB is not a sign bit.
-            (lo_shifted Reg (shr $I64 src_lo (Imm8Reg.Reg amt)))
-            (hi_shifted Reg (sar $I64 src_hi (Imm8Reg.Reg amt)))
+            (lo_shifted Gpr (shr $I64 src_lo (gpr_to_imm8_gpr amt)))
+            (hi_shifted Gpr (sar $I64 src_hi (gpr_to_imm8_gpr amt)))
             ;; `src_hi << (64 - amt)` are the bits to carry over from the low
             ;; half to the high half.
-            (carry Reg (shl $I64 src_hi (Imm8Reg.Reg (sub $I64 (imm $I64 64) (RegMemImm.Reg amt)))))
+            (carry Gpr (shl $I64
+                            src_hi
+                            (gpr_to_imm8_gpr (sub $I64
+                                                  (gpr_new (imm $I64 64))
+                                                  (gpr_to_gpr_mem_imm amt)))))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Reg (with_flags_1 (test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
-                                      (cmove $I64 (CC.Z) (RegMem.Reg (imm $I64 0)) carry)))
+            (carry_ Gpr (gpr_new (with_flags_1 (test (OperandSize.Size64)
+                                                     (gpr_mem_imm_new (RegMemImm.Imm 127))
+                                                     amt)
+                                               (cmove $I64
+                                                      (CC.Z)
+                                                      (gpr_to_gpr_mem (gpr_new (imm $I64 0)))
+                                                      carry))))
             ;; Add the carry into the low half.
-            (lo_shifted_ Reg (or $I64 lo_shifted (RegMemImm.Reg carry_)))
+            (lo_shifted_ Gpr (or $I64 lo_shifted (gpr_to_gpr_mem_imm carry_)))
             ;; Get all sign bits.
-            (sign_bits Reg (sar $I64 src_hi (Imm8Reg.Imm8 63))))
+            (sign_bits Gpr (sar $I64 src_hi (imm8_to_imm8_gpr 63))))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are all sign bits and the lo bits are
         ;; what would otherwise be our hi bits.
-        (with_flags_2 (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
-                      (cmove $I64 (CC.Z) (RegMem.Reg lo_shifted_) hi_shifted)
-                      (cmove $I64 (CC.Z) (RegMem.Reg hi_shifted) sign_bits))))
+        (with_flags_2 (test (OperandSize.Size64)
+                            (gpr_mem_imm_new (RegMemImm.Imm 64))
+                            amt)
+                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
+                      (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) sign_bits))))
 
 (rule (lower (has_type $I128 (sshr src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
       ;; amount to the value's bit width.
-      (let ((amt_ Reg (lo_reg amt)))
+      (let ((amt_ Gpr (lo_gpr amt)))
         (sar_i128 (put_in_regs src) amt_)))
 
 ;; SSE.
@@ -807,9 +844,13 @@
 (rule (sshr_i8x16_bigger_shift _ty (RegMemImm.Imm i))
       (xmm_mem_imm_new (RegMemImm.Imm (u32_add i 8))))
 (rule (sshr_i8x16_bigger_shift ty (RegMemImm.Reg r))
-      (mov_rmi_to_xmm (RegMemImm.Reg (add ty r (RegMemImm.Imm 8)))))
+      (mov_rmi_to_xmm (RegMemImm.Reg (gpr_to_reg (add ty
+                                                      (gpr_new r)
+                                                      (gpr_mem_imm_new (RegMemImm.Imm 8)))))))
 (rule (sshr_i8x16_bigger_shift ty rmi @ (RegMemImm.Mem _m))
-      (mov_rmi_to_xmm (RegMemImm.Reg (add ty (imm ty 8) rmi))))
+      (mov_rmi_to_xmm (RegMemImm.Reg (gpr_to_reg (add ty
+                                                      (gpr_new (imm ty 8))
+                                                      (gpr_mem_imm_new rmi))))))
 
 ;; `sshr.{i16x8,i32x4}` can be a simple `psra{w,d}`, we just have to make sure
 ;; that if the shift amount is in a register, it is in an XMM register.
@@ -834,11 +875,11 @@
       (let ((src_ Xmm (put_in_xmm src))
             (lo Gpr (pextrd $I64 src_ 0))
             (hi Gpr (pextrd $I64 src_ 1))
-            (amt_ Imm8Reg (put_masked_in_imm8_reg amt $I64))
-            (shifted_lo Reg (sar $I64 (gpr_to_reg lo) amt_))
-            (shifted_hi Reg (sar $I64 (gpr_to_reg hi) amt_)))
-        (value_xmm (make_i64x2_from_lanes (reg_mem_to_gpr_mem (RegMem.Reg shifted_lo))
-                                          (reg_mem_to_gpr_mem (RegMem.Reg shifted_hi))))))
+            (amt_ Imm8Gpr (put_masked_in_imm8_gpr amt $I64))
+            (shifted_lo Gpr (sar $I64 lo amt_))
+            (shifted_hi Gpr (sar $I64 hi amt_)))
+        (value_xmm (make_i64x2_from_lanes (gpr_to_gpr_mem shifted_lo)
+                                          (gpr_to_gpr_mem shifted_hi)))))
 
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -846,13 +887,13 @@
 ;; constant.
 
 (rule (lower (has_type (ty_8_or_16 ty) (rotl src amt)))
-      (let ((amt_ Reg (extend_to_reg amt $I32 (ExtendKind.Zero))))
-        (value_reg (x64_rotl ty (put_in_reg src) (Imm8Reg.Reg amt_)))))
+      (let ((amt_ Gpr (extend_to_gpr amt $I32 (ExtendKind.Zero))))
+        (value_gpr (x64_rotl ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
 
 (rule (lower (has_type (ty_8_or_16 ty)
                        (rotl src (u64_from_iconst amt))))
-      (value_reg (x64_rotl ty
-                           (put_in_reg src)
+      (value_gpr (x64_rotl ty
+                           (put_in_gpr src)
                            (const_to_type_masked_imm8 amt ty))))
 
 ;; `i64` and `i32`: we can rely on x86's rotate-amount masking since
@@ -861,13 +902,13 @@
 (rule (lower (has_type (ty_32_or_64 ty) (rotl src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the
       ;; shift amount to the value's bit width.
-      (let ((amt_ Reg (lo_reg amt)))
-        (value_reg (x64_rotl ty (put_in_reg src) (Imm8Reg.Reg amt_)))))
+      (let ((amt_ Gpr (lo_gpr amt)))
+        (value_gpr (x64_rotl ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
 
 (rule (lower (has_type (ty_32_or_64 ty)
                        (rotl src (u64_from_iconst amt))))
-      (value_reg (x64_rotl ty
-                           (put_in_reg src)
+      (value_gpr (x64_rotl ty
+                           (put_in_gpr src)
                            (const_to_type_masked_imm8 amt ty))))
 
 ;; `i128`.
@@ -876,9 +917,11 @@
       (let ((src_ ValueRegs (put_in_regs src))
             ;; NB: Only the low bits of `amt` matter since we logically mask the
             ;; rotation amount to the value's bit width.
-            (amt_ Reg (lo_reg amt)))
+            (amt_ Gpr (lo_gpr amt)))
         (or_i128 (shl_i128 src_ amt_)
-                 (shr_i128 src_ (sub $I64 (imm $I64 128) (RegMemImm.Reg amt_))))))
+                 (shr_i128 src_ (sub $I64
+                                     (gpr_new (imm $I64 128))
+                                     (gpr_to_gpr_mem_imm amt_))))))
 
 ;;;; Rules for `rotr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -886,13 +929,13 @@
 ;; constant.
 
 (rule (lower (has_type (ty_8_or_16 ty) (rotr src amt)))
-      (let ((amt_ Reg (extend_to_reg amt $I32 (ExtendKind.Zero))))
-        (value_reg (x64_rotr ty (put_in_reg src) (Imm8Reg.Reg amt_)))))
+      (let ((amt_ Gpr (extend_to_gpr amt $I32 (ExtendKind.Zero))))
+        (value_gpr (x64_rotr ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
 
 (rule (lower (has_type (ty_8_or_16 ty)
                        (rotr src (u64_from_iconst amt))))
-      (value_reg (x64_rotr ty
-                           (put_in_reg src)
+      (value_gpr (x64_rotr ty
+                           (put_in_gpr src)
                            (const_to_type_masked_imm8 amt ty))))
 
 ;; `i64` and `i32`: we can rely on x86's rotate-amount masking since
@@ -901,13 +944,13 @@
 (rule (lower (has_type (ty_32_or_64 ty) (rotr src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the
       ;; shift amount to the value's bit width.
-      (let ((amt_ Reg (lo_reg amt)))
-        (value_reg (x64_rotr ty (put_in_reg src) (Imm8Reg.Reg amt_)))))
+      (let ((amt_ Gpr (lo_gpr amt)))
+        (value_gpr (x64_rotr ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
 
 (rule (lower (has_type (ty_32_or_64 ty)
                        (rotr src (u64_from_iconst amt))))
-      (value_reg (x64_rotr ty
-                           (put_in_reg src)
+      (value_gpr (x64_rotr ty
+                           (put_in_gpr src)
                            (const_to_type_masked_imm8 amt ty))))
 
 ;; `i128`.
@@ -916,9 +959,11 @@
       (let ((src_ ValueRegs (put_in_regs src))
             ;; NB: Only the low bits of `amt` matter since we logically mask the
             ;; rotation amount to the value's bit width.
-            (amt_ Reg (lo_reg amt)))
+            (amt_ Gpr (lo_gpr amt)))
         (or_i128 (shr_i128 src_ amt_)
-                 (shl_i128 src_ (sub $I64 (imm $I64 128) (RegMemImm.Reg amt_))))))
+                 (shl_i128 src_ (sub $I64
+                                     (gpr_new (imm $I64 128))
+                                     (gpr_to_gpr_mem_imm amt_))))))
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -961,33 +1006,33 @@
 
 ;; Multiply two registers.
 (rule (lower (has_type (fits_in_64 ty) (imul x y)))
-      (value_reg (mul ty
-                      (put_in_reg x)
-                      (RegMemImm.Reg (put_in_reg y)))))
+      (value_gpr (mul ty
+                      (put_in_gpr x)
+                      (put_in_gpr_mem_imm y))))
 
 ;; Multiply a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul x (simm32_from_value y))))
-      (value_reg (mul ty (put_in_reg x) y)))
+      (value_gpr (mul ty (put_in_gpr x) y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul (simm32_from_value x) y)))
-      (value_reg (mul ty (put_in_reg y) x)))
+      (value_gpr (mul ty (put_in_gpr y) x)))
 
 ;; Multiply a register and a memory load.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul x (sinkable_load y))))
-      (value_reg (mul ty
-                      (put_in_reg x)
-                      (sink_load y))))
+      (value_gpr (mul ty
+                      (put_in_gpr x)
+                      (sink_load_to_gpr_mem_imm y))))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul (sinkable_load x) y)))
-      (value_reg (mul ty
-                      (put_in_reg y)
-                      (sink_load x))))
+      (value_gpr (mul ty
+                      (put_in_gpr y)
+                      (sink_load_to_gpr_mem_imm x))))
 
 ;; `i128`.
 
@@ -1007,25 +1052,25 @@
 (rule (lower (has_type $I128 (imul x y)))
       ;; Put `x` into registers and unpack its hi/lo halves.
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Reg (value_regs_get x_regs 0))
-            (x_hi Reg (value_regs_get x_regs 1))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1))
             ;; Put `y` into registers and unpack its hi/lo halves.
             (y_regs ValueRegs (put_in_regs y))
-            (y_lo Reg (value_regs_get y_regs 0))
-            (y_hi Reg (value_regs_get y_regs 1))
+            (y_lo Gpr (value_regs_get_gpr y_regs 0))
+            (y_hi Gpr (value_regs_get_gpr y_regs 1))
             ;; lo_hi = mul x_lo, y_hi
-            (lo_hi Reg (mul $I64 x_lo (RegMemImm.Reg y_hi)))
+            (lo_hi Gpr (mul $I64 x_lo (gpr_to_gpr_mem_imm y_hi)))
             ;; hi_lo = mul x_hi, y_lo
-            (hi_lo Reg (mul $I64 x_hi (RegMemImm.Reg y_lo)))
+            (hi_lo Gpr (mul $I64 x_hi (gpr_to_gpr_mem_imm y_lo)))
             ;; hilo_hilo = add lo_hi, hi_lo
-            (hilo_hilo Reg (add $I64 lo_hi (RegMemImm.Reg hi_lo)))
+            (hilo_hilo Gpr (add $I64 lo_hi (gpr_to_gpr_mem_imm hi_lo)))
             ;; dst_lo:hi_lolo = mulhi_u x_lo, y_lo
-            (mul_regs ValueRegs (mulhi_u $I64 x_lo (RegMem.Reg y_lo)))
-            (dst_lo Reg (value_regs_get mul_regs 0))
-            (hi_lolo Reg (value_regs_get mul_regs 1))
+            (mul_regs ValueRegs (mulhi_u $I64 x_lo (gpr_to_gpr_mem y_lo)))
+            (dst_lo Gpr (value_regs_get_gpr mul_regs 0))
+            (hi_lolo Gpr (value_regs_get_gpr mul_regs 1))
             ;; dst_hi = add hilo_hilo, hi_lolo
-            (dst_hi Reg (add $I64 hilo_hilo (RegMemImm.Reg hi_lolo))))
-        (value_regs dst_lo dst_hi)))
+            (dst_hi Gpr (add $I64 hilo_hilo (gpr_to_gpr_mem_imm hi_lolo))))
+        (value_gprs dst_lo dst_hi)))
 
 ;; SSE.
 
@@ -1310,8 +1355,8 @@
 (decl i128_not (Value) ValueRegs)
 (rule (i128_not x)
       (let ((x_regs ValueRegs (put_in_regs x))
-            (x_lo Gpr (gpr_new (value_regs_get x_regs 0)))
-            (x_hi Gpr (gpr_new (value_regs_get x_regs 1))))
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1)))
         (value_gprs (not $I64 x_lo)
                     (not $I64 x_hi))))
 
@@ -1420,11 +1465,11 @@
 
 (decl cmp_and_choose (Type CC Value Value) ValueRegs)
 (rule (cmp_and_choose (fits_in_64 ty) cc x y)
-      (let ((x_reg Reg (put_in_reg x))
-            (y_reg Reg (put_in_reg y))
+      (let ((x_reg Gpr (put_in_gpr x))
+            (y_reg Gpr (put_in_gpr y))
             (size OperandSize (raw_operand_size_of_type ty)))
-           (value_reg (with_flags_1 (cmp size (RegMemImm.Reg x_reg) y_reg)
-                                    (cmove ty cc (RegMem.Reg y_reg) x_reg)))))
+           (value_reg (with_flags_1 (cmp size (gpr_to_gpr_mem_imm x_reg) y_reg)
+                                    (cmove ty cc (gpr_to_gpr_mem y_reg) x_reg)))))
 
 (rule (lower (has_type (fits_in_64 ty) (umin x y)))
       (cmp_and_choose ty (CC.B) x y))

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle 73285cd431346d53
-src/isa/x64/inst.isle 7513533d16948249
-src/isa/x64/lower.isle 802b6e750d407100
+src/isa/x64/inst.isle 301db31d5f1118ae
+src/isa/x64/lower.isle cdc94aec26c0bc5b

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -15,7 +15,6 @@ pub type ValueSlice<'a> = &'a [Value];
 pub type ValueArray2 = [Value; 2];
 pub type ValueArray3 = [Value; 3];
 pub type WritableReg = Writable<Reg>;
-pub type OptionWritableReg = Option<WritableReg>;
 pub type VecReg = Vec<Reg>;
 pub type VecWritableReg = Vec<WritableReg>;
 pub type ValueRegs = crate::machinst::ValueRegs<Reg>;


### PR DESCRIPTION
We already defined the `Gpr` newtype and used it in a few places, and we already
defined the `Xmm` newtype and used it extensively. This finishes the transition
to using the newtypes extensively in lowering by making use of `Gpr` in more
places.

Fixes #3685

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
