### PR TITLE
Limit stack frame captures to at most 100 frames

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -59,10 +59,7 @@ pub use crate::memory::{DefaultMemoryCreator, Memory, RuntimeLinearMemory, Runti
 pub use crate::mmap::Mmap;
 pub use crate::mmap_vec::MmapVec;
 pub use crate::table::{Table, TableElement};
-pub use crate::traphandlers::{
-    catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, tls_eager_initialize,
-    SignalHandler, TlsRestore, Trap,
-};
+pub use crate::traphandlers::*;
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
     VMGlobalImport, VMInterrupts, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport,

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -61,7 +61,6 @@ use crate::instance::Instance;
 use crate::table::{Table, TableElementType};
 use crate::traphandlers::{raise_lib_trap, resume_panic, Trap};
 use crate::vmcontext::{VMCallerCheckedAnyfunc, VMContext};
-use backtrace::Backtrace;
 use std::mem;
 use std::ptr::{self, NonNull};
 use wasmtime_environ::{
@@ -590,7 +589,7 @@ unsafe fn validate_atomic_addr(
     if addr > instance.get_memory(memory).current_length {
         return Err(Trap::Wasm {
             trap_code: TrapCode::HeapOutOfBounds,
-            backtrace: Backtrace::new_unresolved(),
+            backtrace: crate::capture_backtrace(),
         });
     }
     Ok(())

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1297,7 +1297,7 @@ fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Result<Option<usize>, Tr
             return Err(Trap::new_wasm(
                 None,
                 wasmtime_environ::TrapCode::Interrupt,
-                backtrace::Backtrace::new_unresolved(),
+                wasmtime_runtime::capture_backtrace(),
             ));
         }
         n => n,

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -148,7 +148,7 @@ impl Trap {
     #[cold] // traps are exceptional, this helps move handling off the main path
     pub fn new<I: Into<String>>(message: I) -> Self {
         let reason = TrapReason::Message(message.into());
-        Trap::new_with_trace(None, reason, Backtrace::new_unresolved())
+        Trap::new_with_trace(None, reason, wasmtime_runtime::capture_backtrace())
     }
 
     /// Creates a new `Trap` representing an explicit program exit with a classic `i32`
@@ -158,7 +158,7 @@ impl Trap {
         Trap::new_with_trace(
             None,
             TrapReason::I32Exit(status),
-            Backtrace::new_unresolved(),
+            wasmtime_runtime::capture_backtrace(),
         )
     }
 
@@ -395,7 +395,7 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for Trap {
             trap.clone()
         } else {
             let reason = TrapReason::Error(e.into());
-            Trap::new_with_trace(None, reason, Backtrace::new_unresolved())
+            Trap::new_with_trace(None, reason, wasmtime_runtime::capture_backtrace())
         }
     }
 }


### PR DESCRIPTION
This places a static limit on the number of frames captured by Wasmtime
to ensure that stack traces, for whatever reason, don't get egregiously
long like the issues we've seen in recently in the `windows-2022` CI
upgrade where stack overflow tests caused the system unwinder to report
an infinite stream of frames.

Closes #3858

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
