### PR TITLE
Clarify patch release criteria

### DIFF
--- a/docs/stability-release.md
+++ b/docs/stability-release.md
@@ -10,8 +10,9 @@ The high-level summary of Wasmtime's release process is:
 
 Once a month Wasmtime will issue a new major version. This will be issued with a
 semver-major version update, such as 4.0.0 to 5.0.0. The precise schedule of
-Wasmtime's release may fluctuate slightly depending on public holidays and
-availability of release resources, but the general cadence will be once-a-month.
+Wasmtime's release is currently an automated PR is sent to bump the version on
+the 5th of every month and a release is made when the PR is merged. The PR
+typically gets merged within a few days.
 
 Each major release of Wasmtime reserves the right to break both behavior and API
 backwards-compatibility. This is not expected to happen frequently, however, and
@@ -27,11 +28,17 @@ any breaking change will follow these criteria:
   feedback about embeddings. Release notes will clearly indicate if any major
   breaking changes through accepted RFCs are included in a release.
 
-Patch releases of Wasmtime will only be issued for security and correctness
-issues for on-by-default behavior in the previous releases. If Wasmtime is
-currently at version 5.0.0 then 5.0.1 and 4.0.1 will be issued as patch releases
-if a bug is found. Patch releases are guaranteed to maintain API and behavior
-backwards-compatibility and are intended to be trivial for users to upgrade to.
+Patch releases of Wasmtime will only be issued for security and critical
+correctness issues for on-by-default behavior in the previous releases. If
+Wasmtime is currently at version 5.0.0 then 5.0.1 and 4.0.1 will be issued as
+patch releases if a bug is found. Patch releases are guaranteed to maintain API
+and behavior backwards-compatibility and are intended to be trivial for users to
+upgrade to.
+
+Patch releases for Cranelift will be made for any miscompilations found by
+Cranelift, even those that Wasmtime itself may not exercise. Due to the current
+release process a patch release for Cranelift will issue a patch release for
+Wasmtime as well.
 
 ## What's released?
 


### PR DESCRIPTION
In today's Wasmtime meeting we discussed the acceptance criteria for
patch releases for Wasmtime and Cranelift. The criteria we came up with
were:

* Cranelift will get a patch release for any miscompilation, whether or
  not it affects Wasmtime.
* Wasmtime will get a patch release for security issues and bugs which
  seriously hinder usability.

The consensus at the time was that due to Wasmtime's monthly release
schedule we want to be pretty strict about what generates a patch
release, hence the threshold being at serious bugs as opposed to any
bugs found.

This commit attempts to update the `stability-release.md` document with
our documented release process. The release cadence section is brought
up to date, the Wasmtime section was edited slightly (it largely already
said this which I only just realized), and a Cranelift section was
added.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
