### PR TITLE
Add agenda item for Wasmtime 2022-03-17 meeting.

### DIFF
--- a/meetings/wasmtime/2022/wasmtime-03-17.md
+++ b/meetings/wasmtime/2022/wasmtime-03-17.md
@@ -11,6 +11,9 @@
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Other agenda items
+    1. Release policy discussion
+       - Policy around "when should we do a point release" is underspecified;
+         clarify and establish guidelines one way or another
     1. _Submit a PR to add your item here_
 
 ## Notes


### PR DESCRIPTION
We've had a few requests for point releases in the last few days so, after quick consultation with @alexcrichton, this probably deserves more explicit discussion in our biweekly to set guidelines! (Thanks to folks who've made the requests for spawning this discussion; no pre-judgment intended on the question either way by adding this agenda item)