### PR TITLE
fuzz: Increase more limits when spectest fuzzing

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -354,12 +354,16 @@ impl Config {
             ..
         } = &mut self.wasmtime.strategy
         {
-            limits.memories = 1;
-            limits.tables = 5;
-            limits.table_elements = 1_000;
-            // Set a lower bound of as the spec tests define memories with at
-            // least a few pages and some tests do memory grow operations.
-            limits.memory_pages = std::cmp::max(limits.memory_pages, 900);
+            // Configure the lower bound of a number of limits to what's
+            // required to actually run the spec tests. Fuzz-generated inputs
+            // may have limits less than these thresholds which would cause the
+            // spec tests to fail which isn't particularly interesting.
+            limits.memories = limits.memories.max(1);
+            limits.tables = limits.memories.max(5);
+            limits.table_elements = limits.memories.max(1_000);
+            limits.memory_pages = limits.memory_pages.max(900);
+            limits.count = limits.count.max(40);
+            limits.size = limits.size.max(4096);
 
             match &mut self.wasmtime.memory_config {
                 MemoryConfig::Normal(config) => {


### PR DESCRIPTION
When using the pooling instance allocator for running spec tests we have
to make sure that the configured limits of the allocator aren't so low
as to cause the spec tests to fail due to resource exhaustion issues or
similar. This commit adds in minimum thresholds for instance size as
well as instance count. While here this goes ahead and refactors
everything here to look similar.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
