### PR TITLE
ci: Scope version bump branch name

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Push to remote
         run: |
           git remote set-url origin https://git:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}
-          git push origin HEAD:ci/bump-version -f
+          git push origin HEAD:ci/bump-to-${{ steps.bump.outputs.version }} -f
 
       - name: Make a PR
         # Note that the syntax here is kinda funky, and the general gist is that
@@ -91,7 +91,7 @@ jobs:
             --header "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
             --data @- << EOF
           {
-            "head": "ci/bump-version",
+            "head": "ci/bump-to-${{ steps.bump.outputs.version }}",
             "base": "${{ github.ref_name }}",
             "title": "Release Wasmtime ${{ steps.bump.outputs.version }}",
             "body": $body,


### PR DESCRIPTION
This avoids a situation such as for the last point release where we had
different point releases all use the same branch name which forced us
make one release at a time. By putting the version number in the branch
name that should hopefully fix this.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
