### PR TITLE
feat(wasi)!: clean up `WasiFile` implementation

### DIFF
--- a/crates/wasi-common/cap-std-sync/src/file.rs
+++ b/crates/wasi-common/cap-std-sync/src/file.rs
@@ -26,19 +26,19 @@ impl WasiFile for File {
     fn as_any(&self) -> &dyn Any {
         self
     }
-    async fn datasync(&self) -> Result<(), Error> {
+    async fn datasync(&mut self) -> Result<(), Error> {
         self.0.sync_data()?;
         Ok(())
     }
-    async fn sync(&self) -> Result<(), Error> {
+    async fn sync(&mut self) -> Result<(), Error> {
         self.0.sync_all()?;
         Ok(())
     }
-    async fn get_filetype(&self) -> Result<FileType, Error> {
+    async fn get_filetype(&mut self) -> Result<FileType, Error> {
         let meta = self.0.metadata()?;
         Ok(filetype_from(&meta.file_type()))
     }
-    async fn get_fdflags(&self) -> Result<FdFlags, Error> {
+    async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
         let fdflags = self.0.get_fd_flags()?;
         Ok(from_sysif_fdflags(fdflags))
     }
@@ -54,7 +54,7 @@ impl WasiFile for File {
         self.0.set_fd_flags(set_fd_flags)?;
         Ok(())
     }
-    async fn get_filestat(&self) -> Result<Filestat, Error> {
+    async fn get_filestat(&mut self) -> Result<Filestat, Error> {
         let meta = self.0.metadata()?;
         Ok(Filestat {
             device_id: meta.dev(),
@@ -67,20 +67,20 @@ impl WasiFile for File {
             ctim: meta.created().map(|t| Some(t.into_std())).unwrap_or(None),
         })
     }
-    async fn set_filestat_size(&self, size: u64) -> Result<(), Error> {
+    async fn set_filestat_size(&mut self, size: u64) -> Result<(), Error> {
         self.0.set_len(size)?;
         Ok(())
     }
-    async fn advise(&self, offset: u64, len: u64, advice: Advice) -> Result<(), Error> {
+    async fn advise(&mut self, offset: u64, len: u64, advice: Advice) -> Result<(), Error> {
         self.0.advise(offset, len, convert_advice(advice))?;
         Ok(())
     }
-    async fn allocate(&self, offset: u64, len: u64) -> Result<(), Error> {
+    async fn allocate(&mut self, offset: u64, len: u64) -> Result<(), Error> {
         self.0.allocate(offset, len)?;
         Ok(())
     }
     async fn set_times(
-        &self,
+        &mut self,
         atime: Option<wasi_common::SystemTimeSpec>,
         mtime: Option<wasi_common::SystemTimeSpec>,
     ) -> Result<(), Error> {
@@ -88,41 +88,41 @@ impl WasiFile for File {
             .set_times(convert_systimespec(atime), convert_systimespec(mtime))?;
         Ok(())
     }
-    async fn read_vectored<'a>(&self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
+    async fn read_vectored<'a>(&mut self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
         let n = self.0.read_vectored(bufs)?;
         Ok(n.try_into()?)
     }
     async fn read_vectored_at<'a>(
-        &self,
+        &mut self,
         bufs: &mut [io::IoSliceMut<'a>],
         offset: u64,
     ) -> Result<u64, Error> {
         let n = self.0.read_vectored_at(bufs, offset)?;
         Ok(n.try_into()?)
     }
-    async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+    async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
         let n = self.0.write_vectored(bufs)?;
         Ok(n.try_into()?)
     }
     async fn write_vectored_at<'a>(
-        &self,
+        &mut self,
         bufs: &[io::IoSlice<'a>],
         offset: u64,
     ) -> Result<u64, Error> {
         let n = self.0.write_vectored_at(bufs, offset)?;
         Ok(n.try_into()?)
     }
-    async fn seek(&self, pos: std::io::SeekFrom) -> Result<u64, Error> {
+    async fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64, Error> {
         Ok(self.0.seek(pos)?)
     }
-    async fn peek(&self, buf: &mut [u8]) -> Result<u64, Error> {
+    async fn peek(&mut self, buf: &mut [u8]) -> Result<u64, Error> {
         let n = self.0.peek(buf)?;
         Ok(n.try_into()?)
     }
     async fn num_ready_bytes(&self) -> Result<u64, Error> {
         Ok(self.0.num_ready_bytes()?)
     }
-    fn isatty(&self) -> bool {
+    fn isatty(&mut self) -> bool {
         self.0.is_terminal()
     }
 }

--- a/crates/wasi-common/cap-std-sync/src/net.rs
+++ b/crates/wasi-common/cap-std-sync/src/net.rs
@@ -91,11 +91,11 @@ macro_rules! wasi_listen_write_impl {
                 stream.set_fdflags(fdflags).await?;
                 Ok(Box::new(stream))
             }
-            async fn get_filetype(&self) -> Result<FileType, Error> {
+            async fn get_filetype(&mut self) -> Result<FileType, Error> {
                 Ok(FileType::SocketStream)
             }
             #[cfg(unix)]
-            async fn get_fdflags(&self) -> Result<FdFlags, Error> {
+            async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
                 let fdflags = self.0.as_filelike().get_fd_flags()?;
                 Ok(from_sysif_fdflags(fdflags))
             }
@@ -170,11 +170,11 @@ macro_rules! wasi_stream_write_impl {
             fn as_any(&self) -> &dyn Any {
                 self
             }
-            async fn get_filetype(&self) -> Result<FileType, Error> {
+            async fn get_filetype(&mut self) -> Result<FileType, Error> {
                 Ok(FileType::SocketStream)
             }
             #[cfg(unix)]
-            async fn get_fdflags(&self) -> Result<FdFlags, Error> {
+            async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
                 let fdflags = self.0.as_filelike().get_fd_flags()?;
                 Ok(from_sysif_fdflags(fdflags))
             }
@@ -191,19 +191,19 @@ macro_rules! wasi_stream_write_impl {
                 Ok(())
             }
             async fn read_vectored<'a>(
-                &self,
+                &mut self,
                 bufs: &mut [io::IoSliceMut<'a>],
             ) -> Result<u64, Error> {
                 use std::io::Read;
                 let n = Read::read_vectored(&mut *self.as_socketlike_view::<$std_ty>(), bufs)?;
                 Ok(n.try_into()?)
             }
-            async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+            async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
                 use std::io::Write;
                 let n = Write::write_vectored(&mut *self.as_socketlike_view::<$std_ty>(), bufs)?;
                 Ok(n.try_into()?)
             }
-            async fn peek(&self, buf: &mut [u8]) -> Result<u64, Error> {
+            async fn peek(&mut self, buf: &mut [u8]) -> Result<u64, Error> {
                 let n = self.0.peek(buf)?;
                 Ok(n.try_into()?)
             }

--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -70,22 +70,22 @@ impl WasiCtx {
         Ok(())
     }
 
-    pub fn set_stdin(&mut self, f: Box<dyn WasiFile>) {
-        let rights = Self::stdio_rights(&*f);
+    pub fn set_stdin(&mut self, mut f: Box<dyn WasiFile>) {
+        let rights = Self::stdio_rights(&mut *f);
         self.insert_file(0, f, rights);
     }
 
-    pub fn set_stdout(&mut self, f: Box<dyn WasiFile>) {
-        let rights = Self::stdio_rights(&*f);
+    pub fn set_stdout(&mut self, mut f: Box<dyn WasiFile>) {
+        let rights = Self::stdio_rights(&mut *f);
         self.insert_file(1, f, rights);
     }
 
-    pub fn set_stderr(&mut self, f: Box<dyn WasiFile>) {
-        let rights = Self::stdio_rights(&*f);
+    pub fn set_stderr(&mut self, mut f: Box<dyn WasiFile>) {
+        let rights = Self::stdio_rights(&mut *f);
         self.insert_file(2, f, rights);
     }
 
-    fn stdio_rights(f: &dyn WasiFile) -> FileCaps {
+    fn stdio_rights(f: &mut dyn WasiFile) -> FileCaps {
         let mut rights = FileCaps::all();
 
         // If `f` is a tty, restrict the `tell` and `seek` capabilities, so

--- a/crates/wasi-common/src/file.rs
+++ b/crates/wasi-common/src/file.rs
@@ -5,9 +5,9 @@ use std::any::Any;
 #[wiggle::async_trait]
 pub trait WasiFile: Send + Sync {
     fn as_any(&self) -> &dyn Any;
-    async fn get_filetype(&self) -> Result<FileType, Error>;
+    async fn get_filetype(&mut self) -> Result<FileType, Error>;
 
-    fn isatty(&self) -> bool {
+    fn isatty(&mut self) -> bool {
         false
     }
 
@@ -15,15 +15,15 @@ pub trait WasiFile: Send + Sync {
         Err(Error::badf())
     }
 
-    async fn datasync(&self) -> Result<(), Error> {
+    async fn datasync(&mut self) -> Result<(), Error> {
         Ok(())
     }
 
-    async fn sync(&self) -> Result<(), Error> {
+    async fn sync(&mut self) -> Result<(), Error> {
         Ok(())
     }
 
-    async fn get_fdflags(&self) -> Result<FdFlags, Error> {
+    async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
         Ok(FdFlags::empty())
     }
 
@@ -31,7 +31,7 @@ pub trait WasiFile: Send + Sync {
         Err(Error::badf())
     }
 
-    async fn get_filestat(&self) -> Result<Filestat, Error> {
+    async fn get_filestat(&mut self) -> Result<Filestat, Error> {
         Ok(Filestat {
             device_id: 0,
             inode: 0,
@@ -44,55 +44,58 @@ pub trait WasiFile: Send + Sync {
         })
     }
 
-    async fn set_filestat_size(&self, _size: u64) -> Result<(), Error> {
+    async fn set_filestat_size(&mut self, _size: u64) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn advise(&self, _offset: u64, _len: u64, _advice: Advice) -> Result<(), Error> {
+    async fn advise(&mut self, _offset: u64, _len: u64, _advice: Advice) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn allocate(&self, _offset: u64, _len: u64) -> Result<(), Error> {
+    async fn allocate(&mut self, _offset: u64, _len: u64) -> Result<(), Error> {
         Err(Error::badf())
     }
 
     async fn set_times(
-        &self,
+        &mut self,
         _atime: Option<SystemTimeSpec>,
         _mtime: Option<SystemTimeSpec>,
     ) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn read_vectored<'a>(&self, _bufs: &mut [std::io::IoSliceMut<'a>]) -> Result<u64, Error> {
+    async fn read_vectored<'a>(
+        &mut self,
+        _bufs: &mut [std::io::IoSliceMut<'a>],
+    ) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
     async fn read_vectored_at<'a>(
-        &self,
+        &mut self,
         _bufs: &mut [std::io::IoSliceMut<'a>],
         _offset: u64,
     ) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn write_vectored<'a>(&self, _bufs: &[std::io::IoSlice<'a>]) -> Result<u64, Error> {
+    async fn write_vectored<'a>(&mut self, _bufs: &[std::io::IoSlice<'a>]) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
     async fn write_vectored_at<'a>(
-        &self,
+        &mut self,
         _bufs: &[std::io::IoSlice<'a>],
         _offset: u64,
     ) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn seek(&self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
+    async fn seek(&mut self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn peek(&self, _buf: &mut [u8]) -> Result<u64, Error> {
+    async fn peek(&mut self, _buf: &mut [u8]) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
@@ -190,7 +193,7 @@ impl FileEntry {
         Ok(())
     }
 
-    pub async fn get_fdstat(&self) -> Result<FdStat, Error> {
+    pub async fn get_fdstat(&mut self) -> Result<FdStat, Error> {
         Ok(FdStat {
             filetype: self.file.get_filetype().await?,
             caps: self.caps,

--- a/crates/wasi-common/src/pipe.rs
+++ b/crates/wasi-common/src/pipe.rs
@@ -105,10 +105,10 @@ impl<R: Read + Any + Send + Sync> WasiFile for ReadPipe<R> {
     fn as_any(&self) -> &dyn Any {
         self
     }
-    async fn get_filetype(&self) -> Result<FileType, Error> {
+    async fn get_filetype(&mut self) -> Result<FileType, Error> {
         Ok(FileType::Pipe)
     }
-    async fn read_vectored<'a>(&self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
+    async fn read_vectored<'a>(&mut self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
         let n = self.borrow().read_vectored(bufs)?;
         Ok(n.try_into()?)
     }
@@ -189,13 +189,13 @@ impl<W: Write + Any + Send + Sync> WasiFile for WritePipe<W> {
     fn as_any(&self) -> &dyn Any {
         self
     }
-    async fn get_filetype(&self) -> Result<FileType, Error> {
+    async fn get_filetype(&mut self) -> Result<FileType, Error> {
         Ok(FileType::Pipe)
     }
-    async fn get_fdflags(&self) -> Result<FdFlags, Error> {
+    async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
         Ok(FdFlags::APPEND)
     }
-    async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+    async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
         let n = self.borrow().write_vectored(bufs)?;
         Ok(n.try_into()?)
     }

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -462,8 +462,10 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         fd: types::Fd,
         iovs: &types::IovecArray<'a>,
     ) -> Result<types::Size, Error> {
-        let table = self.table();
-        let f = table.get_file(u32::from(fd))?.get_cap(FileCaps::READ)?;
+        let f = self
+            .table()
+            .get_file_mut(u32::from(fd))?
+            .get_cap_mut(FileCaps::READ)?;
 
         let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> = iovs
             .iter()
@@ -489,10 +491,10 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         iovs: &types::IovecArray<'a>,
         offset: types::Filesize,
     ) -> Result<types::Size, Error> {
-        let table = self.table();
-        let f = table
-            .get_file(u32::from(fd))?
-            .get_cap(FileCaps::READ | FileCaps::SEEK)?;
+        let f = self
+            .table()
+            .get_file_mut(u32::from(fd))?
+            .get_cap_mut(FileCaps::READ | FileCaps::SEEK)?;
 
         let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> = iovs
             .iter()
@@ -517,8 +519,10 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         fd: types::Fd,
         ciovs: &types::CiovecArray<'a>,
     ) -> Result<types::Size, Error> {
-        let table = self.table();
-        let f = table.get_file(u32::from(fd))?.get_cap(FileCaps::WRITE)?;
+        let f = self
+            .table()
+            .get_file_mut(u32::from(fd))?
+            .get_cap_mut(FileCaps::WRITE)?;
 
         let guest_slices: Vec<wiggle::GuestSlice<u8>> = ciovs
             .iter()
@@ -544,10 +548,10 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         ciovs: &types::CiovecArray<'a>,
         offset: types::Filesize,
     ) -> Result<types::Size, Error> {
-        let table = self.table();
-        let f = table
-            .get_file(u32::from(fd))?
-            .get_cap(FileCaps::WRITE | FileCaps::SEEK)?;
+        let f = self
+            .table()
+            .get_file_mut(u32::from(fd))?
+            .get_cap_mut(FileCaps::WRITE | FileCaps::SEEK)?;
 
         let guest_slices: Vec<wiggle::GuestSlice<u8>> = ciovs
             .iter()

--- a/crates/wasi-common/tokio/src/file.rs
+++ b/crates/wasi-common/tokio/src/file.rs
@@ -94,64 +94,64 @@ macro_rules! wasi_file_impl {
             fn as_any(&self) -> &dyn Any {
                 self
             }
-            async fn datasync(&self) -> Result<(), Error> {
+            async fn datasync(&mut self) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.datasync())
             }
-            async fn sync(&self) -> Result<(), Error> {
+            async fn sync(&mut self) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.sync())
             }
-            async fn get_filetype(&self) -> Result<FileType, Error> {
+            async fn get_filetype(&mut self) -> Result<FileType, Error> {
                 block_on_dummy_executor(|| self.0.get_filetype())
             }
-            async fn get_fdflags(&self) -> Result<FdFlags, Error> {
+            async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
                 block_on_dummy_executor(|| self.0.get_fdflags())
             }
             async fn set_fdflags(&mut self, fdflags: FdFlags) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.set_fdflags(fdflags))
             }
-            async fn get_filestat(&self) -> Result<Filestat, Error> {
+            async fn get_filestat(&mut self) -> Result<Filestat, Error> {
                 block_on_dummy_executor(|| self.0.get_filestat())
             }
-            async fn set_filestat_size(&self, size: u64) -> Result<(), Error> {
+            async fn set_filestat_size(&mut self, size: u64) -> Result<(), Error> {
                 block_on_dummy_executor(move || self.0.set_filestat_size(size))
             }
-            async fn advise(&self, offset: u64, len: u64, advice: Advice) -> Result<(), Error> {
+            async fn advise(&mut self, offset: u64, len: u64, advice: Advice) -> Result<(), Error> {
                 block_on_dummy_executor(move || self.0.advise(offset, len, advice))
             }
-            async fn allocate(&self, offset: u64, len: u64) -> Result<(), Error> {
+            async fn allocate(&mut self, offset: u64, len: u64) -> Result<(), Error> {
                 block_on_dummy_executor(move || self.0.allocate(offset, len))
             }
             async fn read_vectored<'a>(
-                &self,
+                &mut self,
                 bufs: &mut [io::IoSliceMut<'a>],
             ) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.read_vectored(bufs))
             }
             async fn read_vectored_at<'a>(
-                &self,
+                &mut self,
                 bufs: &mut [io::IoSliceMut<'a>],
                 offset: u64,
             ) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.read_vectored_at(bufs, offset))
             }
-            async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+            async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.write_vectored(bufs))
             }
             async fn write_vectored_at<'a>(
-                &self,
+                &mut self,
                 bufs: &[io::IoSlice<'a>],
                 offset: u64,
             ) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.write_vectored_at(bufs, offset))
             }
-            async fn seek(&self, pos: std::io::SeekFrom) -> Result<u64, Error> {
+            async fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.seek(pos))
             }
-            async fn peek(&self, buf: &mut [u8]) -> Result<u64, Error> {
+            async fn peek(&mut self, buf: &mut [u8]) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.peek(buf))
             }
             async fn set_times(
-                &self,
+                &mut self,
                 atime: Option<wasi_common::SystemTimeSpec>,
                 mtime: Option<wasi_common::SystemTimeSpec>,
             ) -> Result<(), Error> {
@@ -160,7 +160,7 @@ macro_rules! wasi_file_impl {
             async fn num_ready_bytes(&self) -> Result<u64, Error> {
                 block_on_dummy_executor(|| self.0.num_ready_bytes())
             }
-            fn isatty(&self) -> bool {
+            fn isatty(&mut self) -> bool {
                 self.0.isatty()
             }
 

--- a/crates/wasi-common/tokio/tests/poll_oneoff.rs
+++ b/crates/wasi-common/tokio/tests/poll_oneoff.rs
@@ -20,7 +20,7 @@ async fn empty_file_readable() -> Result<(), Error> {
     let d = workspace.open_dir("d").context("open dir")?;
     let d = Dir::from_cap_std(d);
 
-    let f = d
+    let mut f = d
         .open_file(false, "f", OFlags::CREATE, false, true, FdFlags::empty())
         .await
         .context("create writable file f")?;


### PR DESCRIPTION
This effort includes two major changes:

1. Most methods are given a default implementation. This aids
implementors who only need a few of the methods and it allows us to
remove a bunch of boilerplate code.

2. Most methods are changed to take a mutable reference. This is
important since wasmtime cannot know ahead of time what APIs
implementors are trying to adapt.

BREAKING CHANGE: `WasiFile` has changed method signatures

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>