### PR TITLE
Add support for `async` call hooks

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -272,11 +272,15 @@ macro_rules! generate_wrap_async_func {
         {
             assert!(store.as_context().async_support(), concat!("cannot use `wrap", $num, "_async` without enabling async support on the config"));
             Func::wrap(store, move |mut caller: Caller<'_, T>, $($args: $args),*| {
-                let async_cx = caller.store.as_context_mut().0.async_cx();
-                let mut future = Pin::from(func(caller, $($args),*));
-                match unsafe { async_cx.block_on(future.as_mut()) } {
-                    Ok(ret) => ret.into_fallible(),
-                    Err(e) => R::fallible_from_trap(e),
+                match caller.store.as_context_mut().0.async_cx() {
+                    None => R::fallible_from_trap(Trap::from(anyhow::format_err!("Attempt to start async function on dying fiber"))),
+                    Some(async_cx) => {
+                        let mut future = Pin::from(func(caller, $($args),*));
+                        match unsafe { async_cx.block_on(future.as_mut()) } {
+                            Ok(ret) => ret.into_fallible(),
+                            Err(e) => R::fallible_from_trap(e),
+                        }
+                    }
                 }
             })
         }
@@ -439,7 +443,15 @@ impl Func {
             "cannot use `new_async` without enabling async support in the config"
         );
         Func::new(store, ty, move |mut caller, params, results| {
-            let async_cx = caller.store.as_context_mut().0.async_cx();
+            let async_cx =
+                caller
+                    .store
+                    .as_context_mut()
+                    .0
+                    .async_cx()
+                    .ok_or(anyhow::format_err!(
+                        "Attempt to spawn new action on dying fiber"
+                    ))?;
             let mut future = Pin::from(func(caller, params, results));
             match unsafe { async_cx.block_on(future.as_mut()) } {
                 Ok(Ok(())) => Ok(()),

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -423,6 +423,8 @@ pub use crate::linker::*;
 pub use crate::memory::*;
 pub use crate::module::{FrameInfo, FrameSymbol, Module};
 pub use crate::r#ref::ExternRef;
+#[cfg(feature = "async")]
+pub use crate::store::CallHookHandler;
 pub use crate::store::{AsContext, AsContextMut, CallHook, Store, StoreContext, StoreContextMut};
 pub use crate::trap::*;
 pub use crate::types::*;

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -146,15 +146,11 @@ macro_rules! generate_wrap_async_func {
                 ),
             );
             self.func_wrap(module, name, move |mut caller: Caller<'_, T>, $($args: $args),*| {
-                match caller.store.as_context_mut().0.async_cx() {
-                    None => R::fallible_from_trap(Trap::from(anyhow::format_err!("Attempt to start async function on dying fiber"))),
-                    Some(async_cx) => {
-                        let mut future = Pin::from(func(caller, $($args),*));
-                        match unsafe { async_cx.block_on(future.as_mut()) } {
-                            Ok(ret) => ret.into_fallible(),
-                            Err(e) => R::fallible_from_trap(e),
-                        }
-                    }
+                let async_cx = caller.store.as_context_mut().0.async_cx().expect("Attempt to start async function on dying fiber");
+                let mut future = Pin::from(func(caller, $($args),*));
+                match unsafe { async_cx.block_on(future.as_mut()) } {
+                    Ok(ret) => ret.into_fallible(),
+                    Err(e) => R::fallible_from_trap(e),
                 }
             })
         }
@@ -364,15 +360,12 @@ impl<T> Linker<T> {
             "cannot use `func_new_async` without enabling async support in the config"
         );
         self.func_new(module, name, ty, move |mut caller, params, results| {
-            let async_cx =
-                caller
-                    .store
-                    .as_context_mut()
-                    .0
-                    .async_cx()
-                    .ok_or(anyhow::format_err!(
-                        "Attempt to spawn new function on dying fiber"
-                    ))?;
+            let async_cx = caller
+                .store
+                .as_context_mut()
+                .0
+                .async_cx()
+                .expect("Attempt to spawn new function on dying fiber");
             let mut future = Pin::from(func(caller, params, results));
             match unsafe { async_cx.block_on(future.as_mut()) } {
                 Ok(Ok(())) => Ok(()),

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1188,6 +1188,10 @@ impl StoreOpaque {
         panic!("trampoline missing")
     }
 
+    /// Yields the async context, assuming that we are executing on a fiber and
+    /// that fiber is not in the process of dying. This function will return
+    /// None in the latter case (the fiber is dying), and panic if
+    /// `async_support()` is false.
     #[cfg(feature = "async")]
     #[inline]
     pub fn async_cx(&self) -> Option<AsyncCx> {

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -992,11 +992,11 @@ impl<T> StoreInner<T> {
     }
 
     pub fn call_hook(&mut self, s: CallHook) -> Result<(), Trap> {
-        match self.call_hook {
-            Some(CallHookInner::Sync(ref mut hook)) => hook(&mut self.data, s),
+        match &mut self.call_hook {
+            Some(CallHookInner::Sync(hook)) => hook(&mut self.data, s),
 
             #[cfg(feature = "async")]
-            Some(CallHookInner::Async(ref mut handler)) => unsafe {
+            Some(CallHookInner::Async(handler)) => unsafe {
                 Ok(self
                     .inner
                     .async_cx()

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -621,7 +621,7 @@ impl<T> Store<T> {
     #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
     /// Configures an async function that runs on calls and returns between
     /// WebAssembly and host code. For the non-async equivalent of this method,
-    /// see [`call_hook`].
+    /// see [`Store::call_hook`].
     ///
     /// The function is passed a [`CallHook`] argument, which indicates which
     /// state transition the VM is making.

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1607,6 +1607,14 @@ impl AsyncCx {
                 let poll_cx = *self.current_poll_cx;
                 let _reset = Reset(self.current_poll_cx, poll_cx);
                 *self.current_poll_cx = ptr::null_mut();
+                if poll_cx.is_null() {
+                    // This happens in the case that we are currently cleaning up
+                    // this fiber; we need to just stop anything on here from
+                    // resuming.
+                    return Err(anyhow::format_err!(
+                        "opting out of resuming on a dying fiber"
+                    ))?;
+                }
                 assert!(!poll_cx.is_null());
                 future.as_mut().poll(&mut *poll_cx)
             };

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -1,4 +1,7 @@
 use anyhow::Error;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{self, Poll};
 use wasmtime::*;
 
 // Crate a synchronous Func, call it directly:
@@ -707,6 +710,117 @@ async fn timeout_async_hook() -> Result<(), Error> {
     assert_eq!(store.data().returns_from_wasm, 0);
 
     Ok(())
+}
+
+#[tokio::test]
+async fn drop_suspended_async_hook() -> Result<(), Error> {
+    struct Handler;
+
+    #[async_trait::async_trait]
+    impl CallHookHandler<u32> for Handler {
+        async fn handle_call_event(
+            &self,
+            state: &mut u32,
+            _ch: CallHook,
+        ) -> Result<(), wasmtime::Trap> {
+            assert_eq!(*state, 0);
+            *state += 1;
+            let _dec = Decrement(state);
+
+            // Simulate some sort of event which takes a number of yields
+            for _ in 0..500 {
+                tokio::task::yield_now().await;
+            }
+            Ok(())
+        }
+    }
+
+    let mut config = Config::new();
+    config.async_support(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, 0);
+    store.call_hook_async(Handler);
+
+    let mut linker = Linker::new(&engine);
+
+    // Simulate a host function that has lots of yields with an infinite loop.
+    linker.func_wrap0_async("host", "f", |mut cx| {
+        Box::new(async move {
+            let state = cx.data_mut();
+            assert_eq!(*state, 0);
+            *state += 1;
+            let _dec = Decrement(state);
+            loop {
+                tokio::task::yield_now().await;
+            }
+        })
+    })?;
+
+    let wat = r#"
+        (module
+            (import "host" "f" (func $f))
+            (func (export "") call $f)
+        )
+    "#;
+    let module = Module::new(&engine, wat)?;
+
+    let inst = linker.instantiate(&mut store, &module)?;
+    assert_eq!(*store.data(), 0);
+    let export = inst
+        .get_typed_func::<(), (), _>(&mut store, "")
+        .expect("export is func");
+
+    // First test that if we drop in the middle of an async hook that everything
+    // is alright.
+    PollNTimes {
+        future: Box::pin(export.call_async(&mut store, ())),
+        times: 200,
+    }
+    .await;
+    assert_eq!(*store.data(), 0); // double-check user dtors ran
+
+    // Next test that if we drop while in a host async function that everything
+    // is also alright.
+    PollNTimes {
+        future: Box::pin(export.call_async(&mut store, ())),
+        times: 1_000,
+    }
+    .await;
+    assert_eq!(*store.data(), 0); // double-check user dtors ran
+
+    return Ok(());
+
+    // A helper struct to poll an inner `future` N `times` and then resolve.
+    // This is used above to test that when futures are dropped while they're
+    // pending everything works and is cleaned up on the Wasmtime side of
+    // things.
+    struct PollNTimes<F> {
+        future: F,
+        times: u32,
+    }
+
+    impl<F: Future + Unpin> Future for PollNTimes<F> {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, task: &mut task::Context<'_>) -> Poll<()> {
+            for _ in 0..self.times {
+                match Pin::new(&mut self.future).poll(task) {
+                    Poll::Ready(_) => panic!("future should not be ready"),
+                    Poll::Pending => {}
+                }
+            }
+
+            Poll::Ready(())
+        }
+    }
+
+    // helper struct to decrement a counter on drop
+    struct Decrement<'a>(&'a mut u32);
+
+    impl Drop for Decrement<'_> {
+        fn drop(&mut self) {
+            *self.0 -= 1;
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
The present runtime supports the ability to add aspect-like hooks to wasm entrance/exit via the `call_hook` method. In some cases, it can be useful to have this hook do asynchronous operations; to acquire a lock, for example.

This patch series provides an alternate way for users to provide a call hook that mirrors the resource limiter callbacks. To get around some trickiness with Rust types, closures, and Futures, `call_hook_async` takes an object on which a simple trait is implemented. This hook is then executed using the existing `block_on` mechanism.

Beyond just adding this capability, this patch makes two other changes to the code base to avoid an error condition in which one of these tasks becomes scheduled right as an async fiber is being dropped. The first changes the `async_cx` method so that it returns `Option<AsyncCx>` instead of just `AsyncCx`; this can be an early detection mechanism for the fiber being dropped. The more key one is a late check in `block_on`, which turns a former-panic into being a catchable an error condition.

Many thanks to @alexcrichton, who figured out the "resuming a task on a dying thread" issue.