### PR TITLE
add a config field that allows us to mlock() module mmaps into RAM

### DIFF
--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -436,9 +436,10 @@ impl Mmap {
         );
         #[cfg(unix)]
         unsafe {
-            rustix::io::mlock(
+            rustix::io::mlock_with(
                 self.as_ptr().add(range.start) as *mut _,
                 range.end - range.start,
+                rustix::io::MlockFlags::ONFAULT,
             )?;
         }
         Ok(())

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -449,7 +449,7 @@ impl Mmap {
             Ok(())
         }
         #[cfg(not(target_os = "linux"))]
-        bail!("mlock on fault not supported on this platform");
+        anyhow::bail!("mlock on fault not supported on this platform");
     }
 }
 

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -434,12 +434,19 @@ impl Mmap {
             range.start % region::page::size() == 0,
             "changing of protections isn't page-aligned",
         );
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         unsafe {
             rustix::io::mlock_with(
                 self.as_ptr().add(range.start) as *mut _,
                 range.end - range.start,
                 rustix::io::MlockFlags::ONFAULT,
+            )?;
+        }
+        #[cfg(all(unix, not(target_os = "linux")))]
+        unsafe {
+            rustix::io::mlock(
+                self.as_ptr().add(range.start) as *mut _,
+                range.end - range.start,
             )?;
         }
         Ok(())

--- a/crates/runtime/src/mmap_vec.rs
+++ b/crates/runtime/src/mmap_vec.rs
@@ -128,6 +128,11 @@ impl MmapVec {
     pub fn original_offset(&self) -> usize {
         self.range.start
     }
+
+    /// XXX
+    pub fn mlock(&self) -> Result<()> {
+        self.mmap.mlock(&self.range)
+    }
 }
 
 impl Deref for MmapVec {

--- a/crates/runtime/src/mmap_vec.rs
+++ b/crates/runtime/src/mmap_vec.rs
@@ -129,9 +129,11 @@ impl MmapVec {
         self.range.start
     }
 
-    /// XXX
-    pub fn mlock(&self) -> Result<()> {
-        self.mmap.mlock(&self.range)
+    /// Applies `MLOCK_ONFAULT` for this entire mapping.
+    ///
+    /// See [`Mmap::linux_mlock_onfault`] for more information.
+    pub fn linux_mlock_onfault(&self) -> Result<()> {
+        self.mmap.linux_mlock_onfault(&self.range)
     }
 }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1275,7 +1275,8 @@ impl Config {
     /// what.
     ///
     /// This feature is a Linux-specific configuration option. Enabling this on
-    /// non-Linux platforms will prevent all [`Module`]s from being created.
+    /// non-Linux platforms will prevent all [`Module`](crate::Module)s from
+    /// being created.
     pub fn linux_mlock_modules_onfault(&mut self, enable: bool) -> &mut Self {
         self.linux_mlock_modules_onfault = enable;
         self

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -100,6 +100,7 @@ pub struct Config {
     pub(crate) paged_memory_initialization: bool,
     pub(crate) memory_init_cow: bool,
     pub(crate) memory_guaranteed_dense_image_size: u64,
+    pub(crate) mlock_module_mmaps: bool,
 }
 
 impl Config {
@@ -135,6 +136,7 @@ impl Config {
             paged_memory_initialization: cfg!(all(target_os = "linux", feature = "uffd")),
             memory_init_cow: true,
             memory_guaranteed_dense_image_size: 16 << 20,
+            mlock_module_mmaps: false,
         };
         #[cfg(compiler)]
         {
@@ -1250,6 +1252,12 @@ impl Config {
         self
     }
 
+    /// XXX experiment
+    pub fn mlock_module_mmaps(&mut self, mlock_module_mmaps: bool) -> &mut Self {
+        self.mlock_module_mmaps = mlock_module_mmaps;
+        self
+    }
+
     pub(crate) fn build_allocator(&self) -> Result<Box<dyn InstanceAllocator>> {
         #[cfg(feature = "async")]
         let stack_size = self.async_stack_size;
@@ -1330,6 +1338,7 @@ impl Clone for Config {
             paged_memory_initialization: self.paged_memory_initialization,
             memory_init_cow: self.memory_init_cow,
             memory_guaranteed_dense_image_size: self.memory_guaranteed_dense_image_size,
+            mlock_module_mmaps: self.mlock_module_mmaps,
         }
     }
 }
@@ -1362,7 +1371,13 @@ impl fmt::Debug for Config {
                 "guard_before_linear_memory",
                 &self.tunables.guard_before_linear_memory,
             )
-            .field("parallel_compilation", &self.parallel_compilation);
+            .field("parallel_compilation", &self.parallel_compilation)
+            .field(
+                "paged_memory_initialization",
+                &self.paged_memory_initialization,
+            )
+            .field("memfd", &self.memfd)
+            .field("mlock_module_mmaps", &self.mlock_module_mmaps);
         #[cfg(compiler)]
         {
             f.field("compiler", &self.compiler);

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -136,7 +136,7 @@ impl Config {
             paged_memory_initialization: cfg!(all(target_os = "linux", feature = "uffd")),
             memory_init_cow: true,
             memory_guaranteed_dense_image_size: 16 << 20,
-            linux_mlock_modules_onfault: true,
+            linux_mlock_modules_onfault: false,
         };
         #[cfg(compiler)]
         {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -334,6 +334,12 @@ impl Module {
             }
         };
 
+        if engine.config().mlock_module_mmaps {
+            for (mmap, _info) in artifacts.iter() {
+                mmap.mlock()?;
+            }
+        }
+
         let modules = engine.run_maybe_parallel(artifacts, |(a, b)| {
             CompiledModule::from_artifacts(
                 a,
@@ -516,6 +522,10 @@ impl Module {
     /// state of the file.
     pub unsafe fn deserialize_file(engine: &Engine, path: impl AsRef<Path>) -> Result<Module> {
         let module = SerializedModule::from_file(path.as_ref(), &engine.config().module_version)?;
+
+        if engine.config().mlock_module_mmaps {
+            module.mlock()?;
+        }
         module.into_module(engine)
     }
 

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -334,12 +334,6 @@ impl Module {
             }
         };
 
-        if engine.config().mlock_module_mmaps {
-            for (mmap, _info) in artifacts.iter() {
-                mmap.mlock()?;
-            }
-        }
-
         let modules = engine.run_maybe_parallel(artifacts, |(a, b)| {
             CompiledModule::from_artifacts(
                 a,
@@ -522,10 +516,6 @@ impl Module {
     /// state of the file.
     pub unsafe fn deserialize_file(engine: &Engine, path: impl AsRef<Path>) -> Result<Module> {
         let module = SerializedModule::from_file(path.as_ref(), &engine.config().module_version)?;
-
-        if engine.config().mlock_module_mmaps {
-            module.mlock()?;
-        }
         module.into_module(engine)
     }
 
@@ -548,6 +538,12 @@ impl Module {
                 .iter()
                 .flat_map(|m| m.trampolines().map(|(idx, f, _)| (idx, f))),
         ));
+
+        if engine.config().mlock_module_mmaps {
+            for m in modules.iter() {
+                m.mmap().mlock()?;
+            }
+        }
 
         let module = modules.remove(main_module);
 

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -695,16 +695,6 @@ impl<'a> SerializedModule<'a> {
 
         Ok(())
     }
-
-    pub fn mlock(&self) -> Result<()> {
-        for a in self.artifacts.iter() {
-            match a {
-                MyCow::Owned(a) => a.mlock()?,
-                _ => {}
-            }
-        }
-        Ok(())
-    }
 }
 
 /// Aligns the `val` specified up to `align`, which must be a power of two

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -695,6 +695,16 @@ impl<'a> SerializedModule<'a> {
 
         Ok(())
     }
+
+    pub fn mlock(&self) -> Result<()> {
+        for a in self.artifacts.iter() {
+            match a {
+                MyCow::Owned(a) => a.mlock()?,
+                _ => {}
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Aligns the `val` specified up to `align`, which must be a power of two


### PR DESCRIPTION
Needs benchmarking before this is considered seriously.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
