### PR TITLE
fuzz: Bump table limit with spectest fuzzing

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -343,6 +343,7 @@ impl Config {
         config.reference_types_enabled = true;
         config.multi_value_enabled = true;
         config.max_memories = 1;
+        config.max_tables = 5;
 
         if let InstanceAllocationStrategy::Pooling {
             instance_limits: limits,
@@ -350,6 +351,7 @@ impl Config {
         } = &mut self.wasmtime.strategy
         {
             limits.memories = 1;
+            limits.tables = 5;
             // Set a lower bound of 10 pages as the spec tests define memories with at
             // least a few pages and some tests do memory grow operations.
             limits.memory_pages = std::cmp::max(limits.memory_pages, 10);


### PR DESCRIPTION
Spec tests need multiple tables so increase the limits on the pooling
allocator when enabled for spec tests to ensure that all the spec tests
can run.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
