### PR TITLE
fuzz: Increase table limit in differential_v8 fuzzer

### DIFF
--- a/fuzz/fuzz_targets/differential_v8.rs
+++ b/fuzz/fuzz_targets/differential_v8.rs
@@ -2,6 +2,7 @@
 
 use libfuzzer_sys::arbitrary::{Result, Unstructured};
 use libfuzzer_sys::fuzz_target;
+use wasmtime_fuzzing::generators::InstanceAllocationStrategy;
 use wasmtime_fuzzing::{generators, oracles};
 
 fuzz_target!(|data: &[u8]| {
@@ -23,6 +24,13 @@ fn run(data: &[u8]) -> Result<()> {
     // Allow multiple tables, as set_differential_config() assumes reference
     // types are disabled and therefore sets max_tables to 1
     config.module_config.config.max_tables = 4;
+    if let InstanceAllocationStrategy::Pooling {
+        instance_limits: limits,
+        ..
+    } = &mut config.wasmtime.strategy
+    {
+        limits.tables = 4;
+    }
 
     let module = config.generate(&mut u, Some(1000))?;
     oracles::differential_v8_execution(&module.to_bytes(), &config);


### PR DESCRIPTION
When manually increasing the table limit in this specific fuzzer we also
need to increase the limit in the pooling allocator itself if
configured.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
