### PR TITLE
[AArch64] Improve AtomicRMWLoop

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -6105,8 +6105,80 @@ fn test_aarch64_binemit() {
             ty: I16,
             op: inst_common::AtomicRmwOp::Xor,
         },
-        "3BFF5F487C031ACA3CFF1848B8FFFFB5",
-        "atomically { 16_bits_at_[x25]) Xor= x26 ; x27 = old_value_at_[x25]; x24,x28 = trash }",
+        "3BFF5F487C031A4A3CFF1848B8FFFFB5",
+        "1: ldaxrh w27, [x25]; eor w28, w27, w26; stlxrh w24, w28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I8,
+            op: inst_common::AtomicRmwOp::Add,
+        },
+        "3BFF5F087C031A0B3CFF1808B8FFFFB5",
+        "1: ldaxrb w27, [x25]; add w28, w27, w26; stlxrb w24, w28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I32,
+            op: inst_common::AtomicRmwOp::Or,
+        },
+        "3BFF5F887C031A2A3CFF1888B8FFFFB5",
+        "1: ldaxr w27, [x25]; orr w28, w27, w26; stlxr w24, w28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I64,
+            op: inst_common::AtomicRmwOp::And,
+        },
+        "3BFF5FC87C031A8A3CFF18C8B8FFFFB5",
+        "1: ldaxr x27, [x25]; and x28, x27, x26; stlxr w24, x28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I8,
+            op: inst_common::AtomicRmwOp::Xchg,
+        },
+        "3BFF5F083AFF1808D8FFFFB5",
+        "1: ldaxrb w27, [x25]; stlxrb w24, w26, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I16,
+            op: inst_common::AtomicRmwOp::Nand,
+        },
+        "3BFF5F487C031A0AFC033C2A3CFF184898FFFFB5",
+        "1: ldaxrh w27, [x25]; and w28, w27, w26; mvn w28, w28; stlxrh w24, w28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I32,
+            op: inst_common::AtomicRmwOp::Smin,
+        },
+        "3BFF5F887F031A6B7CB39A9A3CFF188898FFFFB5",
+        "1: ldaxr w27, [x25]; cmp w27, w26; csel w28, w27, w26, lt; stlxr w24, w28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I64,
+            op: inst_common::AtomicRmwOp::Smax,
+        },
+        "3BFF5FC87F031AEB7CC39A9A3CFF18C898FFFFB5",
+        "1: ldaxr x27, [x25]; cmp x27, x26; csel x28, x27, x26, gt; stlxr w24, x28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I8,
+            op: inst_common::AtomicRmwOp::Umin,
+        },
+        "3BFF5F087F031A6B7C339A9A3CFF180898FFFFB5",
+        "1: ldaxrb w27, [x25]; cmp w27, w26; csel w28, w27, w26, lo; stlxrb w24, w28, [x25]; cbnz w24, 1b",
+    ));
+    insns.push((
+        Inst::AtomicRMWLoop {
+            ty: I16,
+            op: inst_common::AtomicRmwOp::Umax,
+        },
+        "3BFF5F487F031A6B7C839A9A3CFF184898FFFFB5",
+        "1: ldaxrh w27, [x25]; cmp w27, w26; csel w28, w27, w26, hi; stlxrh w24, w28, [x25]; cbnz w24, 1b",
     ));
 
     insns.push((
@@ -6462,14 +6534,6 @@ fn test_aarch64_binemit() {
         "lduminal x25, x26, [x27]",
     ));
 
-    insns.push((
-        Inst::AtomicRMWLoop {
-            ty: I32,
-            op: inst_common::AtomicRmwOp::Xchg,
-        },
-        "3BFF5F88FC031AAA3CFF1888B8FFFFB5",
-        "atomically { 32_bits_at_[x25]) Xchg= x26 ; x27 = old_value_at_[x25]; x24,x28 = trash }",
-    ));
     insns.push((
         Inst::AtomicCAS {
             rs: writable_xreg(28),

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
@@ -16,8 +16,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_add_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_add_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 add v0, v1
     return
 }
@@ -28,6 +28,36 @@ block0(v0: i32, v1: i32):
 ;   (original IR block: block0)
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   ldaddal w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_add_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 add v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldaddalh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_add_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 add v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldaddalb w1, w0, [x0]
 ;   Inst 1:   ret
 ; }}
 
@@ -46,8 +76,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_and_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_and_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 and v0, v1
     return
 }
@@ -59,6 +89,140 @@ block0(v0: i32, v1: i32):
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   ldclral w1, w0, [x0]
 ;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_and_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 and v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldclralh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_and_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 and v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldclralb w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_nand_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; and x28, x27, x26; mvn x28, x28; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_nand_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; and w28, w27, w26; mvn w28, w28; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_nand_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; and w28, w27, w26; mvn w28, w28; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_nand_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; and w28, w27, w26; mvn w28, w28; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
 ; }}
 
 function %atomic_rmw_or_i64(i64, i64) {
@@ -76,8 +240,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_or_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_or_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 or v0, v1
     return
 }
@@ -88,6 +252,36 @@ block0(v0: i32, v1: i32):
 ;   (original IR block: block0)
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   ldsetal w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_or_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 or v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldsetalh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_or_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 or v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldsetalb w1, w0, [x0]
 ;   Inst 1:   ret
 ; }}
 
@@ -106,8 +300,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_xor_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_xor_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 xor v0, v1
     return
 }
@@ -118,6 +312,36 @@ block0(v0: i32, v1: i32):
 ;   (original IR block: block0)
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   ldeoral w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_xor_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 xor v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldeoralh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_xor_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 xor v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldeoralb w1, w0, [x0]
 ;   Inst 1:   ret
 ; }}
 
@@ -136,8 +360,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_smax_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_smax_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 smax v0, v1
     return
 }
@@ -148,6 +372,36 @@ block0(v0: i32, v1: i32):
 ;   (original IR block: block0)
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   ldsmaxal w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_smax_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 smax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldsmaxalh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_smax_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 smax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldsmaxalb w1, w0, [x0]
 ;   Inst 1:   ret
 ; }}
 
@@ -166,8 +420,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_umax_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_umax_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 umax v0, v1
     return
 }
@@ -178,6 +432,36 @@ block0(v0: i32, v1: i32):
 ;   (original IR block: block0)
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   ldumaxal w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_umax_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 umax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldumaxalh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_umax_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 umax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldumaxalb w1, w0, [x0]
 ;   Inst 1:   ret
 ; }}
 
@@ -196,8 +480,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_smin_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_smin_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 smin v0, v1
     return
 }
@@ -208,6 +492,36 @@ block0(v0: i32, v1: i32):
 ;   (original IR block: block0)
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   ldsminal w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_smin_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 smin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldsminalh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_smin_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 smin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   ldsminalb w1, w0, [x0]
 ;   Inst 1:   ret
 ; }}
 
@@ -226,8 +540,8 @@ block0(v0: i64, v1: i64):
 ;   Inst 1:   ret
 ; }}
 
-function %atomic_rmw_umin_i32(i32, i32) {
-block0(v0: i32, v1: i32):
+function %atomic_rmw_umin_i32(i64, i32) {
+block0(v0: i64, v1: i32):
     v2 = atomic_rmw.i32 umin v0, v1
     return
 }
@@ -238,6 +552,36 @@ block0(v0: i32, v1: i32):
 ;   (original IR block: block0)
 ;   (instruction range: 0 .. 2)
 ;   Inst 0:   lduminal w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_umin_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 umin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   lduminalh w1, w0, [x0]
+;   Inst 1:   ret
+; }}
+
+function %atomic_rmw_umin_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 umin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 2)
+;   Inst 0:   lduminalb w1, w0, [x0]
 ;   Inst 1:   ret
 ; }}
 

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
@@ -1,0 +1,939 @@
+test compile precise-output
+target aarch64
+
+function %atomic_rmw_add_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 add v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; add x28, x27, x26; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_add_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 add v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; add w28, w27, w26; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_add_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 add v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; add w28, w27, w26; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_add_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 add v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; add w28, w27, w26; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_and_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 and v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; and x28, x27, x26; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_and_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 and v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; and w28, w27, w26; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_and_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 and v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; and w28, w27, w26; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_and_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 and v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; and w28, w27, w26; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_nand_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; and x28, x27, x26; mvn x28, x28; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_nand_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; and w28, w27, w26; mvn w28, w28; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_nand_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; and w28, w27, w26; mvn w28, w28; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_nand_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 nand v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; and w28, w27, w26; mvn w28, w28; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_or_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 or v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; orr x28, x27, x26; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_or_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 or v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; orr w28, w27, w26; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_or_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 or v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; orr w28, w27, w26; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_or_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 or v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; orr w28, w27, w26; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_xor_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 xor v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; eor x28, x27, x26; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_xor_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 xor v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; eor w28, w27, w26; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_xor_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 xor v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; eor w28, w27, w26; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_xor_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 xor v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; eor w28, w27, w26; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smax_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 smax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; cmp x27, x26; csel x28, x27, x26, gt; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smax_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 smax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; cmp w27, w26; csel w28, w27, w26, gt; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smax_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 smax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; cmp w27, w26; csel w28, w27, w26, gt; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smax_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 smax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; cmp w27, w26; csel w28, w27, w26, gt; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umax_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 umax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; cmp x27, x26; csel x28, x27, x26, hi; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umax_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 umax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; cmp w27, w26; csel w28, w27, w26, hi; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umax_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 umax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; cmp w27, w26; csel w28, w27, w26, hi; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umax_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 umax v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; cmp w27, w26; csel w28, w27, w26, hi; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smin_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 smin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; cmp x27, x26; csel x28, x27, x26, lt; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smin_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 smin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; cmp w27, w26; csel w28, w27, w26, lt; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smin_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 smin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; cmp w27, w26; csel w28, w27, w26, lt; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_smin_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 smin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; cmp w27, w26; csel w28, w27, w26, lt; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umin_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 umin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr x27, [x25]; cmp x27, x26; csel x28, x27, x26, lo; stlxr w24, x28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umin_i32(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 umin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxr w27, [x25]; cmp w27, w26; csel w28, w27, w26, lo; stlxr w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umin_i16(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 umin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrh w27, [x25]; cmp w27, w26; csel w28, w27, w26, lo; stlxrh w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+
+function %atomic_rmw_umin_i8(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 umin v0, v1
+    return
+}
+
+; VCode_ShowWithRRU {{
+;   Entry block: 0
+; Block 0:
+;   (original IR block: block0)
+;   (instruction range: 0 .. 13)
+;   Inst 0:   stp fp, lr, [sp, #-16]!
+;   Inst 1:   mov fp, sp
+;   Inst 2:   str x28, [sp, #-16]!
+;   Inst 3:   stp x26, x27, [sp, #-16]!
+;   Inst 4:   stp x24, x25, [sp, #-16]!
+;   Inst 5:   mov x25, x0
+;   Inst 6:   mov x26, x1
+;   Inst 7:   1: ldaxrb w27, [x25]; cmp w27, w26; csel w28, w27, w26, lo; stlxrb w24, w28, [x25]; cbnz w24, 1b
+;   Inst 8:   ldp x24, x25, [sp], #16
+;   Inst 9:   ldp x26, x27, [sp], #16
+;   Inst 10:   ldr x28, [sp], #16
+;   Inst 11:   ldp fp, lr, [sp], #16
+;   Inst 12:   ret
+; }}
+


### PR DESCRIPTION
Add more tests, use accurate disassembly, respect data sizes and
simplify the Xchg implementation.

Copyright (c) 2022, Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
