### PR TITLE
Use const-initialized thread locals

### DIFF
--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -176,7 +176,7 @@ mod details {
 
     // Information about passes in a single thread.
     thread_local! {
-        static CURRENT_PASS: Cell<Pass> = Cell::new(Pass::None);
+        static CURRENT_PASS: Cell<Pass> = const { Cell::new(Pass::None) };
         static PASS_TIME: RefCell<PassTimes> = RefCell::new(Default::default());
     }
 

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -257,7 +257,7 @@ pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
     // when the thread exists. Otherwise this function is only ever called at
     // most once per-thread.
     thread_local! {
-        static STACK: RefCell<Option<Stack>> = RefCell::new(None);
+        static STACK: RefCell<Option<Stack>> = const { RefCell::new(None) };
     }
 
     /// The size of the sigaltstack (not including the guard, which will be


### PR DESCRIPTION
This was a relatively recent feature added to the Rust standard library
which should help accelerate calls into WebAssembly slightly.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
