### PR TITLE
Shrink the size of the anyfunc table in `VMContext`

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -95,8 +95,7 @@ use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex, WasmFuncType, WasmType};
 use target_lexicon::CallingConvention;
 use wasmtime_environ::{
-    packed_option::ReservedValue, FilePos, FunctionInfo, InstructionAddressMap, ModuleTranslation,
-    TrapInformation, TypeTables,
+    FilePos, FunctionInfo, InstructionAddressMap, ModuleTranslation, TrapInformation, TypeTables,
 };
 
 pub use builder::builder;
@@ -259,11 +258,11 @@ fn func_signature(
 ) -> ir::Signature {
     let func = &translation.module.functions[index];
     let call_conv = match translation.module.defined_func_index(index) {
-        // If this is a defined function in the module and it's never possibly
-        // exported, then we can optimize this function to use the fastest
-        // calling convention since it's purely an internal implementation
-        // detail of the module itself.
-        Some(_idx) if func.anyfunc.is_reserved_value() => CallConv::Fast,
+        // If this is a defined function in the module and it doesn't escape
+        // then we can optimize this function to use the fastest calling
+        // convention since it's purely an internal implementation detail of
+        // the module itself.
+        Some(_idx) if !func.is_escaping() => CallConv::Fast,
 
         // ... otherwise if it's an imported function or if it's a possibly
         // exported function then we use the default ABI wasmtime would

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -95,7 +95,8 @@ use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex, WasmFuncType, WasmType};
 use target_lexicon::CallingConvention;
 use wasmtime_environ::{
-    FilePos, FunctionInfo, InstructionAddressMap, ModuleTranslation, TrapInformation, TypeTables,
+    packed_option::ReservedValue, FilePos, FunctionInfo, InstructionAddressMap, ModuleTranslation,
+    TrapInformation, TypeTables,
 };
 
 pub use builder::builder;
@@ -256,12 +257,13 @@ fn func_signature(
     types: &TypeTables,
     index: FuncIndex,
 ) -> ir::Signature {
+    let func = &translation.module.functions[index];
     let call_conv = match translation.module.defined_func_index(index) {
         // If this is a defined function in the module and it's never possibly
         // exported, then we can optimize this function to use the fastest
         // calling convention since it's purely an internal implementation
         // detail of the module itself.
-        Some(idx) if !translation.escaped_funcs.contains(&idx) => CallConv::Fast,
+        Some(_idx) if func.anyfunc.is_reserved_value() => CallConv::Fast,
 
         // ... otherwise if it's an imported function or if it's a possibly
         // exported function then we use the default ABI wasmtime would
@@ -269,11 +271,7 @@ fn func_signature(
         _ => wasmtime_call_conv(isa),
     };
     let mut sig = blank_sig(isa, call_conv);
-    push_types(
-        isa,
-        &mut sig,
-        &types.wasm_signatures[translation.module.functions[index]],
-    );
+    push_types(isa, &mut sig, &types.wasm_signatures[func.signature]);
     return sig;
 }
 

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -1187,7 +1187,7 @@ impl FunctionType {
     /// module, meaning that the function is exported, used in `ref.func`, used
     /// in a table, etc.
     pub fn is_escaping(&self) -> bool {
-        self.anyfunc.is_reserved_value()
+        !self.anyfunc.is_reserved_value()
     }
 }
 

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -1182,6 +1182,15 @@ pub struct FunctionType {
     pub anyfunc: AnyfuncIndex,
 }
 
+impl FunctionType {
+    /// Returns whether this function's type is one that "escapes" the current
+    /// module, meaning that the function is exported, used in `ref.func`, used
+    /// in a table, etc.
+    pub fn is_escaping(&self) -> bool {
+        self.anyfunc.is_reserved_value()
+    }
+}
+
 /// Index into the anyfunc table within a VMContext for a function.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 pub struct AnyfuncIndex(u32);

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -1120,6 +1120,25 @@ impl Module {
             EntityIndex::Module(i) => EntityType::Module(self.modules[i]),
         }
     }
+
+    /// Appends a new function to this module with the given type information,
+    /// used for functions that either don't escape or aren't certain whether
+    /// they escape yet.
+    pub fn push_function(&mut self, signature: SignatureIndex) -> FuncIndex {
+        self.functions.push(FunctionType {
+            signature,
+            anyfunc: AnyfuncIndex::reserved_value(),
+        })
+    }
+
+    /// Appends a new function to this module with the given type information.
+    pub fn push_escaped_function(
+        &mut self,
+        signature: SignatureIndex,
+        anyfunc: AnyfuncIndex,
+    ) -> FuncIndex {
+        self.functions.push(FunctionType { signature, anyfunc })
+    }
 }
 
 /// All types which are recorded for the entirety of a translation.

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -1174,7 +1174,7 @@ pub struct InstanceSignature {
 /// Type information about functions in a wasm module.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FunctionType {
-    /// The type of this function, indexed into the global type tables for
+    /// The type of this function, indexed into the module-wide type tables for
     /// a module compilation.
     pub signature: SignatureIndex,
     /// The index into the anyfunc table, if present. Note that this is

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -244,10 +244,10 @@ impl<'data> ModuleEnvironment<'data> {
                     .functions
                     .iter()
                     .filter_map(|(_, func)| {
-                        if func.anyfunc.is_reserved_value() {
-                            None
-                        } else {
+                        if func.is_escaping() {
                             Some(func.signature)
+                        } else {
+                            None
                         }
                     })
                     .collect();
@@ -1169,13 +1169,13 @@ and for re-adding support for interface types you can see this issue:
     }
 
     fn flag_func_escaped(&mut self, func: FuncIndex) {
-        let anyfunc = &mut self.result.module.functions[func].anyfunc;
+        let ty = &mut self.result.module.functions[func];
         // If this was already assigned an anyfunc index no need to re-assign it.
-        if !anyfunc.is_reserved_value() {
+        if ty.is_escaping() {
             return;
         }
         let index = self.result.module.num_escaped_funcs as u32;
-        *anyfunc = AnyfuncIndex::from_u32(index);
+        ty.anyfunc = AnyfuncIndex::from_u32(index);
         self.result.module.num_escaped_funcs += 1;
     }
 

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -1,7 +1,7 @@
 use crate::module::{
-    AnyfuncIndex, FunctionType, Initializer, InstanceSignature, MemoryInitialization,
-    MemoryInitializer, MemoryPlan, Module, ModuleSignature, ModuleType, ModuleUpvar,
-    TableInitializer, TablePlan, TypeTables,
+    AnyfuncIndex, Initializer, InstanceSignature, MemoryInitialization, MemoryInitializer,
+    MemoryPlan, Module, ModuleSignature, ModuleType, ModuleUpvar, TableInitializer, TablePlan,
+    TypeTables,
 };
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, EntityIndex, EntityType, FuncIndex, Global,
@@ -390,10 +390,7 @@ impl<'data> ModuleEnvironment<'data> {
                     let sigindex = entry?;
                     let ty = TypeIndex::from_u32(sigindex);
                     let sig_index = self.result.module.types[ty].unwrap_function();
-                    self.result.module.functions.push(FunctionType {
-                        signature: sig_index,
-                        anyfunc: AnyfuncIndex::reserved_value(),
-                    });
+                    self.result.module.push_function(sig_index);
                 }
             }
 
@@ -877,10 +874,7 @@ impl<'data> ModuleEnvironment<'data> {
                                     self.result.module.num_imported_tables += 1;
                                 }
                                 EntityType::Function(sig) => {
-                                    self.result.module.functions.push(FunctionType {
-                                        signature: *sig,
-                                        anyfunc: AnyfuncIndex::reserved_value(),
-                                    });
+                                    self.result.module.push_function(*sig);
                                     self.result.module.num_imported_funcs += 1;
                                     self.result.debuginfo.wasm_file.imported_func_count += 1;
                                 }
@@ -1131,12 +1125,7 @@ and for re-adding support for interface types you can see this issue:
 
     fn push_type(&mut self, ty: EntityType) -> EntityIndex {
         match ty {
-            EntityType::Function(ty) => {
-                EntityIndex::Function(self.result.module.functions.push(FunctionType {
-                    signature: ty,
-                    anyfunc: AnyfuncIndex::reserved_value(),
-                }))
-            }
+            EntityType::Function(ty) => EntityIndex::Function(self.result.module.push_function(ty)),
             EntityType::Table(ty) => {
                 let plan = TablePlan::for_table(ty, &self.tunables);
                 EntityIndex::Table(self.result.module.table_plans.push(plan))

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -1045,6 +1045,7 @@ mod tests {
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_defined_globals: 0,
+            num_escaped_funcs: 0,
         });
         assert_eq!(
             offsets.vm_extern_data_ref_count(),
@@ -1071,6 +1072,7 @@ mod tests {
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_defined_globals: 0,
+            num_escaped_funcs: 0,
         });
         assert_eq!(
             offsets.vm_extern_ref_activation_table_next() as usize,
@@ -1097,6 +1099,7 @@ mod tests {
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_defined_globals: 0,
+            num_escaped_funcs: 0,
         });
         assert_eq!(
             offsets.vm_extern_ref_activation_table_end() as usize,

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::Arc;
 use wasmtime_environ::{
-    AnyfuncIndex, EntityIndex, FunctionInfo, FunctionType, Module, ModuleType, SignatureIndex,
+    AnyfuncIndex, EntityIndex, FunctionInfo, Module, ModuleType, SignatureIndex,
 };
 use wasmtime_jit::{CodeMemory, ProfilingAgent};
 use wasmtime_runtime::{
@@ -154,10 +154,7 @@ pub unsafe fn create_raw_function(
 
     let sig_id = SignatureIndex::from_u32(u32::max_value() - 1);
     module.types.push(ModuleType::Function(sig_id));
-    let func_id = module.functions.push(FunctionType {
-        signature: sig_id,
-        anyfunc: AnyfuncIndex::from_u32(0),
-    });
+    let func_id = module.push_escaped_function(sig_id, AnyfuncIndex::from_u32(0));
     module.num_escaped_funcs = 1;
     module
         .exports

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -6,7 +6,9 @@ use anyhow::Result;
 use std::any::Any;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::Arc;
-use wasmtime_environ::{EntityIndex, FunctionInfo, Module, ModuleType, SignatureIndex};
+use wasmtime_environ::{
+    AnyfuncIndex, EntityIndex, FunctionInfo, FunctionType, Module, ModuleType, SignatureIndex,
+};
 use wasmtime_jit::{CodeMemory, ProfilingAgent};
 use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
@@ -152,7 +154,11 @@ pub unsafe fn create_raw_function(
 
     let sig_id = SignatureIndex::from_u32(u32::max_value() - 1);
     module.types.push(ModuleType::Function(sig_id));
-    let func_id = module.functions.push(sig_id);
+    let func_id = module.functions.push(FunctionType {
+        signature: sig_id,
+        anyfunc: AnyfuncIndex::from_u32(0),
+    });
+    module.num_escaped_funcs = 1;
     module
         .exports
         .insert(String::new(), EntityIndex::Function(func_id));

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -2,7 +2,9 @@ use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::{GlobalType, Mutability, Val};
 use anyhow::Result;
-use wasmtime_environ::{EntityIndex, Global, GlobalInit, Module, ModuleType, SignatureIndex};
+use wasmtime_environ::{
+    AnyfuncIndex, EntityIndex, FunctionType, Global, GlobalInit, Module, ModuleType, SignatureIndex,
+};
 use wasmtime_runtime::VMFunctionImport;
 
 pub fn create_global(store: &mut StoreOpaque, gt: &GlobalType, val: Val) -> Result<InstanceId> {
@@ -40,8 +42,12 @@ pub fn create_global(store: &mut StoreOpaque, gt: &GlobalType, val: Val) -> Resu
                 let sig_id = SignatureIndex::from_u32(u32::max_value() - 1);
                 one_signature = Some((sig_id, f.type_index));
                 module.types.push(ModuleType::Function(sig_id));
-                let func_index = module.functions.push(sig_id);
+                let func_index = module.functions.push(FunctionType {
+                    signature: sig_id,
+                    anyfunc: AnyfuncIndex::from_u32(0),
+                });
                 module.num_imported_funcs = 1;
+                module.num_escaped_funcs = 1;
                 module
                     .initializers
                     .push(wasmtime_environ::Initializer::Import {

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -3,7 +3,7 @@ use crate::trampoline::create_handle;
 use crate::{GlobalType, Mutability, Val};
 use anyhow::Result;
 use wasmtime_environ::{
-    AnyfuncIndex, EntityIndex, FunctionType, Global, GlobalInit, Module, ModuleType, SignatureIndex,
+    AnyfuncIndex, EntityIndex, Global, GlobalInit, Module, ModuleType, SignatureIndex,
 };
 use wasmtime_runtime::VMFunctionImport;
 
@@ -42,10 +42,7 @@ pub fn create_global(store: &mut StoreOpaque, gt: &GlobalType, val: Val) -> Resu
                 let sig_id = SignatureIndex::from_u32(u32::max_value() - 1);
                 one_signature = Some((sig_id, f.type_index));
                 module.types.push(ModuleType::Function(sig_id));
-                let func_index = module.functions.push(FunctionType {
-                    signature: sig_id,
-                    anyfunc: AnyfuncIndex::from_u32(0),
-                });
+                let func_index = module.push_escaped_function(sig_id, AnyfuncIndex::from_u32(0));
                 module.num_imported_funcs = 1;
                 module.num_escaped_funcs = 1;
                 module


### PR DESCRIPTION
This commit shrinks the size of the `VMCallerCheckedAnyfunc` table
allocated into a `VMContext` to be the size of the number of "escaped"
functions in a module rather than the number of functions in a module.
Escaped functions include exports, table elements, etc, and are
typically an order of magnitude smaller than the number of functions in
general. This should greatly shrink the `VMContext` for some modules
which while we aren't necessarily having any problems with that today
shouldn't cause any problems in the future.

The original motivation for this was that this came up during the recent
lazy-table-initialization work and while it no longer has a direct
performance benefit since tables aren't initialized at all on
instantiation it should still improve long-running instances
theoretically with smaller `VMContext` allocations as well as better
locality between anyfuncs.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
