### PR TITLE
Fix failing fuzzers with too-small instance sizes

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -260,6 +260,15 @@ fn compile_module(
                 if string.contains("minimum element size") {
                     return None;
                 }
+
+                // Allow modules-failing-to-compile which exceed the requested
+                // size for each instance. This is something that is difficult
+                // to control and ensure it always suceeds, so we simply have a
+                // "random" instance size limit and if a module doesn't fit we
+                // move on to the next fuzz input.
+                if string.contains("instance allocation for this module requires") {
+                    return None;
+                }
             }
 
             panic!("failed to compile module: {:?}", e);


### PR DESCRIPTION
The recent removal of `ModuleLimits` meant that the update to the
fuzzers could quickly fail where the instance size limit was set to
something small (like 0) and then nothing would succeed in compilation.
This allows the modules to fail to compile and then continues to the
next fuzz input in these situations.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
