### PR TITLE
Fix table element limits in spectest fuzzer

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -354,6 +354,7 @@ impl Config {
         {
             limits.memories = 1;
             limits.tables = 5;
+            limits.table_elements = 1_000;
             // Set a lower bound of 10 pages as the spec tests define memories with at
             // least a few pages and some tests do memory grow operations.
             limits.memory_pages = std::cmp::max(limits.memory_pages, 10);
@@ -370,6 +371,7 @@ impl Config {
     /// Converts this to a `wasmtime::Config` object
     pub fn to_wasmtime(&self) -> wasmtime::Config {
         crate::init_fuzzing();
+        log::debug!("creating wasmtime config with {:#?}", self.wasmtime);
 
         let mut cfg = wasmtime::Config::new();
         cfg.wasm_bulk_memory(true)

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -539,7 +539,7 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
 pub fn spectest(mut fuzz_config: generators::Config, test: generators::SpecTest) {
     crate::init_fuzzing();
     fuzz_config.set_spectest_compliant();
-    log::debug!("running {:?} with {:?}", test.file, fuzz_config);
+    log::debug!("running {:?}", test.file);
     let mut wast_context = WastContext::new(fuzz_config.to_store());
     wast_context.register_spectest().unwrap();
     wast_context


### PR DESCRIPTION
Ensure that there's enough table elements allowed to execute the spec
tests since some tests have a minimum required.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
