### PR TITLE
ISLE: fix compile fuzz target, and fix a simple error-reporting bug.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,8 @@ jobs:
     - run: cargo fetch
       working-directory: ./fuzz
     - run: cargo fuzz build --dev
+    # Check that the ISLE fuzz targets build too.
+    - run: cargo fuzz build --dev --fuzz-dir ./cranelift/isle/fuzz
 
   rebuild_isle:
     name: Rebuild ISLE

--- a/cranelift/isle/fuzz/fuzz_targets/compile.rs
+++ b/cranelift/isle/fuzz/fuzz_targets/compile.rs
@@ -5,21 +5,21 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|s: &str| {
     let _ = env_logger::try_init();
 
-    let lexer = isle::lexer::Lexer::from_str(s, "fuzz-input.isle");
+    let lexer = cranelift_isle::lexer::Lexer::from_str(s, "fuzz-input.isle");
     log::debug!("lexer = {:?}", lexer);
     let lexer = match lexer {
         Ok(l) => l,
         Err(_) => return,
     };
 
-    let defs = isle::parser::parse(lexer);
+    let defs = cranelift_isle::parser::parse(lexer);
     log::debug!("defs = {:?}", defs);
     let defs = match defs {
         Ok(d) => d,
         Err(_) => return,
     };
 
-    let code = isle::compile::compile(&defs);
+    let code = cranelift_isle::compile::compile(&defs);
     log::debug!("code = {:?}", code);
     let code = match code {
         Ok(c) => c,

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -795,7 +795,6 @@ impl TermEnv {
         for def in &defs.defs {
             match def {
                 &ast::Def::Decl(ref decl) => {
-                    let tid = TermId(self.terms.len());
                     let name = tyenv.intern_mut(&decl.term);
                     if let Some(tid) = self.term_map.get(&name) {
                         tyenv.report_error(
@@ -807,7 +806,6 @@ impl TermEnv {
                             format!("Duplicate decl for '{}'", decl.term.0),
                         );
                     }
-                    self.term_map.insert(name, tid);
 
                     let arg_tys = decl
                         .arg_tys
@@ -840,6 +838,8 @@ impl TermEnv {
                         }
                     };
 
+                    let tid = TermId(self.terms.len());
+                    self.term_map.insert(name, tid);
                     self.terms.push(Term {
                         id: tid,
                         decl_pos: decl.pos,


### PR DESCRIPTION
It seems our `compile` fuzz target for ISLE has not been regularly
tested, as it was never updated for the `isle` -> `cranelift_isle` crate
renaming. This PR fixes it to compile again.

This also includes a simple fix in the typechecking: when verifying that
a term decl is valid, we might insert a term ID into the name->ID map
before fully checking that all of the types exist, and then skipping
(for error recovery purposes) the actual push onto the term-signature
vector if one of the types does have an error. This phantom TID can
later cause a panic. The fix is to avoid adding to the map until we have
fully verified the term decl.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
