### PR TITLE
Fix a nightly warning

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -2049,7 +2049,7 @@ impl HostFunc {
         ty: FuncType,
         func: impl Fn(Caller<'_, T>, *mut ValRaw) -> Result<(), Trap> + Send + Sync + 'static,
     ) -> Self {
-        let func = move |caller_vmctx, values: *mut ValRaw| unsafe {
+        let func = move |caller_vmctx, values: *mut ValRaw| {
             Caller::<T>::with(caller_vmctx, |caller| func(caller, values))
         };
         let (instance, trampoline) = crate::trampoline::create_function(&ty, func, engine)


### PR DESCRIPTION
Looks like this `unsafe` block is not necessary, even on stable, and
nightly linting has picked it up now.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
