### PR TITLE
Increase instance size limit when fuzzing

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -363,7 +363,7 @@ impl Config {
             limits.table_elements = limits.memories.max(1_000);
             limits.memory_pages = limits.memory_pages.max(900);
             limits.count = limits.count.max(500);
-            limits.size = limits.size.max(4096);
+            limits.size = limits.size.max(64 * 1024);
 
             match &mut self.wasmtime.memory_config {
                 MemoryConfig::Normal(config) => {


### PR DESCRIPTION
In today's installment of the Wondrous Adventures of What Are the Actual
Limits on the Pooling Allocator Required to Run the Spec Tests a fuzz
bug was found where the instance size wasn't big enough to run
`names.wast`. Today's episode is similar to prior episodes where a limit
is bumped until the test passes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
