### PR TITLE
fuzz: Raise memory pages limit for spectest fuzzing

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -355,9 +355,9 @@ impl Config {
             limits.memories = 1;
             limits.tables = 5;
             limits.table_elements = 1_000;
-            // Set a lower bound of 10 pages as the spec tests define memories with at
+            // Set a lower bound of as the spec tests define memories with at
             // least a few pages and some tests do memory grow operations.
-            limits.memory_pages = std::cmp::max(limits.memory_pages, 10);
+            limits.memory_pages = std::cmp::max(limits.memory_pages, 900);
 
             match &mut self.wasmtime.memory_config {
                 MemoryConfig::Normal(config) => {


### PR DESCRIPTION
A recent fuzz failure showed that at least `call.wast` requires a memory
larger than 10 pages, so increase the minimum number of pages that can
be used for executing spec tests.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
