### PR TITLE
Enable SSE 4.2 unconditionally

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86.rs
+++ b/cranelift/codegen/meta/src/isa/x86.rs
@@ -38,7 +38,7 @@ fn define_settings(shared: &SettingGroup) -> SettingGroup {
         "has_sse42",
         "Has support for SSE4.2.",
         "SSE4.2: CPUID.01H:ECX.SSE4_2[bit 20]",
-        false,
+        true,
     );
     let has_avx = settings.add_bool(
         "has_avx",

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -178,7 +178,7 @@ fn isa_constructor(
     let isa_flags = x64_settings::Flags::new(&shared_flags, builder);
 
     // Check for compatibility between flags and ISA level
-    // requested. In particular, SIMD support requires SSE4.1.
+    // requested. In particular, SIMD support requires SSE4.2.
     if shared_flags.enable_simd() {
         if !isa_flags.has_sse3()
             || !isa_flags.has_ssse3()

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -180,9 +180,13 @@ fn isa_constructor(
     // Check for compatibility between flags and ISA level
     // requested. In particular, SIMD support requires SSE4.1.
     if shared_flags.enable_simd() {
-        if !isa_flags.has_sse3() || !isa_flags.has_ssse3() || !isa_flags.has_sse41() {
+        if !isa_flags.has_sse3()
+            || !isa_flags.has_ssse3()
+            || !isa_flags.has_sse41()
+            || !isa_flags.has_sse42()
+        {
             return Err(CodegenError::Unsupported(
-                "SIMD support requires SSE3, SSSE3, and SSE4.1 on x86_64.".into(),
+                "SIMD support requires SSE3, SSSE3, SSE4.1, and SSE4.2 on x86_64.".into(),
             ));
         }
     }
@@ -354,6 +358,7 @@ mod test {
         isa_builder.set("has_sse3", "false").unwrap();
         isa_builder.set("has_ssse3", "false").unwrap();
         isa_builder.set("has_sse41", "false").unwrap();
+        isa_builder.set("has_sse42", "false").unwrap();
         assert!(matches!(
             isa_builder.finish(shared_flags),
             Err(CodegenError::Unsupported(_)),

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -749,8 +749,8 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                     std:"sse3" => clif:"has_sse3" ratio: 1 in 1,
                     std:"ssse3" => clif:"has_ssse3" ratio: 1 in 1,
                     std:"sse4.1" => clif:"has_sse41" ratio: 1 in 1,
+                    std:"sse4.2" => clif:"has_sse42" ratio: 1 in 1,
 
-                    std:"sse4.2" => clif:"has_sse42",
                     std:"popcnt" => clif:"has_popcnt",
                     std:"avx" => clif:"has_avx",
                     std:"avx2" => clif:"has_avx2",

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -552,6 +552,10 @@ impl Config {
     /// this does not enable the [relaxed simd proposal] as that is not
     /// implemented in Wasmtime at this time.
     ///
+    /// On x86_64 platforms note that enabling this feature requires SSE 4.2 and
+    /// below to be available on the target platform. Compilation will fail if
+    /// the compile target does not include SSE 4.2.
+    ///
     /// This is `true` by default.
     ///
     /// [proposal]: https://github.com/webassembly/simd


### PR DESCRIPTION
Fuzzing over the weekend found that `i64x2` comparison operators
require `pcmpgtq` which is an SSE 4.2 instruction. Along the lines of #3816
this commit unconditionally enables and requires SSE 4.2 for compilation
and fuzzing. It will no longer be possible to create a compiler for
x86_64 with simd enabled if SSE 4.2 is disabled.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
