### PR TITLE
Fix allowing an override of `LIBGMP_PATHS`

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/ocaml/Makefile
+++ b/crates/fuzzing/wasm-spec-interpreter/ocaml/Makefile
@@ -13,7 +13,7 @@ SPEC_LIB := $(SPEC_BUILD_DIR)/wasm.cmxa
 
 # A space-separated list of paths that the linker will use to search for libgmp.
 # Override with `make LIBGMP_PATHS=...`.
-LIBGMP_PATHS := /usr/lib /usr/lib/x86_64-linux-gnu
+LIBGMP_PATHS ?= /usr/lib /usr/lib/x86_64-linux-gnu
 
 PKGS = zarith
 


### PR DESCRIPTION
This seems to have intended to allow overrides but the specific Makefile
syntax used didn't actually allow overrides, so update that to allow env
vars from the outside world to override the variable (needed locally on
AArch64 I'm building on which has a different path to libgmp)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
