### PR TITLE
Remove some asserts in `MemoryImage::new`

### DIFF
--- a/crates/runtime/src/cow.rs
+++ b/crates/runtime/src/cow.rs
@@ -90,10 +90,12 @@ impl MemoryImage {
     ) -> Result<Option<MemoryImage>> {
         // Sanity-check that various parameters are page-aligned.
         let len = data.len();
-        let offset = u32::try_from(offset).unwrap();
-        assert_eq!(offset % page_size, 0);
+        assert_eq!(offset % u64::from(page_size), 0);
         assert_eq!((len as u32) % page_size, 0);
-        let linear_memory_offset = usize::try_from(offset).unwrap();
+        let linear_memory_offset = match usize::try_from(offset) {
+            Ok(offset) => offset,
+            Err(_) => return Ok(None),
+        };
 
         // If a backing `mmap` is present then `data` should be a sub-slice of
         // the `mmap`. The sanity-checks here double-check that. Additionally


### PR DESCRIPTION
This commit removes some `.unwrap()` annotations around casts between
integers to either be infallible or handle errors. This fixes a panic in
a fuzz test case that popped out for memory64-using modules. The actual
issue here is pretty benign, we were just too eager about assuming
things fit into 32-bit.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
