### PR TITLE
Relax restrictions in the differential fuzzer

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -404,6 +404,13 @@ pub fn differential_execution(
         };
 
         match (lhs, rhs) {
+            // Different compilation settings can lead to different amounts
+            // of stack space being consumed, so if either the lhs or the rhs
+            // hit a stack overflow then we discard the result of the other side
+            // since if it ran successfully or trapped that's ok in both
+            // situations.
+            (Err(e), _) | (_, Err(e)) if e.trap_code() == Some(TrapCode::StackOverflow) => {}
+
             (Err(a), Err(b)) => {
                 if a.trap_code() != b.trap_code() {
                     fail();


### PR DESCRIPTION
If either end stack overflows we can't validate the other side since the
other side, depending on codegen settings, may have been successful, hit
a different trap, or also stack overflowed.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
