### PR TITLE
Fuzz cranelift cpu flag settings with Wasmtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,9 +2819,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"
@@ -3594,6 +3594,7 @@ dependencies = [
  "env_logger 0.8.3",
  "log",
  "rayon",
+ "target-lexicon",
  "tempfile",
  "v8",
  "wasm-encoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arbitrary"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
+checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
 dependencies = [
  "derive_arbitrary",
 ]

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
 anyhow = "1.0.22"
-arbitrary = { version = "1.0.0", features = ["derive"] }
+arbitrary = { version = "1.1.0", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -13,6 +13,7 @@ arbitrary = { version = "1.0.0", features = ["derive"] }
 env_logger = "0.8.1"
 log = "0.4.8"
 rayon = "1.2.1"
+target-lexicon = "0.12.3"
 tempfile = "3.3.0"
 wasmparser = "0.82"
 wasmprinter = "0.2.32"

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -608,13 +608,13 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
         macro_rules! target_features {
             (
                 test:$test:ident,
-                $(std: $std:tt => clif: $clif:tt $(range: $e:expr)?,)*
+                $(std: $std:tt => clif: $clif:tt $(ratio: $a:expr in $b:expr)?,)*
             ) => ({
                 let mut flags = Vec::new();
                 $(
-                    let range = 0..=1;
-                    $(let range = { drop(range); $e };)?
-                    let enable = u.int_in_range(range)? == 1;
+                    let (low, hi) = (1, 2);
+                    $(let (low, hi) = ($a, $b);)?
+                    let enable = u.ratio(low, hi)?;
                     if enable && !std::$test!($std) {
                         log::error!("want to enable clif `{}` but host doesn't support it",
                             $clif);
@@ -630,7 +630,7 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
         }
         #[cfg(target_arch = "x86_64")]
         {
-            if u.int_in_range(0..=9)? == 0 {
+            if u.ratio(1, 10)? {
                 let flags = target_features! {
                     test: is_x86_feature_detected,
                     std:"sse3" => clif:"has_sse3",
@@ -646,11 +646,11 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
 
                     // not a lot of of cpus support avx512 so these are weighted
                     // to get enabled much less frequently.
-                    std:"avx512bitalg" => clif:"has_avx512bitalg" range:0..=1000,
-                    std:"avx512dq" => clif:"has_avx512dq" range: 0..=1000,
-                    std:"avx512f" => clif:"has_avx512f" range: 0..=1000,
-                    std:"avx512vl" => clif:"has_avx512vl" range: 0..=1000,
-                    std:"avx512vbmi" => clif:"has_avx512vbmi" range: 0..=1000,
+                    std:"avx512bitalg" => clif:"has_avx512bitalg" ratio:1 in 1000,
+                    std:"avx512dq" => clif:"has_avx512dq" ratio: 1 in 1000,
+                    std:"avx512f" => clif:"has_avx512f" ratio: 1 in 1000,
+                    std:"avx512vl" => clif:"has_avx512vl" ratio: 1 in 1000,
+                    std:"avx512vbmi" => clif:"has_avx512vbmi" ratio: 1 in 1000,
                 };
                 return Ok(CodegenSettings::Target {
                     target: target_lexicon::Triple::host().to_string(),

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -608,7 +608,7 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
         macro_rules! target_features {
             (
                 test:$test:ident,
-                $(std: $std:tt => clif: $clif:tt $(ratio: $a:expr in $b:expr)?,)*
+                $(std: $std:tt => clif: $clif:tt $(ratio: $a:tt in $b:tt)?,)*
             ) => ({
                 let mut flags = Vec::new();
                 $(


### PR DESCRIPTION
This commit updates the `Config` fuzz-generator to consume some of the
input as configuration settings for codegen flags we pass to cranelift.
This should allow for ideally some more coverage where settings are
disabled or enabled, ideally finding possible bugs in feature-specific
implementations or generic implementations that are rarely used if the
feature-specific ones almost always take precedent.

The technique used in this commit is to weight selection of codegen
settings less frequently than using the native settings. Afterwards each
listed feature is individually enabled or disabled depending on the
input fuzz data, and if a feature is enabled but the host doesn't
actually support it then the fuzz input is rejected with a log message.
The goal here is to still have many fuzz inputs accepted but also ensure
determinism across hosts. If there's a bug specifically related to
enabling a flag then running it on a host without the flag should
indicate that the flag isn't supported rather than silently leaving it
disabled and reporting the fuzz case a success.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
