### PR TITLE
Downgrade a cpu feature log message

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -724,7 +724,7 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                         // input must be discarded.
                         #[cfg(target_arch = $arch)]
                         if enable && !std::$test!($std) {
-                            log::error!("want to enable clif `{}` but host doesn't support it",
+                            log::warn!("want to enable clif `{}` but host doesn't support it",
                                 $clif);
                             return Err(arbitrary::Error::EmptyChoose)
                         }


### PR DESCRIPTION
It looks like `error!` is printed by default as it's showing up in
oss-fuzz logs, so downgrade this to `warn!` to avoid printing while fuzzing.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
