### PR TITLE
Mention --invoke on "CLI Options for `wasmtime`" page

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -49,7 +49,7 @@ The `run` command accepts an optional `invoke` argument which is the name of
 an exported function of the module to run.
 
 ```sh
-$ wasmtime foo.wasm --invoke initialize
+$ wasmtime run foo.wasm --invoke initialize
 ```
 
 ## `wast`

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -45,6 +45,13 @@ as well as the text format for WebAssembly (`*.wat`):
 $ wasmtime foo.wat
 ```
 
+The `run` command accepts an optional `invoke` argument which is the name of
+an exported function of the module to run.
+
+```sh
+$ wasmtime foo.wasm --invoke initialize
+```
+
 ## `wast`
 
 The `wast` command executes a `*.wast` file which is the test format for the


### PR DESCRIPTION
Mention `invoke` on the [`cli-options.md`](https://github.com/bytecodealliance/wasmtime/blob/main/docs/cli-options.md) page.
While it is mentioned other places, it is not documented here.
Filed in #3827.

(I am not sure who should review this, or how to assign them)