### PR TITLE
Ensure functions are aligned properly on AArch64

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1616,7 +1616,7 @@ impl<I: VCodeInst> MachTextSectionBuilder<I> {
 }
 
 impl<I: VCodeInst> TextSectionBuilder for MachTextSectionBuilder<I> {
-    fn append(&mut self, named: bool, func: &[u8], align: u32) -> u64 {
+    fn append(&mut self, named: bool, func: &[u8], align: Option<u32>) -> u64 {
         // Conditionally emit an island if it's necessary to resolve jumps
         // between functions which are too far away.
         let size = func.len() as u32;
@@ -1624,7 +1624,7 @@ impl<I: VCodeInst> TextSectionBuilder for MachTextSectionBuilder<I> {
             self.buf.emit_island_maybe_forced(self.force_veneers, size);
         }
 
-        self.buf.align_to(align);
+        self.buf.align_to(align.unwrap_or(I::LabelUse::ALIGN));
         let pos = self.buf.cur_offset();
         if named {
             self.buf.bind_label(MachLabel::from_block(self.next_func));

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -370,7 +370,7 @@ pub trait TextSectionBuilder {
     ///
     /// This function returns the offset at which the data was placed in the
     /// text section.
-    fn append(&mut self, labeled: bool, data: &[u8], align: u32) -> u64;
+    fn append(&mut self, labeled: bool, data: &[u8], align: Option<u32>) -> u64;
 
     /// Attempts to resolve a relocation for this function.
     ///

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -264,9 +264,11 @@ impl wasmtime_environ::Compiler for Compiler {
             traps.push(range.clone(), &func.traps);
             func_starts.push(range.start);
             if self.linkopts.padding_between_functions > 0 {
-                builder
-                    .text
-                    .append(false, &vec![0; self.linkopts.padding_between_functions], 1);
+                builder.text.append(
+                    false,
+                    &vec![0; self.linkopts.padding_between_functions],
+                    Some(1),
+                );
             }
         }
 

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -184,12 +184,12 @@ impl<'a> ObjectBuilder<'a> {
     /// that the function resides within the text section.
     fn append_func(
         &mut self,
-        wat: bool,
+        labeled: bool,
         name: Vec<u8>,
         func: &'a CompiledFunction,
     ) -> (SymbolId, Range<u64>) {
         let body_len = func.body.len() as u64;
-        let off = self.text.append(wat, &func.body, 1);
+        let off = self.text.append(labeled, &func.body, None);
 
         let symbol_id = self.obj.add_symbol(Symbol {
             name,
@@ -215,7 +215,7 @@ impl<'a> ObjectBuilder<'a> {
                 let unwind_size = info.emit_size();
                 let mut unwind_info = vec![0; unwind_size];
                 info.emit(&mut unwind_info);
-                let unwind_off = self.text.append(false, &unwind_info, 4);
+                let unwind_off = self.text.append(false, &unwind_info, Some(4));
                 self.windows_unwind_info.push(RUNTIME_FUNCTION {
                     begin: u32::try_from(off).unwrap(),
                     end: u32::try_from(off + body_len).unwrap(),


### PR DESCRIPTION
Previously (as in an hour ago) #3905 landed a new ability for fuzzing to
arbitrarily insert padding between functions. Running some fuzzers
locally though this instantly hit a lot of problems on AArch64 because
the arbitrary padding isn't aligned to 4 bytes like all other functions
are. To fix this issue appending functions now correctly aligns the
output as appropriate for the platform. The alignment argument for
appending was switched to `None` where `None` means "use the platform
default" and otherwise and explicit alignment can be specified for
inserting other data (like arbitrary padding or Windows unwind tables).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
