### PR TITLE
x64: prefix all machine instructions with `x64_`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1152,11 +1152,11 @@
 
 ;; Zero extending uses `movzx`.
 (rule (extend (ExtendKind.Zero) ty mode src)
-      (movzx ty mode src))
+      (x64_movzx ty mode src))
 
 ;; Sign extending uses `movsx`.
 (rule (extend (ExtendKind.Sign) ty mode src)
-      (movsx ty mode src))
+      (x64_movsx ty mode src))
 
 ;;;; Helpers for Working SSE tidbits ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1235,7 +1235,7 @@
 (decl x64_load (Type SyntheticAmode ExtKind) Reg)
 
 (rule (x64_load (fits_in_32 ty) addr (ExtKind.SignExtend))
-      (movsx ty
+      (x64_movsx ty
              (ext_mode (ty_bytes ty) 8)
              addr))
 
@@ -1265,8 +1265,8 @@
                       addr))
 
 ;; Load a constant into an XMM register.
-(decl xmm_load_const (Type VCodeConstant) Xmm)
-(rule (xmm_load_const ty const)
+(decl x64_xmm_load_const (Type VCodeConstant) Xmm)
+(rule (x64_xmm_load_const ty const)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmLoadConst const dst ty))))
         dst))
@@ -1286,16 +1286,16 @@
         dst))
 
 ;; Helper for emitting `add` instructions.
-(decl add (Type Gpr GprMemImm) Gpr)
-(rule (add ty src1 src2)
+(decl x64_add (Type Gpr GprMemImm) Gpr)
+(rule (x64_add ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Add)
                  src1
                  src2))
 
 ;; Helper for creating `add` instructions whose flags are also used.
-(decl add_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
-(rule (add_with_flags_paired ty src1 src2)
+(decl x64_add_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
+(rule (x64_add_with_flags_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
         (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
          (MInst.AluRmiR (operand_size_of_type_32_64 ty)
@@ -1306,8 +1306,8 @@
          dst)))
 
 ;; Helper for creating `adc` instructions.
-(decl adc_paired (Type Gpr GprMemImm) ConsumesFlags)
-(rule (adc_paired ty src1 src2)
+(decl x64_adc_paired (Type Gpr GprMemImm) ConsumesFlags)
+(rule (x64_adc_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
         (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
          (MInst.AluRmiR (operand_size_of_type_32_64 ty)
@@ -1318,16 +1318,16 @@
          dst)))
 
 ;; Helper for emitting `sub` instructions.
-(decl sub (Type Gpr GprMemImm) Gpr)
-(rule (sub ty src1 src2)
+(decl x64_sub (Type Gpr GprMemImm) Gpr)
+(rule (x64_sub ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Sub)
                  src1
                  src2))
 
 ;; Helper for creating `sub` instructions whose flags are also used.
-(decl sub_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
-(rule (sub_with_flags_paired ty src1 src2)
+(decl x64_sub_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
+(rule (x64_sub_with_flags_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
         (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
          (MInst.AluRmiR (operand_size_of_type_32_64 ty)
@@ -1338,8 +1338,8 @@
          dst)))
 
 ;; Helper for creating `sbb` instructions.
-(decl sbb_paired (Type Gpr GprMemImm) ConsumesFlags)
-(rule (sbb_paired ty src1 src2)
+(decl x64_sbb_paired (Type Gpr GprMemImm) ConsumesFlags)
+(rule (x64_sbb_paired ty src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr)))
         (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
          (MInst.AluRmiR (operand_size_of_type_32_64 ty)
@@ -1350,8 +1350,8 @@
          dst)))
 
 ;; Helper for creating `mul` instructions.
-(decl mul (Type Gpr GprMemImm) Gpr)
-(rule (mul ty src1 src2)
+(decl x64_mul (Type Gpr GprMemImm) Gpr)
+(rule (x64_mul ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Mul)
                  src1
@@ -1376,16 +1376,16 @@
                         dst))))
 
 ;; Helper for emitting `or` instructions.
-(decl or (Type Gpr GprMemImm) Gpr)
-(rule (or ty src1 src2)
+(decl x64_or (Type Gpr GprMemImm) Gpr)
+(rule (x64_or ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Or)
                  src1
                  src2))
 
 ;; Helper for emitting `xor` instructions.
-(decl xor (Type Gpr GprMemImm) Gpr)
-(rule (xor ty src1 src2)
+(decl x64_xor (Type Gpr GprMemImm) Gpr)
+(rule (x64_xor ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Xor)
                  src1
@@ -1477,7 +1477,7 @@
 
 ;; TODO: use cmpeqpd for all 1s
 
-;; Helper for creating `MInst.ShifR` instructions.
+;; Helper for creating `MInst.ShiftR` instructions.
 (decl shift_r (Type ShiftKind Gpr Imm8Gpr) Gpr)
 (rule (shift_r ty kind src1 src2)
       (let ((dst WritableGpr (temp_writable_gpr))
@@ -1498,18 +1498,18 @@
       (shift_r ty (ShiftKind.RotateRight) src1 src2))
 
 ;; Helper for creating `shl` instructions.
-(decl shl (Type Gpr Imm8Gpr) Gpr)
-(rule (shl ty src1 src2)
+(decl x64_shl (Type Gpr Imm8Gpr) Gpr)
+(rule (x64_shl ty src1 src2)
       (shift_r ty (ShiftKind.ShiftLeft) src1 src2))
 
 ;; Helper for creating logical shift-right instructions.
-(decl shr (Type Gpr Imm8Gpr) Gpr)
-(rule (shr ty src1 src2)
+(decl x64_shr (Type Gpr Imm8Gpr) Gpr)
+(rule (x64_shr ty src1 src2)
       (shift_r ty (ShiftKind.ShiftRightLogical) src1 src2))
 
 ;; Helper for creating arithmetic shift-right instructions.
-(decl sar (Type Gpr Imm8Gpr) Gpr)
-(rule (sar ty src1 src2)
+(decl x64_sar (Type Gpr Imm8Gpr) Gpr)
+(rule (x64_sar ty src1 src2)
       (shift_r ty (ShiftKind.ShiftRightArithmetic) src1 src2))
 
 ;; Helper for creating `MInst.CmpRmiR` instructions.
@@ -1522,13 +1522,13 @@
                       src2)))
 
 ;; Helper for creating `cmp` instructions.
-(decl cmp (OperandSize GprMemImm Gpr) ProducesFlags)
-(rule (cmp size src1 src2)
+(decl x64_cmp (OperandSize GprMemImm Gpr) ProducesFlags)
+(rule (x64_cmp size src1 src2)
       (cmp_rmi_r size (CmpOpcode.Cmp) src1 src2))
 
 ;; Helper for creating `cmp` instructions with an immediate.
-(decl cmp_imm (OperandSize u32 Gpr) ProducesFlags)
-(rule (cmp_imm size src1 src2)
+(decl x64_cmp_imm (OperandSize u32 Gpr) ProducesFlags)
+(rule (x64_cmp_imm size src1 src2)
       (cmp_rmi_r size (CmpOpcode.Cmp) (RegMemImm.Imm src1) src2))
 
 ;; Helper for creating `MInst.XmmCmpRmR` instructions.
@@ -1537,19 +1537,18 @@
       (ProducesFlags.ProducesFlagsSideEffect
        (MInst.XmmCmpRmR opcode src1 src2)))
 
-;; Helper for creating `fpcmp` instructions (cannot use `fcmp` as it is taken by
-;; `clif.isle`).
-(decl fpcmp (Value Value) ProducesFlags)
-(rule (fpcmp src1 @ (value_type $F32) src2)
+;; Helper for creating floating-point comparison instructions (`UCOMIS[S|D]`).
+(decl x64_ucomis (Value Value) ProducesFlags)
+(rule (x64_ucomis src1 @ (value_type $F32) src2)
       ;; N.B.: cmp can be generated more than once, so cannot do a
       ;; load-op merge. So `put_in_xmm` for src1, not `put_in_xmm_mem`.
       (xmm_cmp_rm_r (SseOpcode.Ucomiss) (put_in_xmm src1) (put_in_xmm src2)))
-(rule (fpcmp src1 @ (value_type $F64) src2)
+(rule (x64_ucomis src1 @ (value_type $F64) src2)
       (xmm_cmp_rm_r (SseOpcode.Ucomisd) (put_in_xmm src1) (put_in_xmm src2)))
 
 ;; Helper for creating `test` instructions.
-(decl test (OperandSize GprMemImm Gpr) ProducesFlags)
-(rule (test size src1 src2)
+(decl x64_test (OperandSize GprMemImm Gpr) ProducesFlags)
+(rule (x64_test size src1 src2)
       (cmp_rmi_r size (CmpOpcode.Test) src1 src2))
 
 ;; Helper for creating `cmove` instructions. Note that these instructions do not
@@ -1659,23 +1658,23 @@
       (cmove_or_xmm ty cc1 cc2 consequent alternative))
 
 ;; Helper for creating `MInst.Setcc` instructions.
-(decl setcc (CC) ConsumesFlags)
-(rule (setcc cc)
+(decl x64_setcc (CC) ConsumesFlags)
+(rule (x64_setcc cc)
       (let ((dst WritableGpr (temp_writable_gpr)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
          (MInst.Setcc cc dst)
          dst)))
 
 ;; Helper for creating `MInst.MovzxRmR` instructions.
-(decl movzx (Type ExtMode GprMem) Gpr)
-(rule (movzx ty mode src)
+(decl x64_movzx (Type ExtMode GprMem) Gpr)
+(rule (x64_movzx ty mode src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.MovzxRmR mode src dst))))
         dst))
 
 ;; Helper for creating `MInst.MovsxRmR` instructions.
-(decl movsx (Type ExtMode GprMem) Gpr)
-(rule (movsx ty mode src)
+(decl x64_movsx (Type ExtMode GprMem) Gpr)
+(rule (x64_movsx ty mode src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.MovsxRmR mode src dst))))
         dst))
@@ -1688,273 +1687,273 @@
         dst))
 
 ;; Helper for creating `paddb` instructions.
-(decl paddb (Xmm XmmMem) Xmm)
-(rule (paddb src1 src2)
+(decl x64_paddb (Xmm XmmMem) Xmm)
+(rule (x64_paddb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Paddb) src1 src2))
 
 ;; Helper for creating `paddw` instructions.
-(decl paddw (Xmm XmmMem) Xmm)
-(rule (paddw src1 src2)
+(decl x64_paddw (Xmm XmmMem) Xmm)
+(rule (x64_paddw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Paddw) src1 src2))
 
 ;; Helper for creating `paddd` instructions.
-(decl paddd (Xmm XmmMem) Xmm)
-(rule (paddd src1 src2)
+(decl x64_paddd (Xmm XmmMem) Xmm)
+(rule (x64_paddd src1 src2)
       (xmm_rm_r $I32X4 (SseOpcode.Paddd) src1 src2))
 
 ;; Helper for creating `paddq` instructions.
-(decl paddq (Xmm XmmMem) Xmm)
-(rule (paddq src1 src2)
+(decl x64_paddq (Xmm XmmMem) Xmm)
+(rule (x64_paddq src1 src2)
       (xmm_rm_r $I64X2 (SseOpcode.Paddq) src1 src2))
 
 ;; Helper for creating `paddsb` instructions.
-(decl paddsb (Xmm XmmMem) Xmm)
-(rule (paddsb src1 src2)
+(decl x64_paddsb (Xmm XmmMem) Xmm)
+(rule (x64_paddsb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Paddsb) src1 src2))
 
 ;; Helper for creating `paddsw` instructions.
-(decl paddsw (Xmm XmmMem) Xmm)
-(rule (paddsw src1 src2)
+(decl x64_paddsw (Xmm XmmMem) Xmm)
+(rule (x64_paddsw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Paddsw) src1 src2))
 
 ;; Helper for creating `paddusb` instructions.
-(decl paddusb (Xmm XmmMem) Xmm)
-(rule (paddusb src1 src2)
+(decl x64_paddusb (Xmm XmmMem) Xmm)
+(rule (x64_paddusb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Paddusb) src1 src2))
 
 ;; Helper for creating `paddusw` instructions.
-(decl paddusw (Xmm XmmMem) Xmm)
-(rule (paddusw src1 src2)
+(decl x64_paddusw (Xmm XmmMem) Xmm)
+(rule (x64_paddusw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Paddusw) src1 src2))
 
 ;; Helper for creating `psubb` instructions.
-(decl psubb (Xmm XmmMem) Xmm)
-(rule (psubb src1 src2)
+(decl x64_psubb (Xmm XmmMem) Xmm)
+(rule (x64_psubb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Psubb) src1 src2))
 
 ;; Helper for creating `psubw` instructions.
-(decl psubw (Xmm XmmMem) Xmm)
-(rule (psubw src1 src2)
+(decl x64_psubw (Xmm XmmMem) Xmm)
+(rule (x64_psubw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Psubw) src1 src2))
 
 ;; Helper for creating `psubd` instructions.
-(decl psubd (Xmm XmmMem) Xmm)
-(rule (psubd src1 src2)
+(decl x64_psubd (Xmm XmmMem) Xmm)
+(rule (x64_psubd src1 src2)
       (xmm_rm_r $I32X4 (SseOpcode.Psubd) src1 src2))
 
 ;; Helper for creating `psubq` instructions.
-(decl psubq (Xmm XmmMem) Xmm)
-(rule (psubq src1 src2)
+(decl x64_psubq (Xmm XmmMem) Xmm)
+(rule (x64_psubq src1 src2)
       (xmm_rm_r $I64X2 (SseOpcode.Psubq) src1 src2))
 
 ;; Helper for creating `psubsb` instructions.
-(decl psubsb (Xmm XmmMem) Xmm)
-(rule (psubsb src1 src2)
+(decl x64_psubsb (Xmm XmmMem) Xmm)
+(rule (x64_psubsb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Psubsb) src1 src2))
 
 ;; Helper for creating `psubsw` instructions.
-(decl psubsw (Xmm XmmMem) Xmm)
-(rule (psubsw src1 src2)
+(decl x64_psubsw (Xmm XmmMem) Xmm)
+(rule (x64_psubsw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Psubsw) src1 src2))
 
 ;; Helper for creating `psubusb` instructions.
-(decl psubusb (Xmm XmmMem) Xmm)
-(rule (psubusb src1 src2)
+(decl x64_psubusb (Xmm XmmMem) Xmm)
+(rule (x64_psubusb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Psubusb) src1 src2))
 
 ;; Helper for creating `psubusw` instructions.
-(decl psubusw (Xmm XmmMem) Xmm)
-(rule (psubusw src1 src2)
+(decl x64_psubusw (Xmm XmmMem) Xmm)
+(rule (x64_psubusw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Psubusw) src1 src2))
 
 ;; Helper for creating `pavgb` instructions.
-(decl pavgb (Xmm XmmMem) Xmm)
-(rule (pavgb src1 src2)
+(decl x64_pavgb (Xmm XmmMem) Xmm)
+(rule (x64_pavgb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Pavgb) src1 src2))
 
 ;; Helper for creating `pavgw` instructions.
-(decl pavgw (Xmm XmmMem) Xmm)
-(rule (pavgw src1 src2)
+(decl x64_pavgw (Xmm XmmMem) Xmm)
+(rule (x64_pavgw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Pavgw) src1 src2))
 
 ;; Helper for creating `pand` instructions.
-(decl pand (Xmm XmmMem) Xmm)
-(rule (pand src1 src2)
+(decl x64_pand (Xmm XmmMem) Xmm)
+(rule (x64_pand src1 src2)
       (xmm_rm_r $F32X4 (SseOpcode.Pand) src1 src2))
 
 ;; Helper for creating `andps` instructions.
-(decl andps (Xmm XmmMem) Xmm)
-(rule (andps src1 src2)
+(decl x64_andps (Xmm XmmMem) Xmm)
+(rule (x64_andps src1 src2)
       (xmm_rm_r $F32X4 (SseOpcode.Andps) src1 src2))
 
 ;; Helper for creating `andpd` instructions.
-(decl andpd (Xmm XmmMem) Xmm)
-(rule (andpd src1 src2)
+(decl x64_andpd (Xmm XmmMem) Xmm)
+(rule (x64_andpd src1 src2)
       (xmm_rm_r $F64X2 (SseOpcode.Andpd) src1 src2))
 
 ;; Helper for creating `por` instructions.
-(decl por (Xmm XmmMem) Xmm)
-(rule (por src1 src2)
+(decl x64_por (Xmm XmmMem) Xmm)
+(rule (x64_por src1 src2)
       (xmm_rm_r $F32X4 (SseOpcode.Por) src1 src2))
 
 ;; Helper for creating `orps` instructions.
-(decl orps (Xmm XmmMem) Xmm)
-(rule (orps src1 src2)
+(decl x64_orps (Xmm XmmMem) Xmm)
+(rule (x64_orps src1 src2)
       (xmm_rm_r $F32X4 (SseOpcode.Orps) src1 src2))
 
 ;; Helper for creating `orpd` instructions.
-(decl orpd (Xmm XmmMem) Xmm)
-(rule (orpd src1 src2)
+(decl x64_orpd (Xmm XmmMem) Xmm)
+(rule (x64_orpd src1 src2)
       (xmm_rm_r $F64X2 (SseOpcode.Orpd) src1 src2))
 
 ;; Helper for creating `pxor` instructions.
-(decl pxor (Xmm XmmMem) Xmm)
-(rule (pxor src1 src2)
+(decl x64_pxor (Xmm XmmMem) Xmm)
+(rule (x64_pxor src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Pxor) src1 src2))
 
 ;; Helper for creating `xorps` instructions.
-(decl xorps (Xmm XmmMem) Xmm)
-(rule (xorps src1 src2)
+(decl x64_xorps (Xmm XmmMem) Xmm)
+(rule (x64_xorps src1 src2)
       (xmm_rm_r $F32X4 (SseOpcode.Xorps) src1 src2))
 
 ;; Helper for creating `xorpd` instructions.
-(decl xorpd (Xmm XmmMem) Xmm)
-(rule (xorpd src1 src2)
+(decl x64_xorpd (Xmm XmmMem) Xmm)
+(rule (x64_xorpd src1 src2)
       (xmm_rm_r $F64X2 (SseOpcode.Xorpd) src1 src2))
 
 ;; Helper for creating `pmullw` instructions.
-(decl pmullw (Xmm XmmMem) Xmm)
-(rule (pmullw src1 src2)
+(decl x64_pmullw (Xmm XmmMem) Xmm)
+(rule (x64_pmullw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Pmullw) src1 src2))
 
 ;; Helper for creating `pmulld` instructions.
-(decl pmulld (Xmm XmmMem) Xmm)
-(rule (pmulld src1 src2)
+(decl x64_pmulld (Xmm XmmMem) Xmm)
+(rule (x64_pmulld src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Pmulld) src1 src2))
 
 ;; Helper for creating `pmulhw` instructions.
-(decl pmulhw (Xmm XmmMem) Xmm)
-(rule (pmulhw src1 src2)
+(decl x64_pmulhw (Xmm XmmMem) Xmm)
+(rule (x64_pmulhw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Pmulhw) src1 src2))
 
 ;; Helper for creating `pmulhuw` instructions.
-(decl pmulhuw (Xmm XmmMem) Xmm)
-(rule (pmulhuw src1 src2)
+(decl x64_pmulhuw (Xmm XmmMem) Xmm)
+(rule (x64_pmulhuw src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Pmulhuw) src1 src2))
 
 ;; Helper for creating `pmuldq` instructions.
-(decl pmuldq (Xmm XmmMem) Xmm)
-(rule (pmuldq src1 src2)
+(decl x64_pmuldq (Xmm XmmMem) Xmm)
+(rule (x64_pmuldq src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Pmuldq) src1 src2))
 
 ;; Helper for creating `pmuludq` instructions.
-(decl pmuludq (Xmm XmmMem) Xmm)
-(rule (pmuludq src1 src2)
+(decl x64_pmuludq (Xmm XmmMem) Xmm)
+(rule (x64_pmuludq src1 src2)
       (xmm_rm_r $I64X2 (SseOpcode.Pmuludq) src1 src2))
 
 ;; Helper for creating `punpckhwd` instructions.
-(decl punpckhwd (Xmm XmmMem) Xmm)
-(rule (punpckhwd src1 src2)
+(decl x64_punpckhwd (Xmm XmmMem) Xmm)
+(rule (x64_punpckhwd src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Punpckhwd) src1 src2))
 
 ;; Helper for creating `punpcklwd` instructions.
-(decl punpcklwd (Xmm XmmMem) Xmm)
-(rule (punpcklwd src1 src2)
+(decl x64_punpcklwd (Xmm XmmMem) Xmm)
+(rule (x64_punpcklwd src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Punpcklwd) src1 src2))
 
 ;; Helper for creating `andnps` instructions.
-(decl andnps (Xmm XmmMem) Xmm)
-(rule (andnps src1 src2)
+(decl x64_andnps (Xmm XmmMem) Xmm)
+(rule (x64_andnps src1 src2)
       (xmm_rm_r $F32X4 (SseOpcode.Andnps) src1 src2))
 
 ;; Helper for creating `andnpd` instructions.
-(decl andnpd (Xmm XmmMem) Xmm)
-(rule (andnpd src1 src2)
+(decl x64_andnpd (Xmm XmmMem) Xmm)
+(rule (x64_andnpd src1 src2)
       (xmm_rm_r $F64X2 (SseOpcode.Andnpd) src1 src2))
 
 ;; Helper for creating `pandn` instructions.
-(decl pandn (Xmm XmmMem) Xmm)
-(rule (pandn src1 src2)
+(decl x64_pandn (Xmm XmmMem) Xmm)
+(rule (x64_pandn src1 src2)
       (xmm_rm_r $F64X2 (SseOpcode.Pandn) src1 src2))
 
 ;; Helper for creating `addss` instructions.
-(decl addss (Xmm XmmMem) Xmm)
-(rule (addss src1 src2)
+(decl x64_addss (Xmm XmmMem) Xmm)
+(rule (x64_addss src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Addss) src1 src2))
 
 ;; Helper for creating `addsd` instructions.
-(decl addsd (Xmm XmmMem) Xmm)
-(rule (addsd src1 src2)
+(decl x64_addsd (Xmm XmmMem) Xmm)
+(rule (x64_addsd src1 src2)
       (xmm_rm_r $F64 (SseOpcode.Addsd) src1 src2))
 
 ;; Helper for creating `addps` instructions.
-(decl addps (Xmm XmmMem) Xmm)
-(rule (addps src1 src2)
+(decl x64_addps (Xmm XmmMem) Xmm)
+(rule (x64_addps src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Addps) src1 src2))
 
 ;; Helper for creating `addpd` instructions.
-(decl addpd (Xmm XmmMem) Xmm)
-(rule (addpd src1 src2)
+(decl x64_addpd (Xmm XmmMem) Xmm)
+(rule (x64_addpd src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Addpd) src1 src2))
 
 ;; Helper for creating `subss` instructions.
-(decl subss (Xmm XmmMem) Xmm)
-(rule (subss src1 src2)
+(decl x64_subss (Xmm XmmMem) Xmm)
+(rule (x64_subss src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Subss) src1 src2))
 
 ;; Helper for creating `subsd` instructions.
-(decl subsd (Xmm XmmMem) Xmm)
-(rule (subsd src1 src2)
+(decl x64_subsd (Xmm XmmMem) Xmm)
+(rule (x64_subsd src1 src2)
       (xmm_rm_r $F64 (SseOpcode.Subsd) src1 src2))
 
 ;; Helper for creating `subps` instructions.
-(decl subps (Xmm XmmMem) Xmm)
-(rule (subps src1 src2)
+(decl x64_subps (Xmm XmmMem) Xmm)
+(rule (x64_subps src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Subps) src1 src2))
 
 ;; Helper for creating `subpd` instructions.
-(decl subpd (Xmm XmmMem) Xmm)
-(rule (subpd src1 src2)
+(decl x64_subpd (Xmm XmmMem) Xmm)
+(rule (x64_subpd src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Subpd) src1 src2))
 
 ;; Helper for creating `mulss` instructions.
-(decl mulss (Xmm XmmMem) Xmm)
-(rule (mulss src1 src2)
+(decl x64_mulss (Xmm XmmMem) Xmm)
+(rule (x64_mulss src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Mulss) src1 src2))
 
 ;; Helper for creating `mulsd` instructions.
-(decl mulsd (Xmm XmmMem) Xmm)
-(rule (mulsd src1 src2)
+(decl x64_mulsd (Xmm XmmMem) Xmm)
+(rule (x64_mulsd src1 src2)
       (xmm_rm_r $F64 (SseOpcode.Mulsd) src1 src2))
 
 ;; Helper for creating `mulps` instructions.
-(decl mulps (Xmm XmmMem) Xmm)
-(rule (mulps src1 src2)
+(decl x64_mulps (Xmm XmmMem) Xmm)
+(rule (x64_mulps src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Mulps) src1 src2))
 
 ;; Helper for creating `mulpd` instructions.
-(decl mulpd (Xmm XmmMem) Xmm)
-(rule (mulpd src1 src2)
+(decl x64_mulpd (Xmm XmmMem) Xmm)
+(rule (x64_mulpd src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Mulpd) src1 src2))
 
 ;; Helper for creating `divss` instructions.
-(decl divss (Xmm XmmMem) Xmm)
-(rule (divss src1 src2)
+(decl x64_divss (Xmm XmmMem) Xmm)
+(rule (x64_divss src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Divss) src1 src2))
 
 ;; Helper for creating `divsd` instructions.
-(decl divsd (Xmm XmmMem) Xmm)
-(rule (divsd src1 src2)
+(decl x64_divsd (Xmm XmmMem) Xmm)
+(rule (x64_divsd src1 src2)
       (xmm_rm_r $F64 (SseOpcode.Divsd) src1 src2))
 
 ;; Helper for creating `divps` instructions.
-(decl divps (Xmm XmmMem) Xmm)
-(rule (divps src1 src2)
+(decl x64_divps (Xmm XmmMem) Xmm)
+(rule (x64_divps src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Divps) src1 src2))
 
 ;; Helper for creating `divpd` instructions.
-(decl divpd (Xmm XmmMem) Xmm)
-(rule (divpd src1 src2)
+(decl x64_divpd (Xmm XmmMem) Xmm)
+(rule (x64_divpd src1 src2)
       (xmm_rm_r $F32 (SseOpcode.Divpd) src1 src2))
 
 (decl sse_blend_op (Type) SseOpcode)
@@ -1968,8 +1967,8 @@
 (rule (sse_mov_op (multi_lane _bits _lanes)) (SseOpcode.Movdqa))
 
 ;; Helper for creating `blendvp{d,s}` and `pblendvb` instructions.
-(decl sse_blend (Type XmmMem XmmMem Xmm) Xmm)
-(rule (sse_blend ty mask src1 src2)
+(decl x64_blend (Type XmmMem XmmMem Xmm) Xmm)
+(rule (x64_blend ty mask src1 src2)
       ;; Move the mask into `xmm0`, as blend instructions implicitly operate on
       ;; that register. (This kind of thing would normally happen inside of
       ;; `Inst::mov_mitosis`, but has to happen here, where we still have the
@@ -1982,8 +1981,8 @@
         (xmm_rm_r ty (sse_blend_op ty) src2 src1)))
 
 ;; Helper for creating `blendvpd` instructions.
-(decl blendvpd (Xmm XmmMem Xmm) Xmm)
-(rule (blendvpd src1 src2 mask)
+(decl x64_blendvpd (Xmm XmmMem Xmm) Xmm)
+(rule (x64_blendvpd src1 src2 mask)
       ;; Move the mask into `xmm0`, as `blendvpd` implicitly operates on that
       ;; register. (This kind of thing would normally happen inside of
       ;; `Inst::mov_mitosis`, but has to happen here, where we still have the
@@ -1996,80 +1995,80 @@
         (xmm_rm_r $F64X2 (SseOpcode.Blendvpd) src1 src2)))
 
 ;; Helper for creating `movsd` instructions.
-(decl movsd (Xmm XmmMem) Xmm)
-(rule (movsd src1 src2)
+(decl x64_movsd (Xmm XmmMem) Xmm)
+(rule (x64_movsd src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Movsd) src1 src2))
 
 ;; Helper for creating `movlhps` instructions.
-(decl movlhps (Xmm XmmMem) Xmm)
-(rule (movlhps src1 src2)
+(decl x64_movlhps (Xmm XmmMem) Xmm)
+(rule (x64_movlhps src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Movlhps) src1 src2))
 
 ;; Helpers for creating `pmaxs*` instructions.
-(decl pmaxs (Type Xmm XmmMem) Xmm)
-(rule (pmaxs $I8X16 x y) (pmaxsb x y))
-(rule (pmaxs $I16X8 x y) (pmaxsw x y))
-(rule (pmaxs $I32X4 x y) (pmaxsd x y))
+(decl x64_pmaxs (Type Xmm XmmMem) Xmm)
+(rule (x64_pmaxs $I8X16 x y) (x64_pmaxsb x y))
+(rule (x64_pmaxs $I16X8 x y) (x64_pmaxsw x y))
+(rule (x64_pmaxs $I32X4 x y) (x64_pmaxsd x y))
 ;; No $I64X2 version (PMAXSQ) in SSE4.1.
-(decl pmaxsb (Xmm XmmMem) Xmm)
-(rule (pmaxsb src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxsb) src1 src2))
-(decl pmaxsw (Xmm XmmMem) Xmm)
-(rule (pmaxsw src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxsw) src1 src2))
-(decl pmaxsd (Xmm XmmMem) Xmm)
-(rule (pmaxsd src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxsd) src1 src2))
+(decl x64_pmaxsb (Xmm XmmMem) Xmm)
+(rule (x64_pmaxsb src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxsb) src1 src2))
+(decl x64_pmaxsw (Xmm XmmMem) Xmm)
+(rule (x64_pmaxsw src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxsw) src1 src2))
+(decl x64_pmaxsd (Xmm XmmMem) Xmm)
+(rule (x64_pmaxsd src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxsd) src1 src2))
 
 ;; Helpers for creating `pmins*` instructions.
-(decl pmins (Type Xmm XmmMem) Xmm)
-(rule (pmins $I8X16 x y) (pminsb x y))
-(rule (pmins $I16X8 x y) (pminsw x y))
-(rule (pmins $I32X4 x y) (pminsd x y))
+(decl x64_pmins (Type Xmm XmmMem) Xmm)
+(rule (x64_pmins $I8X16 x y) (x64_pminsb x y))
+(rule (x64_pmins $I16X8 x y) (x64_pminsw x y))
+(rule (x64_pmins $I32X4 x y) (x64_pminsd x y))
 ;; No $I64X2 version (PMINSQ) in SSE4.1.
-(decl pminsb (Xmm XmmMem) Xmm)
-(rule (pminsb src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminsb) src1 src2))
-(decl pminsw (Xmm XmmMem) Xmm)
-(rule (pminsw src1 src2) (xmm_rm_r $I16X8 (SseOpcode.Pminsw) src1 src2))
-(decl pminsd (Xmm XmmMem) Xmm)
-(rule (pminsd src1 src2) (xmm_rm_r $I32X4 (SseOpcode.Pminsd) src1 src2))
+(decl x64_pminsb (Xmm XmmMem) Xmm)
+(rule (x64_pminsb src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminsb) src1 src2))
+(decl x64_pminsw (Xmm XmmMem) Xmm)
+(rule (x64_pminsw src1 src2) (xmm_rm_r $I16X8 (SseOpcode.Pminsw) src1 src2))
+(decl x64_pminsd (Xmm XmmMem) Xmm)
+(rule (x64_pminsd src1 src2) (xmm_rm_r $I32X4 (SseOpcode.Pminsd) src1 src2))
 
 ;; Helpers for creating `pmaxu*` instructions.
-(decl pmaxu (Type Xmm XmmMem) Xmm)
-(rule (pmaxu $I8X16 x y) (pmaxub x y))
-(rule (pmaxu $I16X8 x y) (pmaxuw x y))
-(rule (pmaxu $I32X4 x y) (pmaxud x y))
+(decl x64_pmaxu (Type Xmm XmmMem) Xmm)
+(rule (x64_pmaxu $I8X16 x y) (x64_pmaxub x y))
+(rule (x64_pmaxu $I16X8 x y) (x64_pmaxuw x y))
+(rule (x64_pmaxu $I32X4 x y) (x64_pmaxud x y))
 ;; No $I64X2 version (PMAXUQ) in SSE4.1.
-(decl pmaxub (Xmm XmmMem) Xmm)
-(rule (pmaxub src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxub) src1 src2))
-(decl pmaxuw (Xmm XmmMem) Xmm)
-(rule (pmaxuw src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxuw) src1 src2))
-(decl pmaxud (Xmm XmmMem) Xmm)
-(rule (pmaxud src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxud) src1 src2))
+(decl x64_pmaxub (Xmm XmmMem) Xmm)
+(rule (x64_pmaxub src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxub) src1 src2))
+(decl x64_pmaxuw (Xmm XmmMem) Xmm)
+(rule (x64_pmaxuw src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxuw) src1 src2))
+(decl x64_pmaxud (Xmm XmmMem) Xmm)
+(rule (x64_pmaxud src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pmaxud) src1 src2))
 
 ;; Helper for creating `pminu*` instructions.
-(decl pminu (Type Xmm XmmMem) Xmm)
-(rule (pminu $I8X16 x y) (pminub x y))
-(rule (pminu $I16X8 x y) (pminuw x y))
-(rule (pminu $I32X4 x y) (pminud x y))
+(decl x64_pminu (Type Xmm XmmMem) Xmm)
+(rule (x64_pminu $I8X16 x y) (x64_pminub x y))
+(rule (x64_pminu $I16X8 x y) (x64_pminuw x y))
+(rule (x64_pminu $I32X4 x y) (x64_pminud x y))
 ;; No $I64X2 version (PMINUQ) in SSE4.1.
-(decl pminub (Xmm XmmMem) Xmm)
-(rule (pminub src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminub) src1 src2))
-(decl pminuw (Xmm XmmMem) Xmm)
-(rule (pminuw src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminuw) src1 src2))
-(decl pminud (Xmm XmmMem) Xmm)
-(rule (pminud src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminud) src1 src2))
+(decl x64_pminub (Xmm XmmMem) Xmm)
+(rule (x64_pminub src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminub) src1 src2))
+(decl x64_pminuw (Xmm XmmMem) Xmm)
+(rule (x64_pminuw src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminuw) src1 src2))
+(decl x64_pminud (Xmm XmmMem) Xmm)
+(rule (x64_pminud src1 src2) (xmm_rm_r $I8X16 (SseOpcode.Pminud) src1 src2))
 
 ;; Helper for creating `punpcklbw` instructions.
-(decl punpcklbw (Xmm XmmMem) Xmm)
-(rule (punpcklbw src1 src2)
+(decl x64_punpcklbw (Xmm XmmMem) Xmm)
+(rule (x64_punpcklbw src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Punpcklbw) src1 src2))
 
 ;; Helper for creating `punpckhbw` instructions.
-(decl punpckhbw (Xmm XmmMem) Xmm)
-(rule (punpckhbw src1 src2)
+(decl x64_punpckhbw (Xmm XmmMem) Xmm)
+(rule (x64_punpckhbw src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Punpckhbw) src1 src2))
 
 ;; Helper for creating `packsswb` instructions.
-(decl packsswb (Xmm XmmMem) Xmm)
-(rule (packsswb src1 src2)
+(decl x64_packsswb (Xmm XmmMem) Xmm)
+(rule (x64_packsswb src1 src2)
       (xmm_rm_r $I8X16 (SseOpcode.Packsswb) src1 src2))
 
 ;; Helper for creating `MInst.XmmRmRImm` instructions.
@@ -2085,8 +2084,8 @@
         dst))
 
 ;; Helper for creating `palignr` instructions.
-(decl palignr (Xmm XmmMem u8 OperandSize) Xmm)
-(rule (palignr src1 src2 imm size)
+(decl x64_palignr (Xmm XmmMem u8 OperandSize) Xmm)
+(rule (x64_palignr src1 src2 imm size)
       (xmm_rm_r_imm (SseOpcode.Palignr)
                     src1
                     src2
@@ -2094,8 +2093,8 @@
                     size))
 
 ;; Helper for creating `cmpps` instructions.
-(decl cmpps (Xmm XmmMem FcmpImm) Xmm)
-(rule (cmpps src1 src2 imm)
+(decl x64_cmpps (Xmm XmmMem FcmpImm) Xmm)
+(rule (x64_cmpps src1 src2 imm)
       (xmm_rm_r_imm (SseOpcode.Cmpps)
                     src1
                     src2
@@ -2103,8 +2102,8 @@
                     (OperandSize.Size32)))
 
 ;; Helper for creating `pinsrb` instructions.
-(decl pinsrb (Xmm GprMem u8) Xmm)
-(rule (pinsrb src1 src2 lane)
+(decl x64_pinsrb (Xmm GprMem u8) Xmm)
+(rule (x64_pinsrb src1 src2 lane)
       (xmm_rm_r_imm (SseOpcode.Pinsrb)
                     src1
                     src2
@@ -2112,8 +2111,8 @@
                     (OperandSize.Size32)))
 
 ;; Helper for creating `pinsrw` instructions.
-(decl pinsrw (Xmm GprMem u8) Xmm)
-(rule (pinsrw src1 src2 lane)
+(decl x64_pinsrw (Xmm GprMem u8) Xmm)
+(rule (x64_pinsrw src1 src2 lane)
       (xmm_rm_r_imm (SseOpcode.Pinsrw)
                     src1
                     src2
@@ -2121,8 +2120,8 @@
                     (OperandSize.Size32)))
 
 ;; Helper for creating `pinsrd` instructions.
-(decl pinsrd (Xmm GprMem u8 OperandSize) Xmm)
-(rule (pinsrd src1 src2 lane size)
+(decl x64_pinsrd (Xmm GprMem u8 OperandSize) Xmm)
+(rule (x64_pinsrd src1 src2 lane size)
       (xmm_rm_r_imm (SseOpcode.Pinsrd)
                     src1
                     src2
@@ -2130,8 +2129,8 @@
                     size))
 
 ;; Helper for creating `pmaddwd` instructions.
-(decl pmaddwd (Xmm XmmMem) Xmm)
-(rule (pmaddwd src1 src2)
+(decl x64_pmaddwd (Xmm XmmMem) Xmm)
+(rule (x64_pmaddwd src1 src2)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Pmaddwd)
                                         src1
@@ -2140,8 +2139,8 @@
         dst))
 
 ;; Helper for creating `insertps` instructions.
-(decl insertps (Xmm XmmMem u8) Xmm)
-(rule (insertps src1 src2 lane)
+(decl x64_insertps (Xmm XmmMem u8) Xmm)
+(rule (x64_insertps src1 src2 lane)
       (xmm_rm_r_imm (SseOpcode.Insertps)
                     src1
                     src2
@@ -2149,8 +2148,8 @@
                     (OperandSize.Size32)))
 
 ;; Helper for creating `pshufd` instructions.
-(decl pshufd (XmmMem u8 OperandSize) Xmm)
-(rule (pshufd src imm size)
+(decl x64_pshufd (XmmMem u8 OperandSize) Xmm)
+(rule (x64_pshufd src imm size)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pshufd)
                                            dst
@@ -2161,8 +2160,8 @@
         dst))
 
 ;; Helper for creating `pshufb` instructions.
-(decl pshufb (Xmm XmmMem) Xmm)
-(rule (pshufb src1 src2)
+(decl x64_pshufb (Xmm XmmMem) Xmm)
+(rule (x64_pshufb src1 src2)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Pshufb)
                                         src1
@@ -2178,28 +2177,28 @@
         dst))
 
 ;; Helper for creating `pmovsxbw` instructions.
-(decl pmovsxbw (XmmMem) Xmm)
-(rule (pmovsxbw src)
+(decl x64_pmovsxbw (XmmMem) Xmm)
+(rule (x64_pmovsxbw src)
       (xmm_unary_rm_r (SseOpcode.Pmovsxbw) src))
 
 ;; Helper for creating `pmovzxbw` instructions.
-(decl pmovzxbw (XmmMem) Xmm)
-(rule (pmovzxbw src)
+(decl x64_pmovzxbw (XmmMem) Xmm)
+(rule (x64_pmovzxbw src)
       (xmm_unary_rm_r (SseOpcode.Pmovzxbw) src))
 
 ;; Helper for creating `pabsb` instructions.
-(decl pabsb (XmmMem) Xmm)
-(rule (pabsb src)
+(decl x64_pabsb (XmmMem) Xmm)
+(rule (x64_pabsb src)
       (xmm_unary_rm_r (SseOpcode.Pabsb) src))
 
 ;; Helper for creating `pabsw` instructions.
-(decl pabsw (XmmMem) Xmm)
-(rule (pabsw src)
+(decl x64_pabsw (XmmMem) Xmm)
+(rule (x64_pabsw src)
       (xmm_unary_rm_r (SseOpcode.Pabsw) src))
 
 ;; Helper for creating `pabsd` instructions.
-(decl pabsd (XmmMem) Xmm)
-(rule (pabsd src)
+(decl x64_pabsd (XmmMem) Xmm)
+(rule (x64_pabsd src)
       (xmm_unary_rm_r (SseOpcode.Pabsd) src))
 
 ;; Helper for creating `MInst.XmmUnaryRmREvex` instructions.
@@ -2210,13 +2209,13 @@
         dst))
 
 ;; Helper for creating `vpabsq` instructions.
-(decl vpabsq (XmmMem) Xmm)
-(rule (vpabsq src)
+(decl x64_vpabsq (XmmMem) Xmm)
+(rule (x64_vpabsq src)
       (xmm_unary_rm_r_evex (Avx512Opcode.Vpabsq) src))
 
 ;; Helper for creating `vpopcntb` instructions.
-(decl vpopcntb (XmmMem) Xmm)
-(rule (vpopcntb src)
+(decl x64_vpopcntb (XmmMem) Xmm)
+(rule (x64_vpopcntb src)
       (xmm_unary_rm_r_evex (Avx512Opcode.Vpopcntb) src))
 
 ;; Helper for creating `MInst.XmmRmREvex` instructions.
@@ -2232,8 +2231,8 @@
 ;; Helper for creating `vpmullq` instructions.
 ;;
 ;; Requires AVX-512 vl and dq.
-(decl vpmullq (XmmMem Xmm) Xmm)
-(rule (vpmullq src1 src2)
+(decl x64_vpmullq (XmmMem Xmm) Xmm)
+(rule (x64_vpmullq src1 src2)
       (xmm_rm_r_evex (Avx512Opcode.Vpmullq)
                      src1
                      src2))
@@ -2271,48 +2270,48 @@
         dst))
 
 ;; Helper for creating `psllw` instructions.
-(decl psllw (Xmm XmmMemImm) Xmm)
-(rule (psllw src1 src2)
+(decl x64_psllw (Xmm XmmMemImm) Xmm)
+(rule (x64_psllw src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psllw) src1 src2))
 
 ;; Helper for creating `pslld` instructions.
-(decl pslld (Xmm XmmMemImm) Xmm)
-(rule (pslld src1 src2)
+(decl x64_pslld (Xmm XmmMemImm) Xmm)
+(rule (x64_pslld src1 src2)
       (xmm_rmi_xmm (SseOpcode.Pslld) src1 src2))
 
 ;; Helper for creating `psllq` instructions.
-(decl psllq (Xmm XmmMemImm) Xmm)
-(rule (psllq src1 src2)
+(decl x64_psllq (Xmm XmmMemImm) Xmm)
+(rule (x64_psllq src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psllq) src1 src2))
 
 ;; Helper for creating `psrlw` instructions.
-(decl psrlw (Xmm XmmMemImm) Xmm)
-(rule (psrlw src1 src2)
+(decl x64_psrlw (Xmm XmmMemImm) Xmm)
+(rule (x64_psrlw src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrlw) src1 src2))
 
 ;; Helper for creating `psrld` instructions.
-(decl psrld (Xmm XmmMemImm) Xmm)
-(rule (psrld src1 src2)
+(decl x64_psrld (Xmm XmmMemImm) Xmm)
+(rule (x64_psrld src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrld) src1 src2))
 
 ;; Helper for creating `psrlq` instructions.
-(decl psrlq (Xmm XmmMemImm) Xmm)
-(rule (psrlq src1 src2)
+(decl x64_psrlq (Xmm XmmMemImm) Xmm)
+(rule (x64_psrlq src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrlq) src1 src2))
 
 ;; Helper for creating `psraw` instructions.
-(decl psraw (Xmm XmmMemImm) Xmm)
-(rule (psraw src1 src2)
+(decl x64_psraw (Xmm XmmMemImm) Xmm)
+(rule (x64_psraw src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psraw) src1 src2))
 
 ;; Helper for creating `psrad` instructions.
-(decl psrad (Xmm XmmMemImm) Xmm)
-(rule (psrad src1 src2)
+(decl x64_psrad (Xmm XmmMemImm) Xmm)
+(rule (x64_psrad src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrad) src1 src2))
 
 ;; Helper for creating `pextrd` instructions.
-(decl pextrd (Type Xmm u8) Gpr)
-(rule (pextrd ty src lane)
+(decl x64_pextrd (Type Xmm u8) Gpr)
+(rule (x64_pextrd ty src lane)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pextrd)
                                            dst
@@ -2327,8 +2326,8 @@
 ;; Note that `Size32` is intentional despite this being used for 64-bit
 ;; operations, since this presumably induces the correct encoding of the
 ;; instruction.
-(decl cmppd (Xmm XmmMem FcmpImm) Xmm)
-(rule (cmppd src1 src2 imm)
+(decl x64_cmppd (Xmm XmmMem FcmpImm) Xmm)
+(rule (x64_cmppd src1 src2 imm)
       (xmm_rm_r_imm (SseOpcode.Cmppd)
                     src1
                     src2
@@ -2343,56 +2342,56 @@
         dst))
 
 ;; Helper for creating `not` instructions.
-(decl not (Type Gpr) Gpr)
-(rule (not ty src)
+(decl x64_not (Type Gpr) Gpr)
+(rule (x64_not ty src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.Not size src dst))))
         dst))
 
 ;; Helper for creating `neg` instructions.
-(decl neg (Type Gpr) Gpr)
-(rule (neg ty src)
+(decl x64_neg (Type Gpr) Gpr)
+(rule (x64_neg ty src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.Neg size src dst))))
         dst))
 
-(decl lea (SyntheticAmode) Gpr)
-(rule (lea addr)
+(decl x64_lea (SyntheticAmode) Gpr)
+(rule (x64_lea addr)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.LoadEffectiveAddress addr dst))))
         dst))
 
 ;; Helper for creating `ud2` instructions.
-(decl ud2 (TrapCode) SideEffectNoResult)
-(rule (ud2 code)
+(decl x64_ud2 (TrapCode) SideEffectNoResult)
+(rule (x64_ud2 code)
       (SideEffectNoResult.Inst (MInst.Ud2 code)))
 
 ;; Helper for creating `hlt` instructions.
-(decl hlt () SideEffectNoResult)
-(rule (hlt)
+(decl x64_hlt () SideEffectNoResult)
+(rule (x64_hlt)
       (SideEffectNoResult.Inst (MInst.Hlt)))
 
 ;; Helper for creating `lzcnt` instructions.
-(decl lzcnt (Type Gpr) Gpr)
-(rule (lzcnt ty src)
+(decl x64_lzcnt (Type Gpr) Gpr)
+(rule (x64_lzcnt ty src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.UnaryRmR size (UnaryRmROpcode.Lzcnt) src dst))))
         dst))
 
 ;; Helper for creating `tzcnt` instructions.
-(decl tzcnt (Type Gpr) Gpr)
-(rule (tzcnt ty src)
+(decl x64_tzcnt (Type Gpr) Gpr)
+(rule (x64_tzcnt ty src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (_ Unit (emit (MInst.UnaryRmR size (UnaryRmROpcode.Tzcnt) src dst))))
         dst))
 
 ;; Helper for creating `bsr` instructions.
-(decl bsr (Type Gpr) ProducesFlags)
-(rule (bsr ty src)
+(decl x64_bsr (Type Gpr) ProducesFlags)
+(rule (x64_bsr ty src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (inst MInst (MInst.UnaryRmR size (UnaryRmROpcode.Bsr) src dst)))
@@ -2402,7 +2401,7 @@
 ;; result of the `bsr`, or `alt` if the input was zero.
 (decl bsr_or_else (Type Gpr Gpr) Gpr)
 (rule (bsr_or_else ty src alt)
-      (let ((bsr ProducesFlags (bsr ty src))
+      (let ((bsr ProducesFlags (x64_bsr ty src))
             ;; Manually extract the result from the bsr, then ignore
             ;; it below, since we need to thread it into the cmove
             ;; before we pass the cmove to with_flags_reg.
@@ -2411,8 +2410,8 @@
         (with_flags_reg (produces_flags_ignore bsr) cmove)))
 
 ;; Helper for creating `bsf` instructions.
-(decl bsf (Type Gpr) ProducesFlags)
-(rule (bsf ty src)
+(decl x64_bsf (Type Gpr) ProducesFlags)
+(rule (x64_bsf ty src)
       (let ((dst WritableGpr (temp_writable_gpr))
             (size OperandSize (operand_size_of_type_32_64 ty))
             (inst MInst (MInst.UnaryRmR size (UnaryRmROpcode.Bsf) src dst)))
@@ -2422,7 +2421,7 @@
 ;; result of the `bsf`, or `alt` if the input was zero.
 (decl bsf_or_else (Type Gpr Gpr) Gpr)
 (rule (bsf_or_else ty src alt)
-      (let ((bsf ProducesFlags (bsf ty src))
+      (let ((bsf ProducesFlags (x64_bsf ty src))
             ;; Manually extract the result from the bsf, then ignore
             ;; it below, since we need to thread it into the cmove
             ;; before we pass the cmove to with_flags_reg.
@@ -2447,93 +2446,93 @@
         dst))
 
 ;; Helper for creating `minss` instructions.
-(decl minss (Xmm Xmm) Xmm)
-(rule (minss x y)
+(decl x64_minss (Xmm Xmm) Xmm)
+(rule (x64_minss x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Minss) x y dst))))
         dst))
 
 ;; Helper for creating `minsd` instructions.
-(decl minsd (Xmm Xmm) Xmm)
-(rule (minsd x y)
+(decl x64_minsd (Xmm Xmm) Xmm)
+(rule (x64_minsd x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Minsd) x y dst))))
         dst))
 
 
 ;; Helper for creating `minps` instructions.
-(decl minps (Xmm Xmm) Xmm)
-(rule (minps x y)
+(decl x64_minps (Xmm Xmm) Xmm)
+(rule (x64_minps x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Minps) x y dst))))
         dst))
 
 ;; Helper for creating `minpd` instructions.
-(decl minpd (Xmm Xmm) Xmm)
-(rule (minpd x y)
+(decl x64_minpd (Xmm Xmm) Xmm)
+(rule (x64_minpd x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Minpd) x y dst))))
         dst))
 
 ;; Helper for creating `maxss` instructions.
-(decl maxss (Xmm Xmm) Xmm)
-(rule (maxss x y)
+(decl x64_maxss (Xmm Xmm) Xmm)
+(rule (x64_maxss x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Maxss) x y dst))))
         dst))
 
 ;; Helper for creating `maxsd` instructions.
-(decl maxsd (Xmm Xmm) Xmm)
-(rule (maxsd x y)
+(decl x64_maxsd (Xmm Xmm) Xmm)
+(rule (x64_maxsd x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Maxsd) x y dst))))
         dst))
 
 ;; Helper for creating `maxps` instructions.
-(decl maxps (Xmm Xmm) Xmm)
-(rule (maxps x y)
+(decl x64_maxps (Xmm Xmm) Xmm)
+(rule (x64_maxps x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Maxps) x y dst))))
         dst))
 
 ;; Helper for creating `maxpd` instructions.
-(decl maxpd (Xmm Xmm) Xmm)
-(rule (maxpd x y)
+(decl x64_maxpd (Xmm Xmm) Xmm)
+(rule (x64_maxpd x y)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmR (SseOpcode.Maxpd) x y dst))))
         dst))
 
 ;; Helpers for creating `pcmpeq*` instructions.
-(decl pcmpeq (Type Xmm XmmMem) Xmm)
-(rule (pcmpeq $I8X16 x y) (pcmpeqb x y))
-(rule (pcmpeq $I16X8 x y) (pcmpeqw x y))
-(rule (pcmpeq $I32X4 x y) (pcmpeqd x y))
-(rule (pcmpeq $I64X2 x y) (pcmpeqq x y))
+(decl x64_pcmpeq (Type Xmm XmmMem) Xmm)
+(rule (x64_pcmpeq $I8X16 x y) (x64_pcmpeqb x y))
+(rule (x64_pcmpeq $I16X8 x y) (x64_pcmpeqw x y))
+(rule (x64_pcmpeq $I32X4 x y) (x64_pcmpeqd x y))
+(rule (x64_pcmpeq $I64X2 x y) (x64_pcmpeqq x y))
 
-(decl pcmpeqb (Xmm XmmMem) Xmm)
-(rule (pcmpeqb x y) (xmm_rm_r $I8X16 (SseOpcode.Pcmpeqb) x y))
-(decl pcmpeqw (Xmm XmmMem) Xmm)
-(rule (pcmpeqw x y) (xmm_rm_r $I16X8 (SseOpcode.Pcmpeqw) x y))
-(decl pcmpeqd (Xmm XmmMem) Xmm)
-(rule (pcmpeqd x y) (xmm_rm_r $I32X4 (SseOpcode.Pcmpeqd) x y))
-(decl pcmpeqq (Xmm XmmMem) Xmm)
-(rule (pcmpeqq x y) (xmm_rm_r $I64X2 (SseOpcode.Pcmpeqq) x y))
+(decl x64_pcmpeqb (Xmm XmmMem) Xmm)
+(rule (x64_pcmpeqb x y) (xmm_rm_r $I8X16 (SseOpcode.Pcmpeqb) x y))
+(decl x64_pcmpeqw (Xmm XmmMem) Xmm)
+(rule (x64_pcmpeqw x y) (xmm_rm_r $I16X8 (SseOpcode.Pcmpeqw) x y))
+(decl x64_pcmpeqd (Xmm XmmMem) Xmm)
+(rule (x64_pcmpeqd x y) (xmm_rm_r $I32X4 (SseOpcode.Pcmpeqd) x y))
+(decl x64_pcmpeqq (Xmm XmmMem) Xmm)
+(rule (x64_pcmpeqq x y) (xmm_rm_r $I64X2 (SseOpcode.Pcmpeqq) x y))
 
 ;; Helpers for creating `pcmpgt*` instructions.
-(decl pcmpgt (Type Xmm XmmMem) Xmm)
-(rule (pcmpgt $I8X16 x y) (pcmpgtb x y))
-(rule (pcmpgt $I16X8 x y) (pcmpgtw x y))
-(rule (pcmpgt $I32X4 x y) (pcmpgtd x y))
-(rule (pcmpgt $I64X2 x y) (pcmpgtq x y))
+(decl x64_pcmpgt (Type Xmm XmmMem) Xmm)
+(rule (x64_pcmpgt $I8X16 x y) (x64_pcmpgtb x y))
+(rule (x64_pcmpgt $I16X8 x y) (x64_pcmpgtw x y))
+(rule (x64_pcmpgt $I32X4 x y) (x64_pcmpgtd x y))
+(rule (x64_pcmpgt $I64X2 x y) (x64_pcmpgtq x y))
 
-(decl pcmpgtb (Xmm XmmMem) Xmm)
-(rule (pcmpgtb x y) (xmm_rm_r $I8X16 (SseOpcode.Pcmpgtb) x y))
-(decl pcmpgtw (Xmm XmmMem) Xmm)
-(rule (pcmpgtw x y) (xmm_rm_r $I16X8 (SseOpcode.Pcmpgtw) x y))
-(decl pcmpgtd (Xmm XmmMem) Xmm)
-(rule (pcmpgtd x y) (xmm_rm_r $I32X4 (SseOpcode.Pcmpgtd) x y))
-(decl pcmpgtq (Xmm XmmMem) Xmm)
-(rule (pcmpgtq x y) (xmm_rm_r $I64X2 (SseOpcode.Pcmpgtq) x y))
+(decl x64_pcmpgtb (Xmm XmmMem) Xmm)
+(rule (x64_pcmpgtb x y) (xmm_rm_r $I8X16 (SseOpcode.Pcmpgtb) x y))
+(decl x64_pcmpgtw (Xmm XmmMem) Xmm)
+(rule (x64_pcmpgtw x y) (xmm_rm_r $I16X8 (SseOpcode.Pcmpgtw) x y))
+(decl x64_pcmpgtd (Xmm XmmMem) Xmm)
+(rule (x64_pcmpgtd x y) (xmm_rm_r $I32X4 (SseOpcode.Pcmpgtd) x y))
+(decl x64_pcmpgtq (Xmm XmmMem) Xmm)
+(rule (x64_pcmpgtq x y) (xmm_rm_r $I64X2 (SseOpcode.Pcmpgtq) x y))
 
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -63,29 +63,29 @@
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x y)))
-      (add ty x y))
+      (x64_add ty x y))
 
 ;; Add a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x (simm32_from_value y))))
-      (add ty x y))
+      (x64_add ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd (simm32_from_value x) y)))
-      (add ty y x))
+      (x64_add ty y x))
 
 ;; Add a register and memory.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd x (sinkable_load y))))
-      (add ty
+      (x64_add ty
            x
            (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd (sinkable_load x) y)))
-      (add ty
+      (x64_add ty
            y
            (sink_load_to_gpr_mem_imm x)))
 
@@ -93,19 +93,19 @@
 
 (rule (lower (has_type (multi_lane 8 16)
                        (iadd x y)))
-      (paddb x y))
+      (x64_paddb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (iadd x y)))
-      (paddw x y))
+      (x64_paddw x y))
 
 (rule (lower (has_type (multi_lane 32 4)
                        (iadd x y)))
-      (paddd x y))
+      (x64_paddd x y))
 
 (rule (lower (has_type (multi_lane 64 2)
                        (iadd x y)))
-      (paddq x y))
+      (x64_paddq x y))
 
 ;; `i128`
 (rule (lower (has_type $I128 (iadd x y)))
@@ -118,28 +118,28 @@
               (y_lo Gpr (value_regs_get_gpr y_regs 0))
               (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do an add followed by an add-with-carry.
-          (with_flags (add_with_flags_paired $I64 x_lo y_lo)
-                      (adc_paired $I64 x_hi y_hi)))))
+          (with_flags (x64_add_with_flags_paired $I64 x_lo y_lo)
+                      (x64_adc_paired $I64 x_hi y_hi)))))
 
 ;;;; Rules for `sadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (sadd_sat x y)))
-      (paddsb x y))
+      (x64_paddsb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (sadd_sat x y)))
-      (paddsw x y))
+      (x64_paddsw x y))
 
 ;;;; Rules for `uadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (uadd_sat x y)))
-      (paddusb x y))
+      (x64_paddusb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (uadd_sat x y)))
-      (paddusw x y))
+      (x64_paddusw x y))
 
 ;;;; Rules for `iadd_ifcout` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -160,27 +160,27 @@
 ;; Add two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x y)))
-      (output_ifcout (add ty x y)))
+      (output_ifcout (x64_add ty x y)))
 
 ;; Add a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (simm32_from_value y))))
-      (output_ifcout (add ty x y)))
+      (output_ifcout (x64_add ty x y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (simm32_from_value x) y)))
-      (output_ifcout (add ty y x)))
+      (output_ifcout (x64_add ty y x)))
 
 ;; Add a register and memory.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout x (sinkable_load y))))
-      (output_ifcout (add ty x (sink_load_to_gpr_mem_imm y))))
+      (output_ifcout (x64_add ty x (sink_load_to_gpr_mem_imm y))))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (iadd_ifcout (sinkable_load x) y)))
-      (output_ifcout (add ty y (sink_load_to_gpr_mem_imm x))))
+      (output_ifcout (x64_add ty y (sink_load_to_gpr_mem_imm x))))
 
 ;; (No `iadd_ifcout` for `i128`.)
 
@@ -190,11 +190,11 @@
 
 ;; When the immediate fits in a `RegMemImm.Imm`, use that.
 (rule (lower (has_type (fits_in_64 ty) (iadd_imm y (simm32_from_imm64 x))))
-      (add ty y x))
+      (x64_add ty y x))
 
 ;; Otherwise, put the immediate into a register.
 (rule (lower (has_type (fits_in_64 ty) (iadd_imm y (u64_from_imm64 x))))
-      (add ty y (imm ty x)))
+      (x64_add ty y (imm ty x)))
 
 ;; `i128`
 
@@ -203,8 +203,8 @@
       (let ((y_regs ValueRegs y)
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-        (with_flags (add_with_flags_paired $I64 y_lo x)
-                    (adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
+        (with_flags (x64_add_with_flags_paired $I64 y_lo x)
+                    (x64_adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
 
 ;; Otherwise, put the immediate into a register.
 (rule (lower (has_type $I128 (iadd_imm y (u64_from_imm64 x))))
@@ -212,8 +212,8 @@
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1))
             (x_lo Gpr (imm $I64 x)))
-        (with_flags (add_with_flags_paired $I64 y_lo x_lo)
-                    (adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
+        (with_flags (x64_add_with_flags_paired $I64 y_lo x_lo)
+                    (x64_adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -222,36 +222,36 @@
 ;; Sub two registers.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x y)))
-      (sub ty x y))
+      (x64_sub ty x y))
 
 ;; Sub a register and an immediate.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x (simm32_from_value y))))
-      (sub ty x y))
+      (x64_sub ty x y))
 
 ;; Sub a register and memory.
 (rule (lower (has_type (fits_in_64 ty)
                        (isub x (sinkable_load y))))
-      (sub ty x
+      (x64_sub ty x
            (sink_load_to_gpr_mem_imm y)))
 
 ;; SSE.
 
 (rule (lower (has_type (multi_lane 8 16)
                        (isub x y)))
-      (psubb x y))
+      (x64_psubb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (isub x y)))
-      (psubw x y))
+      (x64_psubw x y))
 
 (rule (lower (has_type (multi_lane 32 4)
                        (isub x y)))
-      (psubd x y))
+      (x64_psubd x y))
 
 (rule (lower (has_type (multi_lane 64 2)
                        (isub x y)))
-      (psubq x y))
+      (x64_psubq x y))
 
 ;; `i128`
 (rule (lower (has_type $I128 (isub x y)))
@@ -264,28 +264,28 @@
               (y_lo Gpr (value_regs_get_gpr y_regs 0))
               (y_hi Gpr (value_regs_get_gpr y_regs 1)))
           ;; Do a sub followed by an sub-with-borrow.
-          (with_flags (sub_with_flags_paired $I64 x_lo y_lo)
-                      (sbb_paired $I64 x_hi y_hi)))))
+          (with_flags (x64_sub_with_flags_paired $I64 x_lo y_lo)
+                      (x64_sbb_paired $I64 x_hi y_hi)))))
 
 ;;;; Rules for `ssub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (ssub_sat x y)))
-      (psubsb x y))
+      (x64_psubsb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (ssub_sat x y)))
-      (psubsw x y))
+      (x64_psubsw x y))
 
 ;;;; Rules for `usub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (usub_sat x y)))
-      (psubusb x y))
+      (x64_psubusb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (usub_sat x y)))
-      (psubusw x y))
+      (x64_psubusw x y))
 
 ;;;; Rules for `band` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -321,9 +321,9 @@
 ;; SSE.
 
 (decl sse_and (Type Xmm XmmMem) Xmm)
-(rule (sse_and $F32X4 x y) (andps x y))
-(rule (sse_and $F64X2 x y) (andpd x y))
-(rule (sse_and (multi_lane _bits _lanes) x y) (pand x y))
+(rule (sse_and $F32X4 x y) (x64_andps x y))
+(rule (sse_and $F64X2 x y) (x64_andpd x y))
+(rule (sse_and (multi_lane _bits _lanes) x y) (x64_pand x y))
 
 (rule (lower (has_type ty @ (multi_lane _bits _lanes)
                        (band x y)))
@@ -358,36 +358,36 @@
 
 ;; Or two registers.
 (rule (lower (has_type (fits_in_64 ty) (bor x y)))
-      (or ty x y))
+      (x64_or ty x y))
 
 ;; Or with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor x (sinkable_load y))))
-      (or ty x
+      (x64_or ty x
           (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor (sinkable_load x) y)))
-      (or ty y
+      (x64_or ty y
           (sink_load_to_gpr_mem_imm x)))
 
 ;; Or with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor x (simm32_from_value y))))
-      (or ty x y))
+      (x64_or ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bor (simm32_from_value x) y)))
-      (or ty y x))
+      (x64_or ty y x))
 
 ;; SSE.
 
 (decl sse_or (Type Xmm XmmMem) Xmm)
-(rule (sse_or $F32X4 x y) (orps x y))
-(rule (sse_or $F64X2 x y) (orpd x y))
-(rule (sse_or (multi_lane _bits _lanes) x y) (por x y))
+(rule (sse_or $F32X4 x y) (x64_orps x y))
+(rule (sse_or $F64X2 x y) (x64_orpd x y))
+(rule (sse_or (multi_lane _bits _lanes) x y) (x64_por x y))
 
 (rule (lower (has_type ty @ (multi_lane _bits _lanes)
                        (bor x y)))
@@ -401,8 +401,8 @@
             (x_hi Gpr (value_regs_get_gpr x 1))
             (y_lo Gpr (value_regs_get_gpr y 0))
             (y_hi Gpr (value_regs_get_gpr y 1)))
-        (value_gprs (or $I64 x_lo y_lo)
-                    (or $I64 x_hi y_hi))))
+        (value_gprs (x64_or $I64 x_lo y_lo)
+                    (x64_or $I64 x_hi y_hi))))
 
 (rule (lower (has_type $I128 (bor x y)))
       (or_i128 x y))
@@ -415,7 +415,7 @@
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
             (y_lo Gpr (lo_gpr y)))
-        (value_gprs (or $I64 x_lo y_lo)
+        (value_gprs (x64_or $I64 x_lo y_lo)
                     x_hi)))
 
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -424,29 +424,29 @@
 
 ;; Xor two registers.
 (rule (lower (has_type (fits_in_64 ty) (bxor x y)))
-      (xor ty x y))
+      (x64_xor ty x y))
 
 ;; Xor with a memory operand.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor x (sinkable_load y))))
-      (xor ty x
+      (x64_xor ty x
            (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor (sinkable_load x) y)))
-      (xor ty y
+      (x64_xor ty y
            (sink_load_to_gpr_mem_imm x)))
 
 ;; Xor with an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor x (simm32_from_value y))))
-      (xor ty x y))
+      (x64_xor ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (bxor (simm32_from_value x) y)))
-      (xor ty y x))
+      (x64_xor ty y x))
 
 ;; SSE.
 
@@ -462,8 +462,8 @@
             (y_regs ValueRegs y)
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-        (value_gprs (xor $I64 x_lo y_lo)
-                    (xor $I64 x_hi y_hi))))
+        (value_gprs (x64_xor $I64 x_lo y_lo)
+                    (x64_xor $I64 x_hi y_hi))))
 
 (rule (lower (has_type $B128 (bxor x y)))
       ;; Booleans are always `0` or `1`, so we only need to do the `xor` on the
@@ -473,7 +473,7 @@
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
             (y_lo Gpr (lo_gpr y)))
-        (value_gprs (xor $I64 x_lo y_lo)
+        (value_gprs (x64_xor $I64 x_lo y_lo)
                     x_hi)))
 
 ;;;; Rules for `ishl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -481,7 +481,7 @@
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (ishl src amt)))
-      (shl ty src (put_masked_in_imm8_gpr amt ty)))
+      (x64_shl ty src (put_masked_in_imm8_gpr amt ty)))
 
 ;; `i128`.
 
@@ -491,18 +491,18 @@
       (let ((src_lo Gpr (value_regs_get_gpr src 0))
             (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do two 64-bit shifts.
-            (lo_shifted Gpr (shl $I64 src_lo amt))
-            (hi_shifted Gpr (shl $I64 src_hi amt))
+            (lo_shifted Gpr (x64_shl $I64 src_lo amt))
+            (hi_shifted Gpr (x64_shl $I64 src_hi amt))
             ;; `src_lo >> (64 - amt)` are the bits to carry over from the lo
             ;; into the hi.
-            (carry Gpr (shr $I64
+            (carry Gpr (x64_shr $I64
                             src_lo
-                            (sub $I64
+                            (x64_sub $I64
                                  (imm $I64 64)
                                  amt)))
             (zero Gpr (imm $I64 0))
             ;; Nullify the carry if we are shifting in by a multiple of 128.
-            (carry_ Gpr (with_flags_reg (test (OperandSize.Size64)
+            (carry_ Gpr (with_flags_reg (x64_test (OperandSize.Size64)
                                               (RegMemImm.Imm 127)
                                               amt)
                                         (cmove $I64
@@ -510,11 +510,11 @@
                                                zero
                                                carry)))
             ;; Add the carry into the high half.
-            (hi_shifted_ Gpr (or $I64 carry_ hi_shifted)))
+            (hi_shifted_ Gpr (x64_or $I64 carry_ hi_shifted)))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the low bits are zero and the high bits are our
         ;; low bits.
-        (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
+        (with_flags (x64_test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
                     (consumes_flags_concat
                      (cmove $I64 (CC.Z) lo_shifted zero)
                      (cmove $I64 (CC.Z) hi_shifted_ lo_shifted)))))
@@ -536,7 +536,7 @@
             ;; Shift `src` using 16x8. Unfortunately, a 16x8 shift will only be
             ;; correct for half of the lanes; the others must be fixed up with
             ;; the mask below.
-            (unmasked Xmm (psllw src (mov_rmi_to_xmm amt)))
+            (unmasked Xmm (x64_psllw src (mov_rmi_to_xmm amt)))
             (mask_addr SyntheticAmode (ishl_i8x16_mask amt))
             (mask Reg (x64_load $I8X16 mask_addr (ExtKind.None))))
         (sse_and $I8X16 unmasked (RegMem.Reg mask))))
@@ -560,8 +560,8 @@
 (extern constructor ishl_i8x16_mask_table ishl_i8x16_mask_table)
 (rule (ishl_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ishl_i8x16_mask_table))
-            (base_mask_addr Gpr (lea mask_table))
-            (mask_offset Gpr (shl $I64 amt
+            (base_mask_addr Gpr (x64_lea mask_table))
+            (mask_offset Gpr (x64_shl $I64 amt
                                   (imm8_to_imm8_gpr 4))))
         (amode_imm_reg_reg_shift 0
                                  base_mask_addr
@@ -574,13 +574,13 @@
 ;; 16x8, 32x4, and 64x2 shifts can each use a single instruction.
 
 (rule (lower (has_type $I16X8 (ishl src amt)))
-      (psllw src (mov_rmi_to_xmm amt)))
+      (x64_psllw src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I32X4 (ishl src amt)))
-      (pslld src (mov_rmi_to_xmm amt)))
+      (x64_pslld src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I64X2 (ishl src amt)))
-      (psllq src (mov_rmi_to_xmm amt)))
+      (x64_psllq src (mov_rmi_to_xmm amt)))
 
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -588,7 +588,7 @@
 
 (rule (lower (has_type (fits_in_64 ty) (ushr src amt)))
       (let ((src_ Gpr (extend_to_gpr src ty (ExtendKind.Zero))))
-        (shr ty src_ (put_masked_in_imm8_gpr amt ty))))
+        (x64_shr ty src_ (put_masked_in_imm8_gpr amt ty))))
 
 ;; `i128`.
 
@@ -598,24 +598,24 @@
       (let ((src_lo Gpr (value_regs_get_gpr src 0))
             (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do a shift on each half.
-            (lo_shifted Gpr (shr $I64 src_lo amt))
-            (hi_shifted Gpr (shr $I64 src_hi amt))
+            (lo_shifted Gpr (x64_shr $I64 src_lo amt))
+            (hi_shifted Gpr (x64_shr $I64 src_hi amt))
             ;; `src_hi << (64 - amt)` are the bits to carry over from the hi
             ;; into the lo.
-            (carry Gpr (shl $I64
+            (carry Gpr (x64_shl $I64
                             src_hi
-                            (sub $I64
+                            (x64_sub $I64
                                  (imm $I64 64)
                                  amt)))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (with_flags_reg (test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
+            (carry_ Gpr (with_flags_reg (x64_test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
                                         (cmove $I64 (CC.Z) (imm $I64 0) carry)))
             ;; Add the carry bits into the lo.
-            (lo_shifted_ Gpr (or $I64 carry_ lo_shifted)))
+            (lo_shifted_ Gpr (x64_or $I64 carry_ lo_shifted)))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are zero and the lo bits are what
         ;; would otherwise be our hi bits.
-        (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
+        (with_flags (x64_test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
                     (consumes_flags_concat
                      (cmove $I64 (CC.Z) lo_shifted_ hi_shifted)
                      (cmove $I64 (CC.Z) hi_shifted (imm $I64 0))))))
@@ -635,7 +635,7 @@
             ;; Shift `src` using 16x8. Unfortunately, a 16x8 shift will only be
             ;; correct for half of the lanes; the others must be fixed up with
             ;; the mask below.
-            (unmasked Xmm (psrlw src (mov_rmi_to_xmm amt)))
+            (unmasked Xmm (x64_psrlw src (mov_rmi_to_xmm amt)))
             (mask_addr SyntheticAmode (ushr_i8x16_mask amt))
             (mask Reg (x64_load $I8X16 mask_addr (ExtKind.None))))
         (sse_and $I8X16
@@ -661,8 +661,8 @@
 (extern constructor ushr_i8x16_mask_table ushr_i8x16_mask_table)
 (rule (ushr_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ushr_i8x16_mask_table))
-            (base_mask_addr Gpr (lea mask_table))
-            (mask_offset Gpr (shl $I64
+            (base_mask_addr Gpr (x64_lea mask_table))
+            (mask_offset Gpr (x64_shl $I64
                                   amt
                                   (imm8_to_imm8_gpr 4))))
         (amode_imm_reg_reg_shift 0
@@ -676,13 +676,13 @@
 ;; 16x8, 32x4, and 64x2 shifts can each use a single instruction.
 
 (rule (lower (has_type $I16X8 (ushr src amt)))
-      (psrlw src (mov_rmi_to_xmm amt)))
+      (x64_psrlw src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I32X4 (ushr src amt)))
-      (psrld src (mov_rmi_to_xmm amt)))
+      (x64_psrld src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I64X2 (ushr src amt)))
-      (psrlq src (mov_rmi_to_xmm amt)))
+      (x64_psrlq src (mov_rmi_to_xmm amt)))
 
 ;;;; Rules for `sshr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -690,7 +690,7 @@
 
 (rule (lower (has_type (fits_in_64 ty) (sshr src amt)))
       (let ((src_ Gpr (extend_to_gpr src ty (ExtendKind.Sign))))
-        (sar ty src_ (put_masked_in_imm8_gpr amt ty))))
+        (x64_sar ty src_ (put_masked_in_imm8_gpr amt ty))))
 
 ;; `i128`.
 
@@ -701,26 +701,26 @@
             (src_hi Gpr (value_regs_get_gpr src 1))
             ;; Do a shift of each half. NB: the low half uses an unsigned shift
             ;; because its MSB is not a sign bit.
-            (lo_shifted Gpr (shr $I64 src_lo amt))
-            (hi_shifted Gpr (sar $I64 src_hi amt))
+            (lo_shifted Gpr (x64_shr $I64 src_lo amt))
+            (hi_shifted Gpr (x64_sar $I64 src_hi amt))
             ;; `src_hi << (64 - amt)` are the bits to carry over from the low
             ;; half to the high half.
-            (carry Gpr (shl $I64
+            (carry Gpr (x64_shl $I64
                             src_hi
-                            (sub $I64
+                            (x64_sub $I64
                                  (imm $I64 64)
                                  amt)))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (with_flags_reg (test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
+            (carry_ Gpr (with_flags_reg (x64_test (OperandSize.Size64) (RegMemImm.Imm 127) amt)
                                         (cmove $I64 (CC.Z) (imm $I64 0) carry)))
             ;; Add the carry into the low half.
-            (lo_shifted_ Gpr (or $I64 lo_shifted carry_))
+            (lo_shifted_ Gpr (x64_or $I64 lo_shifted carry_))
             ;; Get all sign bits.
-            (sign_bits Gpr (sar $I64 src_hi (imm8_to_imm8_gpr 63))))
+            (sign_bits Gpr (x64_sar $I64 src_hi (imm8_to_imm8_gpr 63))))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are all sign bits and the lo bits are
         ;; what would otherwise be our hi bits.
-        (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
+        (with_flags (x64_test (OperandSize.Size64) (RegMemImm.Imm 64) amt)
                     (consumes_flags_concat
                      (cmove $I64 (CC.Z) lo_shifted_ hi_shifted)
                      (cmove $I64 (CC.Z) hi_shifted sign_bits)))))
@@ -751,22 +751,22 @@
             ;; In order for `packsswb` later to only use the high byte of each
             ;; 16x8 lane, we shift right an extra 8 bits, relying on `psraw` to
             ;; fill in the upper bits appropriately.
-            (lo Xmm (punpcklbw src_ src_))
-            (hi Xmm (punpckhbw src_ src_))
+            (lo Xmm (x64_punpcklbw src_ src_))
+            (hi Xmm (x64_punpckhbw src_ src_))
             (amt_ XmmMemImm (sshr_i8x16_bigger_shift amt_ty amt))
-            (shifted_lo Xmm (psraw lo amt_))
-            (shifted_hi Xmm (psraw hi amt_)))
-        (packsswb shifted_lo shifted_hi)))
+            (shifted_lo Xmm (x64_psraw lo amt_))
+            (shifted_hi Xmm (x64_psraw hi amt_)))
+        (x64_packsswb shifted_lo shifted_hi)))
 
 (decl sshr_i8x16_bigger_shift (Type RegMemImm) XmmMemImm)
 (rule (sshr_i8x16_bigger_shift _ty (RegMemImm.Imm i))
       (xmm_mem_imm_new (RegMemImm.Imm (u32_add i 8))))
 (rule (sshr_i8x16_bigger_shift ty (RegMemImm.Reg r))
-      (mov_rmi_to_xmm (RegMemImm.Reg (add ty
+      (mov_rmi_to_xmm (RegMemImm.Reg (x64_add ty
                                           r
                                           (RegMemImm.Imm 8)))))
 (rule (sshr_i8x16_bigger_shift ty rmi @ (RegMemImm.Mem _m))
-      (mov_rmi_to_xmm (RegMemImm.Reg (add ty
+      (mov_rmi_to_xmm (RegMemImm.Reg (x64_add ty
                                           (imm ty 8)
                                           rmi))))
 
@@ -774,10 +774,10 @@
 ;; that if the shift amount is in a register, it is in an XMM register.
 
 (rule (lower (has_type $I16X8 (sshr src amt)))
-      (psraw src (mov_rmi_to_xmm amt)))
+      (x64_psraw src (mov_rmi_to_xmm amt)))
 
 (rule (lower (has_type $I32X4 (sshr src amt)))
-      (psrad src (mov_rmi_to_xmm amt)))
+      (x64_psrad src (mov_rmi_to_xmm amt)))
 
 ;; The `sshr.i64x2` CLIF instruction has no single x86 instruction in the older
 ;; feature sets. Newer ones like AVX512VL + AVX512F include `vpsraq`, a 128-bit
@@ -789,11 +789,11 @@
 ;; (TODO: when EVEX support is available, add an alternate lowering here).
 (rule (lower (has_type $I64X2 (sshr src amt)))
       (let ((src_ Xmm (put_in_xmm src))
-            (lo Gpr (pextrd $I64 src_ 0))
-            (hi Gpr (pextrd $I64 src_ 1))
+            (lo Gpr (x64_pextrd $I64 src_ 0))
+            (hi Gpr (x64_pextrd $I64 src_ 1))
             (amt_ Imm8Gpr (put_masked_in_imm8_gpr amt $I64))
-            (shifted_lo Gpr (sar $I64 lo amt_))
-            (shifted_hi Gpr (sar $I64 hi amt_)))
+            (shifted_lo Gpr (x64_sar $I64 lo amt_))
+            (shifted_hi Gpr (x64_sar $I64 hi amt_)))
         (make_i64x2_from_lanes shifted_lo
                                shifted_hi)))
 
@@ -833,7 +833,7 @@
             ;; rotation amount to the value's bit width.
             (amt_ Gpr (lo_gpr amt)))
         (or_i128 (shl_i128 src_ amt_)
-                 (shr_i128 src_ (sub $I64
+                 (shr_i128 src_ (x64_sub $I64
                                      (imm $I64 128)
                                      amt_)))))
 
@@ -873,7 +873,7 @@
             ;; rotation amount to the value's bit width.
             (amt_ Gpr (lo_gpr amt)))
         (or_i128 (shr_i128 src_ amt_)
-                 (shl_i128 src_ (sub $I64
+                 (shl_i128 src_ (x64_sub $I64
                                      (imm $I64 128)
                                      amt_)))))
 
@@ -882,31 +882,31 @@
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (ineg x)))
-      (neg ty x))
+      (x64_neg ty x))
 
 ;; SSE.
 
 (rule (lower (has_type $I8X16 (ineg x)))
-      (psubb (imm $I8X16 0) x))
+      (x64_psubb (imm $I8X16 0) x))
 
 (rule (lower (has_type $I16X8 (ineg x)))
-      (psubw (imm $I16X8 0) x))
+      (x64_psubw (imm $I16X8 0) x))
 
 (rule (lower (has_type $I32X4 (ineg x)))
-      (psubd (imm $I32X4 0) x))
+      (x64_psubd (imm $I32X4 0) x))
 
 (rule (lower (has_type $I64X2 (ineg x)))
-      (psubq (imm $I64X2 0) x))
+      (x64_psubq (imm $I64X2 0) x))
 
 ;;;; Rules for `avg_round` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (multi_lane 8 16)
                        (avg_round x y)))
-      (pavgb x y))
+      (x64_pavgb x y))
 
 (rule (lower (has_type (multi_lane 16 8)
                        (avg_round x y)))
-      (pavgw x y))
+      (x64_pavgw x y))
 
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -914,29 +914,29 @@
 
 ;; Multiply two registers.
 (rule (lower (has_type (fits_in_64 ty) (imul x y)))
-      (mul ty x y))
+      (x64_mul ty x y))
 
 ;; Multiply a register and an immediate.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul x (simm32_from_value y))))
-      (mul ty x y))
+      (x64_mul ty x y))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul (simm32_from_value x) y)))
-      (mul ty y x))
+      (x64_mul ty y x))
 
 ;; Multiply a register and a memory load.
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul x (sinkable_load y))))
-      (mul ty
+      (x64_mul ty
            x
            (sink_load_to_gpr_mem_imm y)))
 
 (rule (lower (has_type (fits_in_64 ty)
                        (imul (sinkable_load x) y)))
-      (mul ty y
+      (x64_mul ty y
            (sink_load_to_gpr_mem_imm x)))
 
 ;; `i128`.
@@ -964,17 +964,17 @@
             (y_lo Gpr (value_regs_get_gpr y_regs 0))
             (y_hi Gpr (value_regs_get_gpr y_regs 1))
             ;; lo_hi = mul x_lo, y_hi
-            (lo_hi Gpr (mul $I64 x_lo y_hi))
+            (lo_hi Gpr (x64_mul $I64 x_lo y_hi))
             ;; hi_lo = mul x_hi, y_lo
-            (hi_lo Gpr (mul $I64 x_hi y_lo))
+            (hi_lo Gpr (x64_mul $I64 x_hi y_lo))
             ;; hilo_hilo = add lo_hi, hi_lo
-            (hilo_hilo Gpr (add $I64 lo_hi hi_lo))
+            (hilo_hilo Gpr (x64_add $I64 lo_hi hi_lo))
             ;; dst_lo:hi_lolo = mulhi_u x_lo, y_lo
             (mul_regs ValueRegs (mulhi_u $I64 x_lo y_lo))
             (dst_lo Gpr (value_regs_get_gpr mul_regs 0))
             (hi_lolo Gpr (value_regs_get_gpr mul_regs 1))
             ;; dst_hi = add hilo_hilo, hi_lolo
-            (dst_hi Gpr (add $I64 hilo_hilo hi_lolo)))
+            (dst_hi Gpr (x64_add $I64 hilo_hilo hi_lolo)))
         (value_gprs dst_lo dst_hi)))
 
 ;; SSE.
@@ -982,10 +982,10 @@
 ;; (No i8x16 multiply.)
 
 (rule (lower (has_type (multi_lane 16 8) (imul x y)))
-      (pmullw x y))
+      (x64_pmullw x y))
 
 (rule (lower (has_type (multi_lane 32 4) (imul x y)))
-      (pmulld x y))
+      (x64_pmulld x y))
 
 ;; With AVX-512 we can implement `i64x2` multiplication with a single
 ;; instruction.
@@ -993,7 +993,7 @@
                             (avx512dq_enabled)
                             (multi_lane 64 2))
                        (imul x y)))
-      (vpmullq x y))
+      (x64_vpmullq x y))
 
 ;; Otherwise, for i64x2 multiplication we describe a lane A as being composed of
 ;; a 32-bit upper half "Ah" and a 32-bit lower half "Al". The 32-bit long hand
@@ -1020,21 +1020,21 @@
       (let ((a0 Xmm a)
             (b0 Xmm b)
             ;; a_hi = A >> 32
-            (a_hi Xmm (psrlq a0 (RegMemImm.Imm 32)))
+            (a_hi Xmm (x64_psrlq a0 (RegMemImm.Imm 32)))
             ;; ah_bl = Ah * Bl
-            (ah_bl Xmm (pmuludq a_hi b0))
+            (ah_bl Xmm (x64_pmuludq a_hi b0))
             ;; b_hi = B >> 32
-            (b_hi Xmm (psrlq b0 (RegMemImm.Imm 32)))
+            (b_hi Xmm (x64_psrlq b0 (RegMemImm.Imm 32)))
             ;; al_bh = Al * Bh
-            (al_bh Xmm (pmuludq a0 b_hi))
+            (al_bh Xmm (x64_pmuludq a0 b_hi))
             ;; aa_bb = ah_bl + al_bh
-            (aa_bb Xmm (paddq ah_bl al_bh))
+            (aa_bb Xmm (x64_paddq ah_bl al_bh))
             ;; aa_bb_shifted = aa_bb << 32
-            (aa_bb_shifted Xmm (psllq aa_bb (RegMemImm.Imm 32)))
+            (aa_bb_shifted Xmm (x64_psllq aa_bb (RegMemImm.Imm 32)))
             ;; al_bl = Al * Bl
-            (al_bl Xmm (pmuludq a0 b0)))
+            (al_bl Xmm (x64_pmuludq a0 b0)))
         ;; al_bl + aa_bb_shifted
-        (paddq al_bl aa_bb_shifted)))
+        (x64_paddq al_bl aa_bb_shifted)))
 
 ;; Special case for `i16x8.extmul_high_i8x16_s`.
 (rule (lower (has_type (multi_lane 16 8)
@@ -1043,12 +1043,12 @@
                              (swiden_high (and (value_type (multi_lane 8 16))
                                                y)))))
       (let ((x1 Xmm x)
-            (x2 Xmm (palignr x1 x1 8 (OperandSize.Size32)))
-            (x3 Xmm (pmovsxbw x2))
+            (x2 Xmm (x64_palignr x1 x1 8 (OperandSize.Size32)))
+            (x3 Xmm (x64_pmovsxbw x2))
             (y1 Xmm y)
-            (y2 Xmm (palignr y1 y1 8 (OperandSize.Size32)))
-            (y3 Xmm (pmovsxbw y2)))
-        (pmullw x3 y3)))
+            (y2 Xmm (x64_palignr y1 y1 8 (OperandSize.Size32)))
+            (y3 Xmm (x64_pmovsxbw y2)))
+        (x64_pmullw x3 y3)))
 
 ;; Special case for `i32x4.extmul_high_i16x8_s`.
 (rule (lower (has_type (multi_lane 32 4)
@@ -1058,9 +1058,9 @@
                                                y)))))
       (let ((x2 Xmm x)
             (y2 Xmm y)
-            (lo Xmm (pmullw x2 y2))
-            (hi Xmm (pmulhw x2 y2)))
-        (punpckhwd lo hi)))
+            (lo Xmm (x64_pmullw x2 y2))
+            (hi Xmm (x64_pmulhw x2 y2)))
+        (x64_punpckhwd lo hi)))
 
 ;; Special case for `i64x2.extmul_high_i32x4_s`.
 (rule (lower (has_type (multi_lane 64 2)
@@ -1068,13 +1068,13 @@
                                                x))
                              (swiden_high (and (value_type (multi_lane 32 4))
                                                y)))))
-      (let ((x2 Xmm (pshufd x
+      (let ((x2 Xmm (x64_pshufd x
                             0xFA
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd y
+            (y2 Xmm (x64_pshufd y
                             0xFA
                             (OperandSize.Size32))))
-        (pmuldq x2 y2)))
+        (x64_pmuldq x2 y2)))
 
 ;; Special case for `i16x8.extmul_low_i8x16_s`.
 (rule (lower (has_type (multi_lane 16 8)
@@ -1082,9 +1082,9 @@
                                               x))
                              (swiden_low (and (value_type (multi_lane 8 16))
                                               y)))))
-      (let ((x2 Xmm (pmovsxbw x))
-            (y2 Xmm (pmovsxbw y)))
-        (pmullw x2 y2)))
+      (let ((x2 Xmm (x64_pmovsxbw x))
+            (y2 Xmm (x64_pmovsxbw y)))
+        (x64_pmullw x2 y2)))
 
 ;; Special case for `i32x4.extmul_low_i16x8_s`.
 (rule (lower (has_type (multi_lane 32 4)
@@ -1094,9 +1094,9 @@
                                               y)))))
       (let ((x2 Xmm x)
             (y2 Xmm y)
-            (lo Xmm (pmullw x2 y2))
-            (hi Xmm (pmulhw x2 y2)))
-        (punpcklwd lo hi)))
+            (lo Xmm (x64_pmullw x2 y2))
+            (hi Xmm (x64_pmulhw x2 y2)))
+        (x64_punpcklwd lo hi)))
 
 ;; Special case for `i64x2.extmul_low_i32x4_s`.
 (rule (lower (has_type (multi_lane 64 2)
@@ -1104,13 +1104,13 @@
                                               x))
                              (swiden_low (and (value_type (multi_lane 32 4))
                                               y)))))
-      (let ((x2 Xmm (pshufd x
+      (let ((x2 Xmm (x64_pshufd x
                             0x50
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd y
+            (y2 Xmm (x64_pshufd y
                             0x50
                             (OperandSize.Size32))))
-        (pmuldq x2 y2)))
+        (x64_pmuldq x2 y2)))
 
 ;; Special case for `i16x8.extmul_high_i8x16_u`.
 (rule (lower (has_type (multi_lane 16 8)
@@ -1119,12 +1119,12 @@
                              (uwiden_high (and (value_type (multi_lane 8 16))
                                                y)))))
       (let ((x1 Xmm x)
-            (x2 Xmm (palignr x1 x1 8 (OperandSize.Size32)))
-            (x3 Xmm (pmovzxbw x2))
+            (x2 Xmm (x64_palignr x1 x1 8 (OperandSize.Size32)))
+            (x3 Xmm (x64_pmovzxbw x2))
             (y1 Xmm y)
-            (y2 Xmm (palignr y1 y1 8 (OperandSize.Size32)))
-            (y3 Xmm (pmovzxbw y2)))
-        (pmullw x3 y3)))
+            (y2 Xmm (x64_palignr y1 y1 8 (OperandSize.Size32)))
+            (y3 Xmm (x64_pmovzxbw y2)))
+        (x64_pmullw x3 y3)))
 
 ;; Special case for `i32x4.extmul_high_i16x8_u`.
 (rule (lower (has_type (multi_lane 32 4)
@@ -1134,9 +1134,9 @@
                                                y)))))
       (let ((x2 Xmm x)
             (y2 Xmm y)
-            (lo Xmm (pmullw x2 y2))
-            (hi Xmm (pmulhuw x2 y2)))
-        (punpckhwd lo hi)))
+            (lo Xmm (x64_pmullw x2 y2))
+            (hi Xmm (x64_pmulhuw x2 y2)))
+        (x64_punpckhwd lo hi)))
 
 ;; Special case for `i64x2.extmul_high_i32x4_u`.
 (rule (lower (has_type (multi_lane 64 2)
@@ -1144,13 +1144,13 @@
                                                x))
                              (uwiden_high (and (value_type (multi_lane 32 4))
                                                y)))))
-      (let ((x2 Xmm (pshufd x
+      (let ((x2 Xmm (x64_pshufd x
                             0xFA
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd y
+            (y2 Xmm (x64_pshufd y
                             0xFA
                             (OperandSize.Size32))))
-        (pmuludq x2 y2)))
+        (x64_pmuludq x2 y2)))
 
 ;; Special case for `i16x8.extmul_low_i8x16_u`.
 (rule (lower (has_type (multi_lane 16 8)
@@ -1158,9 +1158,9 @@
                                               x))
                              (uwiden_low (and (value_type (multi_lane 8 16))
                                               y)))))
-      (let ((x2 Xmm (pmovzxbw x))
-            (y2 Xmm (pmovzxbw y)))
-        (pmullw x2 y2)))
+      (let ((x2 Xmm (x64_pmovzxbw x))
+            (y2 Xmm (x64_pmovzxbw y)))
+        (x64_pmullw x2 y2)))
 
 ;; Special case for `i32x4.extmul_low_i16x8_u`.
 (rule (lower (has_type (multi_lane 32 4)
@@ -1170,9 +1170,9 @@
                                               y)))))
       (let ((x2 Xmm x)
             (y2 Xmm y)
-            (lo Xmm (pmullw x2 y2))
-            (hi Xmm (pmulhuw x2 y2)))
-        (punpcklwd lo hi)))
+            (lo Xmm (x64_pmullw x2 y2))
+            (hi Xmm (x64_pmulhuw x2 y2)))
+        (x64_punpcklwd lo hi)))
 
 ;; Special case for `i64x2.extmul_low_i32x4_u`.
 (rule (lower (has_type (multi_lane 64 2)
@@ -1180,20 +1180,20 @@
                                               x))
                              (uwiden_low (and (value_type (multi_lane 32 4))
                                               y)))))
-      (let ((x2 Xmm (pshufd x
+      (let ((x2 Xmm (x64_pshufd x
                             0x50
                             (OperandSize.Size32)))
-            (y2 Xmm (pshufd y
+            (y2 Xmm (x64_pshufd y
                             0x50
                             (OperandSize.Size32))))
-        (pmuludq x2 y2)))
+        (x64_pmuludq x2 y2)))
 
 ;;;; Rules for `band_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl sse_and_not (Type Xmm XmmMem) Xmm)
-(rule (sse_and_not $F32X4 x y) (andnps x y))
-(rule (sse_and_not $F64X2 x y) (andnpd x y))
-(rule (sse_and_not (multi_lane _bits _lanes) x y) (pandn x y))
+(rule (sse_and_not $F32X4 x y) (x64_andnps x y))
+(rule (sse_and_not $F64X2 x y) (x64_andnpd x y))
+(rule (sse_and_not (multi_lane _bits _lanes) x y) (x64_pandn x y))
 
 ;; Note the flipping of operands below. CLIF specifies
 ;;
@@ -1208,20 +1208,20 @@
 ;;;; Rules for `iabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I8X16 (iabs x)))
-      (pabsb x))
+      (x64_pabsb x))
 
 (rule (lower (has_type $I16X8 (iabs x)))
-      (pabsw x))
+      (x64_pabsw x))
 
 (rule (lower (has_type $I32X4 (iabs x)))
-      (pabsd x))
+      (x64_pabsd x))
 
 ;; When AVX512 is available, we can use a single `vpabsq` instruction.
 (rule (lower (has_type (and (avx512vl_enabled)
                             (avx512f_enabled)
                             $I64X2)
                        (iabs x)))
-      (vpabsq x))
+      (x64_vpabsq x))
 
 ;; Otherwise, we use a separate register, `neg`, to contain the results of `0 -
 ;; x` and then blend in those results with `blendvpd` if the MSB of `neg` was
@@ -1229,21 +1229,21 @@
 ;; positive).
 (rule (lower (has_type $I64X2 (iabs x)))
       (let ((rx Xmm x)
-            (neg Xmm (psubq (imm $I64X2 0) rx)))
-        (blendvpd neg rx neg)))
+            (neg Xmm (x64_psubq (imm $I64X2 0) rx)))
+        (x64_blendvpd neg rx neg)))
 
 ;;;; Rules for `fabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Special case for `f32x4.abs`.
 (rule (lower (has_type $F32X4 (fabs x)))
-      (andps x
-             (psrld (vector_all_ones $F32X4)
+      (x64_andps x
+             (x64_psrld (vector_all_ones $F32X4)
                     (RegMemImm.Imm 1))))
 
 ;; Special case for `f64x2.abs`.
 (rule (lower (has_type $F64X2 (fabs x)))
-      (andpd x
-             (psrlq (vector_all_ones $F64X2)
+      (x64_andpd x
+             (x64_psrlq (vector_all_ones $F64X2)
                     (RegMemImm.Imm 1))))
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1251,7 +1251,7 @@
 ;; `i64` and smaller.
 
 (rule (lower (has_type (fits_in_64 ty) (bnot x)))
-      (not ty x))
+      (x64_not ty x))
 
 ;; `i128`.
 
@@ -1260,8 +1260,8 @@
       (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1)))
-        (value_gprs (not $I64 x_lo)
-                    (not $I64 x_hi))))
+        (value_gprs (x64_not $I64 x_lo)
+                    (x64_not $I64 x_hi))))
 
 (rule (lower (has_type $I128 (bnot x)))
       (i128_not x))
@@ -1292,7 +1292,7 @@
 
 (rule (lower (has_type ty @ (multi_lane _bits _lanes)
                        (vselect condition if_true if_false)))
-      (sse_blend ty
+      (x64_blend ty
                  condition
                  if_true
                  if_false))
@@ -1311,23 +1311,23 @@
 
 ;; i8x16.replace_lane
 (rule (vec_insert_lane $I8X16 vec val idx)
-      (pinsrb vec val idx))
+      (x64_pinsrb vec val idx))
 
 ;; i16x8.replace_lane
 (rule (vec_insert_lane $I16X8 vec val idx)
-      (pinsrw vec val idx))
+      (x64_pinsrw vec val idx))
 
 ;; i32x4.replace_lane
 (rule (vec_insert_lane $I32X4 vec val idx)
-      (pinsrd vec val idx (OperandSize.Size32)))
+      (x64_pinsrd vec val idx (OperandSize.Size32)))
 
 ;; i64x2.replace_lane
 (rule (vec_insert_lane $I64X2 vec val idx)
-      (pinsrd vec val idx (OperandSize.Size64)))
+      (x64_pinsrd vec val idx (OperandSize.Size64)))
 
 ;; f32x4.replace_lane
 (rule (vec_insert_lane $F32X4 vec val idx)
-      (insertps vec val (sse_insertps_lane_imm idx)))
+      (x64_insertps vec val (sse_insertps_lane_imm idx)))
 
 ;; External rust code used to calculate the immediate value to `insertps`.
 (decl sse_insertps_lane_imm (u8) u8)
@@ -1349,9 +1349,9 @@
 ;; internally as `xmm_rm_r` will merge the temp register into our `vec`
 ;; register.
 (rule (vec_insert_lane $F64X2 vec (RegMem.Reg val) 0)
-      (movsd vec val))
+      (x64_movsd vec val))
 (rule (vec_insert_lane $F64X2 vec mem 0)
-      (movsd vec (xmm_unary_rm_r (SseOpcode.Movsd)
+      (x64_movsd vec (xmm_unary_rm_r (SseOpcode.Movsd)
                                  mem)))
 
 ;; f64x2.replace_lane 1
@@ -1360,7 +1360,7 @@
 ;; into the second lane where unlike above cases we're not using the lane
 ;; immediate as an immediate to the instruction itself.
 (rule (vec_insert_lane $F64X2 vec val 1)
-      (movlhps vec (reg_mem_to_xmm_mem val)))
+      (x64_movlhps vec (reg_mem_to_xmm_mem val)))
 
 ;;;; Rules for `imin`, `imax`, `umin`, `umax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1371,7 +1371,7 @@
       (let ((x_reg Gpr x)
             (y_reg Gpr y)
             (size OperandSize (raw_operand_size_of_type ty)))
-        (with_flags_reg (cmp size x_reg y_reg)
+        (with_flags_reg (x64_cmp size x_reg y_reg)
                         (cmove ty cc y_reg x_reg))))
 
 (rule (lower (has_type (fits_in_64 ty) (umin x y)))
@@ -1389,56 +1389,56 @@
 ;; SSE `imax`.
 
 (rule (lower (has_type $I8X16 (imax x y)))
-      (pmaxsb x y))
+      (x64_pmaxsb x y))
 
 (rule (lower (has_type $I16X8 (imax x y)))
-      (pmaxsw x y))
+      (x64_pmaxsw x y))
 
 (rule (lower (has_type $I32X4 (imax x y)))
-      (pmaxsd x y))
+      (x64_pmaxsd x y))
 
 ;; SSE `imin`.
 
 (rule (lower (has_type $I8X16 (imin x y)))
-      (pminsb x y))
+      (x64_pminsb x y))
 
 (rule (lower (has_type $I16X8 (imin x y)))
-      (pminsw x y))
+      (x64_pminsw x y))
 
 (rule (lower (has_type $I32X4 (imin x y)))
-      (pminsd x y))
+      (x64_pminsd x y))
 
 ;; SSE `umax`.
 
 (rule (lower (has_type $I8X16 (umax x y)))
-      (pmaxub x y))
+      (x64_pmaxub x y))
 
 (rule (lower (has_type $I16X8 (umax x y)))
-      (pmaxuw x y))
+      (x64_pmaxuw x y))
 
 (rule (lower (has_type $I32X4 (umax x y)))
-      (pmaxud x y))
+      (x64_pmaxud x y))
 
 ;; SSE `umin`.
 
 (rule (lower (has_type $I8X16 (umin x y)))
-      (pminub x y))
+      (x64_pminub x y))
 
 (rule (lower (has_type $I16X8 (umin x y)))
-      (pminuw x y))
+      (x64_pminuw x y))
 
 (rule (lower (has_type $I32X4 (umin x y)))
-      (pminud x y))
+      (x64_pminud x y))
 
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (trap code))
-      (safepoint (ud2 code)))
+      (safepoint (x64_ud2 code)))
 
 ;;;; Rules for `resumable_trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (resumable_trap code))
-      (safepoint (ud2 code)))
+      (safepoint (x64_ud2 code)))
 
 ;;;; Rules for `icmp` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1447,7 +1447,7 @@
 ;; Unfortunately for clarity, the registers are flipped here (TODO).
 (rule (lower (icmp cc a @ (value_type (fits_in_64 ty)) b))
       (let ((size OperandSize (raw_operand_size_of_type ty)))
-           (with_flags (cmp size b a) (setcc cc))))
+           (with_flags (x64_cmp size b a) (x64_setcc cc))))
 
 ;; For XMM-held values, we lower to `PCMP*` instructions, sometimes more than
 ;; one. To note: what is different here about the output values is that each
@@ -1455,56 +1455,56 @@
 ;; whereas for GPR-held values, the result will be simply 0 or 1 (upper bits
 ;; unset).
 (rule (lower (icmp (IntCC.Equal) a @ (value_type (vec128 ty)) b))
-      (pcmpeq ty a b))
+      (x64_pcmpeq ty a b))
 ;; To lower a not-equals comparison, we perform an equality comparison
 ;; (PCMPEQ*) and then invert the bits (PXOR with all 1s).
 (rule (lower (icmp (IntCC.NotEqual) a @ (value_type (vec128 ty)) b))
-      (let ((checked Xmm (pcmpeq ty a b))
+      (let ((checked Xmm (x64_pcmpeq ty a b))
             (all_ones Xmm (vector_all_ones ty)))
-           (pxor checked all_ones)))
+           (x64_pxor checked all_ones)))
 ;; Signed comparisons have a single-instruction lowering, unlike their unsigned
 ;; counterparts. These latter instructions use the unsigned min/max
 ;; (PMINU*/PMAXU*) and negate the result (PXOR with all 1s).
 (rule (lower (icmp (IntCC.SignedGreaterThan) a @ (value_type (vec128 ty)) b))
-      (pcmpgt ty a b))
+      (x64_pcmpgt ty a b))
 (rule (lower (icmp (IntCC.SignedLessThan) a @ (value_type (vec128 ty)) b))
-      (pcmpgt ty b a))
+      (x64_pcmpgt ty b a))
 (rule (lower (icmp (IntCC.UnsignedGreaterThan) a @ (value_type (vec128 ty)) b))
-      (let ((max Xmm (pmaxu ty a b))
-            (eq Xmm (pcmpeq ty max b))
+      (let ((max Xmm (x64_pmaxu ty a b))
+            (eq Xmm (x64_pcmpeq ty max b))
             (all_ones Xmm (vector_all_ones ty)))
-           (pxor eq all_ones)))
+           (x64_pxor eq all_ones)))
 (rule (lower (icmp (IntCC.UnsignedLessThan) a @ (value_type (vec128 ty)) b))
-      (let ((min Xmm (pminu ty a b))
-            (eq Xmm (pcmpeq ty min b))
+      (let ((min Xmm (x64_pminu ty a b))
+            (eq Xmm (x64_pcmpeq ty min b))
             (all_ones Xmm (vector_all_ones ty)))
-           (pxor eq all_ones)))
+           (x64_pxor eq all_ones)))
 ;; To lower signed and unsigned *-or-equals comparisons, we find the minimum
 ;; number (PMIN[U|S]*) and compare that to one of the terms (PCMPEQ*). Note that
 ;; there is no 64x2 version of this lowering (see below).
 (rule (lower (icmp (IntCC.SignedGreaterThanOrEqual) a @ (value_type (vec128 ty)) b))
-      (let ((max Xmm (pmaxs ty a b)))
-           (pcmpeq ty a max)))
+      (let ((max Xmm (x64_pmaxs ty a b)))
+           (x64_pcmpeq ty a max)))
 (rule (lower (icmp (IntCC.SignedLessThanOrEqual) a @ (value_type (vec128 ty)) b))
-      (let ((min Xmm (pmins ty a b)))
-           (pcmpeq ty a min)))
+      (let ((min Xmm (x64_pmins ty a b)))
+           (x64_pcmpeq ty a min)))
 (rule (lower (icmp (IntCC.UnsignedGreaterThanOrEqual) a @ (value_type (vec128 ty)) b))
-      (let ((max Xmm (pmaxu ty a b)))
-           (pcmpeq ty a max)))
+      (let ((max Xmm (x64_pmaxu ty a b)))
+           (x64_pcmpeq ty a max)))
 (rule (lower (icmp (IntCC.UnsignedLessThanOrEqual) a @ (value_type (vec128 ty)) b))
-      (let ((min Xmm (pminu ty a b)))
-           (pcmpeq ty a min)))
+      (let ((min Xmm (x64_pminu ty a b)))
+           (x64_pcmpeq ty a min)))
 ;; The PMIN[S|U]Q instruction is only available in AVX512VL/F so we must instead
 ;; compare with flipped operands (PCMPGT*) and negate the result (PXOR with all
 ;; 1s), emitting one more instruction than the smaller-lane versions.
 (rule (lower (icmp (IntCC.SignedGreaterThanOrEqual) a @ (value_type $I64X2) b))
-      (let ((checked Xmm (pcmpgt $I64X2 b a))
+      (let ((checked Xmm (x64_pcmpgt $I64X2 b a))
             (all_ones Xmm (vector_all_ones $I64X2)))
-           (pxor checked all_ones)))
+           (x64_pxor checked all_ones)))
 (rule (lower (icmp (IntCC.SignedLessThanOrEqual) a @ (value_type $I64X2) b))
-      (let ((checked Xmm (pcmpgt $I64X2 a b))
+      (let ((checked Xmm (x64_pcmpgt $I64X2 a b))
             (all_ones Xmm (vector_all_ones $I64X2)))
-           (pxor checked all_ones)))
+           (x64_pxor checked all_ones)))
 ;; TODO: not used by WebAssembly translation
 ;; (rule (lower (icmp (IntCC.UnsignedGreaterThanOrEqual) a @ (value_type $I64X2) b))
 ;; TODO: not used by WebAssembly translation
@@ -1517,8 +1517,8 @@
             (a_hi Gpr (value_regs_get_gpr a 1))
             (b_lo Gpr (value_regs_get_gpr b 0))
             (b_hi Gpr (value_regs_get_gpr b 1))
-            (cmp_lo Reg (with_flags_reg (cmp (OperandSize.Size64) b_lo a_lo) (setcc (CC.Z))))
-            (cmp_hi Reg (with_flags_reg (cmp (OperandSize.Size64) b_hi a_hi) (setcc (CC.Z))))
+            (cmp_lo Reg (with_flags_reg (x64_cmp (OperandSize.Size64) b_lo a_lo) (x64_setcc (CC.Z))))
+            (cmp_hi Reg (with_flags_reg (x64_cmp (OperandSize.Size64) b_hi a_hi) (x64_setcc (CC.Z))))
             ;; At this point, `cmp_lo` and `cmp_hi` contain either 0 or 1 in the
             ;; lowest 8 bits--`SETcc` guarantees this. The upper bits may be
             ;; unchanged so we must compare against 1 below; this instruction
@@ -1529,18 +1529,18 @@
            ;; then the `ZF` will be set (see `TEST` definition); if either of
            ;; the halves `AND`s to 0, they were not equal, therefore we `SETcc`
            ;; with `NZ`.
-           (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 1) cmp) (setcc (CC.NZ)))))
+           (with_flags (x64_test (OperandSize.Size64) (RegMemImm.Imm 1) cmp) (x64_setcc (CC.NZ)))))
 
 (rule (lower (icmp (IntCC.NotEqual) a @ (value_type $I128) b))
       (let ((a_lo Gpr (value_regs_get_gpr a 0))
             (a_hi Gpr (value_regs_get_gpr a 1))
             (b_lo Gpr (value_regs_get_gpr b 0))
             (b_hi Gpr (value_regs_get_gpr b 1))
-            (cmp_lo Reg (with_flags_reg (cmp (OperandSize.Size64) b_lo a_lo) (setcc (CC.NZ))))
-            (cmp_hi Reg (with_flags_reg (cmp (OperandSize.Size64) b_hi a_hi) (setcc (CC.NZ))))
+            (cmp_lo Reg (with_flags_reg (x64_cmp (OperandSize.Size64) b_lo a_lo) (x64_setcc (CC.NZ))))
+            (cmp_hi Reg (with_flags_reg (x64_cmp (OperandSize.Size64) b_hi a_hi) (x64_setcc (CC.NZ))))
             ;; See comments for `IntCC.Equal`.
-            (cmp Reg (or $I64 cmp_lo cmp_hi)))
-           (with_flags (test (OperandSize.Size64) (RegMemImm.Imm 1) cmp) (setcc (CC.NZ)))))
+            (cmp Reg (x64_or $I64 cmp_lo cmp_hi)))
+           (with_flags (x64_test (OperandSize.Size64) (RegMemImm.Imm 1) cmp) (x64_setcc (CC.NZ)))))
 
 ;;;; Rules for `select` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1570,22 +1570,22 @@
 ;;  - `CC.NBE -> C = 0 AND Z = 0` (not below or equal)
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.Ordered) a b) x y)))
-      (with_flags (fpcmp b a) (cmove_from_values ty (CC.NP) x y)))
+      (with_flags (x64_ucomis b a) (cmove_from_values ty (CC.NP) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.Unordered) a b) x y)))
-      (with_flags (fpcmp b a) (cmove_from_values ty (CC.P) x y)))
+      (with_flags (x64_ucomis b a) (cmove_from_values ty (CC.P) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.GreaterThan) a b) x y)))
-      (with_flags (fpcmp b a) (cmove_from_values ty (CC.NBE) x y)))
+      (with_flags (x64_ucomis b a) (cmove_from_values ty (CC.NBE) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.GreaterThanOrEqual) a b) x y)))
-      (with_flags (fpcmp b a) (cmove_from_values ty (CC.NB) x y)))
+      (with_flags (x64_ucomis b a) (cmove_from_values ty (CC.NB) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.UnorderedOrLessThan) a b) x y)))
-      (with_flags (fpcmp b a) (cmove_from_values ty (CC.B) x y)))
+      (with_flags (x64_ucomis b a) (cmove_from_values ty (CC.B) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.UnorderedOrLessThanOrEqual) a b) x y)))
-      (with_flags (fpcmp b a) (cmove_from_values ty (CC.BE) x y)))
+      (with_flags (x64_ucomis b a) (cmove_from_values ty (CC.BE) x y)))
 
 ;; Certain FloatCC variants are implemented by flipping the operands of the
 ;; comparison (e.g., "greater than" is lowered the same as "less than" but the
@@ -1599,16 +1599,16 @@
 ;; to `CC.NBE`), we also avoid these unordered cases.
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.LessThan) a b) x y)))
-      (with_flags (fpcmp a b) (cmove_from_values ty (CC.NBE) x y)))
+      (with_flags (x64_ucomis a b) (cmove_from_values ty (CC.NBE) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.LessThanOrEqual) a b) x y)))
-      (with_flags (fpcmp a b) (cmove_from_values ty (CC.NB) x y)))
+      (with_flags (x64_ucomis a b) (cmove_from_values ty (CC.NB) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.UnorderedOrGreaterThan) a b) x y)))
-      (with_flags (fpcmp a b) (cmove_from_values ty (CC.B) x y)))
+      (with_flags (x64_ucomis a b) (cmove_from_values ty (CC.B) x y)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.UnorderedOrGreaterThanOrEqual) a b) x y)))
-      (with_flags (fpcmp a b) (cmove_from_values ty (CC.BE) x y)))
+      (with_flags (x64_ucomis a b) (cmove_from_values ty (CC.BE) x y)))
 
 ;; `FloatCC.Equal` and `FloatCC.NotEqual` can only be implemented with multiple
 ;; flag checks. Recall from the flag assignment chart above that equality, e.g.,
@@ -1624,10 +1624,10 @@
 ;; https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/trait.InstBuilder.html#method.fcmp.
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.Equal) a b) x y)))
-      (with_flags (fpcmp a b) (cmove_or_from_values ty (CC.NZ) (CC.P) y x)))
+      (with_flags (x64_ucomis a b) (cmove_or_from_values ty (CC.NZ) (CC.P) y x)))
 
 (rule (lower (has_type ty (select (fcmp (FloatCC.NotEqual) a b) x y)))
-      (with_flags (fpcmp a b) (cmove_or_from_values ty (CC.NZ) (CC.P) x y)))
+      (with_flags (x64_ucomis a b) (cmove_or_from_values ty (CC.NZ) (CC.P) x y)))
 
 ;; Rules for `clz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1640,7 +1640,7 @@
                     (ty_32_or_64 ty)
                     (use_lzcnt))
                    (clz src)))
-      (lzcnt ty src))
+      (x64_lzcnt ty src))
 
 (rule (lower
        (has_type (ty_32_or_64 ty)
@@ -1656,12 +1656,12 @@
        (has_type $I128
                  (clz src)))
       (let ((upper Gpr (do_clz $I64 $I64 (value_regs_get_gpr src 1)))
-            (lower Gpr (add $I64
+            (lower Gpr (x64_add $I64
                             (do_clz $I64 $I64 (value_regs_get_gpr src 0))
                             (RegMemImm.Imm 64)))
             (result_lo Gpr
               (with_flags_reg
-               (cmp_imm (OperandSize.Size64) 64 upper)
+               (x64_cmp_imm (OperandSize.Size64) 64 upper)
                (cmove $I64 (CC.NZ) upper lower))))
         (value_regs result_lo (imm $I64 0))))
 
@@ -1670,7 +1670,7 @@
 (rule (do_clz ty orig_ty src)
       (let ((highest_bit_index Reg (bsr_or_else ty src (imm_i64 $I64 -1)))
             (bits_minus_1 Reg (imm ty (u64_sub (ty_bits_u64 orig_ty) 1))))
-        (sub ty bits_minus_1 highest_bit_index)))
+        (x64_sub ty bits_minus_1 highest_bit_index)))
 
 ;; Rules for `ctz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1682,7 +1682,7 @@
                     (ty_32_or_64 ty)
                     (use_bmi1))
                    (ctz src)))
-      (tzcnt ty src))
+      (x64_tzcnt ty src))
 
 (rule (lower
        (has_type (ty_32_or_64 ty)
@@ -1698,12 +1698,12 @@
        (has_type $I128
                  (ctz src)))
       (let ((lower Gpr (do_ctz $I64 $I64 (value_regs_get_gpr src 0)))
-            (upper Gpr (add $I64
+            (upper Gpr (x64_add $I64
                             (do_ctz $I64 $I64 (value_regs_get_gpr src 1))
                             (RegMemImm.Imm 64)))
             (result_lo Gpr
               (with_flags_reg
-               (cmp_imm (OperandSize.Size64) 64 lower)
+               (x64_cmp_imm (OperandSize.Size64) 64 lower)
                (cmove $I64 (CC.Z) upper lower))))
         (value_regs result_lo (imm $I64 0))))
 
@@ -1734,7 +1734,7 @@
                    (popcnt src)))
       (let ((lo_count Gpr (x64_popcnt $I64 (value_regs_get_gpr src 0)))
             (hi_count Gpr (x64_popcnt $I64 (value_regs_get_gpr src 1))))
-        (value_regs (add $I64 lo_count hi_count) (imm $I64 0))))
+        (value_regs (x64_add $I64 lo_count hi_count) (imm $I64 0))))
 
 (rule (lower
        (has_type (ty_32_or_64 ty)
@@ -1751,22 +1751,22 @@
                  (popcnt src)))
       (let ((lo_count Gpr (do_popcnt $I64 (value_regs_get_gpr src 0)))
             (hi_count Gpr (do_popcnt $I64 (value_regs_get_gpr src 1))))
-        (value_regs (add $I64 lo_count hi_count) (imm $I64 0))))
+        (value_regs (x64_add $I64 lo_count hi_count) (imm $I64 0))))
 
 ;; Implementation of popcount when we don't nave a native popcount
 ;; instruction.
 (decl do_popcnt (Type Gpr) Gpr)
 (rule (do_popcnt $I64 src)
-      (let ((shifted1 Gpr (shr $I64 src (Imm8Reg.Imm8 1)))
+      (let ((shifted1 Gpr (x64_shr $I64 src (Imm8Reg.Imm8 1)))
             (sevens Gpr (imm $I64 0x7777777777777777))
             (masked1 Gpr (x64_and $I64 shifted1 sevens))
             ;; diff1 := src - ((src >> 1) & 0b0111_0111_0111...)
-            (diff1 Gpr (sub $I64 src masked1))
-            (shifted2 Gpr (shr $I64 masked1 (Imm8Reg.Imm8 1)))
+            (diff1 Gpr (x64_sub $I64 src masked1))
+            (shifted2 Gpr (x64_shr $I64 masked1 (Imm8Reg.Imm8 1)))
             (masked2 Gpr (x64_and $I64 shifted2 sevens))
             ;; diff2 := diff1 - ((diff1 >> 1) & 0b0111_0111_0111...)
-            (diff2 Gpr (sub $I64 diff1 masked2))
-            (shifted3 Gpr (shr $I64 masked2 (Imm8Reg.Imm8 1)))
+            (diff2 Gpr (x64_sub $I64 diff1 masked2))
+            (shifted3 Gpr (x64_shr $I64 masked2 (Imm8Reg.Imm8 1)))
             (masked3 Gpr (x64_and $I64 shifted3 sevens))
             ;; diff3 := diff2 - ((diff2 >> 1) & 0b0111_0111_0111...)
             ;;
@@ -1777,10 +1777,10 @@
             ;; was 1. After three steps, we have (nibble / 8) -- 0 or
             ;; 1 for the MSB of the nibble -- plus three possible
             ;; additions for the three other bits.
-            (diff3 Gpr (sub $I64 diff2 masked3))
+            (diff3 Gpr (x64_sub $I64 diff2 masked3))
             ;; Add the two nibbles of each byte together.
-            (sum1 Gpr (add $I64
-                           (shr $I64 diff3 (Imm8Reg.Imm8 4))
+            (sum1 Gpr (x64_add $I64
+                           (x64_shr $I64 diff3 (Imm8Reg.Imm8 4))
                            diff3))
             ;; Mask the above sum to have the popcount for each byte
             ;; in the lower nibble of that byte.
@@ -1792,30 +1792,30 @@
             ;; top byte: it is the sum of the bytes (masked4 >> 56) *
             ;; 0x01 + (masked4 >> 48) * 0x01 + (masked4 >> 40) * 0x01
             ;; + ... + (masked4 >> 0).
-            (mul Gpr (mul $I64 masked4 ones))
+            (mul Gpr (x64_mul $I64 masked4 ones))
             ;; Now take that top byte and return it as the popcount.
-            (final Gpr (shr $I64 mul (Imm8Reg.Imm8 56))))
+            (final Gpr (x64_shr $I64 mul (Imm8Reg.Imm8 56))))
         final))
 
 ;; This is the 32-bit version of the above; the steps for each nibble
 ;; are the same, we just use constants half as wide.
 (rule (do_popcnt $I32 src)
-      (let ((shifted1 Gpr (shr $I32 src (Imm8Reg.Imm8 1)))
+      (let ((shifted1 Gpr (x64_shr $I32 src (Imm8Reg.Imm8 1)))
             (sevens Gpr (imm $I32 0x77777777))
             (masked1 Gpr (x64_and $I32 shifted1 sevens))
-            (diff1 Gpr (sub $I32 src masked1))
-            (shifted2 Gpr (shr $I32 masked1 (Imm8Reg.Imm8 1)))
+            (diff1 Gpr (x64_sub $I32 src masked1))
+            (shifted2 Gpr (x64_shr $I32 masked1 (Imm8Reg.Imm8 1)))
             (masked2 Gpr (x64_and $I32 shifted2 sevens))
-            (diff2 Gpr (sub $I32 diff1 masked2))
-            (shifted3 Gpr (shr $I32 masked2 (Imm8Reg.Imm8 1)))
+            (diff2 Gpr (x64_sub $I32 diff1 masked2))
+            (shifted3 Gpr (x64_shr $I32 masked2 (Imm8Reg.Imm8 1)))
             (masked3 Gpr (x64_and $I32 shifted3 sevens))
-            (diff3 Gpr (sub $I32 diff2 masked3))
-            (sum1 Gpr (add $I32
-                           (shr $I32 diff3 (Imm8Reg.Imm8 4))
+            (diff3 Gpr (x64_sub $I32 diff2 masked3))
+            (sum1 Gpr (x64_add $I32
+                           (x64_shr $I32 diff3 (Imm8Reg.Imm8 4))
                            diff3))
             (masked4 Gpr (x64_and $I32 sum1 (RegMemImm.Imm 0x0f0f0f0f)))
-            (mul Gpr (mul $I32 masked4 (RegMemImm.Imm 0x01010101)))
-            (final Gpr (shr $I32 mul (Imm8Reg.Imm8 24))))
+            (mul Gpr (x64_mul $I32 masked4 (RegMemImm.Imm 0x01010101)))
+            (final Gpr (x64_shr $I32 mul (Imm8Reg.Imm8 24))))
         final))
 
 
@@ -1824,7 +1824,7 @@
                           (avx512vl_enabled)
                           (avx512bitalg_enabled))
                          (popcnt src)))
-      (vpopcntb src))
+      (x64_vpopcntb src))
 
 
 
@@ -1856,17 +1856,17 @@
 (rule (lower (has_type $I8X16
                        (popcnt src)))
       (let ((nibble_table_const VCodeConstant (popcount_4bit_table))
-            (low_mask Xmm (xmm_load_const $I8X16 (popcount_low_mask)))
+            (low_mask Xmm (x64_xmm_load_const $I8X16 (popcount_low_mask)))
             (low_nibbles Xmm (sse_and $I8X16 src low_mask))
             ;; Note that this is a 16x8 shift, but that's OK; we mask
             ;; off anything that traverses from one byte to the next
             ;; with the low_mask below.
-            (shifted_src Xmm (psrlw src (RegMemImm.Imm 4)))
+            (shifted_src Xmm (x64_psrlw src (RegMemImm.Imm 4)))
             (high_nibbles Xmm (sse_and $I8X16 shifted_src low_mask))
-            (lookup Xmm (xmm_load_const $I8X16 (popcount_4bit_table)))
-            (bit_counts_low Xmm (pshufb lookup low_nibbles))
-            (bit_counts_high Xmm (pshufb lookup high_nibbles)))
-        (paddb bit_counts_low bit_counts_high)))
+            (lookup Xmm (x64_xmm_load_const $I8X16 (popcount_4bit_table)))
+            (bit_counts_low Xmm (x64_pshufb lookup low_nibbles))
+            (bit_counts_high Xmm (x64_pshufb lookup high_nibbles)))
+        (x64_paddb bit_counts_low bit_counts_high)))
 
 ;; Rules for `bitrev` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1892,21 +1892,21 @@
       (let ((tymask u64 (ty_mask ty))
             (mask1 Gpr (imm ty (u64_and tymask 0x5555555555555555)))
             (lo1 Gpr (x64_and ty src mask1))
-            (hi1 Gpr (x64_and ty (shr ty src (Imm8Reg.Imm8 1)) mask1))
-            (swap1 Gpr (or ty
-                           (shl ty lo1 (Imm8Reg.Imm8 1))
+            (hi1 Gpr (x64_and ty (x64_shr ty src (Imm8Reg.Imm8 1)) mask1))
+            (swap1 Gpr (x64_or ty
+                           (x64_shl ty lo1 (Imm8Reg.Imm8 1))
                            hi1))
             (mask2 Gpr (imm ty (u64_and tymask 0x3333333333333333)))
             (lo2 Gpr (x64_and ty swap1 mask2))
-            (hi2 Gpr (x64_and ty (shr ty swap1 (Imm8Reg.Imm8 2)) mask2))
-            (swap2 Gpr (or ty
-                           (shl ty lo2 (Imm8Reg.Imm8 2))
+            (hi2 Gpr (x64_and ty (x64_shr ty swap1 (Imm8Reg.Imm8 2)) mask2))
+            (swap2 Gpr (x64_or ty
+                           (x64_shl ty lo2 (Imm8Reg.Imm8 2))
                            hi2))
             (mask4 Gpr (imm ty (u64_and tymask 0x0f0f0f0f0f0f0f0f)))
             (lo4 Gpr (x64_and ty swap2 mask4))
-            (hi4 Gpr (x64_and ty (shr ty swap2 (Imm8Reg.Imm8 4)) mask4))
-            (swap4 Gpr (or ty
-                           (shl ty lo4 (Imm8Reg.Imm8 4))
+            (hi4 Gpr (x64_and ty (x64_shr ty swap2 (Imm8Reg.Imm8 4)) mask4))
+            (swap4 Gpr (x64_or ty
+                           (x64_shl ty lo4 (Imm8Reg.Imm8 4))
                            hi4)))
         swap4))
 
@@ -1916,9 +1916,9 @@
             (tymask u64 (ty_mask ty))
             (mask8 Gpr (imm ty (u64_and tymask 0x00ff00ff00ff00ff)))
             (lo8 Gpr (x64_and ty src_ mask8))
-            (hi8 Gpr (x64_and ty (shr ty src_ (Imm8Reg.Imm8 8)) mask8))
-            (swap8 Gpr (or ty
-                           (shl ty lo8 (Imm8Reg.Imm8 8))
+            (hi8 Gpr (x64_and ty (x64_shr ty src_ (Imm8Reg.Imm8 8)) mask8))
+            (swap8 Gpr (x64_or ty
+                           (x64_shl ty lo8 (Imm8Reg.Imm8 8))
                            hi8)))
         swap8))
 
@@ -1928,9 +1928,9 @@
             (tymask u64 (ty_mask ty))
             (mask16 Gpr (imm ty (u64_and tymask 0x0000ffff0000ffff)))
             (lo16 Gpr (x64_and ty src_ mask16))
-            (hi16 Gpr (x64_and ty (shr ty src_ (Imm8Reg.Imm8 16)) mask16))
-            (swap16 Gpr (or ty
-                            (shl ty lo16 (Imm8Reg.Imm8 16))
+            (hi16 Gpr (x64_and ty (x64_shr ty src_ (Imm8Reg.Imm8 16)) mask16))
+            (swap16 Gpr (x64_or ty
+                            (x64_shl ty lo16 (Imm8Reg.Imm8 16))
                             hi16)))
         swap16))
 
@@ -1939,9 +1939,9 @@
       (let ((src_ Gpr (do_bitrev32 ty src))
             (mask32 Gpr (imm ty 0xffffffff))
             (lo32 Gpr (x64_and ty src_ mask32))
-            (hi32 Gpr (shr ty src_ (Imm8Reg.Imm8 32)))
-            (swap32 Gpr (or ty
-                            (shl ty lo32 (Imm8Reg.Imm8 32))
+            (hi32 Gpr (x64_shr ty src_ (Imm8Reg.Imm8 32)))
+            (swap32 Gpr (x64_or ty
+                            (x64_shl ty lo32 (Imm8Reg.Imm8 32))
                             hi32)))
         swap32))
 
@@ -1950,16 +1950,16 @@
 ;; Null references are represented by the constant value `0`.
 (rule (lower (is_null src @ (value_type $R64)))
       (with_flags
-       (cmp_imm (OperandSize.Size64) 0 src)
-       (setcc (CC.Z))))
+       (x64_cmp_imm (OperandSize.Size64) 0 src)
+       (x64_setcc (CC.Z))))
 
 ;; Rules for `is_invalid` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Null references are represented by the constant value `-1`.
 (rule (lower (is_invalid src @ (value_type $R64)))
       (with_flags
-       (cmp_imm (OperandSize.Size64) 0xffffffff src)  ;; simm32 0xffff_ffff is sign-extended to -1.
-       (setcc (CC.Z))))
+       (x64_cmp_imm (OperandSize.Size64) 0xffffffff src)  ;; simm32 0xffff_ffff is sign-extended to -1.
+       (x64_setcc (CC.Z))))
 
 
 ;; Rules for `uextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2038,7 +2038,7 @@
 ;; 63 bits to spread the sign bit across the result.
 (decl spread_sign_bit (Gpr) Gpr)
 (rule (spread_sign_bit src)
-      (sar $I64 src (Imm8Reg.Imm8 63)))
+      (x64_sar $I64 src (Imm8Reg.Imm8 63)))
 
 ;; I64 -> I128.
 (rule (generic_sextend src (ty_int_bool_64 _) (ty_int_bool_128 _))
@@ -2106,13 +2106,13 @@
 ;; Rules for `debugtrap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (debugtrap))
-      (side_effect (hlt)))
+      (side_effect (x64_hlt)))
 
 ;; Rules for `widening_pairwise_dot_product_s` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I32X4
                        (widening_pairwise_dot_product_s x y)))
-      (pmaddwd x y))
+      (x64_pmaddwd x y))
 
 ;; Rules for `fadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2121,46 +2121,46 @@
 ;; load. Likewise for other ops below.
 
 (rule (lower (has_type $F32 (fadd x y)))
-      (addss x y))
+      (x64_addss x y))
 (rule (lower (has_type $F64 (fadd x y)))
-      (addsd x y))
+      (x64_addsd x y))
 (rule (lower (has_type $F32X4 (fadd x y)))
-      (addps x y))
+      (x64_addps x y))
 (rule (lower (has_type $F64X2 (fadd x y)))
-      (addpd x y))
+      (x64_addpd x y))
 
 ;; Rules for `fsub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fsub x y)))
-      (subss x y))
+      (x64_subss x y))
 (rule (lower (has_type $F64 (fsub x y)))
-      (subsd x y))
+      (x64_subsd x y))
 (rule (lower (has_type $F32X4 (fsub x y)))
-      (subps x y))
+      (x64_subps x y))
 (rule (lower (has_type $F64X2 (fsub x y)))
-      (subpd x y))
+      (x64_subpd x y))
 
 ;; Rules for `fmul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fmul x y)))
-      (mulss x y))
+      (x64_mulss x y))
 (rule (lower (has_type $F64 (fmul x y)))
-      (mulsd x y))
+      (x64_mulsd x y))
 (rule (lower (has_type $F32X4 (fmul x y)))
-      (mulps x y))
+      (x64_mulps x y))
 (rule (lower (has_type $F64X2 (fmul x y)))
-      (mulpd x y))
+      (x64_mulpd x y))
 
 ;; Rules for `fdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fdiv x y)))
-      (divss x y))
+      (x64_divss x y))
 (rule (lower (has_type $F64 (fdiv x y)))
-      (divsd x y))
+      (x64_divsd x y))
 (rule (lower (has_type $F32X4 (fdiv x y)))
-      (divps x y))
+      (x64_divps x y))
 (rule (lower (has_type $F64X2 (fdiv x y)))
-      (divpd x y))
+      (x64_divpd x y))
 
 ;; Rules for `fmin` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2187,8 +2187,8 @@
       ;; above that we have to handle properly. (Conversely, if they
       ;; don't differ, then the native instruction's answer is the
       ;; right one per CLIF semantics.)
-      (let ((min1 Xmm (minps x y))
-            (min2 Xmm (minps y x))
+      (let ((min1 Xmm (x64_minps x y))
+            (min2 Xmm (x64_minps y x))
             ;; Compute the OR of the two. Note that NaNs have an
             ;; exponent field of all-ones (0xFF for F32), so if either
             ;; result is a NaN, this OR will be. And if either is a
@@ -2199,13 +2199,13 @@
             ;; In the case where we don't have a +/-0 mismatch or
             ;; NaNs, then `min1` and `min2` are equal and `min_or` is
             ;; the correct minimum.
-            (min_or Xmm (orps min1 min2))
+            (min_or Xmm (x64_orps min1 min2))
             ;; "compare unordered" produces a true mask (all ones) in
             ;; a given lane if the min is a NaN. We use this to
             ;; generate a mask to ensure quiet NaNs.
-            (is_nan_mask Xmm (cmpps min_or min2 (FcmpImm.Unordered)))
+            (is_nan_mask Xmm (x64_cmpps min_or min2 (FcmpImm.Unordered)))
             ;; OR in the NaN mask.
-            (min_or_2 Xmm (orps min_or is_nan_mask))
+            (min_or_2 Xmm (x64_orps min_or is_nan_mask))
             ;; Shift the NaN mask down so that it covers just the
             ;; fraction below the NaN signalling bit; we'll use this
             ;; to mask off non-canonical NaN payloads.
@@ -2213,25 +2213,25 @@
             ;; All-ones for NaN, shifted down to leave 10 top bits (1
             ;; sign, 8 exponent, 1 QNaN bit that must remain set)
             ;; cleared.
-            (nan_fraction_mask Xmm (psrld is_nan_mask (RegMemImm.Imm 10)))
+            (nan_fraction_mask Xmm (x64_psrld is_nan_mask (RegMemImm.Imm 10)))
             ;; Do a NAND, so that we retain every bit not set in
             ;; `nan_fraction_mask`. This mask will be all zeroes (so
             ;; we retain every bit) in non-NaN cases, and will have
             ;; ones (so we clear those bits) in NaN-payload bits
             ;; otherwise.
-            (final Xmm (andnps nan_fraction_mask min_or_2)))
+            (final Xmm (x64_andnps nan_fraction_mask min_or_2)))
         final))
 
 ;; Likewise for F64 lanes, except that the right-shift is by 13 bits
 ;; (1 sign, 11 exponent, 1 QNaN bit).
 (rule (lower (has_type $F64X2 (fmin x y)))
-      (let ((min1 Xmm (minpd x y))
-            (min2 Xmm (minpd y x))
-            (min_or Xmm (orpd min1 min2))
-            (is_nan_mask Xmm (cmppd min1 min2 (FcmpImm.Unordered)))
-            (min_or_2 Xmm (orpd min_or is_nan_mask))
-            (nan_fraction_mask Xmm (psrlq is_nan_mask (RegMemImm.Imm 13)))
-            (final Xmm (andnpd nan_fraction_mask min_or_2)))
+      (let ((min1 Xmm (x64_minpd x y))
+            (min2 Xmm (x64_minpd y x))
+            (min_or Xmm (x64_orpd min1 min2))
+            (is_nan_mask Xmm (x64_cmppd min1 min2 (FcmpImm.Unordered)))
+            (min_or_2 Xmm (x64_orpd min_or is_nan_mask))
+            (nan_fraction_mask Xmm (x64_psrlq is_nan_mask (RegMemImm.Imm 13)))
+            (final Xmm (x64_andnpd nan_fraction_mask min_or_2)))
         final))
 
 ;; Rules for `fmax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2250,12 +2250,12 @@
       ;; above that we have to handle properly. (Conversely, if they
       ;; don't differ, then the native instruction's answer is the
       ;; right one per CLIF semantics.)
-      (let ((max1 Xmm (maxps x y))
-            (max2 Xmm (maxps y x))
+      (let ((max1 Xmm (x64_maxps x y))
+            (max2 Xmm (x64_maxps y x))
             ;; Compute the XOR of the two maxima. In the case
             ;; where we don't have a +/-0 mismatch or NaNs, then
             ;; `min1` and `min2` are equal and this XOR is zero.
-            (max_xor Xmm (xorps max1 max2))
+            (max_xor Xmm (x64_xorps max1 max2))
             ;; OR the XOR into one of the original maxima. If they are
             ;; equal, this does nothing. If max2 was NaN, its exponent
             ;; bits were all-ones, so the xor's exponent bits were the
@@ -2263,14 +2263,14 @@
             ;; an all-ones exponent (is a NaN). If max1 was NaN, then
             ;; its exponent bits were already all-ones, so the OR will
             ;; be a NaN as well.
-            (max_blended_nan Xmm (orps max1 max_xor))
+            (max_blended_nan Xmm (x64_orps max1 max_xor))
             ;; Subtract the XOR. This ensures that if we had +0 and
             ;; -0, we end up with +0.
-            (max_blended_nan_positive Xmm (subps max_blended_nan max_xor))
+            (max_blended_nan_positive Xmm (x64_subps max_blended_nan max_xor))
             ;; "compare unordered" produces a true mask (all ones) in
             ;; a given lane if the min is a NaN. We use this to
             ;; generate a mask to ensure quiet NaNs.
-            (is_nan_mask Xmm (cmpps max_blended_nan max_blended_nan (FcmpImm.Unordered)))
+            (is_nan_mask Xmm (x64_cmpps max_blended_nan max_blended_nan (FcmpImm.Unordered)))
             ;; Shift the NaN mask down so that it covers just the
             ;; fraction below the NaN signalling bit; we'll use this
             ;; to mask off non-canonical NaN payloads.
@@ -2278,13 +2278,13 @@
             ;; All-ones for NaN, shifted down to leave 10 top bits (1
             ;; sign, 8 exponent, 1 QNaN bit that must remain set)
             ;; cleared.
-            (nan_fraction_mask Xmm (psrld is_nan_mask (RegMemImm.Imm 10)))
+            (nan_fraction_mask Xmm (x64_psrld is_nan_mask (RegMemImm.Imm 10)))
             ;; Do a NAND, so that we retain every bit not set in
             ;; `nan_fraction_mask`. This mask will be all zeroes (so
             ;; we retain every bit) in non-NaN cases, and will have
             ;; ones (so we clear those bits) in NaN-payload bits
             ;; otherwise.
-            (final Xmm (andnps nan_fraction_mask max_blended_nan_positive)))
+            (final Xmm (x64_andnps nan_fraction_mask max_blended_nan_positive)))
         final))
 
 (rule (lower (has_type $F64X2 (fmax x y)))
@@ -2293,12 +2293,12 @@
       ;; above that we have to handle properly. (Conversely, if they
       ;; don't differ, then the native instruction's answer is the
       ;; right one per CLIF semantics.)
-      (let ((max1 Xmm (maxpd x y))
-            (max2 Xmm (maxpd y x))
+      (let ((max1 Xmm (x64_maxpd x y))
+            (max2 Xmm (x64_maxpd y x))
             ;; Compute the XOR of the two maxima. In the case
             ;; where we don't have a +/-0 mismatch or NaNs, then
             ;; `min1` and `min2` are equal and this XOR is zero.
-            (max_xor Xmm (xorpd max1 max2))
+            (max_xor Xmm (x64_xorpd max1 max2))
             ;; OR the XOR into one of the original maxima. If they are
             ;; equal, this does nothing. If max2 was NaN, its exponent
             ;; bits were all-ones, so the xor's exponent bits were the
@@ -2306,15 +2306,15 @@
             ;; an all-ones exponent (is a NaN). If max1 was NaN, then
             ;; its exponent bits were already all-ones, so the OR will
             ;; be a NaN as well.
-            (max_blended_nan Xmm (orpd max1 max_xor))
+            (max_blended_nan Xmm (x64_orpd max1 max_xor))
             ;; Subtract the XOR. This ensures that if we had +0 and
             ;; -0, we end up with +0.
-            (max_blended_nan_positive Xmm (subpd max_blended_nan max_xor))
+            (max_blended_nan_positive Xmm (x64_subpd max_blended_nan max_xor))
             ;; `cmpps` with predicate index `3` is `cmpunordps`, or
             ;; "compare unordered": it produces a true mask (all ones)
             ;; in a given lane if the min is a NaN. We use this to
             ;; generate a mask to ensure quiet NaNs.
-            (is_nan_mask Xmm (cmppd max_blended_nan max_blended_nan (FcmpImm.Unordered)))
+            (is_nan_mask Xmm (x64_cmppd max_blended_nan max_blended_nan (FcmpImm.Unordered)))
             ;; Shift the NaN mask down so that it covers just the
             ;; fraction below the NaN signalling bit; we'll use this
             ;; to mask off non-canonical NaN payloads.
@@ -2322,33 +2322,33 @@
             ;; All-ones for NaN, shifted down to leave 13 top bits (1
             ;; sign, 11 exponent, 1 QNaN bit that must remain set)
             ;; cleared.
-            (nan_fraction_mask Xmm (psrlq is_nan_mask (RegMemImm.Imm 13)))
+            (nan_fraction_mask Xmm (x64_psrlq is_nan_mask (RegMemImm.Imm 13)))
             ;; Do a NAND, so that we retain every bit not set in
             ;; `nan_fraction_mask`. This mask will be all zeroes (so
             ;; we retain every bit) in non-NaN cases, and will have
             ;; ones (so we clear those bits) in NaN-payload bits
             ;; otherwise.
-            (final Xmm (andnpd nan_fraction_mask max_blended_nan_positive)))
+            (final Xmm (x64_andnpd nan_fraction_mask max_blended_nan_positive)))
         final))
 
 ;; Rules for `fmin_pseudo` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fmin_pseudo x y)))
-      (minss y x))
+      (x64_minss y x))
 (rule (lower (has_type $F64 (fmin_pseudo x y)))
-      (minsd y x))
+      (x64_minsd y x))
 (rule (lower (has_type $F32X4 (fmin_pseudo x y)))
-      (minps y x))
+      (x64_minps y x))
 (rule (lower (has_type $F64X2 (fmin_pseudo x y)))
-      (minpd y x))
+      (x64_minpd y x))
 
 ;; Rules for `fmax_pseudo` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fmax_pseudo x y)))
-      (maxss y x))
+      (x64_maxss y x))
 (rule (lower (has_type $F64 (fmax_pseudo x y)))
-      (maxsd y x))
+      (x64_maxsd y x))
 (rule (lower (has_type $F32X4 (fmax_pseudo x y)))
-      (maxps y x))
+      (x64_maxps y x))
 (rule (lower (has_type $F64X2 (fmax_pseudo x y)))
-      (maxpd y x))
+      (x64_maxpd y x))

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 9ea75a6f790b5c03
 src/prelude.isle b2bc986bcbbbb77
-src/isa/x64/inst.isle 5644ccb29bff0b51
-src/isa/x64/lower.isle 4c4b772e7f9e958a
+src/isa/x64/inst.isle bfb0fb7143d8dc34
+src/isa/x64/lower.isle ed84d285e0789fca

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
@@ -949,7 +949,7 @@ pub fn constructor_extend<C: Context>(
             let pattern3_0 = arg2;
             let pattern4_0 = arg3;
             // Rule at src/isa/x64/inst.isle line 1158.
-            let expr0_0 = constructor_movsx(ctx, pattern2_0, pattern3_0, pattern4_0)?;
+            let expr0_0 = constructor_x64_movsx(ctx, pattern2_0, pattern3_0, pattern4_0)?;
             return Some(expr0_0);
         }
         &ExtendKind::Zero => {
@@ -957,7 +957,7 @@ pub fn constructor_extend<C: Context>(
             let pattern3_0 = arg2;
             let pattern4_0 = arg3;
             // Rule at src/isa/x64/inst.isle line 1154.
-            let expr0_0 = constructor_movzx(ctx, pattern2_0, pattern3_0, pattern4_0)?;
+            let expr0_0 = constructor_x64_movzx(ctx, pattern2_0, pattern3_0, pattern4_0)?;
             return Some(expr0_0);
         }
         _ => {}
@@ -1223,7 +1223,7 @@ pub fn constructor_x64_load<C: Context>(
             let expr1_0: u16 = 8;
             let expr2_0 = C::ext_mode(ctx, expr0_0, expr1_0);
             let expr3_0 = constructor_synthetic_amode_to_gpr_mem(ctx, pattern2_0)?;
-            let expr4_0 = constructor_movsx(ctx, pattern1_0, &expr2_0, &expr3_0)?;
+            let expr4_0 = constructor_x64_movsx(ctx, pattern1_0, &expr2_0, &expr3_0)?;
             let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
             return Some(expr5_0);
         }
@@ -1231,8 +1231,8 @@ pub fn constructor_x64_load<C: Context>(
     return None;
 }
 
-// Generated as internal constructor for term xmm_load_const.
-pub fn constructor_xmm_load_const<C: Context>(
+// Generated as internal constructor for term x64_xmm_load_const.
+pub fn constructor_x64_xmm_load_const<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: VCodeConstant,
@@ -1279,8 +1279,8 @@ pub fn constructor_alu_rmi_r<C: Context>(
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term add.
-pub fn constructor_add<C: Context>(
+// Generated as internal constructor for term x64_add.
+pub fn constructor_x64_add<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1295,8 +1295,8 @@ pub fn constructor_add<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term add_with_flags_paired.
-pub fn constructor_add_with_flags_paired<C: Context>(
+// Generated as internal constructor for term x64_add_with_flags_paired.
+pub fn constructor_x64_add_with_flags_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1324,8 +1324,8 @@ pub fn constructor_add_with_flags_paired<C: Context>(
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term adc_paired.
-pub fn constructor_adc_paired<C: Context>(
+// Generated as internal constructor for term x64_adc_paired.
+pub fn constructor_x64_adc_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1353,8 +1353,8 @@ pub fn constructor_adc_paired<C: Context>(
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term sub.
-pub fn constructor_sub<C: Context>(
+// Generated as internal constructor for term x64_sub.
+pub fn constructor_x64_sub<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1369,8 +1369,8 @@ pub fn constructor_sub<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term sub_with_flags_paired.
-pub fn constructor_sub_with_flags_paired<C: Context>(
+// Generated as internal constructor for term x64_sub_with_flags_paired.
+pub fn constructor_x64_sub_with_flags_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1398,8 +1398,8 @@ pub fn constructor_sub_with_flags_paired<C: Context>(
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term sbb_paired.
-pub fn constructor_sbb_paired<C: Context>(
+// Generated as internal constructor for term x64_sbb_paired.
+pub fn constructor_x64_sbb_paired<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1427,8 +1427,8 @@ pub fn constructor_sbb_paired<C: Context>(
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term mul.
-pub fn constructor_mul<C: Context>(
+// Generated as internal constructor for term x64_mul.
+pub fn constructor_x64_mul<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1484,8 +1484,8 @@ pub fn constructor_x64_and_with_flags_paired<C: Context>(
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term or.
-pub fn constructor_or<C: Context>(
+// Generated as internal constructor for term x64_or.
+pub fn constructor_x64_or<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1500,8 +1500,8 @@ pub fn constructor_or<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term xor.
-pub fn constructor_xor<C: Context>(
+// Generated as internal constructor for term x64_xor.
+pub fn constructor_x64_xor<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1714,8 +1714,8 @@ pub fn constructor_x64_rotr<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term shl.
-pub fn constructor_shl<C: Context>(
+// Generated as internal constructor for term x64_shl.
+pub fn constructor_x64_shl<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1730,8 +1730,8 @@ pub fn constructor_shl<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term shr.
-pub fn constructor_shr<C: Context>(
+// Generated as internal constructor for term x64_shr.
+pub fn constructor_x64_shr<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1746,8 +1746,8 @@ pub fn constructor_shr<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term sar.
-pub fn constructor_sar<C: Context>(
+// Generated as internal constructor for term x64_sar.
+pub fn constructor_x64_sar<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Gpr,
@@ -1785,8 +1785,8 @@ pub fn constructor_cmp_rmi_r<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term cmp.
-pub fn constructor_cmp<C: Context>(
+// Generated as internal constructor for term x64_cmp.
+pub fn constructor_x64_cmp<C: Context>(
     ctx: &mut C,
     arg0: &OperandSize,
     arg1: &GprMemImm,
@@ -1801,8 +1801,8 @@ pub fn constructor_cmp<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term cmp_imm.
-pub fn constructor_cmp_imm<C: Context>(
+// Generated as internal constructor for term x64_cmp_imm.
+pub fn constructor_x64_cmp_imm<C: Context>(
     ctx: &mut C,
     arg0: &OperandSize,
     arg1: u32,
@@ -1839,8 +1839,8 @@ pub fn constructor_xmm_cmp_rm_r<C: Context>(
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term fpcmp.
-pub fn constructor_fpcmp<C: Context>(
+// Generated as internal constructor for term x64_ucomis.
+pub fn constructor_x64_ucomis<C: Context>(
     ctx: &mut C,
     arg0: Value,
     arg1: Value,
@@ -1849,7 +1849,7 @@ pub fn constructor_fpcmp<C: Context>(
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == F32 {
         let pattern3_0 = arg1;
-        // Rule at src/isa/x64/inst.isle line 1543.
+        // Rule at src/isa/x64/inst.isle line 1542.
         let expr0_0 = SseOpcode::Ucomiss;
         let expr1_0 = constructor_put_in_xmm(ctx, pattern0_0)?;
         let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -1859,7 +1859,7 @@ pub fn constructor_fpcmp<C: Context>(
     }
     if pattern1_0 == F64 {
         let pattern3_0 = arg1;
-        // Rule at src/isa/x64/inst.isle line 1547.
+        // Rule at src/isa/x64/inst.isle line 1546.
         let expr0_0 = SseOpcode::Ucomisd;
         let expr1_0 = constructor_put_in_xmm(ctx, pattern0_0)?;
         let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
@@ -1870,8 +1870,8 @@ pub fn constructor_fpcmp<C: Context>(
     return None;
 }
 
-// Generated as internal constructor for term test.
-pub fn constructor_test<C: Context>(
+// Generated as internal constructor for term x64_test.
+pub fn constructor_x64_test<C: Context>(
     ctx: &mut C,
     arg0: &OperandSize,
     arg1: &GprMemImm,
@@ -1880,7 +1880,7 @@ pub fn constructor_test<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1552.
+    // Rule at src/isa/x64/inst.isle line 1551.
     let expr0_0 = CmpOpcode::Test;
     let expr1_0 = constructor_cmp_rmi_r(ctx, pattern0_0, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -1898,7 +1898,7 @@ pub fn constructor_cmove<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1559.
+    // Rule at src/isa/x64/inst.isle line 1558.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::Cmove {
@@ -1928,7 +1928,7 @@ pub fn constructor_cmove_xmm<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1567.
+    // Rule at src/isa/x64/inst.isle line 1566.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::XmmCmove {
@@ -1959,7 +1959,7 @@ pub fn constructor_cmove_from_values<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/x64/inst.isle line 1578.
+        // Rule at src/isa/x64/inst.isle line 1577.
         let expr0_0 = C::put_in_regs(ctx, pattern3_0);
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0 = C::temp_writable_gpr(ctx);
@@ -2004,7 +2004,7 @@ pub fn constructor_cmove_from_values<C: Context>(
             let pattern3_0 = arg1;
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/x64/inst.isle line 1602.
+            // Rule at src/isa/x64/inst.isle line 1601.
             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern4_0)?;
             let expr1_0 = constructor_put_in_xmm(ctx, pattern5_0)?;
             let expr2_0 = constructor_cmove_xmm(ctx, pattern2_0, pattern3_0, &expr0_0, expr1_0)?;
@@ -2016,7 +2016,7 @@ pub fn constructor_cmove_from_values<C: Context>(
             let pattern3_0 = arg1;
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
-            // Rule at src/isa/x64/inst.isle line 1599.
+            // Rule at src/isa/x64/inst.isle line 1598.
             let expr0_0 = constructor_put_in_gpr_mem(ctx, pattern4_0)?;
             let expr1_0 = constructor_put_in_gpr(ctx, pattern5_0)?;
             let expr2_0 = constructor_cmove(ctx, pattern2_0, pattern3_0, &expr0_0, expr1_0)?;
@@ -2040,7 +2040,7 @@ pub fn constructor_cmove_or<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/x64/inst.isle line 1609.
+    // Rule at src/isa/x64/inst.isle line 1608.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::temp_writable_gpr(ctx);
     let expr2_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
@@ -2082,7 +2082,7 @@ pub fn constructor_cmove_or_xmm<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/x64/inst.isle line 1621.
+    // Rule at src/isa/x64/inst.isle line 1620.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::temp_writable_xmm(ctx);
     let expr2_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
@@ -2125,7 +2125,7 @@ pub fn constructor_cmove_or_from_values<C: Context>(
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
         let pattern5_0 = arg4;
-        // Rule at src/isa/x64/inst.isle line 1636.
+        // Rule at src/isa/x64/inst.isle line 1635.
         let expr0_0 = C::put_in_regs(ctx, pattern4_0);
         let expr1_0 = C::put_in_regs(ctx, pattern5_0);
         let expr2_0 = C::temp_writable_gpr(ctx);
@@ -2197,7 +2197,7 @@ pub fn constructor_cmove_or_from_values<C: Context>(
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/x64/inst.isle line 1658.
+            // Rule at src/isa/x64/inst.isle line 1657.
             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_0)?;
             let expr1_0 = constructor_put_in_xmm(ctx, pattern6_0)?;
             let expr2_0 = constructor_cmove_or_xmm(
@@ -2212,7 +2212,7 @@ pub fn constructor_cmove_or_from_values<C: Context>(
             let pattern4_0 = arg2;
             let pattern5_0 = arg3;
             let pattern6_0 = arg4;
-            // Rule at src/isa/x64/inst.isle line 1655.
+            // Rule at src/isa/x64/inst.isle line 1654.
             let expr0_0 = constructor_put_in_gpr_mem(ctx, pattern5_0)?;
             let expr1_0 = constructor_put_in_gpr(ctx, pattern6_0)?;
             let expr2_0 =
@@ -2223,10 +2223,10 @@ pub fn constructor_cmove_or_from_values<C: Context>(
     return None;
 }
 
-// Generated as internal constructor for term setcc.
-pub fn constructor_setcc<C: Context>(ctx: &mut C, arg0: &CC) -> Option<ConsumesFlags> {
+// Generated as internal constructor for term x64_setcc.
+pub fn constructor_x64_setcc<C: Context>(ctx: &mut C, arg0: &CC) -> Option<ConsumesFlags> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 1663.
+    // Rule at src/isa/x64/inst.isle line 1662.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = MInst::Setcc {
         cc: pattern0_0.clone(),
@@ -2240,8 +2240,8 @@ pub fn constructor_setcc<C: Context>(ctx: &mut C, arg0: &CC) -> Option<ConsumesF
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term movzx.
-pub fn constructor_movzx<C: Context>(
+// Generated as internal constructor for term x64_movzx.
+pub fn constructor_x64_movzx<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: &ExtMode,
@@ -2250,7 +2250,7 @@ pub fn constructor_movzx<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1671.
+    // Rule at src/isa/x64/inst.isle line 1670.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = MInst::MovzxRmR {
         ext_mode: pattern1_0.clone(),
@@ -2262,8 +2262,8 @@ pub fn constructor_movzx<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term movsx.
-pub fn constructor_movsx<C: Context>(
+// Generated as internal constructor for term x64_movsx.
+pub fn constructor_x64_movsx<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: &ExtMode,
@@ -2272,7 +2272,7 @@ pub fn constructor_movsx<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1678.
+    // Rule at src/isa/x64/inst.isle line 1677.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = MInst::MovsxRmR {
         ext_mode: pattern1_0.clone(),
@@ -2296,7 +2296,7 @@ pub fn constructor_xmm_rm_r<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1685.
+    // Rule at src/isa/x64/inst.isle line 1684.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmRmR {
         op: pattern1_0.clone(),
@@ -2309,594 +2309,594 @@ pub fn constructor_xmm_rm_r<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term paddb.
-pub fn constructor_paddb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddb.
+pub fn constructor_x64_paddb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1692.
+    // Rule at src/isa/x64/inst.isle line 1691.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Paddb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term paddw.
-pub fn constructor_paddw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddw.
+pub fn constructor_x64_paddw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1697.
+    // Rule at src/isa/x64/inst.isle line 1696.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Paddw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term paddd.
-pub fn constructor_paddd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddd.
+pub fn constructor_x64_paddd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1702.
+    // Rule at src/isa/x64/inst.isle line 1701.
     let expr0_0: Type = I32X4;
     let expr1_0 = SseOpcode::Paddd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term paddq.
-pub fn constructor_paddq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddq.
+pub fn constructor_x64_paddq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1707.
+    // Rule at src/isa/x64/inst.isle line 1706.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Paddq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term paddsb.
-pub fn constructor_paddsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddsb.
+pub fn constructor_x64_paddsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1712.
+    // Rule at src/isa/x64/inst.isle line 1711.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Paddsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term paddsw.
-pub fn constructor_paddsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddsw.
+pub fn constructor_x64_paddsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1717.
+    // Rule at src/isa/x64/inst.isle line 1716.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Paddsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term paddusb.
-pub fn constructor_paddusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddusb.
+pub fn constructor_x64_paddusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1722.
+    // Rule at src/isa/x64/inst.isle line 1721.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Paddusb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term paddusw.
-pub fn constructor_paddusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_paddusw.
+pub fn constructor_x64_paddusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1727.
+    // Rule at src/isa/x64/inst.isle line 1726.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Paddusw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubb.
-pub fn constructor_psubb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubb.
+pub fn constructor_x64_psubb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1732.
+    // Rule at src/isa/x64/inst.isle line 1731.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Psubb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubw.
-pub fn constructor_psubw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubw.
+pub fn constructor_x64_psubw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1737.
+    // Rule at src/isa/x64/inst.isle line 1736.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Psubw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubd.
-pub fn constructor_psubd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubd.
+pub fn constructor_x64_psubd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1742.
+    // Rule at src/isa/x64/inst.isle line 1741.
     let expr0_0: Type = I32X4;
     let expr1_0 = SseOpcode::Psubd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubq.
-pub fn constructor_psubq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubq.
+pub fn constructor_x64_psubq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1747.
+    // Rule at src/isa/x64/inst.isle line 1746.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Psubq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubsb.
-pub fn constructor_psubsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubsb.
+pub fn constructor_x64_psubsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1752.
+    // Rule at src/isa/x64/inst.isle line 1751.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Psubsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubsw.
-pub fn constructor_psubsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubsw.
+pub fn constructor_x64_psubsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1757.
+    // Rule at src/isa/x64/inst.isle line 1756.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Psubsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubusb.
-pub fn constructor_psubusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubusb.
+pub fn constructor_x64_psubusb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1762.
+    // Rule at src/isa/x64/inst.isle line 1761.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Psubusb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term psubusw.
-pub fn constructor_psubusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psubusw.
+pub fn constructor_x64_psubusw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1767.
+    // Rule at src/isa/x64/inst.isle line 1766.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Psubusw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pavgb.
-pub fn constructor_pavgb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pavgb.
+pub fn constructor_x64_pavgb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1772.
+    // Rule at src/isa/x64/inst.isle line 1771.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pavgb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pavgw.
-pub fn constructor_pavgw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pavgw.
+pub fn constructor_x64_pavgw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1777.
+    // Rule at src/isa/x64/inst.isle line 1776.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pavgw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pand.
-pub fn constructor_pand<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pand.
+pub fn constructor_x64_pand<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1782.
+    // Rule at src/isa/x64/inst.isle line 1781.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Pand;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term andps.
-pub fn constructor_andps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_andps.
+pub fn constructor_x64_andps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1787.
+    // Rule at src/isa/x64/inst.isle line 1786.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Andps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term andpd.
-pub fn constructor_andpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_andpd.
+pub fn constructor_x64_andpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1792.
+    // Rule at src/isa/x64/inst.isle line 1791.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Andpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term por.
-pub fn constructor_por<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_por.
+pub fn constructor_x64_por<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1797.
+    // Rule at src/isa/x64/inst.isle line 1796.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Por;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term orps.
-pub fn constructor_orps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_orps.
+pub fn constructor_x64_orps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1802.
+    // Rule at src/isa/x64/inst.isle line 1801.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Orps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term orpd.
-pub fn constructor_orpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_orpd.
+pub fn constructor_x64_orpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1807.
+    // Rule at src/isa/x64/inst.isle line 1806.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Orpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pxor.
-pub fn constructor_pxor<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pxor.
+pub fn constructor_x64_pxor<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1812.
+    // Rule at src/isa/x64/inst.isle line 1811.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pxor;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term xorps.
-pub fn constructor_xorps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_xorps.
+pub fn constructor_x64_xorps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1817.
+    // Rule at src/isa/x64/inst.isle line 1816.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Xorps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term xorpd.
-pub fn constructor_xorpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_xorpd.
+pub fn constructor_x64_xorpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1822.
+    // Rule at src/isa/x64/inst.isle line 1821.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Xorpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmullw.
-pub fn constructor_pmullw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmullw.
+pub fn constructor_x64_pmullw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1827.
+    // Rule at src/isa/x64/inst.isle line 1826.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmullw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmulld.
-pub fn constructor_pmulld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmulld.
+pub fn constructor_x64_pmulld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1832.
+    // Rule at src/isa/x64/inst.isle line 1831.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmulld;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmulhw.
-pub fn constructor_pmulhw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmulhw.
+pub fn constructor_x64_pmulhw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1837.
+    // Rule at src/isa/x64/inst.isle line 1836.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmulhw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmulhuw.
-pub fn constructor_pmulhuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmulhuw.
+pub fn constructor_x64_pmulhuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1842.
+    // Rule at src/isa/x64/inst.isle line 1841.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmulhuw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmuldq.
-pub fn constructor_pmuldq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmuldq.
+pub fn constructor_x64_pmuldq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1847.
+    // Rule at src/isa/x64/inst.isle line 1846.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pmuldq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmuludq.
-pub fn constructor_pmuludq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmuludq.
+pub fn constructor_x64_pmuludq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1852.
+    // Rule at src/isa/x64/inst.isle line 1851.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Pmuludq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term punpckhwd.
-pub fn constructor_punpckhwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_punpckhwd.
+pub fn constructor_x64_punpckhwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1857.
+    // Rule at src/isa/x64/inst.isle line 1856.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Punpckhwd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term punpcklwd.
-pub fn constructor_punpcklwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_punpcklwd.
+pub fn constructor_x64_punpcklwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1862.
+    // Rule at src/isa/x64/inst.isle line 1861.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Punpcklwd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term andnps.
-pub fn constructor_andnps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_andnps.
+pub fn constructor_x64_andnps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1867.
+    // Rule at src/isa/x64/inst.isle line 1866.
     let expr0_0: Type = F32X4;
     let expr1_0 = SseOpcode::Andnps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term andnpd.
-pub fn constructor_andnpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_andnpd.
+pub fn constructor_x64_andnpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1872.
+    // Rule at src/isa/x64/inst.isle line 1871.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Andnpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pandn.
-pub fn constructor_pandn<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pandn.
+pub fn constructor_x64_pandn<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1877.
+    // Rule at src/isa/x64/inst.isle line 1876.
     let expr0_0: Type = F64X2;
     let expr1_0 = SseOpcode::Pandn;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term addss.
-pub fn constructor_addss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_addss.
+pub fn constructor_x64_addss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1882.
+    // Rule at src/isa/x64/inst.isle line 1881.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Addss;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term addsd.
-pub fn constructor_addsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_addsd.
+pub fn constructor_x64_addsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1887.
+    // Rule at src/isa/x64/inst.isle line 1886.
     let expr0_0: Type = F64;
     let expr1_0 = SseOpcode::Addsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term addps.
-pub fn constructor_addps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_addps.
+pub fn constructor_x64_addps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1892.
+    // Rule at src/isa/x64/inst.isle line 1891.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Addps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term addpd.
-pub fn constructor_addpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_addpd.
+pub fn constructor_x64_addpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1897.
+    // Rule at src/isa/x64/inst.isle line 1896.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Addpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term subss.
-pub fn constructor_subss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_subss.
+pub fn constructor_x64_subss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1902.
+    // Rule at src/isa/x64/inst.isle line 1901.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Subss;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term subsd.
-pub fn constructor_subsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_subsd.
+pub fn constructor_x64_subsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1907.
+    // Rule at src/isa/x64/inst.isle line 1906.
     let expr0_0: Type = F64;
     let expr1_0 = SseOpcode::Subsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term subps.
-pub fn constructor_subps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_subps.
+pub fn constructor_x64_subps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1912.
+    // Rule at src/isa/x64/inst.isle line 1911.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Subps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term subpd.
-pub fn constructor_subpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_subpd.
+pub fn constructor_x64_subpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1917.
+    // Rule at src/isa/x64/inst.isle line 1916.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Subpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term mulss.
-pub fn constructor_mulss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_mulss.
+pub fn constructor_x64_mulss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1922.
+    // Rule at src/isa/x64/inst.isle line 1921.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Mulss;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term mulsd.
-pub fn constructor_mulsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_mulsd.
+pub fn constructor_x64_mulsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1927.
+    // Rule at src/isa/x64/inst.isle line 1926.
     let expr0_0: Type = F64;
     let expr1_0 = SseOpcode::Mulsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term mulps.
-pub fn constructor_mulps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_mulps.
+pub fn constructor_x64_mulps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1932.
+    // Rule at src/isa/x64/inst.isle line 1931.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Mulps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term mulpd.
-pub fn constructor_mulpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_mulpd.
+pub fn constructor_x64_mulpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1937.
+    // Rule at src/isa/x64/inst.isle line 1936.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Mulpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term divss.
-pub fn constructor_divss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_divss.
+pub fn constructor_x64_divss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1942.
+    // Rule at src/isa/x64/inst.isle line 1941.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Divss;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term divsd.
-pub fn constructor_divsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_divsd.
+pub fn constructor_x64_divsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1947.
+    // Rule at src/isa/x64/inst.isle line 1946.
     let expr0_0: Type = F64;
     let expr1_0 = SseOpcode::Divsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term divps.
-pub fn constructor_divps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_divps.
+pub fn constructor_x64_divps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1952.
+    // Rule at src/isa/x64/inst.isle line 1951.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Divps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term divpd.
-pub fn constructor_divpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_divpd.
+pub fn constructor_x64_divpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 1957.
+    // Rule at src/isa/x64/inst.isle line 1956.
     let expr0_0: Type = F32;
     let expr1_0 = SseOpcode::Divpd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -2907,17 +2907,17 @@ pub fn constructor_divpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> O
 pub fn constructor_sse_blend_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<SseOpcode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32X4 {
-        // Rule at src/isa/x64/inst.isle line 1961.
+        // Rule at src/isa/x64/inst.isle line 1960.
         let expr0_0 = SseOpcode::Blendvps;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
-        // Rule at src/isa/x64/inst.isle line 1962.
+        // Rule at src/isa/x64/inst.isle line 1961.
         let expr0_0 = SseOpcode::Blendvpd;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
-        // Rule at src/isa/x64/inst.isle line 1963.
+        // Rule at src/isa/x64/inst.isle line 1962.
         let expr0_0 = SseOpcode::Pblendvb;
         return Some(expr0_0);
     }
@@ -2928,25 +2928,25 @@ pub fn constructor_sse_blend_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<S
 pub fn constructor_sse_mov_op<C: Context>(ctx: &mut C, arg0: Type) -> Option<SseOpcode> {
     let pattern0_0 = arg0;
     if pattern0_0 == F32X4 {
-        // Rule at src/isa/x64/inst.isle line 1966.
+        // Rule at src/isa/x64/inst.isle line 1965.
         let expr0_0 = SseOpcode::Movaps;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
-        // Rule at src/isa/x64/inst.isle line 1967.
+        // Rule at src/isa/x64/inst.isle line 1966.
         let expr0_0 = SseOpcode::Movapd;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
-        // Rule at src/isa/x64/inst.isle line 1968.
+        // Rule at src/isa/x64/inst.isle line 1967.
         let expr0_0 = SseOpcode::Movdqa;
         return Some(expr0_0);
     }
     return None;
 }
 
-// Generated as internal constructor for term sse_blend.
-pub fn constructor_sse_blend<C: Context>(
+// Generated as internal constructor for term x64_blend.
+pub fn constructor_x64_blend<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: &XmmMem,
@@ -2957,7 +2957,7 @@ pub fn constructor_sse_blend<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 1972.
+    // Rule at src/isa/x64/inst.isle line 1971.
     let expr0_0 = C::xmm0(ctx);
     let expr1_0 = constructor_sse_mov_op(ctx, pattern0_0)?;
     let expr2_0 = MInst::XmmUnaryRmR {
@@ -2971,8 +2971,8 @@ pub fn constructor_sse_blend<C: Context>(
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term blendvpd.
-pub fn constructor_blendvpd<C: Context>(
+// Generated as internal constructor for term x64_blendvpd.
+pub fn constructor_x64_blendvpd<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &XmmMem,
@@ -2981,7 +2981,7 @@ pub fn constructor_blendvpd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 1986.
+    // Rule at src/isa/x64/inst.isle line 1985.
     let expr0_0 = C::xmm0(ctx);
     let expr1_0 = SseOpcode::Movapd;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern2_0);
@@ -2997,30 +2997,30 @@ pub fn constructor_blendvpd<C: Context>(
     return Some(expr7_0);
 }
 
-// Generated as internal constructor for term movsd.
-pub fn constructor_movsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_movsd.
+pub fn constructor_x64_movsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2000.
+    // Rule at src/isa/x64/inst.isle line 1999.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Movsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term movlhps.
-pub fn constructor_movlhps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_movlhps.
+pub fn constructor_x64_movlhps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2005.
+    // Rule at src/isa/x64/inst.isle line 2004.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Movlhps;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmaxs.
-pub fn constructor_pmaxs<C: Context>(
+// Generated as internal constructor for term x64_pmaxs.
+pub fn constructor_x64_pmaxs<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Xmm,
@@ -3030,62 +3030,62 @@ pub fn constructor_pmaxs<C: Context>(
     if pattern0_0 == I8X16 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2010.
-        let expr0_0 = constructor_pmaxsb(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2009.
+        let expr0_0 = constructor_x64_pmaxsb(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I16X8 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2011.
-        let expr0_0 = constructor_pmaxsw(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2010.
+        let expr0_0 = constructor_x64_pmaxsw(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2012.
-        let expr0_0 = constructor_pmaxsd(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2011.
+        let expr0_0 = constructor_x64_pmaxsd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
 }
 
-// Generated as internal constructor for term pmaxsb.
-pub fn constructor_pmaxsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmaxsb.
+pub fn constructor_x64_pmaxsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2015.
+    // Rule at src/isa/x64/inst.isle line 2014.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmaxsw.
-pub fn constructor_pmaxsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmaxsw.
+pub fn constructor_x64_pmaxsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2017.
+    // Rule at src/isa/x64/inst.isle line 2016.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmaxsd.
-pub fn constructor_pmaxsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmaxsd.
+pub fn constructor_x64_pmaxsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2019.
+    // Rule at src/isa/x64/inst.isle line 2018.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmins.
-pub fn constructor_pmins<C: Context>(
+// Generated as internal constructor for term x64_pmins.
+pub fn constructor_x64_pmins<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Xmm,
@@ -3095,62 +3095,62 @@ pub fn constructor_pmins<C: Context>(
     if pattern0_0 == I8X16 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2023.
-        let expr0_0 = constructor_pminsb(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2022.
+        let expr0_0 = constructor_x64_pminsb(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I16X8 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2024.
-        let expr0_0 = constructor_pminsw(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2023.
+        let expr0_0 = constructor_x64_pminsw(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2025.
-        let expr0_0 = constructor_pminsd(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2024.
+        let expr0_0 = constructor_x64_pminsd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
 }
 
-// Generated as internal constructor for term pminsb.
-pub fn constructor_pminsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pminsb.
+pub fn constructor_x64_pminsb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2028.
+    // Rule at src/isa/x64/inst.isle line 2027.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminsb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pminsw.
-pub fn constructor_pminsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pminsw.
+pub fn constructor_x64_pminsw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2030.
+    // Rule at src/isa/x64/inst.isle line 2029.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pminsw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pminsd.
-pub fn constructor_pminsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pminsd.
+pub fn constructor_x64_pminsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2032.
+    // Rule at src/isa/x64/inst.isle line 2031.
     let expr0_0: Type = I32X4;
     let expr1_0 = SseOpcode::Pminsd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmaxu.
-pub fn constructor_pmaxu<C: Context>(
+// Generated as internal constructor for term x64_pmaxu.
+pub fn constructor_x64_pmaxu<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Xmm,
@@ -3160,62 +3160,62 @@ pub fn constructor_pmaxu<C: Context>(
     if pattern0_0 == I8X16 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2036.
-        let expr0_0 = constructor_pmaxub(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2035.
+        let expr0_0 = constructor_x64_pmaxub(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I16X8 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2037.
-        let expr0_0 = constructor_pmaxuw(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2036.
+        let expr0_0 = constructor_x64_pmaxuw(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2038.
-        let expr0_0 = constructor_pmaxud(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2037.
+        let expr0_0 = constructor_x64_pmaxud(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
 }
 
-// Generated as internal constructor for term pmaxub.
-pub fn constructor_pmaxub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmaxub.
+pub fn constructor_x64_pmaxub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2041.
+    // Rule at src/isa/x64/inst.isle line 2040.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxub;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmaxuw.
-pub fn constructor_pmaxuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmaxuw.
+pub fn constructor_x64_pmaxuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2043.
+    // Rule at src/isa/x64/inst.isle line 2042.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxuw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pmaxud.
-pub fn constructor_pmaxud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmaxud.
+pub fn constructor_x64_pmaxud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2045.
+    // Rule at src/isa/x64/inst.isle line 2044.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pmaxud;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pminu.
-pub fn constructor_pminu<C: Context>(
+// Generated as internal constructor for term x64_pminu.
+pub fn constructor_x64_pminu<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Xmm,
@@ -3225,87 +3225,87 @@ pub fn constructor_pminu<C: Context>(
     if pattern0_0 == I8X16 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2049.
-        let expr0_0 = constructor_pminub(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2048.
+        let expr0_0 = constructor_x64_pminub(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I16X8 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2050.
-        let expr0_0 = constructor_pminuw(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2049.
+        let expr0_0 = constructor_x64_pminuw(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2051.
-        let expr0_0 = constructor_pminud(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2050.
+        let expr0_0 = constructor_x64_pminud(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
 }
 
-// Generated as internal constructor for term pminub.
-pub fn constructor_pminub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pminub.
+pub fn constructor_x64_pminub<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2054.
+    // Rule at src/isa/x64/inst.isle line 2053.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminub;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pminuw.
-pub fn constructor_pminuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pminuw.
+pub fn constructor_x64_pminuw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2056.
+    // Rule at src/isa/x64/inst.isle line 2055.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminuw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pminud.
-pub fn constructor_pminud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pminud.
+pub fn constructor_x64_pminud<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2058.
+    // Rule at src/isa/x64/inst.isle line 2057.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pminud;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term punpcklbw.
-pub fn constructor_punpcklbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_punpcklbw.
+pub fn constructor_x64_punpcklbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2062.
+    // Rule at src/isa/x64/inst.isle line 2061.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Punpcklbw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term punpckhbw.
-pub fn constructor_punpckhbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_punpckhbw.
+pub fn constructor_x64_punpckhbw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2067.
+    // Rule at src/isa/x64/inst.isle line 2066.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Punpckhbw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term packsswb.
-pub fn constructor_packsswb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_packsswb.
+pub fn constructor_x64_packsswb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2072.
+    // Rule at src/isa/x64/inst.isle line 2071.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Packsswb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -3326,7 +3326,7 @@ pub fn constructor_xmm_rm_r_imm<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/x64/inst.isle line 2077.
+    // Rule at src/isa/x64/inst.isle line 2076.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::writable_xmm_to_reg(ctx, expr0_0);
     let expr2_0 = MInst::XmmRmRImm {
@@ -3342,8 +3342,8 @@ pub fn constructor_xmm_rm_r_imm<C: Context>(
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term palignr.
-pub fn constructor_palignr<C: Context>(
+// Generated as internal constructor for term x64_palignr.
+pub fn constructor_x64_palignr<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &XmmMem,
@@ -3354,7 +3354,7 @@ pub fn constructor_palignr<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 2089.
+    // Rule at src/isa/x64/inst.isle line 2088.
     let expr0_0 = SseOpcode::Palignr;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::xmm_mem_to_reg_mem(ctx, pattern1_0);
@@ -3363,8 +3363,8 @@ pub fn constructor_palignr<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term cmpps.
-pub fn constructor_cmpps<C: Context>(
+// Generated as internal constructor for term x64_cmpps.
+pub fn constructor_x64_cmpps<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &XmmMem,
@@ -3373,7 +3373,7 @@ pub fn constructor_cmpps<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2098.
+    // Rule at src/isa/x64/inst.isle line 2097.
     let expr0_0 = SseOpcode::Cmpps;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::xmm_mem_to_reg_mem(ctx, pattern1_0);
@@ -3383,8 +3383,8 @@ pub fn constructor_cmpps<C: Context>(
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term pinsrb.
-pub fn constructor_pinsrb<C: Context>(
+// Generated as internal constructor for term x64_pinsrb.
+pub fn constructor_x64_pinsrb<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &GprMem,
@@ -3393,7 +3393,7 @@ pub fn constructor_pinsrb<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2107.
+    // Rule at src/isa/x64/inst.isle line 2106.
     let expr0_0 = SseOpcode::Pinsrb;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::gpr_mem_to_reg_mem(ctx, pattern1_0);
@@ -3402,8 +3402,8 @@ pub fn constructor_pinsrb<C: Context>(
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term pinsrw.
-pub fn constructor_pinsrw<C: Context>(
+// Generated as internal constructor for term x64_pinsrw.
+pub fn constructor_x64_pinsrw<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &GprMem,
@@ -3412,7 +3412,7 @@ pub fn constructor_pinsrw<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2116.
+    // Rule at src/isa/x64/inst.isle line 2115.
     let expr0_0 = SseOpcode::Pinsrw;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::gpr_mem_to_reg_mem(ctx, pattern1_0);
@@ -3421,8 +3421,8 @@ pub fn constructor_pinsrw<C: Context>(
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term pinsrd.
-pub fn constructor_pinsrd<C: Context>(
+// Generated as internal constructor for term x64_pinsrd.
+pub fn constructor_x64_pinsrd<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &GprMem,
@@ -3433,7 +3433,7 @@ pub fn constructor_pinsrd<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 2125.
+    // Rule at src/isa/x64/inst.isle line 2124.
     let expr0_0 = SseOpcode::Pinsrd;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::gpr_mem_to_reg_mem(ctx, pattern1_0);
@@ -3442,11 +3442,11 @@ pub fn constructor_pinsrd<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term pmaddwd.
-pub fn constructor_pmaddwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmaddwd.
+pub fn constructor_x64_pmaddwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2134.
+    // Rule at src/isa/x64/inst.isle line 2133.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Pmaddwd;
     let expr2_0 = MInst::XmmRmR {
@@ -3460,8 +3460,8 @@ pub fn constructor_pmaddwd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term insertps.
-pub fn constructor_insertps<C: Context>(
+// Generated as internal constructor for term x64_insertps.
+pub fn constructor_x64_insertps<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &XmmMem,
@@ -3470,7 +3470,7 @@ pub fn constructor_insertps<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2144.
+    // Rule at src/isa/x64/inst.isle line 2143.
     let expr0_0 = SseOpcode::Insertps;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::xmm_mem_to_reg_mem(ctx, pattern1_0);
@@ -3479,8 +3479,8 @@ pub fn constructor_insertps<C: Context>(
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term pshufd.
-pub fn constructor_pshufd<C: Context>(
+// Generated as internal constructor for term x64_pshufd.
+pub fn constructor_x64_pshufd<C: Context>(
     ctx: &mut C,
     arg0: &XmmMem,
     arg1: u8,
@@ -3489,7 +3489,7 @@ pub fn constructor_pshufd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2153.
+    // Rule at src/isa/x64/inst.isle line 2152.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Pshufd;
     let expr2_0 = constructor_writable_xmm_to_r_reg(ctx, expr0_0)?;
@@ -3508,11 +3508,11 @@ pub fn constructor_pshufd<C: Context>(
     return Some(expr7_0);
 }
 
-// Generated as internal constructor for term pshufb.
-pub fn constructor_pshufb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pshufb.
+pub fn constructor_x64_pshufb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2165.
+    // Rule at src/isa/x64/inst.isle line 2164.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Pshufb;
     let expr2_0 = MInst::XmmRmR {
@@ -3534,7 +3534,7 @@ pub fn constructor_xmm_unary_rm_r<C: Context>(
 ) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2175.
+    // Rule at src/isa/x64/inst.isle line 2174.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmUnaryRmR {
         op: pattern0_0.clone(),
@@ -3546,46 +3546,46 @@ pub fn constructor_xmm_unary_rm_r<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term pmovsxbw.
-pub fn constructor_pmovsxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmovsxbw.
+pub fn constructor_x64_pmovsxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2182.
+    // Rule at src/isa/x64/inst.isle line 2181.
     let expr0_0 = SseOpcode::Pmovsxbw;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term pmovzxbw.
-pub fn constructor_pmovzxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pmovzxbw.
+pub fn constructor_x64_pmovzxbw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2187.
+    // Rule at src/isa/x64/inst.isle line 2186.
     let expr0_0 = SseOpcode::Pmovzxbw;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term pabsb.
-pub fn constructor_pabsb<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pabsb.
+pub fn constructor_x64_pabsb<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2192.
+    // Rule at src/isa/x64/inst.isle line 2191.
     let expr0_0 = SseOpcode::Pabsb;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term pabsw.
-pub fn constructor_pabsw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pabsw.
+pub fn constructor_x64_pabsw<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2197.
+    // Rule at src/isa/x64/inst.isle line 2196.
     let expr0_0 = SseOpcode::Pabsw;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term pabsd.
-pub fn constructor_pabsd<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pabsd.
+pub fn constructor_x64_pabsd<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2202.
+    // Rule at src/isa/x64/inst.isle line 2201.
     let expr0_0 = SseOpcode::Pabsd;
     let expr1_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -3599,7 +3599,7 @@ pub fn constructor_xmm_unary_rm_r_evex<C: Context>(
 ) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2207.
+    // Rule at src/isa/x64/inst.isle line 2206.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmUnaryRmREvex {
         op: pattern0_0.clone(),
@@ -3611,19 +3611,19 @@ pub fn constructor_xmm_unary_rm_r_evex<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term vpabsq.
-pub fn constructor_vpabsq<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_vpabsq.
+pub fn constructor_x64_vpabsq<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2214.
+    // Rule at src/isa/x64/inst.isle line 2213.
     let expr0_0 = Avx512Opcode::Vpabsq;
     let expr1_0 = constructor_xmm_unary_rm_r_evex(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term vpopcntb.
-pub fn constructor_vpopcntb<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_vpopcntb.
+pub fn constructor_x64_vpopcntb<C: Context>(ctx: &mut C, arg0: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2219.
+    // Rule at src/isa/x64/inst.isle line 2218.
     let expr0_0 = Avx512Opcode::Vpopcntb;
     let expr1_0 = constructor_xmm_unary_rm_r_evex(ctx, &expr0_0, pattern0_0)?;
     return Some(expr1_0);
@@ -3639,7 +3639,7 @@ pub fn constructor_xmm_rm_r_evex<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2224.
+    // Rule at src/isa/x64/inst.isle line 2223.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmRmREvex {
         op: pattern0_0.clone(),
@@ -3652,11 +3652,11 @@ pub fn constructor_xmm_rm_r_evex<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term vpmullq.
-pub fn constructor_vpmullq<C: Context>(ctx: &mut C, arg0: &XmmMem, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_vpmullq.
+pub fn constructor_x64_vpmullq<C: Context>(ctx: &mut C, arg0: &XmmMem, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2236.
+    // Rule at src/isa/x64/inst.isle line 2235.
     let expr0_0 = Avx512Opcode::Vpmullq;
     let expr1_0 = constructor_xmm_rm_r_evex(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3674,7 +3674,7 @@ pub fn constructor_mul_hi<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 2245.
+    // Rule at src/isa/x64/inst.isle line 2244.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::temp_writable_gpr(ctx);
     let expr2_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
@@ -3703,7 +3703,7 @@ pub fn constructor_mulhi_u<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2260.
+    // Rule at src/isa/x64/inst.isle line 2259.
     let expr0_0: bool = false;
     let expr1_0 = constructor_mul_hi(ctx, pattern0_0, expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -3719,7 +3719,7 @@ pub fn constructor_xmm_rmi_xmm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2265.
+    // Rule at src/isa/x64/inst.isle line 2264.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::XmmRmiReg {
         opcode: pattern0_0.clone(),
@@ -3732,92 +3732,97 @@ pub fn constructor_xmm_rmi_xmm<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term psllw.
-pub fn constructor_psllw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psllw.
+pub fn constructor_x64_psllw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2275.
+    // Rule at src/isa/x64/inst.isle line 2274.
     let expr0_0 = SseOpcode::Psllw;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term pslld.
-pub fn constructor_pslld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pslld.
+pub fn constructor_x64_pslld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2280.
+    // Rule at src/isa/x64/inst.isle line 2279.
     let expr0_0 = SseOpcode::Pslld;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term psllq.
-pub fn constructor_psllq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psllq.
+pub fn constructor_x64_psllq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2285.
+    // Rule at src/isa/x64/inst.isle line 2284.
     let expr0_0 = SseOpcode::Psllq;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term psrlw.
-pub fn constructor_psrlw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psrlw.
+pub fn constructor_x64_psrlw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2290.
+    // Rule at src/isa/x64/inst.isle line 2289.
     let expr0_0 = SseOpcode::Psrlw;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term psrld.
-pub fn constructor_psrld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psrld.
+pub fn constructor_x64_psrld<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2295.
+    // Rule at src/isa/x64/inst.isle line 2294.
     let expr0_0 = SseOpcode::Psrld;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term psrlq.
-pub fn constructor_psrlq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psrlq.
+pub fn constructor_x64_psrlq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2300.
+    // Rule at src/isa/x64/inst.isle line 2299.
     let expr0_0 = SseOpcode::Psrlq;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term psraw.
-pub fn constructor_psraw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psraw.
+pub fn constructor_x64_psraw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2305.
+    // Rule at src/isa/x64/inst.isle line 2304.
     let expr0_0 = SseOpcode::Psraw;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term psrad.
-pub fn constructor_psrad<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_psrad.
+pub fn constructor_x64_psrad<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMemImm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2310.
+    // Rule at src/isa/x64/inst.isle line 2309.
     let expr0_0 = SseOpcode::Psrad;
     let expr1_0 = constructor_xmm_rmi_xmm(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term pextrd.
-pub fn constructor_pextrd<C: Context>(ctx: &mut C, arg0: Type, arg1: Xmm, arg2: u8) -> Option<Gpr> {
+// Generated as internal constructor for term x64_pextrd.
+pub fn constructor_x64_pextrd<C: Context>(
+    ctx: &mut C,
+    arg0: Type,
+    arg1: Xmm,
+    arg2: u8,
+) -> Option<Gpr> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2315.
+    // Rule at src/isa/x64/inst.isle line 2314.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = SseOpcode::Pextrd;
     let expr2_0 = constructor_writable_gpr_to_r_reg(ctx, expr0_0)?;
@@ -3840,8 +3845,8 @@ pub fn constructor_pextrd<C: Context>(ctx: &mut C, arg0: Type, arg1: Xmm, arg2: 
     return Some(expr11_0);
 }
 
-// Generated as internal constructor for term cmppd.
-pub fn constructor_cmppd<C: Context>(
+// Generated as internal constructor for term x64_cmppd.
+pub fn constructor_x64_cmppd<C: Context>(
     ctx: &mut C,
     arg0: Xmm,
     arg1: &XmmMem,
@@ -3850,7 +3855,7 @@ pub fn constructor_cmppd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2331.
+    // Rule at src/isa/x64/inst.isle line 2330.
     let expr0_0 = SseOpcode::Cmppd;
     let expr1_0 = C::xmm_to_reg(ctx, pattern0_0);
     let expr2_0 = C::xmm_mem_to_reg_mem(ctx, pattern1_0);
@@ -3870,7 +3875,7 @@ pub fn constructor_gpr_to_xmm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2340.
+    // Rule at src/isa/x64/inst.isle line 2339.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = MInst::GprToXmm {
         op: pattern0_0.clone(),
@@ -3883,11 +3888,11 @@ pub fn constructor_gpr_to_xmm<C: Context>(
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term not.
-pub fn constructor_not<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
+// Generated as internal constructor for term x64_not.
+pub fn constructor_x64_not<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2347.
+    // Rule at src/isa/x64/inst.isle line 2346.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::Not {
@@ -3900,11 +3905,11 @@ pub fn constructor_not<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term neg.
-pub fn constructor_neg<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
+// Generated as internal constructor for term x64_neg.
+pub fn constructor_x64_neg<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2355.
+    // Rule at src/isa/x64/inst.isle line 2354.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::Neg {
@@ -3917,10 +3922,10 @@ pub fn constructor_neg<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term lea.
-pub fn constructor_lea<C: Context>(ctx: &mut C, arg0: &SyntheticAmode) -> Option<Gpr> {
+// Generated as internal constructor for term x64_lea.
+pub fn constructor_x64_lea<C: Context>(ctx: &mut C, arg0: &SyntheticAmode) -> Option<Gpr> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2362.
+    // Rule at src/isa/x64/inst.isle line 2361.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = MInst::LoadEffectiveAddress {
         addr: pattern0_0.clone(),
@@ -3931,10 +3936,10 @@ pub fn constructor_lea<C: Context>(ctx: &mut C, arg0: &SyntheticAmode) -> Option
     return Some(expr3_0);
 }
 
-// Generated as internal constructor for term ud2.
-pub fn constructor_ud2<C: Context>(ctx: &mut C, arg0: &TrapCode) -> Option<SideEffectNoResult> {
+// Generated as internal constructor for term x64_ud2.
+pub fn constructor_x64_ud2<C: Context>(ctx: &mut C, arg0: &TrapCode) -> Option<SideEffectNoResult> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2369.
+    // Rule at src/isa/x64/inst.isle line 2368.
     let expr0_0 = MInst::Ud2 {
         trap_code: pattern0_0.clone(),
     };
@@ -3942,19 +3947,19 @@ pub fn constructor_ud2<C: Context>(ctx: &mut C, arg0: &TrapCode) -> Option<SideE
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term hlt.
-pub fn constructor_hlt<C: Context>(ctx: &mut C) -> Option<SideEffectNoResult> {
-    // Rule at src/isa/x64/inst.isle line 2374.
+// Generated as internal constructor for term x64_hlt.
+pub fn constructor_x64_hlt<C: Context>(ctx: &mut C) -> Option<SideEffectNoResult> {
+    // Rule at src/isa/x64/inst.isle line 2373.
     let expr0_0 = MInst::Hlt;
     let expr1_0 = SideEffectNoResult::Inst { inst: expr0_0 };
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term lzcnt.
-pub fn constructor_lzcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
+// Generated as internal constructor for term x64_lzcnt.
+pub fn constructor_x64_lzcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2379.
+    // Rule at src/isa/x64/inst.isle line 2378.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = UnaryRmROpcode::Lzcnt;
@@ -3970,11 +3975,11 @@ pub fn constructor_lzcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Opti
     return Some(expr6_0);
 }
 
-// Generated as internal constructor for term tzcnt.
-pub fn constructor_tzcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
+// Generated as internal constructor for term x64_tzcnt.
+pub fn constructor_x64_tzcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2387.
+    // Rule at src/isa/x64/inst.isle line 2386.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = UnaryRmROpcode::Tzcnt;
@@ -3990,11 +3995,15 @@ pub fn constructor_tzcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Opti
     return Some(expr6_0);
 }
 
-// Generated as internal constructor for term bsr.
-pub fn constructor_bsr<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<ProducesFlags> {
+// Generated as internal constructor for term x64_bsr.
+pub fn constructor_x64_bsr<C: Context>(
+    ctx: &mut C,
+    arg0: Type,
+    arg1: Gpr,
+) -> Option<ProducesFlags> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2395.
+    // Rule at src/isa/x64/inst.isle line 2394.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = UnaryRmROpcode::Bsr;
@@ -4023,8 +4032,8 @@ pub fn constructor_bsr_or_else<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2404.
-    let expr0_0 = constructor_bsr(ctx, pattern0_0, pattern1_0)?;
+    // Rule at src/isa/x64/inst.isle line 2403.
+    let expr0_0 = constructor_x64_bsr(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_produces_flags_get_reg(ctx, &expr0_0)?;
     let expr2_0 = C::gpr_new(ctx, expr1_0);
     let expr3_0 = CC::Z;
@@ -4036,11 +4045,15 @@ pub fn constructor_bsr_or_else<C: Context>(
     return Some(expr8_0);
 }
 
-// Generated as internal constructor for term bsf.
-pub fn constructor_bsf<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<ProducesFlags> {
+// Generated as internal constructor for term x64_bsf.
+pub fn constructor_x64_bsf<C: Context>(
+    ctx: &mut C,
+    arg0: Type,
+    arg1: Gpr,
+) -> Option<ProducesFlags> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2415.
+    // Rule at src/isa/x64/inst.isle line 2414.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = UnaryRmROpcode::Bsf;
@@ -4069,8 +4082,8 @@ pub fn constructor_bsf_or_else<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/x64/inst.isle line 2424.
-    let expr0_0 = constructor_bsf(ctx, pattern0_0, pattern1_0)?;
+    // Rule at src/isa/x64/inst.isle line 2423.
+    let expr0_0 = constructor_x64_bsf(ctx, pattern0_0, pattern1_0)?;
     let expr1_0 = constructor_produces_flags_get_reg(ctx, &expr0_0)?;
     let expr2_0 = C::gpr_new(ctx, expr1_0);
     let expr3_0 = CC::Z;
@@ -4086,7 +4099,7 @@ pub fn constructor_bsf_or_else<C: Context>(
 pub fn constructor_x64_popcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> Option<Gpr> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2435.
+    // Rule at src/isa/x64/inst.isle line 2434.
     let expr0_0 = C::temp_writable_gpr(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = UnaryRmROpcode::Popcnt;
@@ -4114,7 +4127,7 @@ pub fn constructor_xmm_min_max_seq<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/x64/inst.isle line 2443.
+    // Rule at src/isa/x64/inst.isle line 2442.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = C::operand_size_of_type_32_64(ctx, pattern0_0);
     let expr2_0 = MInst::XmmMinMaxSeq {
@@ -4129,11 +4142,11 @@ pub fn constructor_xmm_min_max_seq<C: Context>(
     return Some(expr4_0);
 }
 
-// Generated as internal constructor for term minss.
-pub fn constructor_minss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_minss.
+pub fn constructor_x64_minss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2451.
+    // Rule at src/isa/x64/inst.isle line 2450.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Minss;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4148,11 +4161,11 @@ pub fn constructor_minss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term minsd.
-pub fn constructor_minsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_minsd.
+pub fn constructor_x64_minsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2458.
+    // Rule at src/isa/x64/inst.isle line 2457.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Minsd;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4167,11 +4180,11 @@ pub fn constructor_minsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term minps.
-pub fn constructor_minps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_minps.
+pub fn constructor_x64_minps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2466.
+    // Rule at src/isa/x64/inst.isle line 2465.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Minps;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4186,11 +4199,11 @@ pub fn constructor_minps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term minpd.
-pub fn constructor_minpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_minpd.
+pub fn constructor_x64_minpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2473.
+    // Rule at src/isa/x64/inst.isle line 2472.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Minpd;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4205,11 +4218,11 @@ pub fn constructor_minpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term maxss.
-pub fn constructor_maxss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_maxss.
+pub fn constructor_x64_maxss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2480.
+    // Rule at src/isa/x64/inst.isle line 2479.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Maxss;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4224,11 +4237,11 @@ pub fn constructor_maxss<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term maxsd.
-pub fn constructor_maxsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_maxsd.
+pub fn constructor_x64_maxsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2487.
+    // Rule at src/isa/x64/inst.isle line 2486.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Maxsd;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4243,11 +4256,11 @@ pub fn constructor_maxsd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term maxps.
-pub fn constructor_maxps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_maxps.
+pub fn constructor_x64_maxps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2494.
+    // Rule at src/isa/x64/inst.isle line 2493.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Maxps;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4262,11 +4275,11 @@ pub fn constructor_maxps<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term maxpd.
-pub fn constructor_maxpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
+// Generated as internal constructor for term x64_maxpd.
+pub fn constructor_x64_maxpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2501.
+    // Rule at src/isa/x64/inst.isle line 2500.
     let expr0_0 = C::temp_writable_xmm(ctx);
     let expr1_0 = SseOpcode::Maxpd;
     let expr2_0 = C::xmm_to_xmm_mem(ctx, pattern1_0);
@@ -4281,8 +4294,8 @@ pub fn constructor_maxpd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: Xmm) -> Optio
     return Some(expr5_0);
 }
 
-// Generated as internal constructor for term pcmpeq.
-pub fn constructor_pcmpeq<C: Context>(
+// Generated as internal constructor for term x64_pcmpeq.
+pub fn constructor_x64_pcmpeq<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Xmm,
@@ -4292,80 +4305,80 @@ pub fn constructor_pcmpeq<C: Context>(
     if pattern0_0 == I8X16 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2508.
-        let expr0_0 = constructor_pcmpeqb(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2507.
+        let expr0_0 = constructor_x64_pcmpeqb(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I16X8 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2509.
-        let expr0_0 = constructor_pcmpeqw(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2508.
+        let expr0_0 = constructor_x64_pcmpeqw(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2510.
-        let expr0_0 = constructor_pcmpeqd(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2509.
+        let expr0_0 = constructor_x64_pcmpeqd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2511.
-        let expr0_0 = constructor_pcmpeqq(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2510.
+        let expr0_0 = constructor_x64_pcmpeqq(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
 }
 
-// Generated as internal constructor for term pcmpeqb.
-pub fn constructor_pcmpeqb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpeqb.
+pub fn constructor_x64_pcmpeqb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2514.
+    // Rule at src/isa/x64/inst.isle line 2513.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pcmpeqb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pcmpeqw.
-pub fn constructor_pcmpeqw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpeqw.
+pub fn constructor_x64_pcmpeqw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2516.
+    // Rule at src/isa/x64/inst.isle line 2515.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pcmpeqw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pcmpeqd.
-pub fn constructor_pcmpeqd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpeqd.
+pub fn constructor_x64_pcmpeqd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2518.
+    // Rule at src/isa/x64/inst.isle line 2517.
     let expr0_0: Type = I32X4;
     let expr1_0 = SseOpcode::Pcmpeqd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pcmpeqq.
-pub fn constructor_pcmpeqq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpeqq.
+pub fn constructor_x64_pcmpeqq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2520.
+    // Rule at src/isa/x64/inst.isle line 2519.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Pcmpeqq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pcmpgt.
-pub fn constructor_pcmpgt<C: Context>(
+// Generated as internal constructor for term x64_pcmpgt.
+pub fn constructor_x64_pcmpgt<C: Context>(
     ctx: &mut C,
     arg0: Type,
     arg1: Xmm,
@@ -4375,72 +4388,72 @@ pub fn constructor_pcmpgt<C: Context>(
     if pattern0_0 == I8X16 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2524.
-        let expr0_0 = constructor_pcmpgtb(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2523.
+        let expr0_0 = constructor_x64_pcmpgtb(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I16X8 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2525.
-        let expr0_0 = constructor_pcmpgtw(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2524.
+        let expr0_0 = constructor_x64_pcmpgtw(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I32X4 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2526.
-        let expr0_0 = constructor_pcmpgtd(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2525.
+        let expr0_0 = constructor_x64_pcmpgtd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == I64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
-        // Rule at src/isa/x64/inst.isle line 2527.
-        let expr0_0 = constructor_pcmpgtq(ctx, pattern2_0, pattern3_0)?;
+        // Rule at src/isa/x64/inst.isle line 2526.
+        let expr0_0 = constructor_x64_pcmpgtq(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
 }
 
-// Generated as internal constructor for term pcmpgtb.
-pub fn constructor_pcmpgtb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpgtb.
+pub fn constructor_x64_pcmpgtb<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2530.
+    // Rule at src/isa/x64/inst.isle line 2529.
     let expr0_0: Type = I8X16;
     let expr1_0 = SseOpcode::Pcmpgtb;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pcmpgtw.
-pub fn constructor_pcmpgtw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpgtw.
+pub fn constructor_x64_pcmpgtw<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2532.
+    // Rule at src/isa/x64/inst.isle line 2531.
     let expr0_0: Type = I16X8;
     let expr1_0 = SseOpcode::Pcmpgtw;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pcmpgtd.
-pub fn constructor_pcmpgtd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpgtd.
+pub fn constructor_x64_pcmpgtd<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2534.
+    // Rule at src/isa/x64/inst.isle line 2533.
     let expr0_0: Type = I32X4;
     let expr1_0 = SseOpcode::Pcmpgtd;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
     return Some(expr2_0);
 }
 
-// Generated as internal constructor for term pcmpgtq.
-pub fn constructor_pcmpgtq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
+// Generated as internal constructor for term x64_pcmpgtq.
+pub fn constructor_x64_pcmpgtq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) -> Option<Xmm> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/x64/inst.isle line 2536.
+    // Rule at src/isa/x64/inst.isle line 2535.
     let expr0_0: Type = I64X2;
     let expr1_0 = SseOpcode::Pcmpgtq;
     let expr2_0 = constructor_xmm_rm_r(ctx, expr0_0, &expr1_0, pattern0_0, pattern1_0)?;
@@ -4450,7 +4463,7 @@ pub fn constructor_pcmpgtq<C: Context>(ctx: &mut C, arg0: Xmm, arg1: &XmmMem) ->
 // Generated as internal constructor for term reg_to_xmm_mem.
 pub fn constructor_reg_to_xmm_mem<C: Context>(ctx: &mut C, arg0: Reg) -> Option<XmmMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2590.
+    // Rule at src/isa/x64/inst.isle line 2589.
     let expr0_0 = C::xmm_new(ctx, pattern0_0);
     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
     return Some(expr1_0);
@@ -4459,7 +4472,7 @@ pub fn constructor_reg_to_xmm_mem<C: Context>(ctx: &mut C, arg0: Reg) -> Option<
 // Generated as internal constructor for term xmm_to_reg_mem.
 pub fn constructor_xmm_to_reg_mem<C: Context>(ctx: &mut C, arg0: Reg) -> Option<XmmMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2593.
+    // Rule at src/isa/x64/inst.isle line 2592.
     let expr0_0 = C::xmm_new(ctx, pattern0_0);
     let expr1_0 = C::xmm_to_reg(ctx, expr0_0);
     let expr2_0 = RegMem::Reg { reg: expr1_0 };
@@ -4473,7 +4486,7 @@ pub fn constructor_writable_gpr_to_r_reg<C: Context>(
     arg0: WritableGpr,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2597.
+    // Rule at src/isa/x64/inst.isle line 2596.
     let expr0_0 = C::writable_gpr_to_reg(ctx, pattern0_0);
     let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -4485,7 +4498,7 @@ pub fn constructor_writable_gpr_to_gpr_mem<C: Context>(
     arg0: WritableGpr,
 ) -> Option<GprMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2600.
+    // Rule at src/isa/x64/inst.isle line 2599.
     let expr0_0 = C::writable_gpr_to_gpr(ctx, pattern0_0);
     let expr1_0 = C::gpr_to_gpr_mem(ctx, expr0_0);
     return Some(expr1_0);
@@ -4497,7 +4510,7 @@ pub fn constructor_writable_gpr_to_value_regs<C: Context>(
     arg0: WritableGpr,
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2603.
+    // Rule at src/isa/x64/inst.isle line 2602.
     let expr0_0 = constructor_writable_gpr_to_r_reg(ctx, pattern0_0)?;
     let expr1_0 = C::value_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -4509,7 +4522,7 @@ pub fn constructor_writable_xmm_to_r_reg<C: Context>(
     arg0: WritableXmm,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2606.
+    // Rule at src/isa/x64/inst.isle line 2605.
     let expr0_0 = C::writable_xmm_to_reg(ctx, pattern0_0);
     let expr1_0 = C::writable_reg_to_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -4521,7 +4534,7 @@ pub fn constructor_writable_xmm_to_xmm_mem<C: Context>(
     arg0: WritableXmm,
 ) -> Option<XmmMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2609.
+    // Rule at src/isa/x64/inst.isle line 2608.
     let expr0_0 = C::writable_xmm_to_xmm(ctx, pattern0_0);
     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
     return Some(expr1_0);
@@ -4533,7 +4546,7 @@ pub fn constructor_writable_xmm_to_value_regs<C: Context>(
     arg0: WritableXmm,
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2612.
+    // Rule at src/isa/x64/inst.isle line 2611.
     let expr0_0 = constructor_writable_xmm_to_r_reg(ctx, pattern0_0)?;
     let expr1_0 = C::value_reg(ctx, expr0_0);
     return Some(expr1_0);
@@ -4545,7 +4558,7 @@ pub fn constructor_synthetic_amode_to_gpr_mem<C: Context>(
     arg0: &SyntheticAmode,
 ) -> Option<GprMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2616.
+    // Rule at src/isa/x64/inst.isle line 2615.
     let expr0_0 = C::synthetic_amode_to_reg_mem(ctx, pattern0_0);
     let expr1_0 = C::reg_mem_to_gpr_mem(ctx, &expr0_0);
     return Some(expr1_0);
@@ -4557,7 +4570,7 @@ pub fn constructor_synthetic_amode_to_xmm_mem<C: Context>(
     arg0: &SyntheticAmode,
 ) -> Option<XmmMem> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/x64/inst.isle line 2619.
+    // Rule at src/isa/x64/inst.isle line 2618.
     let expr0_0 = C::synthetic_amode_to_reg_mem(ctx, pattern0_0);
     let expr1_0 = C::reg_mem_to_xmm_mem(ctx, &expr0_0);
     return Some(expr1_0);
@@ -4590,7 +4603,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         let expr9_0 = constructor_x64_popcnt(ctx, expr5_0, expr8_0)?;
                         let expr10_0: Type = I64;
                         let expr11_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
-                        let expr12_0 = constructor_add(ctx, expr10_0, expr4_0, &expr11_0)?;
+                        let expr12_0 = constructor_x64_add(ctx, expr10_0, expr4_0, &expr11_0)?;
                         let expr13_0 = C::gpr_to_reg(ctx, expr12_0);
                         let expr14_0: Type = I64;
                         let expr15_0: u64 = 0;
@@ -4614,7 +4627,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         if let &Opcode::Popcnt = pattern7_0 {
                             // Rule at src/isa/x64/lower.isle line 1822.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr1_0 = constructor_vpopcntb(ctx, &expr0_0)?;
+                            let expr1_0 = constructor_x64_vpopcntb(ctx, &expr0_0)?;
                             let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
@@ -4633,7 +4646,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     if let &Opcode::Clz = pattern6_0 {
                         // Rule at src/isa/x64/lower.isle line 1638.
                         let expr0_0 = constructor_put_in_gpr(ctx, pattern6_1)?;
-                        let expr1_0 = constructor_lzcnt(ctx, pattern3_0, expr0_0)?;
+                        let expr1_0 = constructor_x64_lzcnt(ctx, pattern3_0, expr0_0)?;
                         let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
@@ -4649,7 +4662,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     if let &Opcode::Ctz = pattern6_0 {
                         // Rule at src/isa/x64/lower.isle line 1680.
                         let expr0_0 = constructor_put_in_gpr(ctx, pattern6_1)?;
-                        let expr1_0 = constructor_tzcnt(ctx, pattern3_0, expr0_0)?;
+                        let expr1_0 = constructor_x64_tzcnt(ctx, pattern3_0, expr0_0)?;
                         let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
@@ -4703,7 +4716,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
         } => {
             if let &Opcode::Debugtrap = pattern2_0 {
                 // Rule at src/isa/x64/lower.isle line 2108.
-                let expr0_0 = constructor_hlt(ctx)?;
+                let expr0_0 = constructor_x64_hlt(ctx)?;
                 let expr1_0 = constructor_side_effect(ctx, &expr0_0)?;
                 return Some(expr1_0);
             }
@@ -4741,13 +4754,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
             match pattern2_0 {
                 &Opcode::Trap => {
                     // Rule at src/isa/x64/lower.isle line 1435.
-                    let expr0_0 = constructor_ud2(ctx, pattern2_1)?;
+                    let expr0_0 = constructor_x64_ud2(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
                 &Opcode::ResumableTrap => {
                     // Rule at src/isa/x64/lower.isle line 1440.
-                    let expr0_0 = constructor_ud2(ctx, pattern2_1)?;
+                    let expr0_0 = constructor_x64_ud2(ctx, pattern2_1)?;
                     let expr1_0 = constructor_safepoint(ctx, &expr0_0)?;
                     return Some(expr1_0);
                 }
@@ -4798,15 +4811,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr11_0 = constructor_value_regs_get_gpr(ctx, expr9_0, expr10_0)?;
                             let expr12_0 = OperandSize::Size64;
                             let expr13_0 = C::gpr_to_gpr_mem_imm(ctx, expr8_0);
-                            let expr14_0 = constructor_cmp(ctx, &expr12_0, &expr13_0, expr2_0)?;
+                            let expr14_0 = constructor_x64_cmp(ctx, &expr12_0, &expr13_0, expr2_0)?;
                             let expr15_0 = CC::Z;
-                            let expr16_0 = constructor_setcc(ctx, &expr15_0)?;
+                            let expr16_0 = constructor_x64_setcc(ctx, &expr15_0)?;
                             let expr17_0 = constructor_with_flags_reg(ctx, &expr14_0, &expr16_0)?;
                             let expr18_0 = OperandSize::Size64;
                             let expr19_0 = C::gpr_to_gpr_mem_imm(ctx, expr11_0);
-                            let expr20_0 = constructor_cmp(ctx, &expr18_0, &expr19_0, expr5_0)?;
+                            let expr20_0 = constructor_x64_cmp(ctx, &expr18_0, &expr19_0, expr5_0)?;
                             let expr21_0 = CC::Z;
-                            let expr22_0 = constructor_setcc(ctx, &expr21_0)?;
+                            let expr22_0 = constructor_x64_setcc(ctx, &expr21_0)?;
                             let expr23_0 = constructor_with_flags_reg(ctx, &expr20_0, &expr22_0)?;
                             let expr24_0: Type = I64;
                             let expr25_0 = C::gpr_new(ctx, expr17_0);
@@ -4818,9 +4831,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr31_0 = RegMemImm::Imm { simm32: expr30_0 };
                             let expr32_0 = C::gpr_mem_imm_new(ctx, &expr31_0);
                             let expr33_0 = C::gpr_new(ctx, expr28_0);
-                            let expr34_0 = constructor_test(ctx, &expr29_0, &expr32_0, expr33_0)?;
+                            let expr34_0 =
+                                constructor_x64_test(ctx, &expr29_0, &expr32_0, expr33_0)?;
                             let expr35_0 = CC::NZ;
-                            let expr36_0 = constructor_setcc(ctx, &expr35_0)?;
+                            let expr36_0 = constructor_x64_setcc(ctx, &expr35_0)?;
                             let expr37_0 = constructor_with_flags(ctx, &expr34_0, &expr36_0)?;
                             let expr38_0 = C::output(ctx, expr37_0);
                             return Some(expr38_0);
@@ -4841,29 +4855,30 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr11_0 = constructor_value_regs_get_gpr(ctx, expr9_0, expr10_0)?;
                             let expr12_0 = OperandSize::Size64;
                             let expr13_0 = C::gpr_to_gpr_mem_imm(ctx, expr8_0);
-                            let expr14_0 = constructor_cmp(ctx, &expr12_0, &expr13_0, expr2_0)?;
+                            let expr14_0 = constructor_x64_cmp(ctx, &expr12_0, &expr13_0, expr2_0)?;
                             let expr15_0 = CC::NZ;
-                            let expr16_0 = constructor_setcc(ctx, &expr15_0)?;
+                            let expr16_0 = constructor_x64_setcc(ctx, &expr15_0)?;
                             let expr17_0 = constructor_with_flags_reg(ctx, &expr14_0, &expr16_0)?;
                             let expr18_0 = OperandSize::Size64;
                             let expr19_0 = C::gpr_to_gpr_mem_imm(ctx, expr11_0);
-                            let expr20_0 = constructor_cmp(ctx, &expr18_0, &expr19_0, expr5_0)?;
+                            let expr20_0 = constructor_x64_cmp(ctx, &expr18_0, &expr19_0, expr5_0)?;
                             let expr21_0 = CC::NZ;
-                            let expr22_0 = constructor_setcc(ctx, &expr21_0)?;
+                            let expr22_0 = constructor_x64_setcc(ctx, &expr21_0)?;
                             let expr23_0 = constructor_with_flags_reg(ctx, &expr20_0, &expr22_0)?;
                             let expr24_0: Type = I64;
                             let expr25_0 = C::gpr_new(ctx, expr17_0);
                             let expr26_0 = constructor_reg_to_gpr_mem_imm(ctx, expr23_0)?;
-                            let expr27_0 = constructor_or(ctx, expr24_0, expr25_0, &expr26_0)?;
+                            let expr27_0 = constructor_x64_or(ctx, expr24_0, expr25_0, &expr26_0)?;
                             let expr28_0 = C::gpr_to_reg(ctx, expr27_0);
                             let expr29_0 = OperandSize::Size64;
                             let expr30_0: u32 = 1;
                             let expr31_0 = RegMemImm::Imm { simm32: expr30_0 };
                             let expr32_0 = C::gpr_mem_imm_new(ctx, &expr31_0);
                             let expr33_0 = C::gpr_new(ctx, expr28_0);
-                            let expr34_0 = constructor_test(ctx, &expr29_0, &expr32_0, expr33_0)?;
+                            let expr34_0 =
+                                constructor_x64_test(ctx, &expr29_0, &expr32_0, expr33_0)?;
                             let expr35_0 = CC::NZ;
-                            let expr36_0 = constructor_setcc(ctx, &expr35_0)?;
+                            let expr36_0 = constructor_x64_setcc(ctx, &expr35_0)?;
                             let expr37_0 = constructor_with_flags(ctx, &expr34_0, &expr36_0)?;
                             let expr38_0 = C::output(ctx, expr37_0);
                             return Some(expr38_0);
@@ -4878,11 +4893,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0: Type = I64X2;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern4_1)?;
                             let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern4_0)?;
-                            let expr3_0 = constructor_pcmpgt(ctx, expr0_0, expr1_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_pcmpgt(ctx, expr0_0, expr1_0, &expr2_0)?;
                             let expr4_0: Type = I64X2;
                             let expr5_0 = constructor_vector_all_ones(ctx, expr4_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_pxor(ctx, expr3_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_pxor(ctx, expr3_0, &expr6_0)?;
                             let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
@@ -4891,11 +4906,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0: Type = I64X2;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr3_0 = constructor_pcmpgt(ctx, expr0_0, expr1_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_pcmpgt(ctx, expr0_0, expr1_0, &expr2_0)?;
                             let expr4_0: Type = I64X2;
                             let expr5_0 = constructor_vector_all_ones(ctx, expr4_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_pxor(ctx, expr3_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_pxor(ctx, expr3_0, &expr6_0)?;
                             let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
@@ -4907,9 +4922,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     let expr0_0 = C::raw_operand_size_of_type(ctx, pattern6_0);
                     let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern4_1)?;
                     let expr2_0 = constructor_put_in_gpr(ctx, pattern4_0)?;
-                    let expr3_0 = constructor_cmp(ctx, &expr0_0, &expr1_0, expr2_0)?;
+                    let expr3_0 = constructor_x64_cmp(ctx, &expr0_0, &expr1_0, expr2_0)?;
                     let expr4_0 = C::intcc_to_cc(ctx, pattern2_2);
-                    let expr5_0 = constructor_setcc(ctx, &expr4_0)?;
+                    let expr5_0 = constructor_x64_setcc(ctx, &expr4_0)?;
                     let expr6_0 = constructor_with_flags(ctx, &expr3_0, &expr5_0)?;
                     let expr7_0 = C::output(ctx, expr6_0);
                     return Some(expr7_0);
@@ -4920,7 +4935,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1457.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pcmpeq(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -4928,10 +4944,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1461.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pcmpeq(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_vector_all_ones(ctx, pattern6_0)?;
                             let expr4_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
-                            let expr5_0 = constructor_pxor(ctx, expr2_0, &expr4_0)?;
+                            let expr5_0 = constructor_x64_pxor(ctx, expr2_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
@@ -4939,7 +4956,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1468.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pcmpgt(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pcmpgt(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -4947,10 +4965,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1485.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pmaxs(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pmaxs(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr4_0 = C::xmm_to_xmm_mem(ctx, expr2_0);
-                            let expr5_0 = constructor_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
+                            let expr5_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
@@ -4958,7 +4978,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1470.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_1)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_0)?;
-                            let expr2_0 = constructor_pcmpgt(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pcmpgt(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -4966,10 +4987,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1488.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pmins(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pmins(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr4_0 = C::xmm_to_xmm_mem(ctx, expr2_0);
-                            let expr5_0 = constructor_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
+                            let expr5_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
@@ -4977,12 +5000,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1472.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pmaxu(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pmaxu(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr4_0 = constructor_pcmpeq(ctx, pattern6_0, expr2_0, &expr3_0)?;
+                            let expr4_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr2_0, &expr3_0)?;
                             let expr5_0 = constructor_vector_all_ones(ctx, pattern6_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_pxor(ctx, expr4_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_pxor(ctx, expr4_0, &expr6_0)?;
                             let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
@@ -4990,10 +5015,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1491.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pmaxu(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pmaxu(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr4_0 = C::xmm_to_xmm_mem(ctx, expr2_0);
-                            let expr5_0 = constructor_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
+                            let expr5_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
@@ -5001,12 +5028,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1477.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pminu(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pminu(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr4_0 = constructor_pcmpeq(ctx, pattern6_0, expr2_0, &expr3_0)?;
+                            let expr4_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr2_0, &expr3_0)?;
                             let expr5_0 = constructor_vector_all_ones(ctx, pattern6_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_pxor(ctx, expr4_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_pxor(ctx, expr4_0, &expr6_0)?;
                             let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                             return Some(expr8_0);
                         }
@@ -5014,10 +5043,12 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1494.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern4_1)?;
-                            let expr2_0 = constructor_pminu(ctx, pattern6_0, expr0_0, &expr1_0)?;
+                            let expr2_0 =
+                                constructor_x64_pminu(ctx, pattern6_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern4_0)?;
                             let expr4_0 = C::xmm_to_xmm_mem(ctx, expr2_0);
-                            let expr5_0 = constructor_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
+                            let expr5_0 =
+                                constructor_x64_pcmpeq(ctx, pattern6_0, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
@@ -5038,9 +5069,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         let expr0_0 = OperandSize::Size64;
                         let expr1_0: u32 = 0;
                         let expr2_0 = constructor_put_in_gpr(ctx, pattern2_1)?;
-                        let expr3_0 = constructor_cmp_imm(ctx, &expr0_0, expr1_0, expr2_0)?;
+                        let expr3_0 = constructor_x64_cmp_imm(ctx, &expr0_0, expr1_0, expr2_0)?;
                         let expr4_0 = CC::Z;
-                        let expr5_0 = constructor_setcc(ctx, &expr4_0)?;
+                        let expr5_0 = constructor_x64_setcc(ctx, &expr4_0)?;
                         let expr6_0 = constructor_with_flags(ctx, &expr3_0, &expr5_0)?;
                         let expr7_0 = C::output(ctx, expr6_0);
                         return Some(expr7_0);
@@ -5053,9 +5084,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         let expr0_0 = OperandSize::Size64;
                         let expr1_0: u32 = 4294967295;
                         let expr2_0 = constructor_put_in_gpr(ctx, pattern2_1)?;
-                        let expr3_0 = constructor_cmp_imm(ctx, &expr0_0, expr1_0, expr2_0)?;
+                        let expr3_0 = constructor_x64_cmp_imm(ctx, &expr0_0, expr1_0, expr2_0)?;
                         let expr4_0 = CC::Z;
-                        let expr5_0 = constructor_setcc(ctx, &expr4_0)?;
+                        let expr5_0 = constructor_x64_setcc(ctx, &expr4_0)?;
                         let expr6_0 = constructor_with_flags(ctx, &expr3_0, &expr5_0)?;
                         let expr7_0 = C::output(ctx, expr6_0);
                         return Some(expr7_0);
@@ -5134,7 +5165,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr5_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr6_0: Type = I64;
                             let expr7_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
-                            let expr8_0 = constructor_or(ctx, expr6_0, expr2_0, &expr7_0)?;
+                            let expr8_0 = constructor_x64_or(ctx, expr6_0, expr2_0, &expr7_0)?;
                             let expr9_0 = constructor_value_gprs(ctx, expr8_0, expr4_0)?;
                             let expr10_0 = C::output(ctx, expr9_0);
                             return Some(expr10_0);
@@ -5150,7 +5181,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr5_0 = constructor_lo_gpr(ctx, pattern7_1)?;
                             let expr6_0: Type = I64;
                             let expr7_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
-                            let expr8_0 = constructor_xor(ctx, expr6_0, expr2_0, &expr7_0)?;
+                            let expr8_0 = constructor_x64_xor(ctx, expr6_0, expr2_0, &expr7_0)?;
                             let expr9_0 = constructor_value_gprs(ctx, expr8_0, expr4_0)?;
                             let expr10_0 = C::output(ctx, expr9_0);
                             return Some(expr10_0);
@@ -5399,13 +5430,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr9_0 = constructor_value_regs_get_gpr(ctx, expr5_0, expr8_0)?;
                             let expr10_0: Type = I64;
                             let expr11_0 = C::gpr_to_gpr_mem_imm(ctx, expr7_0);
-                            let expr12_0 = constructor_add_with_flags_paired(
+                            let expr12_0 = constructor_x64_add_with_flags_paired(
                                 ctx, expr10_0, expr2_0, &expr11_0,
                             )?;
                             let expr13_0: Type = I64;
                             let expr14_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
                             let expr15_0 =
-                                constructor_adc_paired(ctx, expr13_0, expr4_0, &expr14_0)?;
+                                constructor_x64_adc_paired(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0 = constructor_with_flags(ctx, &expr12_0, &expr15_0)?;
                             let expr17_0 = C::output(ctx, expr16_0);
                             return Some(expr17_0);
@@ -5425,13 +5456,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr9_0 = constructor_value_regs_get_gpr(ctx, expr5_0, expr8_0)?;
                             let expr10_0: Type = I64;
                             let expr11_0 = C::gpr_to_gpr_mem_imm(ctx, expr7_0);
-                            let expr12_0 = constructor_sub_with_flags_paired(
+                            let expr12_0 = constructor_x64_sub_with_flags_paired(
                                 ctx, expr10_0, expr2_0, &expr11_0,
                             )?;
                             let expr13_0: Type = I64;
                             let expr14_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
                             let expr15_0 =
-                                constructor_sbb_paired(ctx, expr13_0, expr4_0, &expr14_0)?;
+                                constructor_x64_sbb_paired(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0 = constructor_with_flags(ctx, &expr12_0, &expr15_0)?;
                             let expr17_0 = C::output(ctx, expr16_0);
                             return Some(expr17_0);
@@ -5451,13 +5482,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr9_0 = constructor_value_regs_get_gpr(ctx, expr5_0, expr8_0)?;
                             let expr10_0: Type = I64;
                             let expr11_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
-                            let expr12_0 = constructor_mul(ctx, expr10_0, expr2_0, &expr11_0)?;
+                            let expr12_0 = constructor_x64_mul(ctx, expr10_0, expr2_0, &expr11_0)?;
                             let expr13_0: Type = I64;
                             let expr14_0 = C::gpr_to_gpr_mem_imm(ctx, expr7_0);
-                            let expr15_0 = constructor_mul(ctx, expr13_0, expr4_0, &expr14_0)?;
+                            let expr15_0 = constructor_x64_mul(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0: Type = I64;
                             let expr17_0 = C::gpr_to_gpr_mem_imm(ctx, expr15_0);
-                            let expr18_0 = constructor_add(ctx, expr16_0, expr12_0, &expr17_0)?;
+                            let expr18_0 = constructor_x64_add(ctx, expr16_0, expr12_0, &expr17_0)?;
                             let expr19_0: Type = I64;
                             let expr20_0 = C::gpr_to_gpr_mem(ctx, expr7_0);
                             let expr21_0 = constructor_mulhi_u(ctx, expr19_0, expr2_0, &expr20_0)?;
@@ -5467,7 +5498,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr25_0 = constructor_value_regs_get_gpr(ctx, expr21_0, expr24_0)?;
                             let expr26_0: Type = I64;
                             let expr27_0 = C::gpr_to_gpr_mem_imm(ctx, expr25_0);
-                            let expr28_0 = constructor_add(ctx, expr26_0, expr18_0, &expr27_0)?;
+                            let expr28_0 = constructor_x64_add(ctx, expr26_0, expr18_0, &expr27_0)?;
                             let expr29_0 = constructor_value_gprs(ctx, expr23_0, expr28_0)?;
                             let expr30_0 = C::output(ctx, expr29_0);
                             return Some(expr30_0);
@@ -5519,10 +5550,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr9_0 = constructor_value_regs_get_gpr(ctx, expr5_0, expr8_0)?;
                             let expr10_0: Type = I64;
                             let expr11_0 = C::gpr_to_gpr_mem_imm(ctx, expr7_0);
-                            let expr12_0 = constructor_xor(ctx, expr10_0, expr2_0, &expr11_0)?;
+                            let expr12_0 = constructor_x64_xor(ctx, expr10_0, expr2_0, &expr11_0)?;
                             let expr13_0: Type = I64;
                             let expr14_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
-                            let expr15_0 = constructor_xor(ctx, expr13_0, expr4_0, &expr14_0)?;
+                            let expr15_0 = constructor_x64_xor(ctx, expr13_0, expr4_0, &expr14_0)?;
                             let expr16_0 = constructor_value_gprs(ctx, expr12_0, expr15_0)?;
                             let expr17_0 = C::output(ctx, expr16_0);
                             return Some(expr17_0);
@@ -5539,7 +5570,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr6_0 = constructor_imm(ctx, expr4_0, expr5_0)?;
                             let expr7_0 = C::gpr_new(ctx, expr6_0);
                             let expr8_0 = C::gpr_to_gpr_mem_imm(ctx, expr1_0);
-                            let expr9_0 = constructor_sub(ctx, expr3_0, expr7_0, &expr8_0)?;
+                            let expr9_0 = constructor_x64_sub(ctx, expr3_0, expr7_0, &expr8_0)?;
                             let expr10_0 = constructor_shr_i128(ctx, expr0_0, expr9_0)?;
                             let expr11_0 = constructor_or_i128(ctx, expr2_0, expr10_0)?;
                             let expr12_0 = C::output(ctx, expr11_0);
@@ -5557,7 +5588,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr6_0 = constructor_imm(ctx, expr4_0, expr5_0)?;
                             let expr7_0 = C::gpr_new(ctx, expr6_0);
                             let expr8_0 = C::gpr_to_gpr_mem_imm(ctx, expr1_0);
-                            let expr9_0 = constructor_sub(ctx, expr3_0, expr7_0, &expr8_0)?;
+                            let expr9_0 = constructor_x64_sub(ctx, expr3_0, expr7_0, &expr8_0)?;
                             let expr10_0 = constructor_shl_i128(ctx, expr0_0, expr9_0)?;
                             let expr11_0 = constructor_or_i128(ctx, expr2_0, expr10_0)?;
                             let expr12_0 = C::output(ctx, expr11_0);
@@ -5640,10 +5671,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr13_0: u32 = 64;
                             let expr14_0 = RegMemImm::Imm { simm32: expr13_0 };
                             let expr15_0 = C::gpr_mem_imm_new(ctx, &expr14_0);
-                            let expr16_0 = constructor_add(ctx, expr6_0, expr12_0, &expr15_0)?;
+                            let expr16_0 = constructor_x64_add(ctx, expr6_0, expr12_0, &expr15_0)?;
                             let expr17_0 = OperandSize::Size64;
                             let expr18_0: u32 = 64;
-                            let expr19_0 = constructor_cmp_imm(ctx, &expr17_0, expr18_0, expr5_0)?;
+                            let expr19_0 =
+                                constructor_x64_cmp_imm(ctx, &expr17_0, expr18_0, expr5_0)?;
                             let expr20_0: Type = I64;
                             let expr21_0 = CC::NZ;
                             let expr22_0 = C::gpr_to_gpr_mem(ctx, expr5_0);
@@ -5677,10 +5709,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr13_0: u32 = 64;
                             let expr14_0 = RegMemImm::Imm { simm32: expr13_0 };
                             let expr15_0 = C::gpr_mem_imm_new(ctx, &expr14_0);
-                            let expr16_0 = constructor_add(ctx, expr6_0, expr12_0, &expr15_0)?;
+                            let expr16_0 = constructor_x64_add(ctx, expr6_0, expr12_0, &expr15_0)?;
                             let expr17_0 = OperandSize::Size64;
                             let expr18_0: u32 = 64;
-                            let expr19_0 = constructor_cmp_imm(ctx, &expr17_0, expr18_0, expr5_0)?;
+                            let expr19_0 =
+                                constructor_x64_cmp_imm(ctx, &expr17_0, expr18_0, expr5_0)?;
                             let expr20_0: Type = I64;
                             let expr21_0 = CC::Z;
                             let expr22_0 = C::gpr_to_gpr_mem(ctx, expr16_0);
@@ -5710,7 +5743,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr9_0 = constructor_do_popcnt(ctx, expr5_0, expr8_0)?;
                             let expr10_0: Type = I64;
                             let expr11_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
-                            let expr12_0 = constructor_add(ctx, expr10_0, expr4_0, &expr11_0)?;
+                            let expr12_0 = constructor_x64_add(ctx, expr10_0, expr4_0, &expr11_0)?;
                             let expr13_0 = C::gpr_to_reg(ctx, expr12_0);
                             let expr14_0: Type = I64;
                             let expr15_0: u64 = 0;
@@ -5784,12 +5817,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         let expr8_0: Type = I64;
                         let expr9_0 = C::gpr_to_gpr_mem_imm(ctx, expr7_0);
                         let expr10_0 =
-                            constructor_add_with_flags_paired(ctx, expr8_0, expr2_0, &expr9_0)?;
+                            constructor_x64_add_with_flags_paired(ctx, expr8_0, expr2_0, &expr9_0)?;
                         let expr11_0: Type = I64;
                         let expr12_0: u32 = 0;
                         let expr13_0 = RegMemImm::Imm { simm32: expr12_0 };
                         let expr14_0 = C::gpr_mem_imm_new(ctx, &expr13_0);
-                        let expr15_0 = constructor_adc_paired(ctx, expr11_0, expr4_0, &expr14_0)?;
+                        let expr15_0 =
+                            constructor_x64_adc_paired(ctx, expr11_0, expr4_0, &expr14_0)?;
                         let expr16_0 = constructor_with_flags(ctx, &expr10_0, &expr15_0)?;
                         let expr17_0 = C::output(ctx, expr16_0);
                         return Some(expr17_0);
@@ -5811,7 +5845,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2123.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_addss(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_addss(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5820,7 +5854,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2134.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_subss(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_subss(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5829,7 +5863,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2145.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_mulss(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_mulss(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5838,7 +5872,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2156.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_divss(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_divss(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5859,7 +5893,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2336.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                        let expr2_0 = constructor_minss(ctx, expr0_0, expr1_0)?;
+                        let expr2_0 = constructor_x64_minss(ctx, expr0_0, expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5880,7 +5914,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2347.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                        let expr2_0 = constructor_maxss(ctx, expr0_0, expr1_0)?;
+                        let expr2_0 = constructor_x64_maxss(ctx, expr0_0, expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5901,7 +5935,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2125.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_addsd(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_addsd(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5910,7 +5944,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2136.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_subsd(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_subsd(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5919,7 +5953,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2147.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_mulsd(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_mulsd(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5928,7 +5962,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2158.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                        let expr2_0 = constructor_divsd(ctx, expr0_0, &expr1_0)?;
+                        let expr2_0 = constructor_x64_divsd(ctx, expr0_0, &expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5949,7 +5983,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2338.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                        let expr2_0 = constructor_minsd(ctx, expr0_0, expr1_0)?;
+                        let expr2_0 = constructor_x64_minsd(ctx, expr0_0, expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5970,7 +6004,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         // Rule at src/isa/x64/lower.isle line 2349.
                         let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                         let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                        let expr2_0 = constructor_maxsd(ctx, expr0_0, expr1_0)?;
+                        let expr2_0 = constructor_x64_maxsd(ctx, expr0_0, expr1_0)?;
                         let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                         return Some(expr3_0);
                     }
@@ -5991,7 +6025,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1402.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pminsb(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pminsb(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6000,7 +6034,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1424.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pminub(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pminub(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6009,7 +6043,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1391.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pmaxsb(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pmaxsb(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6018,7 +6052,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1413.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pmaxub(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pmaxub(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6028,7 +6062,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psllw(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psllw(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr5_0 = constructor_ishl_i8x16_mask(ctx, &expr4_0)?;
                             let expr6_0: Type = I8X16;
@@ -6047,7 +6081,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psrlw(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psrlw(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr5_0 = constructor_ushr_i8x16_mask(ctx, &expr4_0)?;
                             let expr6_0: Type = I8X16;
@@ -6066,16 +6100,16 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 749.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
-                            let expr2_0 = constructor_punpcklbw(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_punpcklbw(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
-                            let expr4_0 = constructor_punpckhbw(ctx, expr0_0, &expr3_0)?;
+                            let expr4_0 = constructor_x64_punpckhbw(ctx, expr0_0, &expr3_0)?;
                             let expr5_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr6_0 =
                                 constructor_sshr_i8x16_bigger_shift(ctx, pattern8_0, &expr5_0)?;
-                            let expr7_0 = constructor_psraw(ctx, expr2_0, &expr6_0)?;
-                            let expr8_0 = constructor_psraw(ctx, expr4_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_psraw(ctx, expr2_0, &expr6_0)?;
+                            let expr8_0 = constructor_x64_psraw(ctx, expr4_0, &expr6_0)?;
                             let expr9_0 = C::xmm_to_xmm_mem(ctx, expr8_0);
-                            let expr10_0 = constructor_packsswb(ctx, expr7_0, &expr9_0)?;
+                            let expr10_0 = constructor_x64_packsswb(ctx, expr7_0, &expr9_0)?;
                             let expr11_0 = constructor_output_xmm(ctx, expr10_0)?;
                             return Some(expr11_0);
                         }
@@ -6094,14 +6128,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
-                            let expr5_0 = constructor_psubb(ctx, expr3_0, &expr4_0)?;
+                            let expr5_0 = constructor_x64_psubb(ctx, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
                             // Rule at src/isa/x64/lower.isle line 1210.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
-                            let expr1_0 = constructor_pabsb(ctx, &expr0_0)?;
+                            let expr1_0 = constructor_x64_pabsb(ctx, &expr0_0)?;
                             let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
@@ -6110,7 +6144,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = C::popcount_4bit_table(ctx);
                             let expr1_0: Type = I8X16;
                             let expr2_0 = C::popcount_low_mask(ctx);
-                            let expr3_0 = constructor_xmm_load_const(ctx, expr1_0, expr2_0)?;
+                            let expr3_0 = constructor_x64_xmm_load_const(ctx, expr1_0, expr2_0)?;
                             let expr4_0: Type = I8X16;
                             let expr5_0 = constructor_put_in_xmm(ctx, pattern5_1)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
@@ -6119,19 +6153,19 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr9_0: u32 = 4;
                             let expr10_0 = RegMemImm::Imm { simm32: expr9_0 };
                             let expr11_0 = constructor_mov_rmi_to_xmm(ctx, &expr10_0)?;
-                            let expr12_0 = constructor_psrlw(ctx, expr8_0, &expr11_0)?;
+                            let expr12_0 = constructor_x64_psrlw(ctx, expr8_0, &expr11_0)?;
                             let expr13_0: Type = I8X16;
                             let expr14_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
                             let expr15_0 = constructor_sse_and(ctx, expr13_0, expr12_0, &expr14_0)?;
                             let expr16_0: Type = I8X16;
                             let expr17_0 = C::popcount_4bit_table(ctx);
-                            let expr18_0 = constructor_xmm_load_const(ctx, expr16_0, expr17_0)?;
+                            let expr18_0 = constructor_x64_xmm_load_const(ctx, expr16_0, expr17_0)?;
                             let expr19_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                            let expr20_0 = constructor_pshufb(ctx, expr18_0, &expr19_0)?;
+                            let expr20_0 = constructor_x64_pshufb(ctx, expr18_0, &expr19_0)?;
                             let expr21_0 = C::xmm_to_xmm_mem(ctx, expr15_0);
-                            let expr22_0 = constructor_pshufb(ctx, expr18_0, &expr21_0)?;
+                            let expr22_0 = constructor_x64_pshufb(ctx, expr18_0, &expr21_0)?;
                             let expr23_0 = C::xmm_to_xmm_mem(ctx, expr22_0);
-                            let expr24_0 = constructor_paddb(ctx, expr20_0, &expr23_0)?;
+                            let expr24_0 = constructor_x64_paddb(ctx, expr20_0, &expr23_0)?;
                             let expr25_0 = constructor_output_xmm(ctx, expr24_0)?;
                             return Some(expr25_0);
                         }
@@ -6154,7 +6188,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1405.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pminsw(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pminsw(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6163,7 +6197,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1427.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pminuw(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pminuw(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6172,7 +6206,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1394.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pmaxsw(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pmaxsw(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6181,7 +6215,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1416.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pmaxuw(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pmaxuw(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6191,7 +6225,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psllw(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psllw(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6201,7 +6235,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psrlw(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psrlw(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6211,7 +6245,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psraw(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psraw(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6230,14 +6264,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
-                            let expr5_0 = constructor_psubw(ctx, expr3_0, &expr4_0)?;
+                            let expr5_0 = constructor_x64_psubw(ctx, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
                             // Rule at src/isa/x64/lower.isle line 1213.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
-                            let expr1_0 = constructor_pabsw(ctx, &expr0_0)?;
+                            let expr1_0 = constructor_x64_pabsw(ctx, &expr0_0)?;
                             let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
@@ -6260,7 +6294,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1408.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pminsd(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pminsd(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6269,7 +6303,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1430.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pminud(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pminud(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6278,7 +6312,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1397.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pmaxsd(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pmaxsd(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6287,7 +6321,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 1419.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pmaxud(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pmaxud(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6297,7 +6331,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_pslld(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_pslld(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6307,7 +6341,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psrld(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psrld(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6317,7 +6351,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psrad(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psrad(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6326,7 +6360,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2113.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_pmaddwd(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_pmaddwd(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6345,14 +6379,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
-                            let expr5_0 = constructor_psubd(ctx, expr3_0, &expr4_0)?;
+                            let expr5_0 = constructor_x64_psubd(ctx, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
                         &Opcode::Iabs => {
                             // Rule at src/isa/x64/lower.isle line 1216.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
-                            let expr1_0 = constructor_pabsd(ctx, &expr0_0)?;
+                            let expr1_0 = constructor_x64_pabsd(ctx, &expr0_0)?;
                             let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
@@ -6376,7 +6410,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psllq(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psllq(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6386,7 +6420,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = C::put_in_reg_mem_imm(ctx, pattern7_1);
                             let expr2_0 = constructor_mov_rmi_to_xmm(ctx, &expr1_0)?;
-                            let expr3_0 = constructor_psrlq(ctx, expr0_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_psrlq(ctx, expr0_0, &expr2_0)?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -6396,16 +6430,16 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0: Type = I64;
                             let expr2_0: u8 = 0;
-                            let expr3_0 = constructor_pextrd(ctx, expr1_0, expr0_0, expr2_0)?;
+                            let expr3_0 = constructor_x64_pextrd(ctx, expr1_0, expr0_0, expr2_0)?;
                             let expr4_0: Type = I64;
                             let expr5_0: u8 = 1;
-                            let expr6_0 = constructor_pextrd(ctx, expr4_0, expr0_0, expr5_0)?;
+                            let expr6_0 = constructor_x64_pextrd(ctx, expr4_0, expr0_0, expr5_0)?;
                             let expr7_0: Type = I64;
                             let expr8_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, expr7_0);
                             let expr9_0: Type = I64;
-                            let expr10_0 = constructor_sar(ctx, expr9_0, expr3_0, &expr8_0)?;
+                            let expr10_0 = constructor_x64_sar(ctx, expr9_0, expr3_0, &expr8_0)?;
                             let expr11_0: Type = I64;
-                            let expr12_0 = constructor_sar(ctx, expr11_0, expr6_0, &expr8_0)?;
+                            let expr12_0 = constructor_x64_sar(ctx, expr11_0, expr6_0, &expr8_0)?;
                             let expr13_0 = C::gpr_to_gpr_mem(ctx, expr10_0);
                             let expr14_0 = C::gpr_to_gpr_mem(ctx, expr12_0);
                             let expr15_0 =
@@ -6428,7 +6462,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr2_0 = constructor_imm(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = C::xmm_new(ctx, expr2_0);
                             let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern5_1)?;
-                            let expr5_0 = constructor_psubq(ctx, expr3_0, &expr4_0)?;
+                            let expr5_0 = constructor_x64_psubq(ctx, expr3_0, &expr4_0)?;
                             let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                             return Some(expr6_0);
                         }
@@ -6440,9 +6474,10 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr3_0 = constructor_imm(ctx, expr1_0, expr2_0)?;
                             let expr4_0 = C::xmm_new(ctx, expr3_0);
                             let expr5_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
-                            let expr6_0 = constructor_psubq(ctx, expr4_0, &expr5_0)?;
+                            let expr6_0 = constructor_x64_psubq(ctx, expr4_0, &expr5_0)?;
                             let expr7_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
-                            let expr8_0 = constructor_blendvpd(ctx, expr6_0, &expr7_0, expr6_0)?;
+                            let expr8_0 =
+                                constructor_x64_blendvpd(ctx, expr6_0, &expr7_0, expr6_0)?;
                             let expr9_0 = constructor_output_xmm(ctx, expr8_0)?;
                             return Some(expr9_0);
                         }
@@ -6465,7 +6500,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2127.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_addps(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_addps(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6474,7 +6509,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2138.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_subps(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_subps(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6483,7 +6518,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2149.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_mulps(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_mulps(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6492,7 +6527,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2160.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_divps(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_divps(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6501,23 +6536,23 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2184.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_minps(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_minps(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr4_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr5_0 = constructor_minps(ctx, expr3_0, expr4_0)?;
+                            let expr5_0 = constructor_x64_minps(ctx, expr3_0, expr4_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_orps(ctx, expr2_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_orps(ctx, expr2_0, &expr6_0)?;
                             let expr8_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
                             let expr9_0 = FcmpImm::Unordered;
-                            let expr10_0 = constructor_cmpps(ctx, expr7_0, &expr8_0, &expr9_0)?;
+                            let expr10_0 = constructor_x64_cmpps(ctx, expr7_0, &expr8_0, &expr9_0)?;
                             let expr11_0 = C::xmm_to_xmm_mem(ctx, expr10_0);
-                            let expr12_0 = constructor_orps(ctx, expr7_0, &expr11_0)?;
+                            let expr12_0 = constructor_x64_orps(ctx, expr7_0, &expr11_0)?;
                             let expr13_0: u32 = 10;
                             let expr14_0 = RegMemImm::Imm { simm32: expr13_0 };
                             let expr15_0 = constructor_mov_rmi_to_xmm(ctx, &expr14_0)?;
-                            let expr16_0 = constructor_psrld(ctx, expr10_0, &expr15_0)?;
+                            let expr16_0 = constructor_x64_psrld(ctx, expr10_0, &expr15_0)?;
                             let expr17_0 = C::xmm_to_xmm_mem(ctx, expr12_0);
-                            let expr18_0 = constructor_andnps(ctx, expr16_0, &expr17_0)?;
+                            let expr18_0 = constructor_x64_andnps(ctx, expr16_0, &expr17_0)?;
                             let expr19_0 = constructor_output_xmm(ctx, expr18_0)?;
                             return Some(expr19_0);
                         }
@@ -6526,7 +6561,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2340.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr2_0 = constructor_minps(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_minps(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6535,25 +6570,26 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2247.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_maxps(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_maxps(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr4_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr5_0 = constructor_maxps(ctx, expr3_0, expr4_0)?;
+                            let expr5_0 = constructor_x64_maxps(ctx, expr3_0, expr4_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_xorps(ctx, expr2_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_xorps(ctx, expr2_0, &expr6_0)?;
                             let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                            let expr9_0 = constructor_orps(ctx, expr2_0, &expr8_0)?;
+                            let expr9_0 = constructor_x64_orps(ctx, expr2_0, &expr8_0)?;
                             let expr10_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                            let expr11_0 = constructor_subps(ctx, expr9_0, &expr10_0)?;
+                            let expr11_0 = constructor_x64_subps(ctx, expr9_0, &expr10_0)?;
                             let expr12_0 = C::xmm_to_xmm_mem(ctx, expr9_0);
                             let expr13_0 = FcmpImm::Unordered;
-                            let expr14_0 = constructor_cmpps(ctx, expr9_0, &expr12_0, &expr13_0)?;
+                            let expr14_0 =
+                                constructor_x64_cmpps(ctx, expr9_0, &expr12_0, &expr13_0)?;
                             let expr15_0: u32 = 10;
                             let expr16_0 = RegMemImm::Imm { simm32: expr15_0 };
                             let expr17_0 = constructor_mov_rmi_to_xmm(ctx, &expr16_0)?;
-                            let expr18_0 = constructor_psrld(ctx, expr14_0, &expr17_0)?;
+                            let expr18_0 = constructor_x64_psrld(ctx, expr14_0, &expr17_0)?;
                             let expr19_0 = C::xmm_to_xmm_mem(ctx, expr11_0);
-                            let expr20_0 = constructor_andnps(ctx, expr18_0, &expr19_0)?;
+                            let expr20_0 = constructor_x64_andnps(ctx, expr18_0, &expr19_0)?;
                             let expr21_0 = constructor_output_xmm(ctx, expr20_0)?;
                             return Some(expr21_0);
                         }
@@ -6562,7 +6598,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2351.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr2_0 = constructor_maxps(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_maxps(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6581,9 +6617,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         let expr3_0: u32 = 1;
                         let expr4_0 = RegMemImm::Imm { simm32: expr3_0 };
                         let expr5_0 = constructor_mov_rmi_to_xmm(ctx, &expr4_0)?;
-                        let expr6_0 = constructor_psrld(ctx, expr2_0, &expr5_0)?;
+                        let expr6_0 = constructor_x64_psrld(ctx, expr2_0, &expr5_0)?;
                         let expr7_0 = C::xmm_to_xmm_mem(ctx, expr6_0);
-                        let expr8_0 = constructor_andps(ctx, expr0_0, &expr7_0)?;
+                        let expr8_0 = constructor_x64_andps(ctx, expr0_0, &expr7_0)?;
                         let expr9_0 = constructor_output_xmm(ctx, expr8_0)?;
                         return Some(expr9_0);
                     }
@@ -6604,7 +6640,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2129.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_addpd(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_addpd(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6613,7 +6649,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2140.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_subpd(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_subpd(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6622,7 +6658,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2151.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_mulpd(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_mulpd(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6631,7 +6667,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2162.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_divpd(ctx, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_divpd(ctx, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6640,23 +6676,23 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2227.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_minpd(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_minpd(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr4_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr5_0 = constructor_minpd(ctx, expr3_0, expr4_0)?;
+                            let expr5_0 = constructor_x64_minpd(ctx, expr3_0, expr4_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_orpd(ctx, expr2_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_orpd(ctx, expr2_0, &expr6_0)?;
                             let expr8_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
                             let expr9_0 = FcmpImm::Unordered;
-                            let expr10_0 = constructor_cmppd(ctx, expr2_0, &expr8_0, &expr9_0)?;
+                            let expr10_0 = constructor_x64_cmppd(ctx, expr2_0, &expr8_0, &expr9_0)?;
                             let expr11_0 = C::xmm_to_xmm_mem(ctx, expr10_0);
-                            let expr12_0 = constructor_orpd(ctx, expr7_0, &expr11_0)?;
+                            let expr12_0 = constructor_x64_orpd(ctx, expr7_0, &expr11_0)?;
                             let expr13_0: u32 = 13;
                             let expr14_0 = RegMemImm::Imm { simm32: expr13_0 };
                             let expr15_0 = constructor_mov_rmi_to_xmm(ctx, &expr14_0)?;
-                            let expr16_0 = constructor_psrlq(ctx, expr10_0, &expr15_0)?;
+                            let expr16_0 = constructor_x64_psrlq(ctx, expr10_0, &expr15_0)?;
                             let expr17_0 = C::xmm_to_xmm_mem(ctx, expr12_0);
-                            let expr18_0 = constructor_andnpd(ctx, expr16_0, &expr17_0)?;
+                            let expr18_0 = constructor_x64_andnpd(ctx, expr16_0, &expr17_0)?;
                             let expr19_0 = constructor_output_xmm(ctx, expr18_0)?;
                             return Some(expr19_0);
                         }
@@ -6665,7 +6701,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2342.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr2_0 = constructor_minpd(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_minpd(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6674,25 +6710,26 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2290.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_maxpd(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_maxpd(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr4_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr5_0 = constructor_maxpd(ctx, expr3_0, expr4_0)?;
+                            let expr5_0 = constructor_x64_maxpd(ctx, expr3_0, expr4_0)?;
                             let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                            let expr7_0 = constructor_xorpd(ctx, expr2_0, &expr6_0)?;
+                            let expr7_0 = constructor_x64_xorpd(ctx, expr2_0, &expr6_0)?;
                             let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                            let expr9_0 = constructor_orpd(ctx, expr2_0, &expr8_0)?;
+                            let expr9_0 = constructor_x64_orpd(ctx, expr2_0, &expr8_0)?;
                             let expr10_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                            let expr11_0 = constructor_subpd(ctx, expr9_0, &expr10_0)?;
+                            let expr11_0 = constructor_x64_subpd(ctx, expr9_0, &expr10_0)?;
                             let expr12_0 = C::xmm_to_xmm_mem(ctx, expr9_0);
                             let expr13_0 = FcmpImm::Unordered;
-                            let expr14_0 = constructor_cmppd(ctx, expr9_0, &expr12_0, &expr13_0)?;
+                            let expr14_0 =
+                                constructor_x64_cmppd(ctx, expr9_0, &expr12_0, &expr13_0)?;
                             let expr15_0: u32 = 13;
                             let expr16_0 = RegMemImm::Imm { simm32: expr15_0 };
                             let expr17_0 = constructor_mov_rmi_to_xmm(ctx, &expr16_0)?;
-                            let expr18_0 = constructor_psrlq(ctx, expr14_0, &expr17_0)?;
+                            let expr18_0 = constructor_x64_psrlq(ctx, expr14_0, &expr17_0)?;
                             let expr19_0 = C::xmm_to_xmm_mem(ctx, expr11_0);
-                            let expr20_0 = constructor_andnpd(ctx, expr18_0, &expr19_0)?;
+                            let expr20_0 = constructor_x64_andnpd(ctx, expr18_0, &expr19_0)?;
                             let expr21_0 = constructor_output_xmm(ctx, expr20_0)?;
                             return Some(expr21_0);
                         }
@@ -6701,7 +6738,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 2353.
                             let expr0_0 = constructor_put_in_xmm(ctx, pattern7_1)?;
                             let expr1_0 = constructor_put_in_xmm(ctx, pattern7_0)?;
-                            let expr2_0 = constructor_maxpd(ctx, expr0_0, expr1_0)?;
+                            let expr2_0 = constructor_x64_maxpd(ctx, expr0_0, expr1_0)?;
                             let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -6720,9 +6757,9 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         let expr3_0: u32 = 1;
                         let expr4_0 = RegMemImm::Imm { simm32: expr3_0 };
                         let expr5_0 = constructor_mov_rmi_to_xmm(ctx, &expr4_0)?;
-                        let expr6_0 = constructor_psrlq(ctx, expr2_0, &expr5_0)?;
+                        let expr6_0 = constructor_x64_psrlq(ctx, expr2_0, &expr5_0)?;
                         let expr7_0 = C::xmm_to_xmm_mem(ctx, expr6_0);
-                        let expr8_0 = constructor_andpd(ctx, expr0_0, &expr7_0)?;
+                        let expr8_0 = constructor_x64_andpd(ctx, expr0_0, &expr7_0)?;
                         let expr9_0 = constructor_output_xmm(ctx, expr8_0)?;
                         return Some(expr9_0);
                     }
@@ -6779,7 +6816,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::Equal => {
                                         // Rule at src/isa/x64/lower.isle line 1626.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
+                                            constructor_x64_ucomis(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NZ;
                                         let expr2_0 = CC::P;
                                         let expr3_0 = constructor_cmove_or_from_values(
@@ -6794,7 +6831,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::GreaterThan => {
                                         // Rule at src/isa/x64/lower.isle line 1578.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
+                                            constructor_x64_ucomis(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NBE;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6807,7 +6844,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::GreaterThanOrEqual => {
                                         // Rule at src/isa/x64/lower.isle line 1581.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
+                                            constructor_x64_ucomis(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NB;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6820,7 +6857,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::LessThan => {
                                         // Rule at src/isa/x64/lower.isle line 1601.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
+                                            constructor_x64_ucomis(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NBE;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6833,7 +6870,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::LessThanOrEqual => {
                                         // Rule at src/isa/x64/lower.isle line 1604.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
+                                            constructor_x64_ucomis(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NB;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6846,7 +6883,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::NotEqual => {
                                         // Rule at src/isa/x64/lower.isle line 1629.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
+                                            constructor_x64_ucomis(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::NZ;
                                         let expr2_0 = CC::P;
                                         let expr3_0 = constructor_cmove_or_from_values(
@@ -6861,7 +6898,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::Ordered => {
                                         // Rule at src/isa/x64/lower.isle line 1572.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
+                                            constructor_x64_ucomis(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::NP;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6874,7 +6911,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::Unordered => {
                                         // Rule at src/isa/x64/lower.isle line 1575.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
+                                            constructor_x64_ucomis(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::P;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6887,7 +6924,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::UnorderedOrGreaterThan => {
                                         // Rule at src/isa/x64/lower.isle line 1607.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
+                                            constructor_x64_ucomis(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::B;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6900,7 +6937,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::UnorderedOrGreaterThanOrEqual => {
                                         // Rule at src/isa/x64/lower.isle line 1610.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_0, pattern11_1)?;
+                                            constructor_x64_ucomis(ctx, pattern11_0, pattern11_1)?;
                                         let expr1_0 = CC::BE;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6913,7 +6950,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::UnorderedOrLessThan => {
                                         // Rule at src/isa/x64/lower.isle line 1584.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
+                                            constructor_x64_ucomis(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::B;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -6926,7 +6963,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     &FloatCC::UnorderedOrLessThanOrEqual => {
                                         // Rule at src/isa/x64/lower.isle line 1587.
                                         let expr0_0 =
-                                            constructor_fpcmp(ctx, pattern11_1, pattern11_0)?;
+                                            constructor_x64_ucomis(ctx, pattern11_1, pattern11_0)?;
                                         let expr1_0 = CC::BE;
                                         let expr2_0 = constructor_cmove_from_values(
                                             ctx, pattern2_0, &expr1_0, pattern6_1, pattern6_2,
@@ -7008,7 +7045,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     // Rule at src/isa/x64/lower.isle line 992.
                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern11_0)?;
                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern11_1)?;
-                                    let expr2_0 = constructor_vpmullq(ctx, &expr0_0, expr1_0)?;
+                                    let expr2_0 = constructor_x64_vpmullq(ctx, &expr0_0, expr1_0)?;
                                     let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                     return Some(expr3_0);
                                 }
@@ -7028,7 +7065,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         if let &Opcode::Iabs = pattern7_0 {
                             // Rule at src/isa/x64/lower.isle line 1220.
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
-                            let expr1_0 = constructor_vpabsq(ctx, &expr0_0)?;
+                            let expr1_0 = constructor_x64_vpabsq(ctx, &expr0_0)?;
                             let expr2_0 = constructor_output_xmm(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
@@ -7052,7 +7089,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 903.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_pavgb(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_pavgb(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7062,7 +7099,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 136.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddusb(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddusb(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7072,7 +7109,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 126.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddsb(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddsb(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7082,7 +7119,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 282.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubusb(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubusb(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7092,7 +7129,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 272.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubsb(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubsb(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7102,7 +7139,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 94.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddb(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddb(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7112,7 +7149,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 240.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubb(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubb(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7136,7 +7173,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 907.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_pavgw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_pavgw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7146,7 +7183,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 140.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddusw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddusw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7156,7 +7193,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 130.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddsw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddsw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7166,7 +7203,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 286.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubusw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubusw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7176,7 +7213,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 276.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubsw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubsw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7186,7 +7223,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 98.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7196,7 +7233,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 244.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7248,11 +7285,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                 {
                                                                                     // Rule at src/isa/x64/lower.isle line 1080.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
-                                                                                    let expr1_0 = constructor_pmovsxbw(ctx, &expr0_0)?;
+                                                                                    let expr1_0 = constructor_x64_pmovsxbw(ctx, &expr0_0)?;
                                                                                     let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
-                                                                                    let expr3_0 = constructor_pmovsxbw(ctx, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pmovsxbw(ctx, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
-                                                                                    let expr5_0 = constructor_pmullw(ctx, expr1_0, &expr4_0)?;
+                                                                                    let expr5_0 = constructor_x64_pmullw(ctx, expr1_0, &expr4_0)?;
                                                                                     let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                                                                                     return Some(
                                                                                         expr6_0,
@@ -7307,18 +7344,18 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                                                                                     let expr2_0: u8 = 8;
                                                                                     let expr3_0 = OperandSize::Size32;
-                                                                                    let expr4_0 = constructor_palignr(ctx, expr0_0, &expr1_0, expr2_0, &expr3_0)?;
+                                                                                    let expr4_0 = constructor_x64_palignr(ctx, expr0_0, &expr1_0, expr2_0, &expr3_0)?;
                                                                                     let expr5_0 = C::xmm_to_xmm_mem(ctx, expr4_0);
-                                                                                    let expr6_0 = constructor_pmovsxbw(ctx, &expr5_0)?;
+                                                                                    let expr6_0 = constructor_x64_pmovsxbw(ctx, &expr5_0)?;
                                                                                     let expr7_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
                                                                                     let expr9_0: u8 = 8;
                                                                                     let expr10_0 = OperandSize::Size32;
-                                                                                    let expr11_0 = constructor_palignr(ctx, expr7_0, &expr8_0, expr9_0, &expr10_0)?;
+                                                                                    let expr11_0 = constructor_x64_palignr(ctx, expr7_0, &expr8_0, expr9_0, &expr10_0)?;
                                                                                     let expr12_0 = C::xmm_to_xmm_mem(ctx, expr11_0);
-                                                                                    let expr13_0 = constructor_pmovsxbw(ctx, &expr12_0)?;
+                                                                                    let expr13_0 = constructor_x64_pmovsxbw(ctx, &expr12_0)?;
                                                                                     let expr14_0 = C::xmm_to_xmm_mem(ctx, expr13_0);
-                                                                                    let expr15_0 = constructor_pmullw(ctx, expr6_0, &expr14_0)?;
+                                                                                    let expr15_0 = constructor_x64_pmullw(ctx, expr6_0, &expr14_0)?;
                                                                                     let expr16_0 = constructor_output_xmm(ctx, expr15_0)?;
                                                                                     return Some(
                                                                                         expr16_0,
@@ -7370,11 +7407,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                 {
                                                                                     // Rule at src/isa/x64/lower.isle line 1156.
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
-                                                                                    let expr1_0 = constructor_pmovzxbw(ctx, &expr0_0)?;
+                                                                                    let expr1_0 = constructor_x64_pmovzxbw(ctx, &expr0_0)?;
                                                                                     let expr2_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
-                                                                                    let expr3_0 = constructor_pmovzxbw(ctx, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pmovzxbw(ctx, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr3_0);
-                                                                                    let expr5_0 = constructor_pmullw(ctx, expr1_0, &expr4_0)?;
+                                                                                    let expr5_0 = constructor_x64_pmullw(ctx, expr1_0, &expr4_0)?;
                                                                                     let expr6_0 = constructor_output_xmm(ctx, expr5_0)?;
                                                                                     return Some(
                                                                                         expr6_0,
@@ -7429,18 +7466,18 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr1_0 = C::xmm_to_xmm_mem(ctx, expr0_0);
                                                                                     let expr2_0: u8 = 8;
                                                                                     let expr3_0 = OperandSize::Size32;
-                                                                                    let expr4_0 = constructor_palignr(ctx, expr0_0, &expr1_0, expr2_0, &expr3_0)?;
+                                                                                    let expr4_0 = constructor_x64_palignr(ctx, expr0_0, &expr1_0, expr2_0, &expr3_0)?;
                                                                                     let expr5_0 = C::xmm_to_xmm_mem(ctx, expr4_0);
-                                                                                    let expr6_0 = constructor_pmovzxbw(ctx, &expr5_0)?;
+                                                                                    let expr6_0 = constructor_x64_pmovzxbw(ctx, &expr5_0)?;
                                                                                     let expr7_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
                                                                                     let expr9_0: u8 = 8;
                                                                                     let expr10_0 = OperandSize::Size32;
-                                                                                    let expr11_0 = constructor_palignr(ctx, expr7_0, &expr8_0, expr9_0, &expr10_0)?;
+                                                                                    let expr11_0 = constructor_x64_palignr(ctx, expr7_0, &expr8_0, expr9_0, &expr10_0)?;
                                                                                     let expr12_0 = C::xmm_to_xmm_mem(ctx, expr11_0);
-                                                                                    let expr13_0 = constructor_pmovzxbw(ctx, &expr12_0)?;
+                                                                                    let expr13_0 = constructor_x64_pmovzxbw(ctx, &expr12_0)?;
                                                                                     let expr14_0 = C::xmm_to_xmm_mem(ctx, expr13_0);
-                                                                                    let expr15_0 = constructor_pmullw(ctx, expr6_0, &expr14_0)?;
+                                                                                    let expr15_0 = constructor_x64_pmullw(ctx, expr6_0, &expr14_0)?;
                                                                                     let expr16_0 = constructor_output_xmm(ctx, expr15_0)?;
                                                                                     return Some(
                                                                                         expr16_0,
@@ -7462,7 +7499,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 984.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_pmullw(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_pmullw(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7486,7 +7523,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 102.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddd(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddd(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7496,7 +7533,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 248.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubd(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubd(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7550,11 +7587,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr3_0 = constructor_pmullw(ctx, expr0_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pmullw(ctx, expr0_0, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr5_0 = constructor_pmulhw(ctx, expr0_0, &expr4_0)?;
+                                                                                    let expr5_0 = constructor_x64_pmulhw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                                                                                    let expr7_0 = constructor_punpcklwd(ctx, expr3_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_punpcklwd(ctx, expr3_0, &expr6_0)?;
                                                                                     let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
@@ -7608,11 +7645,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr3_0 = constructor_pmullw(ctx, expr0_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pmullw(ctx, expr0_0, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr5_0 = constructor_pmulhw(ctx, expr0_0, &expr4_0)?;
+                                                                                    let expr5_0 = constructor_x64_pmulhw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                                                                                    let expr7_0 = constructor_punpckhwd(ctx, expr3_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_punpckhwd(ctx, expr3_0, &expr6_0)?;
                                                                                     let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
@@ -7666,11 +7703,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr3_0 = constructor_pmullw(ctx, expr0_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pmullw(ctx, expr0_0, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr5_0 = constructor_pmulhuw(ctx, expr0_0, &expr4_0)?;
+                                                                                    let expr5_0 = constructor_x64_pmulhuw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                                                                                    let expr7_0 = constructor_punpcklwd(ctx, expr3_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_punpcklwd(ctx, expr3_0, &expr6_0)?;
                                                                                     let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
@@ -7724,11 +7761,11 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm(ctx, pattern12_1)?;
                                                                                     let expr1_0 = constructor_put_in_xmm(ctx, pattern20_1)?;
                                                                                     let expr2_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr3_0 = constructor_pmullw(ctx, expr0_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pmullw(ctx, expr0_0, &expr2_0)?;
                                                                                     let expr4_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                                                                    let expr5_0 = constructor_pmulhuw(ctx, expr0_0, &expr4_0)?;
+                                                                                    let expr5_0 = constructor_x64_pmulhuw(ctx, expr0_0, &expr4_0)?;
                                                                                     let expr6_0 = C::xmm_to_xmm_mem(ctx, expr5_0);
-                                                                                    let expr7_0 = constructor_punpckhwd(ctx, expr3_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_punpckhwd(ctx, expr3_0, &expr6_0)?;
                                                                                     let expr8_0 = constructor_output_xmm(ctx, expr7_0)?;
                                                                                     return Some(
                                                                                         expr8_0,
@@ -7750,7 +7787,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 987.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_pmulld(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_pmulld(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7774,7 +7811,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 106.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_paddq(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_paddq(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7784,7 +7821,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 252.
                                 let expr0_0 = constructor_put_in_xmm(ctx, pattern9_0)?;
                                 let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern9_1)?;
-                                let expr2_0 = constructor_psubq(ctx, expr0_0, &expr1_0)?;
+                                let expr2_0 = constructor_x64_psubq(ctx, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_xmm(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -7838,13 +7875,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 80;
                                                                                     let expr2_0 = OperandSize::Size32;
-                                                                                    let expr3_0 = constructor_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
                                                                                     let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
                                                                                     let expr5_0: u8 = 80;
                                                                                     let expr6_0 = OperandSize::Size32;
-                                                                                    let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                                                                                    let expr9_0 = constructor_pmuldq(ctx, expr3_0, &expr8_0)?;
+                                                                                    let expr9_0 = constructor_x64_pmuldq(ctx, expr3_0, &expr8_0)?;
                                                                                     let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
@@ -7898,13 +7935,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 250;
                                                                                     let expr2_0 = OperandSize::Size32;
-                                                                                    let expr3_0 = constructor_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
                                                                                     let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
                                                                                     let expr5_0: u8 = 250;
                                                                                     let expr6_0 = OperandSize::Size32;
-                                                                                    let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                                                                                    let expr9_0 = constructor_pmuldq(ctx, expr3_0, &expr8_0)?;
+                                                                                    let expr9_0 = constructor_x64_pmuldq(ctx, expr3_0, &expr8_0)?;
                                                                                     let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
@@ -7958,13 +7995,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 80;
                                                                                     let expr2_0 = OperandSize::Size32;
-                                                                                    let expr3_0 = constructor_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
                                                                                     let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
                                                                                     let expr5_0: u8 = 80;
                                                                                     let expr6_0 = OperandSize::Size32;
-                                                                                    let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                                                                                    let expr9_0 = constructor_pmuludq(ctx, expr3_0, &expr8_0)?;
+                                                                                    let expr9_0 = constructor_x64_pmuludq(ctx, expr3_0, &expr8_0)?;
                                                                                     let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
@@ -8018,13 +8055,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                                     let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern12_1)?;
                                                                                     let expr1_0: u8 = 250;
                                                                                     let expr2_0 = OperandSize::Size32;
-                                                                                    let expr3_0 = constructor_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
+                                                                                    let expr3_0 = constructor_x64_pshufd(ctx, &expr0_0, expr1_0, &expr2_0)?;
                                                                                     let expr4_0 = constructor_put_in_xmm_mem(ctx, pattern20_1)?;
                                                                                     let expr5_0: u8 = 250;
                                                                                     let expr6_0 = OperandSize::Size32;
-                                                                                    let expr7_0 = constructor_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
+                                                                                    let expr7_0 = constructor_x64_pshufd(ctx, &expr4_0, expr5_0, &expr6_0)?;
                                                                                     let expr8_0 = C::xmm_to_xmm_mem(ctx, expr7_0);
-                                                                                    let expr9_0 = constructor_pmuludq(ctx, expr3_0, &expr8_0)?;
+                                                                                    let expr9_0 = constructor_x64_pmuludq(ctx, expr3_0, &expr8_0)?;
                                                                                     let expr10_0 = constructor_output_xmm(ctx, expr9_0)?;
                                                                                     return Some(
                                                                                         expr10_0,
@@ -8049,25 +8086,25 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr2_0: u32 = 32;
                                 let expr3_0 = RegMemImm::Imm { simm32: expr2_0 };
                                 let expr4_0 = constructor_mov_rmi_to_xmm(ctx, &expr3_0)?;
-                                let expr5_0 = constructor_psrlq(ctx, expr0_0, &expr4_0)?;
+                                let expr5_0 = constructor_x64_psrlq(ctx, expr0_0, &expr4_0)?;
                                 let expr6_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                let expr7_0 = constructor_pmuludq(ctx, expr5_0, &expr6_0)?;
+                                let expr7_0 = constructor_x64_pmuludq(ctx, expr5_0, &expr6_0)?;
                                 let expr8_0: u32 = 32;
                                 let expr9_0 = RegMemImm::Imm { simm32: expr8_0 };
                                 let expr10_0 = constructor_mov_rmi_to_xmm(ctx, &expr9_0)?;
-                                let expr11_0 = constructor_psrlq(ctx, expr1_0, &expr10_0)?;
+                                let expr11_0 = constructor_x64_psrlq(ctx, expr1_0, &expr10_0)?;
                                 let expr12_0 = C::xmm_to_xmm_mem(ctx, expr11_0);
-                                let expr13_0 = constructor_pmuludq(ctx, expr0_0, &expr12_0)?;
+                                let expr13_0 = constructor_x64_pmuludq(ctx, expr0_0, &expr12_0)?;
                                 let expr14_0 = C::xmm_to_xmm_mem(ctx, expr13_0);
-                                let expr15_0 = constructor_paddq(ctx, expr7_0, &expr14_0)?;
+                                let expr15_0 = constructor_x64_paddq(ctx, expr7_0, &expr14_0)?;
                                 let expr16_0: u32 = 32;
                                 let expr17_0 = RegMemImm::Imm { simm32: expr16_0 };
                                 let expr18_0 = constructor_mov_rmi_to_xmm(ctx, &expr17_0)?;
-                                let expr19_0 = constructor_psllq(ctx, expr15_0, &expr18_0)?;
+                                let expr19_0 = constructor_x64_psllq(ctx, expr15_0, &expr18_0)?;
                                 let expr20_0 = C::xmm_to_xmm_mem(ctx, expr1_0);
-                                let expr21_0 = constructor_pmuludq(ctx, expr0_0, &expr20_0)?;
+                                let expr21_0 = constructor_x64_pmuludq(ctx, expr0_0, &expr20_0)?;
                                 let expr22_0 = C::xmm_to_xmm_mem(ctx, expr19_0);
-                                let expr23_0 = constructor_paddq(ctx, expr21_0, &expr22_0)?;
+                                let expr23_0 = constructor_x64_paddq(ctx, expr21_0, &expr22_0)?;
                                 let expr24_0 = constructor_output_xmm(ctx, expr23_0)?;
                                 return Some(expr24_0);
                             }
@@ -8141,7 +8178,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr0_0 = constructor_put_in_xmm_mem(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_xmm_mem(ctx, pattern7_1)?;
                             let expr2_0 = constructor_put_in_xmm(ctx, pattern7_2)?;
-                            let expr3_0 = constructor_sse_blend(
+                            let expr3_0 = constructor_x64_blend(
                                 ctx, pattern2_0, &expr0_0, &expr1_0, expr2_0,
                             )?;
                             let expr4_0 = constructor_output_xmm(ctx, expr3_0)?;
@@ -8275,7 +8312,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 74.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
-                                    constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8284,7 +8321,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -8292,7 +8330,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 70.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
-                                    constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8301,14 +8339,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/x64/lower.isle line 64.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -8318,7 +8357,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 228.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
-                                    constructor_sub(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_sub(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8327,14 +8366,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_sub(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/x64/lower.isle line 223.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_sub(ctx, pattern3_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -8344,7 +8384,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 925.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
-                                    constructor_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8353,7 +8393,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -8361,7 +8402,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 921.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
-                                    constructor_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_mul(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8370,14 +8411,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/x64/lower.isle line 916.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_mul(ctx, pattern3_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -8387,7 +8429,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 171.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
-                                    constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = C::gpr_to_reg(ctx, expr1_0);
                                 let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                 return Some(expr3_0);
@@ -8397,7 +8439,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = C::gpr_to_reg(ctx, expr2_0);
                                 let expr4_0 = constructor_output_ifcout(ctx, expr3_0)?;
                                 return Some(expr4_0);
@@ -8406,7 +8449,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 167.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
-                                    constructor_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = C::gpr_to_reg(ctx, expr1_0);
                                 let expr3_0 = constructor_output_ifcout(ctx, expr2_0)?;
                                 return Some(expr3_0);
@@ -8416,7 +8459,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = C::gpr_to_reg(ctx, expr2_0);
                                 let expr4_0 = constructor_output_ifcout(ctx, expr3_0)?;
                                 return Some(expr4_0);
@@ -8424,7 +8468,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 161.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_add(ctx, pattern3_0, expr0_0, &expr1_0)?;
                             let expr3_0 = C::gpr_to_reg(ctx, expr2_0);
                             let expr4_0 = constructor_output_ifcout(ctx, expr3_0)?;
                             return Some(expr4_0);
@@ -8480,7 +8524,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 381.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
-                                    constructor_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8489,7 +8533,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -8497,7 +8542,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 377.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
-                                    constructor_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_or(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8506,14 +8551,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/x64/lower.isle line 360.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_or(ctx, pattern3_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -8523,7 +8569,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 447.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
-                                    constructor_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8532,7 +8578,8 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_1)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
@@ -8540,7 +8587,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 // Rule at src/isa/x64/lower.isle line 443.
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
-                                    constructor_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
+                                    constructor_x64_xor(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
@@ -8549,14 +8596,15 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                                 let expr1_0 =
                                     constructor_sink_load_to_gpr_mem_imm(ctx, &pattern8_0)?;
-                                let expr2_0 = constructor_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                                let expr2_0 =
+                                    constructor_x64_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
                                 let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                                 return Some(expr3_0);
                             }
                             // Rule at src/isa/x64/lower.isle line 426.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_in_gpr_mem_imm(ctx, pattern7_1)?;
-                            let expr2_0 = constructor_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_xor(ctx, pattern3_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -8565,7 +8613,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             // Rule at src/isa/x64/lower.isle line 483.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern7_0)?;
                             let expr1_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, pattern3_0);
-                            let expr2_0 = constructor_shl(ctx, pattern3_0, expr0_0, &expr1_0)?;
+                            let expr2_0 = constructor_x64_shl(ctx, pattern3_0, expr0_0, &expr1_0)?;
                             let expr3_0 = constructor_output_gpr(ctx, expr2_0)?;
                             return Some(expr3_0);
                         }
@@ -8576,7 +8624,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr1_0 =
                                 constructor_extend_to_gpr(ctx, pattern7_0, pattern3_0, &expr0_0)?;
                             let expr2_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, pattern3_0);
-                            let expr3_0 = constructor_shr(ctx, pattern3_0, expr1_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_shr(ctx, pattern3_0, expr1_0, &expr2_0)?;
                             let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -8587,7 +8635,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr1_0 =
                                 constructor_extend_to_gpr(ctx, pattern7_0, pattern3_0, &expr0_0)?;
                             let expr2_0 = C::put_masked_in_imm8_gpr(ctx, pattern7_1, pattern3_0);
-                            let expr3_0 = constructor_sar(ctx, pattern3_0, expr1_0, &expr2_0)?;
+                            let expr3_0 = constructor_x64_sar(ctx, pattern3_0, expr1_0, &expr2_0)?;
                             let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                             return Some(expr4_0);
                         }
@@ -8602,14 +8650,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         &Opcode::Ineg => {
                             // Rule at src/isa/x64/lower.isle line 884.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
-                            let expr1_0 = constructor_neg(ctx, pattern3_0, expr0_0)?;
+                            let expr1_0 = constructor_x64_neg(ctx, pattern3_0, expr0_0)?;
                             let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
                         &Opcode::Bnot => {
                             // Rule at src/isa/x64/lower.isle line 1253.
                             let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
-                            let expr1_0 = constructor_not(ctx, pattern3_0, expr0_0)?;
+                            let expr1_0 = constructor_x64_not(ctx, pattern3_0, expr0_0)?;
                             let expr2_0 = constructor_output_gpr(ctx, expr1_0)?;
                             return Some(expr2_0);
                         }
@@ -8653,7 +8701,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         let expr0_0 = constructor_put_in_gpr(ctx, pattern5_1)?;
                         let expr1_0 = constructor_imm(ctx, pattern3_0, pattern7_0)?;
                         let expr2_0 = constructor_reg_to_gpr_mem_imm(ctx, expr1_0)?;
-                        let expr3_0 = constructor_add(ctx, pattern3_0, expr0_0, &expr2_0)?;
+                        let expr3_0 = constructor_x64_add(ctx, pattern3_0, expr0_0, &expr2_0)?;
                         let expr4_0 = constructor_output_gpr(ctx, expr3_0)?;
                         return Some(expr4_0);
                     }
@@ -8927,21 +8975,21 @@ pub fn constructor_sse_and<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 324.
-        let expr0_0 = constructor_andps(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_andps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 325.
-        let expr0_0 = constructor_andpd(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_andpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 326.
-        let expr0_0 = constructor_pand(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_pand(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
@@ -8959,21 +9007,21 @@ pub fn constructor_sse_or<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 388.
-        let expr0_0 = constructor_orps(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_orps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 389.
-        let expr0_0 = constructor_orpd(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_orpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 390.
-        let expr0_0 = constructor_por(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_por(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
@@ -8998,10 +9046,10 @@ pub fn constructor_or_i128<C: Context>(
     let expr7_0 = constructor_value_regs_get_gpr(ctx, pattern1_0, expr6_0)?;
     let expr8_0: Type = I64;
     let expr9_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
-    let expr10_0 = constructor_or(ctx, expr8_0, expr1_0, &expr9_0)?;
+    let expr10_0 = constructor_x64_or(ctx, expr8_0, expr1_0, &expr9_0)?;
     let expr11_0: Type = I64;
     let expr12_0 = C::gpr_to_gpr_mem_imm(ctx, expr7_0);
-    let expr13_0 = constructor_or(ctx, expr11_0, expr3_0, &expr12_0)?;
+    let expr13_0 = constructor_x64_or(ctx, expr11_0, expr3_0, &expr12_0)?;
     let expr14_0 = constructor_value_gprs(ctx, expr10_0, expr13_0)?;
     return Some(expr14_0);
 }
@@ -9021,10 +9069,10 @@ pub fn constructor_shl_i128<C: Context>(
     let expr3_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr2_0)?;
     let expr4_0: Type = I64;
     let expr5_0 = C::gpr_to_imm8_gpr(ctx, pattern1_0);
-    let expr6_0 = constructor_shl(ctx, expr4_0, expr1_0, &expr5_0)?;
+    let expr6_0 = constructor_x64_shl(ctx, expr4_0, expr1_0, &expr5_0)?;
     let expr7_0: Type = I64;
     let expr8_0 = C::gpr_to_imm8_gpr(ctx, pattern1_0);
-    let expr9_0 = constructor_shl(ctx, expr7_0, expr3_0, &expr8_0)?;
+    let expr9_0 = constructor_x64_shl(ctx, expr7_0, expr3_0, &expr8_0)?;
     let expr10_0: Type = I64;
     let expr11_0: Type = I64;
     let expr12_0: Type = I64;
@@ -9032,9 +9080,9 @@ pub fn constructor_shl_i128<C: Context>(
     let expr14_0 = constructor_imm(ctx, expr12_0, expr13_0)?;
     let expr15_0 = C::gpr_new(ctx, expr14_0);
     let expr16_0 = C::gpr_to_gpr_mem_imm(ctx, pattern1_0);
-    let expr17_0 = constructor_sub(ctx, expr11_0, expr15_0, &expr16_0)?;
+    let expr17_0 = constructor_x64_sub(ctx, expr11_0, expr15_0, &expr16_0)?;
     let expr18_0 = C::gpr_to_imm8_gpr(ctx, expr17_0);
-    let expr19_0 = constructor_shr(ctx, expr10_0, expr1_0, &expr18_0)?;
+    let expr19_0 = constructor_x64_shr(ctx, expr10_0, expr1_0, &expr18_0)?;
     let expr20_0: Type = I64;
     let expr21_0: u64 = 0;
     let expr22_0 = constructor_imm(ctx, expr20_0, expr21_0)?;
@@ -9043,7 +9091,7 @@ pub fn constructor_shl_i128<C: Context>(
     let expr25_0: u32 = 127;
     let expr26_0 = RegMemImm::Imm { simm32: expr25_0 };
     let expr27_0 = C::gpr_mem_imm_new(ctx, &expr26_0);
-    let expr28_0 = constructor_test(ctx, &expr24_0, &expr27_0, pattern1_0)?;
+    let expr28_0 = constructor_x64_test(ctx, &expr24_0, &expr27_0, pattern1_0)?;
     let expr29_0: Type = I64;
     let expr30_0 = CC::Z;
     let expr31_0 = C::gpr_to_gpr_mem(ctx, expr23_0);
@@ -9052,12 +9100,12 @@ pub fn constructor_shl_i128<C: Context>(
     let expr34_0 = C::gpr_new(ctx, expr33_0);
     let expr35_0: Type = I64;
     let expr36_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
-    let expr37_0 = constructor_or(ctx, expr35_0, expr34_0, &expr36_0)?;
+    let expr37_0 = constructor_x64_or(ctx, expr35_0, expr34_0, &expr36_0)?;
     let expr38_0 = OperandSize::Size64;
     let expr39_0: u32 = 64;
     let expr40_0 = RegMemImm::Imm { simm32: expr39_0 };
     let expr41_0 = C::gpr_mem_imm_new(ctx, &expr40_0);
-    let expr42_0 = constructor_test(ctx, &expr38_0, &expr41_0, pattern1_0)?;
+    let expr42_0 = constructor_x64_test(ctx, &expr38_0, &expr41_0, pattern1_0)?;
     let expr43_0: Type = I64;
     let expr44_0 = CC::Z;
     let expr45_0 = C::gpr_to_gpr_mem(ctx, expr6_0);
@@ -9086,12 +9134,12 @@ pub fn constructor_ishl_i8x16_mask<C: Context>(
         &RegMemImm::Reg { reg: pattern1_0 } => {
             // Rule at src/isa/x64/lower.isle line 561.
             let expr0_0 = C::ishl_i8x16_mask_table(ctx);
-            let expr1_0 = constructor_lea(ctx, &expr0_0)?;
+            let expr1_0 = constructor_x64_lea(ctx, &expr0_0)?;
             let expr2_0: Type = I64;
             let expr3_0 = C::gpr_new(ctx, pattern1_0);
             let expr4_0: u8 = 4;
             let expr5_0 = C::imm8_to_imm8_gpr(ctx, expr4_0);
-            let expr6_0 = constructor_shl(ctx, expr2_0, expr3_0, &expr5_0)?;
+            let expr6_0 = constructor_x64_shl(ctx, expr2_0, expr3_0, &expr5_0)?;
             let expr7_0: u32 = 0;
             let expr8_0: u8 = 0;
             let expr9_0 = C::amode_imm_reg_reg_shift(ctx, expr7_0, expr1_0, expr6_0, expr8_0);
@@ -9129,10 +9177,10 @@ pub fn constructor_shr_i128<C: Context>(
     let expr3_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr2_0)?;
     let expr4_0: Type = I64;
     let expr5_0 = C::gpr_to_imm8_gpr(ctx, pattern1_0);
-    let expr6_0 = constructor_shr(ctx, expr4_0, expr1_0, &expr5_0)?;
+    let expr6_0 = constructor_x64_shr(ctx, expr4_0, expr1_0, &expr5_0)?;
     let expr7_0: Type = I64;
     let expr8_0 = C::gpr_to_imm8_gpr(ctx, pattern1_0);
-    let expr9_0 = constructor_shr(ctx, expr7_0, expr3_0, &expr8_0)?;
+    let expr9_0 = constructor_x64_shr(ctx, expr7_0, expr3_0, &expr8_0)?;
     let expr10_0: Type = I64;
     let expr11_0: Type = I64;
     let expr12_0: Type = I64;
@@ -9140,14 +9188,14 @@ pub fn constructor_shr_i128<C: Context>(
     let expr14_0 = constructor_imm(ctx, expr12_0, expr13_0)?;
     let expr15_0 = C::gpr_new(ctx, expr14_0);
     let expr16_0 = C::gpr_to_gpr_mem_imm(ctx, pattern1_0);
-    let expr17_0 = constructor_sub(ctx, expr11_0, expr15_0, &expr16_0)?;
+    let expr17_0 = constructor_x64_sub(ctx, expr11_0, expr15_0, &expr16_0)?;
     let expr18_0 = C::gpr_to_imm8_gpr(ctx, expr17_0);
-    let expr19_0 = constructor_shl(ctx, expr10_0, expr3_0, &expr18_0)?;
+    let expr19_0 = constructor_x64_shl(ctx, expr10_0, expr3_0, &expr18_0)?;
     let expr20_0 = OperandSize::Size64;
     let expr21_0: u32 = 127;
     let expr22_0 = RegMemImm::Imm { simm32: expr21_0 };
     let expr23_0 = C::gpr_mem_imm_new(ctx, &expr22_0);
-    let expr24_0 = constructor_test(ctx, &expr20_0, &expr23_0, pattern1_0)?;
+    let expr24_0 = constructor_x64_test(ctx, &expr20_0, &expr23_0, pattern1_0)?;
     let expr25_0: Type = I64;
     let expr26_0 = CC::Z;
     let expr27_0: Type = I64;
@@ -9159,12 +9207,12 @@ pub fn constructor_shr_i128<C: Context>(
     let expr33_0 = C::gpr_new(ctx, expr32_0);
     let expr34_0: Type = I64;
     let expr35_0 = C::gpr_to_gpr_mem_imm(ctx, expr6_0);
-    let expr36_0 = constructor_or(ctx, expr34_0, expr33_0, &expr35_0)?;
+    let expr36_0 = constructor_x64_or(ctx, expr34_0, expr33_0, &expr35_0)?;
     let expr37_0 = OperandSize::Size64;
     let expr38_0: u32 = 64;
     let expr39_0 = RegMemImm::Imm { simm32: expr38_0 };
     let expr40_0 = C::gpr_mem_imm_new(ctx, &expr39_0);
-    let expr41_0 = constructor_test(ctx, &expr37_0, &expr40_0, pattern1_0)?;
+    let expr41_0 = constructor_x64_test(ctx, &expr37_0, &expr40_0, pattern1_0)?;
     let expr42_0: Type = I64;
     let expr43_0 = CC::Z;
     let expr44_0 = C::gpr_to_gpr_mem(ctx, expr36_0);
@@ -9197,12 +9245,12 @@ pub fn constructor_ushr_i8x16_mask<C: Context>(
         &RegMemImm::Reg { reg: pattern1_0 } => {
             // Rule at src/isa/x64/lower.isle line 662.
             let expr0_0 = C::ushr_i8x16_mask_table(ctx);
-            let expr1_0 = constructor_lea(ctx, &expr0_0)?;
+            let expr1_0 = constructor_x64_lea(ctx, &expr0_0)?;
             let expr2_0: Type = I64;
             let expr3_0 = C::gpr_new(ctx, pattern1_0);
             let expr4_0: u8 = 4;
             let expr5_0 = C::imm8_to_imm8_gpr(ctx, expr4_0);
-            let expr6_0 = constructor_shl(ctx, expr2_0, expr3_0, &expr5_0)?;
+            let expr6_0 = constructor_x64_shl(ctx, expr2_0, expr3_0, &expr5_0)?;
             let expr7_0: u32 = 0;
             let expr8_0: u8 = 0;
             let expr9_0 = C::amode_imm_reg_reg_shift(ctx, expr7_0, expr1_0, expr6_0, expr8_0);
@@ -9240,10 +9288,10 @@ pub fn constructor_sar_i128<C: Context>(
     let expr3_0 = constructor_value_regs_get_gpr(ctx, pattern0_0, expr2_0)?;
     let expr4_0: Type = I64;
     let expr5_0 = C::gpr_to_imm8_gpr(ctx, pattern1_0);
-    let expr6_0 = constructor_shr(ctx, expr4_0, expr1_0, &expr5_0)?;
+    let expr6_0 = constructor_x64_shr(ctx, expr4_0, expr1_0, &expr5_0)?;
     let expr7_0: Type = I64;
     let expr8_0 = C::gpr_to_imm8_gpr(ctx, pattern1_0);
-    let expr9_0 = constructor_sar(ctx, expr7_0, expr3_0, &expr8_0)?;
+    let expr9_0 = constructor_x64_sar(ctx, expr7_0, expr3_0, &expr8_0)?;
     let expr10_0: Type = I64;
     let expr11_0: Type = I64;
     let expr12_0: Type = I64;
@@ -9251,14 +9299,14 @@ pub fn constructor_sar_i128<C: Context>(
     let expr14_0 = constructor_imm(ctx, expr12_0, expr13_0)?;
     let expr15_0 = C::gpr_new(ctx, expr14_0);
     let expr16_0 = C::gpr_to_gpr_mem_imm(ctx, pattern1_0);
-    let expr17_0 = constructor_sub(ctx, expr11_0, expr15_0, &expr16_0)?;
+    let expr17_0 = constructor_x64_sub(ctx, expr11_0, expr15_0, &expr16_0)?;
     let expr18_0 = C::gpr_to_imm8_gpr(ctx, expr17_0);
-    let expr19_0 = constructor_shl(ctx, expr10_0, expr3_0, &expr18_0)?;
+    let expr19_0 = constructor_x64_shl(ctx, expr10_0, expr3_0, &expr18_0)?;
     let expr20_0 = OperandSize::Size64;
     let expr21_0: u32 = 127;
     let expr22_0 = RegMemImm::Imm { simm32: expr21_0 };
     let expr23_0 = C::gpr_mem_imm_new(ctx, &expr22_0);
-    let expr24_0 = constructor_test(ctx, &expr20_0, &expr23_0, pattern1_0)?;
+    let expr24_0 = constructor_x64_test(ctx, &expr20_0, &expr23_0, pattern1_0)?;
     let expr25_0: Type = I64;
     let expr26_0 = CC::Z;
     let expr27_0: Type = I64;
@@ -9270,16 +9318,16 @@ pub fn constructor_sar_i128<C: Context>(
     let expr33_0 = C::gpr_new(ctx, expr32_0);
     let expr34_0: Type = I64;
     let expr35_0 = C::gpr_to_gpr_mem_imm(ctx, expr33_0);
-    let expr36_0 = constructor_or(ctx, expr34_0, expr6_0, &expr35_0)?;
+    let expr36_0 = constructor_x64_or(ctx, expr34_0, expr6_0, &expr35_0)?;
     let expr37_0: Type = I64;
     let expr38_0: u8 = 63;
     let expr39_0 = C::imm8_to_imm8_gpr(ctx, expr38_0);
-    let expr40_0 = constructor_sar(ctx, expr37_0, expr3_0, &expr39_0)?;
+    let expr40_0 = constructor_x64_sar(ctx, expr37_0, expr3_0, &expr39_0)?;
     let expr41_0 = OperandSize::Size64;
     let expr42_0: u32 = 64;
     let expr43_0 = RegMemImm::Imm { simm32: expr42_0 };
     let expr44_0 = C::gpr_mem_imm_new(ctx, &expr43_0);
-    let expr45_0 = constructor_test(ctx, &expr41_0, &expr44_0, pattern1_0)?;
+    let expr45_0 = constructor_x64_test(ctx, &expr41_0, &expr44_0, pattern1_0)?;
     let expr46_0: Type = I64;
     let expr47_0 = CC::Z;
     let expr48_0 = C::gpr_to_gpr_mem(ctx, expr36_0);
@@ -9316,7 +9364,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
             let expr1_0: u32 = 8;
             let expr2_0 = RegMemImm::Imm { simm32: expr1_0 };
             let expr3_0 = C::gpr_mem_imm_new(ctx, &expr2_0);
-            let expr4_0 = constructor_add(ctx, pattern0_0, expr0_0, &expr3_0)?;
+            let expr4_0 = constructor_x64_add(ctx, pattern0_0, expr0_0, &expr3_0)?;
             let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
             let expr6_0 = RegMemImm::Reg { reg: expr5_0 };
             let expr7_0 = constructor_mov_rmi_to_xmm(ctx, &expr6_0)?;
@@ -9330,7 +9378,7 @@ pub fn constructor_sshr_i8x16_bigger_shift<C: Context>(
             let expr1_0 = constructor_imm(ctx, pattern0_0, expr0_0)?;
             let expr2_0 = C::gpr_new(ctx, expr1_0);
             let expr3_0 = C::gpr_mem_imm_new(ctx, pattern1_0);
-            let expr4_0 = constructor_add(ctx, pattern0_0, expr2_0, &expr3_0)?;
+            let expr4_0 = constructor_x64_add(ctx, pattern0_0, expr2_0, &expr3_0)?;
             let expr5_0 = C::gpr_to_reg(ctx, expr4_0);
             let expr6_0 = RegMemImm::Reg { reg: expr5_0 };
             let expr7_0 = constructor_mov_rmi_to_xmm(ctx, &expr6_0)?;
@@ -9353,21 +9401,21 @@ pub fn constructor_sse_and_not<C: Context>(
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 1194.
-        let expr0_0 = constructor_andnps(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_andnps(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if pattern0_0 == F64X2 {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 1195.
-        let expr0_0 = constructor_andnpd(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_andnpd(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         let pattern2_0 = arg1;
         let pattern3_0 = arg2;
         // Rule at src/isa/x64/lower.isle line 1196.
-        let expr0_0 = constructor_pandn(ctx, pattern2_0, pattern3_0)?;
+        let expr0_0 = constructor_x64_pandn(ctx, pattern2_0, pattern3_0)?;
         return Some(expr0_0);
     }
     return None;
@@ -9383,9 +9431,9 @@ pub fn constructor_i128_not<C: Context>(ctx: &mut C, arg0: Value) -> Option<Valu
     let expr3_0: usize = 1;
     let expr4_0 = constructor_value_regs_get_gpr(ctx, expr0_0, expr3_0)?;
     let expr5_0: Type = I64;
-    let expr6_0 = constructor_not(ctx, expr5_0, expr2_0)?;
+    let expr6_0 = constructor_x64_not(ctx, expr5_0, expr2_0)?;
     let expr7_0: Type = I64;
-    let expr8_0 = constructor_not(ctx, expr7_0, expr4_0)?;
+    let expr8_0 = constructor_x64_not(ctx, expr7_0, expr4_0)?;
     let expr9_0 = constructor_value_gprs(ctx, expr6_0, expr8_0)?;
     return Some(expr9_0);
 }
@@ -9405,7 +9453,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern4_0 = arg3;
         // Rule at src/isa/x64/lower.isle line 1313.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
-        let expr1_0 = constructor_pinsrb(ctx, pattern2_0, &expr0_0, pattern4_0)?;
+        let expr1_0 = constructor_x64_pinsrb(ctx, pattern2_0, &expr0_0, pattern4_0)?;
         return Some(expr1_0);
     }
     if pattern0_0 == I16X8 {
@@ -9414,7 +9462,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         let pattern4_0 = arg3;
         // Rule at src/isa/x64/lower.isle line 1317.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
-        let expr1_0 = constructor_pinsrw(ctx, pattern2_0, &expr0_0, pattern4_0)?;
+        let expr1_0 = constructor_x64_pinsrw(ctx, pattern2_0, &expr0_0, pattern4_0)?;
         return Some(expr1_0);
     }
     if pattern0_0 == I32X4 {
@@ -9424,7 +9472,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         // Rule at src/isa/x64/lower.isle line 1321.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = OperandSize::Size32;
-        let expr2_0 = constructor_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
+        let expr2_0 = constructor_x64_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
         return Some(expr2_0);
     }
     if pattern0_0 == I64X2 {
@@ -9434,7 +9482,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         // Rule at src/isa/x64/lower.isle line 1325.
         let expr0_0 = C::reg_mem_to_gpr_mem(ctx, pattern3_0);
         let expr1_0 = OperandSize::Size64;
-        let expr2_0 = constructor_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
+        let expr2_0 = constructor_x64_pinsrd(ctx, pattern2_0, &expr0_0, pattern4_0, &expr1_0)?;
         return Some(expr2_0);
     }
     if pattern0_0 == F32X4 {
@@ -9444,7 +9492,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
         // Rule at src/isa/x64/lower.isle line 1329.
         let expr0_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
         let expr1_0 = C::sse_insertps_lane_imm(ctx, pattern4_0);
-        let expr2_0 = constructor_insertps(ctx, pattern2_0, &expr0_0, expr1_0)?;
+        let expr2_0 = constructor_x64_insertps(ctx, pattern2_0, &expr0_0, expr1_0)?;
         return Some(expr2_0);
     }
     if pattern0_0 == F64X2 {
@@ -9455,7 +9503,7 @@ pub fn constructor_vec_insert_lane<C: Context>(
             if pattern5_0 == 0 {
                 // Rule at src/isa/x64/lower.isle line 1351.
                 let expr0_0 = constructor_reg_to_xmm_mem(ctx, pattern4_0)?;
-                let expr1_0 = constructor_movsd(ctx, pattern2_0, &expr0_0)?;
+                let expr1_0 = constructor_x64_movsd(ctx, pattern2_0, &expr0_0)?;
                 return Some(expr1_0);
             }
         }
@@ -9466,13 +9514,13 @@ pub fn constructor_vec_insert_lane<C: Context>(
             let expr1_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
             let expr2_0 = constructor_xmm_unary_rm_r(ctx, &expr0_0, &expr1_0)?;
             let expr3_0 = C::xmm_to_xmm_mem(ctx, expr2_0);
-            let expr4_0 = constructor_movsd(ctx, pattern2_0, &expr3_0)?;
+            let expr4_0 = constructor_x64_movsd(ctx, pattern2_0, &expr3_0)?;
             return Some(expr4_0);
         }
         if pattern4_0 == 1 {
             // Rule at src/isa/x64/lower.isle line 1362.
             let expr0_0 = C::reg_mem_to_xmm_mem(ctx, pattern3_0);
-            let expr1_0 = constructor_movlhps(ctx, pattern2_0, &expr0_0)?;
+            let expr1_0 = constructor_x64_movlhps(ctx, pattern2_0, &expr0_0)?;
             return Some(expr1_0);
         }
     }
@@ -9497,7 +9545,7 @@ pub fn constructor_cmp_and_choose<C: Context>(
         let expr1_0 = constructor_put_in_gpr(ctx, pattern4_0)?;
         let expr2_0 = C::raw_operand_size_of_type(ctx, pattern1_0);
         let expr3_0 = C::gpr_to_gpr_mem_imm(ctx, expr0_0);
-        let expr4_0 = constructor_cmp(ctx, &expr2_0, &expr3_0, expr1_0)?;
+        let expr4_0 = constructor_x64_cmp(ctx, &expr2_0, &expr3_0, expr1_0)?;
         let expr5_0 = C::gpr_to_gpr_mem(ctx, expr1_0);
         let expr6_0 = constructor_cmove(ctx, pattern1_0, pattern2_0, &expr5_0, expr0_0)?;
         let expr7_0 = constructor_with_flags_reg(ctx, &expr4_0, &expr6_0)?;
@@ -9530,7 +9578,7 @@ pub fn constructor_do_clz<C: Context>(
     let expr9_0 = constructor_imm(ctx, pattern0_0, expr8_0)?;
     let expr10_0 = C::gpr_new(ctx, expr9_0);
     let expr11_0 = constructor_reg_to_gpr_mem_imm(ctx, expr5_0)?;
-    let expr12_0 = constructor_sub(ctx, pattern0_0, expr10_0, &expr11_0)?;
+    let expr12_0 = constructor_x64_sub(ctx, pattern0_0, expr10_0, &expr11_0)?;
     return Some(expr12_0);
 }
 
@@ -9563,7 +9611,7 @@ pub fn constructor_do_popcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> 
         let expr1_0: u8 = 1;
         let expr2_0 = Imm8Reg::Imm8 { imm: expr1_0 };
         let expr3_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr2_0);
-        let expr4_0 = constructor_shr(ctx, expr0_0, pattern2_0, &expr3_0)?;
+        let expr4_0 = constructor_x64_shr(ctx, expr0_0, pattern2_0, &expr3_0)?;
         let expr5_0: Type = I32;
         let expr6_0: u64 = 2004318071;
         let expr7_0 = constructor_imm(ctx, expr5_0, expr6_0)?;
@@ -9573,37 +9621,37 @@ pub fn constructor_do_popcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> 
         let expr11_0 = constructor_x64_and(ctx, expr9_0, expr4_0, &expr10_0)?;
         let expr12_0: Type = I32;
         let expr13_0 = C::gpr_to_gpr_mem_imm(ctx, expr11_0);
-        let expr14_0 = constructor_sub(ctx, expr12_0, pattern2_0, &expr13_0)?;
+        let expr14_0 = constructor_x64_sub(ctx, expr12_0, pattern2_0, &expr13_0)?;
         let expr15_0: Type = I32;
         let expr16_0: u8 = 1;
         let expr17_0 = Imm8Reg::Imm8 { imm: expr16_0 };
         let expr18_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr17_0);
-        let expr19_0 = constructor_shr(ctx, expr15_0, expr11_0, &expr18_0)?;
+        let expr19_0 = constructor_x64_shr(ctx, expr15_0, expr11_0, &expr18_0)?;
         let expr20_0: Type = I32;
         let expr21_0 = C::gpr_to_gpr_mem_imm(ctx, expr8_0);
         let expr22_0 = constructor_x64_and(ctx, expr20_0, expr19_0, &expr21_0)?;
         let expr23_0: Type = I32;
         let expr24_0 = C::gpr_to_gpr_mem_imm(ctx, expr22_0);
-        let expr25_0 = constructor_sub(ctx, expr23_0, expr14_0, &expr24_0)?;
+        let expr25_0 = constructor_x64_sub(ctx, expr23_0, expr14_0, &expr24_0)?;
         let expr26_0: Type = I32;
         let expr27_0: u8 = 1;
         let expr28_0 = Imm8Reg::Imm8 { imm: expr27_0 };
         let expr29_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr28_0);
-        let expr30_0 = constructor_shr(ctx, expr26_0, expr22_0, &expr29_0)?;
+        let expr30_0 = constructor_x64_shr(ctx, expr26_0, expr22_0, &expr29_0)?;
         let expr31_0: Type = I32;
         let expr32_0 = C::gpr_to_gpr_mem_imm(ctx, expr8_0);
         let expr33_0 = constructor_x64_and(ctx, expr31_0, expr30_0, &expr32_0)?;
         let expr34_0: Type = I32;
         let expr35_0 = C::gpr_to_gpr_mem_imm(ctx, expr33_0);
-        let expr36_0 = constructor_sub(ctx, expr34_0, expr25_0, &expr35_0)?;
+        let expr36_0 = constructor_x64_sub(ctx, expr34_0, expr25_0, &expr35_0)?;
         let expr37_0: Type = I32;
         let expr38_0: Type = I32;
         let expr39_0: u8 = 4;
         let expr40_0 = Imm8Reg::Imm8 { imm: expr39_0 };
         let expr41_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr40_0);
-        let expr42_0 = constructor_shr(ctx, expr38_0, expr36_0, &expr41_0)?;
+        let expr42_0 = constructor_x64_shr(ctx, expr38_0, expr36_0, &expr41_0)?;
         let expr43_0 = C::gpr_to_gpr_mem_imm(ctx, expr36_0);
-        let expr44_0 = constructor_add(ctx, expr37_0, expr42_0, &expr43_0)?;
+        let expr44_0 = constructor_x64_add(ctx, expr37_0, expr42_0, &expr43_0)?;
         let expr45_0: Type = I32;
         let expr46_0: u32 = 252645135;
         let expr47_0 = RegMemImm::Imm { simm32: expr46_0 };
@@ -9613,12 +9661,12 @@ pub fn constructor_do_popcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> 
         let expr51_0: u32 = 16843009;
         let expr52_0 = RegMemImm::Imm { simm32: expr51_0 };
         let expr53_0 = C::gpr_mem_imm_new(ctx, &expr52_0);
-        let expr54_0 = constructor_mul(ctx, expr50_0, expr49_0, &expr53_0)?;
+        let expr54_0 = constructor_x64_mul(ctx, expr50_0, expr49_0, &expr53_0)?;
         let expr55_0: Type = I32;
         let expr56_0: u8 = 24;
         let expr57_0 = Imm8Reg::Imm8 { imm: expr56_0 };
         let expr58_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr57_0);
-        let expr59_0 = constructor_shr(ctx, expr55_0, expr54_0, &expr58_0)?;
+        let expr59_0 = constructor_x64_shr(ctx, expr55_0, expr54_0, &expr58_0)?;
         return Some(expr59_0);
     }
     if pattern0_0 == I64 {
@@ -9628,7 +9676,7 @@ pub fn constructor_do_popcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> 
         let expr1_0: u8 = 1;
         let expr2_0 = Imm8Reg::Imm8 { imm: expr1_0 };
         let expr3_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr2_0);
-        let expr4_0 = constructor_shr(ctx, expr0_0, pattern2_0, &expr3_0)?;
+        let expr4_0 = constructor_x64_shr(ctx, expr0_0, pattern2_0, &expr3_0)?;
         let expr5_0: Type = I64;
         let expr6_0: u64 = 8608480567731124087;
         let expr7_0 = constructor_imm(ctx, expr5_0, expr6_0)?;
@@ -9638,37 +9686,37 @@ pub fn constructor_do_popcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> 
         let expr11_0 = constructor_x64_and(ctx, expr9_0, expr4_0, &expr10_0)?;
         let expr12_0: Type = I64;
         let expr13_0 = C::gpr_to_gpr_mem_imm(ctx, expr11_0);
-        let expr14_0 = constructor_sub(ctx, expr12_0, pattern2_0, &expr13_0)?;
+        let expr14_0 = constructor_x64_sub(ctx, expr12_0, pattern2_0, &expr13_0)?;
         let expr15_0: Type = I64;
         let expr16_0: u8 = 1;
         let expr17_0 = Imm8Reg::Imm8 { imm: expr16_0 };
         let expr18_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr17_0);
-        let expr19_0 = constructor_shr(ctx, expr15_0, expr11_0, &expr18_0)?;
+        let expr19_0 = constructor_x64_shr(ctx, expr15_0, expr11_0, &expr18_0)?;
         let expr20_0: Type = I64;
         let expr21_0 = C::gpr_to_gpr_mem_imm(ctx, expr8_0);
         let expr22_0 = constructor_x64_and(ctx, expr20_0, expr19_0, &expr21_0)?;
         let expr23_0: Type = I64;
         let expr24_0 = C::gpr_to_gpr_mem_imm(ctx, expr22_0);
-        let expr25_0 = constructor_sub(ctx, expr23_0, expr14_0, &expr24_0)?;
+        let expr25_0 = constructor_x64_sub(ctx, expr23_0, expr14_0, &expr24_0)?;
         let expr26_0: Type = I64;
         let expr27_0: u8 = 1;
         let expr28_0 = Imm8Reg::Imm8 { imm: expr27_0 };
         let expr29_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr28_0);
-        let expr30_0 = constructor_shr(ctx, expr26_0, expr22_0, &expr29_0)?;
+        let expr30_0 = constructor_x64_shr(ctx, expr26_0, expr22_0, &expr29_0)?;
         let expr31_0: Type = I64;
         let expr32_0 = C::gpr_to_gpr_mem_imm(ctx, expr8_0);
         let expr33_0 = constructor_x64_and(ctx, expr31_0, expr30_0, &expr32_0)?;
         let expr34_0: Type = I64;
         let expr35_0 = C::gpr_to_gpr_mem_imm(ctx, expr33_0);
-        let expr36_0 = constructor_sub(ctx, expr34_0, expr25_0, &expr35_0)?;
+        let expr36_0 = constructor_x64_sub(ctx, expr34_0, expr25_0, &expr35_0)?;
         let expr37_0: Type = I64;
         let expr38_0: Type = I64;
         let expr39_0: u8 = 4;
         let expr40_0 = Imm8Reg::Imm8 { imm: expr39_0 };
         let expr41_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr40_0);
-        let expr42_0 = constructor_shr(ctx, expr38_0, expr36_0, &expr41_0)?;
+        let expr42_0 = constructor_x64_shr(ctx, expr38_0, expr36_0, &expr41_0)?;
         let expr43_0 = C::gpr_to_gpr_mem_imm(ctx, expr36_0);
-        let expr44_0 = constructor_add(ctx, expr37_0, expr42_0, &expr43_0)?;
+        let expr44_0 = constructor_x64_add(ctx, expr37_0, expr42_0, &expr43_0)?;
         let expr45_0: Type = I64;
         let expr46_0: u64 = 1085102592571150095;
         let expr47_0 = constructor_imm(ctx, expr45_0, expr46_0)?;
@@ -9682,12 +9730,12 @@ pub fn constructor_do_popcnt<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -> 
         let expr55_0 = C::gpr_new(ctx, expr54_0);
         let expr56_0: Type = I64;
         let expr57_0 = C::gpr_to_gpr_mem_imm(ctx, expr55_0);
-        let expr58_0 = constructor_mul(ctx, expr56_0, expr51_0, &expr57_0)?;
+        let expr58_0 = constructor_x64_mul(ctx, expr56_0, expr51_0, &expr57_0)?;
         let expr59_0: Type = I64;
         let expr60_0: u8 = 56;
         let expr61_0 = Imm8Reg::Imm8 { imm: expr60_0 };
         let expr62_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr61_0);
-        let expr63_0 = constructor_shr(ctx, expr59_0, expr58_0, &expr62_0)?;
+        let expr63_0 = constructor_x64_shr(ctx, expr59_0, expr58_0, &expr62_0)?;
         return Some(expr63_0);
     }
     return None;
@@ -9708,15 +9756,15 @@ pub fn constructor_do_bitrev8<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) ->
     let expr7_0: u8 = 1;
     let expr8_0 = Imm8Reg::Imm8 { imm: expr7_0 };
     let expr9_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr8_0);
-    let expr10_0 = constructor_shr(ctx, pattern0_0, pattern1_0, &expr9_0)?;
+    let expr10_0 = constructor_x64_shr(ctx, pattern0_0, pattern1_0, &expr9_0)?;
     let expr11_0 = C::gpr_to_gpr_mem_imm(ctx, expr4_0);
     let expr12_0 = constructor_x64_and(ctx, pattern0_0, expr10_0, &expr11_0)?;
     let expr13_0: u8 = 1;
     let expr14_0 = Imm8Reg::Imm8 { imm: expr13_0 };
     let expr15_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr14_0);
-    let expr16_0 = constructor_shl(ctx, pattern0_0, expr6_0, &expr15_0)?;
+    let expr16_0 = constructor_x64_shl(ctx, pattern0_0, expr6_0, &expr15_0)?;
     let expr17_0 = C::gpr_to_gpr_mem_imm(ctx, expr12_0);
-    let expr18_0 = constructor_or(ctx, pattern0_0, expr16_0, &expr17_0)?;
+    let expr18_0 = constructor_x64_or(ctx, pattern0_0, expr16_0, &expr17_0)?;
     let expr19_0: u64 = 3689348814741910323;
     let expr20_0 = C::u64_and(ctx, expr0_0, expr19_0);
     let expr21_0 = constructor_imm(ctx, pattern0_0, expr20_0)?;
@@ -9726,15 +9774,15 @@ pub fn constructor_do_bitrev8<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) ->
     let expr25_0: u8 = 2;
     let expr26_0 = Imm8Reg::Imm8 { imm: expr25_0 };
     let expr27_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr26_0);
-    let expr28_0 = constructor_shr(ctx, pattern0_0, expr18_0, &expr27_0)?;
+    let expr28_0 = constructor_x64_shr(ctx, pattern0_0, expr18_0, &expr27_0)?;
     let expr29_0 = C::gpr_to_gpr_mem_imm(ctx, expr22_0);
     let expr30_0 = constructor_x64_and(ctx, pattern0_0, expr28_0, &expr29_0)?;
     let expr31_0: u8 = 2;
     let expr32_0 = Imm8Reg::Imm8 { imm: expr31_0 };
     let expr33_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr32_0);
-    let expr34_0 = constructor_shl(ctx, pattern0_0, expr24_0, &expr33_0)?;
+    let expr34_0 = constructor_x64_shl(ctx, pattern0_0, expr24_0, &expr33_0)?;
     let expr35_0 = C::gpr_to_gpr_mem_imm(ctx, expr30_0);
-    let expr36_0 = constructor_or(ctx, pattern0_0, expr34_0, &expr35_0)?;
+    let expr36_0 = constructor_x64_or(ctx, pattern0_0, expr34_0, &expr35_0)?;
     let expr37_0: u64 = 1085102592571150095;
     let expr38_0 = C::u64_and(ctx, expr0_0, expr37_0);
     let expr39_0 = constructor_imm(ctx, pattern0_0, expr38_0)?;
@@ -9744,15 +9792,15 @@ pub fn constructor_do_bitrev8<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) ->
     let expr43_0: u8 = 4;
     let expr44_0 = Imm8Reg::Imm8 { imm: expr43_0 };
     let expr45_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr44_0);
-    let expr46_0 = constructor_shr(ctx, pattern0_0, expr36_0, &expr45_0)?;
+    let expr46_0 = constructor_x64_shr(ctx, pattern0_0, expr36_0, &expr45_0)?;
     let expr47_0 = C::gpr_to_gpr_mem_imm(ctx, expr40_0);
     let expr48_0 = constructor_x64_and(ctx, pattern0_0, expr46_0, &expr47_0)?;
     let expr49_0: u8 = 4;
     let expr50_0 = Imm8Reg::Imm8 { imm: expr49_0 };
     let expr51_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr50_0);
-    let expr52_0 = constructor_shl(ctx, pattern0_0, expr42_0, &expr51_0)?;
+    let expr52_0 = constructor_x64_shl(ctx, pattern0_0, expr42_0, &expr51_0)?;
     let expr53_0 = C::gpr_to_gpr_mem_imm(ctx, expr48_0);
-    let expr54_0 = constructor_or(ctx, pattern0_0, expr52_0, &expr53_0)?;
+    let expr54_0 = constructor_x64_or(ctx, pattern0_0, expr52_0, &expr53_0)?;
     return Some(expr54_0);
 }
 
@@ -9772,15 +9820,15 @@ pub fn constructor_do_bitrev16<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -
     let expr8_0: u8 = 8;
     let expr9_0 = Imm8Reg::Imm8 { imm: expr8_0 };
     let expr10_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr9_0);
-    let expr11_0 = constructor_shr(ctx, pattern0_0, expr0_0, &expr10_0)?;
+    let expr11_0 = constructor_x64_shr(ctx, pattern0_0, expr0_0, &expr10_0)?;
     let expr12_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
     let expr13_0 = constructor_x64_and(ctx, pattern0_0, expr11_0, &expr12_0)?;
     let expr14_0: u8 = 8;
     let expr15_0 = Imm8Reg::Imm8 { imm: expr14_0 };
     let expr16_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr15_0);
-    let expr17_0 = constructor_shl(ctx, pattern0_0, expr7_0, &expr16_0)?;
+    let expr17_0 = constructor_x64_shl(ctx, pattern0_0, expr7_0, &expr16_0)?;
     let expr18_0 = C::gpr_to_gpr_mem_imm(ctx, expr13_0);
-    let expr19_0 = constructor_or(ctx, pattern0_0, expr17_0, &expr18_0)?;
+    let expr19_0 = constructor_x64_or(ctx, pattern0_0, expr17_0, &expr18_0)?;
     return Some(expr19_0);
 }
 
@@ -9800,15 +9848,15 @@ pub fn constructor_do_bitrev32<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -
     let expr8_0: u8 = 16;
     let expr9_0 = Imm8Reg::Imm8 { imm: expr8_0 };
     let expr10_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr9_0);
-    let expr11_0 = constructor_shr(ctx, pattern0_0, expr0_0, &expr10_0)?;
+    let expr11_0 = constructor_x64_shr(ctx, pattern0_0, expr0_0, &expr10_0)?;
     let expr12_0 = C::gpr_to_gpr_mem_imm(ctx, expr5_0);
     let expr13_0 = constructor_x64_and(ctx, pattern0_0, expr11_0, &expr12_0)?;
     let expr14_0: u8 = 16;
     let expr15_0 = Imm8Reg::Imm8 { imm: expr14_0 };
     let expr16_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr15_0);
-    let expr17_0 = constructor_shl(ctx, pattern0_0, expr7_0, &expr16_0)?;
+    let expr17_0 = constructor_x64_shl(ctx, pattern0_0, expr7_0, &expr16_0)?;
     let expr18_0 = C::gpr_to_gpr_mem_imm(ctx, expr13_0);
-    let expr19_0 = constructor_or(ctx, pattern0_0, expr17_0, &expr18_0)?;
+    let expr19_0 = constructor_x64_or(ctx, pattern0_0, expr17_0, &expr18_0)?;
     return Some(expr19_0);
 }
 
@@ -9827,13 +9875,13 @@ pub fn constructor_do_bitrev64<C: Context>(ctx: &mut C, arg0: Type, arg1: Gpr) -
         let expr6_0: u8 = 32;
         let expr7_0 = Imm8Reg::Imm8 { imm: expr6_0 };
         let expr8_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr7_0);
-        let expr9_0 = constructor_shr(ctx, pattern0_0, expr0_0, &expr8_0)?;
+        let expr9_0 = constructor_x64_shr(ctx, pattern0_0, expr0_0, &expr8_0)?;
         let expr10_0: u8 = 32;
         let expr11_0 = Imm8Reg::Imm8 { imm: expr10_0 };
         let expr12_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr11_0);
-        let expr13_0 = constructor_shl(ctx, pattern0_0, expr5_0, &expr12_0)?;
+        let expr13_0 = constructor_x64_shl(ctx, pattern0_0, expr5_0, &expr12_0)?;
         let expr14_0 = C::gpr_to_gpr_mem_imm(ctx, expr9_0);
-        let expr15_0 = constructor_or(ctx, pattern0_0, expr13_0, &expr14_0)?;
+        let expr15_0 = constructor_x64_or(ctx, pattern0_0, expr13_0, &expr14_0)?;
         return Some(expr15_0);
     }
     return None;
@@ -9909,6 +9957,6 @@ pub fn constructor_spread_sign_bit<C: Context>(ctx: &mut C, arg0: Gpr) -> Option
     let expr1_0: u8 = 63;
     let expr2_0 = Imm8Reg::Imm8 { imm: expr1_0 };
     let expr3_0 = C::imm8_reg_to_imm8_gpr(ctx, &expr2_0);
-    let expr4_0 = constructor_sar(ctx, expr0_0, pattern0_0, &expr3_0)?;
+    let expr4_0 = constructor_x64_sar(ctx, expr0_0, pattern0_0, &expr3_0)?;
     return Some(expr4_0);
 }


### PR DESCRIPTION
This change is refactoring only--it should have no logic changes. As
discussed previously, prefixing all machine code instructions with
`x64_` will make it easier to identify what parts of the ISLE code
correspond to single instructions and what parts rely on helpers that
may emit more than one instruction.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
