### PR TITLE
Expose details for mlocking modules externally

### DIFF
--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -682,6 +682,14 @@ impl CompiledModule {
     pub fn has_address_map(&self) -> bool {
         !self.address_map_data().is_empty()
     }
+
+    /// Returns the bounds, in host memory, of where this module's compiled
+    /// image resides.
+    pub fn image_range(&self) -> Range<usize> {
+        let base = self.mmap().as_ptr() as usize;
+        let len = self.mmap().len();
+        base..base + len
+    }
 }
 
 type Addr2LineContext<'a> = addr2line::Context<gimli::EndianSlice<'a, gimli::LittleEndian>>;


### PR DESCRIPTION
This commit exposes some various details and config options for having
finer-grain control over mlock-ing the memory of modules. This amounts
to three different changes being present in this commit:

* A new `Module::image_range` API is added to expose the range in host
  memory of where the compiled image resides. This enables embedders to
  make mlock-ing decisions independently of Wasmtime. Otherwise though
  there's not too much useful that can be done with this range
  information at this time.

* A new `Config::force_memory_init_memfd` option has been added. This
  option is used to force the usage of `memfd_create` on Linux even when
  the original module comes from a file on disk. With mlock-ing the main
  purpose for Wasmtime is likely to be avoiding major page faults that
  go back to disk, so this is another major source of avoiding page
  faults by ensuring that the initialization contents of memory are
  always in RAM.

* The `memory_images` field of a `Module` has gone back to being lazily
  created on the first instantiation, effectively reverting #3914. This
  enables embedders to defer the creation of the image to as late as
  possible to allow modules to be created from precompiled images
  without actually loading all the contents of the data segments from
  disk immediately.

These changes are all somewhat low-level controls which aren't intended
to be generally used by embedders. If fine-grained control is desired
though it's hoped that these knobs provide what's necessary to be
achieved.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
