### PR TITLE
ISLE lowering rules: make use of implicit conversions.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1363,77 +1363,77 @@
 (rule (movz imm size)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.MovZ dst imm size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.MovN` instructions.
 (decl movn (MoveWideConst OperandSize) Reg)
 (rule (movn imm size)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.MovN dst imm size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRRImmLogic` instructions.
 (decl alu_rr_imm_logic (ALUOp Type Reg ImmLogic) Reg)
 (rule (alu_rr_imm_logic op ty src imm)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.AluRRImmLogic op (operand_size ty) dst src imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRRImmShift` instructions.
 (decl alu_rr_imm_shift (ALUOp Type Reg ImmShift) Reg)
 (rule (alu_rr_imm_shift op ty src imm)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.AluRRImmShift op (operand_size ty) dst src imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRRR` instructions.
 (decl alu_rrr (ALUOp Type Reg Reg) Reg)
 (rule (alu_rrr op ty src1 src2)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.AluRRR op (operand_size ty) dst src1 src2))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.VecRRR` instructions.
 (decl vec_rrr (VecALUOp Reg Reg VectorSize) Reg)
 (rule (vec_rrr op src1 src2 size)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecRRR op dst src1 src2 size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.VecLanes` instructions.
 (decl vec_lanes (VecLanesOp Reg VectorSize) Reg)
 (rule (vec_lanes op src size)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecLanes op dst src size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.VecDup` instructions.
 (decl vec_dup (Reg VectorSize) Reg)
 (rule (vec_dup src size)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecDup dst src size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRRImm12` instructions.
 (decl alu_rr_imm12 (ALUOp Type Reg Imm12) Reg)
 (rule (alu_rr_imm12 op ty src imm)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.AluRRImm12 op (operand_size ty) dst src imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRRRShift` instructions.
 (decl alu_rrr_shift (ALUOp Type Reg Reg ShiftOpAndAmt) Reg)
 (rule (alu_rrr_shift op ty src1 src2 shift)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.AluRRRShift op (operand_size ty) dst src1 src2 shift))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRRRExtend` instructions.
 (decl alu_rrr_extend (ALUOp Type Reg Reg ExtendOp) Reg)
 (rule (alu_rrr_extend op ty src1 src2 extend)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.AluRRRExtend op (operand_size ty) dst src1 src2 extend))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Same as `alu_rrr_extend`, but takes an `ExtendedValue` packed "pair" instead
 ;; of a `Reg` and an `ExtendOp`.
@@ -1448,14 +1448,14 @@
 (rule (alu_rrrr op src1 src2 src3)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.AluRRRR op dst src1 src2 src3))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.BitRR` instructions.
 (decl bit_rr (BitOp Type Reg) Reg)
 (rule (bit_rr op ty src)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.BitRR op (operand_size ty) dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `adds` instructions.
 (decl add_with_flags_paired (Type Reg Reg) ProducesFlags)
@@ -1463,7 +1463,7 @@
       (let ((dst WritableReg (temp_writable_reg $I64)))
         (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
          (MInst.AluRRR (ALUOp.AddS) (operand_size ty) dst src1 src2)
-         (writable_reg_to_reg dst))))
+         dst)))
 
 ;; Helper for emitting `adc` instructions.
 (decl adc_paired (Type Reg Reg) ConsumesFlags)
@@ -1471,7 +1471,7 @@
       (let ((dst WritableReg (temp_writable_reg $I64)))
         (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
          (MInst.AluRRR (ALUOp.Adc) (operand_size ty) dst src1 src2)
-         (writable_reg_to_reg dst))))
+         dst)))
 
 ;; Helper for emitting `subs` instructions.
 (decl sub_with_flags_paired (Type Reg Reg) ProducesFlags)
@@ -1479,7 +1479,7 @@
       (let ((dst WritableReg (temp_writable_reg $I64)))
         (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
          (MInst.AluRRR (ALUOp.SubS) (operand_size ty) dst src1 src2)
-         (writable_reg_to_reg dst))))
+         dst)))
 
 (decl cmp64_imm (Reg Imm12) ProducesFlags)
 (rule (cmp64_imm src1 src2)
@@ -1493,21 +1493,21 @@
       (let ((dst WritableReg (temp_writable_reg $I64)))
         (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
          (MInst.AluRRR (ALUOp.Sbc) (operand_size ty) dst src1 src2)
-         (writable_reg_to_reg dst))))
+         dst)))
 
 ;; Helper for emitting `MInst.VecMisc` instructions.
 (decl vec_misc (VecMisc2 Reg VectorSize) Reg)
 (rule (vec_misc op src size)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecMisc op dst src size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.VecRRRLong` instructions.
 (decl vec_rrr_long (VecRRRLongOp Reg Reg bool) Reg)
 (rule (vec_rrr_long op src1 src2 high_half)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecRRRLong op dst src1 src2 high_half))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.VecRRRLong` instructions, but for variants
 ;; where the operation both reads and modifies the destination register.
@@ -1518,28 +1518,28 @@
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_1 Unit (emit (MInst.FpuMove128 dst src1)))
             (_2 Unit (emit (MInst.VecRRRLong op dst src2 src3 high_half))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.VecRRNarrow` instructions.
 (decl vec_rr_narrow (VecRRNarrowOp Reg bool) Reg)
 (rule (vec_rr_narrow op src high_half)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecRRNarrow op dst src high_half))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.VecRRLong` instructions.
 (decl vec_rr_long (VecRRLongOp Reg bool) Reg)
 (rule (vec_rr_long op src high_half)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecRRLong op dst src high_half))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.MovToFpu` instructions.
 (decl mov_to_fpu (Reg ScalarSize) Reg)
 (rule (mov_to_fpu x size)
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.MovToFpu dst x size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.MovToVec` instructions.
 (decl mov_to_vec (Reg Reg u8 VectorSize) Reg)
@@ -1547,35 +1547,35 @@
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_1 Unit (emit (MInst.FpuMove128 dst src1)))
             (_2 Unit (emit (MInst.MovToVec dst src2 lane size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.MovFromVec` instructions.
 (decl mov_from_vec (Reg u8 VectorSize) Reg)
 (rule (mov_from_vec rn idx size)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.MovFromVec dst rn idx size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.MovFromVecSigned` instructions.
 (decl mov_from_vec_signed (Reg u8 VectorSize OperandSize) Reg)
 (rule (mov_from_vec_signed rn idx size scalar_size)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.MovFromVecSigned dst rn idx size scalar_size))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.Extend` instructions.
 (decl extend (Reg bool u8 u8) Reg)
 (rule (extend rn signed from_bits to_bits)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.Extend dst rn signed from_bits to_bits))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.LoadAcquire` instructions.
 (decl load_acquire (Type Reg) Reg)
 (rule (load_acquire ty addr)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.LoadAcquire ty dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for generating a `tst` instruction.
 ;;
@@ -1600,7 +1600,7 @@
       (let ((dst WritableReg (temp_writable_reg $I64)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
          (MInst.CSel dst cond if_true if_false)
-         (writable_reg_to_reg dst))))
+         dst)))
 
 ;; Helpers for generating `add` instructions.
 
@@ -1870,36 +1870,36 @@
 ;; Place a `Value` into a register, sign extending it to 32-bits
 (decl put_in_reg_sext32 (Value) Reg)
 (rule (put_in_reg_sext32 val @ (value_type (fits_in_32 ty)))
-      (extend (put_in_reg val) $true (ty_bits ty) 32))
+      (extend val $true (ty_bits ty) 32))
 
 ;; 32/64-bit passthrough.
-(rule (put_in_reg_sext32 val @ (value_type $I32)) (put_in_reg val))
-(rule (put_in_reg_sext32 val @ (value_type $I64)) (put_in_reg val))
+(rule (put_in_reg_sext32 val @ (value_type $I32)) val)
+(rule (put_in_reg_sext32 val @ (value_type $I64)) val)
 
 ;; Place a `Value` into a register, zero extending it to 32-bits
 (decl put_in_reg_zext32 (Value) Reg)
 (rule (put_in_reg_zext32 val @ (value_type (fits_in_32 ty)))
-      (extend (put_in_reg val) $false (ty_bits ty) 32))
+      (extend val $false (ty_bits ty) 32))
 
 ;; 32/64-bit passthrough.
-(rule (put_in_reg_zext32 val @ (value_type $I32)) (put_in_reg val))
-(rule (put_in_reg_zext32 val @ (value_type $I64)) (put_in_reg val))
+(rule (put_in_reg_zext32 val @ (value_type $I32)) val)
+(rule (put_in_reg_zext32 val @ (value_type $I64)) val)
 
 ;; Place a `Value` into a register, sign extending it to 64-bits
 (decl put_in_reg_sext64 (Value) Reg)
 (rule (put_in_reg_sext64 val @ (value_type (fits_in_32 ty)))
-      (extend (put_in_reg val) $true (ty_bits ty) 64))
+      (extend val $true (ty_bits ty) 64))
 
 ;; 64-bit passthrough.
-(rule (put_in_reg_sext64 val @ (value_type $I64)) (put_in_reg val))
+(rule (put_in_reg_sext64 val @ (value_type $I64)) val)
 
 ;; Place a `Value` into a register, zero extending it to 64-bits
 (decl put_in_reg_zext64 (Value) Reg)
 (rule (put_in_reg_zext64 val @ (value_type (fits_in_32 ty)))
-      (extend (put_in_reg val) $false (ty_bits ty) 64))
+      (extend val $false (ty_bits ty) 64))
 
 ;; 64-bit passthrough.
-(rule (put_in_reg_zext64 val @ (value_type $I64)) (put_in_reg val))
+(rule (put_in_reg_zext64 val @ (value_type $I64)) val)
 
 ;; Misc instruction helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -7,20 +7,20 @@
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (iconst (u64_from_imm64 n))))
-      (value_reg (imm ty n)))
+      (imm ty n))
 
 ;;;; Rules for `bconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (bconst $false)))
-      (value_reg (imm ty 0)))
+      (imm ty 0))
 
 (rule (lower (has_type ty (bconst $true)))
-      (value_reg (imm ty 1)))
+      (imm ty 1))
 
 ;;;; Rules for `null` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (null)))
-      (value_reg (imm ty 0)))
+      (imm ty 0))
 
 ;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -28,66 +28,65 @@
 
 ;; Base case, simply adding things in registers.
 (rule (lower (has_type (fits_in_64 ty) (iadd x y)))
-      (value_reg (add ty (put_in_reg x) (put_in_reg y))))
+      (add ty  x y))
 
 ;; Special cases for when one operand is an immediate that fits in 12 bits.
 (rule (lower (has_type (fits_in_64 ty) (iadd x (imm12_from_value y))))
-      (value_reg (add_imm ty (put_in_reg x) y)))
+      (add_imm ty x y))
 
 (rule (lower (has_type (fits_in_64 ty) (iadd (imm12_from_value x) y)))
-      (value_reg (add_imm ty (put_in_reg y) x)))
+      (add_imm ty y x))
 
 ;; Same as the previous special cases, except we can switch the addition to a
 ;; subtraction if the negated immediate fits in 12 bits.
 (rule (lower (has_type (fits_in_64 ty) (iadd x (imm12_from_negated_value y))))
-      (value_reg (sub_imm ty (put_in_reg x) y)))
+      (sub_imm ty x y))
 
 (rule (lower (has_type (fits_in_64 ty) (iadd (imm12_from_negated_value x) y)))
-      (value_reg (sub_imm ty (put_in_reg y) x)))
+      (sub_imm ty y x))
 
 ;; Special cases for when we're adding an extended register where the extending
 ;; operation can get folded into the add itself.
 (rule (lower (has_type (fits_in_64 ty) (iadd x (extended_value_from_value y))))
-      (value_reg (add_extend ty (put_in_reg x) y)))
+      (add_extend ty x y))
 
 (rule (lower (has_type (fits_in_64 ty) (iadd (extended_value_from_value x) y)))
-      (value_reg (add_extend ty (put_in_reg y) x)))
+      (add_extend ty y x))
 
 ;; Special cases for when we're adding the shift of a different
 ;; register by a constant amount and the shift can get folded into the add.
 (rule (lower (has_type (fits_in_64 ty)
-                       (iadd x (def_inst (ishl y (def_inst (iconst (lshl_from_imm64 <ty amt))))))))
-      (value_reg (add_shift ty (put_in_reg x) (put_in_reg y) amt)))
+                       (iadd x (ishl y (iconst (lshl_from_imm64 <ty amt))))))
+      (add_shift ty x y amt))
 
 (rule (lower (has_type (fits_in_64 ty)
-                       (iadd (def_inst (ishl x (def_inst (iconst (lshl_from_imm64 <ty amt))))) y)))
-      (value_reg (add_shift ty (put_in_reg y) (put_in_reg x) amt)))
+                       (iadd (ishl x (iconst (lshl_from_imm64 <ty amt))) y)))
+      (add_shift ty y x amt))
 
 ;; Fold an `iadd` and `imul` combination into a `madd` instruction.
-(rule (lower (has_type (fits_in_64 ty) (iadd x (def_inst (imul y z)))))
-      (value_reg (madd ty (put_in_reg y) (put_in_reg z) (put_in_reg x))))
+(rule (lower (has_type (fits_in_64 ty) (iadd x (imul y z))))
+      (madd ty y z x))
 
-(rule (lower (has_type (fits_in_64 ty) (iadd (def_inst (imul x y)) z)))
-      (value_reg (madd ty (put_in_reg x) (put_in_reg y) (put_in_reg z))))
+(rule (lower (has_type (fits_in_64 ty) (iadd (imul x y) z)))
+      (madd ty x y z))
 
 ;; vectors
 
 (rule (lower (has_type ty @ (multi_lane _ _) (iadd x y)))
-      (value_reg (add_vec (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (add_vec x y (vector_size ty)))
 
 ;; `i128`
 (rule (lower (has_type $I128 (iadd x y)))
-      (let (
+      (let
           ;; Get the high/low registers for `x`.
-          (x_regs ValueRegs (put_in_regs x))
-          (x_lo Reg (value_regs_get x_regs 0))
-          (x_hi Reg (value_regs_get x_regs 1))
+          ((x_regs ValueRegs x)
+           (x_lo Reg (value_regs_get x_regs 0))
+           (x_hi Reg (value_regs_get x_regs 1))
 
-          ;; Get the high/low registers for `y`.
-          (y_regs ValueRegs (put_in_regs y))
-          (y_lo Reg (value_regs_get y_regs 0))
-          (y_hi Reg (value_regs_get y_regs 1))
-        )
+           ;; Get the high/low registers for `y`.
+           (y_regs ValueRegs y)
+           (y_lo Reg (value_regs_get y_regs 0))
+           (y_hi Reg (value_regs_get y_regs 1)))
         ;; the actual addition is `adds` followed by `adc` which comprises the
         ;; low/high bits of the result
         (with_flags
@@ -100,45 +99,44 @@
 
 ;; Base case, simply subtracting things in registers.
 (rule (lower (has_type (fits_in_64 ty) (isub x y)))
-      (value_reg (sub ty (put_in_reg x) (put_in_reg y))))
+      (sub ty x y))
 
 ;; Special case for when one operand is an immediate that fits in 12 bits.
 (rule (lower (has_type (fits_in_64 ty) (isub x (imm12_from_value y))))
-      (value_reg (sub_imm ty (put_in_reg x) y)))
+      (sub_imm ty x y))
 
 ;; Same as the previous special case, except we can switch the subtraction to an
 ;; addition if the negated immediate fits in 12 bits.
 (rule (lower (has_type (fits_in_64 ty) (isub x (imm12_from_negated_value y))))
-      (value_reg (add_imm ty (put_in_reg x) y)))
+      (add_imm ty x y))
 
 ;; Special cases for when we're subtracting an extended register where the
 ;; extending operation can get folded into the sub itself.
 (rule (lower (has_type (fits_in_64 ty) (isub x (extended_value_from_value y))))
-      (value_reg (sub_extend ty (put_in_reg x) y)))
+      (sub_extend ty x y))
 
 ;; Finally a special case for when we're subtracting the shift of a different
 ;; register by a constant amount and the shift can get folded into the sub.
 (rule (lower (has_type (fits_in_64 ty)
-                       (isub x (def_inst (ishl y (def_inst (iconst (lshl_from_imm64 <ty amt))))))))
-      (value_reg (sub_shift ty (put_in_reg x) (put_in_reg y) amt)))
+                       (isub x (ishl y (iconst (lshl_from_imm64 <ty amt))))))
+      (sub_shift ty x y amt))
 
 ;; vectors
 (rule (lower (has_type ty @ (multi_lane _ _) (isub x y)))
-      (value_reg (sub_vec (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (sub_vec x y (vector_size ty)))
 
 ;; `i128`
 (rule (lower (has_type $I128 (isub x y)))
-      (let (
+      (let
           ;; Get the high/low registers for `x`.
-          (x_regs ValueRegs (put_in_regs x))
-          (x_lo Reg (value_regs_get x_regs 0))
-          (x_hi Reg (value_regs_get x_regs 1))
+          ((x_regs ValueRegs x)
+           (x_lo Reg (value_regs_get x_regs 0))
+           (x_hi Reg (value_regs_get x_regs 1))
 
-          ;; Get the high/low registers for `y`.
-          (y_regs ValueRegs (put_in_regs y))
-          (y_lo Reg (value_regs_get y_regs 0))
-          (y_hi Reg (value_regs_get y_regs 1))
-        )
+           ;; Get the high/low registers for `y`.
+           (y_regs ValueRegs y)
+           (y_lo Reg (value_regs_get y_regs 0))
+           (y_hi Reg (value_regs_get y_regs 1)))
         ;; the actual subtraction is `subs` followed by `sbc` which comprises
         ;; the low/high bits of the result
         (with_flags
@@ -148,71 +146,70 @@
 ;;;; Rules for `uadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (vec128 ty) (uadd_sat x y)))
-      (value_reg (uqadd (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (uqadd x y (vector_size ty)))
 
 ;;;; Rules for `sadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (vec128 ty) (sadd_sat x y)))
-      (value_reg (sqadd (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (sqadd x y (vector_size ty)))
 
 ;;;; Rules for `usub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (vec128 ty) (usub_sat x y)))
-      (value_reg (uqsub (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (uqsub x y (vector_size ty)))
 
 ;;;; Rules for `ssub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (vec128 ty) (ssub_sat x y)))
-      (value_reg (sqsub (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (sqsub x y (vector_size ty)))
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `i64` and smaller.
 (rule (lower (has_type (fits_in_64 ty) (ineg x)))
-      (value_reg (sub ty (zero_reg) (put_in_reg x))))
+      (sub ty (zero_reg) x))
 
 ;; vectors.
 (rule (lower (has_type (vec128 ty) (ineg x)))
-      (value_reg (neg (put_in_reg x) (vector_size ty))))
+      (neg x (vector_size ty)))
 
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `i64` and smaller.
 (rule (lower (has_type (fits_in_64 ty) (imul x y)))
-      (value_reg (madd ty (put_in_reg x) (put_in_reg y) (zero_reg))))
+      (madd ty x y (zero_reg)))
 
 ;; `i128`.
 (rule (lower (has_type $I128 (imul x y)))
-      (let (
+      (let
           ;; Get the high/low registers for `x`.
-          (x_regs ValueRegs (put_in_regs x))
-          (x_lo Reg (value_regs_get x_regs 0))
-          (x_hi Reg (value_regs_get x_regs 1))
+          ((x_regs ValueRegs x)
+           (x_lo Reg (value_regs_get x_regs 0))
+           (x_hi Reg (value_regs_get x_regs 1))
 
-          ;; Get the high/low registers for `y`.
-          (y_regs ValueRegs (put_in_regs y))
-          (y_lo Reg (value_regs_get y_regs 0))
-          (y_hi Reg (value_regs_get y_regs 1))
+           ;; Get the high/low registers for `y`.
+           (y_regs ValueRegs y)
+           (y_lo Reg (value_regs_get y_regs 0))
+           (y_hi Reg (value_regs_get y_regs 1))
 
-          ;; 128bit mul formula:
-          ;;   dst_lo = x_lo * y_lo
-          ;;   dst_hi = umulhi(x_lo, y_lo) + (x_lo * y_hi) + (x_hi * y_lo)
-          ;;
-          ;; We can convert the above formula into the following
-          ;; umulh   dst_hi, x_lo, y_lo
-          ;; madd    dst_hi, x_lo, y_hi, dst_hi
-          ;; madd    dst_hi, x_hi, y_lo, dst_hi
-          ;; madd    dst_lo, x_lo, y_lo, zero
-          (dst_hi1 Reg (umulh $I64 x_lo y_lo))
-          (dst_hi2 Reg (madd64 x_lo y_hi dst_hi1))
-          (dst_hi Reg (madd64 x_hi y_lo dst_hi2))
-          (dst_lo Reg (madd64 x_lo y_lo (zero_reg)))
-        )
+           ;; 128bit mul formula:
+           ;;   dst_lo = x_lo * y_lo
+           ;;   dst_hi = umulhi(x_lo, y_lo) + (x_lo * y_hi) + (x_hi * y_lo)
+           ;;
+           ;; We can convert the above formula into the following
+           ;; umulh   dst_hi, x_lo, y_lo
+           ;; madd    dst_hi, x_lo, y_hi, dst_hi
+           ;; madd    dst_hi, x_hi, y_lo, dst_hi
+           ;; madd    dst_lo, x_lo, y_lo, zero
+           (dst_hi1 Reg (umulh $I64 x_lo y_lo))
+           (dst_hi2 Reg (madd64 x_lo y_hi dst_hi1))
+           (dst_hi Reg (madd64 x_hi y_lo dst_hi2))
+           (dst_lo Reg (madd64 x_lo y_lo (zero_reg))))
         (value_regs dst_lo dst_hi)))
 
 ;; Case for i8x16, i16x8, and i32x4.
 (rule (lower (has_type (vec128 ty @ (not_i64x2)) (imul x y)))
-      (value_reg (mul (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (mul x y (vector_size ty)))
 
 ;; Special lowering for i64x2.
 ;;
@@ -244,144 +241,138 @@
 ;;  shll rd.2d, rd.2s, #32
 ;;  umlal rd.2d, tmp2.2s, tmp1.2s
 (rule (lower (has_type $I64X2 (imul x y)))
-      (let (
-          (rn Reg (put_in_reg x))
-          (rm Reg (put_in_reg y))
-          ;; Reverse the 32-bit elements in the 64-bit words.
-          ;;   rd = |g|h|e|f|
-          (rev Reg (rev64 rm (VectorSize.Size32x4)))
+      (let ((rn Reg x)
+            (rm Reg y)
+            ;; Reverse the 32-bit elements in the 64-bit words.
+            ;;   rd = |g|h|e|f|
+            (rev Reg (rev64 rm (VectorSize.Size32x4)))
 
-          ;; Calculate the high half components.
-          ;;   rd = |dg|ch|be|af|
-          ;;
-          ;; Note that this 32-bit multiply of the high half
-          ;; discards the bits that would overflow, same as
-          ;; if 64-bit operations were used. Also the Shll
-          ;; below would shift out the overflow bits anyway.
-          (mul Reg (mul rev rn (VectorSize.Size32x4)))
+            ;; Calculate the high half components.
+            ;;   rd = |dg|ch|be|af|
+            ;;
+            ;; Note that this 32-bit multiply of the high half
+            ;; discards the bits that would overflow, same as
+            ;; if 64-bit operations were used. Also the Shll
+            ;; below would shift out the overflow bits anyway.
+            (mul Reg (mul rev rn (VectorSize.Size32x4)))
 
-          ;; Extract the low half components of rn.
-          ;;   tmp1 = |c|a|
-          (tmp1 Reg (xtn64 rn $false))
+            ;; Extract the low half components of rn.
+            ;;   tmp1 = |c|a|
+            (tmp1 Reg (xtn64 rn $false))
 
-          ;; Sum the respective high half components.
-          ;;   rd = |dg+ch|be+af||dg+ch|be+af|
-          (sum Reg (addp mul mul (VectorSize.Size32x4)))
+            ;; Sum the respective high half components.
+            ;;   rd = |dg+ch|be+af||dg+ch|be+af|
+            (sum Reg (addp mul mul (VectorSize.Size32x4)))
 
-          ;; Extract the low half components of rm.
-          ;;   tmp2 = |g|e|
-          (tmp2 Reg (xtn64 rm $false))
+            ;; Extract the low half components of rm.
+            ;;   tmp2 = |g|e|
+            (tmp2 Reg (xtn64 rm $false))
 
-          ;; Shift the high half components, into the high half.
-          ;;   rd = |dg+ch << 32|be+af << 32|
-          (shift Reg (shll32 sum $false))
+            ;; Shift the high half components, into the high half.
+            ;;   rd = |dg+ch << 32|be+af << 32|
+            (shift Reg (shll32 sum $false))
 
-          ;; Multiply the low components together, and accumulate with the high
-          ;; half.
-          ;;   rd = |rd[1] + cg|rd[0] + ae|
-          (result Reg (umlal32 shift tmp2 tmp1 $false))
-        )
-        (value_reg result)))
+            ;; Multiply the low components together, and accumulate with the high
+            ;; half.
+            ;;   rd = |rd[1] + cg|rd[0] + ae|
+            (result Reg (umlal32 shift tmp2 tmp1 $false)))
+        result))
 
 ;; Special case for `i16x8.extmul_low_i8x16_s`.
 (rule (lower (has_type $I16X8
-                       (imul (def_inst (swiden_low x @ (value_type $I8X16)))
-                             (def_inst (swiden_low y @ (value_type $I8X16))))))
-      (value_reg (smull8 (put_in_reg x) (put_in_reg y) $false)))
+                       (imul (swiden_low x @ (value_type $I8X16))
+                             (swiden_low y @ (value_type $I8X16)))))
+      (smull8 x y $false))
 
 ;; Special case for `i16x8.extmul_high_i8x16_s`.
 (rule (lower (has_type $I16X8
-                       (imul (def_inst (swiden_high x @ (value_type $I8X16)))
-                             (def_inst (swiden_high y @ (value_type $I8X16))))))
-      (value_reg (smull8 (put_in_reg x) (put_in_reg y) $true)))
+                       (imul (swiden_high x @ (value_type $I8X16))
+                             (swiden_high y @ (value_type $I8X16)))))
+      (smull8 x y $true))
 
 ;; Special case for `i16x8.extmul_low_i8x16_u`.
 (rule (lower (has_type $I16X8
-                       (imul (def_inst (uwiden_low x @ (value_type $I8X16)))
-                             (def_inst (uwiden_low y @ (value_type $I8X16))))))
-      (value_reg (umull8 (put_in_reg x) (put_in_reg y) $false)))
+                       (imul (uwiden_low x @ (value_type $I8X16))
+                             (uwiden_low y @ (value_type $I8X16)))))
+      (umull8 x y $false))
 
 ;; Special case for `i16x8.extmul_high_i8x16_u`.
 (rule (lower (has_type $I16X8
-                       (imul (def_inst (uwiden_high x @ (value_type $I8X16)))
-                             (def_inst (uwiden_high y @ (value_type $I8X16))))))
-      (value_reg (umull8 (put_in_reg x) (put_in_reg y) $true)))
+                       (imul (uwiden_high x @ (value_type $I8X16))
+                             (uwiden_high y @ (value_type $I8X16)))))
+      (umull8 x y $true))
 
 ;; Special case for `i32x4.extmul_low_i16x8_s`.
 (rule (lower (has_type $I32X4
-                       (imul (def_inst (swiden_low x @ (value_type $I16X8)))
-                             (def_inst (swiden_low y @ (value_type $I16X8))))))
-      (value_reg (smull16 (put_in_reg x) (put_in_reg y) $false)))
+                       (imul (swiden_low x @ (value_type $I16X8))
+                             (swiden_low y @ (value_type $I16X8)))))
+      (smull16 x y $false))
 
 ;; Special case for `i32x4.extmul_high_i16x8_s`.
 (rule (lower (has_type $I32X4
-                       (imul (def_inst (swiden_high x @ (value_type $I16X8)))
-                             (def_inst (swiden_high y @ (value_type $I16X8))))))
-      (value_reg (smull16 (put_in_reg x) (put_in_reg y) $true)))
+                       (imul (swiden_high x @ (value_type $I16X8))
+                             (swiden_high y @ (value_type $I16X8)))))
+      (smull16 x y $true))
 
 ;; Special case for `i32x4.extmul_low_i16x8_u`.
 (rule (lower (has_type $I32X4
-                       (imul (def_inst (uwiden_low x @ (value_type $I16X8)))
-                             (def_inst (uwiden_low y @ (value_type $I16X8))))))
-      (value_reg (umull16 (put_in_reg x) (put_in_reg y) $false)))
+                       (imul (uwiden_low x @ (value_type $I16X8))
+                             (uwiden_low y @ (value_type $I16X8)))))
+      (umull16 x y $false))
 
 ;; Special case for `i32x4.extmul_high_i16x8_u`.
 (rule (lower (has_type $I32X4
-                       (imul (def_inst (uwiden_high x @ (value_type $I16X8)))
-                             (def_inst (uwiden_high y @ (value_type $I16X8))))))
-      (value_reg (umull16 (put_in_reg x) (put_in_reg y) $true)))
+                       (imul (uwiden_high x @ (value_type $I16X8))
+                             (uwiden_high y @ (value_type $I16X8)))))
+      (umull16 x y $true))
 
 ;; Special case for `i64x2.extmul_low_i32x4_s`.
 (rule (lower (has_type $I64X2
-                       (imul (def_inst (swiden_low x @ (value_type $I32X4)))
-                             (def_inst (swiden_low y @ (value_type $I32X4))))))
-      (value_reg (smull32 (put_in_reg x) (put_in_reg y) $false)))
+                       (imul (swiden_low x @ (value_type $I32X4))
+                             (swiden_low y @ (value_type $I32X4)))))
+      (smull32 x y $false))
 
 ;; Special case for `i64x2.extmul_high_i32x4_s`.
 (rule (lower (has_type $I64X2
-                       (imul (def_inst (swiden_high x @ (value_type $I32X4)))
-                             (def_inst (swiden_high y @ (value_type $I32X4))))))
-      (value_reg (smull32 (put_in_reg x) (put_in_reg y) $true)))
+                       (imul (swiden_high x @ (value_type $I32X4))
+                             (swiden_high y @ (value_type $I32X4)))))
+      (smull32 x y $true))
 
 ;; Special case for `i64x2.extmul_low_i32x4_u`.
 (rule (lower (has_type $I64X2
-                       (imul (def_inst (uwiden_low x @ (value_type $I32X4)))
-                             (def_inst (uwiden_low y @ (value_type $I32X4))))))
-      (value_reg (umull32 (put_in_reg x) (put_in_reg y) $false)))
+                       (imul (uwiden_low x @ (value_type $I32X4))
+                             (uwiden_low y @ (value_type $I32X4)))))
+      (umull32 x y $false))
 
 ;; Special case for `i64x2.extmul_high_i32x4_u`.
 (rule (lower (has_type $I64X2
-                       (imul (def_inst (uwiden_high x @ (value_type $I32X4)))
-                             (def_inst (uwiden_high y @ (value_type $I32X4))))))
-      (value_reg (umull32 (put_in_reg x) (put_in_reg y) $true)))
+                       (imul (uwiden_high x @ (value_type $I32X4))
+                             (uwiden_high y @ (value_type $I32X4)))))
+      (umull32 x y $true))
 
 ;;;; Rules for `smulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I64 (smulhi x y)))
-      (value_reg (smulh $I64 (put_in_reg x) (put_in_reg y))))
+      (smulh $I64 x y))
 
 (rule (lower (has_type (fits_in_32 ty) (smulhi x y)))
-      (let (
-          (x64 Reg (put_in_reg_sext64 x))
-          (y64 Reg (put_in_reg_sext64 y))
-          (mul Reg (madd64 x64 y64 (zero_reg)))
-          (result Reg (asr_imm $I64 mul (imm_shift_from_u8 (ty_bits ty))))
-        )
-        (value_reg result)))
+      (let ((x64 Reg (put_in_reg_sext64 x))
+            (y64 Reg (put_in_reg_sext64 y))
+            (mul Reg (madd64 x64 y64 (zero_reg)))
+            (result Reg (asr_imm $I64 mul (imm_shift_from_u8 (ty_bits ty)))))
+        result))
 
 ;;;; Rules for `umulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I64 (umulhi x y)))
-      (value_reg (umulh $I64 (put_in_reg x) (put_in_reg y))))
+      (umulh $I64 x y))
 
 (rule (lower (has_type (fits_in_32 ty) (umulhi x y)))
-      (let (
-          (x64 Reg (put_in_reg_zext64 x))
-          (y64 Reg (put_in_reg_zext64 y))
-          (mul Reg (madd64 x64 y64 (zero_reg)))
-          (result Reg (lsr_imm $I64 mul (imm_shift_from_u8 (ty_bits ty))))
-        )
-        (value_reg result)))
+      (let ((x64 Reg (put_in_reg_zext64 x))
+            (y64 Reg (put_in_reg_zext64 y))
+            (mul Reg (madd64 x64 y64 (zero_reg)))
+            (result Reg (lsr_imm $I64 mul (imm_shift_from_u8 (ty_bits ty)))))
+        result))
 
 ;;;; Rules for `udiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -391,7 +382,7 @@
 ;; Note that aarch64's `udiv` doesn't trap so to respect the semantics of
 ;; CLIF's `udiv` the check for zero needs to be manually performed.
 (rule (lower (has_type (fits_in_64 ty) (udiv x y)))
-      (value_reg (a64_udiv $I64 (put_in_reg_zext64 x) (put_nonzero_in_reg_zext64 y))))
+      (a64_udiv $I64 (put_in_reg_zext64 x) (put_nonzero_in_reg_zext64 y)))
 
 ;; Helper for placing a `Value` into a `Reg` and validating that it's nonzero.
 (decl put_nonzero_in_reg_zext64 (Value) Reg)
@@ -401,7 +392,7 @@
 ;; Special case where if a `Value` is known to be nonzero we can trivially
 ;; move it into a register.
 (rule (put_nonzero_in_reg_zext64 (and (value_type ty)
-                                      (def_inst (iconst (nonzero_u64_from_imm64 n)))))
+                                      (iconst (nonzero_u64_from_imm64 n))))
       (imm ty n))
 
 ;;;; Rules for `sdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -424,13 +415,11 @@
 ;; TODO: if `y` is -1 then a check that `x` is not INT_MIN is all that's
 ;; necessary, but right now `y` is checked to not be -1 as well.
 (rule (lower (has_type (fits_in_64 ty) (sdiv x y)))
-      (let (
-          (x64 Reg (put_in_reg_sext64 x))
-          (y64 Reg (put_nonzero_in_reg_sext64 y))
-          (valid_x64 Reg (trap_if_div_overflow ty x64 y64))
-          (result Reg (a64_sdiv $I64 valid_x64 y64))
-        )
-        (value_reg result)))
+      (let ((x64 Reg (put_in_reg_sext64 x))
+            (y64 Reg (put_nonzero_in_reg_sext64 y))
+            (valid_x64 Reg (trap_if_div_overflow ty x64 y64))
+            (result Reg (a64_sdiv $I64 valid_x64 y64)))
+        result))
 
 ;; Helper for extracting an immediate that's not 0 and not -1 from an imm64.
 (decl safe_divisor_from_imm64 (u64) Imm64)
@@ -438,8 +427,8 @@
 
 ;; Special case for `sdiv` where no checks are needed due to division by a
 ;; constant meaning the checks are always passed.
-(rule (lower (has_type (fits_in_64 ty) (sdiv x (def_inst (iconst (safe_divisor_from_imm64 y))))))
-      (value_reg (a64_sdiv $I64 (put_in_reg_sext64 x) (imm ty y))))
+(rule (lower (has_type (fits_in_64 ty) (sdiv x (iconst (safe_divisor_from_imm64 y)))))
+      (a64_sdiv $I64 (put_in_reg_sext64 x) (imm ty y)))
 
 ;; Helper for placing a `Value` into a `Reg` and validating that it's nonzero.
 (decl put_nonzero_in_reg_sext64 (Value) Reg)
@@ -449,7 +438,7 @@
 ;; Note that this has a special case where if the `Value` is a constant that's
 ;; not zero we can skip the zero check.
 (rule (put_nonzero_in_reg_sext64 (and (value_type ty)
-                                      (def_inst (iconst (nonzero_u64_from_imm64 n)))))
+                                      (iconst (nonzero_u64_from_imm64 n))))
       (imm ty n))
 
 ;;;; Rules for `urem` and `srem` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -467,42 +456,38 @@
 ;;   msub rd, rd, y, x  ; rd = x - rd * y
 
 (rule (lower (has_type (fits_in_64 ty) (urem x y)))
-      (let (
-          (x64 Reg (put_in_reg_zext64 x))
-          (y64 Reg (put_nonzero_in_reg_zext64 y))
-          (div Reg (a64_udiv $I64 x64 y64))
-          (result Reg (msub64 div y64 x64))
-        )
-        (value_reg result)))
+      (let ((x64 Reg (put_in_reg_zext64 x))
+            (y64 Reg (put_nonzero_in_reg_zext64 y))
+            (div Reg (a64_udiv $I64 x64 y64))
+            (result Reg (msub64 div y64 x64)))
+        result))
 
 (rule (lower (has_type (fits_in_64 ty) (srem x y)))
-      (let (
-          (x64 Reg (put_in_reg_sext64 x))
-          (y64 Reg (put_nonzero_in_reg_sext64 y))
-          (div Reg (a64_sdiv $I64 x64 y64))
-          (result Reg (msub64 div y64 x64))
-        )
-        (value_reg result)))
+      (let ((x64 Reg (put_in_reg_sext64 x))
+            (y64 Reg (put_nonzero_in_reg_sext64 y))
+            (div Reg (a64_sdiv $I64 x64 y64))
+            (result Reg (msub64 div y64 x64)))
+        result))
 
 ;;;; Rules for `uextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; General rule for extending input to an output which fits in a single
 ;; register.
 (rule (lower (has_type (fits_in_64 out) (uextend x @ (value_type in))))
-      (value_reg (extend (put_in_reg x) $false (ty_bits in) (ty_bits out))))
+      (extend x $false (ty_bits in) (ty_bits out)))
 
 ;; Extraction of a vector lane automatically extends as necessary, so we can
 ;; skip an explicit extending instruction.
 (rule (lower (has_type (fits_in_64 out)
-                       (uextend (def_inst (extractlane vec @ (value_type in)
-                                                       (u8_from_uimm8 lane))))))
-      (value_reg (mov_from_vec (put_in_reg vec) lane (vector_size in))))
+                       (uextend (extractlane vec @ (value_type in)
+                                             (u8_from_uimm8 lane)))))
+      (mov_from_vec (put_in_reg vec) lane (vector_size in)))
 
 ;; Atomic loads will also automatically zero their upper bits so the `uextend`
 ;; instruction can effectively get skipped here.
 (rule (lower (has_type (fits_in_64 out)
                        (uextend (and (value_type in) (sinkable_atomic_load addr)))))
-      (value_reg (load_acquire in (sink_atomic_load addr))))
+      (load_acquire in (sink_atomic_load addr)))
 
 ;; Conversion to 128-bit needs a zero-extension of the lower bits and the upper
 ;; bits are all zero.
@@ -512,8 +497,8 @@
 ;; Like above where vector extraction automatically zero-extends extending to
 ;; i128 only requires generating a 0 constant for the upper bits.
 (rule (lower (has_type $I128
-                       (uextend (def_inst (extractlane vec @ (value_type in)
-                                                       (u8_from_uimm8 lane))))))
+                       (uextend (extractlane vec @ (value_type in)
+                                             (u8_from_uimm8 lane)))))
       (value_regs (mov_from_vec (put_in_reg vec) lane (vector_size in)) (imm $I64 0)))
 
 ;;;; Rules for `sextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -521,24 +506,22 @@
 ;; General rule for extending input to an output which fits in a single
 ;; register.
 (rule (lower (has_type (fits_in_64 out) (sextend x @ (value_type in))))
-      (value_reg (extend (put_in_reg x) $true (ty_bits in) (ty_bits out))))
+      (extend x $true (ty_bits in) (ty_bits out)))
 
 ;; Extraction of a vector lane automatically extends as necessary, so we can
 ;; skip an explicit extending instruction.
 (rule (lower (has_type (fits_in_64 out)
-                       (sextend (def_inst (extractlane vec @ (value_type in)
-                                                       (u8_from_uimm8 lane))))))
-      (value_reg (mov_from_vec_signed (put_in_reg vec)
-                                      lane
-                                      (vector_size in)
-                                      (size_from_ty out))))
+                       (sextend (extractlane vec @ (value_type in)
+                                             (u8_from_uimm8 lane)))))
+      (mov_from_vec_signed (put_in_reg vec)
+                           lane
+                           (vector_size in)
+                           (size_from_ty out)))
 
 ;; 64-bit to 128-bit only needs to sign-extend the input to the upper bits.
 (rule (lower (has_type $I128 (sextend x)))
-      (let (
-          (lo Reg (put_in_reg_sext64 x))
-          (hi Reg (asr_imm $I64 lo (imm_shift_from_u8 63)))
-        )
+      (let ((lo Reg (put_in_reg_sext64 x))
+            (hi Reg (asr_imm $I64 lo (imm_shift_from_u8 63))))
         (value_regs lo hi)))
 
 ;; Like above where vector extraction automatically zero-extends extending to
@@ -547,27 +530,23 @@
 ;; Note that `mov_from_vec_signed` doesn't exist for i64x2, so that's
 ;; specifically excluded here.
 (rule (lower (has_type $I128
-                       (sextend (def_inst (extractlane vec @ (value_type in @ (not_i64x2))
-                                                       (u8_from_uimm8 lane))))))
-      (let (
-          (lo Reg (mov_from_vec_signed (put_in_reg vec)
-                                       lane
-                                       (vector_size in)
-                                       (size_from_ty $I64)))
-          (hi Reg (asr_imm $I64 lo (imm_shift_from_u8 63)))
-        )
+                       (sextend (extractlane vec @ (value_type in @ (not_i64x2))
+                                             (u8_from_uimm8 lane)))))
+      (let ((lo Reg (mov_from_vec_signed (put_in_reg vec)
+                                         lane
+                                         (vector_size in)
+                                         (size_from_ty $I64)))
+            (hi Reg (asr_imm $I64 lo (imm_shift_from_u8 63))))
         (value_regs lo hi)))
 
 ;; Extension from an extraction of i64x2 into i128.
 (rule (lower (has_type $I128
-                       (sextend (def_inst (extractlane vec @ (value_type $I64X2)
-                                                       (u8_from_uimm8 lane))))))
-      (let (
-          (lo Reg (mov_from_vec (put_in_reg vec)
-                                lane
-                                (VectorSize.Size64x2)))
-          (hi Reg (asr_imm $I64 lo (imm_shift_from_u8 63)))
-        )
+                       (sextend (extractlane vec @ (value_type $I64X2)
+                                             (u8_from_uimm8 lane)))))
+      (let ((lo Reg (mov_from_vec (put_in_reg vec)
+                                  lane
+                                  (VectorSize.Size64x2)))
+            (hi Reg (asr_imm $I64 lo (imm_shift_from_u8 63))))
         (value_regs lo hi)))
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -578,98 +557,96 @@
 ;;
 ;;      NOT rd, rm ==> ORR_NOT rd, zero, rm
 (rule (lower (has_type (fits_in_64 ty) (bnot x)))
-      (value_reg (orr_not ty (zero_reg) (put_in_reg x))))
+      (orr_not ty (zero_reg) x))
 
 ;; Special case to use `orr_not_shift` if it's a `bnot` of a const-left-shifted
 ;; value.
 (rule (lower (has_type (fits_in_64 ty)
-                       (bnot (def_inst (ishl x (def_inst (iconst (lshl_from_imm64 <ty amt))))))))
-      (value_reg (orr_not_shift ty (zero_reg) (put_in_reg x) amt)))
+                       (bnot (ishl x (iconst (lshl_from_imm64 <ty amt))))))
+      (orr_not_shift ty (zero_reg) x amt))
 
 ;; Implementation of `bnot` for `i128`.
 (rule (lower (has_type $I128 (bnot x)))
-      (let (
-          (x_regs ValueRegs (put_in_regs x))
-          (x_lo Reg (value_regs_get x_regs 0))
-          (x_hi Reg (value_regs_get x_regs 1))
-          (new_lo Reg (orr_not $I64 (zero_reg) x_lo))
-          (new_hi Reg (orr_not $I64 (zero_reg) x_hi))
-        )
+      (let ((x_regs ValueRegs x)
+            (x_lo Reg (value_regs_get x_regs 0))
+            (x_hi Reg (value_regs_get x_regs 1))
+            (new_lo Reg (orr_not $I64 (zero_reg) x_lo))
+            (new_hi Reg (orr_not $I64 (zero_reg) x_hi)))
         (value_regs new_lo new_hi)))
 
 ;; Implementation of `bnot` for vector types.
 (rule (lower (has_type (vec128 ty) (bnot x)))
-      (value_reg (not (put_in_reg x) (vector_size ty))))
+      (not x (vector_size ty)))
 
 ;;;; Rules for `band` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (fits_in_32 ty) (band x y)))
-      (value_reg (alu_rs_imm_logic_commutative (ALUOp.And) ty x y)))
+      (alu_rs_imm_logic_commutative (ALUOp.And) ty x y))
 
 (rule (lower (has_type $I64 (band x y)))
-      (value_reg (alu_rs_imm_logic_commutative (ALUOp.And) $I64 x y)))
+      (alu_rs_imm_logic_commutative (ALUOp.And) $I64 x y))
 
 (rule (lower (has_type $I128 (band x y))) (i128_alu_bitop (ALUOp.And) $I64 x y))
 
 (rule (lower (has_type (vec128 ty) (band x y)))
-      (value_reg (and_vec (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (and_vec x y (vector_size ty)))
 
 ;;;; Rules for `bor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (fits_in_32 ty) (bor x y)))
-      (value_reg (alu_rs_imm_logic_commutative (ALUOp.Orr) ty x y)))
+      (alu_rs_imm_logic_commutative (ALUOp.Orr) ty x y))
 
 (rule (lower (has_type $I64 (bor x y)))
-      (value_reg (alu_rs_imm_logic_commutative (ALUOp.Orr) $I64 x y)))
+      (alu_rs_imm_logic_commutative (ALUOp.Orr) $I64 x y))
 
 (rule (lower (has_type $I128 (bor x y))) (i128_alu_bitop (ALUOp.Orr) $I64 x y))
 
 (rule (lower (has_type (vec128 ty) (bor x y)))
-      (value_reg (orr_vec (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (orr_vec x y (vector_size ty)))
 
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (fits_in_32 ty) (bxor x y)))
-      (value_reg (alu_rs_imm_logic_commutative (ALUOp.Eor) ty x y)))
+      (alu_rs_imm_logic_commutative (ALUOp.Eor) ty x y))
 
 (rule (lower (has_type $I64 (bxor x y)))
-      (value_reg (alu_rs_imm_logic_commutative (ALUOp.Eor) $I64 x y)))
+      (alu_rs_imm_logic_commutative (ALUOp.Eor) $I64 x y))
 
 (rule (lower (has_type $I128 (bxor x y))) (i128_alu_bitop (ALUOp.Eor) $I64 x y))
 
 (rule (lower (has_type (vec128 ty) (bxor x y)))
-      (value_reg (eor_vec (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (eor_vec x y (vector_size ty)))
 
 ;;;; Rules for `band_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (fits_in_32 ty) (band_not x y)))
-      (value_reg (alu_rs_imm_logic (ALUOp.AndNot) ty x y)))
+      (alu_rs_imm_logic (ALUOp.AndNot) ty x y))
 
 (rule (lower (has_type $I64 (band_not x y)))
-      (value_reg (alu_rs_imm_logic (ALUOp.AndNot) $I64 x y)))
+      (alu_rs_imm_logic (ALUOp.AndNot) $I64 x y))
 
 (rule (lower (has_type $I128 (band_not x y))) (i128_alu_bitop (ALUOp.AndNot) $I64 x y))
 
 (rule (lower (has_type (vec128 ty) (band_not x y)))
-      (value_reg (bic_vec (put_in_reg x) (put_in_reg y) (vector_size ty))))
+      (bic_vec x y (vector_size ty)))
 
 ;;;; Rules for `bor_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (fits_in_32 ty) (bor_not x y)))
-      (value_reg (alu_rs_imm_logic (ALUOp.OrrNot) ty x y)))
+      (alu_rs_imm_logic (ALUOp.OrrNot) ty x y))
 
 (rule (lower (has_type $I64 (bor_not x y)))
-      (value_reg (alu_rs_imm_logic (ALUOp.OrrNot) $I64 x y)))
+      (alu_rs_imm_logic (ALUOp.OrrNot) $I64 x y))
 
 (rule (lower (has_type $I128 (bor_not x y))) (i128_alu_bitop (ALUOp.OrrNot) $I64 x y))
 
 ;;;; Rules for `bxor_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (fits_in_32 ty) (bxor_not x y)))
-      (value_reg (alu_rs_imm_logic (ALUOp.EorNot) $I32 x y)))
+      (alu_rs_imm_logic (ALUOp.EorNot) $I32 x y))
 
 (rule (lower (has_type $I64 (bxor_not x y)))
-      (value_reg (alu_rs_imm_logic (ALUOp.EorNot) $I64 x y)))
+      (alu_rs_imm_logic (ALUOp.EorNot) $I64 x y))
 
 (rule (lower (has_type $I128 (bxor_not x y))) (i128_alu_bitop (ALUOp.EorNot) $I64 x y))
 
@@ -677,15 +654,15 @@
 
 ;; Shift for i8/i16/i32.
 (rule (lower (has_type (fits_in_32 ty) (ishl x y)))
-      (value_reg (do_shift (ALUOp.Lsl) ty (put_in_reg x) y)))
+      (do_shift (ALUOp.Lsl) ty x y))
 
 ;; Shift for i64.
 (rule (lower (has_type $I64 (ishl x y)))
-      (value_reg (do_shift (ALUOp.Lsl) $I64 (put_in_reg x) y)))
+      (do_shift (ALUOp.Lsl) $I64 x y))
 
 ;; Shift for i128.
 (rule (lower (has_type $I128 (ishl x y)))
-      (lower_shl128 (put_in_regs x) (value_regs_get (put_in_regs y) 0)))
+      (lower_shl128 x (value_regs_get y 0)))
 
 ;;     lsl     lo_lshift, src_lo, amt
 ;;     lsl     hi_lshift, src_hi, amt
@@ -698,13 +675,12 @@
 ;;     csel    dst_lo, xzr, lo_lshift, ne
 (decl lower_shl128 (ValueRegs Reg) ValueRegs)
 (rule (lower_shl128 src amt)
-      (let (
-          (src_lo Reg (value_regs_get src 0))
-          (src_hi Reg (value_regs_get src 1))
-          (lo_lshift Reg (lsl $I64 src_lo amt))
-          (hi_lshift Reg (lsl $I64 src_hi amt))
-          (inv_amt Reg (orr_not $I32 (zero_reg) amt))
-          (lo_rshift Reg (lsr $I64 (lsr_imm $I64 src_lo (imm_shift_from_u8 1))
+      (let ((src_lo Reg (value_regs_get src 0))
+            (src_hi Reg (value_regs_get src 1))
+            (lo_lshift Reg (lsl $I64 src_lo amt))
+            (hi_lshift Reg (lsl $I64 src_hi amt))
+            (inv_amt Reg (orr_not $I32 (zero_reg) amt))
+            (lo_rshift Reg (lsr $I64 (lsr_imm $I64 src_lo (imm_shift_from_u8 1))
                                 inv_amt))
           (maybe_hi Reg (orr $I64 hi_lshift lo_rshift))
         )
@@ -716,11 +692,9 @@
 
 ;; Shift for vector types.
 (rule (lower (has_type (vec128 ty) (ishl x y)))
-      (let (
-          (size VectorSize (vector_size ty))
-          (shift Reg (vec_dup (put_in_reg y) size))
-        )
-        (value_reg (sshl (put_in_reg x) shift size))))
+      (let ((size VectorSize (vector_size ty))
+            (shift Reg (vec_dup y size)))
+        (sshl x shift size)))
 
 ;; Helper function to emit a shift operation with the opcode specified and
 ;; the output type specified. The `Reg` provided is shifted by the `Value`
@@ -740,18 +714,16 @@
 ;; types (i16, i8) we need to do this manually, so we wrap the shift amount
 ;; with an AND instruction
 (rule (do_shift op (fits_in_16 ty) x y)
-      (let (
-          (shift_amt Reg (value_regs_get (put_in_regs y) 0))
-          (masked_shift_amt Reg (and_imm $I32 shift_amt (shift_mask ty)))
-        )
+      (let ((shift_amt Reg (value_regs_get y 0))
+            (masked_shift_amt Reg (and_imm $I32 shift_amt (shift_mask ty))))
         (alu_rrr op $I32 x masked_shift_amt)))
 
 (decl shift_mask (Type) ImmLogic)
 (extern constructor shift_mask shift_mask)
 
 ;; 32/64-bit shift base cases.
-(rule (do_shift op $I32 x y) (alu_rrr op $I32 x (value_regs_get (put_in_regs y) 0)))
-(rule (do_shift op $I64 x y) (alu_rrr op $I64 x (value_regs_get (put_in_regs y) 0)))
+(rule (do_shift op $I32 x y) (alu_rrr op $I32 x (value_regs_get y 0)))
+(rule (do_shift op $I64 x y) (alu_rrr op $I64 x (value_regs_get y 0)))
 
 ;; Special case for shifting by a constant value where the value can fit into an
 ;; `ImmShift`.
@@ -759,30 +731,28 @@
 ;; Note that this rule explicitly has a higher priority than the others
 ;; to ensure it's attempted first, otherwise the type-based filters on the
 ;; previous rules seem to take priority over this rule.
-(rule 1 (do_shift op ty x (def_inst (iconst (imm_shift_from_imm64 <ty shift))))
+(rule 1 (do_shift op ty x (iconst (imm_shift_from_imm64 <ty shift)))
       (alu_rr_imm_shift op ty x shift))
 
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Shift for i8/i16/i32.
 (rule (lower (has_type (fits_in_32 ty) (ushr x y)))
-      (value_reg (do_shift (ALUOp.Lsr) ty (put_in_reg_zext32 x) y)))
+      (do_shift (ALUOp.Lsr) ty (put_in_reg_zext32 x) y))
 
 ;; Shift for i64.
 (rule (lower (has_type $I64 (ushr x y)))
-      (value_reg (do_shift (ALUOp.Lsr) $I64 (put_in_reg_zext64 x) y)))
+      (do_shift (ALUOp.Lsr) $I64 (put_in_reg_zext64 x) y))
 
 ;; Shift for i128.
 (rule (lower (has_type $I128 (ushr x y)))
-      (lower_ushr128 (put_in_regs x) (value_regs_get (put_in_regs y) 0)))
+      (lower_ushr128 x (value_regs_get y 0)))
 
 ;; Vector shifts.
 (rule (lower (has_type (vec128 ty) (ushr x y)))
-      (let (
-          (size VectorSize (vector_size ty))
-          (shift Reg (vec_dup (sub $I32 (zero_reg) (put_in_reg y)) size))
-        )
-        (value_reg (ushl (put_in_reg x) shift size))))
+      (let ((size VectorSize (vector_size ty))
+            (shift Reg (vec_dup (sub $I32 (zero_reg) y) size)))
+        (ushl x shift size)))
 
 ;;     lsr       lo_rshift, src_lo, amt
 ;;     lsr       hi_rshift, src_hi, amt
@@ -795,14 +765,13 @@
 ;;     csel      dst_lo, hi_rshift, maybe_lo, ne
 (decl lower_ushr128 (ValueRegs Reg) ValueRegs)
 (rule (lower_ushr128 src amt)
-      (let (
-          (src_lo Reg (value_regs_get src 0))
-          (src_hi Reg (value_regs_get src 1))
-          (lo_rshift Reg (lsr $I64 src_lo amt))
-          (hi_rshift Reg (lsr $I64 src_hi amt))
-
-          (inv_amt Reg (orr_not $I32 (zero_reg) amt))
-          (hi_lshift Reg (lsl $I64 (lsl_imm $I64 src_hi (imm_shift_from_u8 1))
+      (let ((src_lo Reg (value_regs_get src 0))
+            (src_hi Reg (value_regs_get src 1))
+            (lo_rshift Reg (lsr $I64 src_lo amt))
+            (hi_rshift Reg (lsr $I64 src_hi amt))
+            
+            (inv_amt Reg (orr_not $I32 (zero_reg) amt))
+            (hi_lshift Reg (lsl $I64 (lsl_imm $I64 src_hi (imm_shift_from_u8 1))
                                 inv_amt))
           (maybe_lo Reg (orr $I64 lo_rshift hi_lshift))
         )
@@ -816,25 +785,23 @@
 
 ;; Shift for i8/i16/i32.
 (rule (lower (has_type (fits_in_32 ty) (sshr x y)))
-      (value_reg (do_shift (ALUOp.Asr) ty (put_in_reg_sext32 x) y)))
+      (do_shift (ALUOp.Asr) ty (put_in_reg_sext32 x) y))
 
 ;; Shift for i64.
 (rule (lower (has_type $I64 (sshr x y)))
-      (value_reg (do_shift (ALUOp.Asr) $I64 (put_in_reg_sext64 x) y)))
+      (do_shift (ALUOp.Asr) $I64 (put_in_reg_sext64 x) y))
 
 ;; Shift for i128.
 (rule (lower (has_type $I128 (sshr x y)))
-      (lower_sshr128 (put_in_regs x) (value_regs_get (put_in_regs y) 0)))
+      (lower_sshr128 x (value_regs_get y 0)))
 
 ;; Vector shifts.
 ;;
 ;; Note that right shifts are implemented with a negative left shift.
 (rule (lower (has_type (vec128 ty) (sshr x y)))
-      (let (
-          (size VectorSize (vector_size ty))
-          (shift Reg (vec_dup (sub $I32 (zero_reg) (put_in_reg y)) size))
-        )
-        (value_reg (sshl (put_in_reg x) shift size))))
+      (let ((size VectorSize (vector_size ty))
+            (shift Reg (vec_dup (sub $I32 (zero_reg) y) size)))
+        (sshl x shift size)))
 
 ;;     lsr       lo_rshift, src_lo, amt
 ;;     asr       hi_rshift, src_hi, amt
@@ -848,14 +815,13 @@
 ;;     csel      dst_lo, hi_rshift, maybe_lo, ne
 (decl lower_sshr128 (ValueRegs Reg) ValueRegs)
 (rule (lower_sshr128 src amt)
-      (let (
-          (src_lo Reg (value_regs_get src 0))
-          (src_hi Reg (value_regs_get src 1))
-          (lo_rshift Reg (lsr $I64 src_lo amt))
-          (hi_rshift Reg (asr $I64 src_hi amt))
+      (let ((src_lo Reg (value_regs_get src 0))
+            (src_hi Reg (value_regs_get src 1))
+            (lo_rshift Reg (lsr $I64 src_lo amt))
+            (hi_rshift Reg (asr $I64 src_hi amt))
 
-          (inv_amt Reg (orr_not $I32 (zero_reg) amt))
-          (hi_lshift Reg (lsl $I64 (lsl_imm $I64 src_hi (imm_shift_from_u8 1))
+            (inv_amt Reg (orr_not $I32 (zero_reg) amt))
+            (hi_lshift Reg (lsl $I64 (lsl_imm $I64 src_hi (imm_shift_from_u8 1))
                                 inv_amt))
           (hi_sign Reg (asr_imm $I64 src_hi (imm_shift_from_u8 63)))
           (maybe_lo Reg (orr $I64 lo_rshift hi_lshift))
@@ -870,12 +836,12 @@
 
 ;; General 8/16-bit case.
 (rule (lower (has_type (fits_in_16 ty) (rotl x y)))
-      (let ((neg_shift Reg (sub $I32 (zero_reg) (put_in_reg y))))
-        (value_reg (small_rotr ty (put_in_reg_zext32 x) neg_shift))))
+      (let ((neg_shift Reg (sub $I32 (zero_reg) y)))
+        (small_rotr ty (put_in_reg_zext32 x) neg_shift)))
 
 ;; Specialization for the 8/16-bit case when the rotation amount is an immediate.
-(rule (lower (has_type (fits_in_16 ty) (rotl x (def_inst (iconst (imm_shift_from_imm64 <ty n))))))
-      (value_reg (small_rotr_imm ty (put_in_reg_zext32 x) (negate_imm_shift ty n))))
+(rule (lower (has_type (fits_in_16 ty) (rotl x (iconst (imm_shift_from_imm64 <ty n)))))
+      (small_rotr_imm ty (put_in_reg_zext32 x) (negate_imm_shift ty n)))
 
 ;; aarch64 doesn't have a left-rotate instruction, but a left rotation of K
 ;; places is effectively a right rotation of N - K places, if N is the integer's
@@ -887,21 +853,21 @@
 
 ;; General 32-bit case.
 (rule (lower (has_type $I32 (rotl x y)))
-      (let ((neg_shift Reg (sub $I32 (zero_reg) (put_in_reg y))))
-        (value_reg (a64_rotr $I32 (put_in_reg x) neg_shift))))
+      (let ((neg_shift Reg (sub $I32 (zero_reg) y)))
+        (a64_rotr $I32 x neg_shift)))
 
 ;; General 64-bit case.
 (rule (lower (has_type $I64 (rotl x y)))
-      (let ((neg_shift Reg (sub $I64 (zero_reg) (put_in_reg y))))
-        (value_reg (a64_rotr $I64 (put_in_reg x) neg_shift))))
+      (let ((neg_shift Reg (sub $I64 (zero_reg) y)))
+        (a64_rotr $I64 x neg_shift)))
 
 ;; Specialization for the 32-bit case when the rotation amount is an immediate.
-(rule (lower (has_type $I32 (rotl x (def_inst (iconst (imm_shift_from_imm64 <$I32 n))))))
-      (value_reg (a64_rotr_imm $I32 (put_in_reg x) (negate_imm_shift $I32 n))))
+(rule (lower (has_type $I32 (rotl x (iconst (imm_shift_from_imm64 <$I32 n)))))
+      (a64_rotr_imm $I32 x (negate_imm_shift $I32 n)))
 
 ;; Specialization for the 64-bit case when the rotation amount is an immediate.
-(rule (lower (has_type $I64 (rotl x (def_inst (iconst (imm_shift_from_imm64 <$I64 n))))))
-      (value_reg (a64_rotr_imm $I64 (put_in_reg x) (negate_imm_shift $I64 n))))
+(rule (lower (has_type $I64 (rotl x (iconst (imm_shift_from_imm64 <$I64 n)))))
+      (a64_rotr_imm $I64 x (negate_imm_shift $I64 n)))
 
 (decl negate_imm_shift (Type ImmShift) ImmShift)
 (extern constructor negate_imm_shift negate_imm_shift)
@@ -910,13 +876,11 @@
 ;;
 ;; TODO: much better codegen is possible with a constant amount.
 (rule (lower (has_type $I128 (rotl x y)))
-      (let (
-          (val ValueRegs (put_in_regs x))
-          (amt Reg (value_regs_get (put_in_regs y) 0))
-          (neg_amt Reg (sub $I64 (imm $I64 128) amt))
-          (lshift ValueRegs (lower_shl128 val amt))
-          (rshift ValueRegs (lower_ushr128 val neg_amt))
-        )
+      (let ((val ValueRegs x)
+            (amt Reg (value_regs_get y 0))
+            (neg_amt Reg (sub $I64 (imm $I64 128) amt))
+            (lshift ValueRegs (lower_shl128 val amt))
+            (rshift ValueRegs (lower_ushr128 val neg_amt)))
         (value_regs
           (orr $I64 (value_regs_get lshift 0) (value_regs_get rshift 0))
           (orr $I64 (value_regs_get lshift 1) (value_regs_get rshift 1)))))
@@ -925,27 +889,27 @@
 
 ;; General 8/16-bit case.
 (rule (lower (has_type (fits_in_16 ty) (rotr x y)))
-      (value_reg (small_rotr ty (put_in_reg_zext32 x) (put_in_reg y))))
+      (small_rotr ty (put_in_reg_zext32 x) y))
 
 ;; General 32-bit case.
 (rule (lower (has_type $I32 (rotr x y)))
-      (value_reg (a64_rotr $I32 (put_in_reg x) (put_in_reg y))))
+      (a64_rotr $I32 x y))
 
 ;; General 64-bit case.
 (rule (lower (has_type $I64 (rotr x y)))
-      (value_reg (a64_rotr $I64 (put_in_reg x) (put_in_reg y))))
+      (a64_rotr $I64 x y))
 
 ;; Specialization for the 8/16-bit case when the rotation amount is an immediate.
-(rule (lower (has_type (fits_in_16 ty) (rotr x (def_inst (iconst (imm_shift_from_imm64 <ty n))))))
-      (value_reg (small_rotr_imm ty (put_in_reg_zext32 x) n)))
+(rule (lower (has_type (fits_in_16 ty) (rotr x (iconst (imm_shift_from_imm64 <ty n)))))
+      (small_rotr_imm ty (put_in_reg_zext32 x) n))
 
 ;; Specialization for the 32-bit case when the rotation amount is an immediate.
-(rule (lower (has_type $I32 (rotr x (def_inst (iconst (imm_shift_from_imm64 <$I32 n))))))
-      (value_reg (a64_rotr_imm $I32 (put_in_reg x) n)))
+(rule (lower (has_type $I32 (rotr x (iconst (imm_shift_from_imm64 <$I32 n)))))
+      (a64_rotr_imm $I32 x n))
 
 ;; Specialization for the 64-bit case when the rotation amount is an immediate.
-(rule (lower (has_type $I64 (rotr x (def_inst (iconst (imm_shift_from_imm64 <$I64 n))))))
-      (value_reg (a64_rotr_imm $I64 (put_in_reg x) n)))
+(rule (lower (has_type $I64 (rotr x (iconst (imm_shift_from_imm64 <$I64 n)))))
+      (a64_rotr_imm $I64 x n))
 
 ;; For a < 32-bit rotate-right, we synthesize this as:
 ;;
@@ -961,13 +925,11 @@
 ;;    orr rd, val_lshift val_rshift
 (decl small_rotr (Type Reg Reg) Reg)
 (rule (small_rotr ty val amt)
-      (let (
-          (masked_amt Reg (and_imm $I32 amt (rotr_mask ty)))
-          (tmp_sub Reg (sub_imm $I32 masked_amt (u8_into_imm12 (ty_bits ty))))
-          (neg_amt Reg (sub $I32 (zero_reg) tmp_sub))
-          (val_rshift Reg (lsr $I32 val masked_amt))
-          (val_lshift Reg (lsl $I32 val neg_amt))
-        )
+      (let ((masked_amt Reg (and_imm $I32 amt (rotr_mask ty)))
+            (tmp_sub Reg (sub_imm $I32 masked_amt (u8_into_imm12 (ty_bits ty))))
+            (neg_amt Reg (sub $I32 (zero_reg) tmp_sub))
+            (val_rshift Reg (lsr $I32 val masked_amt))
+            (val_lshift Reg (lsl $I32 val neg_amt)))
         (orr $I32 val_lshift val_rshift)))
 
 (decl rotr_mask (Type) ImmLogic)
@@ -984,10 +946,8 @@
 ;;    orr rd, val_lshift, val_rshift
 (decl small_rotr_imm (Type Reg ImmShift) Reg)
 (rule (small_rotr_imm ty val amt)
-      (let (
-          (val_rshift Reg (lsr_imm $I32 val amt))
-          (val_lshift Reg (lsl_imm $I32 val (rotr_opposite_amount ty amt)))
-        )
+      (let ((val_rshift Reg (lsr_imm $I32 val amt))
+            (val_lshift Reg (lsl_imm $I32 val (rotr_opposite_amount ty amt))))
         (orr $I32 val_lshift val_rshift)))
 
 (decl rotr_opposite_amount (Type ImmShift) ImmShift)
@@ -997,15 +957,13 @@
 ;;
 ;; TODO: much better codegen is possible with a constant amount.
 (rule (lower (has_type $I128 (rotr x y)))
-      (let (
-          (val ValueRegs (put_in_regs x))
-          (amt Reg (value_regs_get (put_in_regs y) 0))
-          (neg_amt Reg (sub $I64 (imm $I64 128) amt))
-          (rshift ValueRegs (lower_ushr128 val amt))
-          (lshift ValueRegs (lower_shl128 val neg_amt))
-          (hi Reg (orr $I64 (value_regs_get rshift 1) (value_regs_get lshift 1)))
-          (lo Reg (orr $I64 (value_regs_get rshift 0) (value_regs_get lshift 0)))
-        )
+      (let ((val ValueRegs x)
+            (amt Reg (value_regs_get y 0))
+            (neg_amt Reg (sub $I64 (imm $I64 128) amt))
+            (rshift ValueRegs (lower_ushr128 val amt))
+            (lshift ValueRegs (lower_shl128 val neg_amt))
+            (hi Reg (orr $I64 (value_regs_get rshift 1) (value_regs_get lshift 1)))
+            (lo Reg (orr $I64 (value_regs_get rshift 0) (value_regs_get lshift 0))))
         (value_regs lo hi)))
 
 ;;;; Rules for `bitrev` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1014,39 +972,37 @@
 ;; the reversed result in the highest 8 bits, so we need to shift them down into
 ;; place.
 (rule (lower (has_type $I8 (bitrev x)))
-      (value_reg (lsr_imm $I32 (rbit $I32 (put_in_reg x)) (imm_shift_from_u8 24))))
+      (lsr_imm $I32 (rbit $I32 x) (imm_shift_from_u8 24)))
 
 ;; Reversing an 16-bit value with a 32-bit bitrev instruction will place
 ;; the reversed result in the highest 16 bits, so we need to shift them down into
 ;; place.
 (rule (lower (has_type $I16 (bitrev x)))
-      (value_reg (lsr_imm $I32 (rbit $I32 (put_in_reg x)) (imm_shift_from_u8 16))))
+      (lsr_imm $I32 (rbit $I32 x) (imm_shift_from_u8 16)))
 
 (rule (lower (has_type $I128 (bitrev x)))
-      (let (
-          (val ValueRegs (put_in_regs x))
-          (lo_rev Reg (rbit $I64 (value_regs_get val 0)))
-          (hi_rev Reg (rbit $I64 (value_regs_get val 1)))
-        )
+      (let ((val ValueRegs x)
+            (lo_rev Reg (rbit $I64 (value_regs_get val 0)))
+            (hi_rev Reg (rbit $I64 (value_regs_get val 1))))
         (value_regs hi_rev lo_rev)))
 
 (rule (lower (has_type ty (bitrev x)))
-      (value_reg (rbit ty (put_in_reg x))))
+      (rbit ty x))
 
 
 ;;;; Rules for `clz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I8 (clz x)))
-      (value_reg (sub_imm $I32 (a64_clz $I32 (put_in_reg_zext32 x)) (u8_into_imm12 24))))
+      (sub_imm $I32 (a64_clz $I32 (put_in_reg_zext32 x)) (u8_into_imm12 24)))
 
 (rule (lower (has_type $I16 (clz x)))
-      (value_reg (sub_imm $I32 (a64_clz $I32 (put_in_reg_zext32 x)) (u8_into_imm12 16))))
+      (sub_imm $I32 (a64_clz $I32 (put_in_reg_zext32 x)) (u8_into_imm12 16)))
 
 (rule (lower (has_type $I128 (clz x)))
-      (lower_clz128 (put_in_regs x)))
+      (lower_clz128 x))
 
 (rule (lower (has_type ty (clz x)))
-      (value_reg (a64_clz ty (put_in_reg x))))
+      (a64_clz ty x))
 
 ;; clz hi_clz, hi
 ;; clz lo_clz, lo
@@ -1055,12 +1011,10 @@
 ;; mov  dst_hi, 0
 (decl lower_clz128 (ValueRegs) ValueRegs)
 (rule (lower_clz128 val)
-      (let (
-        (hi_clz Reg (a64_clz $I64 (value_regs_get val 1)))
-        (lo_clz Reg (a64_clz $I64 (value_regs_get val 0)))
-        (tmp Reg (lsr_imm $I64 hi_clz (imm_shift_from_u8 6)))
-      )
-      (value_regs (madd64 lo_clz tmp hi_clz) (imm $I64 0))))
+      (let ((hi_clz Reg (a64_clz $I64 (value_regs_get val 1)))
+            (lo_clz Reg (a64_clz $I64 (value_regs_get val 0)))
+            (tmp Reg (lsr_imm $I64 hi_clz (imm_shift_from_u8 6))))
+        (value_regs (madd64 lo_clz tmp hi_clz) (imm $I64 0))))
 
 ;;;; Rules for `ctz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1069,29 +1023,27 @@
 ;; leading zeros of the reversed value.
 
 (rule (lower (has_type $I8 (ctz x)))
-      (value_reg (a64_clz $I32 (orr_imm $I32 (rbit $I32 (put_in_reg x)) (u64_into_imm_logic $I32 0x800000)))))
+      (a64_clz $I32 (orr_imm $I32 (rbit $I32 x) (u64_into_imm_logic $I32 0x800000))))
 
 (rule (lower (has_type $I16 (ctz x)))
-      (value_reg (a64_clz $I32 (orr_imm $I32 (rbit $I32 (put_in_reg x)) (u64_into_imm_logic $I32 0x8000)))))
+      (a64_clz $I32 (orr_imm $I32 (rbit $I32 x) (u64_into_imm_logic $I32 0x8000))))
 
 (rule (lower (has_type $I128 (ctz x)))
-      (let (
-        (val ValueRegs (put_in_regs x))
-        (lo Reg (rbit $I64 (value_regs_get val 0)))
-        (hi Reg (rbit $I64 (value_regs_get val 1)))
-      )
-      (lower_clz128 (value_regs hi lo))))
+      (let ((val ValueRegs x)
+            (lo Reg (rbit $I64 (value_regs_get val 0)))
+            (hi Reg (rbit $I64 (value_regs_get val 1))))
+        (lower_clz128 (value_regs hi lo))))
 
 (rule (lower (has_type ty (ctz x)))
-      (value_reg (a64_clz ty (rbit ty (put_in_reg x)))))
+      (a64_clz ty (rbit ty x)))
 
 ;;;; Rules for `cls` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I8 (cls x)))
-      (value_reg (sub_imm $I32 (a64_cls $I32 (put_in_reg_zext32 x)) (u8_into_imm12 24))))
+      (sub_imm $I32 (a64_cls $I32 (put_in_reg_zext32 x)) (u8_into_imm12 24)))
 
 (rule (lower (has_type $I16 (cls x)))
-      (value_reg (sub_imm $I32 (a64_cls $I32 (put_in_reg_zext32 x)) (u8_into_imm12 16))))
+      (sub_imm $I32 (a64_cls $I32 (put_in_reg_zext32 x)) (u8_into_imm12 16)))
 
 ;; cls lo_cls, lo
 ;; cls hi_cls, hi
@@ -1103,24 +1055,21 @@
 ;; add  out_lo, maybe_lo, hi_cls
 ;; mov  out_hi, 0
 (rule (lower (has_type $I128 (cls x)))
-      (let (
-          (val ValueRegs (put_in_regs x))
-          (lo Reg (value_regs_get val 0))
-          (hi Reg (value_regs_get val 1))
-          (lo_cls Reg (a64_cls $I64 lo))
-          (hi_cls Reg (a64_cls $I64 hi))
-          (sign_eq_eon Reg (eon $I64 hi lo))
-          (sign_eq Reg (lsr_imm $I64 sign_eq_eon (imm_shift_from_u8 63)))
-          (lo_sign_bits Reg (madd64 lo_cls sign_eq sign_eq))
-          (maybe_lo Reg (with_flags_reg
-                         (cmp64_imm hi_cls (u8_into_imm12 63))
-                         (csel (Cond.Eq) lo_sign_bits (zero_reg))
-          ))
-        )
+      (let ((val ValueRegs x)
+            (lo Reg (value_regs_get val 0))
+            (hi Reg (value_regs_get val 1))
+            (lo_cls Reg (a64_cls $I64 lo))
+            (hi_cls Reg (a64_cls $I64 hi))
+            (sign_eq_eon Reg (eon $I64 hi lo))
+            (sign_eq Reg (lsr_imm $I64 sign_eq_eon (imm_shift_from_u8 63)))
+            (lo_sign_bits Reg (madd64 lo_cls sign_eq sign_eq))
+            (maybe_lo Reg (with_flags_reg
+                           (cmp64_imm hi_cls (u8_into_imm12 63))
+                           (csel (Cond.Eq) lo_sign_bits (zero_reg)))))
         (value_regs (add $I64 maybe_lo hi_cls) (imm $I64 0))))
 
 (rule (lower (has_type ty (cls x)))
-      (value_reg (a64_cls ty (put_in_reg x))))
+      (a64_cls ty x))
 
 ;;;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1142,46 +1091,36 @@
 ;;         mov out_hi, 0
 
 (rule (lower (has_type $I8 (popcnt x)))
-      (let (
-          (tmp Reg (mov_to_fpu (put_in_reg x) (ScalarSize.Size32)))
-          (nbits Reg (vec_cnt tmp (VectorSize.Size8x8)))
-        )
-        (value_reg (mov_from_vec nbits 0 (VectorSize.Size8x16)))))
+      (let ((tmp Reg (mov_to_fpu x (ScalarSize.Size32)))
+            (nbits Reg (vec_cnt tmp (VectorSize.Size8x8))))
+        (mov_from_vec nbits 0 (VectorSize.Size8x16))))
 
 ;; Note that this uses `addp` instead of `addv` as it's usually cheaper.
 (rule (lower (has_type $I16 (popcnt x)))
-      (let (
-          (tmp Reg (mov_to_fpu (put_in_reg x) (ScalarSize.Size32)))
-          (nbits Reg (vec_cnt tmp (VectorSize.Size8x8)))
-          (added Reg (addp nbits nbits (VectorSize.Size8x8)))
-        )
-        (value_reg (mov_from_vec added 0 (VectorSize.Size8x16)))))
+      (let ((tmp Reg (mov_to_fpu x (ScalarSize.Size32)))
+            (nbits Reg (vec_cnt tmp (VectorSize.Size8x8)))
+            (added Reg (addp nbits nbits (VectorSize.Size8x8))))
+        (mov_from_vec added 0 (VectorSize.Size8x16))))
 
 (rule (lower (has_type $I32 (popcnt x)))
-      (let (
-          (tmp Reg (mov_to_fpu (put_in_reg x) (ScalarSize.Size32)))
-          (nbits Reg (vec_cnt tmp (VectorSize.Size8x8)))
-          (added Reg (addv nbits (VectorSize.Size8x8)))
-        )
-        (value_reg (mov_from_vec added 0 (VectorSize.Size8x16)))))
+      (let ((tmp Reg (mov_to_fpu x (ScalarSize.Size32)))
+            (nbits Reg (vec_cnt tmp (VectorSize.Size8x8)))
+            (added Reg (addv nbits (VectorSize.Size8x8))))
+        (mov_from_vec added 0 (VectorSize.Size8x16))))
 
 (rule (lower (has_type $I64 (popcnt x)))
-      (let (
-          (tmp Reg (mov_to_fpu (put_in_reg x) (ScalarSize.Size64)))
-          (nbits Reg (vec_cnt tmp (VectorSize.Size8x8)))
-          (added Reg (addv nbits (VectorSize.Size8x8)))
-        )
-        (value_reg (mov_from_vec added 0 (VectorSize.Size8x16)))))
+      (let ((tmp Reg (mov_to_fpu x (ScalarSize.Size64)))
+            (nbits Reg (vec_cnt tmp (VectorSize.Size8x8)))
+            (added Reg (addv nbits (VectorSize.Size8x8))))
+        (mov_from_vec added 0 (VectorSize.Size8x16))))
 
 (rule (lower (has_type $I128 (popcnt x)))
-      (let (
-          (val ValueRegs (put_in_regs x))
-          (tmp_half Reg (mov_to_fpu (value_regs_get val 0) (ScalarSize.Size64)))
-          (tmp Reg (mov_to_vec tmp_half (value_regs_get val 1) 1 (VectorSize.Size64x2)))
-          (nbits Reg (vec_cnt tmp (VectorSize.Size8x16)))
-          (added Reg (addv nbits (VectorSize.Size8x16)))
-        )
+      (let ((val ValueRegs x)
+            (tmp_half Reg (mov_to_fpu (value_regs_get val 0) (ScalarSize.Size64)))
+            (tmp Reg (mov_to_vec tmp_half (value_regs_get val 1) 1 (VectorSize.Size64x2)))
+            (nbits Reg (vec_cnt tmp (VectorSize.Size8x16)))
+            (added Reg (addv nbits (VectorSize.Size8x16))))
         (value_regs (mov_from_vec added 0 (VectorSize.Size8x16)) (imm $I64 0))))
 
 (rule (lower (has_type $I8X16 (popcnt x)))
-      (value_reg (vec_cnt (put_in_reg x) (VectorSize.Size8x16))))
+      (vec_cnt x (VectorSize.Size8x16)))

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 980b300b3ec3e338
-src/isa/aarch64/inst.isle 62ab4218b01cc799
-src/isa/aarch64/lower.isle 4496f1be20d545
+src/prelude.isle 8bf92e18323e7041
+src/isa/aarch64/inst.isle 3678d0a37bdb4cff
+src/isa/aarch64/lower.isle 1bc1f817a4721801

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
@@ -3422,7 +3422,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             {
                 match pattern5_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 1016.
+                        // Rule at src/isa/aarch64/lower.isle line 974.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = C::put_in_reg(ctx, pattern5_1);
@@ -3434,7 +3434,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr7_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1039.
+                        // Rule at src/isa/aarch64/lower.isle line 995.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3446,7 +3446,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr7_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1090.
+                        // Rule at src/isa/aarch64/lower.isle line 1042.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3458,7 +3458,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr7_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1071.
+                        // Rule at src/isa/aarch64/lower.isle line 1025.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0: Type = I32;
@@ -3473,7 +3473,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr10_0);
                     }
                     &Opcode::Popcnt => {
-                        // Rule at src/isa/aarch64/lower.isle line 1144.
+                        // Rule at src/isa/aarch64/lower.isle line 1093.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3498,7 +3498,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             {
                 match pattern5_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 1022.
+                        // Rule at src/isa/aarch64/lower.isle line 980.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = C::put_in_reg(ctx, pattern5_1);
@@ -3510,7 +3510,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr7_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1042.
+                        // Rule at src/isa/aarch64/lower.isle line 998.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3522,7 +3522,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr7_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1093.
+                        // Rule at src/isa/aarch64/lower.isle line 1045.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3534,7 +3534,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr7_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1074.
+                        // Rule at src/isa/aarch64/lower.isle line 1028.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0: Type = I32;
@@ -3549,7 +3549,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         return Some(expr10_0);
                     }
                     &Opcode::Popcnt => {
-                        // Rule at src/isa/aarch64/lower.isle line 1152.
+                        // Rule at src/isa/aarch64/lower.isle line 1099.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3595,7 +3595,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 899.
+                                                // Rule at src/isa/aarch64/lower.isle line 865.
                                                 let expr0_0: Type = I32;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0: Type = I32;
@@ -3611,7 +3611,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 889.
+                            // Rule at src/isa/aarch64/lower.isle line 855.
                             let expr0_0: Type = I32;
                             let expr1_0 = C::zero_reg(ctx);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3642,7 +3642,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 943.
+                                                // Rule at src/isa/aarch64/lower.isle line 907.
                                                 let expr0_0: Type = I32;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0 = constructor_a64_rotr_imm(
@@ -3658,7 +3658,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 931.
+                            // Rule at src/isa/aarch64/lower.isle line 895.
                             let expr0_0: Type = I32;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3674,7 +3674,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Popcnt = pattern5_0 {
-                        // Rule at src/isa/aarch64/lower.isle line 1160.
+                        // Rule at src/isa/aarch64/lower.isle line 1105.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3702,7 +3702,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Umulhi => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 374.
+                            // Rule at src/isa/aarch64/lower.isle line 367.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3712,7 +3712,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Smulhi => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 360.
+                            // Rule at src/isa/aarch64/lower.isle line 355.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3722,7 +3722,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 609.
+                            // Rule at src/isa/aarch64/lower.isle line 586.
                             let expr0_0 = ALUOp::And;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
@@ -3733,7 +3733,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 622.
+                            // Rule at src/isa/aarch64/lower.isle line 599.
                             let expr0_0 = ALUOp::Orr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
@@ -3744,7 +3744,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 635.
+                            // Rule at src/isa/aarch64/lower.isle line 612.
                             let expr0_0 = ALUOp::Eor;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
@@ -3755,7 +3755,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::BandNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 648.
+                            // Rule at src/isa/aarch64/lower.isle line 625.
                             let expr0_0 = ALUOp::AndNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic(
@@ -3766,7 +3766,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::BorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 661.
+                            // Rule at src/isa/aarch64/lower.isle line 638.
                             let expr0_0 = ALUOp::OrrNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic(
@@ -3777,7 +3777,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::BxorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 671.
+                            // Rule at src/isa/aarch64/lower.isle line 648.
                             let expr0_0 = ALUOp::EorNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic(
@@ -3806,7 +3806,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 903.
+                                                // Rule at src/isa/aarch64/lower.isle line 869.
                                                 let expr0_0: Type = I64;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0: Type = I64;
@@ -3822,7 +3822,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 894.
+                            // Rule at src/isa/aarch64/lower.isle line 860.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::zero_reg(ctx);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3853,7 +3853,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 947.
+                                                // Rule at src/isa/aarch64/lower.isle line 911.
                                                 let expr0_0: Type = I64;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0 = constructor_a64_rotr_imm(
@@ -3869,7 +3869,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 935.
+                            // Rule at src/isa/aarch64/lower.isle line 899.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3879,7 +3879,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 683.
+                            // Rule at src/isa/aarch64/lower.isle line 660.
                             let expr0_0 = ALUOp::Lsl;
                             let expr1_0: Type = I64;
                             let expr2_0 = C::put_in_reg(ctx, pattern7_0);
@@ -3890,7 +3890,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 772.
+                            // Rule at src/isa/aarch64/lower.isle line 744.
                             let expr0_0 = ALUOp::Lsr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
@@ -3901,7 +3901,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 822.
+                            // Rule at src/isa/aarch64/lower.isle line 791.
                             let expr0_0 = ALUOp::Asr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
@@ -3918,7 +3918,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Popcnt = pattern5_0 {
-                        // Rule at src/isa/aarch64/lower.isle line 1168.
+                        // Rule at src/isa/aarch64/lower.isle line 1111.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size64;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3967,7 +3967,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 130.
+                            // Rule at src/isa/aarch64/lower.isle line 129.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -3988,7 +3988,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 185.
+                            // Rule at src/isa/aarch64/lower.isle line 183.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4010,7 +4010,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 612.
+                            // Rule at src/isa/aarch64/lower.isle line 589.
                             let expr0_0 = ALUOp::And;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4020,7 +4020,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 625.
+                            // Rule at src/isa/aarch64/lower.isle line 602.
                             let expr0_0 = ALUOp::Orr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4030,7 +4030,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 638.
+                            // Rule at src/isa/aarch64/lower.isle line 615.
                             let expr0_0 = ALUOp::Eor;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4040,7 +4040,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::BandNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 651.
+                            // Rule at src/isa/aarch64/lower.isle line 628.
                             let expr0_0 = ALUOp::AndNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4050,7 +4050,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::BorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 664.
+                            // Rule at src/isa/aarch64/lower.isle line 641.
                             let expr0_0 = ALUOp::OrrNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4060,7 +4060,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::BxorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 674.
+                            // Rule at src/isa/aarch64/lower.isle line 651.
                             let expr0_0 = ALUOp::EorNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4070,7 +4070,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Rotl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 912.
+                            // Rule at src/isa/aarch64/lower.isle line 878.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4099,7 +4099,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Rotr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 999.
+                            // Rule at src/isa/aarch64/lower.isle line 959.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4128,7 +4128,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 687.
+                            // Rule at src/isa/aarch64/lower.isle line 664.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4138,7 +4138,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 776.
+                            // Rule at src/isa/aarch64/lower.isle line 748.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4148,7 +4148,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 826.
+                            // Rule at src/isa/aarch64/lower.isle line 795.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4165,7 +4165,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Bnot => {
-                            // Rule at src/isa/aarch64/lower.isle line 590.
+                            // Rule at src/isa/aarch64/lower.isle line 569.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4181,7 +4181,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr11_0);
                         }
                         &Opcode::Bitrev => {
-                            // Rule at src/isa/aarch64/lower.isle line 1025.
+                            // Rule at src/isa/aarch64/lower.isle line 983.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: Type = I64;
                             let expr2_0: usize = 0;
@@ -4195,13 +4195,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr9_0);
                         }
                         &Opcode::Clz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1045.
+                            // Rule at src/isa/aarch64/lower.isle line 1001.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0 = constructor_lower_clz128(ctx, expr0_0)?;
                             return Some(expr1_0);
                         }
                         &Opcode::Cls => {
-                            // Rule at src/isa/aarch64/lower.isle line 1105.
+                            // Rule at src/isa/aarch64/lower.isle line 1057.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4234,7 +4234,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr28_0);
                         }
                         &Opcode::Ctz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1077.
+                            // Rule at src/isa/aarch64/lower.isle line 1031.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: Type = I64;
                             let expr2_0: usize = 0;
@@ -4249,7 +4249,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr10_0);
                         }
                         &Opcode::Popcnt => {
-                            // Rule at src/isa/aarch64/lower.isle line 1176.
+                            // Rule at src/isa/aarch64/lower.isle line 1117.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4287,7 +4287,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                        // Rule at src/isa/aarch64/lower.isle line 514.
+                                        // Rule at src/isa/aarch64/lower.isle line 499.
                                         let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                         let expr1_0 = constructor_vector_size(ctx, pattern11_0)?;
                                         let expr2_0 = constructor_mov_from_vec(
@@ -4304,7 +4304,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 509.
+                            // Rule at src/isa/aarch64/lower.isle line 494.
                             let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern5_1)?;
                             let expr1_0: Type = I64;
                             let expr2_0: u64 = 0;
@@ -4325,7 +4325,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         if pattern11_0 == I64X2 {
                                             let pattern13_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                            // Rule at src/isa/aarch64/lower.isle line 562.
+                                            // Rule at src/isa/aarch64/lower.isle line 543.
                                             let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                             let expr1_0 = VectorSize::Size64x2;
                                             let expr2_0 = constructor_mov_from_vec(
@@ -4345,7 +4345,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         }
                                         if let Some(()) = C::not_i64x2(ctx, pattern11_0) {
                                             let pattern13_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                            // Rule at src/isa/aarch64/lower.isle line 549.
+                                            // Rule at src/isa/aarch64/lower.isle line 532.
                                             let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                             let expr1_0 =
                                                 constructor_vector_size(ctx, pattern11_0)?;
@@ -4370,7 +4370,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 537.
+                            // Rule at src/isa/aarch64/lower.isle line 522.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern5_1)?;
                             let expr1_0: Type = I64;
                             let expr2_0: u8 = 63;
@@ -4393,7 +4393,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } = &pattern4_0
             {
                 if let &Opcode::Popcnt = pattern5_0 {
-                    // Rule at src/isa/aarch64/lower.isle line 1186.
+                    // Rule at src/isa/aarch64/lower.isle line 1125.
                     let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                     let expr1_0 = VectorSize::Size8x16;
                     let expr2_0 = constructor_vec_cnt(ctx, expr0_0, &expr1_0)?;
@@ -4433,7 +4433,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 287.
+                                                        // Rule at src/isa/aarch64/lower.isle line 282.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4464,7 +4464,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 293.
+                                                        // Rule at src/isa/aarch64/lower.isle line 288.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4495,7 +4495,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 299.
+                                                        // Rule at src/isa/aarch64/lower.isle line 294.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4526,7 +4526,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 305.
+                                                        // Rule at src/isa/aarch64/lower.isle line 300.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4581,7 +4581,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 311.
+                                                        // Rule at src/isa/aarch64/lower.isle line 306.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4612,7 +4612,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 317.
+                                                        // Rule at src/isa/aarch64/lower.isle line 312.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4643,7 +4643,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 323.
+                                                        // Rule at src/isa/aarch64/lower.isle line 318.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4674,7 +4674,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 329.
+                                                        // Rule at src/isa/aarch64/lower.isle line 324.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4729,7 +4729,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 335.
+                                                        // Rule at src/isa/aarch64/lower.isle line 330.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4760,7 +4760,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 341.
+                                                        // Rule at src/isa/aarch64/lower.isle line 336.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4791,7 +4791,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 347.
+                                                        // Rule at src/isa/aarch64/lower.isle line 342.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4822,7 +4822,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 353.
+                                                        // Rule at src/isa/aarch64/lower.isle line 348.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4843,7 +4843,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                         }
                     }
-                    // Rule at src/isa/aarch64/lower.isle line 246.
+                    // Rule at src/isa/aarch64/lower.isle line 243.
                     let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                     let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                     let expr2_0 = VectorSize::Size32x4;
@@ -4917,28 +4917,28 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } => {
                 match pattern4_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 1033.
+                        // Rule at src/isa/aarch64/lower.isle line 989.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_rbit(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = C::value_reg(ctx, expr1_0);
                         return Some(expr2_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1048.
+                        // Rule at src/isa/aarch64/lower.isle line 1004.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_a64_clz(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = C::value_reg(ctx, expr1_0);
                         return Some(expr2_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1122.
+                        // Rule at src/isa/aarch64/lower.isle line 1071.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_a64_cls(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = C::value_reg(ctx, expr1_0);
                         return Some(expr2_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1085.
+                        // Rule at src/isa/aarch64/lower.isle line 1037.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_rbit(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = constructor_a64_clz(ctx, pattern2_0, expr1_0)?;
@@ -4970,7 +4970,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Isub => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 126.
+                        // Rule at src/isa/aarch64/lower.isle line 125.
                         let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr2_0 = constructor_vector_size(ctx, pattern2_0)?;
@@ -5007,7 +5007,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         if let Some(pattern13_0) =
                                             C::imm_shift_from_imm64(ctx, pattern10_1, pattern12_0)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 877.
+                                            // Rule at src/isa/aarch64/lower.isle line 843.
                                             let expr0_0 =
                                                 constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                                             let expr1_0 =
@@ -5022,7 +5022,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/aarch64/lower.isle line 872.
+                        // Rule at src/isa/aarch64/lower.isle line 838.
                         let expr0_0: Type = I32;
                         let expr1_0 = C::zero_reg(ctx);
                         let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5049,7 +5049,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         if let Some(pattern13_0) =
                                             C::imm_shift_from_imm64(ctx, pattern10_1, pattern12_0)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 939.
+                                            // Rule at src/isa/aarch64/lower.isle line 903.
                                             let expr0_0 =
                                                 constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                                             let expr1_0 = constructor_small_rotr_imm(
@@ -5065,7 +5065,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/aarch64/lower.isle line 927.
+                        // Rule at src/isa/aarch64/lower.isle line 891.
                         let expr0_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr2_0 = constructor_small_rotr(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -5086,7 +5086,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 match pattern5_0 {
                     &Opcode::Umulhi => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 377.
+                        // Rule at src/isa/aarch64/lower.isle line 370.
                         let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_1)?;
                         let expr2_0 = C::zero_reg(ctx);
@@ -5100,7 +5100,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Smulhi => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 363.
+                        // Rule at src/isa/aarch64/lower.isle line 358.
                         let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_reg_sext64(ctx, pattern7_1)?;
                         let expr2_0 = C::zero_reg(ctx);
@@ -5114,7 +5114,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Band => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 606.
+                        // Rule at src/isa/aarch64/lower.isle line 583.
                         let expr0_0 = ALUOp::And;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5124,7 +5124,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Bor => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 619.
+                        // Rule at src/isa/aarch64/lower.isle line 596.
                         let expr0_0 = ALUOp::Orr;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5134,7 +5134,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Bxor => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 632.
+                        // Rule at src/isa/aarch64/lower.isle line 609.
                         let expr0_0 = ALUOp::Eor;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5144,7 +5144,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::BandNot => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 645.
+                        // Rule at src/isa/aarch64/lower.isle line 622.
                         let expr0_0 = ALUOp::AndNot;
                         let expr1_0 = constructor_alu_rs_imm_logic(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5154,7 +5154,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::BorNot => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 658.
+                        // Rule at src/isa/aarch64/lower.isle line 635.
                         let expr0_0 = ALUOp::OrrNot;
                         let expr1_0 = constructor_alu_rs_imm_logic(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5164,7 +5164,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::BxorNot => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 668.
+                        // Rule at src/isa/aarch64/lower.isle line 645.
                         let expr0_0 = ALUOp::EorNot;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_alu_rs_imm_logic(
@@ -5175,7 +5175,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Ishl => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 679.
+                        // Rule at src/isa/aarch64/lower.isle line 656.
                         let expr0_0 = ALUOp::Lsl;
                         let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                         let expr2_0 =
@@ -5185,7 +5185,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Ushr => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 768.
+                        // Rule at src/isa/aarch64/lower.isle line 740.
                         let expr0_0 = ALUOp::Lsr;
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr2_0 =
@@ -5195,7 +5195,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     }
                     &Opcode::Sshr => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 818.
+                        // Rule at src/isa/aarch64/lower.isle line 787.
                         let expr0_0 = ALUOp::Asr;
                         let expr1_0 = constructor_put_in_reg_sext32(ctx, pattern7_0)?;
                         let expr2_0 =
@@ -5482,7 +5482,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             if let Some(pattern13_0) =
                                                 C::imm12_from_u64(ctx, pattern12_0)
                                             {
-                                                // Rule at src/isa/aarch64/lower.isle line 106.
+                                                // Rule at src/isa/aarch64/lower.isle line 105.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr1_0 = constructor_sub_imm(
                                                     ctx,
@@ -5496,7 +5496,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                             if let Some(pattern13_0) =
                                                 C::imm12_from_negated_u64(ctx, pattern12_0)
                                             {
-                                                // Rule at src/isa/aarch64/lower.isle line 111.
+                                                // Rule at src/isa/aarch64/lower.isle line 110.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr1_0 = constructor_add_imm(
                                                     ctx,
@@ -5536,7 +5536,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                     pattern17_0,
                                                                 )
                                                             {
-                                                                // Rule at src/isa/aarch64/lower.isle line 121.
+                                                                // Rule at src/isa/aarch64/lower.isle line 120.
                                                                 let expr0_0 =
                                                                     C::put_in_reg(ctx, pattern7_0);
                                                                 let expr1_0 =
@@ -5564,14 +5564,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                             if let Some(pattern8_0) = C::extended_value_from_value(ctx, pattern7_1)
                             {
-                                // Rule at src/isa/aarch64/lower.isle line 116.
+                                // Rule at src/isa/aarch64/lower.isle line 115.
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_sub_extend(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = C::value_reg(ctx, expr1_0);
                                 return Some(expr2_0);
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 102.
+                            // Rule at src/isa/aarch64/lower.isle line 101.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -5580,7 +5580,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 181.
+                            // Rule at src/isa/aarch64/lower.isle line 179.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = C::zero_reg(ctx);
@@ -5591,7 +5591,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Udiv => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 393.
+                            // Rule at src/isa/aarch64/lower.isle line 384.
                             let expr0_0: Type = I64;
                             let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr2_0 = constructor_put_nonzero_in_reg_zext64(ctx, pattern7_1)?;
@@ -5612,7 +5612,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         if let Some(pattern12_0) =
                                             C::safe_divisor_from_imm64(ctx, pattern10_1)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 441.
+                                            // Rule at src/isa/aarch64/lower.isle line 430.
                                             let expr0_0: Type = I64;
                                             let expr1_0 =
                                                 constructor_put_in_reg_sext64(ctx, pattern7_0)?;
@@ -5627,7 +5627,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 426.
+                            // Rule at src/isa/aarch64/lower.isle line 417.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_sext64(ctx, pattern7_1)?;
                             let expr2_0 = constructor_trap_if_div_overflow(
@@ -5640,7 +5640,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Urem => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 469.
+                            // Rule at src/isa/aarch64/lower.isle line 458.
                             let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_zext64(ctx, pattern7_1)?;
                             let expr2_0: Type = I64;
@@ -5651,7 +5651,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Srem => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 478.
+                            // Rule at src/isa/aarch64/lower.isle line 465.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_sext64(ctx, pattern7_1)?;
                             let expr2_0: Type = I64;
@@ -5669,7 +5669,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/aarch64/lower.isle line 171.
+                            // Rule at src/isa/aarch64/lower.isle line 169.
                             let expr0_0 = C::zero_reg(ctx);
                             let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -5706,7 +5706,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                 pattern16_0,
                                                             )
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 585.
+                                                            // Rule at src/isa/aarch64/lower.isle line 564.
                                                             let expr0_0 = C::zero_reg(ctx);
                                                             let expr1_0 =
                                                                 C::put_in_reg(ctx, pattern11_0);
@@ -5729,7 +5729,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 580.
+                            // Rule at src/isa/aarch64/lower.isle line 559.
                             let expr0_0 = C::zero_reg(ctx);
                             let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr2_0 = constructor_orr_not(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -5748,7 +5748,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                        // Rule at src/isa/aarch64/lower.isle line 496.
+                                        // Rule at src/isa/aarch64/lower.isle line 481.
                                         let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                         let expr1_0 = constructor_vector_size(ctx, pattern11_0)?;
                                         let expr2_0 = constructor_mov_from_vec(
@@ -5764,13 +5764,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                             let pattern7_0 = C::value_type(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::sinkable_atomic_load(ctx, pattern5_1) {
-                                // Rule at src/isa/aarch64/lower.isle line 503.
+                                // Rule at src/isa/aarch64/lower.isle line 488.
                                 let expr0_0 = C::sink_atomic_load(ctx, &pattern8_0);
                                 let expr1_0 = constructor_load_acquire(ctx, pattern7_0, expr0_0)?;
                                 let expr2_0 = C::value_reg(ctx, expr1_0);
                                 return Some(expr2_0);
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 491.
+                            // Rule at src/isa/aarch64/lower.isle line 476.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0: bool = false;
                             let expr2_0 = C::ty_bits(ctx, pattern7_0);
@@ -5792,7 +5792,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                        // Rule at src/isa/aarch64/lower.isle line 528.
+                                        // Rule at src/isa/aarch64/lower.isle line 513.
                                         let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                         let expr1_0 = constructor_vector_size(ctx, pattern11_0)?;
                                         let expr2_0 = constructor_size_from_ty(ctx, pattern3_0)?;
@@ -5809,7 +5809,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                             let pattern7_0 = C::value_type(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 523.
+                            // Rule at src/isa/aarch64/lower.isle line 508.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0: bool = true;
                             let expr2_0 = C::ty_bits(ctx, pattern7_0);
@@ -5835,7 +5835,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::UaddSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 150.
+                            // Rule at src/isa/aarch64/lower.isle line 148.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5845,7 +5845,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::SaddSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 155.
+                            // Rule at src/isa/aarch64/lower.isle line 153.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5855,7 +5855,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::UsubSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 160.
+                            // Rule at src/isa/aarch64/lower.isle line 158.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5865,7 +5865,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::SsubSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 165.
+                            // Rule at src/isa/aarch64/lower.isle line 163.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5875,7 +5875,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 614.
+                            // Rule at src/isa/aarch64/lower.isle line 591.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5885,7 +5885,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 627.
+                            // Rule at src/isa/aarch64/lower.isle line 604.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5895,7 +5895,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 640.
+                            // Rule at src/isa/aarch64/lower.isle line 617.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5905,7 +5905,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::BandNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 653.
+                            // Rule at src/isa/aarch64/lower.isle line 630.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -5915,7 +5915,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 718.
+                            // Rule at src/isa/aarch64/lower.isle line 694.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vec_dup(ctx, expr1_0, &expr0_0)?;
@@ -5926,7 +5926,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 780.
+                            // Rule at src/isa/aarch64/lower.isle line 752.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0: Type = I32;
                             let expr2_0 = C::zero_reg(ctx);
@@ -5940,7 +5940,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 832.
+                            // Rule at src/isa/aarch64/lower.isle line 801.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0: Type = I32;
                             let expr2_0 = C::zero_reg(ctx);
@@ -5961,7 +5961,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/aarch64/lower.isle line 175.
+                            // Rule at src/isa/aarch64/lower.isle line 173.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr2_0 = constructor_neg(ctx, expr0_0, &expr1_0)?;
@@ -5969,7 +5969,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr3_0);
                         }
                         &Opcode::Bnot => {
-                            // Rule at src/isa/aarch64/lower.isle line 601.
+                            // Rule at src/isa/aarch64/lower.isle line 578.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr2_0 = constructor_not(ctx, expr0_0, &expr1_0)?;
@@ -5990,7 +5990,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 {
                     if let &Opcode::Imul = pattern6_0 {
                         let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, pattern6_1);
-                        // Rule at src/isa/aarch64/lower.isle line 214.
+                        // Rule at src/isa/aarch64/lower.isle line 211.
                         let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern8_1);
                         let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6018,14 +6018,14 @@ pub fn constructor_put_nonzero_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Valu
         {
             if let &Opcode::Iconst = pattern4_0 {
                 if let Some(pattern6_0) = C::nonzero_u64_from_imm64(ctx, pattern4_1) {
-                    // Rule at src/isa/aarch64/lower.isle line 403.
+                    // Rule at src/isa/aarch64/lower.isle line 394.
                     let expr0_0 = constructor_imm(ctx, pattern1_0, pattern6_0)?;
                     return Some(expr0_0);
                 }
             }
         }
     }
-    // Rule at src/isa/aarch64/lower.isle line 398.
+    // Rule at src/isa/aarch64/lower.isle line 389.
     let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern0_0)?;
     let expr1_0 = constructor_trap_if_zero_divisor(ctx, expr0_0)?;
     return Some(expr1_0);
@@ -6044,14 +6044,14 @@ pub fn constructor_put_nonzero_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Valu
         {
             if let &Opcode::Iconst = pattern4_0 {
                 if let Some(pattern6_0) = C::nonzero_u64_from_imm64(ctx, pattern4_1) {
-                    // Rule at src/isa/aarch64/lower.isle line 451.
+                    // Rule at src/isa/aarch64/lower.isle line 440.
                     let expr0_0 = constructor_imm(ctx, pattern1_0, pattern6_0)?;
                     return Some(expr0_0);
                 }
             }
         }
     }
-    // Rule at src/isa/aarch64/lower.isle line 446.
+    // Rule at src/isa/aarch64/lower.isle line 435.
     let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern0_0)?;
     let expr1_0 = constructor_trap_if_zero_divisor(ctx, expr0_0)?;
     return Some(expr1_0);
@@ -6065,7 +6065,7 @@ pub fn constructor_lower_shl128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 700.
+    // Rule at src/isa/aarch64/lower.isle line 677.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6125,7 +6125,7 @@ pub fn constructor_do_shift<C: Context>(
                 };
                 if let Some(pattern8_0) = closure8() {
                     if let Some(pattern9_0) = C::imm_shift_from_imm64(ctx, pattern6_1, pattern8_0) {
-                        // Rule at src/isa/aarch64/lower.isle line 762.
+                        // Rule at src/isa/aarch64/lower.isle line 734.
                         let expr0_0 = constructor_alu_rr_imm_shift(
                             ctx, pattern0_0, pattern1_0, pattern2_0, pattern9_0,
                         )?;
@@ -6140,7 +6140,7 @@ pub fn constructor_do_shift<C: Context>(
     if pattern1_0 == I32 {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 753.
+        // Rule at src/isa/aarch64/lower.isle line 725.
         let expr0_0: Type = I32;
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0: usize = 0;
@@ -6151,7 +6151,7 @@ pub fn constructor_do_shift<C: Context>(
     if pattern1_0 == I64 {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 754.
+        // Rule at src/isa/aarch64/lower.isle line 726.
         let expr0_0: Type = I64;
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0: usize = 0;
@@ -6162,7 +6162,7 @@ pub fn constructor_do_shift<C: Context>(
     if let Some(pattern2_0) = C::fits_in_16(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 742.
+        // Rule at src/isa/aarch64/lower.isle line 716.
         let expr0_0 = C::put_in_regs(ctx, pattern4_0);
         let expr1_0: usize = 0;
         let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -6184,7 +6184,7 @@ pub fn constructor_lower_ushr128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 797.
+    // Rule at src/isa/aarch64/lower.isle line 767.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6227,7 +6227,7 @@ pub fn constructor_lower_sshr128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 850.
+    // Rule at src/isa/aarch64/lower.isle line 817.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6275,7 +6275,7 @@ pub fn constructor_small_rotr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/lower.isle line 963.
+    // Rule at src/isa/aarch64/lower.isle line 927.
     let expr0_0: Type = I32;
     let expr1_0 = C::rotr_mask(ctx, pattern0_0);
     let expr2_0 = constructor_and_imm(ctx, expr0_0, pattern2_0, expr1_0)?;
@@ -6305,7 +6305,7 @@ pub fn constructor_small_rotr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/lower.isle line 986.
+    // Rule at src/isa/aarch64/lower.isle line 948.
     let expr0_0: Type = I32;
     let expr1_0 = constructor_lsr_imm(ctx, expr0_0, pattern1_0, pattern2_0)?;
     let expr2_0: Type = I32;
@@ -6319,7 +6319,7 @@ pub fn constructor_small_rotr_imm<C: Context>(
 // Generated as internal constructor for term lower_clz128.
 pub fn constructor_lower_clz128<C: Context>(ctx: &mut C, arg0: ValueRegs) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/lower.isle line 1057.
+    // Rule at src/isa/aarch64/lower.isle line 1013.
     let expr0_0: Type = I64;
     let expr1_0: usize = 1;
     let expr2_0 = C::value_regs_get(ctx, pattern0_0, expr1_0);

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1128,10 +1128,10 @@
 (decl lower_address (MemFlags Value Offset32) MemArg)
 
 (rule (lower_address flags addr (i64_from_offset offset))
-      (memarg_reg_plus_off (put_in_reg addr) offset flags))
+      (memarg_reg_plus_off addr offset flags))
 
 (rule (lower_address flags (def_inst (iadd x y)) (i64_from_offset 0))
-      (memarg_reg_plus_reg (put_in_reg x) (put_in_reg y) flags))
+      (memarg_reg_plus_reg x y flags))
 
 (rule (lower_address flags
         (def_inst (symbol_value (symbol_value_data name (reloc_distance_near) offset)))
@@ -1163,7 +1163,7 @@
 (rule (stack_addr_impl ty stack_slot offset)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (abi_stackslot_addr dst stack_slot offset))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 
 ;; Helpers for extracting extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1293,12 +1293,12 @@
 ;; Construct a register pair from a writable register pair.
 (decl writable_regpair_to_regpair (WritableRegPair) RegPair)
 (rule (writable_regpair_to_regpair (WritableRegPair.WritableRegPair hi lo))
-      (RegPair.RegPair (writable_reg_to_reg hi) (writable_reg_to_reg lo)))
+      (RegPair.RegPair hi lo))
 
 ;; Uninitalized register pair that can be used for piecewise initialization.
 (decl uninitialized_regpair () RegPair)
 (rule (uninitialized_regpair)
-      (writable_regpair_to_regpair (temp_writable_regpair)))
+      (temp_writable_regpair))
 
 ;; Retrieve the high word of the register pair.
 (decl regpair_hi (RegPair) Reg)
@@ -1316,70 +1316,70 @@
 (rule (alu_rrr ty op src1 src2)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.AluRRR op dst src1 src2))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRRSImm16` instructions.
 (decl alu_rrsimm16 (Type ALUOp Reg i16) Reg)
 (rule (alu_rrsimm16 ty op src imm)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.AluRRSImm16 op dst src imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRR` instructions.
 (decl alu_rr (Type ALUOp Reg Reg) Reg)
 (rule (alu_rr ty op src1 src2)
       (let ((dst WritableReg (copy_writable_reg ty src1))
             (_ Unit (emit (MInst.AluRR op dst src2))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRX` instructions.
 (decl alu_rx (Type ALUOp Reg MemArg) Reg)
 (rule (alu_rx ty op src mem)
       (let ((dst WritableReg (copy_writable_reg ty src))
             (_ Unit (emit (MInst.AluRX op dst mem))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRSImm16` instructions.
 (decl alu_rsimm16 (Type ALUOp Reg i16) Reg)
 (rule (alu_rsimm16 ty op src imm)
       (let ((dst WritableReg (copy_writable_reg ty src))
             (_ Unit (emit (MInst.AluRSImm16 op dst imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRSImm32` instructions.
 (decl alu_rsimm32 (Type ALUOp Reg i32) Reg)
 (rule (alu_rsimm32 ty op src imm)
       (let ((dst WritableReg (copy_writable_reg ty src))
             (_ Unit (emit (MInst.AluRSImm32 op dst imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRUImm32` instructions.
 (decl alu_ruimm32 (Type ALUOp Reg u32) Reg)
 (rule (alu_ruimm32 ty op src imm)
       (let ((dst WritableReg (copy_writable_reg ty src))
             (_ Unit (emit (MInst.AluRUImm32 op dst imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRUImm16Shifted` instructions.
 (decl alu_ruimm16shifted (Type ALUOp Reg UImm16Shifted) Reg)
 (rule (alu_ruimm16shifted ty op src imm)
       (let ((dst WritableReg (copy_writable_reg ty src))
             (_ Unit (emit (MInst.AluRUImm16Shifted op dst imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AluRUImm32Shifted` instructions.
 (decl alu_ruimm32shifted (Type ALUOp Reg UImm32Shifted) Reg)
 (rule (alu_ruimm32shifted ty op src imm)
       (let ((dst WritableReg (copy_writable_reg ty src))
             (_ Unit (emit (MInst.AluRUImm32Shifted op dst imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.SMulWide` instructions.
 (decl smul_wide (Reg Reg) RegPair)
 (rule (smul_wide src1 src2)
       (let ((dst WritableRegPair (temp_writable_regpair))
             (_ Unit (emit (MInst.SMulWide src1 src2))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Helper for emitting `MInst.UMulWide` instructions.
 (decl umul_wide (Reg Reg) RegPair)
@@ -1387,42 +1387,42 @@
       (let ((dst WritableRegPair (temp_writable_regpair))
             (_1 Unit (emit (MInst.Mov64 (writable_regpair_lo dst) src2)))
             (_2 Unit (emit (MInst.UMulWide src1))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Helper for emitting `MInst.SDivMod32` instructions.
 (decl sdivmod32 (RegPair Reg) RegPair)
 (rule (sdivmod32 src1 src2)
       (let ((dst WritableRegPair (copy_writable_regpair src1))
             (_ Unit (emit (MInst.SDivMod32 src2))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Helper for emitting `MInst.SDivMod64` instructions.
 (decl sdivmod64 (RegPair Reg) RegPair)
 (rule (sdivmod64 src1 src2)
       (let ((dst WritableRegPair (copy_writable_regpair src1))
             (_ Unit (emit (MInst.SDivMod64 src2))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Helper for emitting `MInst.UDivMod32` instructions.
 (decl udivmod32 (RegPair Reg) RegPair)
 (rule (udivmod32 src1 src2)
       (let ((dst WritableRegPair (copy_writable_regpair src1))
             (_ Unit (emit (MInst.UDivMod32 src2))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Helper for emitting `MInst.UDivMod64` instructions.
 (decl udivmod64 (RegPair Reg) RegPair)
 (rule (udivmod64 src1 src2)
       (let ((dst WritableRegPair (copy_writable_regpair src1))
             (_ Unit (emit (MInst.UDivMod64 src2))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Helper for emitting `MInst.ShiftRR` instructions.
 (decl shift_rr (Type ShiftOp Reg u8 Reg) Reg)
 (rule (shift_rr ty op src shift_imm shift_reg)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.ShiftRR op dst src shift_imm shift_reg))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.RxSBGTest` instructions.
 (decl rxsbg_test (RxSBGOp Reg Reg u8 u8 i8) ProducesFlags)
@@ -1435,7 +1435,7 @@
 (rule (unary_rr ty op src)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.UnaryRR op dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.CmpRR` instructions.
 (decl cmp_rr (CmpOp Reg Reg) ProducesFlags)
@@ -1467,21 +1467,21 @@
 (rule (atomic_rmw_impl ty op src mem)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.AtomicRmw op dst src mem))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AtomicCas32` instructions.
 (decl atomic_cas32 (Reg Reg MemArg) Reg)
 (rule (atomic_cas32 src1 src2 mem)
       (let ((dst WritableReg (copy_writable_reg $I32 src1))
             (_ Unit (emit (MInst.AtomicCas32 dst src2 mem))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.AtomicCas64` instructions.
 (decl atomic_cas64 (Reg Reg MemArg) Reg)
 (rule (atomic_cas64 src1 src2 mem)
       (let ((dst WritableReg (copy_writable_reg $I64 src1))
             (_ Unit (emit (MInst.AtomicCas64 dst src2 mem))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.Fence` instructions.
 (decl fence_impl () SideEffectNoResult)
@@ -1493,35 +1493,35 @@
 (rule (load32 addr)
       (let ((dst WritableReg (temp_writable_reg $I32))
             (_ Unit (emit (MInst.Load32 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.Load64` instructions.
 (decl load64 (MemArg) Reg)
 (rule (load64 addr)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.Load64 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.LoadRev16` instructions.
 (decl loadrev16 (MemArg) Reg)
 (rule (loadrev16 addr)
       (let ((dst WritableReg (temp_writable_reg $I32))
             (_ Unit (emit (MInst.LoadRev16 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.LoadRev32` instructions.
 (decl loadrev32 (MemArg) Reg)
 (rule (loadrev32 addr)
       (let ((dst WritableReg (temp_writable_reg $I32))
             (_ Unit (emit (MInst.LoadRev32 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.LoadRev64` instructions.
 (decl loadrev64 (MemArg) Reg)
 (rule (loadrev64 addr)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.LoadRev64 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.Store8` instructions.
 (decl store8 (Reg MemArg) SideEffectNoResult)
@@ -1583,28 +1583,28 @@
 (rule (fpu_rr ty op src)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.FpuRR op dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuRRR` instructions.
 (decl fpu_rrr (Type FPUOp2 Reg Reg) Reg)
 (rule (fpu_rrr ty op src1 src2)
       (let ((dst WritableReg (copy_writable_reg ty src1))
             (_ Unit (emit (MInst.FpuRRR op dst src2))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuRRRR` instructions.
 (decl fpu_rrrr (Type FPUOp3 Reg Reg Reg) Reg)
 (rule (fpu_rrrr ty op src1 src2 src3)
       (let ((dst WritableReg (copy_writable_reg ty src1))
             (_ Unit (emit (MInst.FpuRRRR op dst src2 src3))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuCopysign` instructions.
 (decl fpu_copysign (Type Reg Reg) Reg)
 (rule (fpu_copysign ty src1 src2)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.FpuCopysign dst src1 src2))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuCmp32` instructions.
 (decl fpu_cmp32 (Reg Reg) ProducesFlags)
@@ -1621,70 +1621,70 @@
 (rule (fpu_to_int ty op src)
       (let ((dst WritableReg (temp_writable_reg ty)))
         (ProducesFlags.ProducesFlagsReturnsReg (MInst.FpuToInt op dst src)
-                                               (writable_reg_to_reg dst))))
+                                               dst)))
 
 ;; Helper for emitting `MInst.IntToFpu` instructions.
 (decl int_to_fpu (Type IntToFpuOp Reg) Reg)
 (rule (int_to_fpu ty op src)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.IntToFpu op dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuRound` instructions.
 (decl fpu_round (Type FpuRoundMode Reg) Reg)
 (rule (fpu_round ty mode src)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.FpuRound mode dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuVecRRR` instructions.
 (decl fpuvec_rrr (Type FPUOp2 Reg Reg) Reg)
 (rule (fpuvec_rrr ty op src1 src2)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.FpuVecRRR op dst src1 src2))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.MovToFpr` instructions.
 (decl mov_to_fpr (Reg) Reg)
 (rule (mov_to_fpr src)
       (let ((dst WritableReg (temp_writable_reg $F64))
             (_ Unit (emit (MInst.MovToFpr dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.MovFromFpr` instructions.
 (decl mov_from_fpr (Reg) Reg)
 (rule (mov_from_fpr src)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.MovFromFpr dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuLoad32` instructions.
 (decl fpu_load32 (MemArg) Reg)
 (rule (fpu_load32 addr)
       (let ((dst WritableReg (temp_writable_reg $F32))
             (_ Unit (emit (MInst.FpuLoad32 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuLoad64` instructions.
 (decl fpu_load64 (MemArg) Reg)
 (rule (fpu_load64 addr)
       (let ((dst WritableReg (temp_writable_reg $F64))
             (_ Unit (emit (MInst.FpuLoad64 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuLoadRev32` instructions.
 (decl fpu_loadrev32 (MemArg) Reg)
 (rule (fpu_loadrev32 addr)
       (let ((dst WritableReg (temp_writable_reg $F32))
             (_ Unit (emit (MInst.FpuLoadRev32 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuLoadRev64` instructions.
 (decl fpu_loadrev64 (MemArg) Reg)
 (rule (fpu_loadrev64 addr)
       (let ((dst WritableReg (temp_writable_reg $F64))
             (_ Unit (emit (MInst.FpuLoadRev64 dst addr))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.FpuStore32` instructions.
 (decl fpu_store32 (Reg MemArg) SideEffectNoResult)
@@ -1712,14 +1712,14 @@
       (let ((dst WritableReg (temp_writable_reg $I64))
             (boxed_name BoxExternalName (box_external_name name))
             (_ Unit (emit (MInst.LoadExtNameFar dst boxed_name offset))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.LoadAddr` instructions.
 (decl load_addr (MemArg) Reg)
 (rule (load_addr mem)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.LoadAddr dst mem))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Helper for emitting `MInst.Jump` instructions.
 (decl jump_impl (MachLabel) SideEffectNoResult)
@@ -1784,45 +1784,45 @@
 (decl push_alu_reg (VecMInstBuilder ALUOp WritableReg Reg Reg) Reg)
 (rule (push_alu_reg ib op (real_reg dst) src1 src2)
       (let ((_ Unit (inst_builder_push ib (MInst.AluRRR op dst src1 src2))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Push a `MInst.AluRUImm32Shifted` instruction to a sequence.
 (decl push_alu_uimm32shifted (VecMInstBuilder ALUOp WritableReg Reg UImm32Shifted) Reg)
 (rule (push_alu_uimm32shifted ib op (real_reg dst) (same_reg <dst) imm)
       (let ((_ Unit (inst_builder_push ib (MInst.AluRUImm32Shifted op dst imm))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Push a `MInst.ShiftRR` instruction to a sequence.
 (decl push_shift (VecMInstBuilder ShiftOp WritableReg Reg u8 Reg) Reg)
 (rule (push_shift ib op (real_reg dst) src shift_imm shift_reg)
       (let ((_ Unit (inst_builder_push ib
                       (MInst.ShiftRR op dst src shift_imm shift_reg))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Push a `MInst.RxSBG` instruction to a sequence.
 (decl push_rxsbg (VecMInstBuilder RxSBGOp WritableReg Reg Reg u8 u8 i8) Reg)
 (rule (push_rxsbg ib op (real_reg dst) (same_reg <dst) src start_bit end_bit rotate_amt)
       (let ((_ Unit (inst_builder_push ib
                       (MInst.RxSBG op dst src start_bit end_bit rotate_amt))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Push a `MInst.UnaryRR` instruction to a sequence.
 (decl push_unary (VecMInstBuilder UnaryOp WritableReg Reg) Reg)
 (rule (push_unary ib op (real_reg dst) src)
       (let ((_ Unit (inst_builder_push ib (MInst.UnaryRR op dst src))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Push a `MInst.AtomicCas32` instruction to a sequence.
 (decl push_atomic_cas32 (VecMInstBuilder WritableReg Reg MemArg) Reg)
 (rule (push_atomic_cas32 ib (real_reg dst_src1) src2 mem)
       (let ((_ Unit (inst_builder_push ib (MInst.AtomicCas32 dst_src1 src2 mem))))
-        (writable_reg_to_reg dst_src1)))
+        dst_src1))
 
 ;; Push a `MInst.AtomicCas64` instruction to a sequence.
 (decl push_atomic_cas64 (VecMInstBuilder WritableReg Reg MemArg) Reg)
 (rule (push_atomic_cas64 ib (real_reg dst_src1) src2 mem)
       (let ((_ Unit (inst_builder_push ib (MInst.AtomicCas64 dst_src1 src2 mem))))
-        (writable_reg_to_reg dst_src1)))
+        dst_src1))
 
 ;; Push instructions to break out of the loop if condition is met.
 (decl push_break_if (VecMInstBuilder ProducesFlags Cond) Reg)
@@ -1863,7 +1863,7 @@
 
 ;; Likewise, but returning a Reg instead of a WritableReg.
 (decl copy_reg (Type Reg) Reg)
-(rule (copy_reg ty reg) (writable_reg_to_reg (copy_writable_reg ty reg)))
+(rule (copy_reg ty reg) (copy_writable_reg ty reg))
 
 ;; Move from memory location into destination.
 (decl emit_load (Type WritableReg MemArg) Unit)
@@ -1938,7 +1938,7 @@
 (rule (imm ty n)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit_imm ty dst n)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Place an immediate into the low half of a register pair.
 ;; The high half is taken from the input.
@@ -1946,7 +1946,7 @@
 (rule (imm_regpair_lo ty n regpair)
       (let ((dst WritableRegPair (copy_writable_regpair regpair))
             (_ Unit (emit_imm ty (writable_regpair_lo dst) n)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Place an immediate into the high half of a register pair.
 ;; The low half is taken from the input.
@@ -1954,7 +1954,7 @@
 (rule (imm_regpair_hi ty n regpair)
       (let ((dst WritableRegPair (copy_writable_regpair regpair))
             (_ Unit (emit_imm ty (writable_regpair_hi dst) n)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 
 ;; Helpers for generating extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2003,7 +2003,7 @@
 (rule (zext32_reg ty src)
       (let ((dst WritableReg (temp_writable_reg $I32))
             (_ Unit (emit_zext32_reg dst ty src)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Sign-extend a register from a smaller `Type` into a 32-bit register.
 ;; This handles both integer and boolean input types (except $B1).
@@ -2011,7 +2011,7 @@
 (rule (sext32_reg ty src)
       (let ((dst WritableReg (temp_writable_reg $I32))
             (_ Unit (emit_sext32_reg dst ty src)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Zero-extend a register from a smaller `Type` into a 64-bit register.
 ;; This handles both integer and boolean input types (except $B1).
@@ -2019,7 +2019,7 @@
 (rule (zext64_reg ty src)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit_zext64_reg dst ty src)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Sign-extend a register from a smaller `Type` into a 64-bit register.
 ;; This handles both integer and boolean input types (except $B1).
@@ -2027,7 +2027,7 @@
 (rule (sext64_reg ty src)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit_sext64_reg dst ty src)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 
 ;; Zero-extend memory from a smaller `Type` into a 32-bit destination.  (Non-SSA form.)
@@ -2057,28 +2057,28 @@
 (rule (zext32_mem ty mem)
       (let ((dst WritableReg (temp_writable_reg $I32))
             (_ Unit (emit_zext32_mem dst ty mem)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Sign-extend memory from a smaller `Type` into a 32-bit register.
 (decl sext32_mem (Type MemArg) Reg)
 (rule (sext32_mem ty mem)
       (let ((dst WritableReg (temp_writable_reg $I32))
             (_ Unit (emit_sext32_mem dst ty mem)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Zero-extend memory from a smaller `Type` into a 64-bit register.
 (decl zext64_mem (Type MemArg) Reg)
 (rule (zext64_mem ty mem)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit_zext64_mem dst ty mem)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Sign-extend memory from a smaller `Type` into a 64-bit register.
 (decl sext64_mem (Type MemArg) Reg)
 (rule (sext64_mem ty mem)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit_sext64_mem dst ty mem)))
-        (writable_reg_to_reg dst)))
+        dst))
 
 
 ;; Place `Value` into destination, zero-extending to 32 bits if smaller.  (Non-SSA form.)
@@ -2175,7 +2175,7 @@
 (rule (put_in_regpair_lo_zext32 val regpair)
       (let ((dst WritableRegPair (copy_writable_regpair regpair))
             (_ Unit (emit_put_in_reg_zext32 (writable_regpair_lo dst) val)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Place `Value` into the low half of a register pair, sign-extending
 ;; to 32 bits if smaller.  The high half is taken from the input.
@@ -2183,7 +2183,7 @@
 (rule (put_in_regpair_lo_sext32 val regpair)
       (let ((dst WritableRegPair (copy_writable_regpair regpair))
             (_ Unit (emit_put_in_reg_sext32 (writable_regpair_lo dst) val)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Place `Value` into the low half of a register pair, zero-extending
 ;; to 64 bits if smaller.  The high half is taken from the input.
@@ -2191,7 +2191,7 @@
 (rule (put_in_regpair_lo_zext64 val regpair)
       (let ((dst WritableRegPair (copy_writable_regpair regpair))
             (_ Unit (emit_put_in_reg_zext64 (writable_regpair_lo dst) val)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Place `Value` into the low half of a register pair, sign-extending
 ;; to 64 bits if smaller.  The high half is taken from the input.
@@ -2199,7 +2199,7 @@
 (rule (put_in_regpair_lo_sext64 val regpair)
       (let ((dst WritableRegPair (copy_writable_regpair regpair))
             (_ Unit (emit_put_in_reg_sext64 (writable_regpair_lo dst) val)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 
 ;; Helpers for generating conditional moves ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2208,10 +2208,10 @@
 (decl emit_cmov_imm (Type WritableReg Cond i16) ConsumesFlags)
 (rule (emit_cmov_imm (gpr32_ty _ty) dst cond imm)
       (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov32SImm16 dst cond imm)
-                                             (writable_reg_to_reg dst)))
+                                             dst))
 (rule (emit_cmov_imm (gpr64_ty _ty) dst cond imm)
       (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov64SImm16 dst cond imm)
-                                             (writable_reg_to_reg dst)))
+                                             dst))
 
 ;; Conditionally select between immediate and source register.
 (decl cmov_imm (Type Cond i16 Reg) ConsumesFlags)
@@ -2226,7 +2226,7 @@
       (let ((dst WritableRegPair (copy_writable_regpair src))
             (consumer ConsumesFlags (emit_cmov_imm ty (writable_regpair_lo dst) cond imm))
             (_ Reg (with_flags_reg producer consumer)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Conditionally modify the high word of a register pair.
 ;; This cannot be ConsumesFlags since the return value is not a register.
@@ -2235,22 +2235,22 @@
       (let ((dst WritableRegPair (copy_writable_regpair src))
             (consumer ConsumesFlags (emit_cmov_imm ty (writable_regpair_hi dst) cond imm))
             (_ Reg (with_flags_reg producer consumer)))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; Conditionally select between two source registers.  (Non-SSA form.)
 (decl emit_cmov_reg (Type WritableReg Cond Reg) ConsumesFlags)
 (rule (emit_cmov_reg (gpr32_ty _ty) dst cond src)
       (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov32 dst cond src)
-                                             (writable_reg_to_reg dst)))
+                                             dst))
 (rule (emit_cmov_reg (gpr64_ty _ty) dst cond src)
       (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.CMov64 dst cond src)
-                                             (writable_reg_to_reg dst)))
+                                             dst))
 (rule (emit_cmov_reg $F32 dst cond src)
       (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.FpuCMov32 dst cond src)
-                                             (writable_reg_to_reg dst)))
+                                             dst))
 (rule (emit_cmov_reg $F64 dst cond src)
       (ConsumesFlags.ConsumesFlagsReturnsReg (MInst.FpuCMov64 dst cond src)
-                                             (writable_reg_to_reg dst)))
+                                             dst))
 
 ;; Conditionally select between two source registers.
 (decl cmov_reg (Type Cond Reg Reg) ConsumesFlags)
@@ -2339,7 +2339,7 @@
             (_1 Unit (emit_producer producer))
             (_2 Unit (emit_mov ty dst reg_false))
             (_3 Unit (emit_consumer (emit_cmov_reg ty dst cond reg_true))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Use a boolean condition to select between two immediate values.
 (decl select_bool_imm (Type ProducesBool i16 u64) Reg)
@@ -2348,7 +2348,7 @@
             (_1 Unit (emit_producer producer))
             (_2 Unit (emit_imm ty dst imm_false))
             (_3 Unit (emit_consumer (emit_cmov_imm ty dst cond imm_true))))
-        (writable_reg_to_reg dst)))
+        dst))
 
 ;; Lower a boolean condition to a boolean type.  The value used to represent
 ;; "true" is -1 for all result types except for $B1, which uses 1.
@@ -2504,7 +2504,7 @@
 (rule (clz_reg 64 x)
       (let ((dst WritableRegPair (temp_writable_regpair))
             (_ Unit (emit (MInst.Flogr x))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 ;; If another zero return value was requested, we need to override the flogr
 ;; result.  This cannot use any of the normal flags mechanisms because we need
@@ -2515,7 +2515,7 @@
             (_1 Unit (emit (MInst.Flogr x)))
             (_2 Unit (emit (MInst.CMov64SImm16 (writable_regpair_hi dst)
                               (intcc_as_cond (IntCC.Equal)) zeroval))))
-        (writable_regpair_to_regpair dst)))
+        dst))
 
 
 ;; Helpers for generating `add` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3243,3 +3243,7 @@
 (decl fcmp_reg (Type Reg Reg) ProducesFlags)
 (rule (fcmp_reg $F32 src1 src2) (fpu_cmp32 src1 src2))
 (rule (fcmp_reg $F64 src1 src2) (fpu_cmp64 src1 src2))
+
+;; Implicit conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(convert WritableRegPair RegPair writable_regpair_to_regpair)

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -13,121 +13,121 @@
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (iconst (u64_from_imm64 n))))
-      (value_reg (imm ty n)))
+      (imm ty n))
 
 
 ;;;; Rules for `bconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (bconst $false)))
-      (value_reg (imm ty 0)))
+      (imm ty 0))
 (rule (lower (has_type ty (bconst $true)))
-      (value_reg (imm ty 1)))
+      (imm ty 1))
 
 
 ;;;; Rules for `f32const` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (f32const (u64_from_ieee32 x)))
-      (value_reg (imm $F32 x)))
+      (imm $F32 x))
 
 
 ;;;; Rules for `f64const` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (f64const (u64_from_ieee64 x)))
-      (value_reg (imm $F64 x)))
+      (imm $F64 x))
 
 
 ;;;; Rules for `null` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (null)))
-      (value_reg (imm ty 0)))
+      (imm ty 0))
 
 
 ;;;; Rules for `nop` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (nop))
-      (value_reg (invalid_reg)))
+      (invalid_reg))
 
 
 ;;;; Rules for `copy` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (copy x))
-      (value_reg (put_in_reg x)))
+      x)
 
 
 ;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty) (iadd x y)))
-      (value_reg (add_reg ty (put_in_reg x) (put_in_reg y))))
+      (add_reg ty x y))
 
 ;; Add a register and a sign-extended register.
 (rule (lower (has_type (fits_in_64 ty) (iadd x (sext32_value y))))
-      (value_reg (add_reg_sext32 ty (put_in_reg x) (put_in_reg y))))
+      (add_reg_sext32 ty x y))
 (rule (lower (has_type (fits_in_64 ty) (iadd (sext32_value x) y)))
-      (value_reg (add_reg_sext32 ty (put_in_reg y) (put_in_reg x))))
+      (add_reg_sext32 ty y x))
 
 ;; Add a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty) (iadd x (i16_from_value y))))
-      (value_reg (add_simm16 ty (put_in_reg x) y)))
+      (add_simm16 ty x y))
 (rule (lower (has_type (fits_in_64 ty) (iadd (i16_from_value x) y)))
-      (value_reg (add_simm16 ty (put_in_reg y) x)))
+      (add_simm16 ty y x))
 (rule (lower (has_type (fits_in_64 ty) (iadd x (i32_from_value y))))
-      (value_reg (add_simm32 ty (put_in_reg x) y)))
+      (add_simm32 ty x y))
 (rule (lower (has_type (fits_in_64 ty) (iadd (i32_from_value x) y)))
-      (value_reg (add_simm32 ty (put_in_reg y) x)))
+      (add_simm32 ty y x))
 
 ;; Add a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (iadd x (sinkable_load_32_64 y))))
-      (value_reg (add_mem ty (put_in_reg x) (sink_load y))))
+      (add_mem ty x (sink_load y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd (sinkable_load_32_64 x) y)))
-      (value_reg (add_mem ty (put_in_reg y) (sink_load x))))
+      (add_mem ty y (sink_load x)))
 
 ;; Add a register and memory (16-bit types).
 (rule (lower (has_type (fits_in_64 ty) (iadd x (sinkable_load_16 y))))
-      (value_reg (add_mem_sext16 ty (put_in_reg x) (sink_load y))))
+      (add_mem_sext16 ty x (sink_load y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd (sinkable_load_16 x) y)))
-      (value_reg (add_mem_sext16 ty (put_in_reg y) (sink_load x))))
+      (add_mem_sext16 ty y (sink_load x)))
 
 ;; Add a register and sign-extended memory.
 (rule (lower (has_type (fits_in_64 ty) (iadd x (sinkable_sload16 y))))
-      (value_reg (add_mem_sext16 ty (put_in_reg x) (sink_sload16 y))))
+      (add_mem_sext16 ty x (sink_sload16 y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd (sinkable_sload16 x) y)))
-      (value_reg (add_mem_sext16 ty (put_in_reg y) (sink_sload16 x))))
+      (add_mem_sext16 ty y (sink_sload16 x)))
 (rule (lower (has_type (fits_in_64 ty) (iadd x (sinkable_sload32 y))))
-      (value_reg (add_mem_sext32 ty (put_in_reg x) (sink_sload32 y))))
+      (add_mem_sext32 ty x (sink_sload32 y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd (sinkable_sload32 x) y)))
-      (value_reg (add_mem_sext32 ty (put_in_reg y) (sink_sload32 x))))
+      (add_mem_sext32 ty y (sink_sload32 x)))
 
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Sub two registers.
 (rule (lower (has_type (fits_in_64 ty) (isub x y)))
-      (value_reg (sub_reg ty (put_in_reg x) (put_in_reg y))))
+      (sub_reg ty x y))
 
 ;; Sub a register and a sign-extended register.
 (rule (lower (has_type (fits_in_64 ty) (isub x (sext32_value y))))
-      (value_reg (sub_reg_sext32 ty (put_in_reg x) (put_in_reg y))))
+      (sub_reg_sext32 ty x y))
 
 ;; Sub a register and an immediate (using add of the negated value).
 (rule (lower (has_type (fits_in_64 ty) (isub x (i16_from_negated_value y))))
-      (value_reg (add_simm16 ty (put_in_reg x) y)))
+      (add_simm16 ty x y))
 (rule (lower (has_type (fits_in_64 ty) (isub x (i32_from_negated_value y))))
-      (value_reg (add_simm32 ty (put_in_reg x) y)))
+      (add_simm32 ty x y))
 
 ;; Sub a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (isub x (sinkable_load_32_64 y))))
-      (value_reg (sub_mem ty (put_in_reg x) (sink_load y))))
+      (sub_mem ty x (sink_load y)))
 
 ;; Sub a register and memory (16-bit types).
 (rule (lower (has_type (fits_in_64 ty) (isub x (sinkable_load_16 y))))
-      (value_reg (sub_mem_sext16 ty (put_in_reg x) (sink_load y))))
+      (sub_mem_sext16 ty x (sink_load y)))
 
 ;; Sub a register and sign-extended memory.
 (rule (lower (has_type (fits_in_64 ty) (isub x (sinkable_sload16 y))))
-      (value_reg (sub_mem_sext16 ty (put_in_reg x) (sink_sload16 y))))
+      (sub_mem_sext16 ty x (sink_sload16 y)))
 (rule (lower (has_type (fits_in_64 ty) (isub x (sinkable_sload32 y))))
-      (value_reg (sub_mem_sext32 ty (put_in_reg x) (sink_sload32 y))))
+      (sub_mem_sext32 ty x (sink_sload32 y)))
 
 
 ;;;; Rules for `iabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -135,11 +135,11 @@
 ;; Absolute value of a register.
 ;; For types smaller than 32-bit, the input value must be sign-extended.
 (rule (lower (has_type (fits_in_64 ty) (iabs x)))
-      (value_reg (abs_reg (ty_ext32 ty) (put_in_reg_sext32 x))))
+      (abs_reg (ty_ext32 ty) (put_in_reg_sext32 x)))
 
 ;; Absolute value of a sign-extended register.
 (rule (lower (has_type (fits_in_64 ty) (iabs (sext32_value x))))
-      (value_reg (abs_reg_sext32 ty (put_in_reg x))))
+      (abs_reg_sext32 ty x))
 
 
 ;;;; Rules for `iadd_ifcout` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -156,87 +156,87 @@
 
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x y)))
-      (value_regs_ifcout (add_logical_reg ty (put_in_reg x) (put_in_reg y))))
+      (value_regs_ifcout (add_logical_reg ty x y)))
 
 ;; Add a register and a zero-extended register.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (zext32_value y))))
-      (value_regs_ifcout (add_logical_reg_zext32 ty (put_in_reg x) (put_in_reg y))))
+      (value_regs_ifcout (add_logical_reg_zext32 ty x y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (zext32_value x) y)))
-      (value_regs_ifcout (add_logical_reg_zext32 ty (put_in_reg y) (put_in_reg x))))
+      (value_regs_ifcout (add_logical_reg_zext32 ty y x)))
 
 ;; Add a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (u32_from_value y))))
-      (value_regs_ifcout (add_logical_zimm32 ty (put_in_reg x) y)))
+      (value_regs_ifcout (add_logical_zimm32 ty x y)))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (u32_from_value x) y)))
-      (value_regs_ifcout (add_logical_zimm32 ty (put_in_reg y) x)))
+      (value_regs_ifcout (add_logical_zimm32 ty y x)))
 
 ;; Add a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (sinkable_load_32_64 y))))
-      (value_regs_ifcout (add_logical_mem ty (put_in_reg x) (sink_load y))))
+      (value_regs_ifcout (add_logical_mem ty x (sink_load y))))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (sinkable_load_32_64 x) y)))
-      (value_regs_ifcout (add_logical_mem ty (put_in_reg y) (sink_load x))))
+      (value_regs_ifcout (add_logical_mem ty y (sink_load x))))
 
 ;; Add a register and zero-extended memory.
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout x (sinkable_uload32 y))))
-      (value_regs_ifcout (add_logical_mem_zext32 ty (put_in_reg x) (sink_uload32 y))))
+      (value_regs_ifcout (add_logical_mem_zext32 ty x (sink_uload32 y))))
 (rule (lower (has_type (fits_in_64 ty) (iadd_ifcout (sinkable_uload32 x) y)))
-      (value_regs_ifcout (add_logical_mem_zext32 ty (put_in_reg y) (sink_uload32 x))))
+      (value_regs_ifcout (add_logical_mem_zext32 ty y (sink_uload32 x))))
 
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Negate a register.
 (rule (lower (has_type (fits_in_64 ty) (ineg x)))
-      (value_reg (neg_reg ty (put_in_reg x))))
+      (neg_reg ty x))
 
 ;; Negate a sign-extended register.
 (rule (lower (has_type (fits_in_64 ty) (ineg (sext32_value x))))
-      (value_reg (neg_reg_sext32 ty (put_in_reg x))))
+      (neg_reg_sext32 ty x))
 
 
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Multiply two registers.
 (rule (lower (has_type (fits_in_64 ty) (imul x y)))
-      (value_reg (mul_reg ty (put_in_reg x) (put_in_reg y))))
+      (mul_reg ty x y))
 
 ;; Multiply a register and a sign-extended register.
 (rule (lower (has_type (fits_in_64 ty) (imul x (sext32_value y))))
-      (value_reg (mul_reg_sext32 ty (put_in_reg x) (put_in_reg y))))
+      (mul_reg_sext32 ty x y))
 (rule (lower (has_type (fits_in_64 ty) (imul (sext32_value x) y)))
-      (value_reg (mul_reg_sext32 ty (put_in_reg y) (put_in_reg x))))
+      (mul_reg_sext32 ty y x))
 
 ;; Multiply a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty) (imul x (i16_from_value y))))
-      (value_reg (mul_simm16 ty (put_in_reg x) y)))
+      (mul_simm16 ty x y))
 (rule (lower (has_type (fits_in_64 ty) (imul (i16_from_value x) y)))
-      (value_reg (mul_simm16 ty (put_in_reg y) x)))
+      (mul_simm16 ty y x))
 (rule (lower (has_type (fits_in_64 ty) (imul x (i32_from_value y))))
-      (value_reg (mul_simm32 ty (put_in_reg x) y)))
+      (mul_simm32 ty x y))
 (rule (lower (has_type (fits_in_64 ty) (imul (i32_from_value x) y)))
-      (value_reg (mul_simm32 ty (put_in_reg y) x)))
+      (mul_simm32 ty y x))
 
 ;; Multiply a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (imul x (sinkable_load_32_64 y))))
-      (value_reg (mul_mem ty (put_in_reg x) (sink_load y))))
+      (mul_mem ty x (sink_load y)))
 (rule (lower (has_type (fits_in_64 ty) (imul (sinkable_load_32_64 x) y)))
-      (value_reg (mul_mem ty (put_in_reg y) (sink_load x))))
+      (mul_mem ty y (sink_load x)))
 
 ;; Multiply a register and memory (16-bit types).
 (rule (lower (has_type (fits_in_64 ty) (imul x (sinkable_load_16 y))))
-      (value_reg (mul_mem_sext16 ty (put_in_reg x) (sink_load y))))
+      (mul_mem_sext16 ty x (sink_load y)))
 (rule (lower (has_type (fits_in_64 ty) (imul (sinkable_load_16 x) y)))
-      (value_reg (mul_mem_sext16 ty (put_in_reg y) (sink_load x))))
+      (mul_mem_sext16 ty y (sink_load x)))
 
 ;; Multiply a register and sign-extended memory.
 (rule (lower (has_type (fits_in_64 ty) (imul x (sinkable_sload16 y))))
-      (value_reg (mul_mem_sext16 ty (put_in_reg x) (sink_sload16 y))))
+      (mul_mem_sext16 ty x (sink_sload16 y)))
 (rule (lower (has_type (fits_in_64 ty) (imul (sinkable_sload16 x) y)))
-      (value_reg (mul_mem_sext16 ty (put_in_reg y) (sink_sload16 x))))
+      (mul_mem_sext16 ty y (sink_sload16 x)))
 (rule (lower (has_type (fits_in_64 ty) (imul x (sinkable_sload32 y))))
-      (value_reg (mul_mem_sext32 ty (put_in_reg x) (sink_sload32 y))))
+      (mul_mem_sext32 ty x (sink_sload32 y)))
 (rule (lower (has_type (fits_in_64 ty) (imul (sinkable_sload32 x) y)))
-      (value_reg (mul_mem_sext32 ty (put_in_reg y) (sink_sload32 x))))
+      (mul_mem_sext32 ty y (sink_sload32 x)))
 
 
 ;;;; Rules for `umulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -246,19 +246,19 @@
       (let ((ext_reg_x Reg (put_in_reg_zext32 x))
             (ext_reg_y Reg (put_in_reg_zext32 y))
             (ext_mul Reg (mul_reg $I32 ext_reg_x ext_reg_y)))
-        (value_reg (lshr_imm $I32 ext_mul (ty_bits ty)))))
+        (lshr_imm $I32 ext_mul (ty_bits ty))))
 
 ;; Multiply high part unsigned, 32-bit types.  (Uses 64-bit multiply.)
 (rule (lower (has_type $I32 (umulhi x y)))
       (let ((ext_reg_x Reg (put_in_reg_zext64 x))
             (ext_reg_y Reg (put_in_reg_zext64 y))
             (ext_mul Reg (mul_reg $I64 ext_reg_x ext_reg_y)))
-        (value_reg (lshr_imm $I64 ext_mul 32))))
+        (lshr_imm $I64 ext_mul 32)))
 
 ;; Multiply high part unsigned, 64-bit types.  (Uses umul_wide.)
 (rule (lower (has_type $I64 (umulhi x y)))
-      (let ((pair RegPair (umul_wide (put_in_reg x) (put_in_reg y))))
-        (value_reg (copy_reg $I64 (regpair_hi pair)))))
+      (let ((pair RegPair (umul_wide x y)))
+        (copy_reg $I64 (regpair_hi pair))))
 
 
 ;;;; Rules for `smulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -268,19 +268,19 @@
       (let ((ext_reg_x Reg (put_in_reg_sext32 x))
             (ext_reg_y Reg (put_in_reg_sext32 y))
             (ext_mul Reg (mul_reg $I32 ext_reg_x ext_reg_y)))
-        (value_reg (ashr_imm $I32 ext_mul (ty_bits ty)))))
+        (ashr_imm $I32 ext_mul (ty_bits ty))))
 
 ;; Multiply high part signed, 32-bit types.  (Uses 64-bit multiply.)
 (rule (lower (has_type $I32 (smulhi x y)))
       (let ((ext_reg_x Reg (put_in_reg_sext64 x))
             (ext_reg_y Reg (put_in_reg_sext64 y))
             (ext_mul Reg (mul_reg $I64 ext_reg_x ext_reg_y)))
-        (value_reg (ashr_imm $I64 ext_mul 32))))
+        (ashr_imm $I64 ext_mul 32)))
 
 ;; Multiply high part signed, 64-bit types.  (Uses smul_wide.)
 (rule (lower (has_type $I64 (smulhi x y)))
-      (let ((pair RegPair (smul_wide (put_in_reg x) (put_in_reg y))))
-        (value_reg (copy_reg $I64 (regpair_hi pair)))))
+      (let ((pair RegPair (smul_wide x y)))
+        (copy_reg $I64 (regpair_hi pair))))
 
 
 ;;;; Rules for `udiv` and `urem` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -319,7 +319,7 @@
             ;; Emit the actual divide instruction.
             (pair RegPair (udivmod ext_ty ext_x ext_y)))
         ;; The quotient can be found in the low half of the result.
-        (value_reg (copy_reg ty (regpair_lo pair)))))
+        (copy_reg ty (regpair_lo pair))))
 
 ;; Implement `urem`.  Same as `udiv`, but finds the remainder in
 ;; the high half of the result register pair instead.
@@ -331,7 +331,7 @@
             (ext_ty Type (ty_ext32 ty))
             (_ Reg (maybe_trap_if_zero_divisor DZcheck ext_ty ext_y))
             (pair RegPair (udivmod ext_ty ext_x ext_y)))
-        (value_reg (copy_reg ty (regpair_hi pair)))))
+        (copy_reg ty (regpair_hi pair))))
 
 ;; Determine whether we need to perform a divide-by-zero-check.
 ;;
@@ -390,7 +390,7 @@
             ;; Emit the actual divide instruction.
             (pair RegPair (sdivmod ext_ty ext_x ext_y)))
         ;; The quotient can be found in the low half of the result.
-        (value_reg (copy_reg ty (regpair_lo pair)))))
+        (copy_reg ty (regpair_lo pair))))
 
 ;; Implement `srem`.  Same as `sdiv`, but finds the remainder in
 ;; the high half of the result register pair instead.  Also, handle
@@ -404,7 +404,7 @@
             (_ Reg (maybe_trap_if_zero_divisor DZcheck ext_ty ext_y))
             (checked_x RegPair (maybe_avoid_srem_overflow OFcheck ext_ty ext_x ext_y))
             (pair RegPair (sdivmod ext_ty checked_x ext_y)))
-        (value_reg (copy_reg ty (regpair_hi pair)))))
+        (copy_reg ty (regpair_hi pair))))
 
 ;; Determine whether we need to perform an integer-overflow check.
 ;;
@@ -475,13 +475,13 @@
 
 ;; Shift left, shift amount in register.
 (rule (lower (has_type (fits_in_64 ty) (ishl x y)))
-      (let ((masked_amt Reg (mask_amt_reg ty (put_in_reg y))))
-        (value_reg (lshl_reg ty (put_in_reg x) masked_amt))))
+      (let ((masked_amt Reg (mask_amt_reg ty y)))
+        (lshl_reg ty x masked_amt)))
 
 ;; Shift left, immediate shift amount.
 (rule (lower (has_type (fits_in_64 ty) (ishl x (i64_from_value y))))
       (let ((masked_amt u8 (mask_amt_imm ty y)))
-        (value_reg (lshl_imm ty (put_in_reg x) masked_amt))))
+        (lshl_imm ty x masked_amt)))
 
 
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -490,15 +490,15 @@
 ;; For types smaller than 32-bit, the input value must be zero-extended.
 (rule (lower (has_type (fits_in_64 ty) (ushr x y)))
       (let ((ext_reg Reg (put_in_reg_zext32 x))
-            (masked_amt Reg (mask_amt_reg ty (put_in_reg y))))
-        (value_reg (lshr_reg (ty_ext32 ty) ext_reg masked_amt))))
+            (masked_amt Reg (mask_amt_reg ty y)))
+        (lshr_reg (ty_ext32 ty) ext_reg masked_amt)))
 
 ;; Shift right logical, immediate shift amount.
 ;; For types smaller than 32-bit, the input value must be zero-extended.
 (rule (lower (has_type (fits_in_64 ty) (ushr x (i64_from_value y))))
       (let ((ext_reg Reg (put_in_reg_zext32 x))
             (masked_amt u8 (mask_amt_imm ty y)))
-        (value_reg (lshr_imm (ty_ext32 ty) ext_reg masked_amt))))
+        (lshr_imm (ty_ext32 ty) ext_reg masked_amt)))
 
 
 ;;;; Rules for `sshr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -507,39 +507,39 @@
 ;; For types smaller than 32-bit, the input value must be sign-extended.
 (rule (lower (has_type (fits_in_64 ty) (sshr x y)))
       (let ((ext_reg Reg (put_in_reg_sext32 x))
-            (masked_amt Reg (mask_amt_reg ty (put_in_reg y))))
-        (value_reg (ashr_reg (ty_ext32 ty) ext_reg masked_amt))))
+            (masked_amt Reg (mask_amt_reg ty y)))
+        (ashr_reg (ty_ext32 ty) ext_reg masked_amt)))
 
 ;; Shift right arithmetic, immediate shift amount.
 ;; For types smaller than 32-bit, the input value must be sign-extended.
 (rule (lower (has_type (fits_in_64 ty) (sshr x (i64_from_value y))))
       (let ((ext_reg Reg (put_in_reg_sext32 x))
             (masked_amt u8 (mask_amt_imm ty y)))
-        (value_reg (ashr_imm (ty_ext32 ty) ext_reg masked_amt))))
+        (ashr_imm (ty_ext32 ty) ext_reg masked_amt)))
 
 
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Rotate left, shift amount in register.  32-bit or 64-bit types.
 (rule (lower (has_type (ty_32_or_64 ty) (rotl x y)))
-      (value_reg (rot_reg ty (put_in_reg x) (put_in_reg y))))
+      (rot_reg ty x y))
 
 ;; Rotate left arithmetic, immediate shift amount.  32-bit or 64-bit types.
 (rule (lower (has_type (ty_32_or_64 ty) (rotl x (i64_from_value y))))
       (let ((masked_amt u8 (mask_amt_imm ty y)))
-        (value_reg (rot_imm ty (put_in_reg x) masked_amt))))
+        (rot_imm ty x masked_amt)))
 
 ;; Rotate left, shift amount in register.  8-bit or 16-bit types.
 ;; Implemented via a pair of 32-bit shifts on the zero-extended input.
 (rule (lower (has_type (ty_8_or_16 ty) (rotl x y)))
       (let ((ext_reg Reg (put_in_reg_zext32 x))
             (ext_ty Type (ty_ext32 ty))
-            (pos_amt Reg (put_in_reg y))
+            (pos_amt Reg y)
             (neg_amt Reg (neg_reg ty pos_amt))
             (masked_pos_amt Reg (mask_amt_reg ty pos_amt))
             (masked_neg_amt Reg (mask_amt_reg ty neg_amt)))
-        (value_reg (or_reg ty (lshl_reg ext_ty ext_reg masked_pos_amt)
-                              (lshr_reg ext_ty ext_reg masked_neg_amt)))))
+        (or_reg ty (lshl_reg ext_ty ext_reg masked_pos_amt)
+                (lshr_reg ext_ty ext_reg masked_neg_amt))))
 
 ;; Rotate left, immediate shift amount.  8-bit or 16-bit types.
 ;; Implemented via a pair of 32-bit shifts on the zero-extended input.
@@ -549,8 +549,8 @@
             (ext_ty Type (ty_ext32 ty))
             (masked_pos_amt u8 (mask_amt_imm ty pos_amt))
             (masked_neg_amt u8 (mask_amt_imm ty neg_amt)))
-        (value_reg (or_reg ty (lshl_imm ext_ty ext_reg masked_pos_amt)
-                              (lshr_imm ext_ty ext_reg masked_neg_amt)))))
+        (or_reg ty (lshl_imm ext_ty ext_reg masked_pos_amt)
+                (lshr_imm ext_ty ext_reg masked_neg_amt))))
 
 
 ;;;; Rules for `rotr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -558,26 +558,26 @@
 ;; Rotate right, shift amount in register.  32-bit or 64-bit types.
 ;; Implemented as rotate left with negated rotate amount.
 (rule (lower (has_type (ty_32_or_64 ty) (rotr x y)))
-      (let ((negated_amt Reg (neg_reg ty (put_in_reg y))))
-        (value_reg (rot_reg ty (put_in_reg x) negated_amt))))
+      (let ((negated_amt Reg (neg_reg ty y)))
+        (rot_reg ty x negated_amt)))
 
 ;; Rotate right arithmetic, immediate shift amount.  32-bit or 64-bit types.
 ;; Implemented as rotate left with negated rotate amount.
 (rule (lower (has_type (ty_32_or_64 ty) (rotr x (i64_from_negated_value y))))
       (let ((negated_amt u8 (mask_amt_imm ty y)))
-        (value_reg (rot_imm ty (put_in_reg x) negated_amt))))
+        (rot_imm ty x negated_amt)))
 
 ;; Rotate right, shift amount in register.  8-bit or 16-bit types.
 ;; Implemented as rotate left with negated rotate amount.
 (rule (lower (has_type (ty_8_or_16 ty) (rotr x y)))
       (let ((ext_reg Reg (put_in_reg_zext32 x))
             (ext_ty Type (ty_ext32 ty))
-            (pos_amt Reg (put_in_reg y))
+            (pos_amt Reg y)
             (neg_amt Reg (neg_reg ty pos_amt))
             (masked_pos_amt Reg (mask_amt_reg ty pos_amt))
             (masked_neg_amt Reg (mask_amt_reg ty neg_amt)))
-        (value_reg (or_reg ty (lshl_reg ext_ty ext_reg masked_neg_amt)
-                              (lshr_reg ext_ty ext_reg masked_pos_amt)))))
+        (or_reg ty (lshl_reg ext_ty ext_reg masked_neg_amt)
+                (lshr_reg ext_ty ext_reg masked_pos_amt))))
 
 ;; Rotate right, immediate shift amount.  8-bit or 16-bit types.
 ;; Implemented as rotate left with negated rotate amount.
@@ -587,170 +587,170 @@
             (ext_ty Type (ty_ext32 ty))
             (masked_pos_amt u8 (mask_amt_imm ty pos_amt))
             (masked_neg_amt u8 (mask_amt_imm ty neg_amt)))
-        (value_reg (or_reg ty (lshl_imm ext_ty ext_reg masked_neg_amt)
-                              (lshr_imm ext_ty ext_reg masked_pos_amt)))))
+        (or_reg ty (lshl_imm ext_ty ext_reg masked_neg_amt)
+                (lshr_imm ext_ty ext_reg masked_pos_amt))))
 
 ;;;; Rules for `ireduce` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Always a no-op.
 (rule (lower (ireduce x))
-      (value_reg (put_in_reg x)))
+      x)
 
 
 ;;;; Rules for `uextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; 16- or 32-bit target types.
 (rule (lower (has_type (gpr32_ty _ty) (uextend x)))
-      (value_reg (put_in_reg_zext32 x)))
+      (put_in_reg_zext32 x))
 
 ;; 64-bit target types.
 (rule (lower (has_type (gpr64_ty _ty) (uextend x)))
-      (value_reg (put_in_reg_zext64 x)))
+      (put_in_reg_zext64 x))
 
 
 ;;;; Rules for `sextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; 16- or 32-bit target types.
 (rule (lower (has_type (gpr32_ty _ty) (sextend x)))
-      (value_reg (put_in_reg_sext32 x)))
+      (put_in_reg_sext32 x))
 
 ;; 64-bit target types.
 (rule (lower (has_type (gpr64_ty _ty) (sextend x)))
-      (value_reg (put_in_reg_sext64 x)))
+      (put_in_reg_sext64 x))
 
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; z15 version using a single instruction (NOR).
 (rule (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bnot x)))
-      (let ((rx Reg (put_in_reg x)))
-        (value_reg (or_not_reg ty rx rx))))
+      (let ((rx Reg x))
+        (or_not_reg ty rx rx)))
 
 ;; z14 version using XOR with -1.
 (rule (lower (has_type (and (mie2_disabled) (fits_in_64 ty)) (bnot x)))
-      (value_reg (not_reg ty (put_in_reg x))))
+      (not_reg ty x))
 
 
 ;;;; Rules for `band` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; And two registers.
 (rule (lower (has_type (fits_in_64 ty) (band x y)))
-      (value_reg (and_reg ty (put_in_reg x) (put_in_reg y))))
+      (and_reg ty x y))
 
 ;; And a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty) (band x (uimm16shifted_from_inverted_value y))))
-      (value_reg (and_uimm16shifted ty (put_in_reg x) y)))
+      (and_uimm16shifted ty x y))
 (rule (lower (has_type (fits_in_64 ty) (band (uimm16shifted_from_inverted_value x) y)))
-      (value_reg (and_uimm16shifted ty (put_in_reg y) x)))
+      (and_uimm16shifted ty y x))
 (rule (lower (has_type (fits_in_64 ty) (band x (uimm32shifted_from_inverted_value y))))
-      (value_reg (and_uimm32shifted ty (put_in_reg x) y)))
+      (and_uimm32shifted ty x y))
 (rule (lower (has_type (fits_in_64 ty) (band (uimm32shifted_from_inverted_value x) y)))
-      (value_reg (and_uimm32shifted ty (put_in_reg y) x)))
+      (and_uimm32shifted ty y x))
 
 ;; And a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (band x (sinkable_load_32_64 y))))
-      (value_reg (and_mem ty (put_in_reg x) (sink_load y))))
+      (and_mem ty x (sink_load y)))
 (rule (lower (has_type (fits_in_64 ty) (band (sinkable_load_32_64 x) y)))
-      (value_reg (and_mem ty (put_in_reg y) (sink_load x))))
+      (and_mem ty y (sink_load x)))
 
 
 ;;;; Rules for `bor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Or two registers.
 (rule (lower (has_type (fits_in_64 ty) (bor x y)))
-      (value_reg (or_reg ty (put_in_reg x) (put_in_reg y))))
+      (or_reg ty x y))
 
 ;; Or a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty) (bor x (uimm16shifted_from_value y))))
-      (value_reg (or_uimm16shifted ty (put_in_reg x) y)))
+      (or_uimm16shifted ty x y))
 (rule (lower (has_type (fits_in_64 ty) (bor (uimm16shifted_from_value x) y)))
-      (value_reg (or_uimm16shifted ty (put_in_reg y) x)))
+      (or_uimm16shifted ty y x))
 (rule (lower (has_type (fits_in_64 ty) (bor x (uimm32shifted_from_value y))))
-      (value_reg (or_uimm32shifted ty (put_in_reg x) y)))
+      (or_uimm32shifted ty x y))
 (rule (lower (has_type (fits_in_64 ty) (bor (uimm32shifted_from_value x) y)))
-      (value_reg (or_uimm32shifted ty (put_in_reg y) x)))
+      (or_uimm32shifted ty y x))
 
 ;; Or a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (bor x (sinkable_load_32_64 y))))
-      (value_reg (or_mem ty (put_in_reg x) (sink_load y))))
+      (or_mem ty x (sink_load y)))
 (rule (lower (has_type (fits_in_64 ty) (bor (sinkable_load_32_64 x) y)))
-      (value_reg (or_mem ty (put_in_reg y) (sink_load x))))
+      (or_mem ty y (sink_load x)))
 
 
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Xor two registers.
 (rule (lower (has_type (fits_in_64 ty) (bxor x y)))
-      (value_reg (xor_reg ty (put_in_reg x) (put_in_reg y))))
+      (xor_reg ty x y))
 
 ;; Xor a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty) (bxor x (uimm32shifted_from_value y))))
-      (value_reg (xor_uimm32shifted ty (put_in_reg x) y)))
+      (xor_uimm32shifted ty x y))
 (rule (lower (has_type (fits_in_64 ty) (bxor (uimm32shifted_from_value x) y)))
-      (value_reg (xor_uimm32shifted ty (put_in_reg y) x)))
+      (xor_uimm32shifted ty y x))
 
 ;; Xor a register and memory (32/64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (bxor x (sinkable_load_32_64 y))))
-      (value_reg (xor_mem ty (put_in_reg x) (sink_load y))))
+      (xor_mem ty x (sink_load y)))
 (rule (lower (has_type (fits_in_64 ty) (bxor (sinkable_load_32_64 x) y)))
-      (value_reg (xor_mem ty (put_in_reg y) (sink_load x))))
+      (xor_mem ty y (sink_load x)))
 
 
 ;;;; Rules for `band_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; z15 version using a single instruction.
 (rule (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (band_not x y)))
-      (value_reg (and_not_reg ty (put_in_reg x) (put_in_reg y))))
+      (and_not_reg ty x y))
 
 ;; z14 version using XOR with -1.
 (rule (lower (has_type (and (mie2_disabled) (fits_in_64 ty)) (band_not x y)))
-      (value_reg (not_reg ty (and_reg ty (put_in_reg x) (put_in_reg y)))))
+      (not_reg ty (and_reg ty x y)))
 
 
 ;;;; Rules for `bor_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; z15 version using a single instruction.
 (rule (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bor_not x y)))
-      (value_reg (or_not_reg ty (put_in_reg x) (put_in_reg y))))
+      (or_not_reg ty x y))
 
 ;; z14 version using XOR with -1.
 (rule (lower (has_type (and (mie2_disabled) (fits_in_64 ty)) (bor_not x y)))
-      (value_reg (not_reg ty (or_reg ty (put_in_reg x) (put_in_reg y)))))
+      (not_reg ty (or_reg ty x y)))
 
 
 ;;;; Rules for `bxor_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; z15 version using a single instruction.
 (rule (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bxor_not x y)))
-      (value_reg (xor_not_reg ty (put_in_reg x) (put_in_reg y))))
+      (xor_not_reg ty x y))
 
 ;; z14 version using XOR with -1.
 (rule (lower (has_type (and (mie2_disabled) (fits_in_64 ty)) (bxor_not x y)))
-      (value_reg (not_reg ty (xor_reg ty (put_in_reg x) (put_in_reg y)))))
+      (not_reg ty (xor_reg ty x y)))
 
 
 ;;;; Rules for `bitselect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; z15 version using a NAND instruction.
 (rule (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bitselect x y z)))
-      (let ((rx Reg (put_in_reg x))
-            (if_true Reg (and_reg ty (put_in_reg y) rx))
-            (if_false Reg (and_not_reg ty (put_in_reg z) rx)))
-        (value_reg (or_reg ty if_false if_true))))
+      (let ((rx Reg x)
+            (if_true Reg (and_reg ty y rx))
+            (if_false Reg (and_not_reg ty z rx)))
+        (or_reg ty if_false if_true)))
 
 ;; z14 version using XOR with -1.
 (rule (lower (has_type (and (mie2_disabled) (fits_in_64 ty)) (bitselect x y z)))
-      (let ((rx Reg (put_in_reg x))
-            (if_true Reg (and_reg ty (put_in_reg y) rx))
-            (if_false Reg (not_reg ty (and_reg ty (put_in_reg z) rx))))
-        (value_reg (or_reg ty if_false if_true))))
+      (let ((rx Reg x)
+            (if_true Reg (and_reg ty y rx))
+            (if_false Reg (not_reg ty (and_reg ty z rx))))
+        (or_reg ty if_false if_true)))
 
 
 ;;;; Rules for `breduce` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Always a no-op.
 (rule (lower (breduce x))
-      (value_reg (put_in_reg x)))
+      x)
 
 
 ;;;; Rules for `bextend` and `bmask` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -758,51 +758,51 @@
 ;; Use a common helper to type cast bools to either bool or integer types.
 (decl cast_bool (Type Value) Reg)
 (rule (lower (has_type ty (bextend x)))
-      (value_reg (cast_bool ty x)))
+      (cast_bool ty x))
 (rule (lower (has_type ty (bmask x)))
-      (value_reg (cast_bool ty x)))
+      (cast_bool ty x))
 
 ;; If the target has the same or a smaller size than the source, it's a no-op.
-(rule (cast_bool $B1 x @ (value_type $B1)) (put_in_reg x))
-(rule (cast_bool $B1 x @ (value_type $B8)) (put_in_reg x))
-(rule (cast_bool $B8 x @ (value_type $B8)) (put_in_reg x))
-(rule (cast_bool $I8 x @ (value_type $B8)) (put_in_reg x))
-(rule (cast_bool (fits_in_16 _ty) x @ (value_type $B16)) (put_in_reg x))
-(rule (cast_bool (fits_in_32 _ty) x @ (value_type $B32)) (put_in_reg x))
-(rule (cast_bool (fits_in_64 _ty) x @ (value_type $B64)) (put_in_reg x))
+(rule (cast_bool $B1 x @ (value_type $B1)) x)
+(rule (cast_bool $B1 x @ (value_type $B8)) x)
+(rule (cast_bool $B8 x @ (value_type $B8)) x)
+(rule (cast_bool $I8 x @ (value_type $B8)) x)
+(rule (cast_bool (fits_in_16 _ty) x @ (value_type $B16)) x)
+(rule (cast_bool (fits_in_32 _ty) x @ (value_type $B32)) x)
+(rule (cast_bool (fits_in_64 _ty) x @ (value_type $B64)) x)
 
 ;; Single-bit values are sign-extended via a pair of shifts.
 (rule (cast_bool (gpr32_ty ty) x @ (value_type $B1))
-      (ashr_imm $I32 (lshl_imm $I32 (put_in_reg x) 31) 31))
+      (ashr_imm $I32 (lshl_imm $I32 x 31) 31))
 (rule (cast_bool (gpr64_ty ty) x @ (value_type $B1))
-      (ashr_imm $I64 (lshl_imm $I64 (put_in_reg x) 63) 63))
+      (ashr_imm $I64 (lshl_imm $I64 x 63) 63))
 
 ;; Other values are just sign-extended normally.
 (rule (cast_bool (gpr32_ty _ty) x @ (value_type $B8))
-      (sext32_reg $I8 (put_in_reg x)))
+      (sext32_reg $I8 x))
 (rule (cast_bool (gpr32_ty _ty) x @ (value_type $B16))
-      (sext32_reg $I16 (put_in_reg x)))
+      (sext32_reg $I16 x))
 (rule (cast_bool (gpr64_ty _ty) x @ (value_type $B8))
-      (sext64_reg $I8 (put_in_reg x)))
+      (sext64_reg $I8 x))
 (rule (cast_bool (gpr64_ty _ty) x @ (value_type $B16))
-      (sext64_reg $I16 (put_in_reg x)))
+      (sext64_reg $I16 x))
 (rule (cast_bool (gpr64_ty _ty) x @ (value_type $B32))
-      (sext64_reg $I32 (put_in_reg x)))
+      (sext64_reg $I32 x))
 
 
 ;;;; Rules for `bint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Mask with 1 to get a 0/1 result (8- or 16-bit types).
 (rule (lower (has_type (fits_in_16 ty) (bint x)))
-      (value_reg (and_uimm16shifted ty (put_in_reg x) (uimm16shifted 1 0))))
+      (and_uimm16shifted ty x (uimm16shifted 1 0)))
 
 ;; Mask with 1 to get a 0/1 result (32-bit types).
 (rule (lower (has_type (fits_in_32 ty) (bint x)))
-      (value_reg (and_uimm32shifted ty (put_in_reg x) (uimm32shifted 1 0))))
+      (and_uimm32shifted ty x (uimm32shifted 1 0)))
 
 ;; Mask with 1 to get a 0/1 result (64-bit types).
 (rule (lower (has_type (fits_in_64 ty) (bint x)))
-      (value_reg (and_reg ty (put_in_reg x) (imm ty 1))))
+      (and_reg ty x (imm ty 1)))
 
 
 ;;;; Rules for `clz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -823,7 +823,7 @@
             ;; Ask for a value of 64 in the all-zero 64-bit input case.
             ;; After compensation this will match the expected semantics.
             (clz RegPair (clz_reg 64 ext_reg)))
-        (value_reg (clz_offset ty (regpair_hi clz)))))
+        (clz_offset ty (regpair_hi clz))))
 
 
 ;;;; Rules for `cls` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -838,7 +838,7 @@
             (signbit_copies Reg (ashr_imm $I64 ext_reg 63))
             (inv_reg Reg (xor_reg $I64 ext_reg signbit_copies))
             (clz RegPair (clz_reg 64 inv_reg)))
-        (value_reg (clz_offset ty (regpair_hi clz)))))
+        (clz_offset ty (regpair_hi clz))))
 
 
 ;;;; Rules for `ctz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -857,10 +857,10 @@
 ;; the input type size.  This way the 64-bit algorithm above will handle
 ;; that case correctly automatically.
 (rule (lower (has_type (gpr32_ty ty) (ctz x)))
-      (let ((rx Reg (or_uimm16shifted $I64 (put_in_reg x) (ctz_guardbit ty)))
+      (let ((rx Reg (or_uimm16shifted $I64 x (ctz_guardbit ty)))
             (lastbit Reg (and_reg $I64 rx (neg_reg $I64 rx)))
             (clz RegPair (clz_reg 64 lastbit)))
-        (value_reg (sub_reg ty (imm ty 63) (regpair_hi clz)))))
+        (sub_reg ty (imm ty 63) (regpair_hi clz))))
 
 (decl ctz_guardbit (Type) UImm16Shifted)
 (rule (ctz_guardbit $I8) (uimm16shifted 256 0))
@@ -872,22 +872,22 @@
 ;; result with the value -1 via a conditional move, which will then lead to
 ;; the correct result after the final subtraction from 63.
 (rule (lower (has_type (gpr64_ty _ty) (ctz x)))
-      (let ((rx Reg (put_in_reg x))
+      (let ((rx Reg x)
             (lastbit Reg (and_reg $I64 rx (neg_reg $I64 rx)))
             (clz RegPair (clz_reg -1 lastbit)))
-        (value_reg (sub_reg $I64 (imm $I64 63) (regpair_hi clz)))))
+        (sub_reg $I64 (imm $I64 63) (regpair_hi clz))))
 
 
 ;;;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Population count for 8-bit types is supported by the POPCNT instruction.
 (rule (lower (has_type $I8 (popcnt x)))
-      (value_reg (popcnt_byte (put_in_reg x))))
+      (popcnt_byte x))
 
 ;; On z15, the POPCNT instruction has a variant to compute a full 64-bit
 ;; population count, which we also use for 16- and 32-bit types.
 (rule (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (popcnt x)))
-      (value_reg (popcnt_reg (put_in_reg_zext64 x))))
+      (popcnt_reg (put_in_reg_zext64 x)))
 
 ;; On z14, we use the regular POPCNT, which computes the population count
 ;; of each input byte separately, so we need to accumulate those partial
@@ -896,157 +896,157 @@
 ;; any unrelated bits to give a clean result.
 
 (rule (lower (has_type (and (mie2_disabled) $I16) (popcnt x)))
-      (let ((cnt2 Reg (popcnt_byte (put_in_reg x)))
+      (let ((cnt2 Reg (popcnt_byte x))
             (cnt1 Reg (add_reg $I32 cnt2 (lshl_imm $I32 cnt2 8))))
-        (value_reg (lshr_imm $I32 cnt1 8))))
+        (lshr_imm $I32 cnt1 8)))
 
 (rule (lower (has_type (and (mie2_disabled) $I32) (popcnt x)))
-      (let ((cnt4 Reg (popcnt_byte (put_in_reg x)))
+      (let ((cnt4 Reg (popcnt_byte x))
             (cnt2 Reg (add_reg $I32 cnt4 (lshl_imm $I32 cnt4 16)))
             (cnt1 Reg (add_reg $I32 cnt2 (lshl_imm $I32 cnt2 8))))
-        (value_reg (lshr_imm $I32 cnt1 24))))
+        (lshr_imm $I32 cnt1 24)))
 
 (rule (lower (has_type (and (mie2_disabled) $I64) (popcnt x)))
-      (let ((cnt8 Reg (popcnt_byte (put_in_reg x)))
+      (let ((cnt8 Reg (popcnt_byte x))
             (cnt4 Reg (add_reg $I64 cnt8 (lshl_imm $I64 cnt8 32)))
             (cnt2 Reg (add_reg $I64 cnt4 (lshl_imm $I64 cnt4 16)))
             (cnt1 Reg (add_reg $I64 cnt2 (lshl_imm $I64 cnt2 8))))
-        (value_reg (lshr_imm $I64 cnt1 56))))
+        (lshr_imm $I64 cnt1 56)))
 
 
 ;;;; Rules for `fadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Add two registers.
 (rule (lower (has_type ty (fadd x y)))
-      (value_reg (fadd_reg ty (put_in_reg x) (put_in_reg y))))
+      (fadd_reg ty x y))
 
 
 ;;;; Rules for `fsub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Subtract two registers.
 (rule (lower (has_type ty (fsub x y)))
-      (value_reg (fsub_reg ty (put_in_reg x) (put_in_reg y))))
+      (fsub_reg ty x y))
 
 
 ;;;; Rules for `fmul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Multiply two registers.
 (rule (lower (has_type ty (fmul x y)))
-      (value_reg (fmul_reg ty (put_in_reg x) (put_in_reg y))))
+      (fmul_reg ty x y))
 
 
 ;;;; Rules for `fdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Divide two registers.
 (rule (lower (has_type ty (fdiv x y)))
-      (value_reg (fdiv_reg ty (put_in_reg x) (put_in_reg y))))
+      (fdiv_reg ty x y))
 
 
 ;;;; Rules for `fmin` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Minimum of two registers.
 (rule (lower (has_type ty (fmin x y)))
-      (value_reg (fmin_reg ty (put_in_reg x) (put_in_reg y))))
+      (fmin_reg ty x y))
 
 
 ;;;; Rules for `fmax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Maximum of two registers.
 (rule (lower (has_type ty (fmax x y)))
-      (value_reg (fmax_reg ty (put_in_reg x) (put_in_reg y))))
+      (fmax_reg ty x y))
 
 
 ;;;; Rules for `fcopysign` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Copysign of two registers.
 (rule (lower (has_type ty (fcopysign x y)))
-      (value_reg (fpu_copysign ty (put_in_reg x) (put_in_reg y))))
+      (fpu_copysign ty x y))
 
 
 ;;;; Rules for `fma` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Multiply-and-add of three registers.
 (rule (lower (has_type ty (fma x y z)))
-      (value_reg (fma_reg ty (put_in_reg x) (put_in_reg y) (put_in_reg z))))
+      (fma_reg ty x y z))
 
 
 ;;;; Rules for `sqrt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Square root of a register.
 (rule (lower (has_type ty (sqrt x)))
-      (value_reg (sqrt_reg ty (put_in_reg x))))
+      (sqrt_reg ty x))
 
 
 ;;;; Rules for `fneg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Negated value of a register.
 (rule (lower (has_type ty (fneg x)))
-      (value_reg (fneg_reg ty (put_in_reg x))))
+      (fneg_reg ty x))
 
 
 ;;;; Rules for `fabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Absolute value of a register.
 (rule (lower (has_type ty (fabs x)))
-      (value_reg (fabs_reg ty (put_in_reg x))))
+      (fabs_reg ty x))
 
 
 ;;;; Rules for `ceil` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Round value in a register towards positive infinity.
 (rule (lower (has_type ty (ceil x)))
-      (value_reg (ceil_reg ty (put_in_reg x))))
+      (ceil_reg ty x))
 
 
 ;;;; Rules for `floor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Round value in a register towards negative infinity.
 (rule (lower (has_type ty (floor x)))
-      (value_reg (floor_reg ty (put_in_reg x))))
+      (floor_reg ty x))
 
 
 ;;;; Rules for `trunc` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Round value in a register towards zero.
 (rule (lower (has_type ty (trunc x)))
-      (value_reg (trunc_reg ty (put_in_reg x))))
+      (trunc_reg ty x))
 
 
 ;;;; Rules for `nearest` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Round value in a register towards nearest.
 (rule (lower (has_type ty (nearest x)))
-      (value_reg (nearest_reg ty (put_in_reg x))))
+      (nearest_reg ty x))
 
 
 ;;;; Rules for `fpromote` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Promote a register.
 (rule (lower (has_type dst_ty (fpromote x @ (value_type src_ty))))
-      (value_reg (fpromote_reg dst_ty src_ty (put_in_reg x))))
+      (fpromote_reg dst_ty src_ty x))
 
 
 ;;;; Rules for `fdemote` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Demote a register.
 (rule (lower (has_type dst_ty (fdemote x @ (value_type src_ty))))
-      (value_reg (fdemote_reg dst_ty src_ty (put_in_reg x))))
+      (fdemote_reg dst_ty src_ty x))
 
 
 ;;;; Rules for `fcvt_from_uint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Convert an unsigned integer value in a register to floating-point.
 (rule (lower (has_type dst_ty (fcvt_from_uint x @ (value_type src_ty))))
-      (value_reg (fcvt_from_uint_reg dst_ty (ty_ext32 src_ty)
-                                            (put_in_reg_zext32 x))))
+      (fcvt_from_uint_reg dst_ty (ty_ext32 src_ty)
+                          (put_in_reg_zext32 x)))
 
 
 ;;;; Rules for `fcvt_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Convert a signed integer value in a register to floating-point.
 (rule (lower (has_type dst_ty (fcvt_from_sint x @ (value_type src_ty))))
-      (value_reg (fcvt_from_sint_reg dst_ty (ty_ext32 src_ty)
-                                            (put_in_reg_sext32 x))))
+      (fcvt_from_sint_reg dst_ty (ty_ext32 src_ty)
+                          (put_in_reg_sext32 x)))
 
 
 ;;;; Rules for `fcvt_to_uint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1055,7 +1055,7 @@
 ;; Traps if the input cannot be represented in the output type.
 ;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
 (rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_uint x @ (value_type src_ty))))
-      (let ((src Reg (put_in_reg x))
+      (let ((src Reg x)
             ;; First, check whether the input is a NaN, and trap if so.
             (_ Reg (trap_if (fcmp_reg src_ty src src)
                             (floatcc_as_cond (FloatCC.Unordered))
@@ -1067,7 +1067,7 @@
             (dst Reg (trap_if (fcvt_to_uint_reg_with_flags dst_ty src_ty src)
                               (floatcc_as_cond (FloatCC.Unordered))
                               (trap_code_integer_overflow))))
-        (value_reg dst)))
+        dst))
 
 
 ;;;; Rules for `fcvt_to_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1076,7 +1076,7 @@
 ;; Traps if the input cannot be represented in the output type.
 ;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
 (rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_sint x @ (value_type src_ty))))
-      (let ((src Reg (put_in_reg x))
+      (let ((src Reg x)
             ;; First, check whether the input is a NaN, and trap if so.
             (_ Reg (trap_if (fcmp_reg src_ty src src)
                             (floatcc_as_cond (FloatCC.Unordered))
@@ -1088,7 +1088,7 @@
             (dst Reg (trap_if (fcvt_to_sint_reg_with_flags dst_ty src_ty src)
                               (floatcc_as_cond (FloatCC.Unordered))
                               (trap_code_integer_overflow))))
-        (value_reg dst)))
+        dst))
 
 
 ;;;; Rules for `fcvt_to_uint_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1096,7 +1096,7 @@
 ;; Convert a floating-point value in a register to an unsigned integer value.
 ;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
 (rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_uint_sat x @ (value_type src_ty))))
-      (let ((src Reg (put_in_reg x))
+      (let ((src Reg x)
             (dst Reg (fcvt_to_uint_reg dst_ty src_ty src))
             ;; In most special cases, the Z instruction already yields the
             ;; result expected by Cranelift semantics.  The only exception
@@ -1105,7 +1105,7 @@
             (sat Reg (with_flags_reg (fcmp_reg src_ty src src)
                                      (cmov_imm dst_ty
                                                (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
-        (value_reg sat)))
+        sat))
 
 
 ;;;; Rules for `fcvt_to_sint_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1113,7 +1113,7 @@
 ;; Convert a floating-point value in a register to a signed integer value.
 ;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
 (rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_sint_sat x @ (value_type src_ty))))
-      (let ((src Reg (put_in_reg x))
+      (let ((src Reg x)
             (dst Reg (fcvt_to_sint_reg dst_ty src_ty src))
             ;; In most special cases, the Z instruction already yields the
             ;; result expected by Cranelift semantics.  The only exception
@@ -1122,46 +1122,46 @@
             (sat Reg (with_flags_reg (fcmp_reg src_ty src src)
                                      (cmov_imm dst_ty
                                                (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
-        (value_reg sat)))
+        sat))
 
 
 ;;;; Rules for `bitcast` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Reinterpret a 64-bit integer value as floating-point.
 (rule (lower (has_type $F64 (bitcast x @ (value_type $I64))))
-      (value_reg (mov_to_fpr (put_in_reg x))))
+      (mov_to_fpr x))
 
 ;; Reinterpret a 64-bit floating-point value as integer.
 (rule (lower (has_type $I64 (bitcast x @ (value_type $F64))))
-      (value_reg (mov_from_fpr (put_in_reg x))))
+      (mov_from_fpr x))
 
 ;; Reinterpret a 32-bit integer value as floating-point (via $I64).
 ;; Note that a 32-bit float is located in the high bits of the GPR.
 (rule (lower (has_type $F32 (bitcast x @ (value_type $I32))))
-      (value_reg (mov_to_fpr (lshl_imm $I64 (put_in_reg x) 32))))
+      (mov_to_fpr (lshl_imm $I64 x 32)))
 
 ;; Reinterpret a 32-bit floating-point value as integer (via $I64).
 ;; Note that a 32-bit float is located in the high bits of the GPR.
 (rule (lower (has_type $I32 (bitcast x @ (value_type $F32))))
-      (value_reg (lshr_imm $I64 (mov_from_fpr (put_in_reg x)) 32)))
+      (lshr_imm $I64 (mov_from_fpr x) 32))
 
 
 ;;;; Rules for `stack_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Load the address of a stack slot.
 (rule (lower (has_type ty (stack_addr stack_slot offset)))
-      (value_reg (stack_addr_impl ty stack_slot offset)))
+      (stack_addr_impl ty stack_slot offset))
 
 
 ;;;; Rules for `func_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Load the address of a function, target reachable via PC-relative instruction.
 (rule (lower (func_addr (func_ref_data _ name (reloc_distance_near))))
-      (value_reg (load_addr (memarg_symbol name 0 (memflags_trusted)))))
+      (load_addr (memarg_symbol name 0 (memflags_trusted))))
 
 ;; Load the address of a function, general case.
 (rule (lower (func_addr (func_ref_data _ name _)))
-      (value_reg (load_ext_name_far name 0)))
+      (load_ext_name_far name 0))
 
 
 ;;;; Rules for `symbol_value` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1169,102 +1169,102 @@
 ;; Load the address of a symbol, target reachable via PC-relative instruction.
 (rule (lower (symbol_value (symbol_value_data name (reloc_distance_near)
                                                    (memarg_symbol_offset offset))))
-      (value_reg (load_addr (memarg_symbol name offset (memflags_trusted)))))
+      (load_addr (memarg_symbol name offset (memflags_trusted))))
 
 ;; Load the address of a symbol, general case.
 (rule (lower (symbol_value (symbol_value_data name _ offset)))
-      (value_reg (load_ext_name_far name offset)))
+      (load_ext_name_far name offset))
 
 
 ;;;; Rules for `load` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Load 8-bit integers.
 (rule (lower (has_type $I8 (load flags addr offset)))
-      (value_reg (zext32_mem $I8 (lower_address flags addr offset))))
+      (zext32_mem $I8 (lower_address flags addr offset)))
 
 ;; Load 16-bit big-endian integers.
 (rule (lower (has_type $I16 (load flags @ (bigendian) addr offset)))
-      (value_reg (zext32_mem $I16 (lower_address flags addr offset))))
+      (zext32_mem $I16 (lower_address flags addr offset)))
 
 ;; Load 16-bit little-endian integers.
 (rule (lower (has_type $I16 (load flags @ (littleendian) addr offset)))
-      (value_reg (loadrev16 (lower_address flags addr offset))))
+      (loadrev16 (lower_address flags addr offset)))
 
 ;; Load 32-bit big-endian integers.
 (rule (lower (has_type $I32 (load flags @ (bigendian) addr offset)))
-      (value_reg (load32 (lower_address flags addr offset))))
+      (load32 (lower_address flags addr offset)))
 
 ;; Load 32-bit little-endian integers.
 (rule (lower (has_type $I32 (load flags @ (littleendian) addr offset)))
-      (value_reg (loadrev32 (lower_address flags addr offset))))
+      (loadrev32 (lower_address flags addr offset)))
 
 ;; Load 64-bit big-endian integers.
 (rule (lower (has_type $I64 (load flags @ (bigendian) addr offset)))
-      (value_reg (load64 (lower_address flags addr offset))))
+      (load64 (lower_address flags addr offset)))
 
 ;; Load 64-bit little-endian integers.
 (rule (lower (has_type $I64 (load flags @ (littleendian) addr offset)))
-      (value_reg (loadrev64 (lower_address flags addr offset))))
+      (loadrev64 (lower_address flags addr offset)))
 
 ;; Load 64-bit big-endian references.
 (rule (lower (has_type $R64 (load flags @ (bigendian) addr offset)))
-      (value_reg (load64 (lower_address flags addr offset))))
+      (load64 (lower_address flags addr offset)))
 
 ;; Load 64-bit little-endian references.
 (rule (lower (has_type $R64 (load flags @ (littleendian) addr offset)))
-      (value_reg (loadrev64 (lower_address flags addr offset))))
+      (loadrev64 (lower_address flags addr offset)))
 
 ;; Load 32-bit big-endian floating-point values.
 (rule (lower (has_type $F32 (load flags @ (bigendian) addr offset)))
-      (value_reg (fpu_load32 (lower_address flags addr offset))))
+      (fpu_load32 (lower_address flags addr offset)))
 
 ;; Load 32-bit little-endian floating-point values (z15 instruction).
 (rule (lower (has_type (and (vxrs_ext2_enabled) $F32)
                        (load flags @ (littleendian) addr offset)))
-      (value_reg (fpu_loadrev32 (lower_address flags addr offset))))
+      (fpu_loadrev32 (lower_address flags addr offset)))
 
 ;; Load 32-bit little-endian floating-point values (via GPR on z14).
 (rule (lower (has_type (and (vxrs_ext2_disabled) $F32)
                        (load flags @ (littleendian) addr offset)))
       (let ((gpr Reg (loadrev32 (lower_address flags addr offset))))
-        (value_reg (mov_to_fpr (lshl_imm $I64 gpr 32)))))
+        (mov_to_fpr (lshl_imm $I64 gpr 32))))
 
 ;; Load 64-bit big-endian floating-point values.
 (rule (lower (has_type $F64 (load flags @ (bigendian) addr offset)))
-      (value_reg (fpu_load64 (lower_address flags addr offset))))
+      (fpu_load64 (lower_address flags addr offset)))
 
 ;; Load 64-bit little-endian floating-point values (z15 instruction).
 (rule (lower (has_type (and (vxrs_ext2_enabled) $F64)
                             (load flags @ (littleendian) addr offset)))
-      (value_reg (fpu_loadrev64 (lower_address flags addr offset))))
+      (fpu_loadrev64 (lower_address flags addr offset)))
 
 ;; Load 64-bit little-endian floating-point values (via GPR on z14).
 (rule (lower (has_type (and (vxrs_ext2_disabled) $F64)
                             (load flags @ (littleendian) addr offset)))
       (let ((gpr Reg (loadrev64 (lower_address flags addr offset))))
-        (value_reg (mov_to_fpr gpr))))
+        (mov_to_fpr gpr)))
 
 
 ;;;; Rules for `uload8` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; 16- or 32-bit target types.
 (rule (lower (has_type (gpr32_ty _ty) (uload8 flags addr offset)))
-      (value_reg (zext32_mem $I8 (lower_address flags addr offset))))
+      (zext32_mem $I8 (lower_address flags addr offset)))
 
 ;; 64-bit target types.
 (rule (lower (has_type (gpr64_ty _ty) (uload8 flags addr offset)))
-      (value_reg (zext64_mem $I8 (lower_address flags addr offset))))
+      (zext64_mem $I8 (lower_address flags addr offset)))
 
 
 ;;;; Rules for `sload8` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; 16- or 32-bit target types.
 (rule (lower (has_type (gpr32_ty _ty) (sload8 flags addr offset)))
-      (value_reg (sext32_mem $I8 (lower_address flags addr offset))))
+      (sext32_mem $I8 (lower_address flags addr offset)))
 
 ;; 64-bit target types.
 (rule (lower (has_type (gpr64_ty _ty) (sload8 flags addr offset)))
-      (value_reg (sext64_mem $I8 (lower_address flags addr offset))))
+      (sext64_mem $I8 (lower_address flags addr offset)))
 
 
 ;;;; Rules for `uload16` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1272,24 +1272,24 @@
 ;; 32-bit target type, big-endian source value.
 (rule (lower (has_type (gpr32_ty _ty)
                        (uload16 flags @ (bigendian) addr offset)))
-      (value_reg (zext32_mem $I16 (lower_address flags addr offset))))
+      (zext32_mem $I16 (lower_address flags addr offset)))
 
 ;; 32-bit target type, little-endian source value (via explicit extension).
 (rule (lower (has_type (gpr32_ty _ty)
                        (uload16 flags @ (littleendian) addr offset)))
       (let ((reg16 Reg (loadrev16 (lower_address flags addr offset))))
-        (value_reg (zext32_reg $I16 reg16))))
+        (zext32_reg $I16 reg16)))
 
 ;; 64-bit target type, big-endian source value.
 (rule (lower (has_type (gpr64_ty _ty)
                        (uload16 flags @ (bigendian) addr offset)))
-      (value_reg (zext64_mem $I16 (lower_address flags addr offset))))
+      (zext64_mem $I16 (lower_address flags addr offset)))
 
 ;; 64-bit target type, little-endian source value (via explicit extension).
 (rule (lower (has_type (gpr64_ty _ty)
                        (uload16 flags @ (littleendian) addr offset)))
       (let ((reg16 Reg (loadrev16 (lower_address flags addr offset))))
-        (value_reg (zext64_reg $I16 reg16))))
+        (zext64_reg $I16 reg16)))
 
 
 ;;;; Rules for `sload16` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1297,24 +1297,24 @@
 ;; 32-bit target type, big-endian source value.
 (rule (lower (has_type (gpr32_ty _ty)
                        (sload16 flags @ (bigendian) addr offset)))
-      (value_reg (sext32_mem $I16 (lower_address flags addr offset))))
+      (sext32_mem $I16 (lower_address flags addr offset)))
 
 ;; 32-bit target type, little-endian source value (via explicit extension).
 (rule (lower (has_type (gpr32_ty _ty)
                        (sload16 flags @ (littleendian) addr offset)))
       (let ((reg16 Reg (loadrev16 (lower_address flags addr offset))))
-        (value_reg (sext32_reg $I16 reg16))))
+        (sext32_reg $I16 reg16)))
 
 ;; 64-bit target type, big-endian source value.
 (rule (lower (has_type (gpr64_ty _ty)
                        (sload16 flags @ (bigendian) addr offset)))
-      (value_reg (sext64_mem $I16 (lower_address flags addr offset))))
+      (sext64_mem $I16 (lower_address flags addr offset)))
 
 ;; 64-bit target type, little-endian source value (via explicit extension).
 (rule (lower (has_type (gpr64_ty _ty)
                        (sload16 flags @ (littleendian) addr offset)))
       (let ((reg16 Reg (loadrev16 (lower_address flags addr offset))))
-        (value_reg (sext64_reg $I16 reg16))))
+        (sext64_reg $I16 reg16)))
 
 
 ;;;; Rules for `uload32` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1322,13 +1322,13 @@
 ;; 64-bit target type, big-endian source value.
 (rule (lower (has_type (gpr64_ty _ty)
                        (uload32 flags @ (bigendian) addr offset)))
-      (value_reg (zext64_mem $I32 (lower_address flags addr offset))))
+      (zext64_mem $I32 (lower_address flags addr offset)))
 
 ;; 64-bit target type, little-endian source value (via explicit extension).
 (rule (lower (has_type (gpr64_ty _ty)
                        (uload32 flags @ (littleendian) addr offset)))
       (let ((reg32 Reg (loadrev32 (lower_address flags addr offset))))
-        (value_reg (zext64_reg $I32 reg32))))
+        (zext64_reg $I32 reg32)))
 
 
 ;;;; Rules for `sload32` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1336,13 +1336,13 @@
 ;; 64-bit target type, big-endian source value.
 (rule (lower (has_type (gpr64_ty _ty)
                        (sload32 flags @ (bigendian) addr offset)))
-      (value_reg (sext64_mem $I32 (lower_address flags addr offset))))
+      (sext64_mem $I32 (lower_address flags addr offset)))
 
 ;; 64-bit target type, little-endian source value (via explicit extension).
 (rule (lower (has_type (gpr64_ty _ty)
                        (sload32 flags @ (littleendian) addr offset)))
       (let ((reg32 Reg (loadrev32 (lower_address flags addr offset))))
-        (value_reg (sext64_reg $I32 reg32))))
+        (sext64_reg $I32 reg32)))
 
 
 ;;;; Rules for `store` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1498,50 +1498,50 @@
 ;; Atomic AND for 32/64-bit big-endian types, using a single instruction.
 (rule (lower (has_type (ty_32_or_64 ty)
                 (atomic_rmw flags @ (bigendian) (AtomicRmwOp.And) addr src)))
-      (value_reg (atomic_rmw_and ty (put_in_reg src)
-                                 (lower_address flags addr (zero_offset)))))
+      (atomic_rmw_and ty (put_in_reg src)
+                      (lower_address flags addr (zero_offset))))
 
 ;; Atomic AND for 32/64-bit big-endian types, using byte-swapped input/output.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_rmw flags @ (littleendian) (AtomicRmwOp.And) addr src)))
-      (value_reg (bswap_reg ty (atomic_rmw_and ty (bswap_reg ty (put_in_reg src))
-                                 (lower_address flags addr (zero_offset))))))
+      (bswap_reg ty (atomic_rmw_and ty (bswap_reg ty (put_in_reg src))
+                                    (lower_address flags addr (zero_offset)))))
 
 ;; Atomic OR for 32/64-bit big-endian types, using a single instruction.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_rmw flags @ (bigendian) (AtomicRmwOp.Or) addr src)))
-      (value_reg (atomic_rmw_or ty (put_in_reg src)
-                                (lower_address flags addr (zero_offset)))))
+      (atomic_rmw_or ty (put_in_reg src)
+                     (lower_address flags addr (zero_offset))))
 
 ;; Atomic OR for 32/64-bit little-endian types, using byte-swapped input/output.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_rmw flags @ (littleendian) (AtomicRmwOp.Or) addr src)))
-      (value_reg (bswap_reg ty (atomic_rmw_or ty (bswap_reg ty (put_in_reg src))
-                                 (lower_address flags addr (zero_offset))))))
+      (bswap_reg ty (atomic_rmw_or ty (bswap_reg ty (put_in_reg src))
+                                   (lower_address flags addr (zero_offset)))))
 
 ;; Atomic XOR for 32/64-bit big-endian types, using a single instruction.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_rmw flags @ (bigendian) (AtomicRmwOp.Xor) addr src)))
-      (value_reg (atomic_rmw_xor ty (put_in_reg src)
-                                 (lower_address flags addr (zero_offset)))))
+      (atomic_rmw_xor ty (put_in_reg src)
+                      (lower_address flags addr (zero_offset))))
 
 ;; Atomic XOR for 32/64-bit little-endian types, using byte-swapped input/output.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_rmw flags @ (littleendian) (AtomicRmwOp.Xor) addr src)))
-      (value_reg (bswap_reg ty (atomic_rmw_xor ty (bswap_reg ty (put_in_reg src))
-                                 (lower_address flags addr (zero_offset))))))
+      (bswap_reg ty (atomic_rmw_xor ty (bswap_reg ty (put_in_reg src))
+                                    (lower_address flags addr (zero_offset)))))
 
 ;; Atomic ADD for 32/64-bit big-endian types, using a single instruction.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_rmw flags @ (bigendian) (AtomicRmwOp.Add) addr src)))
-      (value_reg (atomic_rmw_add ty (put_in_reg src)
-                                 (lower_address flags addr (zero_offset)))))
+      (atomic_rmw_add ty (put_in_reg src)
+                      (lower_address flags addr (zero_offset))))
 
 ;; Atomic SUB for 32/64-bit big-endian types, using atomic ADD with negated input.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_rmw flags @ (bigendian) (AtomicRmwOp.Sub) addr src)))
-      (value_reg (atomic_rmw_add ty (neg_reg ty (put_in_reg src))
-                                 (lower_address flags addr (zero_offset)))))
+      (atomic_rmw_add ty (neg_reg ty (put_in_reg src))
+                      (lower_address flags addr (zero_offset))))
 
 
 ;; Atomic operations that require a compare-and-swap loop.
@@ -1556,7 +1556,7 @@
             (val1 Reg (atomic_rmw_body ib ty flags op
                         (casloop_tmp_reg) val0 src_reg)))
         ;; Emit compare-and-swap loop and extract final result.
-        (value_reg (casloop ib ty flags addr_reg val1))))
+        (casloop ib ty flags addr_reg val1)))
 
 ;; Operations for 8/16-bit types must operate on the surrounding aligned word.
 (rule (lower (has_type (ty_8_or_16 ty) (atomic_rmw flags op addr src)))
@@ -1573,7 +1573,7 @@
                         (casloop_tmp_reg) val1 src_reg))
             (val3 Reg (casloop_rotate_out ib ty flags bitshift val2)))
         ;; Emit compare-and-swap loop and extract final result.
-        (value_reg (casloop_subword ib ty flags aligned_addr bitshift val3))))
+        (casloop_subword ib ty flags aligned_addr bitshift val3)))
 
 ;; Loop bodies for atomic read-modify-write operations.
 (decl atomic_rmw_body (VecMInstBuilder Type MemFlags AtomicRmwOp
@@ -1754,16 +1754,16 @@
 ;; 32/64-bit big-endian atomic compare-and-swap instruction.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_cas flags @ (bigendian) addr src1 src2)))
-      (value_reg (atomic_cas_impl ty (put_in_reg src1) (put_in_reg src2)
-                                 (lower_address flags addr (zero_offset)))))
+      (atomic_cas_impl ty (put_in_reg src1) (put_in_reg src2)
+                       (lower_address flags addr (zero_offset))))
 
 ;; 32/64-bit little-endian atomic compare-and-swap instruction.
 ;; Implemented by byte-swapping old/new inputs and the output.
 (rule (lower (has_type (ty_32_or_64 ty)
                (atomic_cas flags @ (littleendian) addr src1 src2)))
-      (value_reg (bswap_reg ty (atomic_cas_impl ty (bswap_reg ty (put_in_reg src1))
-                                                   (bswap_reg ty (put_in_reg src2))
-                            (lower_address flags addr (zero_offset))))))
+      (bswap_reg ty (atomic_cas_impl ty (bswap_reg ty (put_in_reg src1))
+                                     (bswap_reg ty (put_in_reg src2))
+                                     (lower_address flags addr (zero_offset)))))
 
 ;; 8/16-bit atomic compare-and-swap implemented via loop.
 (rule (lower (has_type (ty_8_or_16 ty) (atomic_cas flags addr src1 src2)))
@@ -1781,7 +1781,7 @@
                         (casloop_tmp_reg) val1 src1_reg src2_reg))
             (val3 Reg (casloop_rotate_out ib ty flags bitshift val2)))
         ;; Emit compare-and-swap loop and extract final result.
-        (value_reg (casloop_subword ib ty flags aligned_addr bitshift val3))))
+        (casloop_subword ib ty flags aligned_addr bitshift val3)))
 
 ;; Emit loop body instructions to perform a subword compare-and-swap.
 (decl atomic_cas_body (VecMInstBuilder Type MemFlags
@@ -1824,31 +1824,31 @@
 
 ;; 8-bit atomic load.
 (rule (lower (has_type $I8 (atomic_load flags addr)))
-      (value_reg (zext32_mem $I8 (lower_address flags addr (zero_offset)))))
+      (zext32_mem $I8 (lower_address flags addr (zero_offset))))
 
 ;; 16-bit big-endian atomic load.
 (rule (lower (has_type $I16 (atomic_load flags @ (bigendian) addr)))
-      (value_reg (zext32_mem $I16 (lower_address flags addr (zero_offset)))))
+      (zext32_mem $I16 (lower_address flags addr (zero_offset))))
 
 ;; 16-bit little-endian atomic load.
 (rule (lower (has_type $I16 (atomic_load flags @ (littleendian) addr)))
-      (value_reg (loadrev16 (lower_address flags addr (zero_offset)))))
+      (loadrev16 (lower_address flags addr (zero_offset))))
 
 ;; 32-bit big-endian atomic load.
 (rule (lower (has_type $I32 (atomic_load flags @ (bigendian) addr)))
-      (value_reg (load32 (lower_address flags addr (zero_offset)))))
+      (load32 (lower_address flags addr (zero_offset))))
 
 ;; 32-bit little-endian atomic load.
 (rule (lower (has_type $I32 (atomic_load flags @ (littleendian) addr)))
-      (value_reg (loadrev32 (lower_address flags addr (zero_offset)))))
+      (loadrev32 (lower_address flags addr (zero_offset))))
 
 ;; 64-bit big-endian atomic load.
 (rule (lower (has_type $I64 (atomic_load flags @ (bigendian) addr)))
-      (value_reg (load64 (lower_address flags addr (zero_offset)))))
+      (load64 (lower_address flags addr (zero_offset))))
 
 ;; 64-bit little-endian atomic load.
 (rule (lower (has_type $I64 (atomic_load flags @ (littleendian) addr)))
-      (value_reg (loadrev64 (lower_address flags addr (zero_offset)))))
+      (loadrev64 (lower_address flags addr (zero_offset))))
 
 
 ;;;; Rules for `atomic_store` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1913,7 +1913,7 @@
 ;; integer comparison and immediately lower it to a 0/1 integer result.
 ;; In this case, it is safe to sink memory loads.
 (rule (lower (has_type ty (icmp int_cc x y)))
-      (value_reg (lower_bool ty (icmp_val $true int_cc x y))))
+      (lower_bool ty (icmp_val $true int_cc x y)))
 
 
 ;; Return a `ProducesBool` to implement any integer comparison.
@@ -1938,7 +1938,7 @@
 
 ;; Compare (signed) a register and a sign-extended register.
 (rule (icmps_val _ x @ (value_type (fits_in_64 ty)) (sext32_value y))
-      (icmps_reg_sext32 ty (put_in_reg x) (put_in_reg y)))
+      (icmps_reg_sext32 ty x y))
 
 ;; Compare (signed) a register and an immediate.
 (rule (icmps_val _ x @ (value_type (fits_in_64 ty)) (i16_from_value y))
@@ -1948,7 +1948,7 @@
 
 ;; Compare (signed) a register and memory (32/64-bit types).
 (rule (icmps_val $true x @ (value_type (fits_in_64 ty)) (sinkable_load_32_64 y))
-      (icmps_mem ty (put_in_reg x) (sink_load y)))
+      (icmps_mem ty x (sink_load y)))
 
 ;; Compare (signed) a register and memory (16-bit types).
 (rule (icmps_val $true x @ (value_type (fits_in_64 ty)) (sinkable_load_16 y))
@@ -1956,9 +1956,9 @@
 
 ;; Compare (signed) a register and sign-extended memory.
 (rule (icmps_val $true x @ (value_type (fits_in_64 ty)) (sinkable_sload16 y))
-      (icmps_mem_sext16 ty (put_in_reg x) (sink_sload16 y)))
+      (icmps_mem_sext16 ty x (sink_sload16 y)))
 (rule (icmps_val $true x @ (value_type (fits_in_64 ty)) (sinkable_sload32 y))
-      (icmps_mem_sext32 ty (put_in_reg x) (sink_sload32 y)))
+      (icmps_mem_sext32 ty x (sink_sload32 y)))
 
 
 ;; Return a `ProducesBool` to implement unsigned integer comparisons.
@@ -1970,7 +1970,7 @@
 
 ;; Compare (unsigned) a register and a sign-extended register.
 (rule (icmpu_val _ x @ (value_type (fits_in_64 ty)) (zext32_value y))
-      (icmpu_reg_zext32 ty (put_in_reg x) (put_in_reg y)))
+      (icmpu_reg_zext32 ty x y))
 
 ;; Compare (unsigned) a register and an immediate.
 (rule (icmpu_val _ x @ (value_type (fits_in_64 ty)) (u32_from_value y))
@@ -1978,7 +1978,7 @@
 
 ;; Compare (unsigned) a register and memory (32/64-bit types).
 (rule (icmpu_val $true x @ (value_type (fits_in_64 ty)) (sinkable_load_32_64 y))
-      (icmpu_mem ty (put_in_reg x) (sink_load y)))
+      (icmpu_mem ty x (sink_load y)))
 
 ;; Compare (unsigned) a register and memory (16-bit types).
 ;; Note that the ISA only provides instructions with a PC-relative memory
@@ -1992,9 +1992,9 @@
 ;; address here, so we need to check whether the sinkable load matches this.
 (rule (icmpu_val $true x @ (value_type (fits_in_64 ty))
                  (sinkable_uload16 (uload16_sym y)))
-      (icmpu_mem_zext16 ty (put_in_reg x) (sink_uload16 y)))
+      (icmpu_mem_zext16 ty x (sink_uload16 y)))
 (rule (icmpu_val $true x @ (value_type (fits_in_64 ty)) (sinkable_uload32 y))
-      (icmpu_mem_zext32 ty (put_in_reg x) (sink_uload32 y)))
+      (icmpu_mem_zext32 ty x (sink_uload32 y)))
 
 
 ;;;; Rules for `fcmp` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2002,12 +2002,12 @@
 ;; Main `fcmp` entry point.  Generate a `ProducesBool` capturing the
 ;; integer comparison and immediately lower it to a 0/1 integer result.
 (rule (lower (has_type ty (fcmp float_cc x y)))
-      (value_reg (lower_bool ty (fcmp_val float_cc x y))))
+      (lower_bool ty (fcmp_val float_cc x y)))
 
 ;; Return a `ProducesBool` to implement any floating-point comparison.
 (decl fcmp_val (FloatCC Value Value) ProducesBool)
 (rule (fcmp_val float_cc x @ (value_type ty) y)
-      (bool (fcmp_reg ty (put_in_reg x) (put_in_reg y))
+      (bool (fcmp_reg ty x y)
             (floatcc_as_cond float_cc)))
 
 
@@ -2015,14 +2015,14 @@
 
 ;; Null references are represented by the constant value 0.
 (rule (lower (has_type $B1 (is_null x @ (value_type $R64))))
-      (value_reg (lower_bool $B1 (bool (icmps_simm16 $I64 (put_in_reg x) 0)
-                                       (intcc_as_cond (IntCC.Equal))))))
+      (lower_bool $B1 (bool (icmps_simm16 $I64 x 0)
+                            (intcc_as_cond (IntCC.Equal)))))
 
 
 ;; Invalid references are represented by the constant value -1.
 (rule (lower (has_type $B1 (is_invalid x @ (value_type $R64))))
-      (value_reg (lower_bool $B1 (bool (icmps_simm16 $I64 (put_in_reg x) -1)
-                                       (intcc_as_cond (IntCC.Equal))))))
+      (lower_bool $B1 (bool (icmps_simm16 $I64 x -1)
+                            (intcc_as_cond (IntCC.Equal)))))
 
 
 ;;;; Rules for `select` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2032,9 +2032,9 @@
 ;; instruction (possibly via an intermediate `bint`), directly use that compare.
 ;; Note that it is not safe to sink memory loads here, see the `icmp` comment.
 (decl value_nonzero (Value) ProducesBool)
-(rule (value_nonzero (def_inst (bint val))) (value_nonzero val))
-(rule (value_nonzero (def_inst (icmp int_cc x y))) (icmp_val $false int_cc x y))
-(rule (value_nonzero (def_inst (fcmp float_cc x y))) (fcmp_val float_cc x y))
+(rule (value_nonzero (bint val)) (value_nonzero val))
+(rule (value_nonzero (icmp int_cc x y)) (icmp_val $false int_cc x y))
+(rule (value_nonzero (fcmp float_cc x y)) (fcmp_val float_cc x y))
 (rule (value_nonzero val @ (value_type (gpr32_ty ty)))
       (bool (icmps_simm16 $I32 (put_in_reg_sext32 val) 0)
                           (intcc_as_cond (IntCC.NotEqual))))
@@ -2044,8 +2044,8 @@
 
 ;; Main `select` entry point.  Lower the `value_nonzero` result.
 (rule (lower (has_type ty (select val_cond val_true val_false)))
-      (value_reg (select_bool_reg ty (value_nonzero val_cond)
-                                  (put_in_reg val_true) (put_in_reg val_false))))
+      (select_bool_reg ty (value_nonzero val_cond)
+                       (put_in_reg val_true) (put_in_reg val_false)))
 
 
 ;;;; Rules for `selectif_spectre_guard` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2056,9 +2056,9 @@
 ;; recognized by the code below, other uses will fail to lower.
 
 (rule (lower (has_type ty (selectif_spectre_guard int_cc
-                             (def_inst (ifcmp x y)) val_true val_false)))
-      (value_reg (select_bool_reg ty (icmp_val $false int_cc x y)
-                                  (put_in_reg val_true) (put_in_reg val_false))))
+                             (ifcmp x y) val_true val_false)))
+      (select_bool_reg ty (icmp_val $false int_cc x y)
+                       (put_in_reg val_true) (put_in_reg val_false)))
 
 
 ;;;; Rules for `jump` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2128,7 +2128,7 @@
 ;; Similarly to `selectif_spectre_guard`, we only recognize specific patterns
 ;; generated by common code here.  Others will fail to lower.
 
-(rule (lower_branch (brif int_cc (def_inst (ifcmp x y)) _ _) targets)
+(rule (lower_branch (brif int_cc (ifcmp x y) _ _) targets)
       (value_regs_none (cond_br_bool (icmp_val $false int_cc x y)
                                      (vec_element targets 0)
                                      (vec_element targets 1))))
@@ -2178,7 +2178,7 @@
 ;; Recognize the case of `ifcmp` feeding into `trapif`.  Directly generate
 ;; the desired comparison here; there is no separate `ifcmp` lowering.
 
-(rule (lower (trapif int_cc (def_inst (ifcmp x y)) trap_code))
+(rule (lower (trapif int_cc (ifcmp x y) trap_code))
       (safepoint (trap_if_bool (icmp_val $false int_cc x y) trap_code)))
 
 ;; Recognize the case of `iadd_ifcout` feeding into `trapif`.  Note that
@@ -2204,7 +2204,7 @@
 ;; of the unsigned_add_overflow_condition call to the correct mask.
 
 (rule (lower (trapif (IntCC.UnsignedGreaterThan)
-                     (def_inst (iadd_ifcout x y)) trap_code))
+                     (iadd_ifcout x y) trap_code))
       (value_regs_none (trap_if_impl (mask_as_cond 3) trap_code)))
 
 

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 980b300b3ec3e338
-src/isa/s390x/inst.isle b0f53fcf0cdadde1
-src/isa/s390x/lower.isle 59264a7442cf6e1c
+src/prelude.isle 8bf92e18323e7041
+src/isa/s390x/inst.isle d91a16074ab186a8
+src/isa/s390x/lower.isle 5626c0ef61594d61

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
@@ -8210,21 +8210,18 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             match pattern2_0 {
                 &Opcode::Copy => {
                     // Rule at src/isa/s390x/lower.isle line 53.
-                    let expr0_0 = C::put_in_reg(ctx, pattern2_1);
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
-                    return Some(expr1_0);
+                    let expr0_0 = C::put_in_regs(ctx, pattern2_1);
+                    return Some(expr0_0);
                 }
                 &Opcode::Breduce => {
                     // Rule at src/isa/s390x/lower.isle line 752.
-                    let expr0_0 = C::put_in_reg(ctx, pattern2_1);
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
-                    return Some(expr1_0);
+                    let expr0_0 = C::put_in_regs(ctx, pattern2_1);
+                    return Some(expr0_0);
                 }
                 &Opcode::Ireduce => {
                     // Rule at src/isa/s390x/lower.isle line 596.
-                    let expr0_0 = C::put_in_reg(ctx, pattern2_1);
-                    let expr1_0 = C::value_reg(ctx, expr0_0);
-                    return Some(expr1_0);
+                    let expr0_0 = C::put_in_regs(ctx, pattern2_1);
+                    return Some(expr0_0);
                 }
                 _ => {}
             }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -162,27 +162,27 @@
        ;; GPR conditional move with the `OR` of two conditions; overwrites
        ;; the destination register.
        (CmoveOr (size OperandSize)
-              (cc1 CC)
-              (cc2 CC)
-              (consequent GprMem)
-              (alternative Gpr)
-              (dst WritableGpr))
+                (cc1 CC)
+                (cc2 CC)
+                (consequent GprMem)
+                (alternative Gpr)
+                (dst WritableGpr))
 
        ;; XMM conditional move; overwrites the destination register.
        (XmmCmove (size OperandSize)
-              (cc CC)
-              (consequent XmmMem)
-              (alternative Xmm)
-              (dst WritableXmm))
+                 (cc CC)
+                 (consequent XmmMem)
+                 (alternative Xmm)
+                 (dst WritableXmm))
 
        ;; XMM conditional move with the `OR` of two conditions; overwrites
        ;; the destination register.
        (XmmCmoveOr (size OperandSize)
-              (cc1 CC)
-              (cc2 CC)
-              (consequent XmmMem)
-              (alternative Xmm)
-              (dst WritableXmm))
+                   (cc1 CC)
+                   (cc2 CC)
+                   (consequent XmmMem)
+                   (alternative Xmm)
+                   (dst WritableXmm))
 
        ;; =========================================
        ;; Stack manipulation.
@@ -960,6 +960,13 @@
 (decl reg_to_gpr_mem (Reg) GprMem)
 (extern constructor reg_to_gpr_mem reg_to_gpr_mem)
 
+;; Construct a `GprMemImm` from a `Reg`.
+;;
+;; Asserts that the `Reg` is a GPR.
+(decl reg_to_gpr_mem_imm (Reg) GprMemImm)
+(rule (reg_to_gpr_mem_imm r)
+      (gpr_to_gpr_mem_imm (gpr_new r)))
+
 ;; Put a value into a GPR.
 ;;
 ;; Asserts that the value goes into a GPR.
@@ -1188,44 +1195,41 @@
 ;; that everything is equal to itself.
 (decl vector_all_ones (Type) Xmm)
 (rule (vector_all_ones ty)
-      (let ((wr WritableXmm (temp_writable_xmm))
-            (r Xmm (writable_xmm_to_xmm wr))
+      (let ((r WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (sse_cmp_op $I32X4)
                                         r
-                                        (xmm_to_xmm_mem r)
-                                        wr))))
+                                        r
+                                        r))))
         r))
 
 ;; Helper for creating an SSE register holding an `i64x2` from two `i64` values.
 (decl make_i64x2_from_lanes (GprMem GprMem) Xmm)
 (rule (make_i64x2_from_lanes lo hi)
-      (let ((dst_xmm_w WritableXmm (temp_writable_xmm))
-            (dst_reg_w WritableReg (writable_xmm_to_reg dst_xmm_w))
-            (dst_xmm_r Xmm (writable_xmm_to_xmm dst_xmm_w))
-            (dst_reg_r Reg (xmm_to_reg dst_xmm_r))
-            (_0 Unit (emit (MInst.XmmUninitializedValue dst_xmm_w)))
+      (let ((dst_xmm WritableXmm (temp_writable_xmm))
+            (dst_reg WritableReg dst_xmm)
+            (_0 Unit (emit (MInst.XmmUninitializedValue dst_xmm)))
             (_1 Unit (emit (MInst.XmmRmRImm (SseOpcode.Pinsrd)
-                                            dst_reg_r
-                                            (gpr_mem_to_reg_mem lo)
-                                            dst_reg_w
+                                            dst_reg
+                                            lo
+                                            dst_reg
                                             0
                                             (OperandSize.Size64))))
             (_2 Unit (emit (MInst.XmmRmRImm (SseOpcode.Pinsrd)
-                                            dst_reg_r
-                                            (gpr_mem_to_reg_mem hi)
-                                            dst_reg_w
+                                            dst_reg
+                                            hi
+                                            dst_reg
                                             1
                                             (OperandSize.Size64)))))
-        dst_xmm_r))
+        dst_xmm))
 
 ;; Move a `RegMemImm.Reg` operand to an XMM register, if necessary.
 (decl mov_rmi_to_xmm (RegMemImm) XmmMemImm)
 (rule (mov_rmi_to_xmm rmi @ (RegMemImm.Mem _)) (xmm_mem_imm_new rmi))
 (rule (mov_rmi_to_xmm rmi @ (RegMemImm.Imm _)) (xmm_mem_imm_new rmi))
 (rule (mov_rmi_to_xmm (RegMemImm.Reg r))
-      (xmm_to_xmm_mem_imm (gpr_to_xmm (SseOpcode.Movd)
-                                      (reg_to_gpr_mem r)
-                                      (OperandSize.Size32))))
+      (gpr_to_xmm (SseOpcode.Movd)
+                  r
+                  (OperandSize.Size32)))
 
 ;;;; Helpers for Emitting Loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1233,34 +1237,34 @@
 (decl x64_load (Type SyntheticAmode ExtKind) Reg)
 
 (rule (x64_load (fits_in_32 ty) addr (ExtKind.SignExtend))
-      (gpr_to_reg (movsx ty
-                         (ext_mode (ty_bytes ty) 8)
-                         (reg_mem_to_gpr_mem (synthetic_amode_to_reg_mem addr)))))
+      (movsx ty
+             (ext_mode (ty_bytes ty) 8)
+             addr))
 
 (rule (x64_load $I64 addr _ext_kind)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.Mov64MR addr dst))))
-        (gpr_to_reg (writable_gpr_to_gpr dst))))
+        dst))
 
 (rule (x64_load $F32 addr _ext_kind)
-      (xmm_to_reg (xmm_unary_rm_r (SseOpcode.Movss)
-                                  (reg_mem_to_xmm_mem (synthetic_amode_to_reg_mem addr)))))
+      (xmm_unary_rm_r (SseOpcode.Movss)
+                      addr))
 
 (rule (x64_load $F64 addr _ext_kind)
-      (xmm_to_reg (xmm_unary_rm_r (SseOpcode.Movsd)
-                                  (reg_mem_to_xmm_mem (synthetic_amode_to_reg_mem addr)))))
+      (xmm_unary_rm_r (SseOpcode.Movsd)
+                      addr))
 
 (rule (x64_load $F32X4 addr _ext_kind)
-      (xmm_to_reg (xmm_unary_rm_r (SseOpcode.Movups)
-                                  (reg_mem_to_xmm_mem (synthetic_amode_to_reg_mem addr)))))
+      (xmm_unary_rm_r (SseOpcode.Movups)
+                      addr))
 
 (rule (x64_load $F64X2 addr _ext_kind)
-      (xmm_to_reg (xmm_unary_rm_r (SseOpcode.Movupd)
-                                  (reg_mem_to_xmm_mem (synthetic_amode_to_reg_mem addr)))))
+      (xmm_unary_rm_r (SseOpcode.Movupd)
+                      addr))
 
 (rule (x64_load (multi_lane _bits _lanes) addr _ext_kind)
-      (xmm_to_reg (xmm_unary_rm_r (SseOpcode.Movdqu)
-                                  (reg_mem_to_xmm_mem (synthetic_amode_to_reg_mem addr)))))
+      (xmm_unary_rm_r (SseOpcode.Movdqu)
+                      addr))
 
 ;;;; Instruction Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -1274,7 +1278,7 @@
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.AluRmiR size opcode src1 src2 dst))))
-        (writable_gpr_to_gpr dst)))
+        dst))
 
 ;; Helper for emitting `add` instructions.
 (decl add (Type Gpr GprMemImm) Gpr)
@@ -1294,7 +1298,7 @@
                         src1
                         src2
                         dst)
-         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+         dst)))
 
 ;; Helper for creating `adc` instructions.
 (decl adc_paired (Type Gpr GprMemImm) ConsumesFlags)
@@ -1306,7 +1310,7 @@
                         src1
                         src2
                         dst)
-         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+         dst)))
 
 ;; Helper for emitting `sub` instructions.
 (decl sub (Type Gpr GprMemImm) Gpr)
@@ -1326,7 +1330,7 @@
                         src1
                         src2
                         dst)
-         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+         dst)))
 
 ;; Helper for creating `sbb` instructions.
 (decl sbb_paired (Type Gpr GprMemImm) ConsumesFlags)
@@ -1338,7 +1342,7 @@
                         src1
                         src2
                         dst)
-         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+         dst)))
 
 ;; Helper for creating `mul` instructions.
 (decl mul (Type Gpr GprMemImm) Gpr)
@@ -1380,19 +1384,19 @@
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.Imm size simm64 dst))))
-        (gpr_to_reg (writable_gpr_to_gpr dst))))
+        dst))
 
 ;; `f32` immediates.
 (rule (imm $F32 bits)
-      (xmm_to_reg (gpr_to_xmm (SseOpcode.Movd)
-                              (reg_mem_to_gpr_mem (RegMem.Reg (imm $I32 bits)))
-                              (OperandSize.Size32))))
+      (gpr_to_xmm (SseOpcode.Movd)
+                  (imm $I32 bits)
+                  (OperandSize.Size32)))
 
 ;; `f64` immediates.
 (rule (imm $F64 bits)
-      (xmm_to_reg (gpr_to_xmm (SseOpcode.Movq)
-                              (reg_mem_to_gpr_mem (RegMem.Reg (imm $I64 bits)))
-                              (OperandSize.Size64))))
+      (gpr_to_xmm (SseOpcode.Movq)
+                  (imm $I64 bits)
+                  (OperandSize.Size64)))
 
 (decl nonzero_u64_fits_in_u32 (u64) u64)
 (extern extractor nonzero_u64_fits_in_u32 nonzero_u64_fits_in_u32)
@@ -1402,17 +1406,17 @@
 (rule (imm $I64 (nonzero_u64_fits_in_u32 x))
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.Imm (OperandSize.Size32) x dst))))
-        (gpr_to_reg (writable_gpr_to_gpr dst))))
+        dst))
 
 ;; Special case for integer zero immediates: turn them into an `xor r, r`.
 (rule (imm (fits_in_64 ty) 0)
       (let ((wgpr WritableGpr (temp_writable_gpr))
-            (g Gpr (writable_gpr_to_gpr wgpr))
+            (g Gpr wgpr)
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.AluRmiR size
                                          (AluRmiROpcode.Xor)
                                          g
-                                         (gpr_to_gpr_mem_imm g)
+                                         g
                                          wgpr))))
         (gpr_to_reg g)))
 
@@ -1420,20 +1424,20 @@
 ;; specific to the vector type.
 (rule (imm ty @ (multi_lane _bits _lanes) 0)
       (let ((wr WritableXmm (temp_writable_xmm))
-            (r Xmm (writable_xmm_to_xmm wr))
+            (r Xmm wr)
             (_ Unit (emit (MInst.XmmRmR (sse_xor_op ty)
                                         r
-                                        (xmm_to_xmm_mem r)
+                                        r
                                         wr))))
         (xmm_to_reg r)))
 
 ;; Special case for `f32` zero immediates to use `xorps`.
 (rule (imm $F32 0)
       (let ((wr WritableXmm (temp_writable_xmm))
-            (r Xmm (writable_xmm_to_xmm wr))
+            (r Xmm wr)
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Xorps)
                                         r
-                                        (xmm_to_xmm_mem r)
+                                        r
                                         wr))))
         (xmm_to_reg r)))
 
@@ -1442,10 +1446,10 @@
 ;; Special case for `f64` zero immediates to use `xorpd`.
 (rule (imm $F64 0)
       (let ((wr WritableXmm (temp_writable_xmm))
-            (r Xmm (writable_xmm_to_xmm wr))
+            (r Xmm wr)
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Xorpd)
                                         r
-                                        (xmm_to_xmm_mem r)
+                                        r
                                         wr))))
         (xmm_to_reg r)))
 
@@ -1459,7 +1463,7 @@
             ;; rely on their shift-amount-masking semantics.
             (size OperandSize (raw_operand_size_of_type ty))
             (_ Unit (emit (MInst.ShiftR size kind src1 src2 dst))))
-        (writable_gpr_to_gpr dst)))
+        dst))
 
 ;; Helper for creating `rotl` instructions.
 (decl x64_rotl (Type Gpr Imm8Gpr) Gpr)
@@ -1528,7 +1532,7 @@
             (size OperandSize (operand_size_of_type_32_64 ty)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
          (MInst.Cmove size cc consequent alternative dst)
-         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+         dst)))
 
 (decl cmove_xmm (Type CC XmmMem Xmm) ConsumesFlags)
 (rule (cmove_xmm ty cc consequent alternative)
@@ -1536,38 +1540,38 @@
             (size OperandSize (operand_size_of_type_32_64 ty)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
          (MInst.XmmCmove size cc consequent alternative dst)
-         (xmm_to_reg (writable_xmm_to_xmm dst)))))
+         dst)))
 
 ;; Helper for creating `cmove` instructions directly from values. This allows us
 ;; to special-case the `I128` types and default to the `cmove` helper otherwise.
 ;; It also eliminates some `put_in_reg*` boilerplate in the lowering ISLE code.
 (decl cmove_from_values (Type CC Value Value) ConsumesFlags)
 (rule (cmove_from_values $I128 cc consequent alternative)
-      (let ((cons ValueRegs (put_in_regs consequent))
-            (alt ValueRegs (put_in_regs alternative))
+      (let ((cons ValueRegs consequent)
+            (alt ValueRegs alternative)
             (dst1 WritableGpr (temp_writable_gpr))
             (dst2 WritableGpr (temp_writable_gpr))
             (size OperandSize (OperandSize.Size64))
             (lower_cmove MInst (MInst.Cmove
                                 size cc
-                                (gpr_to_gpr_mem (value_regs_get_gpr cons 0))
-                                (value_regs_get_gpr alt 0) dst1))
+                                (value_regs_get_gpr cons 0)
+                                (value_regs_get_gpr alt 0)
+                                dst1))
             (upper_cmove MInst (MInst.Cmove
                                 size cc
-                                (gpr_to_gpr_mem (value_regs_get_gpr cons 1))
-                                (value_regs_get_gpr alt 1) dst2)))
+                                (value_regs_get_gpr cons 1)
+                                (value_regs_get_gpr alt 1)
+                                dst2)))
         (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
          lower_cmove
          upper_cmove
-         (value_regs
-          (gpr_to_reg (writable_gpr_to_gpr dst1))
-          (gpr_to_reg (writable_gpr_to_gpr dst2))))))
+         (value_regs dst1 dst2))))
 
 (rule (cmove_from_values (is_gpr_type (is_single_register_type ty)) cc consequent alternative)
-      (cmove ty cc (put_in_gpr_mem consequent) (put_in_gpr alternative)))
+      (cmove ty cc consequent alternative))
 
 (rule (cmove_from_values (is_xmm_type (is_single_register_type ty)) cc consequent alternative)
-      (cmove_xmm ty cc (put_in_xmm_mem consequent) (put_in_xmm alternative)))
+      (cmove_xmm ty cc consequent alternative))
 
 ;; Helper for creating `cmove` instructions with the logical OR of multiple
 ;; flags. Note that these instructions will always result in more than one
@@ -1578,7 +1582,7 @@
             (size OperandSize (operand_size_of_type_32_64 ty)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
          (MInst.CmoveOr size cc1 cc2 consequent alternative dst)
-         (gpr_to_reg (writable_gpr_to_gpr dst)))))
+         dst)))
 
 (decl cmove_or_xmm (Type CC CC XmmMem Xmm) ConsumesFlags)
 (rule (cmove_or_xmm ty cc1 cc2 consequent alternative)
@@ -1586,52 +1590,51 @@
             (size OperandSize (operand_size_of_type_32_64 ty)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
          (MInst.XmmCmoveOr size cc1 cc2 consequent alternative dst)
-         (xmm_to_reg (writable_xmm_to_xmm dst)))))
+         dst)))
 
 ;; Helper for creating `cmove_or` instructions directly from values. This allows
 ;; us to special-case the `I128` types and default to the `cmove_or` helper
 ;; otherwise.
 (decl cmove_or_from_values (Type CC CC Value Value) ConsumesFlags)
 (rule (cmove_or_from_values $I128 cc1 cc2 consequent alternative)
-      (let ((cons ValueRegs (put_in_regs consequent))
-            (alt ValueRegs (put_in_regs alternative))
+      (let ((cons ValueRegs consequent)
+            (alt ValueRegs alternative)
             (dst1 WritableGpr (temp_writable_gpr))
             (dst2 WritableGpr (temp_writable_gpr))
             (size OperandSize (OperandSize.Size64))
-            (lower_cmove MInst (MInst.CmoveOr size cc1 cc2 (gpr_to_gpr_mem (value_regs_get_gpr cons 0)) (value_regs_get_gpr alt 0) dst1))
-            (upper_cmove MInst (MInst.CmoveOr size cc1 cc2 (gpr_to_gpr_mem (value_regs_get_gpr cons 1)) (value_regs_get_gpr alt 1) dst2)))
+            (lower_cmove MInst (MInst.CmoveOr size cc1 cc2 (value_regs_get_gpr cons 0) (value_regs_get_gpr alt 0) dst1))
+            (upper_cmove MInst (MInst.CmoveOr size cc1 cc2 (value_regs_get_gpr cons 1) (value_regs_get_gpr alt 1) dst2)))
         (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
          lower_cmove
          upper_cmove
-         (value_regs (gpr_to_reg (writable_gpr_to_gpr dst1))
-                     (gpr_to_reg (writable_gpr_to_gpr dst2))))))
+         (value_regs dst1 dst2))))
 
 (rule (cmove_or_from_values (is_gpr_type (is_single_register_type ty)) cc1 cc2 consequent alternative)
-      (cmove_or ty cc1 cc2 (put_in_gpr_mem consequent) (put_in_gpr alternative)))
+      (cmove_or ty cc1 cc2 consequent alternative))
 
 (rule (cmove_or_from_values (is_xmm_type (is_single_register_type ty)) cc1 cc2 consequent alternative)
-      (cmove_or_xmm ty cc1 cc2 (put_in_xmm_mem consequent) (put_in_xmm alternative)))
+      (cmove_or_xmm ty cc1 cc2 consequent alternative))
 
 ;; Helper for creating `MInst.MovzxRmR` instructions.
 (decl movzx (Type ExtMode GprMem) Gpr)
 (rule (movzx ty mode src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.MovzxRmR mode src dst))))
-        (writable_gpr_to_gpr dst)))
+        dst))
 
 ;; Helper for creating `MInst.MovsxRmR` instructions.
 (decl movsx (Type ExtMode GprMem) Gpr)
 (rule (movsx ty mode src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.MovsxRmR mode src dst))))
-        (writable_gpr_to_gpr dst)))
+        dst))
 
 ;; Helper for creating `MInst.XmmRmR` instructions.
 (decl xmm_rm_r (Type SseOpcode Xmm XmmMem) Xmm)
 (rule (xmm_rm_r ty op src1 src2)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR op src1 src2 dst))))
-        (writable_xmm_to_xmm dst)))
+        dst))
 
 ;; Helper for creating `paddb` instructions.
 (decl paddb (Xmm XmmMem) Xmm)
@@ -1857,7 +1860,7 @@
       ;; `Inst` itself.)
       (let ((mask2 WritableXmm (xmm0))
             (_ Unit (emit (MInst.XmmUnaryRmR (SseOpcode.Movapd)
-                                             (xmm_to_xmm_mem mask)
+                                             mask
                                              mask2))))
         (xmm_rm_r $F64X2 (SseOpcode.Blendvpd) src1 src2)))
 
@@ -1953,17 +1956,17 @@
             (_ Unit (emit (MInst.XmmRmRImm op
                                            src1
                                            src2
-                                           (writable_xmm_to_reg dst)
+                                           dst
                                            imm
                                            size))))
-        (writable_xmm_to_xmm dst)))
+        dst))
 
 ;; Helper for creating `palignr` instructions.
 (decl palignr (Xmm XmmMem u8 OperandSize) Xmm)
 (rule (palignr src1 src2 imm size)
       (xmm_rm_r_imm (SseOpcode.Palignr)
-                    (xmm_to_reg src1)
-                    (xmm_mem_to_reg_mem src2)
+                    src1
+                    src2
                     imm
                     size))
 
@@ -1971,8 +1974,8 @@
 (decl cmpps (Xmm XmmMem FcmpImm) Xmm)
 (rule (cmpps src1 src2 imm)
       (xmm_rm_r_imm (SseOpcode.Cmpps)
-                    (xmm_to_reg src1)
-                    (xmm_mem_to_reg_mem src2)
+                    src1
+                    src2
                     (encode_fcmp_imm imm)
                     (OperandSize.Size32)))
 
@@ -1980,8 +1983,8 @@
 (decl pinsrb (Xmm GprMem u8) Xmm)
 (rule (pinsrb src1 src2 lane)
       (xmm_rm_r_imm (SseOpcode.Pinsrb)
-                    (xmm_to_reg src1)
-                    (gpr_mem_to_reg_mem src2)
+                    src1
+                    src2
                     lane
                     (OperandSize.Size32)))
 
@@ -1989,8 +1992,8 @@
 (decl pinsrw (Xmm GprMem u8) Xmm)
 (rule (pinsrw src1 src2 lane)
       (xmm_rm_r_imm (SseOpcode.Pinsrw)
-                    (xmm_to_reg src1)
-                    (gpr_mem_to_reg_mem src2)
+                    src1
+                    src2
                     lane
                     (OperandSize.Size32)))
 
@@ -1998,8 +2001,8 @@
 (decl pinsrd (Xmm GprMem u8 OperandSize) Xmm)
 (rule (pinsrd src1 src2 lane size)
       (xmm_rm_r_imm (SseOpcode.Pinsrd)
-                    (xmm_to_reg src1)
-                    (gpr_mem_to_reg_mem src2)
+                    src1
+                    src2
                     lane
                     size))
 
@@ -2007,20 +2010,19 @@
 (decl insertps (Xmm XmmMem u8) Xmm)
 (rule (insertps src1 src2 lane)
       (xmm_rm_r_imm (SseOpcode.Insertps)
-                    (xmm_to_reg src1)
-                    (xmm_mem_to_reg_mem src2)
+                    src1
+                    src2
                     lane
                     (OperandSize.Size32)))
 
 ;; Helper for creating `pshufd` instructions.
 (decl pshufd (XmmMem u8 OperandSize) Xmm)
 (rule (pshufd src imm size)
-      (let ((w_dst WritableXmm (temp_writable_xmm))
-            (dst Xmm (writable_xmm_to_xmm w_dst))
+      (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pshufd)
-                                           (xmm_to_reg dst)
-                                           (xmm_mem_to_reg_mem src)
-                                           (writable_xmm_to_reg w_dst)
+                                           dst
+                                           src
+                                           dst
                                            imm
                                            size))))
         dst))
@@ -2030,7 +2032,7 @@
 (rule (xmm_unary_rm_r op src)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmUnaryRmR op src dst))))
-        (writable_xmm_to_xmm dst)))
+        dst))
 
 ;; Helper for creating `pmovsxbw` instructions.
 (decl pmovsxbw (XmmMem) Xmm)
@@ -2062,7 +2064,7 @@
 (rule (xmm_unary_rm_r_evex op src)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmUnaryRmREvex op src dst))))
-        (writable_xmm_to_xmm dst)))
+        dst))
 
 ;; Helper for creating `vpabsq` instructions.
 (decl vpabsq (XmmMem) Xmm)
@@ -2077,7 +2079,7 @@
                                             src1
                                             src2
                                             dst))))
-        (writable_xmm_to_xmm dst)))
+        dst))
 
 ;; Helper for creating `vpmullq` instructions.
 ;;
@@ -2102,8 +2104,7 @@
                                        src2
                                        dst_lo
                                        dst_hi))))
-        (value_gprs (writable_gpr_to_gpr dst_lo)
-                    (writable_gpr_to_gpr dst_hi))))
+        (value_gprs dst_lo dst_hi)))
 
 ;; Helper for creating `mul` instructions that return both the lower and
 ;; (unsigned) higher halves of the result.
@@ -2119,7 +2120,7 @@
                                            src1
                                            src2
                                            dst))))
-        (writable_xmm_to_xmm dst)))
+        dst))
 
 ;; Helper for creating `psllw` instructions.
 (decl psllw (Xmm XmmMemImm) Xmm)
@@ -2164,15 +2165,14 @@
 ;; Helper for creating `pextrd` instructions.
 (decl pextrd (Type Xmm u8) Gpr)
 (rule (pextrd ty src lane)
-      (let ((w_dst WritableGpr (temp_writable_gpr))
-            (r_dst Gpr (writable_gpr_to_gpr w_dst))
+      (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pextrd)
-                                           (gpr_to_reg r_dst)
-                                           (RegMem.Reg (xmm_to_reg src))
-                                           (writable_gpr_to_reg w_dst)
+                                           dst
+                                           src
+                                           dst
                                            lane
                                            (operand_size_of_type_32_64 (lane_type ty))))))
-        r_dst))
+        dst))
 
 ;; Helper for creating `cmppd` instructions.
 ;;
@@ -2182,8 +2182,8 @@
 (decl cmppd (Xmm XmmMem FcmpImm) Xmm)
 (rule (cmppd src1 src2 imm)
       (xmm_rm_r_imm (SseOpcode.Cmppd)
-                    (xmm_to_reg src1)
-                    (xmm_mem_to_reg_mem src2)
+                    src1
+                    src2
                     (encode_fcmp_imm imm)
                     (OperandSize.Size32)))
 
@@ -2192,7 +2192,7 @@
 (rule (gpr_to_xmm op src size)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.GprToXmm op src dst size))))
-        (writable_xmm_to_xmm dst)))
+        dst))
 
 ;; Helper for creating `not` instructions.
 (decl not (Type Gpr) Gpr)
@@ -2200,7 +2200,7 @@
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.Not size src dst))))
-        (writable_gpr_to_gpr dst)))
+        dst))
 
 ;; Helper for creating `neg` instructions.
 (decl neg (Type Gpr) Gpr)
@@ -2208,15 +2208,84 @@
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.Neg size src dst))))
-        (writable_gpr_to_gpr dst)))
+        dst))
 
 (decl lea (SyntheticAmode) Gpr)
 (rule (lea addr)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.LoadEffectiveAddress addr dst))))
-        (writable_gpr_to_gpr dst)))
+        dst))
 
 ;; Helper for creating `ud2` instructions.
 (decl ud2 (TrapCode) SideEffectNoResult)
 (rule (ud2 code)
       (SideEffectNoResult.Inst (MInst.Ud2 code)))
+
+;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(convert Gpr ValueRegs value_gpr)
+(convert Value Gpr put_in_gpr)
+(convert Value GprMem put_in_gpr_mem)
+(convert Value GprMemImm put_in_gpr_mem_imm)
+(convert Value RegMem put_in_reg_mem)
+(convert Value RegMemImm put_in_reg_mem_imm)
+(convert Gpr GprMemImm gpr_to_gpr_mem_imm)
+(convert Gpr GprMem gpr_to_gpr_mem)
+(convert Gpr Reg gpr_to_reg)
+(convert GprMem RegMem gpr_mem_to_reg_mem)
+(convert Reg Gpr gpr_new)
+(convert WritableGpr Gpr writable_gpr_to_gpr)
+(convert RegMemImm GprMemImm gpr_mem_imm_new)
+(convert RegMem GprMem reg_mem_to_gpr_mem)
+(convert Reg GprMem reg_to_gpr_mem)
+(convert Reg GprMemImm reg_to_gpr_mem_imm)
+(convert WritableGpr WritableReg writable_gpr_to_reg)
+(convert WritableGpr Reg writable_gpr_to_r_reg)
+
+(convert Xmm ValueRegs value_xmm)
+(convert Value Xmm put_in_xmm)
+(convert Value XmmMem put_in_xmm_mem)
+(convert Value XmmMemImm put_in_xmm_mem_imm)
+(convert Xmm Reg xmm_to_reg)
+(convert Xmm RegMem xmm_to_reg_mem)
+(convert Reg Xmm xmm_new)
+(convert Reg XmmMem reg_to_xmm_mem)
+(convert RegMem XmmMem reg_mem_to_xmm_mem)
+(convert RegMemImm XmmMemImm mov_rmi_to_xmm)
+(convert Xmm XmmMem xmm_to_xmm_mem)
+(convert Xmm XmmMemImm xmm_to_xmm_mem_imm)
+(convert XmmMem RegMem xmm_mem_to_reg_mem)
+(convert WritableXmm Xmm writable_xmm_to_xmm)
+(convert WritableXmm WritableReg writable_xmm_to_reg)
+(convert WritableXmm Reg writable_xmm_to_r_reg)
+(convert WritableXmm XmmMem writable_xmm_to_xmm_mem)
+
+(convert Gpr Imm8Gpr gpr_to_imm8_gpr)
+
+(convert Amode SyntheticAmode amode_to_synthetic_amode)
+(convert SyntheticAmode GprMem synthetic_amode_to_gpr_mem)
+(convert SyntheticAmode XmmMem synthetic_amode_to_xmm_mem)
+
+(decl reg_to_xmm_mem (Reg) XmmMem)
+(rule (reg_to_xmm_mem r)
+      (xmm_to_xmm_mem (xmm_new r)))
+(decl xmm_to_reg_mem (Reg) XmmMem)
+(rule (xmm_to_reg_mem r)
+      (RegMem.Reg (xmm_to_reg r)))
+
+(decl writable_gpr_to_r_reg (WritableGpr) Reg)
+(rule (writable_gpr_to_r_reg w_gpr)
+      (writable_reg_to_reg (writable_gpr_to_reg w_gpr)))
+(decl writable_xmm_to_r_reg (WritableXmm) Reg)
+(rule (writable_xmm_to_r_reg w_xmm)
+      (writable_reg_to_reg (writable_xmm_to_reg w_xmm)))
+(decl writable_xmm_to_xmm_mem (WritableXmm) XmmMem)
+(rule (writable_xmm_to_xmm_mem w_xmm)
+      (xmm_to_xmm_mem (writable_xmm_to_xmm w_xmm)))
+
+(decl synthetic_amode_to_gpr_mem (SyntheticAmode) GprMem)
+(rule (synthetic_amode_to_gpr_mem amode)
+      (synthetic_amode_to_reg_mem amode))
+(decl synthetic_amode_to_xmm_mem (SyntheticAmode) XmmMem)
+(rule (synthetic_amode_to_xmm_mem amode)
+      (synthetic_amode_to_reg_mem amode))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -9,7 +9,7 @@
 ;; `i64` and smaller.
 (rule (lower (has_type (fits_in_64 ty)
                        (iconst (u64_from_imm64 x))))
-      (value_reg (imm ty x)))
+      (imm ty x))
 
 ;; `i128`
 (rule (lower (has_type $I128
@@ -23,11 +23,11 @@
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bconst $false)))
-      (value_reg (imm ty 0)))
+      (imm ty 0))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bconst $true)))
-      (value_reg (imm ty 1)))
+      (imm ty 1))
 
 ;; `b128`
 
@@ -44,17 +44,17 @@
 ;;;; Rules for `f32const` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (f32const (u64_from_ieee32 x)))
-      (value_reg (imm $F32 x)))
+      (imm $F32 x))
 
 ;;;; Rules for `f64const` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (f64const (u64_from_ieee64 x)))
-      (value_reg (imm $F64 x)))
+      (imm $F64 x))
 
 ;;;; Rules for `null` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (null)))
-      (value_reg (imm ty 0)))
+      (imm ty 0))
 
 ;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -63,93 +63,83 @@
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x y)))
-      (value_gpr (add ty
-                      (put_in_gpr x)
-                      (gpr_to_gpr_mem_imm (put_in_gpr y)))))
+      (add ty x y))
 
 ;; Add a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x (simm32_from_value y))))
-      (value_gpr (add ty (put_in_gpr x) y)))
+      (add ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd (simm32_from_value x) y)))
-      (value_gpr (add ty (put_in_gpr y) x)))
+      (add ty y x))
 
 ;; Add a register and memory.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x (sinkable_load y))))
-      (value_gpr (add ty
-                      (put_in_gpr x)
-                      (sink_load_to_gpr_mem_imm y))))
+      (add ty
+           x
+           (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd (sinkable_load x) y)))
-      (value_gpr (add ty
-                      (put_in_gpr y)
-                      (sink_load_to_gpr_mem_imm x))))
+      (add ty
+           y
+           (sink_load_to_gpr_mem_imm x)))
 
 ;; SSE.
 
 (rule (lower (has_type (multi_lane 8 16)
                        (iadd x y)))
-      (value_xmm (paddb (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (paddb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (iadd x y)))
-      (value_xmm (paddw (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (paddw x y))
 
 (rule (lower (has_type (multi_lane 32 4)
                        (iadd x y)))
-      (value_xmm (paddd (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (paddd x y))
 
 (rule (lower (has_type (multi_lane 64 2)
                        (iadd x y)))
-      (value_xmm (paddq (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (paddq x y))
 
 ;; `i128`
 (rule (lower (has_type $I128 (iadd x y)))
       ;; Get the high/low registers for `x`.
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1)))
         ;; Get the high/low registers for `y`.
-        (let ((y_regs ValueRegs (put_in_regs y))
+        (let ((y_regs ValueRegs y)
               (y_lo Gpr (value_regs_get_gpr y_regs 0))
               (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do an add followed by an add-with-carry.
-          (with_flags (add_with_flags_paired $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
-                      (adc_paired $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
+          (with_flags (add_with_flags_paired $I64 x_lo y_lo)
+                      (adc_paired $I64 x_hi y_hi)))))
 
 ;;;; Rules for `sadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (sadd_sat x y)))
-      (value_xmm (paddsb (put_in_xmm x)
-                         (put_in_xmm_mem y))))
+      (paddsb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (sadd_sat x y)))
-      (value_xmm (paddsw (put_in_xmm x)
-                         (put_in_xmm_mem y))))
+      (paddsw x y))
 
 ;;;; Rules for `uadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (uadd_sat x y)))
-      (value_xmm (paddusb (put_in_xmm x)
-                          (put_in_xmm_mem y))))
+      (paddusb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (uadd_sat x y)))
-      (value_xmm (paddusw (put_in_xmm x)
-                          (put_in_xmm_mem y))))
+      (paddusw x y))
 
 ;;;; Rules for `iadd_ifcout` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -163,46 +153,43 @@
 ;; actually uses the register assigned to the SSA `iflags`-typed
 ;; `Value`.
 
+(decl unused_iflags () Gpr)
+(rule (unused_iflags)
+      (temp_writable_gpr))
+
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x y)))
-      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
-        (value_gprs (add ty
-                        (put_in_gpr x)
-                        (put_in_gpr_mem_imm y))
-                   unused_iflags)))
+      (value_gprs (add ty x y)
+                  (unused_iflags)))
 
 ;; Add a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (simm32_from_value y))))
-      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
-        (value_gprs (add ty (put_in_gpr x) y)
-                    unused_iflags)))
+      (value_gprs (add ty x y)
+                  (unused_iflags)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (simm32_from_value x) y)))
-      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
-        (value_gprs (add ty (put_in_gpr y) x)
-                    unused_iflags)))
+      (value_gprs (add ty y x)
+                  (unused_iflags)))
 
 ;; Add a register and memory.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (sinkable_load y))))
-      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
-        (value_gprs (add ty
-                         (put_in_gpr x)
-                         (sink_load_to_gpr_mem_imm y))
-                    unused_iflags)))
+      (value_gprs (add ty
+                       x
+                       (sink_load_to_gpr_mem_imm y))
+                  (unused_iflags)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (sinkable_load x) y)))
-      (let ((unused_iflags Gpr (writable_gpr_to_gpr (temp_writable_gpr))))
-        (value_gprs (add ty
-                         (put_in_gpr y)
-                         (sink_load_to_gpr_mem_imm x))
-                    unused_iflags)))
+      (value_gprs (add ty
+                       y
+                       (sink_load_to_gpr_mem_imm x))
+                  (unused_iflags)))
 
 ;; (No `iadd_ifcout` for `i128`.)
 
@@ -212,30 +199,30 @@
 
 ;; When the immediate fits in a `RegMemImm.Imm`, use that.
 (rule (lower (has_type (fits_in_64 ty) (iadd_imm y (simm32_from_imm64 x))))
-      (value_gpr (add ty (put_in_gpr y) x)))
+      (add ty y x))
 
 ;; Otherwise, put the immediate into a register.
 (rule (lower (has_type (fits_in_64 ty) (iadd_imm y (u64_from_imm64 x))))
-      (value_gpr (add ty (put_in_gpr y) (gpr_to_gpr_mem_imm (gpr_new (imm ty x))))))
+      (add ty y (imm ty x)))
 
 ;; `i128`
 
 ;; When the immediate fits in a `RegMemImm.Imm`, use that.
 (rule (lower (has_type $I128 (iadd_imm y (simm32_from_imm64 x))))
-      (let ((y_regs ValueRegs (put_in_regs y))
+      (let ((y_regs ValueRegs y)
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
         (with_flags (add_with_flags_paired $I64 y_lo x)
-                    (adc_paired $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
+                    (adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
 
 ;; Otherwise, put the immediate into a register.
 (rule (lower (has_type $I128 (iadd_imm y (u64_from_imm64 x))))
-      (let ((y_regs ValueRegs (put_in_regs y))
+      (let ((y_regs ValueRegs y)
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1))
-            (x_lo Gpr (gpr_new (imm $I64 x))))
-        (with_flags (add_with_flags_paired $I64 y_lo (gpr_to_gpr_mem_imm x_lo))
-                    (adc_paired $I64 y_hi (gpr_mem_imm_new (RegMemImm.Imm 0))))))
+            (x_lo Gpr (imm $I64 x)))
+        (with_flags (add_with_flags_paired $I64 y_lo x_lo)
+                    (adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -244,81 +231,70 @@
 ;; Sub two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x y)))
-      (value_gpr (sub ty
-                      (put_in_gpr x)
-                      (put_in_gpr_mem_imm y))))
+      (sub ty x y))
 
 ;; Sub a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x (simm32_from_value y))))
-      (value_gpr (sub ty (put_in_gpr x) y)))
+      (sub ty x y))
 
 ;; Sub a register and memory.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x (sinkable_load y))))
-      (value_gpr (sub ty
-                      (put_in_gpr x)
-                      (sink_load_to_gpr_mem_imm y))))
+      (sub ty x
+           (sink_load_to_gpr_mem_imm y)))
 
 ;; SSE.
 
 (rule (lower (has_type (multi_lane 8 16)
                        (isub x y)))
-      (value_xmm (psubb (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (psubb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (isub x y)))
-      (value_xmm (psubw (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (psubw x y))
 
 (rule (lower (has_type (multi_lane 32 4)
                        (isub x y)))
-      (value_xmm (psubd (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (psubd x y))
 
 (rule (lower (has_type (multi_lane 64 2)
                        (isub x y)))
-      (value_xmm (psubq (put_in_xmm x)
-                        (put_in_xmm_mem y))))
+      (psubq x y))
 
 ;; `i128`
 (rule (lower (has_type $I128 (isub x y)))
       ;; Get the high/low registers for `x`.
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1)))
         ;; Get the high/low registers for `y`.
-        (let ((y_regs ValueRegs (put_in_regs y))
+        (let ((y_regs ValueRegs y)
               (y_lo Gpr (value_regs_get_gpr y_regs 0))
               (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do a sub followed by an sub-with-borrow.
-          (with_flags (sub_with_flags_paired $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
-                      (sbb_paired $I64 x_hi (gpr_to_gpr_mem_imm y_hi))))))
+          (with_flags (sub_with_flags_paired $I64 x_lo y_lo)
+                      (sbb_paired $I64 x_hi y_hi)))))
 
 ;;;; Rules for `ssub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (ssub_sat x y)))
-      (value_xmm (psubsb (put_in_xmm x)
-                         (put_in_xmm_mem y))))
+      (psubsb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (ssub_sat x y)))
-      (value_xmm (psubsw (put_in_xmm x)
-                         (put_in_xmm_mem y))))
+      (psubsw x y))
 
 ;;;; Rules for `usub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (usub_sat x y)))
-      (value_xmm (psubusb (put_in_xmm x)
-                          (put_in_xmm_mem y))))
+      (psubusb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (usub_sat x y)))
-      (value_xmm (psubusw (put_in_xmm x)
-                          (put_in_xmm_mem y))))
+      (psubusw x y))
 
 ;;;; Rules for `band` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -326,37 +302,30 @@
 
 ;; And two registers.
 (rule (lower (has_type (fits_in_64 ty) (band x y)))
-      (value_gpr (x64_and ty
-                          (put_in_gpr x)
-                          (put_in_gpr_mem_imm y))))
+      (x64_and ty x y))
 
 ;; And with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band x (sinkable_load y))))
-      (value_gpr (x64_and ty
-                          (put_in_gpr x)
-                          (sink_load_to_gpr_mem_imm y))))
+      (x64_and ty x
+               (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band (sinkable_load x) y)))
-      (value_gpr (x64_and ty
-                          (put_in_gpr y)
-                          (sink_load_to_gpr_mem_imm x))))
+      (x64_and ty
+               y
+               (sink_load_to_gpr_mem_imm x)))
 
 ;; And with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band x (simm32_from_value y))))
-      (value_gpr (x64_and ty
-                          (put_in_gpr x)
-                          y)))
+      (x64_and ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (band (simm32_from_value x) y)))
-      (value_gpr (x64_and ty
-                          (put_in_gpr y)
-                          x)))
+      (x64_and ty y x))
 
 ;; SSE.
 
@@ -367,31 +336,29 @@
 
 (rule (lower (has_type ty @ (multi_lane _bits _lanes)
                        (band x y)))
-      (value_xmm (sse_and ty
-                          (put_in_xmm x)
-                          (put_in_xmm_mem y))))
+      (sse_and ty x y))
 
 ;; `{i,b}128`.
 
 (rule (lower (has_type $I128 (band x y)))
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
-            (y_regs ValueRegs (put_in_regs y))
+            (y_regs ValueRegs y)
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-        (value_gprs (x64_and $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
-                    (x64_and $I64 x_hi (gpr_to_gpr_mem_imm y_hi)))))
+        (value_gprs (x64_and $I64 x_lo y_lo)
+                    (x64_and $I64 x_hi y_hi))))
 
 (rule (lower (has_type $B128 (band x y)))
       ;; Booleans are always `0` or `1`, so we only need to do the `and` on the
       ;; low half. The high half is always zero but, rather than generate a new
       ;; zero, we just reuse `x`'s high half which is already zero.
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
             (y_lo Gpr (lo_gpr y)))
-        (value_gprs (x64_and $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+        (value_gprs (x64_and $I64 x_lo y_lo)
                     x_hi)))
 
 ;;;; Rules for `bor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -400,37 +367,29 @@
 
 ;; Or two registers.
 (rule (lower (has_type (fits_in_64 ty) (bor x y)))
-      (value_gpr (or ty
-                     (put_in_gpr x)
-                     (put_in_gpr_mem_imm y))))
+      (or ty x y))
 
 ;; Or with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor x (sinkable_load y))))
-      (value_gpr (or ty
-                     (put_in_gpr x)
-                     (sink_load_to_gpr_mem_imm y))))
+      (or ty x
+          (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor (sinkable_load x) y)))
-      (value_gpr (or ty
-                     (put_in_gpr y)
-                     (sink_load_to_gpr_mem_imm x))))
+      (or ty y
+          (sink_load_to_gpr_mem_imm x)))
 
 ;; Or with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor x (simm32_from_value y))))
-      (value_gpr (or ty
-                     (put_in_gpr x)
-                     y)))
+      (or ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor (simm32_from_value x) y)))
-      (value_gpr (or ty
-                     (put_in_gpr y)
-                     x)))
+      (or ty y x))
 
 ;; SSE.
 
@@ -441,9 +400,7 @@
 
 (rule (lower (has_type ty @ (multi_lane _bits _lanes)
                        (bor x y)))
-      (value_xmm (sse_or ty
-                         (put_in_xmm x)
-                         (put_in_xmm_mem y))))
+      (sse_or ty x y))
 
 ;; `{i,b}128`.
 
@@ -453,21 +410,21 @@
             (x_hi Gpr (value_regs_get_gpr x 1))
             (y_lo Gpr (value_regs_get_gpr y 0))
             (y_hi Gpr (value_regs_get_gpr y 1)))
-        (value_gprs (or $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
-                    (or $I64 x_hi (gpr_to_gpr_mem_imm y_hi)))))
+        (value_gprs (or $I64 x_lo y_lo)
+                    (or $I64 x_hi y_hi))))
 
 (rule (lower (has_type $I128 (bor x y)))
-      (or_i128 (put_in_regs x) (put_in_regs y)))
+      (or_i128 x y))
 
 (rule (lower (has_type $B128 (bor x y)))
       ;; Booleans are always `0` or `1`, so we only need to do the `or` on the
       ;; low half. The high half is always zero but, rather than generate a new
       ;; zero, we just reuse `x`'s high half which is already zero.
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
             (y_lo Gpr (lo_gpr y)))
-        (value_gprs (or $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+        (value_gprs (or $I64 x_lo y_lo)
                     x_hi)))
 
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -476,64 +433,56 @@
 
 ;; Xor two registers.
 (rule (lower (has_type (fits_in_64 ty) (bxor x y)))
-      (value_gpr (xor ty
-                      (put_in_gpr x)
-                      (put_in_gpr_mem_imm y))))
+      (xor ty x y))
 
 ;; Xor with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor x (sinkable_load y))))
-      (value_gpr (xor ty
-                      (put_in_gpr x)
-                      (sink_load_to_gpr_mem_imm y))))
+      (xor ty x
+           (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor (sinkable_load x) y)))
-      (value_gpr (xor ty
-                      (put_in_gpr y)
-                      (sink_load_to_gpr_mem_imm x))))
+      (xor ty y
+           (sink_load_to_gpr_mem_imm x)))
 
 ;; Xor with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor x (simm32_from_value y))))
-      (value_gpr (xor ty
-                      (put_in_gpr x)
-                      y)))
+      (xor ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor (simm32_from_value x) y)))
-      (value_gpr (xor ty
-                      (put_in_gpr y)
-                      x)))
+      (xor ty y x))
 
 ;; SSE.
 
 (rule (lower (has_type ty @ (multi_lane _bits _lanes) (bxor x y)))
-      (value_xmm (sse_xor ty (put_in_xmm x) (put_in_xmm_mem y))))
+      (sse_xor ty x y))
 
 ;; `{i,b}128`.
 
 (rule (lower (has_type $I128 (bxor x y)))
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
-            (y_regs ValueRegs (put_in_regs y))
+            (y_regs ValueRegs y)
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-        (value_gprs (xor $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
-                    (xor $I64 x_hi (gpr_to_gpr_mem_imm y_hi)))))
+        (value_gprs (xor $I64 x_lo y_lo)
+                    (xor $I64 x_hi y_hi))))
 
 (rule (lower (has_type $B128 (bxor x y)))
       ;; Booleans are always `0` or `1`, so we only need to do the `xor` on the
       ;; low half. The high half is always zero but, rather than generate a new
       ;; zero, we just reuse `x`'s high half which is already zero.
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
             (y_lo Gpr (lo_gpr y)))
-        (value_gprs (xor $I64 x_lo (gpr_to_gpr_mem_imm y_lo))
+        (value_gprs (xor $I64 x_lo y_lo)
                     x_hi)))
 
 ;;;; Rules for `ishl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -541,7 +490,7 @@
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (ishl src amt)))
-      (value_gpr (shl ty (put_in_gpr src) (put_masked_in_imm8_gpr amt ty))))
+      (shl ty src (put_masked_in_imm8_gpr amt ty)))
 
 ;; `i128`.
 
@@ -551,39 +500,39 @@
       (let ((src_lo Gpr (value_regs_get_gpr src 0))
             (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do two 64-bit shifts.
-            (lo_shifted Gpr (shl $I64 src_lo (gpr_to_imm8_gpr amt)))
-            (hi_shifted Gpr (shl $I64 src_hi (gpr_to_imm8_gpr amt)))
+            (lo_shifted Gpr (shl $I64 src_lo amt))
+            (hi_shifted Gpr (shl $I64 src_hi amt))
             ;; `src_lo >> (64 - amt)` are the bits to carry over from the lo
             ;; into the hi.
             (carry Gpr (shr $I64
                             src_lo
-                            (gpr_to_imm8_gpr (sub $I64
-                                                  (gpr_new (imm $I64 64))
-                                                  (gpr_to_gpr_mem_imm amt)))))
-            (zero Gpr (gpr_new (imm $I64 0)))
+                            (sub $I64
+                                 (imm $I64 64)
+                                 amt)))
+            (zero Gpr (imm $I64 0))
             ;; Nullify the carry if we are shifting in by a multiple of 128.
-            (carry_ Gpr (gpr_new (with_flags_reg (test (OperandSize.Size64)
-                                                     (gpr_mem_imm_new (RegMemImm.Imm 127))
-                                                     amt)
-                                               (cmove $I64
-                                                      (CC.Z)
-                                                      (gpr_to_gpr_mem zero)
-                                                      carry))))
+            (carry_ Gpr (with_flags_reg (test (OperandSize.Size64)
+                                              (RegMemImm.Imm 127)
+                                              amt)
+                                        (cmove $I64
+                                               (CC.Z)
+                                               zero
+                                               carry)))
             ;; Add the carry into the high half.
-            (hi_shifted_ Gpr (or $I64 carry_ (gpr_to_gpr_mem_imm hi_shifted))))
+            (hi_shifted_ Gpr (or $I64 carry_ hi_shifted)))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the low bits are zero and the high bits are our
         ;; low bits.
-        (with_flags (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 64)) amt)
+        (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
                     (consumes_flags_concat
-                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted) zero)
-                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted_) lo_shifted)))))
+                     (cmove $I64 (CC.Z) lo_shifted zero)
+                     (cmove $I64 (CC.Z) hi_shifted_ lo_shifted)))))
 
 (rule (lower (has_type $I128 (ishl src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
       ;; amount to the value's bit width.
       (let ((amt_ Gpr (lo_gpr amt)))
-        (shl_i128 (put_in_regs src) amt_)))
+        (shl_i128 src amt_)))
 
 ;; SSE.
 
@@ -592,16 +541,14 @@
 ;; instructions. The basic idea, whether the amount to shift by is an immediate
 ;; or not, is to use a 16x8 shift and then mask off the incorrect bits to 0s.
 (rule (lower (has_type $I8X16 (ishl src amt)))
-      (let ((src_ Xmm (put_in_xmm src))
-            (amt_gpr RegMemImm (put_in_reg_mem_imm amt))
-            (amt_xmm XmmMemImm (mov_rmi_to_xmm amt_gpr))
+      (let (
             ;; Shift `src` using 16x8. Unfortunately, a 16x8 shift will only be
             ;; correct for half of the lanes; the others must be fixed up with
             ;; the mask below.
-            (unmasked Xmm (psllw src_ amt_xmm))
-            (mask_addr SyntheticAmode (ishl_i8x16_mask amt_gpr))
+            (unmasked Xmm (psllw src (mov_rmi_to_xmm amt)))
+            (mask_addr SyntheticAmode (ishl_i8x16_mask amt))
             (mask Reg (x64_load $I8X16 mask_addr (ExtKind.None))))
-        (value_xmm (sse_and $I8X16 unmasked (reg_mem_to_xmm_mem (RegMem.Reg mask))))))
+        (sse_and $I8X16 unmasked (RegMem.Reg mask))))
 
 ;; Get the address of the mask to use when fixing up the lanes that weren't
 ;; correctly generated by the 16x8 shift.
@@ -623,29 +570,26 @@
 (rule (ishl_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ishl_i8x16_mask_table))
             (base_mask_addr Gpr (lea mask_table))
-            (mask_offset Gpr (shl $I64
-                                  (gpr_new amt)
+            (mask_offset Gpr (shl $I64 amt
                                   (imm8_to_imm8_gpr 4))))
-        (amode_to_synthetic_amode (amode_imm_reg_reg_shift 0
-                                                           base_mask_addr
-                                                           mask_offset
-                                                           0))))
+        (amode_imm_reg_reg_shift 0
+                                 base_mask_addr
+                                 mask_offset
+                                 0)))
+
 (rule (ishl_i8x16_mask (RegMemImm.Mem amt))
       (ishl_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))
 
 ;; 16x8, 32x4, and 64x2 shifts can each use a single instruction.
 
 (rule (lower (has_type $I16X8 (ishl src amt)))
-      (value_xmm (psllw (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (psllw src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I32X4 (ishl src amt)))
-      (value_xmm (pslld (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (pslld src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I64X2 (ishl src amt)))
-      (value_xmm (psllq (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (psllq src (mov_rmi_to_xmm amt)))
 
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -653,7 +597,7 @@
 
 (rule (lower (has_type (fits_in_64 ty) (ushr src amt)))
       (let ((src_ Gpr (extend_to_gpr src ty (ExtendKind.Zero))))
-        (value_gpr (shr ty src_ (put_masked_in_imm8_gpr amt ty)))))
+        (shr ty src_ (put_masked_in_imm8_gpr amt ty))))
 
 ;; `i128`.
 
@@ -663,51 +607,49 @@
       (let ((src_lo Gpr (value_regs_get_gpr src 0))
             (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do a shift on each half.
-            (lo_shifted Gpr (shr $I64 src_lo (gpr_to_imm8_gpr amt)))
-            (hi_shifted Gpr (shr $I64 src_hi (gpr_to_imm8_gpr amt)))
+            (lo_shifted Gpr (shr $I64 src_lo amt))
+            (hi_shifted Gpr (shr $I64 src_hi amt))
             ;; `src_hi << (64 - amt)` are the bits to carry over from the hi
             ;; into the lo.
             (carry Gpr (shl $I64
                             src_hi
-                            (gpr_to_imm8_gpr (sub $I64
-                                                  (gpr_new (imm $I64 64))
-                                                  (gpr_to_gpr_mem_imm amt)))))
+                            (sub $I64
+                                 (imm $I64 64)
+                                 amt)))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (gpr_new (with_flags_reg (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 127)) amt)
-                                        (cmove $I64 (CC.Z) (gpr_to_gpr_mem (gpr_new (imm $I64 0))) carry))))
+            (carry_ Gpr (with_flags_reg (test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
+                                        (cmove $I64 (CC.Z) (imm $I64 0) carry)))
             ;; Add the carry bits into the lo.
-            (lo_shifted_ Gpr (or $I64 carry_ (gpr_to_gpr_mem_imm lo_shifted))))
+            (lo_shifted_ Gpr (or $I64 carry_ lo_shifted)))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are zero and the lo bits are what
         ;; would otherwise be our hi bits.
-        (with_flags (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 64)) amt)
+        (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
                     (consumes_flags_concat
-                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
-                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) (gpr_new (imm $I64 0)))))))
+                     (cmove $I64 (CC.Z) lo_shifted_ hi_shifted)
+                     (cmove $I64 (CC.Z) hi_shifted (imm $I64 0))))))
 
 (rule (lower (has_type $I128 (ushr src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
       ;; amount to the value's bit width.
       (let ((amt_ Gpr (lo_gpr amt)))
-        (shr_i128 (put_in_regs src) amt_)))
+        (shr_i128 src amt_)))
 
 ;; SSE.
 
 ;; There are no 8x16 shifts in x64. Do the same 16x8-shift-and-mask thing we do
 ;; with 8x16 `ishl`.
 (rule (lower (has_type $I8X16 (ushr src amt)))
-      (let ((src_ Xmm (put_in_xmm src))
-            (amt_gpr RegMemImm (put_in_reg_mem_imm amt))
-            (amt_xmm XmmMemImm (mov_rmi_to_xmm amt_gpr))
+      (let (
             ;; Shift `src` using 16x8. Unfortunately, a 16x8 shift will only be
             ;; correct for half of the lanes; the others must be fixed up with
             ;; the mask below.
-            (unmasked Xmm (psrlw src_ amt_xmm))
-            (mask_addr SyntheticAmode (ushr_i8x16_mask amt_gpr))
+            (unmasked Xmm (psrlw src (mov_rmi_to_xmm amt)))
+            (mask_addr SyntheticAmode (ushr_i8x16_mask amt))
             (mask Reg (x64_load $I8X16 mask_addr (ExtKind.None))))
-        (value_xmm (sse_and $I8X16
-                            unmasked
-                            (reg_mem_to_xmm_mem (RegMem.Reg mask))))))
+        (sse_and $I8X16
+                 unmasked
+                 (RegMem.Reg mask))))
 
 ;; Get the address of the mask to use when fixing up the lanes that weren't
 ;; correctly generated by the 16x8 shift.
@@ -730,28 +672,26 @@
       (let ((mask_table SyntheticAmode (ushr_i8x16_mask_table))
             (base_mask_addr Gpr (lea mask_table))
             (mask_offset Gpr (shl $I64
-                                  (gpr_new amt)
+                                  amt
                                   (imm8_to_imm8_gpr 4))))
-        (amode_to_synthetic_amode (amode_imm_reg_reg_shift 0
-                                                           base_mask_addr
-                                                           mask_offset
-                                                           0))))
+        (amode_imm_reg_reg_shift 0
+                                 base_mask_addr
+                                 mask_offset
+                                 0)))
+
 (rule (ushr_i8x16_mask (RegMemImm.Mem amt))
       (ushr_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))
 
 ;; 16x8, 32x4, and 64x2 shifts can each use a single instruction.
 
 (rule (lower (has_type $I16X8 (ushr src amt)))
-      (value_xmm (psrlw (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (psrlw src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I32X4 (ushr src amt)))
-      (value_xmm (psrld (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (psrld src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I64X2 (ushr src amt)))
-      (value_xmm (psrlq (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (psrlq src (mov_rmi_to_xmm amt)))
 
 ;;;; Rules for `sshr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -759,7 +699,7 @@
 
 (rule (lower (has_type (fits_in_64 ty) (sshr src amt)))
       (let ((src_ Gpr (extend_to_gpr src ty (ExtendKind.Sign))))
-        (value_gpr (sar ty src_ (put_masked_in_imm8_gpr amt ty)))))
+        (sar ty src_ (put_masked_in_imm8_gpr amt ty))))
 
 ;; `i128`.
 
@@ -770,35 +710,35 @@
             (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do a shift of each half. NB: the low half uses an unsigned shift
             ;; because its MSB is not a sign bit.
-            (lo_shifted Gpr (shr $I64 src_lo (gpr_to_imm8_gpr amt)))
-            (hi_shifted Gpr (sar $I64 src_hi (gpr_to_imm8_gpr amt)))
+            (lo_shifted Gpr (shr $I64 src_lo amt))
+            (hi_shifted Gpr (sar $I64 src_hi amt))
             ;; `src_hi << (64 - amt)` are the bits to carry over from the low
             ;; half to the high half.
             (carry Gpr (shl $I64
                             src_hi
-                            (gpr_to_imm8_gpr (sub $I64
-                                                  (gpr_new (imm $I64 64))
-                                                  (gpr_to_gpr_mem_imm amt)))))
+                            (sub $I64
+                                 (imm $I64 64)
+                                 amt)))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (gpr_new (with_flags_reg (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 127)) amt)
-                                    (cmove $I64 (CC.Z) (gpr_to_gpr_mem (gpr_new (imm $I64 0))) carry))))
+            (carry_ Gpr (with_flags_reg (test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
+                                        (cmove $I64 (CC.Z) (imm $I64 0) carry)))
             ;; Add the carry into the low half.
-            (lo_shifted_ Gpr (or $I64 lo_shifted (gpr_to_gpr_mem_imm carry_)))
+            (lo_shifted_ Gpr (or $I64 lo_shifted carry_))
             ;; Get all sign bits.
             (sign_bits Gpr (sar $I64 src_hi (imm8_to_imm8_gpr 63))))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are all sign bits and the lo bits are
         ;; what would otherwise be our hi bits.
-        (with_flags (test (OperandSize.Size64) (gpr_mem_imm_new (RegMemImm.Imm 64)) amt)
+        (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
                     (consumes_flags_concat
-                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem lo_shifted_) hi_shifted)
-                     (cmove $I64 (CC.Z) (gpr_to_gpr_mem hi_shifted) sign_bits)))))
+                     (cmove $I64 (CC.Z) lo_shifted_ hi_shifted)
+                     (cmove $I64 (CC.Z) hi_shifted sign_bits)))))
 
 (rule (lower (has_type $I128 (sshr src amt)))
       ;; NB: Only the low bits of `amt` matter since we logically mask the shift
       ;; amount to the value's bit width.
       (let ((amt_ Gpr (lo_gpr amt)))
-        (sar_i128 (put_in_regs src) amt_)))
+        (sar_i128 src amt_)))
 
 ;; SSE.
 
@@ -820,35 +760,33 @@
             ;; In order for `packsswb` later to only use the high byte of each
             ;; 16x8 lane, we shift right an extra 8 bits, relying on `psraw` to
             ;; fill in the upper bits appropriately.
-            (lo Xmm (punpcklbw src_ (xmm_to_xmm_mem src_)))
-            (hi Xmm (punpckhbw src_ (xmm_to_xmm_mem src_)))
-            (amt_ XmmMemImm (sshr_i8x16_bigger_shift amt_ty (put_in_reg_mem_imm amt)))
+            (lo Xmm (punpcklbw src_ src_))
+            (hi Xmm (punpckhbw src_ src_))
+            (amt_ XmmMemImm (sshr_i8x16_bigger_shift amt_ty amt))
             (shifted_lo Xmm (psraw lo amt_))
             (shifted_hi Xmm (psraw hi amt_)))
-        (value_xmm (packsswb shifted_lo (xmm_to_xmm_mem shifted_hi)))))
+        (packsswb shifted_lo shifted_hi)))
 
 (decl sshr_i8x16_bigger_shift (Type RegMemImm) XmmMemImm)
 (rule (sshr_i8x16_bigger_shift _ty (RegMemImm.Imm i))
       (xmm_mem_imm_new (RegMemImm.Imm (u32_add i 8))))
 (rule (sshr_i8x16_bigger_shift ty (RegMemImm.Reg r))
-      (mov_rmi_to_xmm (RegMemImm.Reg (gpr_to_reg (add ty
-                                                      (gpr_new r)
-                                                      (gpr_mem_imm_new (RegMemImm.Imm 8)))))))
+      (mov_rmi_to_xmm (RegMemImm.Reg (add ty
+                                          r
+                                          (RegMemImm.Imm 8)))))
 (rule (sshr_i8x16_bigger_shift ty rmi @ (RegMemImm.Mem _m))
-      (mov_rmi_to_xmm (RegMemImm.Reg (gpr_to_reg (add ty
-                                                      (gpr_new (imm ty 8))
-                                                      (gpr_mem_imm_new rmi))))))
+      (mov_rmi_to_xmm (RegMemImm.Reg (add ty
+                                          (imm ty 8)
+                                          rmi))))
 
 ;; `sshr.{i16x8,i32x4}` can be a simple `psra{w,d}`, we just have to make sure
 ;; that if the shift amount is in a register, it is in an XMM register.
 
 (rule (lower (has_type $I16X8 (sshr src amt)))
-      (value_xmm (psraw (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (psraw src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I32X4 (sshr src amt)))
-      (value_xmm (psrad (put_in_xmm src)
-                        (mov_rmi_to_xmm (put_in_reg_mem_imm amt)))))
+      (psrad src (mov_rmi_to_xmm amt)))
 
 ;; The `sshr.i64x2` CLIF instruction has no single x86 instruction in the older
 ;; feature sets. Newer ones like AVX512VL + AVX512F include `vpsraq`, a 128-bit
@@ -865,8 +803,8 @@
             (amt_ Imm8Gpr (put_masked_in_imm8_gpr amt $I64))
             (shifted_lo Gpr (sar $I64 lo amt_))
             (shifted_hi Gpr (sar $I64 hi amt_)))
-        (value_xmm (make_i64x2_from_lanes (gpr_to_gpr_mem shifted_lo)
-                                          (gpr_to_gpr_mem shifted_hi)))))
+        (make_i64x2_from_lanes shifted_lo
+                               shifted_hi)))
 
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -875,13 +813,12 @@
 
 (rule (lower (has_type (ty_8_or_16 ty) (rotl src amt)))
       (let ((amt_ Gpr (extend_to_gpr amt $I32 (ExtendKind.Zero))))
-        (value_gpr (x64_rotl ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
+        (x64_rotl ty src (gpr_to_imm8_gpr amt_))))
 
 (rule (lower (has_type (ty_8_or_16 ty)
                        (rotl src (u64_from_iconst amt))))
-      (value_gpr (x64_rotl ty
-                           (put_in_gpr src)
-                           (const_to_type_masked_imm8 amt ty))))
+      (x64_rotl ty src
+                (const_to_type_masked_imm8 amt ty)))
 
 ;; `i64` and `i32`: we can rely on x86's rotate-amount masking since
 ;;  we operate on the whole register.
@@ -890,25 +827,24 @@
       ;; NB: Only the low bits of `amt` matter since we logically mask the
       ;; shift amount to the value's bit width.
       (let ((amt_ Gpr (lo_gpr amt)))
-        (value_gpr (x64_rotl ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
+        (x64_rotl ty src amt_)))
 
 (rule (lower (has_type (ty_32_or_64 ty)
                        (rotl src (u64_from_iconst amt))))
-      (value_gpr (x64_rotl ty
-                           (put_in_gpr src)
-                           (const_to_type_masked_imm8 amt ty))))
+      (x64_rotl ty src
+                (const_to_type_masked_imm8 amt ty)))
 
 ;; `i128`.
 
 (rule (lower (has_type $I128 (rotl src amt)))
-      (let ((src_ ValueRegs (put_in_regs src))
+      (let ((src_ ValueRegs src)
             ;; NB: Only the low bits of `amt` matter since we logically mask the
             ;; rotation amount to the value's bit width.
             (amt_ Gpr (lo_gpr amt)))
         (or_i128 (shl_i128 src_ amt_)
                  (shr_i128 src_ (sub $I64
-                                     (gpr_new (imm $I64 128))
-                                     (gpr_to_gpr_mem_imm amt_))))))
+                                     (imm $I64 128)
+                                     amt_)))))
 
 ;;;; Rules for `rotr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -917,13 +853,12 @@
 
 (rule (lower (has_type (ty_8_or_16 ty) (rotr src amt)))
       (let ((amt_ Gpr (extend_to_gpr amt $I32 (ExtendKind.Zero))))
-        (value_gpr (x64_rotr ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
+        (x64_rotr ty src amt_)))
 
 (rule (lower (has_type (ty_8_or_16 ty)
                        (rotr src (u64_from_iconst amt))))
-      (value_gpr (x64_rotr ty
-                           (put_in_gpr src)
-                           (const_to_type_masked_imm8 amt ty))))
+      (x64_rotr ty src
+                (const_to_type_masked_imm8 amt ty)))
 
 ;; `i64` and `i32`: we can rely on x86's rotate-amount masking since
 ;;  we operate on the whole register.
@@ -932,60 +867,55 @@
       ;; NB: Only the low bits of `amt` matter since we logically mask the
       ;; shift amount to the value's bit width.
       (let ((amt_ Gpr (lo_gpr amt)))
-        (value_gpr (x64_rotr ty (put_in_gpr src) (gpr_to_imm8_gpr amt_)))))
+        (x64_rotr ty src amt_)))
 
 (rule (lower (has_type (ty_32_or_64 ty)
                        (rotr src (u64_from_iconst amt))))
-      (value_gpr (x64_rotr ty
-                           (put_in_gpr src)
-                           (const_to_type_masked_imm8 amt ty))))
+      (x64_rotr ty src
+                (const_to_type_masked_imm8 amt ty)))
 
 ;; `i128`.
 
 (rule (lower (has_type $I128 (rotr src amt)))
-      (let ((src_ ValueRegs (put_in_regs src))
+      (let ((src_ ValueRegs src)
             ;; NB: Only the low bits of `amt` matter since we logically mask the
             ;; rotation amount to the value's bit width.
             (amt_ Gpr (lo_gpr amt)))
         (or_i128 (shr_i128 src_ amt_)
                  (shl_i128 src_ (sub $I64
-                                     (gpr_new (imm $I64 128))
-                                     (gpr_to_gpr_mem_imm amt_))))))
+                                     (imm $I64 128)
+                                     amt_)))))
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (ineg x)))
-      (value_gpr (neg ty (put_in_gpr x))))
+      (neg ty x))
 
 ;; SSE.
 
 (rule (lower (has_type $I8X16 (ineg x)))
-      (value_xmm (psubb (xmm_new (imm $I8X16 0))
-                        (put_in_xmm_mem x))))
+      (psubb (imm $I8X16 0) x))
 
 (rule (lower (has_type $I16X8 (ineg x)))
-      (value_xmm (psubw (xmm_new (imm $I16X8 0))
-                        (put_in_xmm_mem x))))
+      (psubw (imm $I16X8 0) x))
 
 (rule (lower (has_type $I32X4 (ineg x)))
-      (value_xmm (psubd (xmm_new (imm $I32X4 0))
-                        (put_in_xmm_mem x))))
+      (psubd (imm $I32X4 0) x))
 
 (rule (lower (has_type $I64X2 (ineg x)))
-      (value_xmm (psubq (xmm_new (imm $I64X2 0))
-                        (put_in_xmm_mem x))))
+      (psubq (imm $I64X2 0) x))
 
 ;;;; Rules for `avg_round` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (avg_round x y)))
-      (value_xmm (pavgb (put_in_xmm x) (put_in_xmm_mem y))))
+      (pavgb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (avg_round x y)))
-      (value_xmm (pavgw (put_in_xmm x) (put_in_xmm_mem y))))
+      (pavgw x y))
 
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -993,33 +923,30 @@
 
 ;; Multiply two registers.
 (rule (lower (has_type (fits_in_64 ty) (imul x y)))
-      (value_gpr (mul ty
-                      (put_in_gpr x)
-                      (put_in_gpr_mem_imm y))))
+      (mul ty x y))
 
 ;; Multiply a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul x (simm32_from_value y))))
-      (value_gpr (mul ty (put_in_gpr x) y)))
+      (mul ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul (simm32_from_value x) y)))
-      (value_gpr (mul ty (put_in_gpr y) x)))
+      (mul ty y x))
 
 ;; Multiply a register and a memory load.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul x (sinkable_load y))))
-      (value_gpr (mul ty
-                      (put_in_gpr x)
-                      (sink_load_to_gpr_mem_imm y))))
+      (mul ty
+           x
+           (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul (sinkable_load x) y)))
-      (value_gpr (mul ty
-                      (put_in_gpr y)
-                      (sink_load_to_gpr_mem_imm x))))
+      (mul ty y
+           (sink_load_to_gpr_mem_imm x)))
 
 ;; `i128`.
 
@@ -1038,25 +965,25 @@
 ;;   return (dst_lo, dst_hi)
 (rule (lower (has_type $I128 (imul x y)))
       ;; Put `x` into registers and unpack its hi/lo halves.
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
             ;; Put `y` into registers and unpack its hi/lo halves.
-            (y_regs ValueRegs (put_in_regs y))
+            (y_regs ValueRegs y)
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1))
             ;; lo_hi = mul x_lo, y_hi
-            (lo_hi Gpr (mul $I64 x_lo (gpr_to_gpr_mem_imm y_hi)))
+            (lo_hi Gpr (mul $I64 x_lo y_hi))
             ;; hi_lo = mul x_hi, y_lo
-            (hi_lo Gpr (mul $I64 x_hi (gpr_to_gpr_mem_imm y_lo)))
+            (hi_lo Gpr (mul $I64 x_hi y_lo))
             ;; hilo_hilo = add lo_hi, hi_lo
-            (hilo_hilo Gpr (add $I64 lo_hi (gpr_to_gpr_mem_imm hi_lo)))
+            (hilo_hilo Gpr (add $I64 lo_hi hi_lo))
             ;; dst_lo:hi_lolo = mulhi_u x_lo, y_lo
-            (mul_regs ValueRegs (mulhi_u $I64 x_lo (gpr_to_gpr_mem y_lo)))
+            (mul_regs ValueRegs (mulhi_u $I64 x_lo y_lo))
             (dst_lo Gpr (value_regs_get_gpr mul_regs 0))
             (hi_lolo Gpr (value_regs_get_gpr mul_regs 1))
             ;; dst_hi = add hilo_hilo, hi_lolo
-            (dst_hi Gpr (add $I64 hilo_hilo (gpr_to_gpr_mem_imm hi_lolo))))
+            (dst_hi Gpr (add $I64 hilo_hilo hi_lolo)))
         (value_gprs dst_lo dst_hi)))
 
 ;; SSE.
@@ -1064,10 +991,10 @@
 ;; (No i8x16 multiply.)
 
 (rule (lower (has_type (multi_lane 16 8) (imul x y)))
-      (value_xmm (pmullw (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmullw x y))
 
 (rule (lower (has_type (multi_lane 32 4) (imul x y)))
-      (value_xmm (pmulld (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmulld x y))
 
 ;; With AVX-512 we can implement `i64x2` multiplication with a single
 ;; instruction.
@@ -1075,7 +1002,7 @@
                             (avx512dq_enabled)
                             (multi_lane 64 2))
                        (imul x y)))
-      (value_xmm (vpmullq (put_in_xmm_mem x) (put_in_xmm y))))
+      (vpmullq x y))
 
 ;; Otherwise, for i64x2 multiplication we describe a lane A as being composed of
 ;; a 32-bit upper half "Ah" and a 32-bit lower half "Al". The 32-bit long hand
@@ -1099,176 +1026,176 @@
 ;; 32-bits when doing calculations, i.e., `Ah == A >> 32`.
 (rule (lower (has_type (multi_lane 64 2)
                        (imul a b)))
-      (let ((a0 Xmm (put_in_xmm a))
-            (b0 Xmm (put_in_xmm b))
+      (let ((a0 Xmm a)
+            (b0 Xmm b)
             ;; a_hi = A >> 32
-            (a_hi Xmm (psrlq a0 (xmm_mem_imm_new (RegMemImm.Imm 32))))
+            (a_hi Xmm (psrlq a0 (RegMemImm.Imm 32)))
             ;; ah_bl = Ah * Bl
-            (ah_bl Xmm (pmuludq a_hi (xmm_to_xmm_mem b0)))
+            (ah_bl Xmm (pmuludq a_hi b0))
             ;; b_hi = B >> 32
-            (b_hi Xmm (psrlq b0 (xmm_mem_imm_new (RegMemImm.Imm 32))))
+            (b_hi Xmm (psrlq b0 (RegMemImm.Imm 32)))
             ;; al_bh = Al * Bh
-            (al_bh Xmm (pmuludq a0 (xmm_to_xmm_mem b_hi)))
+            (al_bh Xmm (pmuludq a0 b_hi))
             ;; aa_bb = ah_bl + al_bh
-            (aa_bb Xmm (paddq ah_bl (xmm_to_xmm_mem al_bh)))
+            (aa_bb Xmm (paddq ah_bl al_bh))
             ;; aa_bb_shifted = aa_bb << 32
-            (aa_bb_shifted Xmm (psllq aa_bb (xmm_mem_imm_new (RegMemImm.Imm 32))))
+            (aa_bb_shifted Xmm (psllq aa_bb (RegMemImm.Imm 32)))
             ;; al_bl = Al * Bl
-            (al_bl Xmm (pmuludq a0 (xmm_to_xmm_mem b0))))
+            (al_bl Xmm (pmuludq a0 b0)))
         ;; al_bl + aa_bb_shifted
-        (value_xmm (paddq al_bl (xmm_to_xmm_mem aa_bb_shifted)))))
+        (paddq al_bl aa_bb_shifted)))
 
 ;; Special case for `i16x8.extmul_high_i8x16_s`.
 (rule (lower (has_type (multi_lane 16 8)
-                       (imul (def_inst (swiden_high (and (value_type (multi_lane 8 16))
-                                                         x)))
-                             (def_inst (swiden_high (and (value_type (multi_lane 8 16))
-                                                         y))))))
-      (let ((x1 Xmm (put_in_xmm x))
-            (x2 Xmm (palignr x1 (xmm_to_xmm_mem x1) 8 (OperandSize.Size32)))
-            (x3 Xmm (pmovsxbw (xmm_to_xmm_mem x2)))
-            (y1 Xmm (put_in_xmm y))
-            (y2 Xmm (palignr y1 (xmm_to_xmm_mem y1) 8 (OperandSize.Size32)))
-            (y3 Xmm (pmovsxbw (xmm_to_xmm_mem y2))))
-        (value_xmm (pmullw x3 (xmm_to_xmm_mem y3)))))
+                       (imul (swiden_high (and (value_type (multi_lane 8 16))
+                                               x))
+                             (swiden_high (and (value_type (multi_lane 8 16))
+                                               y)))))
+      (let ((x1 Xmm x)
+            (x2 Xmm (palignr x1 x1 8 (OperandSize.Size32)))
+            (x3 Xmm (pmovsxbw x2))
+            (y1 Xmm y)
+            (y2 Xmm (palignr y1 y1 8 (OperandSize.Size32)))
+            (y3 Xmm (pmovsxbw y2)))
+        (pmullw x3 y3)))
 
 ;; Special case for `i32x4.extmul_high_i16x8_s`.
 (rule (lower (has_type (multi_lane 32 4)
-                       (imul (def_inst (swiden_high (and (value_type (multi_lane 16 8))
-                                                         x)))
-                             (def_inst (swiden_high (and (value_type (multi_lane 16 8))
-                                                         y))))))
-      (let ((x2 Xmm (put_in_xmm x))
-            (y2 Xmm (put_in_xmm y))
-            (lo Xmm (pmullw x2 (xmm_to_xmm_mem y2)))
-            (hi Xmm (pmulhw x2 (xmm_to_xmm_mem y2))))
-        (value_xmm (punpckhwd lo (xmm_to_xmm_mem hi)))))
+                       (imul (swiden_high (and (value_type (multi_lane 16 8))
+                                               x))
+                             (swiden_high (and (value_type (multi_lane 16 8))
+                                               y)))))
+      (let ((x2 Xmm x)
+            (y2 Xmm y)
+            (lo Xmm (pmullw x2 y2))
+            (hi Xmm (pmulhw x2 y2)))
+        (punpckhwd lo hi)))
 
 ;; Special case for `i64x2.extmul_high_i32x4_s`.
 (rule (lower (has_type (multi_lane 64 2)
-                       (imul (def_inst (swiden_high (and (value_type (multi_lane 32 4))
-                                                         x)))
-                             (def_inst (swiden_high (and (value_type (multi_lane 32 4))
-                                                         y))))))
-      (let ((x2 Xmm (pshufd (put_in_xmm_mem x)
+                       (imul (swiden_high (and (value_type (multi_lane 32 4))
+                                               x))
+                             (swiden_high (and (value_type (multi_lane 32 4))
+                                               y)))))
+      (let ((x2 Xmm (pshufd x
                             0xFA
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd (put_in_xmm_mem y)
+            (y2 Xmm (pshufd y
                             0xFA
                             (OperandSize.Size32))))
-        (value_xmm (pmuldq x2 (xmm_to_xmm_mem y2)))))
+        (pmuldq x2 y2)))
 
 ;; Special case for `i16x8.extmul_low_i8x16_s`.
 (rule (lower (has_type (multi_lane 16 8)
-                       (imul (def_inst (swiden_low (and (value_type (multi_lane 8 16))
-                                                        x)))
-                             (def_inst (swiden_low (and (value_type (multi_lane 8 16))
-                                                        y))))))
-      (let ((x2 Xmm (pmovsxbw (put_in_xmm_mem x)))
-            (y2 Xmm (pmovsxbw (put_in_xmm_mem y))))
-        (value_xmm (pmullw x2 (xmm_to_xmm_mem y2)))))
+                       (imul (swiden_low (and (value_type (multi_lane 8 16))
+                                              x))
+                             (swiden_low (and (value_type (multi_lane 8 16))
+                                              y)))))
+      (let ((x2 Xmm (pmovsxbw x))
+            (y2 Xmm (pmovsxbw y)))
+        (pmullw x2 y2)))
 
 ;; Special case for `i32x4.extmul_low_i16x8_s`.
 (rule (lower (has_type (multi_lane 32 4)
-                       (imul (def_inst (swiden_low (and (value_type (multi_lane 16 8))
-                                                        x)))
-                             (def_inst (swiden_low (and (value_type (multi_lane 16 8))
-                                                        y))))))
-      (let ((x2 Xmm (put_in_xmm x))
-            (y2 Xmm (put_in_xmm y))
-            (lo Xmm (pmullw x2 (xmm_to_xmm_mem y2)))
-            (hi Xmm (pmulhw x2 (xmm_to_xmm_mem y2))))
-        (value_xmm (punpcklwd lo (xmm_to_xmm_mem hi)))))
+                       (imul (swiden_low (and (value_type (multi_lane 16 8))
+                                              x))
+                             (swiden_low (and (value_type (multi_lane 16 8))
+                                              y)))))
+      (let ((x2 Xmm x)
+            (y2 Xmm y)
+            (lo Xmm (pmullw x2 y2))
+            (hi Xmm (pmulhw x2 y2)))
+        (punpcklwd lo hi)))
 
 ;; Special case for `i64x2.extmul_low_i32x4_s`.
 (rule (lower (has_type (multi_lane 64 2)
-                       (imul (def_inst (swiden_low (and (value_type (multi_lane 32 4))
-                                                        x)))
-                             (def_inst (swiden_low (and (value_type (multi_lane 32 4))
-                                                        y))))))
-      (let ((x2 Xmm (pshufd (put_in_xmm_mem x)
+                       (imul (swiden_low (and (value_type (multi_lane 32 4))
+                                              x))
+                             (swiden_low (and (value_type (multi_lane 32 4))
+                                              y)))))
+      (let ((x2 Xmm (pshufd x
                             0x50
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd (put_in_xmm_mem y)
+            (y2 Xmm (pshufd y
                             0x50
                             (OperandSize.Size32))))
-        (value_xmm (pmuldq x2 (xmm_to_xmm_mem y2)))))
+        (pmuldq x2 y2)))
 
 ;; Special case for `i16x8.extmul_high_i8x16_u`.
 (rule (lower (has_type (multi_lane 16 8)
-                       (imul (def_inst (uwiden_high (and (value_type (multi_lane 8 16))
-                                                         x)))
-                             (def_inst (uwiden_high (and (value_type (multi_lane 8 16))
-                                                         y))))))
-      (let ((x1 Xmm (put_in_xmm x))
-            (x2 Xmm (palignr x1 (xmm_to_xmm_mem x1) 8 (OperandSize.Size32)))
-            (x3 Xmm (pmovzxbw (xmm_to_xmm_mem x2)))
-            (y1 Xmm (put_in_xmm y))
-            (y2 Xmm (palignr y1 (xmm_to_xmm_mem y1) 8 (OperandSize.Size32)))
-            (y3 Xmm (pmovzxbw (xmm_to_xmm_mem y2))))
-        (value_xmm (pmullw x3 (xmm_to_xmm_mem y3)))))
+                       (imul (uwiden_high (and (value_type (multi_lane 8 16))
+                                               x))
+                             (uwiden_high (and (value_type (multi_lane 8 16))
+                                               y)))))
+      (let ((x1 Xmm x)
+            (x2 Xmm (palignr x1 x1 8 (OperandSize.Size32)))
+            (x3 Xmm (pmovzxbw x2))
+            (y1 Xmm y)
+            (y2 Xmm (palignr y1 y1 8 (OperandSize.Size32)))
+            (y3 Xmm (pmovzxbw y2)))
+        (pmullw x3 y3)))
 
 ;; Special case for `i32x4.extmul_high_i16x8_u`.
 (rule (lower (has_type (multi_lane 32 4)
-                       (imul (def_inst (uwiden_high (and (value_type (multi_lane 16 8))
-                                                         x)))
-                             (def_inst (uwiden_high (and (value_type (multi_lane 16 8))
-                                                         y))))))
-      (let ((x2 Xmm (put_in_xmm x))
-            (y2 Xmm (put_in_xmm y))
-            (lo Xmm (pmullw x2 (xmm_to_xmm_mem y2)))
-            (hi Xmm (pmulhuw x2 (xmm_to_xmm_mem y2))))
-        (value_xmm (punpckhwd lo (xmm_to_xmm_mem hi)))))
+                       (imul (uwiden_high (and (value_type (multi_lane 16 8))
+                                               x))
+                             (uwiden_high (and (value_type (multi_lane 16 8))
+                                               y)))))
+      (let ((x2 Xmm x)
+            (y2 Xmm y)
+            (lo Xmm (pmullw x2 y2))
+            (hi Xmm (pmulhuw x2 y2)))
+        (punpckhwd lo hi)))
 
 ;; Special case for `i64x2.extmul_high_i32x4_u`.
 (rule (lower (has_type (multi_lane 64 2)
-                       (imul (def_inst (uwiden_high (and (value_type (multi_lane 32 4))
-                                                         x)))
-                             (def_inst (uwiden_high (and (value_type (multi_lane 32 4))
-                                                         y))))))
-      (let ((x2 Xmm (pshufd (put_in_xmm_mem x)
+                       (imul (uwiden_high (and (value_type (multi_lane 32 4))
+                                               x))
+                             (uwiden_high (and (value_type (multi_lane 32 4))
+                                               y)))))
+      (let ((x2 Xmm (pshufd x
                             0xFA
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd (put_in_xmm_mem y)
+            (y2 Xmm (pshufd y
                             0xFA
                             (OperandSize.Size32))))
-        (value_xmm (pmuludq x2 (xmm_to_xmm_mem y2)))))
+        (pmuludq x2 y2)))
 
 ;; Special case for `i16x8.extmul_low_i8x16_u`.
 (rule (lower (has_type (multi_lane 16 8)
-                       (imul (def_inst (uwiden_low (and (value_type (multi_lane 8 16))
-                                                        x)))
-                             (def_inst (uwiden_low (and (value_type (multi_lane 8 16))
-                                                        y))))))
-      (let ((x2 Xmm (pmovzxbw (put_in_xmm_mem x)))
-            (y2 Xmm (pmovzxbw (put_in_xmm_mem y))))
-        (value_xmm (pmullw x2 (xmm_to_xmm_mem y2)))))
+                       (imul (uwiden_low (and (value_type (multi_lane 8 16))
+                                              x))
+                             (uwiden_low (and (value_type (multi_lane 8 16))
+                                              y)))))
+      (let ((x2 Xmm (pmovzxbw x))
+            (y2 Xmm (pmovzxbw y)))
+        (pmullw x2 y2)))
 
 ;; Special case for `i32x4.extmul_low_i16x8_u`.
 (rule (lower (has_type (multi_lane 32 4)
-                       (imul (def_inst (uwiden_low (and (value_type (multi_lane 16 8))
-                                                        x)))
-                             (def_inst (uwiden_low (and (value_type (multi_lane 16 8))
-                                                        y))))))
-      (let ((x2 Xmm (put_in_xmm x))
-            (y2 Xmm (put_in_xmm y))
-            (lo Xmm (pmullw x2 (xmm_to_xmm_mem y2)))
-            (hi Xmm (pmulhuw x2 (xmm_to_xmm_mem y2))))
-        (value_xmm (punpcklwd lo (xmm_to_xmm_mem hi)))))
+                       (imul (uwiden_low (and (value_type (multi_lane 16 8))
+                                              x))
+                             (uwiden_low (and (value_type (multi_lane 16 8))
+                                              y)))))
+      (let ((x2 Xmm x)
+            (y2 Xmm y)
+            (lo Xmm (pmullw x2 y2))
+            (hi Xmm (pmulhuw x2 y2)))
+        (punpcklwd lo hi)))
 
 ;; Special case for `i64x2.extmul_low_i32x4_u`.
 (rule (lower (has_type (multi_lane 64 2)
-                       (imul (def_inst (uwiden_low (and (value_type (multi_lane 32 4))
-                                                        x)))
-                             (def_inst (uwiden_low (and (value_type (multi_lane 32 4))
-                                                        y))))))
-      (let ((x2 Xmm (pshufd (put_in_xmm_mem x)
+                       (imul (uwiden_low (and (value_type (multi_lane 32 4))
+                                              x))
+                             (uwiden_low (and (value_type (multi_lane 32 4))
+                                              y)))))
+      (let ((x2 Xmm (pshufd x
                             0x50
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd (put_in_xmm_mem y)
+            (y2 Xmm (pshufd y
                             0x50
                             (OperandSize.Size32))))
-        (value_xmm (pmuludq x2 (xmm_to_xmm_mem y2)))))
+        (pmuludq x2 y2)))
 
 ;;;; Rules for `band_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1285,63 +1212,61 @@
 ;;
 ;;   pandn(x, y) = and(not(x), y)
 (rule (lower (has_type ty (band_not x y)))
-      (value_xmm (sse_and_not ty
-                              (put_in_xmm y)
-                              (put_in_xmm_mem x))))
+      (sse_and_not ty y x))
 
 ;;;; Rules for `iabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I8X16 (iabs x)))
-      (value_xmm (pabsb (put_in_xmm_mem x))))
+      (pabsb x))
 
 (rule (lower (has_type $I16X8 (iabs x)))
-      (value_xmm (pabsw (put_in_xmm_mem x))))
+      (pabsw x))
 
 (rule (lower (has_type $I32X4 (iabs x)))
-      (value_xmm (pabsd (put_in_xmm_mem x))))
+      (pabsd x))
 
 ;; When AVX512 is available, we can use a single `vpabsq` instruction.
 (rule (lower (has_type (and (avx512vl_enabled)
                             (avx512f_enabled)
                             $I64X2)
                        (iabs x)))
-      (value_xmm (vpabsq (put_in_xmm_mem x))))
+      (vpabsq x))
 
-;; Otherwise, we use a separate xmmister, `neg`, to contain the results of `0 -
+;; Otherwise, we use a separate register, `neg`, to contain the results of `0 -
 ;; x` and then blend in those results with `blendvpd` if the MSB of `neg` was
 ;; set to 1 (i.e. if `neg` was negative or, conversely, if `x` was originally
 ;; positive).
 (rule (lower (has_type $I64X2 (iabs x)))
-      (let ((rx Xmm (put_in_xmm x))
-            (neg Xmm (psubq (xmm_new (imm $I64X2 0)) (xmm_to_xmm_mem rx))))
-        (value_xmm (blendvpd neg (xmm_to_xmm_mem rx) neg))))
+      (let ((rx Xmm x)
+            (neg Xmm (psubq (imm $I64X2 0) rx)))
+        (blendvpd neg rx neg)))
 
 ;;;; Rules for `fabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Special case for `f32x4.abs`.
 (rule (lower (has_type $F32X4 (fabs x)))
-      (value_xmm (andps (put_in_xmm x)
-                        (xmm_to_xmm_mem (psrld (vector_all_ones $F32X4)
-                                               (xmm_mem_imm_new (RegMemImm.Imm 1)))))))
+      (andps x
+             (psrld (vector_all_ones $F32X4)
+                    (RegMemImm.Imm 1))))
 
 ;; Special case for `f64x2.abs`.
 (rule (lower (has_type $F64X2 (fabs x)))
-      (value_xmm (andpd (put_in_xmm x)
-                        (xmm_to_xmm_mem (psrlq (vector_all_ones $F64X2)
-                                               (xmm_mem_imm_new (RegMemImm.Imm 1)))))))
+      (andpd x
+             (psrlq (vector_all_ones $F64X2)
+                    (RegMemImm.Imm 1))))
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (bnot x)))
-      (value_gpr (not ty (put_in_gpr x))))
+      (not ty x))
 
 ;; `i128`.
 
 (decl i128_not (Value) ValueRegs)
 (rule (i128_not x)
-      (let ((x_regs ValueRegs (put_in_regs x))
+      (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1)))
         (value_gprs (not $I64 x_lo)
@@ -1356,7 +1281,7 @@
 ;; Special case for vector-types where bit-negation is an xor against an
 ;; all-one value
 (rule (lower (has_type ty @ (multi_lane _bits _lanes) (bnot x)))
-      (value_xmm (sse_xor ty (put_in_xmm x) (xmm_to_xmm_mem (vector_all_ones ty)))))
+      (sse_xor ty x (vector_all_ones ty)))
 
 ;;;; Rules for `bitselect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1367,24 +1292,24 @@
       ;; a = and if_true, condition
       ;; b = and_not condition, if_false
       ;; or b, a
-      (let ((cond_xmm Xmm (put_in_xmm condition))
-            (a Xmm (sse_and ty (put_in_xmm if_true) (xmm_to_xmm_mem cond_xmm)))
-            (b Xmm (sse_and_not ty cond_xmm (put_in_xmm_mem if_false))))
-        (value_xmm (sse_or ty b (xmm_to_xmm_mem a)))))
+      (let ((cond_xmm Xmm condition)
+            (a Xmm (sse_and ty if_true cond_xmm))
+            (b Xmm (sse_and_not ty cond_xmm if_false)))
+        (sse_or ty b a)))
 
 ;;;; Rules for `vselect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty @ (multi_lane _bits _lanes)
                        (vselect condition if_true if_false)))
-      (value_xmm (sse_blend ty
-                            (put_in_xmm_mem condition)
-                            (put_in_xmm_mem if_true)
-                            (put_in_xmm if_false))))
+      (sse_blend ty
+                 condition
+                 if_true
+                 if_false))
 
 ;;;; Rules for `insertlane` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (insertlane vec @ (value_type ty) val (u8_from_uimm8 idx)))
-      (value_xmm (vec_insert_lane ty (put_in_xmm vec) (put_in_reg_mem val) idx)))
+      (vec_insert_lane ty vec val idx))
 
 ;; Helper function used below for `insertlane` but also here for other
 ;; lowerings.
@@ -1395,23 +1320,23 @@
 
 ;; i8x16.replace_lane
 (rule (vec_insert_lane $I8X16 vec val idx)
-      (pinsrb vec (reg_mem_to_gpr_mem val) idx))
+      (pinsrb vec val idx))
 
 ;; i16x8.replace_lane
 (rule (vec_insert_lane $I16X8 vec val idx)
-      (pinsrw vec (reg_mem_to_gpr_mem val) idx))
+      (pinsrw vec val idx))
 
 ;; i32x4.replace_lane
 (rule (vec_insert_lane $I32X4 vec val idx)
-      (pinsrd vec (reg_mem_to_gpr_mem val) idx (OperandSize.Size32)))
+      (pinsrd vec val idx (OperandSize.Size32)))
 
 ;; i64x2.replace_lane
 (rule (vec_insert_lane $I64X2 vec val idx)
-      (pinsrd vec (reg_mem_to_gpr_mem val) idx (OperandSize.Size64)))
+      (pinsrd vec val idx (OperandSize.Size64)))
 
 ;; f32x4.replace_lane
 (rule (vec_insert_lane $F32X4 vec val idx)
-      (insertps vec (reg_mem_to_xmm_mem val) (sse_insertps_lane_imm idx)))
+      (insertps vec val (sse_insertps_lane_imm idx)))
 
 ;; External rust code used to calculate the immediate value to `insertps`.
 (decl sse_insertps_lane_imm (u8) u8)
@@ -1433,10 +1358,10 @@
 ;; internally as `xmm_rm_r` will merge the temp register into our `vec`
 ;; register.
 (rule (vec_insert_lane $F64X2 vec (RegMem.Reg val) 0)
-      (movsd vec (reg_mem_to_xmm_mem (RegMem.Reg val))))
+      (movsd vec val))
 (rule (vec_insert_lane $F64X2 vec mem 0)
-      (movsd vec (xmm_to_xmm_mem (xmm_unary_rm_r (SseOpcode.Movsd)
-                                                 (reg_mem_to_xmm_mem mem)))))
+      (movsd vec (xmm_unary_rm_r (SseOpcode.Movsd)
+                                 mem)))
 
 ;; f64x2.replace_lane 1
 ;;
@@ -1452,11 +1377,11 @@
 
 (decl cmp_and_choose (Type CC Value Value) ValueRegs)
 (rule (cmp_and_choose (fits_in_64 ty) cc x y)
-      (let ((x_reg Gpr (put_in_gpr x))
-            (y_reg Gpr (put_in_gpr y))
+      (let ((x_reg Gpr x)
+            (y_reg Gpr y)
             (size OperandSize (raw_operand_size_of_type ty)))
-           (value_reg (with_flags_reg (cmp size (gpr_to_gpr_mem_imm x_reg) y_reg)
-                                    (cmove ty cc (gpr_to_gpr_mem y_reg) x_reg)))))
+        (with_flags_reg (cmp size x_reg y_reg)
+                        (cmove ty cc y_reg x_reg))))
 
 (rule (lower (has_type (fits_in_64 ty) (umin x y)))
       (cmp_and_choose ty (CC.B) x y))
@@ -1473,46 +1398,46 @@
 ;; SSE `imax`.
 
 (rule (lower (has_type $I8X16 (imax x y)))
-      (value_xmm (pmaxsb (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmaxsb x y))
 
 (rule (lower (has_type $I16X8 (imax x y)))
-      (value_xmm (pmaxsw (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmaxsw x y))
 
 (rule (lower (has_type $I32X4 (imax x y)))
-      (value_xmm (pmaxsd (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmaxsd x y))
 
 ;; SSE `imin`.
 
 (rule (lower (has_type $I8X16 (imin x y)))
-      (value_xmm (pminsb (put_in_xmm x) (put_in_xmm_mem y))))
+      (pminsb x y))
 
 (rule (lower (has_type $I16X8 (imin x y)))
-      (value_xmm (pminsw (put_in_xmm x) (put_in_xmm_mem y))))
+      (pminsw x y))
 
 (rule (lower (has_type $I32X4 (imin x y)))
-      (value_xmm (pminsd (put_in_xmm x) (put_in_xmm_mem y))))
+      (pminsd x y))
 
 ;; SSE `umax`.
 
 (rule (lower (has_type $I8X16 (umax x y)))
-      (value_xmm (pmaxub (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmaxub x y))
 
 (rule (lower (has_type $I16X8 (umax x y)))
-      (value_xmm (pmaxuw (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmaxuw x y))
 
 (rule (lower (has_type $I32X4 (umax x y)))
-      (value_xmm (pmaxud (put_in_xmm x) (put_in_xmm_mem y))))
+      (pmaxud x y))
 
 ;; SSE `umin`.
 
 (rule (lower (has_type $I8X16 (umin x y)))
-      (value_xmm (pminub (put_in_xmm x) (put_in_xmm_mem y))))
+      (pminub x y))
 
 (rule (lower (has_type $I16X8 (umin x y)))
-      (value_xmm (pminuw (put_in_xmm x) (put_in_xmm_mem y))))
+      (pminuw x y))
 
 (rule (lower (has_type $I32X4 (umin x y)))
-      (value_xmm (pminud (put_in_xmm x) (put_in_xmm_mem y))))
+      (pminud x y))
 
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
-src/prelude.isle 980b300b3ec3e338
-src/isa/x64/inst.isle ac88a0ae153ed210
-src/isa/x64/lower.isle 1ebdd4469355e2cf
+src/prelude.isle 8bf92e18323e7041
+src/isa/x64/inst.isle 1948445a25530d71
+src/isa/x64/lower.isle d1ee574941be387

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
@@ -487,7 +487,7 @@ pub enum MInst {
     },
 }
 
-/// Internal type ExtendKind: defined at src/isa/x64/inst.isle line 1118.
+/// Internal type ExtendKind: defined at src/isa/x64/inst.isle line 1125.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ExtendKind {
     Sign,
@@ -683,10 +683,19 @@ pub fn constructor_operand_size_bits<C: Context>(ctx: &mut C, arg0: &OperandSize
     return None;
 }
 
+// Generated as internal constructor for term reg_to_gpr_mem_imm.
+pub fn constructor_reg_to_gpr_mem_imm<C: Context>(ctx: &mut C, arg0: Reg) -> Option<GprMemImm> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 967.
+    let expr0_0 = C::gpr_new(ctx, pattern0_0);
+    let expr1_0 = C::gpr_to_gpr_mem_imm(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
 // Generated as internal constructor for term put_in_gpr.
 pub fn constructor_put_in_gpr<C: Context>(ctx: &mut C, arg0: Value) -> Option<Gpr> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 967.
+    // Rule at src/isa/x64/inst.isle line 974.
     let expr0_0 = C::put_in_reg(ctx, pattern0_0);
     let expr1_0 = C::gpr_new(ctx, expr0_0);
     return Some(expr1_0);
@@ -695,7 +704,7 @@ pub fn constructor_put_in_gpr<C: Context>(ctx: &mut C, arg0: Value) -> Option<Gp
 // Generated as internal constructor for term put_in_gpr_mem.
 pub fn constructor_put_in_gpr_mem<C: Context>(ctx: &mut C, arg0: Value) -> Option<GprMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 974.
+    // Rule at src/isa/x64/inst.isle line 981.
     let expr0_0 = C::put_in_reg_mem(ctx, pattern0_0);
     let expr1_0 = C::reg_mem_to_gpr_mem(ctx, &expr0_0);
     return Some(expr1_0);
@@ -704,7 +713,7 @@ pub fn constructor_put_in_gpr_mem<C: Context>(ctx: &mut C, arg0: Value) -> Optio
 // Generated as internal constructor for term put_in_gpr_mem_imm.
 pub fn constructor_put_in_gpr_mem_imm<C: Context>(ctx: &mut C, arg0: Value) -> Option<GprMemImm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 981.
+    // Rule at src/isa/x64/inst.isle line 988.
     let expr0_0 = C::put_in_reg_mem_imm(ctx, pattern0_0);
     let expr1_0 = C::gpr_mem_imm_new(ctx, &expr0_0);
     return Some(expr1_0);
@@ -713,7 +722,7 @@ pub fn constructor_put_in_gpr_mem_imm<C: Context>(ctx: &mut C, arg0: Value) -> O
 // Generated as internal constructor for term put_in_xmm.
 pub fn constructor_put_in_xmm<C: Context>(ctx: &mut C, arg0: Value) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 988.
+    // Rule at src/isa/x64/inst.isle line 995.
     let expr0_0 = C::put_in_reg(ctx, pattern0_0);
     let expr1_0 = C::xmm_new(ctx, expr0_0);
     return Some(expr1_0);
@@ -722,7 +731,7 @@ pub fn constructor_put_in_xmm<C: Context>(ctx: &mut C, arg0: Value) -> Option<Xm
 // Generated as internal constructor for term put_in_xmm_mem.
 pub fn constructor_put_in_xmm_mem<C: Context>(ctx: &mut C, arg0: Value) -> Option<XmmMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 995.
+    // Rule at src/isa/x64/inst.isle line 1002.
     let expr0_0 = C::put_in_reg_mem(ctx, pattern0_0);
     let expr1_0 = C::reg_mem_to_xmm_mem(ctx, &expr0_0);
     return Some(expr1_0);
@@ -731,7 +740,7 @@ pub fn constructor_put_in_xmm_mem<C: Context>(ctx: &mut C, arg0: Value) -> Optio
 // Generated as internal constructor for term put_in_xmm_mem_imm.
 pub fn constructor_put_in_xmm_mem_imm<C: Context>(ctx: &mut C, arg0: Value) -> Option<XmmMemImm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 1002.
+    // Rule at src/isa/x64/inst.isle line 1009.
     let expr0_0 = C::put_in_reg_mem_imm(ctx, pattern0_0);
     let expr1_0 = C::xmm_mem_imm_new(ctx, &expr0_0);
     return Some(expr1_0);
@@ -740,7 +749,7 @@ pub fn constructor_put_in_xmm_mem_imm<C: Context>(ctx: &mut C, arg0: Value) -> O
 // Generated as internal constructor for term value_gpr.
 pub fn constructor_value_gpr<C: Context>(ctx: &mut C, arg0: Gpr) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 1007.
+    // Rule at src/isa/x64/inst.isle line 1014.
     let expr0_0 = C::gpr_to_reg(ctx, pattern0_0);
     let expr1_0 = C::value_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -750,7 +759,7 @@ pub fn constructor_value_gpr<C: Context>(ctx: &mut C, arg0: Gpr) -> Option<Value
 pub fn constructor_value_gprs<C: Context>(ctx: &mut C, arg0: Gpr, arg1: Gpr) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1012.
+    // Rule at src/isa/x64/inst.isle line 1019.
     let expr0_0 = C::gpr_to_reg(ctx, pattern0_0);
     let expr1_0 = C::gpr_to_reg(ctx, pattern1_0);
     let expr2_0 = C::value_regs(ctx, expr0_0, expr1_0);
@@ -760,7 +769,7 @@ pub fn constructor_value_gprs<C: Context>(ctx: &mut C, arg0: Gpr, arg1: Gpr) -> 
 // Generated as internal constructor for term value_xmm.
 pub fn constructor_value_xmm<C: Context>(ctx: &mut C, arg0: Xmm) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 1017.
+    // Rule at src/isa/x64/inst.isle line 1024.
     let expr0_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr1_0 = C::value_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -774,7 +783,7 @@ pub fn constructor_value_regs_get_gpr<C: Context>(
 ) -> Option<Gpr> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1024.
+    // Rule at src/isa/x64/inst.isle line 1031.
     let expr0_0 = C::value_regs_get(ctx, pattern0_0, pattern1_0);
     let expr1_0 = C::gpr_new(ctx, expr0_0);
     return Some(expr1_0);
@@ -783,7 +792,7 @@ pub fn constructor_value_regs_get_gpr<C: Context>(
 // Generated as internal constructor for term lo_gpr.
 pub fn constructor_lo_gpr<C: Context>(ctx: &mut C, arg0: Value) -> Option<Gpr> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 1037.
+    // Rule at src/isa/x64/inst.isle line 1044.
     let expr0_0 = constructor_lo_reg(ctx, pattern0_0)?;
     let expr1_0 = C::gpr_new(ctx, expr0_0);
     return Some(expr1_0);
@@ -795,7 +804,7 @@ pub fn constructor_sink_load_to_gpr_mem_imm<C: Context>(
     arg0: &SinkableLoad,
 ) -> Option<GprMemImm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 1108.
+    // Rule at src/isa/x64/inst.isle line 1115.
     let expr0_0 = C::sink_load(ctx, pattern0_0);
     let expr1_0 = C::gpr_mem_imm_new(ctx, &expr0_0);
     return Some(expr1_0);
@@ -813,12 +822,12 @@ pub fn constructor_extend_to_gpr<C: Context>(
     let pattern2_0 = arg1;
     if pattern2_0 == pattern1_0 {
         let pattern4_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 1130.
+        // Rule at src/isa/x64/inst.isle line 1137.
         let expr0_0 = constructor_put_in_gpr(ctx, pattern0_0)?;
         return Some(expr0_0);
     }
     let pattern3_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1133.
+    // Rule at src/isa/x64/inst.isle line 1140.
     let expr0_0 = C::ty_bits_u16(ctx, pattern1_0);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern2_0);
     let expr2_0 = constructor_operand_size_bits(ctx, &expr1_0)?;
@@ -842,7 +851,7 @@ pub fn constructor_extend<C: Context>(
             let pattern2_0 = arg1;
             let pattern3_0 = arg2;
             let pattern4_0 = arg3;
-            // Rule at src/isa/x64/inst.isle line 1153.
+            // Rule at src/isa/x64/inst.isle line 1160.
             let expr0_0 = constructor_movsx(ctx, pattern2_0, pattern3_0, pattern4_0)?;
             return Some(expr0_0);
         }
@@ -850,7 +859,7 @@ pub fn constructor_extend<C: Context>(
             let pattern2_0 = arg1;
             let pattern3_0 = arg2;
             let pattern4_0 = arg3;
-            // Rule at src/isa/x64/inst.isle line 1149.
+            // Rule at src/isa/x64/inst.isle line 1156.
             let expr0_0 = constructor_movzx(ctx, pattern2_0, pattern3_0, pattern4_0)?;
             return Some(expr0_0);
         }
@@ -863,17 +872,17 @@ pub fn constructor_extend<C: Context>(
 pub fn constructor_sse_xor_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<SseOpcode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32X4 {
-        // Rule at src/isa/x64/inst.isle line 1160.
+        // Rule at src/isa/x64/inst.isle line 1167.
         let expr0_0 = SseOpcode::Xorps;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
-        // Rule at src/isa/x64/inst.isle line 1161.
+        // Rule at src/isa/x64/inst.isle line 1168.
         let expr0_0 = SseOpcode::Xorpd;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
-        // Rule at src/isa/x64/inst.isle line 1162.
+        // Rule at src/isa/x64/inst.isle line 1169.
         let expr0_0 = SseOpcode::Pxor;
         return Some(expr0_0);
     }
@@ -890,7 +899,7 @@ pub fn constructor_sse_xor<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1166.
+    // Rule at src/isa/x64/inst.isle line 1173.
     let expr0_0 = constructor_sse_xor_op(ctx, pattern0_0)?;
     let expr1_0 = constructor_xmm_rm_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -900,40 +909,40 @@ pub fn constructor_sse_xor<C: Context>(
 pub fn constructor_sse_cmp_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<SseOpcode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32X4 {
-        // Rule at src/isa/x64/inst.isle line 1175.
+        // Rule at src/isa/x64/inst.isle line 1182.
         let expr0_0 = SseOpcode::Cmpps;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
-        // Rule at src/isa/x64/inst.isle line 1176.
+        // Rule at src/isa/x64/inst.isle line 1183.
         let expr0_0 = SseOpcode::Cmppd;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         if pattern1_0 == 8 {
             if pattern1_1 == 16 {
-                // Rule at src/isa/x64/inst.isle line 1171.
+                // Rule at src/isa/x64/inst.isle line 1178.
                 let expr0_0 = SseOpcode::Pcmpeqb;
                 return Some(expr0_0);
             }
         }
         if pattern1_0 == 16 {
             if pattern1_1 == 8 {
-                // Rule at src/isa/x64/inst.isle line 1172.
+                // Rule at src/isa/x64/inst.isle line 1179.
                 let expr0_0 = SseOpcode::Pcmpeqw;
                 return Some(expr0_0);
             }
         }
         if pattern1_0 == 32 {
             if pattern1_1 == 4 {
-                // Rule at src/isa/x64/inst.isle line 1173.
+                // Rule at src/isa/x64/inst.isle line 1180.
                 let expr0_0 = SseOpcode::Pcmpeqd;
                 return Some(expr0_0);
             }
         }
         if pattern1_0 == 64 {
             if pattern1_1 == 2 {
-                // Rule at src/isa/x64/inst.isle line 1174.
+                // Rule at src/isa/x64/inst.isle line 1181.
                 let expr0_0 = SseOpcode::Pcmpeqq;
                 return Some(expr0_0);
             }
@@ -945,20 +954,21 @@ pub fn constructor_sse_cmp_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<Sse
 // Generated as internal constructor for term vector_all_ones.
 pub fn constructor_vector_all_ones<C: Context>(ctx: &mut C, arg0: Type) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 1190.
+    // Rule at src/isa/x64/inst.isle line 1197.
     let expr0_0 = C::temp_writable_xmm(ctx);
-    let expr1_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
-    let expr2_0: Type = I32X4;
-    let expr3_0 = constructor_sse_cmp_op(ctx, expr2_0)?;
-    let expr4_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
+    let expr1_0: Type = I32X4;
+    let expr2_0 = constructor_sse_cmp_op(ctx, expr1_0)?;
+    let expr3_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
+    let expr4_0 = constructor_writable_xmm_to_xmm_mem(ctx, expr0_0)?;
     let expr5_0 = MInst::XmmRmR {
-        op: expr3_0,
-        src1: expr1_0,
+        op: expr2_0,
+        src1: expr3_0,
         src2: expr4_0,
         dst: expr0_0,
     };
     let expr6_0 = C::emit(ctx, &expr5_0);
-    return Some(expr1_0);
+    let expr7_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
+    return Some(expr7_0);
 }
 
 // Generated as internal constructor for term make_i64x2_from_lanes.
@@ -969,40 +979,41 @@ pub fn constructor_make_i64x2_from_lanes<C: Context>(
 ) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1201.
+    // Rule at src/isa/x64/inst.isle line 1207.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::writable_xmm_to_reg(ctx, expr0_0);
-    let expr2_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
-    let expr3_0 = C::xmm_to_reg(ctx, expr2_0);
-    let expr4_0 = MInst::XmmUninitializedValue { dst: expr0_0 };
-    let expr5_0 = C::emit(ctx, &expr4_0);
-    let expr6_0 = SseOpcode::Pinsrd;
-    let expr7_0 = C::gpr_mem_to_reg_mem(ctx, pattern0_0);
-    let expr8_0: u8 = 0;
-    let expr9_0 = OperandSize::Size64;
-    let expr10_0 = MInst::XmmRmRImm {
-        op: expr6_0,
-        src1: expr3_0,
-        src2: expr7_0,
+    let expr2_0 = MInst::XmmUninitializedValue { dst: expr0_0 };
+    let expr3_0 = C::emit(ctx, &expr2_0);
+    let expr4_0 = SseOpcode::Pinsrd;
+    let expr5_0 = C::writable_reg_to_reg(ctx, expr1_0);
+    let expr6_0 = C::gpr_mem_to_reg_mem(ctx, pattern0_0);
+    let expr7_0: u8 = 0;
+    let expr8_0 = OperandSize::Size64;
+    let expr9_0 = MInst::XmmRmRImm {
+        op: expr4_0,
+        src1: expr5_0,
+        src2: expr6_0,
         dst: expr1_0,
-        imm: expr8_0,
-        size: expr9_0,
+        imm: expr7_0,
+        size: expr8_0,
     };
-    let expr11_0 = C::emit(ctx, &expr10_0);
-    let expr12_0 = SseOpcode::Pinsrd;
+    let expr10_0 = C::emit(ctx, &expr9_0);
+    let expr11_0 = SseOpcode::Pinsrd;
+    let expr12_0 = C::writable_reg_to_reg(ctx, expr1_0);
     let expr13_0 = C::gpr_mem_to_reg_mem(ctx, pattern1_0);
     let expr14_0: u8 = 1;
     let expr15_0 = OperandSize::Size64;
     let expr16_0 = MInst::XmmRmRImm {
-        op: expr12_0,
-        src1: expr3_0,
+        op: expr11_0,
+        src1: expr12_0,
         src2: expr13_0,
         dst: expr1_0,
         imm: expr14_0,
         size: expr15_0,
     };
     let expr17_0 = C::emit(ctx, &expr16_0);
-    return Some(expr2_0);
+    let expr18_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
+    return Some(expr18_0);
 }
 
 // Generated as internal constructor for term mov_rmi_to_xmm.
@@ -1010,12 +1021,12 @@ pub fn constructor_mov_rmi_to_xmm<C: Context>(ctx: &mut C, arg0: &RegMemImm) -> 
     let pattern0_0 = arg0;
     match pattern0_0 {
         &RegMemImm::Imm { simm32: pattern1_0 } => {
-            // Rule at src/isa/x64/inst.isle line 1224.
+            // Rule at src/isa/x64/inst.isle line 1228.
             let expr0_0 = C::xmm_mem_imm_new(ctx, pattern0_0);
             return Some(expr0_0);
         }
         &RegMemImm::Reg { reg: pattern1_0 } => {
-            // Rule at src/isa/x64/inst.isle line 1225.
+            // Rule at src/isa/x64/inst.isle line 1229.
             let expr0_0 = SseOpcode::Movd;
             let expr1_0 = C::reg_to_gpr_mem(ctx, pattern1_0);
             let expr2_0 = OperandSize::Size32;
@@ -1026,7 +1037,7 @@ pub fn constructor_mov_rmi_to_xmm<C: Context>(ctx: &mut C, arg0: &RegMemImm) -> 
         &RegMemImm::Mem {
             addr: ref pattern1_0,
         } => {
-            // Rule at src/isa/x64/inst.isle line 1223.
+            // Rule at src/isa/x64/inst.isle line 1227.
             let expr0_0 = C::xmm_mem_imm_new(ctx, pattern0_0);
             return Some(expr0_0);
         }
@@ -1046,85 +1057,78 @@ pub fn constructor_x64_load<C: Context>(
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 1240.
+        // Rule at src/isa/x64/inst.isle line 1244.
         let expr0_0 = C::temp_writable_gpr(ctx);
         let expr1_0 = MInst::Mov64MR {
             src: pattern2_0.clone(),
             dst: expr0_0,
         };
         let expr2_0 = C::emit(ctx, &expr1_0);
-        let expr3_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-        let expr4_0 = C::gpr_to_reg(ctx, expr3_0);
-        return Some(expr4_0);
+        let expr3_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+        return Some(expr3_0);
     }
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 1245.
+        // Rule at src/isa/x64/inst.isle line 1249.
         let expr0_0 = SseOpcode::Movss;
-        let expr1_0 = C::synthetic_amode_to_reg_mem(ctx, pattern2_0);
-        let expr2_0 = C::reg_mem_to_xmm_mem(ctx, &expr1_0);
-        let expr3_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr2_0)?;
-        let expr4_0 = C::xmm_to_reg(ctx, expr3_0);
-        return Some(expr4_0);
+        let expr1_0 = constructor_synthetic_amode_to_xmm_mem(ctx, pattern2_0)?;
+        let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
+        let expr3_0 = C::xmm_to_reg(ctx, expr2_0);
+        return Some(expr3_0);
     }
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 1249.
+        // Rule at src/isa/x64/inst.isle line 1253.
         let expr0_0 = SseOpcode::Movsd;
-        let expr1_0 = C::synthetic_amode_to_reg_mem(ctx, pattern2_0);
-        let expr2_0 = C::reg_mem_to_xmm_mem(ctx, &expr1_0);
-        let expr3_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr2_0)?;
-        let expr4_0 = C::xmm_to_reg(ctx, expr3_0);
-        return Some(expr4_0);
+        let expr1_0 = constructor_synthetic_amode_to_xmm_mem(ctx, pattern2_0)?;
+        let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
+        let expr3_0 = C::xmm_to_reg(ctx, expr2_0);
+        return Some(expr3_0);
     }
     if pattern0_0 == F32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 1253.
+        // Rule at src/isa/x64/inst.isle line 1257.
         let expr0_0 = SseOpcode::Movups;
-        let expr1_0 = C::synthetic_amode_to_reg_mem(ctx, pattern2_0);
-        let expr2_0 = C::reg_mem_to_xmm_mem(ctx, &expr1_0);
-        let expr3_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr2_0)?;
-        let expr4_0 = C::xmm_to_reg(ctx, expr3_0);
-        return Some(expr4_0);
+        let expr1_0 = constructor_synthetic_amode_to_xmm_mem(ctx, pattern2_0)?;
+        let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
+        let expr3_0 = C::xmm_to_reg(ctx, expr2_0);
+        return Some(expr3_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 1257.
+        // Rule at src/isa/x64/inst.isle line 1261.
         let expr0_0 = SseOpcode::Movupd;
-        let expr1_0 = C::synthetic_amode_to_reg_mem(ctx, pattern2_0);
-        let expr2_0 = C::reg_mem_to_xmm_mem(ctx, &expr1_0);
-        let expr3_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr2_0)?;
-        let expr4_0 = C::xmm_to_reg(ctx, expr3_0);
-        return Some(expr4_0);
+        let expr1_0 = constructor_synthetic_amode_to_xmm_mem(ctx, pattern2_0)?;
+        let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
+        let expr3_0 = C::xmm_to_reg(ctx, expr2_0);
+        return Some(expr3_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 1261.
+        // Rule at src/isa/x64/inst.isle line 1265.
         let expr0_0 = SseOpcode::Movdqu;
-        let expr1_0 = C::synthetic_amode_to_reg_mem(ctx, pattern2_0);
-        let expr2_0 = C::reg_mem_to_xmm_mem(ctx, &expr1_0);
-        let expr3_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr2_0)?;
-        let expr4_0 = C::xmm_to_reg(ctx, expr3_0);
-        return Some(expr4_0);
+        let expr1_0 = constructor_synthetic_amode_to_xmm_mem(ctx, pattern2_0)?;
+        let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
+        let expr3_0 = C::xmm_to_reg(ctx, expr2_0);
+        return Some(expr3_0);
     }
     if let Some(pattern1_0) = C::fits_in_32(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         if let &ExtKind::SignExtend = pattern3_0 {
-            // Rule at src/isa/x64/inst.isle line 1235.
+            // Rule at src/isa/x64/inst.isle line 1239.
             let expr0_0 = C::ty_bytes(ctx, pattern1_0);
             let expr1_0: u16 = 8;
             let expr2_0 = C::ext_mode(ctx, expr0_0, expr1_0);
-            let expr3_0 = C::synthetic_amode_to_reg_mem(ctx, pattern2_0);
-            let expr4_0 = C::reg_mem_to_gpr_mem(ctx, &expr3_0);
-            let expr5_0 = constructor_movsx(ctx, pattern1_0, &expr2_0, &expr4_0)?;
-            let expr6_0 = C::gpr_to_reg(ctx, expr5_0);
-            return Some(expr6_0);
+            let expr3_0 = constructor_synthetic_amode_to_gpr_mem(ctx, pattern2_0)?;
+            let expr4_0 = constructor_movsx(ctx, pattern1_0, &expr2_0, &expr3_0)?;
+            let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
+            return Some(expr5_0);
         }
     }
     return None;
@@ -1142,7 +1146,7 @@ pub fn constructor_alu_rmi_r<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1273.
+    // Rule at src/isa/x64/inst.isle line 1277.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::AluRmiR {
@@ -1167,7 +1171,7 @@ pub fn constructor_add<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1281.
+    // Rule at src/isa/x64/inst.isle line 1285.
     let expr0_0 = AluRmiROpcode::Add;
     let expr1_0 = constructor_alu_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1183,7 +1187,7 @@ pub fn constructor_add_with_flags_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1289.
+    // Rule at src/isa/x64/inst.isle line 1293.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = AluRmiROpcode::Add;
@@ -1194,13 +1198,12 @@ pub fn constructor_add_with_flags_paired<C: Context>(
         src2: pattern2_0.clone(),
         dst: expr0_0,
     };
-    let expr4_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
-    let expr6_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
+    let expr4_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+    let expr5_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
         inst: expr3_0,
-        result: expr5_0,
+        result: expr4_0,
     };
-    return Some(expr6_0);
+    return Some(expr5_0);
 }
 
 // Generated as internal constructor for term adc_paired.
@@ -1213,7 +1216,7 @@ pub fn constructor_adc_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1301.
+    // Rule at src/isa/x64/inst.isle line 1305.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = AluRmiROpcode::Adc;
@@ -1224,13 +1227,12 @@ pub fn constructor_adc_paired<C: Context>(
         src2: pattern2_0.clone(),
         dst: expr0_0,
     };
-    let expr4_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
-    let expr6_0 = ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
+    let expr4_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+    let expr5_0 = ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
         inst: expr3_0,
-        result: expr5_0,
+        result: expr4_0,
     };
-    return Some(expr6_0);
+    return Some(expr5_0);
 }
 
 // Generated as internal constructor for term sub.
@@ -1243,7 +1245,7 @@ pub fn constructor_sub<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1313.
+    // Rule at src/isa/x64/inst.isle line 1317.
     let expr0_0 = AluRmiROpcode::Sub;
     let expr1_0 = constructor_alu_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1259,7 +1261,7 @@ pub fn constructor_sub_with_flags_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1321.
+    // Rule at src/isa/x64/inst.isle line 1325.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = AluRmiROpcode::Sub;
@@ -1270,13 +1272,12 @@ pub fn constructor_sub_with_flags_paired<C: Context>(
         src2: pattern2_0.clone(),
         dst: expr0_0,
     };
-    let expr4_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
-    let expr6_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
+    let expr4_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+    let expr5_0 = ProducesFlags::ProducesFlagsReturnsResultWithConsumer {
         inst: expr3_0,
-        result: expr5_0,
+        result: expr4_0,
     };
-    return Some(expr6_0);
+    return Some(expr5_0);
 }
 
 // Generated as internal constructor for term sbb_paired.
@@ -1289,7 +1290,7 @@ pub fn constructor_sbb_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1333.
+    // Rule at src/isa/x64/inst.isle line 1337.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = AluRmiROpcode::Sbb;
@@ -1300,13 +1301,12 @@ pub fn constructor_sbb_paired<C: Context>(
         src2: pattern2_0.clone(),
         dst: expr0_0,
     };
-    let expr4_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
-    let expr6_0 = ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
+    let expr4_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+    let expr5_0 = ConsumesFlags::ConsumesFlagsReturnsResultWithProducer {
         inst: expr3_0,
-        result: expr5_0,
+        result: expr4_0,
     };
-    return Some(expr6_0);
+    return Some(expr5_0);
 }
 
 // Generated as internal constructor for term mul.
@@ -1319,7 +1319,7 @@ pub fn constructor_mul<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1345.
+    // Rule at src/isa/x64/inst.isle line 1349.
     let expr0_0 = AluRmiROpcode::Mul;
     let expr1_0 = constructor_alu_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1335,7 +1335,7 @@ pub fn constructor_x64_and<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1353.
+    // Rule at src/isa/x64/inst.isle line 1357.
     let expr0_0 = AluRmiROpcode::And;
     let expr1_0 = constructor_alu_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1351,7 +1351,7 @@ pub fn constructor_or<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1361.
+    // Rule at src/isa/x64/inst.isle line 1365.
     let expr0_0 = AluRmiROpcode::Or;
     let expr1_0 = constructor_alu_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1367,7 +1367,7 @@ pub fn constructor_xor<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1369.
+    // Rule at src/isa/x64/inst.isle line 1373.
     let expr0_0 = AluRmiROpcode::Xor;
     let expr1_0 = constructor_alu_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1379,7 +1379,7 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
     if pattern0_0 == I64 {
         let pattern2_0 = arg1;
         if let Some(pattern3_0) = C::nonzero_u64_fits_in_u32(ctx, pattern2_0) {
-            // Rule at src/isa/x64/inst.isle line 1402.
+            // Rule at src/isa/x64/inst.isle line 1406.
             let expr0_0 = C::temp_writable_gpr(ctx);
             let expr1_0 = OperandSize::Size32;
             let expr2_0 = MInst::Imm {
@@ -1388,15 +1388,14 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
                 dst: expr0_0,
             };
             let expr3_0 = C::emit(ctx, &expr2_0);
-            let expr4_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-            let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
-            return Some(expr5_0);
+            let expr4_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+            return Some(expr4_0);
         }
     }
     if pattern0_0 == F32 {
         let pattern2_0 = arg1;
         if pattern2_0 == 0 {
-            // Rule at src/isa/x64/inst.isle line 1431.
+            // Rule at src/isa/x64/inst.isle line 1435.
             let expr0_0 = C::temp_writable_xmm(ctx);
             let expr1_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
             let expr2_0 = SseOpcode::Xorps;
@@ -1411,21 +1410,20 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
             let expr6_0 = C::xmm_to_reg(ctx, expr1_0);
             return Some(expr6_0);
         }
-        // Rule at src/isa/x64/inst.isle line 1386.
+        // Rule at src/isa/x64/inst.isle line 1390.
         let expr0_0 = SseOpcode::Movd;
         let expr1_0: Type = I32;
         let expr2_0 = constructor_imm(ctx, expr1_0, pattern2_0)?;
-        let expr3_0 = RegMem::Reg { reg: expr2_0 };
-        let expr4_0 = C::reg_mem_to_gpr_mem(ctx, &expr3_0);
-        let expr5_0 = OperandSize::Size32;
-        let expr6_0 = constructor_gpr_to_xmm(ctx, &expr0_0, &expr4_0, &expr5_0)?;
-        let expr7_0 = C::xmm_to_reg(ctx, expr6_0);
-        return Some(expr7_0);
+        let expr3_0 = C::reg_to_gpr_mem(ctx, expr2_0);
+        let expr4_0 = OperandSize::Size32;
+        let expr5_0 = constructor_gpr_to_xmm(ctx, &expr0_0, &expr3_0, &expr4_0)?;
+        let expr6_0 = C::xmm_to_reg(ctx, expr5_0);
+        return Some(expr6_0);
     }
     if pattern0_0 == F64 {
         let pattern2_0 = arg1;
         if pattern2_0 == 0 {
-            // Rule at src/isa/x64/inst.isle line 1443.
+            // Rule at src/isa/x64/inst.isle line 1447.
             let expr0_0 = C::temp_writable_xmm(ctx);
             let expr1_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
             let expr2_0 = SseOpcode::Xorpd;
@@ -1440,21 +1438,20 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
             let expr6_0 = C::xmm_to_reg(ctx, expr1_0);
             return Some(expr6_0);
         }
-        // Rule at src/isa/x64/inst.isle line 1392.
+        // Rule at src/isa/x64/inst.isle line 1396.
         let expr0_0 = SseOpcode::Movq;
         let expr1_0: Type = I64;
         let expr2_0 = constructor_imm(ctx, expr1_0, pattern2_0)?;
-        let expr3_0 = RegMem::Reg { reg: expr2_0 };
-        let expr4_0 = C::reg_mem_to_gpr_mem(ctx, &expr3_0);
-        let expr5_0 = OperandSize::Size64;
-        let expr6_0 = constructor_gpr_to_xmm(ctx, &expr0_0, &expr4_0, &expr5_0)?;
-        let expr7_0 = C::xmm_to_reg(ctx, expr6_0);
-        return Some(expr7_0);
+        let expr3_0 = C::reg_to_gpr_mem(ctx, expr2_0);
+        let expr4_0 = OperandSize::Size64;
+        let expr5_0 = constructor_gpr_to_xmm(ctx, &expr0_0, &expr3_0, &expr4_0)?;
+        let expr6_0 = C::xmm_to_reg(ctx, expr5_0);
+        return Some(expr6_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         if pattern2_0 == 0 {
-            // Rule at src/isa/x64/inst.isle line 1421.
+            // Rule at src/isa/x64/inst.isle line 1425.
             let expr0_0 = C::temp_writable_xmm(ctx);
             let expr1_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
             let expr2_0 = constructor_sse_xor_op(ctx, pattern0_0)?;
@@ -1473,7 +1470,7 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
     if let Some(pattern1_0) = C::fits_in_64(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         if pattern2_0 == 0 {
-            // Rule at src/isa/x64/inst.isle line 1408.
+            // Rule at src/isa/x64/inst.isle line 1412.
             let expr0_0 = C::temp_writable_gpr(ctx);
             let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
             let expr2_0 = C::operand_size_of_type_32_64(ctx, pattern1_0);
@@ -1490,7 +1487,7 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
             let expr7_0 = C::gpr_to_reg(ctx, expr1_0);
             return Some(expr7_0);
         }
-        // Rule at src/isa/x64/inst.isle line 1379.
+        // Rule at src/isa/x64/inst.isle line 1383.
         let expr0_0 = C::temp_writable_gpr(ctx);
         let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern1_0);
         let expr2_0 = MInst::Imm {
@@ -1499,9 +1496,8 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
             dst: expr0_0,
         };
         let expr3_0 = C::emit(ctx, &expr2_0);
-        let expr4_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-        let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
-        return Some(expr5_0);
+        let expr4_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+        return Some(expr4_0);
     }
     return None;
 }
@@ -1518,7 +1514,7 @@ pub fn constructor_shift_r<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1456.
+    // Rule at src/isa/x64/inst.isle line 1460.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::raw_operand_size_of_type(ctx, pattern0_0);
     let expr2_0 = MInst::ShiftR {
@@ -1543,7 +1539,7 @@ pub fn constructor_x64_rotl<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1466.
+    // Rule at src/isa/x64/inst.isle line 1470.
     let expr0_0 = ShiftKind::RotateLeft;
     let expr1_0 = constructor_shift_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1559,7 +1555,7 @@ pub fn constructor_x64_rotr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1471.
+    // Rule at src/isa/x64/inst.isle line 1475.
     let expr0_0 = ShiftKind::RotateRight;
     let expr1_0 = constructor_shift_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1575,7 +1571,7 @@ pub fn constructor_shl<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1476.
+    // Rule at src/isa/x64/inst.isle line 1480.
     let expr0_0 = ShiftKind::ShiftLeft;
     let expr1_0 = constructor_shift_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1591,7 +1587,7 @@ pub fn constructor_shr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1481.
+    // Rule at src/isa/x64/inst.isle line 1485.
     let expr0_0 = ShiftKind::ShiftRightLogical;
     let expr1_0 = constructor_shift_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1607,7 +1603,7 @@ pub fn constructor_sar<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1486.
+    // Rule at src/isa/x64/inst.isle line 1490.
     let expr0_0 = ShiftKind::ShiftRightArithmetic;
     let expr1_0 = constructor_shift_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1625,7 +1621,7 @@ pub fn constructor_cmp_rmi_r<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1491.
+    // Rule at src/isa/x64/inst.isle line 1495.
     let expr0_0 = MInst::CmpRmiR {
         size: pattern0_0.clone(),
         opcode: pattern1_0.clone(),
@@ -1646,7 +1642,7 @@ pub fn constructor_cmp<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1500.
+    // Rule at src/isa/x64/inst.isle line 1504.
     let expr0_0 = CmpOpcode::Cmp;
     let expr1_0 = constructor_cmp_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1662,7 +1658,7 @@ pub fn constructor_xmm_cmp_rm_r<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1505.
+    // Rule at src/isa/x64/inst.isle line 1509.
     let expr0_0 = MInst::XmmCmpRmR {
         op: pattern0_0.clone(),
         src: pattern1_0.clone(),
@@ -1682,7 +1678,7 @@ pub fn constructor_fpcmp<C: Context>(
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == F32 {
         let pattern3_0 = arg1;
-        // Rule at src/isa/x64/inst.isle line 1512.
+        // Rule at src/isa/x64/inst.isle line 1516.
         let expr0_0 = SseOpcode::Ucomiss;
         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern0_0)?;
         let expr2_0 = constructor_put_in_xmm(ctx, pattern3_0)?;
@@ -1691,7 +1687,7 @@ pub fn constructor_fpcmp<C: Context>(
     }
     if pattern1_0 == F64 {
         let pattern3_0 = arg1;
-        // Rule at src/isa/x64/inst.isle line 1514.
+        // Rule at src/isa/x64/inst.isle line 1518.
         let expr0_0 = SseOpcode::Ucomisd;
         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern0_0)?;
         let expr2_0 = constructor_put_in_xmm(ctx, pattern3_0)?;
@@ -1711,7 +1707,7 @@ pub fn constructor_test<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1519.
+    // Rule at src/isa/x64/inst.isle line 1523.
     let expr0_0 = CmpOpcode::Test;
     let expr1_0 = constructor_cmp_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1729,7 +1725,7 @@ pub fn constructor_cmove<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1526.
+    // Rule at src/isa/x64/inst.isle line 1530.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::Cmove {
@@ -1739,13 +1735,12 @@ pub fn constructor_cmove<C: Context>(
         alternative: pattern3_0,
         dst: expr0_0,
     };
-    let expr3_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    let expr4_0 = C::gpr_to_reg(ctx, expr3_0);
-    let expr5_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
+    let expr3_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+    let expr4_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
         inst: expr2_0,
-        result: expr4_0,
+        result: expr3_0,
     };
-    return Some(expr5_0);
+    return Some(expr4_0);
 }
 
 // Generated as internal constructor for term cmove_xmm.
@@ -1760,7 +1755,7 @@ pub fn constructor_cmove_xmm<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1534.
+    // Rule at src/isa/x64/inst.isle line 1538.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::XmmCmove {
@@ -1770,13 +1765,12 @@ pub fn constructor_cmove_xmm<C: Context>(
         alternative: pattern3_0,
         dst: expr0_0,
     };
-    let expr3_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
-    let expr4_0 = C::xmm_to_reg(ctx, expr3_0);
-    let expr5_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
+    let expr3_0 = constructor_writable_xmm_to_r_reg(ctx, expr0_0)?;
+    let expr4_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
         inst: expr2_0,
-        result: expr4_0,
+        result: expr3_0,
     };
-    return Some(expr5_0);
+    return Some(expr4_0);
 }
 
 // Generated as internal constructor for term cmove_from_values.
@@ -1792,7 +1786,7 @@ pub fn constructor_cmove_from_values<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/inst.isle line 1545.
+        // Rule at src/isa/x64/inst.isle line 1549.
         let expr0_0 = C::put_in_regs(ctx, pattern3_0);
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0 = C::temp_writable_gpr(ctx);
@@ -1822,24 +1816,22 @@ pub fn constructor_cmove_from_values<C: Context>(
             alternative: expr15_0,
             dst: expr3_0,
         };
-        let expr17_0 = C::writable_gpr_to_gpr(ctx, expr2_0);
-        let expr18_0 = C::gpr_to_reg(ctx, expr17_0);
-        let expr19_0 = C::writable_gpr_to_gpr(ctx, expr3_0);
-        let expr20_0 = C::gpr_to_reg(ctx, expr19_0);
-        let expr21_0 = C::value_regs(ctx, expr18_0, expr20_0);
-        let expr22_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
+        let expr17_0 = constructor_writable_gpr_to_r_reg(ctx, expr2_0)?;
+        let expr18_0 = constructor_writable_gpr_to_r_reg(ctx, expr3_0)?;
+        let expr19_0 = C::value_regs(ctx, expr17_0, expr18_0);
+        let expr20_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
             inst1: expr10_0,
             inst2: expr16_0,
-            result: expr21_0,
+            result: expr19_0,
         };
-        return Some(expr22_0);
+        return Some(expr20_0);
     }
     if let Some(pattern1_0) = C::is_xmm_type(ctx, pattern0_0) {
         if let Some(pattern2_0) = C::is_single_register_type(ctx, pattern1_0) {
             let pattern3_0 = arg1;
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/x64/inst.isle line 1569.
+            // Rule at src/isa/x64/inst.isle line 1573.
             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern4_0)?;
             let expr1_0 = constructor_put_in_xmm(ctx, pattern5_0)?;
             let expr2_0 = constructor_cmove_xmm(ctx, pattern2_0, pattern3_0, &expr0_0, expr1_0)?;
@@ -1851,7 +1843,7 @@ pub fn constructor_cmove_from_values<C: Context>(
             let pattern3_0 = arg1;
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/x64/inst.isle line 1566.
+            // Rule at src/isa/x64/inst.isle line 1570.
             let expr0_0 = constructor_put_in_gpr_mem(ctx, pattern4_0)?;
             let expr1_0 = constructor_put_in_gpr(ctx, pattern5_0)?;
             let expr2_0 = constructor_cmove(ctx, pattern2_0, pattern3_0, &expr0_0, expr1_0)?;
@@ -1875,7 +1867,7 @@ pub fn constructor_cmove_or<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/x64/inst.isle line 1576.
+    // Rule at src/isa/x64/inst.isle line 1580.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::CmoveOr {
@@ -1886,13 +1878,12 @@ pub fn constructor_cmove_or<C: Context>(
         alternative: pattern4_0,
         dst: expr0_0,
     };
-    let expr3_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    let expr4_0 = C::gpr_to_reg(ctx, expr3_0);
-    let expr5_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
+    let expr3_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+    let expr4_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
         inst: expr2_0,
-        result: expr4_0,
+        result: expr3_0,
     };
-    return Some(expr5_0);
+    return Some(expr4_0);
 }
 
 // Generated as internal constructor for term cmove_or_xmm.
@@ -1909,7 +1900,7 @@ pub fn constructor_cmove_or_xmm<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/x64/inst.isle line 1584.
+    // Rule at src/isa/x64/inst.isle line 1588.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::XmmCmoveOr {
@@ -1920,13 +1911,12 @@ pub fn constructor_cmove_or_xmm<C: Context>(
         alternative: pattern4_0,
         dst: expr0_0,
     };
-    let expr3_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
-    let expr4_0 = C::xmm_to_reg(ctx, expr3_0);
-    let expr5_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
+    let expr3_0 = constructor_writable_xmm_to_r_reg(ctx, expr0_0)?;
+    let expr4_0 = ConsumesFlags::ConsumesFlagsReturnsReg {
         inst: expr2_0,
-        result: expr4_0,
+        result: expr3_0,
     };
-    return Some(expr5_0);
+    return Some(expr4_0);
 }
 
 // Generated as internal constructor for term cmove_or_from_values.
@@ -1944,7 +1934,7 @@ pub fn constructor_cmove_or_from_values<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/x64/inst.isle line 1595.
+        // Rule at src/isa/x64/inst.isle line 1599.
         let expr0_0 = C::put_in_regs(ctx, pattern4_0);
         let expr1_0 = C::put_in_regs(ctx, pattern5_0);
         let expr2_0 = C::temp_writable_gpr(ctx);
@@ -1976,17 +1966,15 @@ pub fn constructor_cmove_or_from_values<C: Context>(
             alternative: expr15_0,
             dst: expr3_0,
         };
-        let expr17_0 = C::writable_gpr_to_gpr(ctx, expr2_0);
-        let expr18_0 = C::gpr_to_reg(ctx, expr17_0);
-        let expr19_0 = C::writable_gpr_to_gpr(ctx, expr3_0);
-        let expr20_0 = C::gpr_to_reg(ctx, expr19_0);
-        let expr21_0 = C::value_regs(ctx, expr18_0, expr20_0);
-        let expr22_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
+        let expr17_0 = constructor_writable_gpr_to_r_reg(ctx, expr2_0)?;
+        let expr18_0 = constructor_writable_gpr_to_r_reg(ctx, expr3_0)?;
+        let expr19_0 = C::value_regs(ctx, expr17_0, expr18_0);
+        let expr20_0 = ConsumesFlags::ConsumesFlagsTwiceReturnsValueRegs {
             inst1: expr10_0,
             inst2: expr16_0,
-            result: expr21_0,
+            result: expr19_0,
         };
-        return Some(expr22_0);
+        return Some(expr20_0);
     }
     if let Some(pattern1_0) = C::is_xmm_type(ctx, pattern0_0) {
         if let Some(pattern2_0) = C::is_single_register_type(ctx, pattern1_0) {
@@ -1994,7 +1982,7 @@ pub fn constructor_cmove_or_from_values<C: Context>(
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/x64/inst.isle line 1612.
+            // Rule at src/isa/x64/inst.isle line 1615.
             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_0)?;
             let expr1_0 = constructor_put_in_xmm(ctx, pattern6_0)?;
             let expr2_0 = constructor_cmove_or_xmm(
@@ -2009,7 +1997,7 @@ pub fn constructor_cmove_or_from_values<C: Context>(
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/x64/inst.isle line 1609.
+            // Rule at src/isa/x64/inst.isle line 1612.
             let expr0_0 = constructor_put_in_gpr_mem(ctx, pattern5_0)?;
             let expr1_0 = constructor_put_in_gpr(ctx, pattern6_0)?;
             let expr2_0 =
@@ -2030,7 +2018,7 @@ pub fn constructor_movzx<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1617.
+    // Rule at src/isa/x64/inst.isle line 1620.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = MInst::MovzxRmR {
         ext_mode: pattern1_0.clone(),
@@ -2052,7 +2040,7 @@ pub fn constructor_movsx<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1624.
+    // Rule at src/isa/x64/inst.isle line 1627.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = MInst::MovsxRmR {
         ext_mode: pattern1_0.clone(),
@@ -2076,7 +2064,7 @@ pub fn constructor_xmm_rm_r<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1631.
+    // Rule at src/isa/x64/inst.isle line 1634.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmRmR {
         op: pattern1_0.clone(),
@@ -2093,7 +2081,7 @@ pub fn constructor_xmm_rm_r<C: Context>(
 pub fn constructor_paddb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1638.
+    // Rule at src/isa/x64/inst.isle line 1641.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Paddb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2104,7 +2092,7 @@ pub fn constructor_paddb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_paddw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1643.
+    // Rule at src/isa/x64/inst.isle line 1646.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Paddw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2115,7 +2103,7 @@ pub fn constructor_paddw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_paddd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1648.
+    // Rule at src/isa/x64/inst.isle line 1651.
     let expr0_0: Type = I32X4;
     let expr1_0 = SseOpcode::Paddd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2126,7 +2114,7 @@ pub fn constructor_paddd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_paddq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1653.
+    // Rule at src/isa/x64/inst.isle line 1656.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Paddq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2137,7 +2125,7 @@ pub fn constructor_paddq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_paddsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1658.
+    // Rule at src/isa/x64/inst.isle line 1661.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Paddsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2148,7 +2136,7 @@ pub fn constructor_paddsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_paddsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1663.
+    // Rule at src/isa/x64/inst.isle line 1666.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Paddsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2159,7 +2147,7 @@ pub fn constructor_paddsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_paddusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1668.
+    // Rule at src/isa/x64/inst.isle line 1671.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Paddusb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2170,7 +2158,7 @@ pub fn constructor_paddusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 pub fn constructor_paddusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1673.
+    // Rule at src/isa/x64/inst.isle line 1676.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Paddusw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2181,7 +2169,7 @@ pub fn constructor_paddusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 pub fn constructor_psubb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1678.
+    // Rule at src/isa/x64/inst.isle line 1681.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Psubb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2192,7 +2180,7 @@ pub fn constructor_psubb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_psubw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1683.
+    // Rule at src/isa/x64/inst.isle line 1686.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Psubw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2203,7 +2191,7 @@ pub fn constructor_psubw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_psubd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1688.
+    // Rule at src/isa/x64/inst.isle line 1691.
     let expr0_0: Type = I32X4;
     let expr1_0 = SseOpcode::Psubd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2214,7 +2202,7 @@ pub fn constructor_psubd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_psubq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1693.
+    // Rule at src/isa/x64/inst.isle line 1696.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Psubq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2225,7 +2213,7 @@ pub fn constructor_psubq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_psubsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1698.
+    // Rule at src/isa/x64/inst.isle line 1701.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Psubsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2236,7 +2224,7 @@ pub fn constructor_psubsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_psubsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1703.
+    // Rule at src/isa/x64/inst.isle line 1706.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Psubsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2247,7 +2235,7 @@ pub fn constructor_psubsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_psubusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1708.
+    // Rule at src/isa/x64/inst.isle line 1711.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Psubusb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2258,7 +2246,7 @@ pub fn constructor_psubusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 pub fn constructor_psubusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1713.
+    // Rule at src/isa/x64/inst.isle line 1716.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Psubusw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2269,7 +2257,7 @@ pub fn constructor_psubusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 pub fn constructor_pavgb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1718.
+    // Rule at src/isa/x64/inst.isle line 1721.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pavgb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2280,7 +2268,7 @@ pub fn constructor_pavgb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_pavgw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1723.
+    // Rule at src/isa/x64/inst.isle line 1726.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pavgw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2291,7 +2279,7 @@ pub fn constructor_pavgw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_pand<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1728.
+    // Rule at src/isa/x64/inst.isle line 1731.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Pand;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2302,7 +2290,7 @@ pub fn constructor_pand<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Op
 pub fn constructor_andps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1733.
+    // Rule at src/isa/x64/inst.isle line 1736.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Andps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2313,7 +2301,7 @@ pub fn constructor_andps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_andpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1738.
+    // Rule at src/isa/x64/inst.isle line 1741.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Andpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2324,7 +2312,7 @@ pub fn constructor_andpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_por<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1743.
+    // Rule at src/isa/x64/inst.isle line 1746.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Por;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2335,7 +2323,7 @@ pub fn constructor_por<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Opt
 pub fn constructor_orps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1748.
+    // Rule at src/isa/x64/inst.isle line 1751.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Orps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2346,7 +2334,7 @@ pub fn constructor_orps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Op
 pub fn constructor_orpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1753.
+    // Rule at src/isa/x64/inst.isle line 1756.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Orpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2357,7 +2345,7 @@ pub fn constructor_orpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Op
 pub fn constructor_pxor<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1758.
+    // Rule at src/isa/x64/inst.isle line 1761.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pxor;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2368,7 +2356,7 @@ pub fn constructor_pxor<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Op
 pub fn constructor_xorps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1763.
+    // Rule at src/isa/x64/inst.isle line 1766.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Xorps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2379,7 +2367,7 @@ pub fn constructor_xorps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_xorpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1768.
+    // Rule at src/isa/x64/inst.isle line 1771.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Xorpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2390,7 +2378,7 @@ pub fn constructor_xorpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_pmullw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1773.
+    // Rule at src/isa/x64/inst.isle line 1776.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmullw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2401,7 +2389,7 @@ pub fn constructor_pmullw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmulld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1778.
+    // Rule at src/isa/x64/inst.isle line 1781.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmulld;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2412,7 +2400,7 @@ pub fn constructor_pmulld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmulhw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1783.
+    // Rule at src/isa/x64/inst.isle line 1786.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmulhw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2423,7 +2411,7 @@ pub fn constructor_pmulhw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmulhuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1788.
+    // Rule at src/isa/x64/inst.isle line 1791.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmulhuw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2434,7 +2422,7 @@ pub fn constructor_pmulhuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 pub fn constructor_pmuldq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1793.
+    // Rule at src/isa/x64/inst.isle line 1796.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmuldq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2445,7 +2433,7 @@ pub fn constructor_pmuldq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmuludq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1798.
+    // Rule at src/isa/x64/inst.isle line 1801.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Pmuludq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2456,7 +2444,7 @@ pub fn constructor_pmuludq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 pub fn constructor_punpckhwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1803.
+    // Rule at src/isa/x64/inst.isle line 1806.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Punpckhwd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2467,7 +2455,7 @@ pub fn constructor_punpckhwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) 
 pub fn constructor_punpcklwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1808.
+    // Rule at src/isa/x64/inst.isle line 1811.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Punpcklwd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2478,7 +2466,7 @@ pub fn constructor_punpcklwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) 
 pub fn constructor_andnps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1813.
+    // Rule at src/isa/x64/inst.isle line 1816.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Andnps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2489,7 +2477,7 @@ pub fn constructor_andnps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_andnpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1818.
+    // Rule at src/isa/x64/inst.isle line 1821.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Andnpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2500,7 +2488,7 @@ pub fn constructor_andnpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pandn<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1823.
+    // Rule at src/isa/x64/inst.isle line 1826.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Pandn;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2511,17 +2499,17 @@ pub fn constructor_pandn<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_sse_blend_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<SseOpcode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32X4 {
-        // Rule at src/isa/x64/inst.isle line 1827.
+        // Rule at src/isa/x64/inst.isle line 1830.
         let expr0_0 = SseOpcode::Blendvps;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
-        // Rule at src/isa/x64/inst.isle line 1828.
+        // Rule at src/isa/x64/inst.isle line 1831.
         let expr0_0 = SseOpcode::Blendvpd;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
-        // Rule at src/isa/x64/inst.isle line 1829.
+        // Rule at src/isa/x64/inst.isle line 1832.
         let expr0_0 = SseOpcode::Pblendvb;
         return Some(expr0_0);
     }
@@ -2532,17 +2520,17 @@ pub fn constructor_sse_blend_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<S
 pub fn constructor_sse_mov_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<SseOpcode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32X4 {
-        // Rule at src/isa/x64/inst.isle line 1832.
+        // Rule at src/isa/x64/inst.isle line 1835.
         let expr0_0 = SseOpcode::Movaps;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
-        // Rule at src/isa/x64/inst.isle line 1833.
+        // Rule at src/isa/x64/inst.isle line 1836.
         let expr0_0 = SseOpcode::Movapd;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
-        // Rule at src/isa/x64/inst.isle line 1834.
+        // Rule at src/isa/x64/inst.isle line 1837.
         let expr0_0 = SseOpcode::Movdqa;
         return Some(expr0_0);
     }
@@ -2561,7 +2549,7 @@ pub fn constructor_sse_blend<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1838.
+    // Rule at src/isa/x64/inst.isle line 1841.
     let expr0_0 = C::xmm0(ctx);
     let expr1_0 = constructor_sse_mov_op(ctx, pattern0_0)?;
     let expr2_0 = MInst::XmmUnaryRmR {
@@ -2585,7 +2573,7 @@ pub fn constructor_blendvpd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1852.
+    // Rule at src/isa/x64/inst.isle line 1855.
     let expr0_0 = C::xmm0(ctx);
     let expr1_0 = SseOpcode::Movapd;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern2_0);
@@ -2605,7 +2593,7 @@ pub fn constructor_blendvpd<C: Context>(
 pub fn constructor_movsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1866.
+    // Rule at src/isa/x64/inst.isle line 1869.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Movsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2616,7 +2604,7 @@ pub fn constructor_movsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_movlhps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1871.
+    // Rule at src/isa/x64/inst.isle line 1874.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Movlhps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2627,7 +2615,7 @@ pub fn constructor_movlhps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 pub fn constructor_pmaxsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1876.
+    // Rule at src/isa/x64/inst.isle line 1879.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2638,7 +2626,7 @@ pub fn constructor_pmaxsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmaxsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1881.
+    // Rule at src/isa/x64/inst.isle line 1884.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2649,7 +2637,7 @@ pub fn constructor_pmaxsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmaxsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1886.
+    // Rule at src/isa/x64/inst.isle line 1889.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2660,7 +2648,7 @@ pub fn constructor_pmaxsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pminsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1891.
+    // Rule at src/isa/x64/inst.isle line 1894.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2671,7 +2659,7 @@ pub fn constructor_pminsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pminsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1896.
+    // Rule at src/isa/x64/inst.isle line 1899.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2682,7 +2670,7 @@ pub fn constructor_pminsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pminsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1901.
+    // Rule at src/isa/x64/inst.isle line 1904.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2693,7 +2681,7 @@ pub fn constructor_pminsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmaxub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1906.
+    // Rule at src/isa/x64/inst.isle line 1909.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxub;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2704,7 +2692,7 @@ pub fn constructor_pmaxub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmaxuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1911.
+    // Rule at src/isa/x64/inst.isle line 1914.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxuw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2715,7 +2703,7 @@ pub fn constructor_pmaxuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pmaxud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1916.
+    // Rule at src/isa/x64/inst.isle line 1919.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxud;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2726,7 +2714,7 @@ pub fn constructor_pmaxud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pminub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1921.
+    // Rule at src/isa/x64/inst.isle line 1924.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminub;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2737,7 +2725,7 @@ pub fn constructor_pminub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pminuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1926.
+    // Rule at src/isa/x64/inst.isle line 1929.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminuw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2748,7 +2736,7 @@ pub fn constructor_pminuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_pminud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1931.
+    // Rule at src/isa/x64/inst.isle line 1934.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminud;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2759,7 +2747,7 @@ pub fn constructor_pminud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> 
 pub fn constructor_punpcklbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1936.
+    // Rule at src/isa/x64/inst.isle line 1939.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Punpcklbw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2770,7 +2758,7 @@ pub fn constructor_punpcklbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) 
 pub fn constructor_punpckhbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1941.
+    // Rule at src/isa/x64/inst.isle line 1944.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Punpckhbw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2781,7 +2769,7 @@ pub fn constructor_punpckhbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) 
 pub fn constructor_packsswb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1946.
+    // Rule at src/isa/x64/inst.isle line 1949.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Packsswb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2802,7 +2790,7 @@ pub fn constructor_xmm_rm_r_imm<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/x64/inst.isle line 1951.
+    // Rule at src/isa/x64/inst.isle line 1954.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::writable_xmm_to_reg(ctx, expr0_0);
     let expr2_0 = MInst::XmmRmRImm {
@@ -2830,7 +2818,7 @@ pub fn constructor_palignr<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1963.
+    // Rule at src/isa/x64/inst.isle line 1966.
     let expr0_0 = SseOpcode::Palignr;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::xmm_mem_to_reg_mem(ctx, pattern1_0);
@@ -2849,7 +2837,7 @@ pub fn constructor_cmpps<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1972.
+    // Rule at src/isa/x64/inst.isle line 1975.
     let expr0_0 = SseOpcode::Cmpps;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::xmm_mem_to_reg_mem(ctx, pattern1_0);
@@ -2869,7 +2857,7 @@ pub fn constructor_pinsrb<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1981.
+    // Rule at src/isa/x64/inst.isle line 1984.
     let expr0_0 = SseOpcode::Pinsrb;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::gpr_mem_to_reg_mem(ctx, pattern1_0);
@@ -2888,7 +2876,7 @@ pub fn constructor_pinsrw<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1990.
+    // Rule at src/isa/x64/inst.isle line 1993.
     let expr0_0 = SseOpcode::Pinsrw;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::gpr_mem_to_reg_mem(ctx, pattern1_0);
@@ -2909,7 +2897,7 @@ pub fn constructor_pinsrd<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1999.
+    // Rule at src/isa/x64/inst.isle line 2002.
     let expr0_0 = SseOpcode::Pinsrd;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::gpr_mem_to_reg_mem(ctx, pattern1_0);
@@ -2928,7 +2916,7 @@ pub fn constructor_insertps<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2008.
+    // Rule at src/isa/x64/inst.isle line 2011.
     let expr0_0 = SseOpcode::Insertps;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::xmm_mem_to_reg_mem(ctx, pattern1_0);
@@ -2947,23 +2935,23 @@ pub fn constructor_pshufd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2017.
+    // Rule at src/isa/x64/inst.isle line 2020.
     let expr0_0 = C::temp_writable_xmm(ctx);
-    let expr1_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
-    let expr2_0 = SseOpcode::Pshufd;
-    let expr3_0 = C::xmm_to_reg(ctx, expr1_0);
-    let expr4_0 = C::xmm_mem_to_reg_mem(ctx, pattern0_0);
-    let expr5_0 = C::writable_xmm_to_reg(ctx, expr0_0);
-    let expr6_0 = MInst::XmmRmRImm {
-        op: expr2_0,
-        src1: expr3_0,
-        src2: expr4_0,
-        dst: expr5_0,
+    let expr1_0 = SseOpcode::Pshufd;
+    let expr2_0 = constructor_writable_xmm_to_r_reg(ctx, expr0_0)?;
+    let expr3_0 = C::xmm_mem_to_reg_mem(ctx, pattern0_0);
+    let expr4_0 = C::writable_xmm_to_reg(ctx, expr0_0);
+    let expr5_0 = MInst::XmmRmRImm {
+        op: expr1_0,
+        src1: expr2_0,
+        src2: expr3_0,
+        dst: expr4_0,
         imm: pattern1_0,
         size: pattern2_0.clone(),
     };
-    let expr7_0 = C::emit(ctx, &expr6_0);
-    return Some(expr1_0);
+    let expr6_0 = C::emit(ctx, &expr5_0);
+    let expr7_0 = C::writable_xmm_to_xmm(ctx, expr0_0);
+    return Some(expr7_0);
 }
 
 // Generated as internal constructor for term xmm_unary_rm_r.
@@ -2974,7 +2962,7 @@ pub fn constructor_xmm_unary_rm_r<C: Context>(
 ) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2030.
+    // Rule at src/isa/x64/inst.isle line 2032.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmUnaryRmR {
         op: pattern0_0.clone(),
@@ -2989,7 +2977,7 @@ pub fn constructor_xmm_unary_rm_r<C: Context>(
 // Generated as internal constructor for term pmovsxbw.
 pub fn constructor_pmovsxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2037.
+    // Rule at src/isa/x64/inst.isle line 2039.
     let expr0_0 = SseOpcode::Pmovsxbw;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -2998,7 +2986,7 @@ pub fn constructor_pmovsxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xm
 // Generated as internal constructor for term pmovzxbw.
 pub fn constructor_pmovzxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2042.
+    // Rule at src/isa/x64/inst.isle line 2044.
     let expr0_0 = SseOpcode::Pmovzxbw;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -3007,7 +2995,7 @@ pub fn constructor_pmovzxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xm
 // Generated as internal constructor for term pabsb.
 pub fn constructor_pabsb<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2047.
+    // Rule at src/isa/x64/inst.isle line 2049.
     let expr0_0 = SseOpcode::Pabsb;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -3016,7 +3004,7 @@ pub fn constructor_pabsb<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> 
 // Generated as internal constructor for term pabsw.
 pub fn constructor_pabsw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2052.
+    // Rule at src/isa/x64/inst.isle line 2054.
     let expr0_0 = SseOpcode::Pabsw;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -3025,7 +3013,7 @@ pub fn constructor_pabsw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> 
 // Generated as internal constructor for term pabsd.
 pub fn constructor_pabsd<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2057.
+    // Rule at src/isa/x64/inst.isle line 2059.
     let expr0_0 = SseOpcode::Pabsd;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -3039,7 +3027,7 @@ pub fn constructor_xmm_unary_rm_r_evex<C: Context>(
 ) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2062.
+    // Rule at src/isa/x64/inst.isle line 2064.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmUnaryRmREvex {
         op: pattern0_0.clone(),
@@ -3054,7 +3042,7 @@ pub fn constructor_xmm_unary_rm_r_evex<C: Context>(
 // Generated as internal constructor for term vpabsq.
 pub fn constructor_vpabsq<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2069.
+    // Rule at src/isa/x64/inst.isle line 2071.
     let expr0_0 = Avx512Opcode::Vpabsq;
     let expr1_0 = constructor_xmm_unary_rm_r_evex(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -3070,7 +3058,7 @@ pub fn constructor_xmm_rm_r_evex<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2074.
+    // Rule at src/isa/x64/inst.isle line 2076.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmRmREvex {
         op: pattern0_0.clone(),
@@ -3087,7 +3075,7 @@ pub fn constructor_xmm_rm_r_evex<C: Context>(
 pub fn constructor_vpmullq<C: Context>(ctx: &mut C, arg0: &XmmMem, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2086.
+    // Rule at src/isa/x64/inst.isle line 2088.
     let expr0_0 = Avx512Opcode::Vpmullq;
     let expr1_0 = constructor_xmm_rm_r_evex(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3105,7 +3093,7 @@ pub fn constructor_mul_hi<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 2095.
+    // Rule at src/isa/x64/inst.isle line 2097.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::temp_writable_gpr(ctx);
     let expr2_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
@@ -3134,7 +3122,7 @@ pub fn constructor_mulhi_u<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2111.
+    // Rule at src/isa/x64/inst.isle line 2112.
     let expr0_0: bool = false;
     let expr1_0 = constructor_mul_hi(ctx, pattern0_0, expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -3150,7 +3138,7 @@ pub fn constructor_xmm_rmi_xmm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2116.
+    // Rule at src/isa/x64/inst.isle line 2117.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmRmiReg {
         opcode: pattern0_0.clone(),
@@ -3167,7 +3155,7 @@ pub fn constructor_xmm_rmi_xmm<C: Context>(
 pub fn constructor_psllw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2126.
+    // Rule at src/isa/x64/inst.isle line 2127.
     let expr0_0 = SseOpcode::Psllw;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3177,7 +3165,7 @@ pub fn constructor_psllw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -
 pub fn constructor_pslld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2131.
+    // Rule at src/isa/x64/inst.isle line 2132.
     let expr0_0 = SseOpcode::Pslld;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3187,7 +3175,7 @@ pub fn constructor_pslld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -
 pub fn constructor_psllq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2136.
+    // Rule at src/isa/x64/inst.isle line 2137.
     let expr0_0 = SseOpcode::Psllq;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3197,7 +3185,7 @@ pub fn constructor_psllq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -
 pub fn constructor_psrlw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2141.
+    // Rule at src/isa/x64/inst.isle line 2142.
     let expr0_0 = SseOpcode::Psrlw;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3207,7 +3195,7 @@ pub fn constructor_psrlw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -
 pub fn constructor_psrld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2146.
+    // Rule at src/isa/x64/inst.isle line 2147.
     let expr0_0 = SseOpcode::Psrld;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3217,7 +3205,7 @@ pub fn constructor_psrld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -
 pub fn constructor_psrlq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2151.
+    // Rule at src/isa/x64/inst.isle line 2152.
     let expr0_0 = SseOpcode::Psrlq;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3227,7 +3215,7 @@ pub fn constructor_psrlq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -
 pub fn constructor_psraw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2156.
+    // Rule at src/isa/x64/inst.isle line 2157.
     let expr0_0 = SseOpcode::Psraw;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3237,7 +3225,7 @@ pub fn constructor_psraw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -
 pub fn constructor_psrad<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2161.
+    // Rule at src/isa/x64/inst.isle line 2162.
     let expr0_0 = SseOpcode::Psrad;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3248,26 +3236,27 @@ pub fn constructor_pextrd<C: Context>(ctx: &mut C, arg0: Type, arg1: Xmm, arg2: 
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2166.
+    // Rule at src/isa/x64/inst.isle line 2167.
     let expr0_0 = C::temp_writable_gpr(ctx);
-    let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-    let expr2_0 = SseOpcode::Pextrd;
-    let expr3_0 = C::gpr_to_reg(ctx, expr1_0);
-    let expr4_0 = C::xmm_to_reg(ctx, pattern1_0);
-    let expr5_0 = RegMem::Reg { reg: expr4_0 };
+    let expr1_0 = SseOpcode::Pextrd;
+    let expr2_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
+    let expr3_0 = C::xmm_to_reg(ctx, pattern1_0);
+    let expr4_0 = constructor_xmm_to_reg_mem(ctx, expr3_0)?;
+    let expr5_0 = C::xmm_mem_to_reg_mem(ctx, &expr4_0);
     let expr6_0 = C::writable_gpr_to_reg(ctx, expr0_0);
     let expr7_0 = C::lane_type(ctx, pattern0_0);
     let expr8_0 = C::operand_size_of_type_32_64(ctx, expr7_0);
     let expr9_0 = MInst::XmmRmRImm {
-        op: expr2_0,
-        src1: expr3_0,
+        op: expr1_0,
+        src1: expr2_0,
         src2: expr5_0,
         dst: expr6_0,
         imm: pattern2_0,
         size: expr8_0,
     };
     let expr10_0 = C::emit(ctx, &expr9_0);
-    return Some(expr1_0);
+    let expr11_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
+    return Some(expr11_0);
 }
 
 // Generated as internal constructor for term cmppd.
@@ -3372,6 +3361,86 @@ pub fn constructor_ud2<C: Context>(ctx: &mut C, arg0: &TrapCode) -> Option<SideE
     return Some(expr1_0);
 }
 
+// Generated as internal constructor for term reg_to_xmm_mem.
+pub fn constructor_reg_to_xmm_mem<C: Context>(ctx: &mut C, arg0: Reg) -> Option<XmmMem> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 2270.
+    let expr0_0 = C::xmm_new(ctx, pattern0_0);
+    let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term xmm_to_reg_mem.
+pub fn constructor_xmm_to_reg_mem<C: Context>(ctx: &mut C, arg0: Reg) -> Option<XmmMem> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 2273.
+    let expr0_0 = C::xmm_new(ctx, pattern0_0);
+    let expr1_0 = C::xmm_to_reg(ctx, expr0_0);
+    let expr2_0 = RegMem::Reg { reg: expr1_0 };
+    let expr3_0 = C::reg_mem_to_xmm_mem(ctx, &expr2_0);
+    return Some(expr3_0);
+}
+
+// Generated as internal constructor for term writable_gpr_to_r_reg.
+pub fn constructor_writable_gpr_to_r_reg<C: Context>(
+    ctx: &mut C,
+    arg0: WritableGpr,
+) -> Option<Reg> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 2277.
+    let expr0_0 = C::writable_gpr_to_reg(ctx, pattern0_0);
+    let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term writable_xmm_to_r_reg.
+pub fn constructor_writable_xmm_to_r_reg<C: Context>(
+    ctx: &mut C,
+    arg0: WritableXmm,
+) -> Option<Reg> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 2280.
+    let expr0_0 = C::writable_xmm_to_reg(ctx, pattern0_0);
+    let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term writable_xmm_to_xmm_mem.
+pub fn constructor_writable_xmm_to_xmm_mem<C: Context>(
+    ctx: &mut C,
+    arg0: WritableXmm,
+) -> Option<XmmMem> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 2283.
+    let expr0_0 = C::writable_xmm_to_xmm(ctx, pattern0_0);
+    let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term synthetic_amode_to_gpr_mem.
+pub fn constructor_synthetic_amode_to_gpr_mem<C: Context>(
+    ctx: &mut C,
+    arg0: &SyntheticAmode,
+) -> Option<GprMem> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 2287.
+    let expr0_0 = C::synthetic_amode_to_reg_mem(ctx, pattern0_0);
+    let expr1_0 = C::reg_mem_to_gpr_mem(ctx, &expr0_0);
+    return Some(expr1_0);
+}
+
+// Generated as internal constructor for term synthetic_amode_to_xmm_mem.
+pub fn constructor_synthetic_amode_to_xmm_mem<C: Context>(
+    ctx: &mut C,
+    arg0: &SyntheticAmode,
+) -> Option<XmmMem> {
+    let pattern0_0 = arg0;
+    // Rule at src/isa/x64/inst.isle line 2290.
+    let expr0_0 = C::synthetic_amode_to_reg_mem(ctx, pattern0_0);
+    let expr1_0 = C::reg_mem_to_xmm_mem(ctx, &expr0_0);
+    return Some(expr1_0);
+}
+
 // Generated as internal constructor for term lower.
 pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
@@ -3409,13 +3478,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
         } => {
             match pattern2_0 {
                 &Opcode::Trap => {
-                    // Rule at src/isa/x64/lower.isle line 1519.
+                    // Rule at src/isa/x64/lower.isle line 1444.
                     let expr0_0 = constructor_ud2(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::ResumableTrap => {
-                    // Rule at src/isa/x64/lower.isle line 1524.
+                    // Rule at src/isa/x64/lower.isle line 1449.
                     let expr0_0 = constructor_ud2(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
@@ -3432,7 +3501,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 let (pattern4_0, pattern4_1) = C::unpack_value_array_2(ctx, pattern2_1);
                 let pattern5_0 = C::value_type(ctx, pattern4_0);
                 let pattern6_0 = C::u8_from_uimm8(ctx, pattern2_2);
-                // Rule at src/isa/x64/lower.isle line 1386.
+                // Rule at src/isa/x64/lower.isle line 1311.
                 let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                 let expr1_0 = C::put_in_reg_mem(ctx, pattern4_1);
                 let expr2_0 =
@@ -3484,7 +3553,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 386.
+                            // Rule at src/isa/x64/lower.isle line 353.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3499,7 +3568,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 462.
+                            // Rule at src/isa/x64/lower.isle line 419.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3514,7 +3583,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 528.
+                            // Rule at src/isa/x64/lower.isle line 477.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3535,7 +3604,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Bnot = pattern5_0 {
-                        // Rule at src/isa/x64/lower.isle line 1353.
+                        // Rule at src/isa/x64/lower.isle line 1278.
                         let expr0_0 = constructor_i128_not(ctx, pattern5_1)?;
                         return Some(expr0_0);
                     }
@@ -3569,7 +3638,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Iadd => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 117.
+                            // Rule at src/isa/x64/lower.isle line 111.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3594,7 +3663,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 286.
+                            // Rule at src/isa/x64/lower.isle line 266.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3619,7 +3688,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1039.
+                            // Rule at src/isa/x64/lower.isle line 966.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3654,7 +3723,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 376.
+                            // Rule at src/isa/x64/lower.isle line 343.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3676,7 +3745,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 459.
+                            // Rule at src/isa/x64/lower.isle line 416.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0 = constructor_or_i128(ctx, expr0_0, expr1_0)?;
@@ -3684,7 +3753,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 518.
+                            // Rule at src/isa/x64/lower.isle line 467.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3706,7 +3775,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Rotl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 903.
+                            // Rule at src/isa/x64/lower.isle line 839.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr2_0 = constructor_shl_i128(ctx, expr0_0, expr1_0)?;
@@ -3723,7 +3792,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Rotr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 945.
+                            // Rule at src/isa/x64/lower.isle line 879.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr2_0 = constructor_shr_i128(ctx, expr0_0, expr1_0)?;
@@ -3740,7 +3809,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 582.
+                            // Rule at src/isa/x64/lower.isle line 531.
                             let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr1_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr2_0 = constructor_shl_i128(ctx, expr1_0, expr0_0)?;
@@ -3748,7 +3817,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 688.
+                            // Rule at src/isa/x64/lower.isle line 632.
                             let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr1_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr2_0 = constructor_shr_i128(ctx, expr1_0, expr0_0)?;
@@ -3756,7 +3825,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 797.
+                            // Rule at src/isa/x64/lower.isle line 737.
                             let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr1_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr2_0 = constructor_sar_i128(ctx, expr1_0, expr0_0)?;
@@ -3770,7 +3839,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Bnot = pattern5_0 {
-                        // Rule at src/isa/x64/lower.isle line 1350.
+                        // Rule at src/isa/x64/lower.isle line 1275.
                         let expr0_0 = constructor_i128_not(ctx, pattern5_1)?;
                         return Some(expr0_0);
                     }
@@ -3782,7 +3851,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     if let &Opcode::IaddImm = pattern5_0 {
                         let pattern7_0 = C::u64_from_imm64(ctx, pattern5_2);
-                        // Rule at src/isa/x64/lower.isle line 232.
+                        // Rule at src/isa/x64/lower.isle line 219.
                         let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                         let expr1_0: usize = 0;
                         let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -3817,7 +3886,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1486.
+                            // Rule at src/isa/x64/lower.isle line 1411.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminsb(ctx, expr0_0, &expr1_0)?;
@@ -3826,7 +3895,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1508.
+                            // Rule at src/isa/x64/lower.isle line 1433.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminub(ctx, expr0_0, &expr1_0)?;
@@ -3835,7 +3904,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1475.
+                            // Rule at src/isa/x64/lower.isle line 1400.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxsb(ctx, expr0_0, &expr1_0)?;
@@ -3844,7 +3913,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1497.
+                            // Rule at src/isa/x64/lower.isle line 1422.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxub(ctx, expr0_0, &expr1_0)?;
@@ -3853,44 +3922,46 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 594.
+                            // Rule at src/isa/x64/lower.isle line 543.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psllw(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_ishl_i8x16_mask(ctx, &expr1_0)?;
-                            let expr5_0: Type = I8X16;
-                            let expr6_0 = ExtKind::None;
-                            let expr7_0 = constructor_x64_load(ctx, expr5_0, &expr4_0, &expr6_0)?;
-                            let expr8_0: Type = I8X16;
-                            let expr9_0 = RegMem::Reg { reg: expr7_0 };
-                            let expr10_0 = C::reg_mem_to_xmm_mem(ctx, &expr9_0);
-                            let expr11_0 = constructor_sse_and(ctx, expr8_0, expr3_0, &expr10_0)?;
-                            let expr12_0 = constructor_value_xmm(ctx, expr11_0)?;
-                            return Some(expr12_0);
+                            let expr4_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
+                            let expr5_0 = constructor_ishl_i8x16_mask(ctx, &expr4_0)?;
+                            let expr6_0: Type = I8X16;
+                            let expr7_0 = ExtKind::None;
+                            let expr8_0 = constructor_x64_load(ctx, expr6_0, &expr5_0, &expr7_0)?;
+                            let expr9_0: Type = I8X16;
+                            let expr10_0 = RegMem::Reg { reg: expr8_0 };
+                            let expr11_0 = C::reg_mem_to_xmm_mem(ctx, &expr10_0);
+                            let expr12_0 = constructor_sse_and(ctx, expr9_0, expr3_0, &expr11_0)?;
+                            let expr13_0 = constructor_value_xmm(ctx, expr12_0)?;
+                            return Some(expr13_0);
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 698.
+                            // Rule at src/isa/x64/lower.isle line 642.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
                             let expr3_0 = constructor_psrlw(ctx, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_ushr_i8x16_mask(ctx, &expr1_0)?;
-                            let expr5_0: Type = I8X16;
-                            let expr6_0 = ExtKind::None;
-                            let expr7_0 = constructor_x64_load(ctx, expr5_0, &expr4_0, &expr6_0)?;
-                            let expr8_0: Type = I8X16;
-                            let expr9_0 = RegMem::Reg { reg: expr7_0 };
-                            let expr10_0 = C::reg_mem_to_xmm_mem(ctx, &expr9_0);
-                            let expr11_0 = constructor_sse_and(ctx, expr8_0, expr3_0, &expr10_0)?;
-                            let expr12_0 = constructor_value_xmm(ctx, expr11_0)?;
-                            return Some(expr12_0);
+                            let expr4_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
+                            let expr5_0 = constructor_ushr_i8x16_mask(ctx, &expr4_0)?;
+                            let expr6_0: Type = I8X16;
+                            let expr7_0 = ExtKind::None;
+                            let expr8_0 = constructor_x64_load(ctx, expr6_0, &expr5_0, &expr7_0)?;
+                            let expr9_0: Type = I8X16;
+                            let expr10_0 = RegMem::Reg { reg: expr8_0 };
+                            let expr11_0 = C::reg_mem_to_xmm_mem(ctx, &expr10_0);
+                            let expr12_0 = constructor_sse_and(ctx, expr9_0, expr3_0, &expr11_0)?;
+                            let expr13_0 = constructor_value_xmm(ctx, expr12_0)?;
+                            return Some(expr13_0);
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             let pattern8_0 = C::value_type(ctx, pattern7_1);
-                            // Rule at src/isa/x64/lower.isle line 818.
+                            // Rule at src/isa/x64/lower.isle line 758.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                             let expr2_0 = constructor_punpcklbw(ctx, expr0_0, &expr1_0)?;
@@ -3915,7 +3986,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 964.
+                            // Rule at src/isa/x64/lower.isle line 898.
                             let expr0_0: Type = I8X16;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
@@ -3926,7 +3997,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1294.
+                            // Rule at src/isa/x64/lower.isle line 1219.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr1_0 = constructor_pabsb(ctx, &expr0_0)?;
                             let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
@@ -3948,7 +4019,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1489.
+                            // Rule at src/isa/x64/lower.isle line 1414.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminsw(ctx, expr0_0, &expr1_0)?;
@@ -3957,7 +4028,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1511.
+                            // Rule at src/isa/x64/lower.isle line 1436.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminuw(ctx, expr0_0, &expr1_0)?;
@@ -3966,7 +4037,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1478.
+                            // Rule at src/isa/x64/lower.isle line 1403.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxsw(ctx, expr0_0, &expr1_0)?;
@@ -3975,7 +4046,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1500.
+                            // Rule at src/isa/x64/lower.isle line 1425.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxuw(ctx, expr0_0, &expr1_0)?;
@@ -3984,7 +4055,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 638.
+                            // Rule at src/isa/x64/lower.isle line 585.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -3994,7 +4065,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 744.
+                            // Rule at src/isa/x64/lower.isle line 687.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -4004,7 +4075,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 845.
+                            // Rule at src/isa/x64/lower.isle line 785.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -4021,7 +4092,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 968.
+                            // Rule at src/isa/x64/lower.isle line 901.
                             let expr0_0: Type = I16X8;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
@@ -4032,7 +4103,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1297.
+                            // Rule at src/isa/x64/lower.isle line 1222.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr1_0 = constructor_pabsw(ctx, &expr0_0)?;
                             let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
@@ -4054,7 +4125,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1492.
+                            // Rule at src/isa/x64/lower.isle line 1417.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminsd(ctx, expr0_0, &expr1_0)?;
@@ -4063,7 +4134,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1514.
+                            // Rule at src/isa/x64/lower.isle line 1439.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pminud(ctx, expr0_0, &expr1_0)?;
@@ -4072,7 +4143,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1481.
+                            // Rule at src/isa/x64/lower.isle line 1406.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxsd(ctx, expr0_0, &expr1_0)?;
@@ -4081,7 +4152,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1503.
+                            // Rule at src/isa/x64/lower.isle line 1428.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_pmaxud(ctx, expr0_0, &expr1_0)?;
@@ -4090,7 +4161,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 642.
+                            // Rule at src/isa/x64/lower.isle line 588.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -4100,7 +4171,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 748.
+                            // Rule at src/isa/x64/lower.isle line 690.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -4110,7 +4181,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 849.
+                            // Rule at src/isa/x64/lower.isle line 788.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -4127,7 +4198,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 972.
+                            // Rule at src/isa/x64/lower.isle line 904.
                             let expr0_0: Type = I32X4;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
@@ -4138,7 +4209,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1300.
+                            // Rule at src/isa/x64/lower.isle line 1225.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
                             let expr1_0 = constructor_pabsd(ctx, &expr0_0)?;
                             let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
@@ -4160,7 +4231,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 646.
+                            // Rule at src/isa/x64/lower.isle line 591.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -4170,7 +4241,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 752.
+                            // Rule at src/isa/x64/lower.isle line 693.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
@@ -4180,7 +4251,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 861.
+                            // Rule at src/isa/x64/lower.isle line 799.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0: Type = I64;
                             let expr2_0: u8 = 0;
@@ -4210,7 +4281,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 976.
+                            // Rule at src/isa/x64/lower.isle line 907.
                             let expr0_0: Type = I64X2;
                             let expr1_0: u64 = 0;
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
@@ -4221,7 +4292,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
-                            // Rule at src/isa/x64/lower.isle line 1314.
+                            // Rule at src/isa/x64/lower.isle line 1239.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                             let expr1_0: Type = I64X2;
                             let expr2_0: u64 = 0;
@@ -4248,13 +4319,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } = &pattern4_0
             {
                 if let &Opcode::Fabs = pattern5_0 {
-                    // Rule at src/isa/x64/lower.isle line 1322.
+                    // Rule at src/isa/x64/lower.isle line 1247.
                     let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                     let expr1_0: Type = F32X4;
                     let expr2_0 = constructor_vector_all_ones(ctx, expr1_0)?;
                     let expr3_0: u32 = 1;
                     let expr4_0 = RegMemImm::Imm { simm32: expr3_0 };
-                    let expr5_0 = C::xmm_mem_imm_new(ctx, &expr4_0);
+                    let expr5_0 = constructor_mov_rmi_to_xmm(ctx, &expr4_0)?;
                     let expr6_0 = constructor_psrld(ctx, expr2_0, &expr5_0)?;
                     let expr7_0 = C::xmm_to_xmm_mem(ctx, expr6_0);
                     let expr8_0 = constructor_andps(ctx, expr0_0, &expr7_0)?;
@@ -4271,13 +4342,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } = &pattern4_0
             {
                 if let &Opcode::Fabs = pattern5_0 {
-                    // Rule at src/isa/x64/lower.isle line 1328.
+                    // Rule at src/isa/x64/lower.isle line 1253.
                     let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                     let expr1_0: Type = F64X2;
                     let expr2_0 = constructor_vector_all_ones(ctx, expr1_0)?;
                     let expr3_0: u32 = 1;
                     let expr4_0 = RegMemImm::Imm { simm32: expr3_0 };
-                    let expr5_0 = C::xmm_mem_imm_new(ctx, &expr4_0);
+                    let expr5_0 = constructor_mov_rmi_to_xmm(ctx, &expr4_0)?;
                     let expr6_0 = constructor_psrlq(ctx, expr2_0, &expr5_0)?;
                     let expr7_0 = C::xmm_to_xmm_mem(ctx, expr6_0);
                     let expr8_0 = constructor_andpd(ctx, expr0_0, &expr7_0)?;
@@ -4305,7 +4376,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
             } => {
                 if let &Opcode::BandNot = pattern4_0 {
                     let (pattern6_0, pattern6_1) = C::unpack_value_array_2(ctx, pattern4_1);
-                    // Rule at src/isa/x64/lower.isle line 1287.
+                    // Rule at src/isa/x64/lower.isle line 1214.
                     let expr0_0 = constructor_put_in_xmm(ctx, pattern6_1)?;
                     let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern6_0)?;
                     let expr2_0 = constructor_sse_and_not(ctx, pattern2_0, expr0_0, &expr1_0)?;
@@ -4333,7 +4404,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                     C::unpack_value_array_2(ctx, pattern9_1);
                                 match pattern9_2 {
                                     &FloatCC::Equal => {
-                                        // Rule at src/isa/x64/lower.isle line 1608.
+                                        // Rule at src/isa/x64/lower.isle line 1533.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NZ;
@@ -4347,7 +4418,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr4_0);
                                     }
                                     &FloatCC::GreaterThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1560.
+                                        // Rule at src/isa/x64/lower.isle line 1485.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NBE;
@@ -4359,7 +4430,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::GreaterThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1563.
+                                        // Rule at src/isa/x64/lower.isle line 1488.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NB;
@@ -4371,7 +4442,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::LessThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1583.
+                                        // Rule at src/isa/x64/lower.isle line 1508.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NBE;
@@ -4383,7 +4454,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::LessThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1586.
+                                        // Rule at src/isa/x64/lower.isle line 1511.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NB;
@@ -4395,7 +4466,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::NotEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1611.
+                                        // Rule at src/isa/x64/lower.isle line 1536.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NZ;
@@ -4409,7 +4480,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr4_0);
                                     }
                                     &FloatCC::Ordered => {
-                                        // Rule at src/isa/x64/lower.isle line 1554.
+                                        // Rule at src/isa/x64/lower.isle line 1479.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NP;
@@ -4421,7 +4492,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::Unordered => {
-                                        // Rule at src/isa/x64/lower.isle line 1557.
+                                        // Rule at src/isa/x64/lower.isle line 1482.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::P;
@@ -4433,7 +4504,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::UnorderedOrGreaterThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1589.
+                                        // Rule at src/isa/x64/lower.isle line 1514.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::B;
@@ -4445,7 +4516,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::UnorderedOrGreaterThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1592.
+                                        // Rule at src/isa/x64/lower.isle line 1517.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::BE;
@@ -4457,7 +4528,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::UnorderedOrLessThan => {
-                                        // Rule at src/isa/x64/lower.isle line 1566.
+                                        // Rule at src/isa/x64/lower.isle line 1491.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::B;
@@ -4469,7 +4540,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         return Some(expr3_0);
                                     }
                                     &FloatCC::UnorderedOrLessThanOrEqual => {
-                                        // Rule at src/isa/x64/lower.isle line 1569.
+                                        // Rule at src/isa/x64/lower.isle line 1494.
                                         let expr0_0 =
                                             constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::BE;
@@ -4503,7 +4574,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 if let &Opcode::Imul = pattern9_0 {
                                     let (pattern11_0, pattern11_1) =
                                         C::unpack_value_array_2(ctx, pattern9_1);
-                                    // Rule at src/isa/x64/lower.isle line 1074.
+                                    // Rule at src/isa/x64/lower.isle line 1001.
                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern11_0)?;
                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern11_1)?;
                                     let expr2_0 = constructor_vpmullq(ctx, &expr0_0, expr1_0)?;
@@ -4524,7 +4595,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     } = &pattern6_0
                     {
                         if let &Opcode::Iabs = pattern7_0 {
-                            // Rule at src/isa/x64/lower.isle line 1304.
+                            // Rule at src/isa/x64/lower.isle line 1229.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr1_0 = constructor_vpabsq(ctx, &expr0_0)?;
                             let expr2_0 = constructor_value_xmm(ctx, expr1_0)?;
@@ -4547,7 +4618,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::AvgRound => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 982.
+                                // Rule at src/isa/x64/lower.isle line 912.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pavgb(ctx, expr0_0, &expr1_0)?;
@@ -4557,7 +4628,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::UaddSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 144.
+                                // Rule at src/isa/x64/lower.isle line 136.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddusb(ctx, expr0_0, &expr1_0)?;
@@ -4567,7 +4638,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::SaddSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 132.
+                                // Rule at src/isa/x64/lower.isle line 126.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddsb(ctx, expr0_0, &expr1_0)?;
@@ -4577,7 +4648,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::UsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 313.
+                                // Rule at src/isa/x64/lower.isle line 291.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubusb(ctx, expr0_0, &expr1_0)?;
@@ -4587,7 +4658,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::SsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 301.
+                                // Rule at src/isa/x64/lower.isle line 281.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubsb(ctx, expr0_0, &expr1_0)?;
@@ -4597,7 +4668,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Iadd => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 96.
+                                // Rule at src/isa/x64/lower.isle line 94.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddb(ctx, expr0_0, &expr1_0)?;
@@ -4607,7 +4678,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 265.
+                                // Rule at src/isa/x64/lower.isle line 249.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubb(ctx, expr0_0, &expr1_0)?;
@@ -4631,7 +4702,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::AvgRound => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 986.
+                                // Rule at src/isa/x64/lower.isle line 916.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pavgw(ctx, expr0_0, &expr1_0)?;
@@ -4641,7 +4712,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::UaddSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 149.
+                                // Rule at src/isa/x64/lower.isle line 140.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddusw(ctx, expr0_0, &expr1_0)?;
@@ -4651,7 +4722,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::SaddSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 137.
+                                // Rule at src/isa/x64/lower.isle line 130.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddsw(ctx, expr0_0, &expr1_0)?;
@@ -4661,7 +4732,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::UsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 318.
+                                // Rule at src/isa/x64/lower.isle line 295.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubusw(ctx, expr0_0, &expr1_0)?;
@@ -4671,7 +4742,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::SsubSat => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 306.
+                                // Rule at src/isa/x64/lower.isle line 285.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubsw(ctx, expr0_0, &expr1_0)?;
@@ -4681,7 +4752,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Iadd => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 101.
+                                // Rule at src/isa/x64/lower.isle line 98.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddw(ctx, expr0_0, &expr1_0)?;
@@ -4691,7 +4762,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 270.
+                                // Rule at src/isa/x64/lower.isle line 253.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubw(ctx, expr0_0, &expr1_0)?;
@@ -4744,7 +4815,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1162.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1089.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_pmovsxbw(ctx, &expr0_0)?;
                                                                                     let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
@@ -4800,7 +4871,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1122.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1049.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                                                                                     let expr2_0: u8 = 8;
@@ -4866,7 +4937,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1238.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1165.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_pmovzxbw(ctx, &expr0_0)?;
                                                                                     let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
@@ -4922,7 +4993,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 8 {
                                                                                 if pattern23_1 == 16
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1198.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1125.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                                                                                     let expr2_0: u8 = 8;
@@ -4957,7 +5028,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         }
                                     }
                                 }
-                                // Rule at src/isa/x64/lower.isle line 1066.
+                                // Rule at src/isa/x64/lower.isle line 993.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pmullw(ctx, expr0_0, &expr1_0)?;
@@ -4981,7 +5052,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Iadd => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 106.
+                                // Rule at src/isa/x64/lower.isle line 102.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddd(ctx, expr0_0, &expr1_0)?;
@@ -4991,7 +5062,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 275.
+                                // Rule at src/isa/x64/lower.isle line 257.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubd(ctx, expr0_0, &expr1_0)?;
@@ -5044,7 +5115,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1172.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1099.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5102,7 +5173,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1136.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1063.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5160,7 +5231,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1248.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1175.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5218,7 +5289,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 16 {
                                                                                 if pattern23_1 == 8
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1212.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1139.
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5245,7 +5316,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         }
                                     }
                                 }
-                                // Rule at src/isa/x64/lower.isle line 1069.
+                                // Rule at src/isa/x64/lower.isle line 996.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_pmulld(ctx, expr0_0, &expr1_0)?;
@@ -5269,7 +5340,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Iadd => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 111.
+                                // Rule at src/isa/x64/lower.isle line 106.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_paddq(ctx, expr0_0, &expr1_0)?;
@@ -5279,7 +5350,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             &Opcode::Isub => {
                                 let (pattern9_0, pattern9_1) =
                                     C::unpack_value_array_2(ctx, pattern7_1);
-                                // Rule at src/isa/x64/lower.isle line 280.
+                                // Rule at src/isa/x64/lower.isle line 261.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
                                 let expr2_0 = constructor_psubq(ctx, expr0_0, &expr1_0)?;
@@ -5332,7 +5403,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1184.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1111.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 80;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5392,7 +5463,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1148.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1075.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 250;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5452,7 +5523,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1260.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1187.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 80;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5512,7 +5583,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                                                             if pattern23_0 == 32 {
                                                                                 if pattern23_1 == 4
                                                                                 {
-                                                                                    // Rule at src/isa/x64/lower.isle line 1224.
+                                                                                    // Rule at src/isa/x64/lower.isle line 1151.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 250;
                                                                                     let expr2_0 = OperandSize::Size32;
@@ -5541,18 +5612,18 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                         }
                                     }
                                 }
-                                // Rule at src/isa/x64/lower.isle line 1100.
+                                // Rule at src/isa/x64/lower.isle line 1027.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm(ctx, pattern9_1)?;
                                 let expr2_0: u32 = 32;
                                 let expr3_0 = RegMemImm::Imm { simm32: expr2_0 };
-                                let expr4_0 = C::xmm_mem_imm_new(ctx, &expr3_0);
+                                let expr4_0 = constructor_mov_rmi_to_xmm(ctx, &expr3_0)?;
                                 let expr5_0 = constructor_psrlq(ctx, expr0_0, &expr4_0)?;
                                 let expr6_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
                                 let expr7_0 = constructor_pmuludq(ctx, expr5_0, &expr6_0)?;
                                 let expr8_0: u32 = 32;
                                 let expr9_0 = RegMemImm::Imm { simm32: expr8_0 };
-                                let expr10_0 = C::xmm_mem_imm_new(ctx, &expr9_0);
+                                let expr10_0 = constructor_mov_rmi_to_xmm(ctx, &expr9_0)?;
                                 let expr11_0 = constructor_psrlq(ctx, expr1_0, &expr10_0)?;
                                 let expr12_0 = C::xmm_to_xmm_mem(ctx, expr11_0);
                                 let expr13_0 = constructor_pmuludq(ctx, expr0_0, &expr12_0)?;
@@ -5560,7 +5631,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr15_0 = constructor_paddq(ctx, expr7_0, &expr14_0)?;
                                 let expr16_0: u32 = 32;
                                 let expr17_0 = RegMemImm::Imm { simm32: expr16_0 };
-                                let expr18_0 = C::xmm_mem_imm_new(ctx, &expr17_0);
+                                let expr18_0 = constructor_mov_rmi_to_xmm(ctx, &expr17_0)?;
                                 let expr19_0 = constructor_psllq(ctx, expr15_0, &expr18_0)?;
                                 let expr20_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
                                 let expr21_0 = constructor_pmuludq(ctx, expr0_0, &expr20_0)?;
@@ -5583,7 +5654,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 368.
+                            // Rule at src/isa/x64/lower.isle line 337.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sse_and(ctx, pattern2_0, expr0_0, &expr1_0)?;
@@ -5592,7 +5663,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 442.
+                            // Rule at src/isa/x64/lower.isle line 401.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sse_or(ctx, pattern2_0, expr0_0, &expr1_0)?;
@@ -5601,7 +5672,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 513.
+                            // Rule at src/isa/x64/lower.isle line 462.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sse_xor(ctx, pattern2_0, expr0_0, &expr1_0)?;
@@ -5619,7 +5690,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::Bitselect => {
                             let (pattern7_0, pattern7_1, pattern7_2) =
                                 C::unpack_value_array_3(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1363.
+                            // Rule at src/isa/x64/lower.isle line 1288.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr2_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
@@ -5635,7 +5706,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::Vselect => {
                             let (pattern7_0, pattern7_1, pattern7_2) =
                                 C::unpack_value_array_3(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1377.
+                            // Rule at src/isa/x64/lower.isle line 1302.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_put_in_xmm(ctx, pattern7_2)?;
@@ -5653,7 +5724,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Bnot = pattern5_0 {
-                        // Rule at src/isa/x64/lower.isle line 1358.
+                        // Rule at src/isa/x64/lower.isle line 1283.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                         let expr1_0 = constructor_vector_all_ones(ctx, pattern2_0)?;
                         let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -5708,7 +5779,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                     match pattern5_0 {
                         &Opcode::Imin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1467.
+                            // Rule at src/isa/x64/lower.isle line 1392.
                             let expr0_0 = CC::L;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
@@ -5717,7 +5788,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umin => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1461.
+                            // Rule at src/isa/x64/lower.isle line 1386.
                             let expr0_0 = CC::B;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
@@ -5726,7 +5797,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Imax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1470.
+                            // Rule at src/isa/x64/lower.isle line 1395.
                             let expr0_0 = CC::NL;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
@@ -5735,7 +5806,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Umax => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 1464.
+                            // Rule at src/isa/x64/lower.isle line 1389.
                             let expr0_0 = CC::NB;
                             let expr1_0 = constructor_cmp_and_choose(
                                 ctx, pattern3_0, &expr0_0, pattern7_0, pattern7_1,
@@ -5745,7 +5816,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::Iadd => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 76.
+                                // Rule at src/isa/x64/lower.isle line 74.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5753,7 +5824,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 88.
+                                // Rule at src/isa/x64/lower.isle line 86.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5762,7 +5833,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 72.
+                                // Rule at src/isa/x64/lower.isle line 70.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5770,7 +5841,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 82.
+                                // Rule at src/isa/x64/lower.isle line 80.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5780,16 +5851,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             }
                             // Rule at src/isa/x64/lower.isle line 64.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
-                            let expr1_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
-                            let expr2_0 = C::gpr_to_gpr_mem_imm(ctx, expr1_0);
-                            let expr3_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr2_0)?;
-                            let expr4_0 = constructor_value_gpr(ctx, expr3_0)?;
-                            return Some(expr4_0);
+                            let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
+                            let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
+                            return Some(expr3_0);
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 252.
+                                // Rule at src/isa/x64/lower.isle line 237.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sub(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5797,7 +5867,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 257.
+                                // Rule at src/isa/x64/lower.isle line 242.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5805,7 +5875,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 245.
+                            // Rule at src/isa/x64/lower.isle line 232.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, &expr1_0)?;
@@ -5815,7 +5885,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 1006.
+                                // Rule at src/isa/x64/lower.isle line 934.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5823,7 +5893,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 1018.
+                                // Rule at src/isa/x64/lower.isle line 946.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5832,7 +5902,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 1002.
+                                // Rule at src/isa/x64/lower.isle line 930.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5840,7 +5910,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 1012.
+                                // Rule at src/isa/x64/lower.isle line 940.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5848,7 +5918,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 995.
+                            // Rule at src/isa/x64/lower.isle line 925.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
@@ -5858,60 +5928,55 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::IaddIfcout => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 183.
-                                let expr0_0 = C::temp_writable_gpr(ctx);
-                                let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-                                let expr2_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
-                                let expr3_0 =
-                                    constructor_add(ctx, pattern3_0, expr2_0, &pattern8_0)?;
-                                let expr4_0 = constructor_value_gprs(ctx, expr3_0, expr1_0)?;
-                                return Some(expr4_0);
+                                // Rule at src/isa/x64/lower.isle line 173.
+                                let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
+                                let expr1_0 =
+                                    constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                let expr2_0 = constructor_unused_iflags(ctx)?;
+                                let expr3_0 = constructor_value_gprs(ctx, expr1_0, expr2_0)?;
+                                return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 199.
-                                let expr0_0 = C::temp_writable_gpr(ctx);
-                                let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-                                let expr2_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
-                                let expr3_0 =
+                                // Rule at src/isa/x64/lower.isle line 187.
+                                let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
+                                let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr4_0 = constructor_add(ctx, pattern3_0, expr2_0, &expr3_0)?;
-                                let expr5_0 = constructor_value_gprs(ctx, expr4_0, expr1_0)?;
-                                return Some(expr5_0);
-                            }
-                            if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 177.
-                                let expr0_0 = C::temp_writable_gpr(ctx);
-                                let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-                                let expr2_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
-                                let expr3_0 =
-                                    constructor_add(ctx, pattern3_0, expr2_0, &pattern8_0)?;
-                                let expr4_0 = constructor_value_gprs(ctx, expr3_0, expr1_0)?;
+                                let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr3_0 = constructor_unused_iflags(ctx)?;
+                                let expr4_0 = constructor_value_gprs(ctx, expr2_0, expr3_0)?;
                                 return Some(expr4_0);
                             }
-                            if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 191.
-                                let expr0_0 = C::temp_writable_gpr(ctx);
-                                let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-                                let expr2_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
-                                let expr3_0 =
-                                    constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr4_0 = constructor_add(ctx, pattern3_0, expr2_0, &expr3_0)?;
-                                let expr5_0 = constructor_value_gprs(ctx, expr4_0, expr1_0)?;
-                                return Some(expr5_0);
+                            if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
+                                // Rule at src/isa/x64/lower.isle line 168.
+                                let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
+                                let expr1_0 =
+                                    constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                let expr2_0 = constructor_unused_iflags(ctx)?;
+                                let expr3_0 = constructor_value_gprs(ctx, expr1_0, expr2_0)?;
+                                return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 167.
-                            let expr0_0 = C::temp_writable_gpr(ctx);
-                            let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
-                            let expr2_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
-                            let expr3_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
-                            let expr4_0 = constructor_add(ctx, pattern3_0, expr2_0, &expr3_0)?;
-                            let expr5_0 = constructor_value_gprs(ctx, expr4_0, expr1_0)?;
-                            return Some(expr5_0);
+                            if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
+                                // Rule at src/isa/x64/lower.isle line 180.
+                                let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
+                                let expr1_0 =
+                                    constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
+                                let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr3_0 = constructor_unused_iflags(ctx)?;
+                                let expr4_0 = constructor_value_gprs(ctx, expr2_0, expr3_0)?;
+                                return Some(expr4_0);
+                            }
+                            // Rule at src/isa/x64/lower.isle line 161.
+                            let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
+                            let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
+                            let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr3_0 = constructor_unused_iflags(ctx)?;
+                            let expr4_0 = constructor_value_gprs(ctx, expr2_0, expr3_0)?;
+                            return Some(expr4_0);
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 355.
+                                // Rule at src/isa/x64/lower.isle line 326.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_x64_and(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5919,7 +5984,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 341.
+                                // Rule at src/isa/x64/lower.isle line 314.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5929,7 +5994,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 349.
+                                // Rule at src/isa/x64/lower.isle line 322.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_x64_and(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5937,7 +6002,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 335.
+                                // Rule at src/isa/x64/lower.isle line 309.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5946,7 +6011,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 328.
+                            // Rule at src/isa/x64/lower.isle line 304.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_x64_and(ctx, pattern3_0, expr0_0, &expr1_0)?;
@@ -5956,7 +6021,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 429.
+                                // Rule at src/isa/x64/lower.isle line 390.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5964,7 +6029,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 415.
+                                // Rule at src/isa/x64/lower.isle line 379.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5973,7 +6038,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 423.
+                                // Rule at src/isa/x64/lower.isle line 386.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -5981,7 +6046,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 409.
+                                // Rule at src/isa/x64/lower.isle line 374.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -5989,7 +6054,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 402.
+                            // Rule at src/isa/x64/lower.isle line 369.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
@@ -5999,7 +6064,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 505.
+                                // Rule at src/isa/x64/lower.isle line 456.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -6007,7 +6072,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_0) {
-                                // Rule at src/isa/x64/lower.isle line 491.
+                                // Rule at src/isa/x64/lower.isle line 445.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -6016,7 +6081,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr3_0);
                             }
                             if let Some(pattern8_0) = C::simm32_from_value(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 499.
+                                // Rule at src/isa/x64/lower.isle line 452.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
@@ -6024,7 +6089,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 return Some(expr2_0);
                             }
                             if let Some(pattern8_0) = C::sinkable_load(ctx, pattern7_1) {
-                                // Rule at src/isa/x64/lower.isle line 485.
+                                // Rule at src/isa/x64/lower.isle line 440.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
@@ -6032,7 +6097,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 let expr3_0 = constructor_value_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
-                            // Rule at src/isa/x64/lower.isle line 478.
+                            // Rule at src/isa/x64/lower.isle line 435.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
                             let expr2_0 = constructor_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
@@ -6041,7 +6106,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 543.
+                            // Rule at src/isa/x64/lower.isle line 492.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, pattern3_0);
                             let expr2_0 = constructor_shl(ctx, pattern3_0, expr0_0, &expr1_0)?;
@@ -6050,7 +6115,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 654.
+                            // Rule at src/isa/x64/lower.isle line 598.
                             let expr0_0 = ExtendKind::Zero;
                             let expr1_0 =
                                 constructor_extend_to_gpr(ctx, pattern7_0, pattern3_0, &expr0_0)?;
@@ -6061,7 +6126,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/x64/lower.isle line 760.
+                            // Rule at src/isa/x64/lower.isle line 700.
                             let expr0_0 = ExtendKind::Sign;
                             let expr1_0 =
                                 constructor_extend_to_gpr(ctx, pattern7_0, pattern3_0, &expr0_0)?;
@@ -6079,14 +6144,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/x64/lower.isle line 959.
+                            // Rule at src/isa/x64/lower.isle line 893.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
                             let expr1_0 = constructor_neg(ctx, pattern3_0, expr0_0)?;
                             let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         &Opcode::Bnot => {
-                            // Rule at src/isa/x64/lower.isle line 1337.
+                            // Rule at src/isa/x64/lower.isle line 1262.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
                             let expr1_0 = constructor_not(ctx, pattern3_0, expr0_0)?;
                             let expr2_0 = constructor_value_gpr(ctx, expr1_0)?;
@@ -6102,14 +6167,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                 } => {
                     if let &Opcode::IaddImm = pattern5_0 {
                         let pattern7_0 = C::u64_from_imm64(ctx, pattern5_2);
-                        // Rule at src/isa/x64/lower.isle line 218.
+                        // Rule at src/isa/x64/lower.isle line 205.
                         let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
                         let expr1_0 = constructor_imm(ctx, pattern3_0, pattern7_0)?;
-                        let expr2_0 = C::gpr_new(ctx, expr1_0);
-                        let expr3_0 = C::gpr_to_gpr_mem_imm(ctx, expr2_0);
-                        let expr4_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr3_0)?;
-                        let expr5_0 = constructor_value_gpr(ctx, expr4_0)?;
-                        return Some(expr5_0);
+                        let expr2_0 = constructor_reg_to_gpr_mem_imm(ctx, expr1_0)?;
+                        let expr3_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr2_0)?;
+                        let expr4_0 = constructor_value_gpr(ctx, expr3_0)?;
+                        return Some(expr4_0);
                     }
                 }
                 _ => {}
@@ -6134,7 +6198,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 895.
+                                    // Rule at src/isa/x64/lower.isle line 832.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
@@ -6145,7 +6209,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 889.
+                        // Rule at src/isa/x64/lower.isle line 826.
                         let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                         let expr2_0 = C::gpr_to_imm8_gpr(ctx, expr0_0);
@@ -6164,7 +6228,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 937.
+                                    // Rule at src/isa/x64/lower.isle line 872.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
@@ -6175,7 +6239,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 931.
+                        // Rule at src/isa/x64/lower.isle line 866.
                         let expr0_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                         let expr2_0 = C::gpr_to_imm8_gpr(ctx, expr0_0);
@@ -6206,7 +6270,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 880.
+                                    // Rule at src/isa/x64/lower.isle line 818.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
@@ -6217,7 +6281,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 876.
+                        // Rule at src/isa/x64/lower.isle line 814.
                         let expr0_0: Type = I32;
                         let expr1_0 = ExtendKind::Zero;
                         let expr2_0 =
@@ -6239,7 +6303,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                             {
                                 if let &Opcode::Iconst = pattern10_0 {
                                     let pattern12_0 = C::u64_from_imm64(ctx, pattern10_1);
-                                    // Rule at src/isa/x64/lower.isle line 922.
+                                    // Rule at src/isa/x64/lower.isle line 858.
                                     let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                     let expr1_0 =
                                         C::const_to_type_masked_imm8(ctx, pattern12_0, pattern3_0);
@@ -6250,7 +6314,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
                                 }
                             }
                         }
-                        // Rule at src/isa/x64/lower.isle line 918.
+                        // Rule at src/isa/x64/lower.isle line 854.
                         let expr0_0: Type = I32;
                         let expr1_0 = ExtendKind::Zero;
                         let expr2_0 =
@@ -6269,6 +6333,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<ValueReg
     return None;
 }
 
+// Generated as internal constructor for term unused_iflags.
+pub fn constructor_unused_iflags<C: Context>(ctx: &mut C) -> Option<Gpr> {
+    // Rule at src/isa/x64/lower.isle line 157.
+    let expr0_0 = C::temp_writable_gpr(ctx);
+    let expr1_0 = C::writable_gpr_to_gpr(ctx, expr0_0);
+    return Some(expr1_0);
+}
+
 // Generated as internal constructor for term sse_and.
 pub fn constructor_sse_and<C: Context>(
     ctx: &mut C,
@@ -6280,21 +6352,21 @@ pub fn constructor_sse_and<C: Context>(
     if pattern0_0 == F32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 364.
+        // Rule at src/isa/x64/lower.isle line 333.
         let expr0_0 = constructor_andps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 365.
+        // Rule at src/isa/x64/lower.isle line 334.
         let expr0_0 = constructor_andpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 366.
+        // Rule at src/isa/x64/lower.isle line 335.
         let expr0_0 = constructor_pand(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -6312,21 +6384,21 @@ pub fn constructor_sse_or<C: Context>(
     if pattern0_0 == F32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 438.
+        // Rule at src/isa/x64/lower.isle line 397.
         let expr0_0 = constructor_orps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 439.
+        // Rule at src/isa/x64/lower.isle line 398.
         let expr0_0 = constructor_orpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 440.
+        // Rule at src/isa/x64/lower.isle line 399.
         let expr0_0 = constructor_por(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -6341,7 +6413,7 @@ pub fn constructor_or_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 451.
+    // Rule at src/isa/x64/lower.isle line 408.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6368,7 +6440,7 @@ pub fn constructor_shl_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 549.
+    // Rule at src/isa/x64/lower.isle line 498.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6433,12 +6505,12 @@ pub fn constructor_ishl_i8x16_mask<C: Context>(
     let pattern0_0 = arg0;
     match pattern0_0 {
         &RegMemImm::Imm { simm32: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 614.
+            // Rule at src/isa/x64/lower.isle line 561.
             let expr0_0 = C::ishl_i8x16_mask_for_const(ctx, pattern1_0);
             return Some(expr0_0);
         }
         &RegMemImm::Reg { reg: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 623.
+            // Rule at src/isa/x64/lower.isle line 570.
             let expr0_0 = C::ishl_i8x16_mask_table(ctx);
             let expr1_0 = constructor_lea(ctx, &expr0_0)?;
             let expr2_0: Type = I64;
@@ -6455,7 +6527,7 @@ pub fn constructor_ishl_i8x16_mask<C: Context>(
         &RegMemImm::Mem {
             addr: ref pattern1_0,
         } => {
-            // Rule at src/isa/x64/lower.isle line 633.
+            // Rule at src/isa/x64/lower.isle line 580.
             let expr0_0: Type = I64;
             let expr1_0 = ExtKind::None;
             let expr2_0 = constructor_x64_load(ctx, expr0_0, pattern1_0, &expr1_0)?;
@@ -6476,7 +6548,7 @@ pub fn constructor_shr_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 661.
+    // Rule at src/isa/x64/lower.isle line 605.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6507,34 +6579,33 @@ pub fn constructor_shr_i128<C: Context>(
     let expr27_0: Type = I64;
     let expr28_0: u64 = 0;
     let expr29_0 = constructor_imm(ctx, expr27_0, expr28_0)?;
-    let expr30_0 = C::gpr_new(ctx, expr29_0);
-    let expr31_0 = C::gpr_to_gpr_mem(ctx, expr30_0);
-    let expr32_0 = constructor_cmove(ctx, expr25_0, &expr26_0, &expr31_0, expr19_0)?;
-    let expr33_0 = constructor_with_flags_reg(ctx, &expr24_0, &expr32_0)?;
-    let expr34_0 = C::gpr_new(ctx, expr33_0);
-    let expr35_0: Type = I64;
-    let expr36_0 = C::gpr_to_gpr_mem_imm(ctx, expr6_0);
-    let expr37_0 = constructor_or(ctx, expr35_0, expr34_0, &expr36_0)?;
-    let expr38_0 = OperandSize::Size64;
-    let expr39_0: u32 = 64;
-    let expr40_0 = RegMemImm::Imm { simm32: expr39_0 };
-    let expr41_0 = C::gpr_mem_imm_new(ctx, &expr40_0);
-    let expr42_0 = constructor_test(ctx, &expr38_0, &expr41_0, pattern1_0)?;
-    let expr43_0: Type = I64;
-    let expr44_0 = CC::Z;
-    let expr45_0 = C::gpr_to_gpr_mem(ctx, expr37_0);
-    let expr46_0 = constructor_cmove(ctx, expr43_0, &expr44_0, &expr45_0, expr9_0)?;
-    let expr47_0: Type = I64;
-    let expr48_0 = CC::Z;
-    let expr49_0 = C::gpr_to_gpr_mem(ctx, expr9_0);
-    let expr50_0: Type = I64;
-    let expr51_0: u64 = 0;
-    let expr52_0 = constructor_imm(ctx, expr50_0, expr51_0)?;
-    let expr53_0 = C::gpr_new(ctx, expr52_0);
-    let expr54_0 = constructor_cmove(ctx, expr47_0, &expr48_0, &expr49_0, expr53_0)?;
-    let expr55_0 = constructor_consumes_flags_concat(ctx, &expr46_0, &expr54_0)?;
-    let expr56_0 = constructor_with_flags(ctx, &expr42_0, &expr55_0)?;
-    return Some(expr56_0);
+    let expr30_0 = C::reg_to_gpr_mem(ctx, expr29_0);
+    let expr31_0 = constructor_cmove(ctx, expr25_0, &expr26_0, &expr30_0, expr19_0)?;
+    let expr32_0 = constructor_with_flags_reg(ctx, &expr24_0, &expr31_0)?;
+    let expr33_0 = C::gpr_new(ctx, expr32_0);
+    let expr34_0: Type = I64;
+    let expr35_0 = C::gpr_to_gpr_mem_imm(ctx, expr6_0);
+    let expr36_0 = constructor_or(ctx, expr34_0, expr33_0, &expr35_0)?;
+    let expr37_0 = OperandSize::Size64;
+    let expr38_0: u32 = 64;
+    let expr39_0 = RegMemImm::Imm { simm32: expr38_0 };
+    let expr40_0 = C::gpr_mem_imm_new(ctx, &expr39_0);
+    let expr41_0 = constructor_test(ctx, &expr37_0, &expr40_0, pattern1_0)?;
+    let expr42_0: Type = I64;
+    let expr43_0 = CC::Z;
+    let expr44_0 = C::gpr_to_gpr_mem(ctx, expr36_0);
+    let expr45_0 = constructor_cmove(ctx, expr42_0, &expr43_0, &expr44_0, expr9_0)?;
+    let expr46_0: Type = I64;
+    let expr47_0 = CC::Z;
+    let expr48_0 = C::gpr_to_gpr_mem(ctx, expr9_0);
+    let expr49_0: Type = I64;
+    let expr50_0: u64 = 0;
+    let expr51_0 = constructor_imm(ctx, expr49_0, expr50_0)?;
+    let expr52_0 = C::gpr_new(ctx, expr51_0);
+    let expr53_0 = constructor_cmove(ctx, expr46_0, &expr47_0, &expr48_0, expr52_0)?;
+    let expr54_0 = constructor_consumes_flags_concat(ctx, &expr45_0, &expr53_0)?;
+    let expr55_0 = constructor_with_flags(ctx, &expr41_0, &expr54_0)?;
+    return Some(expr55_0);
 }
 
 // Generated as internal constructor for term ushr_i8x16_mask.
@@ -6545,12 +6616,12 @@ pub fn constructor_ushr_i8x16_mask<C: Context>(
     let pattern0_0 = arg0;
     match pattern0_0 {
         &RegMemImm::Imm { simm32: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 720.
+            // Rule at src/isa/x64/lower.isle line 662.
             let expr0_0 = C::ushr_i8x16_mask_for_const(ctx, pattern1_0);
             return Some(expr0_0);
         }
         &RegMemImm::Reg { reg: pattern1_0 } => {
-            // Rule at src/isa/x64/lower.isle line 729.
+            // Rule at src/isa/x64/lower.isle line 671.
             let expr0_0 = C::ushr_i8x16_mask_table(ctx);
             let expr1_0 = constructor_lea(ctx, &expr0_0)?;
             let expr2_0: Type = I64;
@@ -6567,7 +6638,7 @@ pub fn constructor_ushr_i8x16_mask<C: Context>(
         &RegMemImm::Mem {
             addr: ref pattern1_0,
         } => {
-            // Rule at src/isa/x64/lower.isle line 739.
+            // Rule at src/isa/x64/lower.isle line 682.
             let expr0_0: Type = I64;
             let expr1_0 = ExtKind::None;
             let expr2_0 = constructor_x64_load(ctx, expr0_0, pattern1_0, &expr1_0)?;
@@ -6588,7 +6659,7 @@ pub fn constructor_sar_i128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/lower.isle line 767.
+    // Rule at src/isa/x64/lower.isle line 707.
     let expr0_0: usize = 0;
     let expr1_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr0_0)?;
     let expr2_0: usize = 1;
@@ -6619,34 +6690,33 @@ pub fn constructor_sar_i128<C: Context>(
     let expr27_0: Type = I64;
     let expr28_0: u64 = 0;
     let expr29_0 = constructor_imm(ctx, expr27_0, expr28_0)?;
-    let expr30_0 = C::gpr_new(ctx, expr29_0);
-    let expr31_0 = C::gpr_to_gpr_mem(ctx, expr30_0);
-    let expr32_0 = constructor_cmove(ctx, expr25_0, &expr26_0, &expr31_0, expr19_0)?;
-    let expr33_0 = constructor_with_flags_reg(ctx, &expr24_0, &expr32_0)?;
-    let expr34_0 = C::gpr_new(ctx, expr33_0);
-    let expr35_0: Type = I64;
-    let expr36_0 = C::gpr_to_gpr_mem_imm(ctx, expr34_0);
-    let expr37_0 = constructor_or(ctx, expr35_0, expr6_0, &expr36_0)?;
-    let expr38_0: Type = I64;
-    let expr39_0: u8 = 63;
-    let expr40_0 = C::imm8_to_imm8_gpr(ctx, expr39_0);
-    let expr41_0 = constructor_sar(ctx, expr38_0, expr3_0, &expr40_0)?;
-    let expr42_0 = OperandSize::Size64;
-    let expr43_0: u32 = 64;
-    let expr44_0 = RegMemImm::Imm { simm32: expr43_0 };
-    let expr45_0 = C::gpr_mem_imm_new(ctx, &expr44_0);
-    let expr46_0 = constructor_test(ctx, &expr42_0, &expr45_0, pattern1_0)?;
-    let expr47_0: Type = I64;
-    let expr48_0 = CC::Z;
-    let expr49_0 = C::gpr_to_gpr_mem(ctx, expr37_0);
-    let expr50_0 = constructor_cmove(ctx, expr47_0, &expr48_0, &expr49_0, expr9_0)?;
-    let expr51_0: Type = I64;
-    let expr52_0 = CC::Z;
-    let expr53_0 = C::gpr_to_gpr_mem(ctx, expr9_0);
-    let expr54_0 = constructor_cmove(ctx, expr51_0, &expr52_0, &expr53_0, expr41_0)?;
-    let expr55_0 = constructor_consumes_flags_concat(ctx, &expr50_0, &expr54_0)?;
-    let expr56_0 = constructor_with_flags(ctx, &expr46_0, &expr55_0)?;
-    return Some(expr56_0);
+    let expr30_0 = C::reg_to_gpr_mem(ctx, expr29_0);
+    let expr31_0 = constructor_cmove(ctx, expr25_0, &expr26_0, &expr30_0, expr19_0)?;
+    let expr32_0 = constructor_with_flags_reg(ctx, &expr24_0, &expr31_0)?;
+    let expr33_0 = C::gpr_new(ctx, expr32_0);
+    let expr34_0: Type = I64;
+    let expr35_0 = C::gpr_to_gpr_mem_imm(ctx, expr33_0);
+    let expr36_0 = constructor_or(ctx, expr34_0, expr6_0, &expr35_0)?;
+    let expr37_0: Type = I64;
+    let expr38_0: u8 = 63;
+    let expr39_0 = C::imm8_to_imm8_gpr(ctx, expr38_0);
+    let expr40_0 = constructor_sar(ctx, expr37_0, expr3_0, &expr39_0)?;
+    let expr41_0 = OperandSize::Size64;
+    let expr42_0: u32 = 64;
+    let expr43_0 = RegMemImm::Imm { simm32: expr42_0 };
+    let expr44_0 = C::gpr_mem_imm_new(ctx, &expr43_0);
+    let expr45_0 = constructor_test(ctx, &expr41_0, &expr44_0, pattern1_0)?;
+    let expr46_0: Type = I64;
+    let expr47_0 = CC::Z;
+    let expr48_0 = C::gpr_to_gpr_mem(ctx, expr36_0);
+    let expr49_0 = constructor_cmove(ctx, expr46_0, &expr47_0, &expr48_0, expr9_0)?;
+    let expr50_0: Type = I64;
+    let expr51_0 = CC::Z;
+    let expr52_0 = C::gpr_to_gpr_mem(ctx, expr9_0);
+    let expr53_0 = constructor_cmove(ctx, expr50_0, &expr51_0, &expr52_0, expr40_0)?;
+    let expr54_0 = constructor_consumes_flags_concat(ctx, &expr49_0, &expr53_0)?;
+    let expr55_0 = constructor_with_flags(ctx, &expr45_0, &expr54_0)?;
+    return Some(expr55_0);
 }
 
 // Generated as internal constructor for term sshr_i8x16_bigger_shift.
@@ -6659,7 +6729,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
     let pattern1_0 = arg1;
     match pattern1_0 {
         &RegMemImm::Imm { simm32: pattern2_0 } => {
-            // Rule at src/isa/x64/lower.isle line 831.
+            // Rule at src/isa/x64/lower.isle line 771.
             let expr0_0: u32 = 8;
             let expr1_0 = C::u32_add(ctx, pattern2_0, expr0_0);
             let expr2_0 = RegMemImm::Imm { simm32: expr1_0 };
@@ -6667,7 +6737,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
             return Some(expr3_0);
         }
         &RegMemImm::Reg { reg: pattern2_0 } => {
-            // Rule at src/isa/x64/lower.isle line 833.
+            // Rule at src/isa/x64/lower.isle line 773.
             let expr0_0 = C::gpr_new(ctx, pattern2_0);
             let expr1_0: u32 = 8;
             let expr2_0 = RegMemImm::Imm { simm32: expr1_0 };
@@ -6681,7 +6751,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
         &RegMemImm::Mem {
             addr: ref pattern2_0,
         } => {
-            // Rule at src/isa/x64/lower.isle line 837.
+            // Rule at src/isa/x64/lower.isle line 777.
             let expr0_0: u64 = 8;
             let expr1_0 = constructor_imm(ctx, pattern0_0, expr0_0)?;
             let expr2_0 = C::gpr_new(ctx, expr1_0);
@@ -6708,21 +6778,21 @@ pub fn constructor_sse_and_not<C: Context>(
     if pattern0_0 == F32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 1276.
+        // Rule at src/isa/x64/lower.isle line 1203.
         let expr0_0 = constructor_andnps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 1277.
+        // Rule at src/isa/x64/lower.isle line 1204.
         let expr0_0 = constructor_andnpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/lower.isle line 1278.
+        // Rule at src/isa/x64/lower.isle line 1205.
         let expr0_0 = constructor_pandn(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
@@ -6732,7 +6802,7 @@ pub fn constructor_sse_and_not<C: Context>(
 // Generated as internal constructor for term i128_not.
 pub fn constructor_i128_not<C: Context>(ctx: &mut C, arg0: Value) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/lower.isle line 1343.
+    // Rule at src/isa/x64/lower.isle line 1268.
     let expr0_0 = C::put_in_regs(ctx, pattern0_0);
     let expr1_0: usize = 0;
     let expr2_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr1_0)?;
@@ -6759,7 +6829,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1397.
+        // Rule at src/isa/x64/lower.isle line 1322.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = constructor_pinsrb(ctx, pattern2_0, &expr0_0, pattern4_0)?;
         return Some(expr1_0);
@@ -6768,7 +6838,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1401.
+        // Rule at src/isa/x64/lower.isle line 1326.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = constructor_pinsrw(ctx, pattern2_0, &expr0_0, pattern4_0)?;
         return Some(expr1_0);
@@ -6777,7 +6847,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1405.
+        // Rule at src/isa/x64/lower.isle line 1330.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = OperandSize::Size32;
         let expr2_0 = constructor_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
@@ -6787,7 +6857,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1409.
+        // Rule at src/isa/x64/lower.isle line 1334.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = OperandSize::Size64;
         let expr2_0 = constructor_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
@@ -6797,7 +6867,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1413.
+        // Rule at src/isa/x64/lower.isle line 1338.
         let expr0_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
         let expr1_0 = C::sse_insertps_lane_imm(ctx, pattern4_0);
         let expr2_0 = constructor_insertps(ctx, pattern2_0, &expr0_0, expr1_0)?;
@@ -6809,16 +6879,15 @@ pub fn constructor_vec_insert_lane<C: Context>(
         if let &RegMem::Reg { reg: pattern4_0 } = pattern3_0 {
             let pattern5_0 = arg3;
             if pattern5_0 == 0 {
-                // Rule at src/isa/x64/lower.isle line 1435.
-                let expr0_0 = RegMem::Reg { reg: pattern4_0 };
-                let expr1_0 = C::reg_mem_to_xmm_mem(ctx, &expr0_0);
-                let expr2_0 = constructor_movsd(ctx, pattern2_0, &expr1_0)?;
-                return Some(expr2_0);
+                // Rule at src/isa/x64/lower.isle line 1360.
+                let expr0_0 = constructor_reg_to_xmm_mem(ctx, pattern4_0)?;
+                let expr1_0 = constructor_movsd(ctx, pattern2_0, &expr0_0)?;
+                return Some(expr1_0);
             }
         }
         let pattern4_0 = arg3;
         if pattern4_0 == 0 {
-            // Rule at src/isa/x64/lower.isle line 1437.
+            // Rule at src/isa/x64/lower.isle line 1362.
             let expr0_0 = SseOpcode::Movsd;
             let expr1_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
             let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
@@ -6827,7 +6896,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
             return Some(expr4_0);
         }
         if pattern4_0 == 1 {
-            // Rule at src/isa/x64/lower.isle line 1446.
+            // Rule at src/isa/x64/lower.isle line 1371.
             let expr0_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
             let expr1_0 = constructor_movlhps(ctx, pattern2_0, &expr0_0)?;
             return Some(expr1_0);
@@ -6849,7 +6918,7 @@ pub fn constructor_cmp_and_choose<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/lower.isle line 1454.
+        // Rule at src/isa/x64/lower.isle line 1379.
         let expr0_0 = constructor_put_in_gpr(ctx, pattern3_0)?;
         let expr1_0 = constructor_put_in_gpr(ctx, pattern4_0)?;
         let expr2_0 = C::raw_operand_size_of_type(ctx, pattern1_0);

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -431,4 +431,10 @@
 (decl reloc_distance_near () RelocDistance)
 (extern extractor reloc_distance_near reloc_distance_near)
 
+;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(convert Inst Value def_inst)
+(convert Reg ValueRegs value_reg)
+(convert Value Reg put_in_reg)
+(convert Value ValueRegs put_in_regs)
+(convert WritableReg Reg writable_reg_to_reg)


### PR DESCRIPTION
This PR makes use of the new implicit-conversion feature of the ISLE DSL
that was introduced in #3807 in order to make the lowering rules
significantly simpler and more concise.

The basic idea is to eliminate the repetitive and mechanical use of
terms that convert from one type to another when there is only one real
way to do the conversion -- for example, to go from a `WritableReg` to a
`Reg`, the only sensible way is to use `writable_reg_to_reg`.

This PR generally takes any term of the form "A_to_B" and makes it an
automatic conversion, as well as some others that are similar in spirit.

The notable exception to the pure-value-conversion category is the
`put_in_reg` family of operations, which actually do have side-effects.
However, as noted in the doc additions in #3807, this is fine as long as
the side-effects are idempotent. And on balance, making `put_in_reg`
automatic is a significant clarity win -- together with other operand
converters, it enables rules like:

```
;; Add two registers.
(rule (lower (has_type (fits_in_64 ty)
                       (iadd x y)))
      (add ty x y))
```

There may be other converters that we could define to make the rules
even simpler; we can make such improvements as we think of them, but
this should be a good start!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
