### PR TITLE
fix(wasi): enable all `WasiFile`s to be pollable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,6 +3204,7 @@ dependencies = [
  "bitflags",
  "cap-rand",
  "cap-std",
+ "io-extras",
  "rustix",
  "thiserror",
  "tracing",

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -30,6 +30,7 @@ bitflags = "1.2"
 rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies]
+io-extras = "0.13.2"
 winapi = "0.3"
 
 [badges]

--- a/crates/wasi-common/cap-std-sync/src/file.rs
+++ b/crates/wasi-common/cap-std-sync/src/file.rs
@@ -26,6 +26,15 @@ impl WasiFile for File {
     fn as_any(&self) -> &dyn Any {
         self
     }
+    #[cfg(unix)]
+    fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+        Some(self.0.as_fd())
+    }
+
+    #[cfg(windows)]
+    fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+        Some(self.0.as_raw_handle_or_socket())
+    }
     async fn datasync(&mut self) -> Result<(), Error> {
         self.0.sync_data()?;
         Ok(())

--- a/crates/wasi-common/cap-std-sync/src/net.rs
+++ b/crates/wasi-common/cap-std-sync/src/net.rs
@@ -85,6 +85,15 @@ macro_rules! wasi_listen_write_impl {
             fn as_any(&self) -> &dyn Any {
                 self
             }
+            #[cfg(unix)]
+            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+                Some(self.0.as_fd())
+            }
+
+            #[cfg(windows)]
+            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+                Some(self.0.as_raw_handle_or_socket())
+            }
             async fn sock_accept(&mut self, fdflags: FdFlags) -> Result<Box<dyn WasiFile>, Error> {
                 let (stream, _) = self.0.accept()?;
                 let mut stream = <$stream>::from_cap_std(stream);
@@ -169,6 +178,15 @@ macro_rules! wasi_stream_write_impl {
         impl WasiFile for $ty {
             fn as_any(&self) -> &dyn Any {
                 self
+            }
+            #[cfg(unix)]
+            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+                Some(self.0.as_fd())
+            }
+
+            #[cfg(windows)]
+            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+                Some(self.0.as_raw_handle_or_socket())
             }
             async fn get_filetype(&mut self) -> Result<FileType, Error> {
                 Ok(FileType::SocketStream)

--- a/crates/wasi-common/cap-std-sync/src/sched/unix.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/unix.rs
@@ -1,15 +1,8 @@
 use cap_std::time::Duration;
-use io_lifetimes::{AsFd, BorrowedFd};
 use rustix::io::{PollFd, PollFlags};
 use std::convert::TryInto;
-use wasi_common::{
-    file::WasiFile,
-    sched::{
-        subscription::{RwEventFlags, Subscription},
-        Poll,
-    },
-    Error, ErrorExt,
-};
+use wasi_common::sched::subscription::{RwEventFlags, Subscription};
+use wasi_common::{sched::Poll, Error, ErrorExt};
 
 pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
     if poll.is_empty() {
@@ -19,16 +12,18 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
     for s in poll.rw_subscriptions() {
         match s {
             Subscription::Read(f) => {
-                let fd = wasi_file_fd(f.file).ok_or(
-                    Error::invalid_argument().context("read subscription fd downcast failed"),
-                )?;
+                let fd = f
+                    .file
+                    .pollable()
+                    .ok_or(Error::invalid_argument().context("file is not pollable"))?;
                 pollfds.push(PollFd::from_borrowed_fd(fd, PollFlags::IN));
             }
 
             Subscription::Write(f) => {
-                let fd = wasi_file_fd(f.file).ok_or(
-                    Error::invalid_argument().context("write subscription fd downcast failed"),
-                )?;
+                let fd = f
+                    .file
+                    .pollable()
+                    .ok_or(Error::invalid_argument().context("file is not pollable"))?;
                 pollfds.push(PollFd::from_borrowed_fd(fd, PollFlags::OUT));
             }
             Subscription::MonotonicClock { .. } => unreachable!(),
@@ -84,31 +79,4 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
             .unwrap()
     }
     Ok(())
-}
-
-fn wasi_file_fd(f: &dyn WasiFile) -> Option<BorrowedFd<'_>> {
-    let a = f.as_any();
-    if a.is::<crate::file::File>() {
-        Some(a.downcast_ref::<crate::file::File>().unwrap().as_fd())
-    } else if a.is::<crate::net::TcpStream>() {
-        Some(a.downcast_ref::<crate::net::TcpStream>().unwrap().as_fd())
-    } else if a.is::<crate::net::TcpListener>() {
-        Some(a.downcast_ref::<crate::net::TcpListener>().unwrap().as_fd())
-    } else if a.is::<crate::net::UnixStream>() {
-        Some(a.downcast_ref::<crate::net::UnixStream>().unwrap().as_fd())
-    } else if a.is::<crate::net::UnixListener>() {
-        Some(
-            a.downcast_ref::<crate::net::UnixListener>()
-                .unwrap()
-                .as_fd(),
-        )
-    } else if a.is::<crate::stdio::Stdin>() {
-        Some(a.downcast_ref::<crate::stdio::Stdin>().unwrap().as_fd())
-    } else if a.is::<crate::stdio::Stdout>() {
-        Some(a.downcast_ref::<crate::stdio::Stdout>().unwrap().as_fd())
-    } else if a.is::<crate::stdio::Stderr>() {
-        Some(a.downcast_ref::<crate::stdio::Stderr>().unwrap().as_fd())
-    } else {
-        None
-    }
 }

--- a/crates/wasi-common/cap-std-sync/src/stdio.rs
+++ b/crates/wasi-common/cap-std-sync/src/stdio.rs
@@ -31,6 +31,15 @@ impl WasiFile for Stdin {
     fn as_any(&self) -> &dyn Any {
         self
     }
+    #[cfg(unix)]
+    fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+        Some(self.0.as_fd())
+    }
+
+    #[cfg(windows)]
+    fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+        Some(self.0.as_raw_handle_or_socket())
+    }
     async fn get_filetype(&mut self) -> Result<FileType, Error> {
         if self.isatty() {
             Ok(FileType::CharacterDevice)
@@ -97,6 +106,15 @@ macro_rules! wasi_file_write_impl {
         impl WasiFile for $ty {
             fn as_any(&self) -> &dyn Any {
                 self
+            }
+            #[cfg(unix)]
+            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+                Some(self.0.as_fd())
+            }
+
+            #[cfg(windows)]
+            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+                Some(self.0.as_raw_handle_or_socket())
             }
             async fn get_filetype(&mut self) -> Result<FileType, Error> {
                 if self.isatty() {

--- a/crates/wasi-common/src/file.rs
+++ b/crates/wasi-common/src/file.rs
@@ -7,6 +7,16 @@ pub trait WasiFile: Send + Sync {
     fn as_any(&self) -> &dyn Any;
     async fn get_filetype(&mut self) -> Result<FileType, Error>;
 
+    #[cfg(unix)]
+    fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+        None
+    }
+
+    #[cfg(windows)]
+    fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+        None
+    }
+
     fn isatty(&mut self) -> bool {
         false
     }

--- a/crates/wasi-common/tokio/src/file.rs
+++ b/crates/wasi-common/tokio/src/file.rs
@@ -94,6 +94,15 @@ macro_rules! wasi_file_impl {
             fn as_any(&self) -> &dyn Any {
                 self
             }
+            #[cfg(unix)]
+            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+                Some(self.0.as_fd())
+            }
+
+            #[cfg(windows)]
+            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+                Some(self.0.as_raw_handle_or_socket())
+            }
             async fn datasync(&mut self) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.datasync())
             }

--- a/crates/wasi-common/tokio/src/sched/windows.rs
+++ b/crates/wasi-common/tokio/src/sched/windows.rs
@@ -1,5 +1,4 @@
 use crate::block_on_dummy_executor;
-use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};
 use wasi_cap_std_sync::sched::windows::poll_oneoff_;
 use wasi_common::{file::WasiFile, sched::Poll, Error};
 
@@ -8,52 +7,9 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
     // we use the blocking poll_oneoff implementation from the wasi-cap-std-crate.
     // We provide a function specific to this crate's WasiFile types for downcasting
     // to a RawHandle.
-    block_on_dummy_executor(move || poll_oneoff_(poll, wasi_file_is_stdin, wasi_file_raw_handle))
+    block_on_dummy_executor(move || poll_oneoff_(poll, wasi_file_is_stdin))
 }
 
 pub fn wasi_file_is_stdin(f: &dyn WasiFile) -> bool {
     f.as_any().is::<crate::stdio::Stdin>()
-}
-
-fn wasi_file_raw_handle(f: &dyn WasiFile) -> Option<RawHandleOrSocket> {
-    let a = f.as_any();
-    if a.is::<crate::file::File>() {
-        Some(
-            a.downcast_ref::<crate::file::File>()
-                .unwrap()
-                .as_raw_handle_or_socket(),
-        )
-    } else if a.is::<crate::net::TcpListener>() {
-        Some(
-            a.downcast_ref::<crate::net::TcpListener>()
-                .unwrap()
-                .as_raw_handle_or_socket(),
-        )
-    } else if a.is::<crate::net::TcpStream>() {
-        Some(
-            a.downcast_ref::<crate::net::TcpStream>()
-                .unwrap()
-                .as_raw_handle_or_socket(),
-        )
-    } else if a.is::<crate::stdio::Stdin>() {
-        Some(
-            a.downcast_ref::<crate::stdio::Stdin>()
-                .unwrap()
-                .as_raw_handle_or_socket(),
-        )
-    } else if a.is::<crate::stdio::Stdout>() {
-        Some(
-            a.downcast_ref::<crate::stdio::Stdout>()
-                .unwrap()
-                .as_raw_handle_or_socket(),
-        )
-    } else if a.is::<crate::stdio::Stderr>() {
-        Some(
-            a.downcast_ref::<crate::stdio::Stderr>()
-                .unwrap()
-                .as_raw_handle_or_socket(),
-        )
-    } else {
-        None
-    }
 }


### PR DESCRIPTION
Currently, the use of the downcast method means that you have to use one
of the hard-coded types. But Enarx needs to define its own `WasiFile`
implementations. This works fine, except the resulting files cannot be
used in poll because they aren't part of the hard-coded list.

Replace this with an accessor method for the pollable type in
`WasiFile`. Because we provide a default implementation of the method
and manually implement it on all the hard-coded types, this is backwards
compatible.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
