### PR TITLE
CI: Fix workflow syntax in triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: bytecodealliance/labeler@schedule-fork
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-      if: ${{ github.event_name == "schedule" }}
+      if: ${{ github.event_name == 'schedule' }}
 
     # @-mention people who are subscribed to a label when an issue/PR is given
     # that label.


### PR DESCRIPTION
I guess single quotes are required?