### PR TITLE
Unconditionally enable sse3, ssse3, and sse4.1 when fuzzing

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -701,7 +701,7 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                     test: is_x86_feature_detected,
 
                     // These features are considered to be baseline required by
-                    // Wasmtime. Currently SIMD some simd code generation will
+                    // Wasmtime. Currently some SIMD code generation will
                     // fail if these features are disabled, so unconditionally
                     // enable them as we're not interested in fuzzing without
                     // them.

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -699,9 +699,16 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
             if u.ratio(1, 10)? {
                 let flags = target_features! {
                     test: is_x86_feature_detected,
-                    std:"sse3" => clif:"has_sse3",
-                    std:"ssse3" => clif:"has_ssse3",
-                    std:"sse4.1" => clif:"has_sse41",
+
+                    // These features are considered to be baseline required by
+                    // Wasmtime. Currently SIMD some simd code generation will
+                    // fail if these features are disabled, so unconditionally
+                    // enable them as we're not interested in fuzzing without
+                    // them.
+                    std:"sse3" => clif:"has_sse3" ratio: 1 in 1,
+                    std:"ssse3" => clif:"has_ssse3" ratio: 1 in 1,
+                    std:"sse4.1" => clif:"has_sse41" ratio: 1 in 1,
+
                     std:"sse4.2" => clif:"has_sse42",
                     std:"popcnt" => clif:"has_popcnt",
                     std:"avx" => clif:"has_avx",


### PR DESCRIPTION
This commit unconditionally enables some x86_64 instructions when
fuzzing because the cranelift backend is known to not work if these
features are disabled. From discussion on the wasm simd proposal the
assumed general baseline for running simd code is SSE4.1 anyway.

At this time I haven't added any sort of checks in Wasmtime itself.
Wasmtime by default uses the native architecture and when explicitly
enabling features this still needs to be explicitly specified.

Closes #3809

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
