### PR TITLE
Decrease default wasm stack to 512k from 1M

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -115,7 +115,15 @@ impl Config {
             profiler: Arc::new(NullProfilerAgent),
             mem_creator: None,
             allocation_strategy: InstanceAllocationStrategy::OnDemand,
-            max_wasm_stack: 1 << 20,
+            // 512k of stack -- note that this is chosen currently to not be too
+            // big, not be too small, and be a good default for most platforms.
+            // One platform of particular note is Windows where the stack size
+            // of the main thread seems to, by default, be smaller than that of
+            // Linux and macOS. This 512k value at least lets our current test
+            // suite pass on the main thread of Windows (using `--test-threads
+            // 1` forces this), or at least it passed when this change was
+            // committed.
+            max_wasm_stack: 512 * 1024,
             wasm_backtrace_details_env_used: false,
             features: WasmFeatures::default(),
             #[cfg(feature = "async")]
@@ -444,7 +452,7 @@ impl Config {
     /// on stack overflow, a host function that overflows the stack will
     /// abort the process.
     ///
-    /// By default this option is 1 MiB.
+    /// By default this option is 512 KiB.
     pub fn max_wasm_stack(&mut self, size: usize) -> Result<&mut Self> {
         #[cfg(feature = "async")]
         if size > self.async_stack_size {

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -4,8 +4,8 @@ use wasmtime::*;
 #[test]
 fn host_always_has_some_stack() -> anyhow::Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
-    // assume hosts always have at least 512k of stack
-    const HOST_STACK: usize = 512 * 1024;
+    // assume hosts always have at least 128k of stack
+    const HOST_STACK: usize = 128 * 1024;
 
     let mut store = Store::<()>::default();
 


### PR DESCRIPTION
This commit aims to achieve the goal of being able to run the test suite
on Windows with `--test-threads 1`, or more notably allowing Wasmtime's
defaults to work better with the main thread on Windows which appears to
have a smaller stack by default than Linux by comparison. In decreasing
the default wasm stack size a test is also update to probe for less
stack to work on Windows' main thread by default, ideally allowing the
full test suite to work with `--test-threads 1` (although this isn't
added to CI as it's not really critical).

Closes #3857

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
