### PR TITLE
Support disabling backtraces at compile time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,8 @@ jobs:
     - run: cargo check -p wasmtime --no-default-features --features uffd
     - run: cargo check -p wasmtime --no-default-features --features pooling-allocator
     - run: cargo check -p wasmtime --no-default-features --features cranelift
-    - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache
+    - run: cargo check -p wasmtime --no-default-features --features wasm-backtrace
+    - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache,wasm-backtrace
 
     # Check that benchmarks of the cranelift project build
     - run: cargo check --benches -p cranelift-codegen

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ default = [
   "wasi-nn",
   "pooling-allocator",
   "memory-init-cow",
+  "wasm-backtrace",
 ]
 jitdump = ["wasmtime/jitdump"]
 vtune = ["wasmtime/vtune"]
@@ -109,6 +110,7 @@ memory-init-cow = ["wasmtime/memory-init-cow"]
 pooling-allocator = ["wasmtime/pooling-allocator"]
 all-arch = ["wasmtime/all-arch"]
 posix-signals-on-macos = ["wasmtime/posix-signals-on-macos"]
+wasm-backtrace = ["wasmtime/wasm-backtrace"]
 
 # Stub feature that does nothing, for Cargo-features compatibility: the new
 # backend is the default now.

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 env_logger = "0.8"
 anyhow = "1.0"
 once_cell = "1.3"
-wasmtime = { path = "../wasmtime", default-features = false, features = ['cranelift'] }
+wasmtime = { path = "../wasmtime", default-features = false, features = ['cranelift', 'wasm-backtrace'] }
 wasmtime-c-api-macros = { path = "macros" }
 
 # Optional dependency for the `wat2wasm` API

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -188,9 +188,13 @@ impl wasmtime_environ::Compiler for Compiler {
 
         let stack_maps = mach_stack_maps_to_stack_maps(result.buffer.stack_maps());
 
-        let unwind_info = context
-            .create_unwind_info(isa)
-            .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?;
+        let unwind_info = if isa.flags().unwind_info() {
+            context
+                .create_unwind_info(isa)
+                .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?
+        } else {
+            None
+        };
 
         let address_transform =
             self.get_function_address_map(&context, &input, code_buf.len() as u32, tunables);
@@ -566,9 +570,13 @@ impl Compiler {
             .relocs()
             .is_empty());
 
-        let unwind_info = context
-            .create_unwind_info(isa)
-            .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?;
+        let unwind_info = if isa.flags().unwind_info() {
+            context
+                .create_unwind_info(isa)
+                .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?
+        } else {
+            None
+        };
 
         Ok(CompiledFunction {
             body: code_buf,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,7 +22,7 @@ indexmap = "1.0.2"
 thiserror = "1.0.4"
 more-asserts = "0.2.1"
 cfg-if = "1.0"
-backtrace = "0.3.61"
+backtrace = { version = "0.3.61", optional = true }
 rand = "0.8.3"
 anyhow = "1.0.38"
 memfd = { version = "0.4.1", optional = true }
@@ -46,8 +46,8 @@ cc = "1.0"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = []
 memory-init-cow = ['memfd']
+wasm-backtrace = ["backtrace"]
 
 async = ["wasmtime-fiber"]
 

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -704,6 +704,7 @@ impl VMExternRefActivationsTable {
         }
     }
 
+    #[cfg_attr(not(feature = "wasm-backtrace"), allow(dead_code))]
     fn insert_precise_stack_root(
         precise_stack_roots: &mut HashSet<VMExternRefWithTraits>,
         root: NonNull<VMExternData>,
@@ -866,6 +867,7 @@ impl<T> std::ops::DerefMut for DebugOnly<T> {
 ///
 /// Additionally, you must have registered the stack maps for every Wasm module
 /// that has frames on the stack with the given `stack_maps_registry`.
+#[cfg_attr(not(feature = "wasm-backtrace"), allow(unused_mut, unused_variables))]
 pub unsafe fn gc(
     module_info_lookup: &dyn ModuleInfoLookup,
     externref_activations_table: &mut VMExternRefActivationsTable,
@@ -893,6 +895,7 @@ pub unsafe fn gc(
         None => {
             if cfg!(debug_assertions) {
                 // Assert that there aren't any Wasm frames on the stack.
+                #[cfg(feature = "wasm-backtrace")]
                 backtrace::trace(|frame| {
                     assert!(module_info_lookup.lookup(frame.ip() as usize).is_none());
                     true
@@ -917,7 +920,7 @@ pub unsafe fn gc(
     //   newly-discovered precise set.
 
     // The SP of the previous (younger) frame we processed.
-    let mut last_sp = None;
+    let mut last_sp: Option<usize> = None;
 
     // Whether we have found our stack canary or not yet.
     let mut found_canary = false;
@@ -934,6 +937,7 @@ pub unsafe fn gc(
         });
     }
 
+    #[cfg(feature = "wasm-backtrace")]
     backtrace::trace(|frame| {
         let pc = frame.ip() as usize;
         let sp = frame.sp() as usize;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::mmap_vec::MmapVec;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
     catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, tls_eager_initialize,
-    SignalHandler, TlsRestore, Trap,
+    Backtrace, SignalHandler, TlsRestore, Trap,
 };
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -61,7 +61,6 @@ use crate::instance::Instance;
 use crate::table::{Table, TableElementType};
 use crate::traphandlers::{raise_lib_trap, resume_panic, Trap};
 use crate::vmcontext::{VMCallerCheckedAnyfunc, VMContext};
-use backtrace::Backtrace;
 use std::mem;
 use std::ptr::{self, NonNull};
 use wasmtime_environ::{
@@ -588,10 +587,7 @@ unsafe fn validate_atomic_addr(
     addr: usize,
 ) -> Result<(), Trap> {
     if addr > instance.get_memory(memory).current_length {
-        return Err(Trap::Wasm {
-            trap_code: TrapCode::HeapOutOfBounds,
-            backtrace: Backtrace::new_unresolved(),
-        });
+        return Err(Trap::wasm(TrapCode::HeapOutOfBounds));
     }
     Ok(())
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"
 cfg-if = "1.0"
-backtrace = "0.3.61"
+backtrace = { version = "0.3.61", optional = true }
 log = "0.4.8"
 wat = { version = "1.0.36", optional = true }
 serde = { version = "1.0.94", features = ["derive"] }
@@ -61,6 +61,7 @@ default = [
   'pooling-allocator',
   'memory-init-cow',
   'vtune',
+  'wasm-backtrace',
 ]
 
 # An on-by-default feature enabling runtime compilation of WebAssembly modules
@@ -108,3 +109,9 @@ posix-signals-on-macos = ["wasmtime-runtime/posix-signals-on-macos"]
 # Enabling this feature has no effect on unsupported platforms or when the
 # `uffd` feature is enabled.
 memory-init-cow = ["wasmtime-runtime/memory-init-cow"]
+
+# Enables runtime support necessary to capture backtraces of WebAssembly code
+# that is running.
+#
+# This is enabled by default.
+wasm-backtrace = ["wasmtime-runtime/wasm-backtrace", "backtrace"]

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -304,7 +304,7 @@ impl Engine {
             // can affect the way the generated code performs or behaves at
             // runtime.
             "avoid_div_traps" => *value == FlagValue::Bool(true),
-            "unwind_info" => *value == FlagValue::Bool(true),
+            "unwind_info" => *value == FlagValue::Bool(cfg!(feature = "wasm-backtrace")),
             "libcall_call_conv" => *value == FlagValue::Enum("isa_default".into()),
 
             // Features wasmtime doesn't use should all be disabled, since

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -290,6 +290,14 @@
 //!   run-time via [`Config::memory_init_cow`] (which is also enabled by
 //!   default).
 //!
+//! * `wasm-backtrace` - Enabled by default, this feature builds in support to
+//!   generate backtraces at runtime for WebAssembly modules. This means that
+//!   unwinding information is compiled into wasm modules and necessary runtime
+//!   dependencies are enabled as well. If this is turned off then some methods
+//!   to look at trap frames will not be available. Additionally at this time
+//!   disabling this feature means that the reference types feature is always
+//!   disabled as well.
+//!
 //! ## Examples
 //!
 //! In addition to the examples below be sure to check out the [online embedding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,9 @@ impl CommonOptions {
             config.wasm_bulk_memory(enable);
         }
         if let Some(enable) = reference_types {
+            #[cfg(feature = "wasm-backtrace")]
             config.wasm_reference_types(enable);
+            drop(enable); // suppress unused warnings
         }
         if let Some(enable) = multi_value {
             config.wasm_multi_value(enable);


### PR DESCRIPTION
This commit adds support to Wasmtime to disable, at compile time, the
gathering of backtraces on traps. The `wasmtime` crate now sports a
`wasm-backtrace` feature which, when disabled, will mean that backtraces
are never collected at compile time nor are unwinding tables inserted
into compiled objects.

The motivation for this commit stems from the fact that generating a
backtrace is quite a slow operation. Currently backtrace generation is
done with libunwind and `_Unwind_Backtrace` typically found in glibc or
other system libraries. When thousands of modules are loaded into the
same process though this means that the initial backtrace can take
nearly half a second and all subsequent backtraces can take upwards of
hundreds of milliseconds. Relative to all other operations in Wasmtime
this is extremely expensive at this time. In the future we'd like to
implement a more performant backtrace scheme but such an implementation
would require coordination with Cranelift and is a big chunk of work
that may take some time, so in the meantime if embedders don't need a
backtrace they can still use this option to disable backtraces at
compile time and avoid the performance pitfalls of collecting
backtraces.

In general I tried to originally make this a runtime configuration
option but ended up opting for a compile-time option because `Trap::new`
otherwise has no arguments and always captures a backtrace. By making
this a compile-time option it was possible to configure, statically, the
behavior of `Trap::new`. Additionally I also tried to minimize the
amount of `#[cfg]` necessary by largely only having it at the producer
and consumer sites.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
