### PR TITLE
memfd: make "dense image" heuristic limit configurable.

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -257,6 +257,7 @@ pub struct WasmtimeConfig {
     pub memory_config: MemoryConfig,
     force_jump_veneers: bool,
     memfd: bool,
+    memfd_guaranteed_dense_image_size: u64,
     use_precompiled_cwasm: bool,
     /// Configuration for the instance allocation strategy to use.
     pub strategy: InstanceAllocationStrategy,
@@ -428,6 +429,12 @@ impl Config {
             .interruptable(self.wasmtime.interruptable)
             .consume_fuel(self.wasmtime.consume_fuel)
             .memfd(self.wasmtime.memfd)
+            .memfd_guaranteed_dense_image_size(std::cmp::min(
+                // Clamp this at 16MiB so we don't get huge in-memory
+                // images during fuzzing.
+                16 << 20,
+                self.wasmtime.memfd_guaranteed_dense_image_size,
+            ))
             .allocation_strategy(self.wasmtime.strategy.to_wasmtime());
 
         self.wasmtime.codegen.configure(&mut cfg);

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -105,6 +105,7 @@ pub struct Config {
     pub(crate) parallel_compilation: bool,
     pub(crate) paged_memory_initialization: bool,
     pub(crate) memfd: bool,
+    pub(crate) memfd_guaranteed_dense_image_size: u64,
 }
 
 impl Config {
@@ -131,6 +132,7 @@ impl Config {
             // Default to paged memory initialization when using uffd on linux
             paged_memory_initialization: cfg!(all(target_os = "linux", feature = "uffd")),
             memfd: false,
+            memfd_guaranteed_dense_image_size: 16 << 20,
         };
         #[cfg(compiler)]
         {
@@ -1199,6 +1201,47 @@ impl Config {
         self
     }
 
+    /// Configures the "guaranteed dense image size" for memfd.
+    ///
+    /// When using the memfd feature to initialize memory efficiently,
+    /// compiled modules contain an image of the module's initial
+    /// heap. If the module has a fairly sparse initial heap, with
+    /// just a few data segments at very different offsets, this could
+    /// result in a large region of zero bytes in the image. In other
+    /// words, it's not very memory-efficient.
+    ///
+    /// We normally use a heuristic to avoid this: if less than half
+    /// of the initialized range (first non-zero to last non-zero
+    /// byte) of any memory in the module has pages with nonzero
+    /// bytes, then we avoid memfd for the entire module.
+    ///
+    /// However, if the embedder always needs the instantiation-time
+    /// efficiency of memfd, and is otherwise carefully controlling
+    /// parameters of the modules (for example, by limiting the
+    /// maximum heap size of the modules), then it may be desirable to
+    /// ensure memfd is used even if this could go against the
+    /// heuristic above. Thus, we add another condition: there is a
+    /// size of initialized data region up to which we *always* allow
+    /// memfd. The embedder can set this to a known maximum heap size
+    /// if they desire to always get the benefits of memfd.
+    ///
+    /// In the future we may implement a "best of both worlds"
+    /// solution where we have a dense image up to some limit, and
+    /// then support a sparse list of initializers beyond that; this
+    /// would get most of the benefit of memfd and pay the incremental
+    /// cost of eager initialization only for those bits of memory
+    /// that are out-of-bounds. However, for now, an embedder desiring
+    /// fast instantiation should ensure that this setting is as large
+    /// as the maximum module initial memory content size.
+    ///
+    /// By default this value is 16 MiB.
+    #[cfg(feature = "memfd")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "memfd")))]
+    pub fn memfd_guaranteed_dense_image_size(&mut self, size_in_bytes: u64) -> &mut Self {
+        self.memfd_guaranteed_dense_image_size = size_in_bytes;
+        self
+    }
+
     pub(crate) fn build_allocator(&self) -> Result<Box<dyn InstanceAllocator>> {
         #[cfg(feature = "async")]
         let stack_size = self.async_stack_size;
@@ -1269,6 +1312,7 @@ impl Clone for Config {
             parallel_compilation: self.parallel_compilation,
             paged_memory_initialization: self.paged_memory_initialization,
             memfd: self.memfd,
+            memfd_guaranteed_dense_image_size: self.memfd_guaranteed_dense_image_size,
         }
     }
 }

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -432,7 +432,8 @@ impl Module {
             // such as mmap'ing from a file to get copy-on-write.
             if engine.config().memfd {
                 let align = engine.compiler().page_size_align();
-                translation.try_static_init(align);
+                let max_always_allowed = engine.config().memfd_guaranteed_dense_image_size;
+                translation.try_static_init(align, max_always_allowed);
             }
 
             // Attempt to convert table initializer segments to


### PR DESCRIPTION
In #3820 we see an issue with the new heuristics that control use of
memfd: it's entirely possible for a reasonable Wasm module produced by a
snapshotting system to have a relatively sparse heap (less than 50%
filled). A system that avoids memfd because of this would have an
undesirable performance reduction on such modules.

Ultimately we should try to implement a hybrid scheme where we support
outlier/leftover initializers, but for now this PR makes the "always
allow dense" limit configurable. This way, embedders that want to ensure
that memfd is used can do so, if they have other knowledge about the
maximum heap size allowed in their system.

(Partially addresses #3820 but let's leave it open to track the hybrid
idea)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
