### PR TITLE
Reduce benchmark runtime on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -360,8 +360,8 @@ jobs:
     - run: rustup target add wasm32-wasi
     - name: Install Rust
       run: rustup update stable && rustup default stable
-    - run: cargo bench
-    - run: cargo bench --features uffd
+    - run: cargo test --benches --release
+    - run: cargo test --benches --release --features uffd
 
   # Verify that cranelift's code generation is deterministic
   meta_determinist_check:

--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -86,7 +86,7 @@ fn bench_parallel(c: &mut Criterion, path: &Path) {
             (engine, pre)
         });
 
-        for threads in 1..=num_cpus::get_physical() {
+        for threads in 1..=num_cpus::get_physical().min(16) {
             let name = format!(
                 "{}: with {} thread{}",
                 path.file_name().unwrap().to_str().unwrap(),


### PR DESCRIPTION
After adding the `call`-oriented benchmark recently I just noticed that
running benchmarks on CI is taking 30+ minutes which is not intended.
Instead of running a full benchmark run on CI (which I believe we're not
looking at anyway) instead only run the benchmarks for a single
iteration to ensure they still work but otherwise don't collect
statistics about them.

Additionally cap the number of parallel instantiations to 16 to avoid
running tons of tests for machines with lots of cpus.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
