### PR TITLE
[AArch64] Refactor ALUOp3

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -18,6 +18,7 @@
        ;; An ALU operation with three register sources and a register destination.
        (AluRRRR
         (alu_op ALUOp3)
+        (size OperandSize)
         (rd WritableReg)
         (rn Reg)
         (rm Reg)
@@ -833,13 +834,9 @@
 (type ALUOp3
   (enum
     ;; Multiply-add
-    (MAdd32)
-    ;; Multiply-add
-    (MAdd64)
+    (MAdd)
     ;; Multiply-sub
-    (MSub32)
-    ;; Multiply-sub
-    (MSub64)
+    (MSub)
 ))
 
 (type UImm5 (primitive UImm5))
@@ -1461,10 +1458,10 @@
         (alu_rrr_extend op ty src1 src2 extend)))
 
 ;; Helper for emitting `MInst.AluRRRR` instructions.
-(decl alu_rrrr (ALUOp3 Reg Reg Reg) Reg)
-(rule (alu_rrrr op src1 src2 src3)
+(decl alu_rrrr (ALUOp3 Type Reg Reg Reg) Reg)
+(rule (alu_rrrr op ty src1 src2 src3)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.AluRRRR op dst src1 src2 src3))))
+            (_ Unit (emit (MInst.AluRRRR op (operand_size ty) dst src1 src2 src3))))
         dst))
 
 ;; Helper for emitting `MInst.BitRR` instructions.
@@ -1656,19 +1653,12 @@
 ;; Helpers for generating `madd` instructions.
 
 (decl madd (Type Reg Reg Reg) Reg)
-(rule (madd (fits_in_32 _ty) x y z) (madd32 x y z))
-(rule (madd $I64 x y z) (madd64 x y z))
-
-(decl madd32 (Reg Reg Reg) Reg)
-(rule (madd32 x y z) (alu_rrrr (ALUOp3.MAdd32) x y z))
-
-(decl madd64 (Reg Reg Reg) Reg)
-(rule (madd64 x y z) (alu_rrrr (ALUOp3.MAdd64) x y z))
+(rule (madd ty x y z) (alu_rrrr (ALUOp3.MAdd) ty x y z))
 
 ;; Helpers for generating `msub` instructions.
 
-(decl msub64 (Reg Reg Reg) Reg)
-(rule (msub64 x y z) (alu_rrrr (ALUOp3.MSub64) x y z))
+(decl msub (Type Reg Reg Reg) Reg)
+(rule (msub ty x y z) (alu_rrrr (ALUOp3.MSub) ty x y z))
 
 ;; Helper for generating `uqadd` instructions.
 (decl uqadd (Reg Reg VectorSize) Reg)

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -758,6 +758,7 @@ impl MachInstEmit for Inst {
             }
             &Inst::AluRRRR {
                 alu_op,
+                size,
                 rd,
                 rm,
                 rn,
@@ -769,11 +770,10 @@ impl MachInstEmit for Inst {
                 let ra = allocs.next(ra);
 
                 let (top11, bit15) = match alu_op {
-                    ALUOp3::MAdd32 => (0b0_00_11011_000, 0),
-                    ALUOp3::MSub32 => (0b0_00_11011_000, 1),
-                    ALUOp3::MAdd64 => (0b1_00_11011_000, 0),
-                    ALUOp3::MSub64 => (0b1_00_11011_000, 1),
+                    ALUOp3::MAdd => (0b0_00_11011_000, 0),
+                    ALUOp3::MSub => (0b0_00_11011_000, 1),
                 };
+                let top11 = top11 | size.sf_bit() << 10;
                 sink.put4(enc_arith_rrrr(top11, rm, bit15, ra, rn, rd));
             }
             &Inst::AluRRImm12 {

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -995,7 +995,8 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::AluRRRR {
-            alu_op: ALUOp3::MAdd32,
+            alu_op: ALUOp3::MAdd,
+            size: OperandSize::Size32,
             rd: writable_xreg(1),
             rn: xreg(2),
             rm: xreg(3),
@@ -1006,7 +1007,8 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AluRRRR {
-            alu_op: ALUOp3::MAdd64,
+            alu_op: ALUOp3::MAdd,
+            size: OperandSize::Size64,
             rd: writable_xreg(1),
             rn: xreg(2),
             rm: xreg(3),
@@ -1017,7 +1019,8 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AluRRRR {
-            alu_op: ALUOp3::MSub32,
+            alu_op: ALUOp3::MSub,
+            size: OperandSize::Size32,
             rd: writable_xreg(1),
             rn: xreg(2),
             rm: xreg(3),
@@ -1028,7 +1031,8 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AluRRRR {
-            alu_op: ALUOp3::MSub64,
+            alu_op: ALUOp3::MSub,
+            size: OperandSize::Size64,
             rd: writable_xreg(1),
             rn: xreg(2),
             rm: xreg(3),

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1288,16 +1288,15 @@ impl Inst {
             }
             &Inst::AluRRRR {
                 alu_op,
+                size,
                 rd,
                 rn,
                 rm,
                 ra,
             } => {
-                let (op, size) = match alu_op {
-                    ALUOp3::MAdd32 => ("madd", OperandSize::Size32),
-                    ALUOp3::MAdd64 => ("madd", OperandSize::Size64),
-                    ALUOp3::MSub32 => ("msub", OperandSize::Size32),
-                    ALUOp3::MSub64 => ("msub", OperandSize::Size64),
+                let op = match alu_op {
+                    ALUOp3::MAdd => "madd",
+                    ALUOp3::MSub => "msub",
                 };
                 let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
                 let rn = pretty_print_ireg(rn, size, allocs);

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -70,6 +70,10 @@
 (rule (lower (has_type (fits_in_64 ty) (iadd (imul x y) z)))
       (madd ty x y z))
 
+;; Fold an `isub` and `imul` combination into a `msub` instruction.
+(rule (lower (has_type (fits_in_64 ty) (isub x (imul y z))))
+      (msub ty y z x))
+
 ;; vectors
 
 (rule (lower (has_type ty @ (multi_lane _ _) (iadd x y)))
@@ -202,9 +206,9 @@
            ;; madd    dst_hi, x_hi, y_lo, dst_hi
            ;; madd    dst_lo, x_lo, y_lo, zero
            (dst_hi1 Reg (umulh $I64 x_lo y_lo))
-           (dst_hi2 Reg (madd64 x_lo y_hi dst_hi1))
-           (dst_hi Reg (madd64 x_hi y_lo dst_hi2))
-           (dst_lo Reg (madd64 x_lo y_lo (zero_reg))))
+           (dst_hi2 Reg (madd $I64 x_lo y_hi dst_hi1))
+           (dst_hi Reg (madd $I64 x_hi y_lo dst_hi2))
+           (dst_lo Reg (madd $I64 x_lo y_lo (zero_reg))))
         (value_regs dst_lo dst_hi)))
 
 ;; Case for i8x16, i16x8, and i32x4.
@@ -358,7 +362,7 @@
 (rule (lower (has_type (fits_in_32 ty) (smulhi x y)))
       (let ((x64 Reg (put_in_reg_sext64 x))
             (y64 Reg (put_in_reg_sext64 y))
-            (mul Reg (madd64 x64 y64 (zero_reg)))
+            (mul Reg (madd $I64 x64 y64 (zero_reg)))
             (result Reg (asr_imm $I64 mul (imm_shift_from_u8 (ty_bits ty)))))
         result))
 
@@ -368,11 +372,13 @@
       (umulh $I64 x y))
 
 (rule (lower (has_type (fits_in_32 ty) (umulhi x y)))
-      (let ((x64 Reg (put_in_reg_zext64 x))
-            (y64 Reg (put_in_reg_zext64 y))
-            (mul Reg (madd64 x64 y64 (zero_reg)))
-            (result Reg (lsr_imm $I64 mul (imm_shift_from_u8 (ty_bits ty)))))
-        result))
+      (let (
+          (x64 Reg (put_in_reg_zext64 x))
+          (y64 Reg (put_in_reg_zext64 y))
+          (mul Reg (madd $I64 x64 y64 (zero_reg)))
+          (result Reg (lsr_imm $I64 mul (imm_shift_from_u8 (ty_bits ty))))
+        )
+        (value_reg result)))
 
 ;;;; Rules for `udiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -459,14 +465,14 @@
       (let ((x64 Reg (put_in_reg_zext64 x))
             (y64 Reg (put_nonzero_in_reg_zext64 y))
             (div Reg (a64_udiv $I64 x64 y64))
-            (result Reg (msub64 div y64 x64)))
+            (result Reg (msub $I64 div y64 x64)))
         result))
 
 (rule (lower (has_type (fits_in_64 ty) (srem x y)))
       (let ((x64 Reg (put_in_reg_sext64 x))
             (y64 Reg (put_nonzero_in_reg_sext64 y))
             (div Reg (a64_sdiv $I64 x64 y64))
-            (result Reg (msub64 div y64 x64)))
+            (result Reg (msub $I64 div y64 x64)))
         result))
 
 ;;;; Rules for `uextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1014,7 +1020,7 @@
       (let ((hi_clz Reg (a64_clz $I64 (value_regs_get val 1)))
             (lo_clz Reg (a64_clz $I64 (value_regs_get val 0)))
             (tmp Reg (lsr_imm $I64 hi_clz (imm_shift_from_u8 6))))
-        (value_regs (madd64 lo_clz tmp hi_clz) (imm $I64 0))))
+        (value_regs (madd $I64 lo_clz tmp hi_clz) (imm $I64 0))))
 
 ;;;; Rules for `ctz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1062,7 +1068,7 @@
             (hi_cls Reg (a64_cls $I64 hi))
             (sign_eq_eon Reg (eon $I64 hi lo))
             (sign_eq Reg (lsr_imm $I64 sign_eq_eon (imm_shift_from_u8 63)))
-            (lo_sign_bits Reg (madd64 lo_cls sign_eq sign_eq))
+            (lo_sign_bits Reg (madd $I64 lo_cls sign_eq sign_eq))
             (maybe_lo Reg (with_flags_reg
                            (cmp64_imm hi_cls (u8_into_imm12 63))
                            (csel (Cond.Eq) lo_sign_bits (zero_reg)))))

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.manifest
@@ -1,4 +1,4 @@
 src/clif.isle 443b34b797fc8ace
 src/prelude.isle afd037c4d91c875c
-src/isa/aarch64/inst.isle 544b7126192140d5
-src/isa/aarch64/lower.isle d88b62dd6b40622
+src/isa/aarch64/inst.isle a44074e06f955750
+src/isa/aarch64/lower.isle 71c7e603b0e4bdef

--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
@@ -184,6 +184,7 @@ pub enum MInst {
     },
     AluRRRR {
         alu_op: ALUOp3,
+        size: OperandSize,
         rd: WritableReg,
         rn: Reg,
         rm: Reg,
@@ -746,7 +747,7 @@ pub enum MInst {
     },
 }
 
-/// Internal type ALUOp: defined at src/isa/aarch64/inst.isle line 795.
+/// Internal type ALUOp: defined at src/isa/aarch64/inst.isle line 796.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ALUOp {
     Add,
@@ -774,16 +775,14 @@ pub enum ALUOp {
     SbcS,
 }
 
-/// Internal type ALUOp3: defined at src/isa/aarch64/inst.isle line 833.
+/// Internal type ALUOp3: defined at src/isa/aarch64/inst.isle line 834.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ALUOp3 {
-    MAdd32,
-    MAdd64,
-    MSub32,
-    MSub64,
+    MAdd,
+    MSub,
 }
 
-/// Internal type BitOp: defined at src/isa/aarch64/inst.isle line 876.
+/// Internal type BitOp: defined at src/isa/aarch64/inst.isle line 873.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum BitOp {
     RBit,
@@ -791,7 +790,7 @@ pub enum BitOp {
     Cls,
 }
 
-/// Internal type FPUOp1: defined at src/isa/aarch64/inst.isle line 943.
+/// Internal type FPUOp1: defined at src/isa/aarch64/inst.isle line 940.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FPUOp1 {
     Abs32,
@@ -804,7 +803,7 @@ pub enum FPUOp1 {
     Cvt64To32,
 }
 
-/// Internal type FPUOp2: defined at src/isa/aarch64/inst.isle line 956.
+/// Internal type FPUOp2: defined at src/isa/aarch64/inst.isle line 953.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FPUOp2 {
     Add32,
@@ -825,14 +824,14 @@ pub enum FPUOp2 {
     Uqsub64,
 }
 
-/// Internal type FPUOp3: defined at src/isa/aarch64/inst.isle line 981.
+/// Internal type FPUOp3: defined at src/isa/aarch64/inst.isle line 978.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FPUOp3 {
     MAdd32,
     MAdd64,
 }
 
-/// Internal type FpuToIntOp: defined at src/isa/aarch64/inst.isle line 988.
+/// Internal type FpuToIntOp: defined at src/isa/aarch64/inst.isle line 985.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FpuToIntOp {
     F32ToU32,
@@ -845,7 +844,7 @@ pub enum FpuToIntOp {
     F64ToI64,
 }
 
-/// Internal type IntToFpuOp: defined at src/isa/aarch64/inst.isle line 1001.
+/// Internal type IntToFpuOp: defined at src/isa/aarch64/inst.isle line 998.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum IntToFpuOp {
     U32ToF32,
@@ -858,7 +857,7 @@ pub enum IntToFpuOp {
     I64ToF64,
 }
 
-/// Internal type FpuRoundMode: defined at src/isa/aarch64/inst.isle line 1015.
+/// Internal type FpuRoundMode: defined at src/isa/aarch64/inst.isle line 1012.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FpuRoundMode {
     Minus32,
@@ -871,7 +870,7 @@ pub enum FpuRoundMode {
     Nearest64,
 }
 
-/// Internal type VecExtendOp: defined at src/isa/aarch64/inst.isle line 1028.
+/// Internal type VecExtendOp: defined at src/isa/aarch64/inst.isle line 1025.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecExtendOp {
     Sxtl8,
@@ -882,7 +881,7 @@ pub enum VecExtendOp {
     Uxtl32,
 }
 
-/// Internal type VecALUOp: defined at src/isa/aarch64/inst.isle line 1045.
+/// Internal type VecALUOp: defined at src/isa/aarch64/inst.isle line 1042.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecALUOp {
     Sqadd,
@@ -924,7 +923,7 @@ pub enum VecALUOp {
     Sqrdmulh,
 }
 
-/// Internal type VecMisc2: defined at src/isa/aarch64/inst.isle line 1124.
+/// Internal type VecMisc2: defined at src/isa/aarch64/inst.isle line 1121.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecMisc2 {
     Not,
@@ -955,7 +954,7 @@ pub enum VecMisc2 {
     Fcmlt0,
 }
 
-/// Internal type VecRRLongOp: defined at src/isa/aarch64/inst.isle line 1181.
+/// Internal type VecRRLongOp: defined at src/isa/aarch64/inst.isle line 1178.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecRRLongOp {
     Fcvtl16,
@@ -965,7 +964,7 @@ pub enum VecRRLongOp {
     Shll32,
 }
 
-/// Internal type VecRRNarrowOp: defined at src/isa/aarch64/inst.isle line 1196.
+/// Internal type VecRRNarrowOp: defined at src/isa/aarch64/inst.isle line 1193.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecRRNarrowOp {
     Xtn16,
@@ -984,7 +983,7 @@ pub enum VecRRNarrowOp {
     Fcvtn64,
 }
 
-/// Internal type VecRRRLongOp: defined at src/isa/aarch64/inst.isle line 1228.
+/// Internal type VecRRRLongOp: defined at src/isa/aarch64/inst.isle line 1225.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecRRRLongOp {
     Smull8,
@@ -998,13 +997,13 @@ pub enum VecRRRLongOp {
     Umlal32,
 }
 
-/// Internal type VecPairOp: defined at src/isa/aarch64/inst.isle line 1245.
+/// Internal type VecPairOp: defined at src/isa/aarch64/inst.isle line 1242.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecPairOp {
     Addp,
 }
 
-/// Internal type VecRRPairLongOp: defined at src/isa/aarch64/inst.isle line 1253.
+/// Internal type VecRRPairLongOp: defined at src/isa/aarch64/inst.isle line 1250.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecRRPairLongOp {
     Saddlp8,
@@ -1013,14 +1012,14 @@ pub enum VecRRPairLongOp {
     Uaddlp16,
 }
 
-/// Internal type VecLanesOp: defined at src/isa/aarch64/inst.isle line 1264.
+/// Internal type VecLanesOp: defined at src/isa/aarch64/inst.isle line 1261.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecLanesOp {
     Addv,
     Uminv,
 }
 
-/// Internal type VecShiftImmOp: defined at src/isa/aarch64/inst.isle line 1273.
+/// Internal type VecShiftImmOp: defined at src/isa/aarch64/inst.isle line 1270.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VecShiftImmOp {
     Shl,
@@ -1028,7 +1027,7 @@ pub enum VecShiftImmOp {
     Sshr,
 }
 
-/// Internal type AtomicRMWOp: defined at src/isa/aarch64/inst.isle line 1284.
+/// Internal type AtomicRMWOp: defined at src/isa/aarch64/inst.isle line 1281.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum AtomicRMWOp {
     Add,
@@ -1269,12 +1268,12 @@ pub fn constructor_with_flags_reg<C: Context>(
 pub fn constructor_operand_size<C: Context>(ctx: &mut C, arg0: Type) -> Option<OperandSize> {
     let pattern0_0 = arg0;
     if let Some(pattern1_0) = C::fits_in_32(ctx, pattern0_0) {
-        // Rule at src/isa/aarch64/inst.isle line 894.
+        // Rule at src/isa/aarch64/inst.isle line 891.
         let expr0_0 = OperandSize::Size32;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::fits_in_64(ctx, pattern0_0) {
-        // Rule at src/isa/aarch64/inst.isle line 895.
+        // Rule at src/isa/aarch64/inst.isle line 892.
         let expr0_0 = OperandSize::Size64;
         return Some(expr0_0);
     }
@@ -1287,28 +1286,28 @@ pub fn constructor_vector_size<C: Context>(ctx: &mut C, arg0: Type) -> Option<Ve
     if let Some((pattern1_0, pattern1_1)) = C::multi_lane(ctx, pattern0_0) {
         if pattern1_0 == 8 {
             if pattern1_1 == 16 {
-                // Rule at src/isa/aarch64/inst.isle line 937.
+                // Rule at src/isa/aarch64/inst.isle line 934.
                 let expr0_0 = VectorSize::Size8x16;
                 return Some(expr0_0);
             }
         }
         if pattern1_0 == 16 {
             if pattern1_1 == 8 {
-                // Rule at src/isa/aarch64/inst.isle line 938.
+                // Rule at src/isa/aarch64/inst.isle line 935.
                 let expr0_0 = VectorSize::Size16x8;
                 return Some(expr0_0);
             }
         }
         if pattern1_0 == 32 {
             if pattern1_1 == 4 {
-                // Rule at src/isa/aarch64/inst.isle line 939.
+                // Rule at src/isa/aarch64/inst.isle line 936.
                 let expr0_0 = VectorSize::Size32x4;
                 return Some(expr0_0);
             }
         }
         if pattern1_0 == 64 {
             if pattern1_1 == 2 {
-                // Rule at src/isa/aarch64/inst.isle line 940.
+                // Rule at src/isa/aarch64/inst.isle line 937.
                 let expr0_0 = VectorSize::Size64x2;
                 return Some(expr0_0);
             }
@@ -1325,7 +1324,7 @@ pub fn constructor_movz<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1380.
+    // Rule at src/isa/aarch64/inst.isle line 1377.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovZ {
@@ -1346,7 +1345,7 @@ pub fn constructor_movn<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1387.
+    // Rule at src/isa/aarch64/inst.isle line 1384.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovN {
@@ -1371,7 +1370,7 @@ pub fn constructor_alu_rr_imm_logic<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1394.
+    // Rule at src/isa/aarch64/inst.isle line 1391.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
@@ -1399,7 +1398,7 @@ pub fn constructor_alu_rr_imm_shift<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1401.
+    // Rule at src/isa/aarch64/inst.isle line 1398.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
@@ -1427,7 +1426,7 @@ pub fn constructor_alu_rrr<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1408.
+    // Rule at src/isa/aarch64/inst.isle line 1405.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
@@ -1455,7 +1454,7 @@ pub fn constructor_vec_rrr<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1415.
+    // Rule at src/isa/aarch64/inst.isle line 1412.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecRRR {
@@ -1480,7 +1479,7 @@ pub fn constructor_vec_lanes<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1422.
+    // Rule at src/isa/aarch64/inst.isle line 1419.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecLanes {
@@ -1498,7 +1497,7 @@ pub fn constructor_vec_lanes<C: Context>(
 pub fn constructor_vec_dup<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1429.
+    // Rule at src/isa/aarch64/inst.isle line 1426.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecDup {
@@ -1523,7 +1522,7 @@ pub fn constructor_alu_rr_imm12<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1436.
+    // Rule at src/isa/aarch64/inst.isle line 1433.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
@@ -1553,7 +1552,7 @@ pub fn constructor_alu_rrr_shift<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/aarch64/inst.isle line 1443.
+    // Rule at src/isa/aarch64/inst.isle line 1440.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
@@ -1584,7 +1583,7 @@ pub fn constructor_alu_rrr_extend<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/aarch64/inst.isle line 1450.
+    // Rule at src/isa/aarch64/inst.isle line 1447.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
@@ -1613,7 +1612,7 @@ pub fn constructor_alu_rr_extend_reg<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1458.
+    // Rule at src/isa/aarch64/inst.isle line 1455.
     let expr0_0 = C::put_extended_in_reg(ctx, pattern3_0);
     let expr1_0 = C::get_extended_op(ctx, pattern3_0);
     let expr2_0 =
@@ -1625,27 +1624,31 @@ pub fn constructor_alu_rr_extend_reg<C: Context>(
 pub fn constructor_alu_rrrr<C: Context>(
     ctx: &mut C,
     arg0: &ALUOp3,
-    arg1: Reg,
+    arg1: Type,
     arg2: Reg,
     arg3: Reg,
+    arg4: Reg,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1465.
+    let pattern4_0 = arg4;
+    // Rule at src/isa/aarch64/inst.isle line 1462.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
-    let expr2_0 = MInst::AluRRRR {
+    let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
+    let expr3_0 = MInst::AluRRRR {
         alu_op: pattern0_0.clone(),
+        size: expr2_0,
         rd: expr1_0,
-        rn: pattern1_0,
-        rm: pattern2_0,
-        ra: pattern3_0,
+        rn: pattern2_0,
+        rm: pattern3_0,
+        ra: pattern4_0,
     };
-    let expr3_0 = C::emit(ctx, &expr2_0);
-    let expr4_0 = C::writable_reg_to_reg(ctx, expr1_0);
-    return Some(expr4_0);
+    let expr4_0 = C::emit(ctx, &expr3_0);
+    let expr5_0 = C::writable_reg_to_reg(ctx, expr1_0);
+    return Some(expr5_0);
 }
 
 // Generated as internal constructor for term bit_rr.
@@ -1658,7 +1661,7 @@ pub fn constructor_bit_rr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1472.
+    // Rule at src/isa/aarch64/inst.isle line 1469.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = constructor_operand_size(ctx, pattern1_0)?;
@@ -1683,7 +1686,7 @@ pub fn constructor_add_with_flags_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1479.
+    // Rule at src/isa/aarch64/inst.isle line 1476.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = ALUOp::AddS;
@@ -1713,7 +1716,7 @@ pub fn constructor_adc_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1487.
+    // Rule at src/isa/aarch64/inst.isle line 1484.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = ALUOp::Adc;
@@ -1743,7 +1746,7 @@ pub fn constructor_sub_with_flags_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1495.
+    // Rule at src/isa/aarch64/inst.isle line 1492.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = ALUOp::SubS;
@@ -1771,7 +1774,7 @@ pub fn constructor_cmp64_imm<C: Context>(
 ) -> Option<ProducesFlags> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1502.
+    // Rule at src/isa/aarch64/inst.isle line 1499.
     let expr0_0 = ALUOp::SubS;
     let expr1_0 = OperandSize::Size64;
     let expr2_0 = C::writable_zero_reg(ctx);
@@ -1796,7 +1799,7 @@ pub fn constructor_sbc_paired<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1509.
+    // Rule at src/isa/aarch64/inst.isle line 1506.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = ALUOp::Sbc;
@@ -1826,7 +1829,7 @@ pub fn constructor_vec_misc<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1517.
+    // Rule at src/isa/aarch64/inst.isle line 1514.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecMisc {
@@ -1852,7 +1855,7 @@ pub fn constructor_vec_rrr_long<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1524.
+    // Rule at src/isa/aarch64/inst.isle line 1521.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecRRRLong {
@@ -1881,7 +1884,7 @@ pub fn constructor_vec_rrrr_long<C: Context>(
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
     let pattern4_0 = arg4;
-    // Rule at src/isa/aarch64/inst.isle line 1534.
+    // Rule at src/isa/aarch64/inst.isle line 1531.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuMove128 {
@@ -1911,7 +1914,7 @@ pub fn constructor_vec_rr_narrow<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1542.
+    // Rule at src/isa/aarch64/inst.isle line 1539.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecRRNarrow {
@@ -1935,7 +1938,7 @@ pub fn constructor_vec_rr_long<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1549.
+    // Rule at src/isa/aarch64/inst.isle line 1546.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::VecRRLong {
@@ -1957,7 +1960,7 @@ pub fn constructor_mov_to_fpu<C: Context>(
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1556.
+    // Rule at src/isa/aarch64/inst.isle line 1553.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovToFpu {
@@ -1982,7 +1985,7 @@ pub fn constructor_mov_to_vec<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1563.
+    // Rule at src/isa/aarch64/inst.isle line 1560.
     let expr0_0: Type = I8X16;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::FpuMove128 {
@@ -2011,7 +2014,7 @@ pub fn constructor_mov_from_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1571.
+    // Rule at src/isa/aarch64/inst.isle line 1568.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovFromVec {
@@ -2037,7 +2040,7 @@ pub fn constructor_mov_from_vec_signed<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1578.
+    // Rule at src/isa/aarch64/inst.isle line 1575.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::MovFromVecSigned {
@@ -2064,7 +2067,7 @@ pub fn constructor_extend<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1585.
+    // Rule at src/isa/aarch64/inst.isle line 1582.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::Extend {
@@ -2083,7 +2086,7 @@ pub fn constructor_extend<C: Context>(
 pub fn constructor_load_acquire<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1592.
+    // Rule at src/isa/aarch64/inst.isle line 1589.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::LoadAcquire {
@@ -2106,7 +2109,7 @@ pub fn constructor_tst_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1602.
+    // Rule at src/isa/aarch64/inst.isle line 1599.
     let expr0_0 = ALUOp::AndS;
     let expr1_0 = constructor_operand_size(ctx, pattern0_0)?;
     let expr2_0 = C::writable_zero_reg(ctx);
@@ -2131,7 +2134,7 @@ pub fn constructor_csel<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1616.
+    // Rule at src/isa/aarch64/inst.isle line 1613.
     let expr0_0: Type = I64;
     let expr1_0 = C::temp_writable_reg(ctx, expr0_0);
     let expr2_0 = MInst::CSel {
@@ -2153,7 +2156,7 @@ pub fn constructor_add<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1625.
+    // Rule at src/isa/aarch64/inst.isle line 1622.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2169,7 +2172,7 @@ pub fn constructor_add_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1628.
+    // Rule at src/isa/aarch64/inst.isle line 1625.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rr_imm12(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2185,7 +2188,7 @@ pub fn constructor_add_extend<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1631.
+    // Rule at src/isa/aarch64/inst.isle line 1628.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rr_extend_reg(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2203,7 +2206,7 @@ pub fn constructor_add_shift<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1634.
+    // Rule at src/isa/aarch64/inst.isle line 1631.
     let expr0_0 = ALUOp::Add;
     let expr1_0 = constructor_alu_rrr_shift(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2221,7 +2224,7 @@ pub fn constructor_add_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1637.
+    // Rule at src/isa/aarch64/inst.isle line 1634.
     let expr0_0 = VecALUOp::Add;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2232,7 +2235,7 @@ pub fn constructor_sub<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1642.
+    // Rule at src/isa/aarch64/inst.isle line 1639.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2248,7 +2251,7 @@ pub fn constructor_sub_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1645.
+    // Rule at src/isa/aarch64/inst.isle line 1642.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rr_imm12(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2264,7 +2267,7 @@ pub fn constructor_sub_extend<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1648.
+    // Rule at src/isa/aarch64/inst.isle line 1645.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rr_extend_reg(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2282,7 +2285,7 @@ pub fn constructor_sub_shift<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1651.
+    // Rule at src/isa/aarch64/inst.isle line 1648.
     let expr0_0 = ALUOp::Sub;
     let expr1_0 = constructor_alu_rrr_shift(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2300,7 +2303,7 @@ pub fn constructor_sub_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1654.
+    // Rule at src/isa/aarch64/inst.isle line 1651.
     let expr0_0 = VecALUOp::Sub;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2315,55 +2318,34 @@ pub fn constructor_madd<C: Context>(
     arg3: Reg,
 ) -> Option<Reg> {
     let pattern0_0 = arg0;
-    if pattern0_0 == I64 {
-        let pattern2_0 = arg1;
-        let pattern3_0 = arg2;
-        let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/inst.isle line 1660.
-        let expr0_0 = constructor_madd64(ctx, pattern2_0, pattern3_0, pattern4_0)?;
-        return Some(expr0_0);
-    }
-    if let Some(pattern1_0) = C::fits_in_32(ctx, pattern0_0) {
-        let pattern2_0 = arg1;
-        let pattern3_0 = arg2;
-        let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/inst.isle line 1659.
-        let expr0_0 = constructor_madd32(ctx, pattern2_0, pattern3_0, pattern4_0)?;
-        return Some(expr0_0);
-    }
-    return None;
-}
-
-// Generated as internal constructor for term madd32.
-pub fn constructor_madd32<C: Context>(ctx: &mut C, arg0: Reg, arg1: Reg, arg2: Reg) -> Option<Reg> {
-    let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1663.
-    let expr0_0 = ALUOp3::MAdd32;
-    let expr1_0 = constructor_alu_rrrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
+    let pattern3_0 = arg3;
+    // Rule at src/isa/aarch64/inst.isle line 1656.
+    let expr0_0 = ALUOp3::MAdd;
+    let expr1_0 = constructor_alu_rrrr(
+        ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
+    )?;
     return Some(expr1_0);
 }
 
-// Generated as internal constructor for term madd64.
-pub fn constructor_madd64<C: Context>(ctx: &mut C, arg0: Reg, arg1: Reg, arg2: Reg) -> Option<Reg> {
+// Generated as internal constructor for term msub.
+pub fn constructor_msub<C: Context>(
+    ctx: &mut C,
+    arg0: Type,
+    arg1: Reg,
+    arg2: Reg,
+    arg3: Reg,
+) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1666.
-    let expr0_0 = ALUOp3::MAdd64;
-    let expr1_0 = constructor_alu_rrrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
-    return Some(expr1_0);
-}
-
-// Generated as internal constructor for term msub64.
-pub fn constructor_msub64<C: Context>(ctx: &mut C, arg0: Reg, arg1: Reg, arg2: Reg) -> Option<Reg> {
-    let pattern0_0 = arg0;
-    let pattern1_0 = arg1;
-    let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1671.
-    let expr0_0 = ALUOp3::MSub64;
-    let expr1_0 = constructor_alu_rrrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
+    let pattern3_0 = arg3;
+    // Rule at src/isa/aarch64/inst.isle line 1661.
+    let expr0_0 = ALUOp3::MSub;
+    let expr1_0 = constructor_alu_rrrr(
+        ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
+    )?;
     return Some(expr1_0);
 }
 
@@ -2377,7 +2359,7 @@ pub fn constructor_uqadd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1675.
+    // Rule at src/isa/aarch64/inst.isle line 1665.
     let expr0_0 = VecALUOp::Uqadd;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2393,7 +2375,7 @@ pub fn constructor_sqadd<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1679.
+    // Rule at src/isa/aarch64/inst.isle line 1669.
     let expr0_0 = VecALUOp::Sqadd;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2409,7 +2391,7 @@ pub fn constructor_uqsub<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1683.
+    // Rule at src/isa/aarch64/inst.isle line 1673.
     let expr0_0 = VecALUOp::Uqsub;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2425,7 +2407,7 @@ pub fn constructor_sqsub<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1687.
+    // Rule at src/isa/aarch64/inst.isle line 1677.
     let expr0_0 = VecALUOp::Sqsub;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2436,7 +2418,7 @@ pub fn constructor_umulh<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: R
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1691.
+    // Rule at src/isa/aarch64/inst.isle line 1681.
     let expr0_0 = ALUOp::UMulH;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2447,7 +2429,7 @@ pub fn constructor_smulh<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: R
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1695.
+    // Rule at src/isa/aarch64/inst.isle line 1685.
     let expr0_0 = ALUOp::SMulH;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2463,7 +2445,7 @@ pub fn constructor_mul<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1699.
+    // Rule at src/isa/aarch64/inst.isle line 1689.
     let expr0_0 = VecALUOp::Mul;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2473,7 +2455,7 @@ pub fn constructor_mul<C: Context>(
 pub fn constructor_neg<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1703.
+    // Rule at src/isa/aarch64/inst.isle line 1693.
     let expr0_0 = VecMisc2::Neg;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2483,7 +2465,7 @@ pub fn constructor_neg<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) ->
 pub fn constructor_rev64<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1707.
+    // Rule at src/isa/aarch64/inst.isle line 1697.
     let expr0_0 = VecMisc2::Rev64;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2493,7 +2475,7 @@ pub fn constructor_rev64<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) 
 pub fn constructor_xtn64<C: Context>(ctx: &mut C, arg0: Reg, arg1: bool) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1711.
+    // Rule at src/isa/aarch64/inst.isle line 1701.
     let expr0_0 = VecRRNarrowOp::Xtn64;
     let expr1_0 = constructor_vec_rr_narrow(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2509,7 +2491,7 @@ pub fn constructor_addp<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1715.
+    // Rule at src/isa/aarch64/inst.isle line 1705.
     let expr0_0 = VecALUOp::Addp;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2519,7 +2501,7 @@ pub fn constructor_addp<C: Context>(
 pub fn constructor_addv<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1719.
+    // Rule at src/isa/aarch64/inst.isle line 1709.
     let expr0_0 = VecLanesOp::Addv;
     let expr1_0 = constructor_vec_lanes(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2529,7 +2511,7 @@ pub fn constructor_addv<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -
 pub fn constructor_shll32<C: Context>(ctx: &mut C, arg0: Reg, arg1: bool) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1723.
+    // Rule at src/isa/aarch64/inst.isle line 1713.
     let expr0_0 = VecRRLongOp::Shll32;
     let expr1_0 = constructor_vec_rr_long(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2547,7 +2529,7 @@ pub fn constructor_umlal32<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1727.
+    // Rule at src/isa/aarch64/inst.isle line 1717.
     let expr0_0 = VecRRRLongOp::Umlal32;
     let expr1_0 = constructor_vec_rrrr_long(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2565,7 +2547,7 @@ pub fn constructor_smull8<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1731.
+    // Rule at src/isa/aarch64/inst.isle line 1721.
     let expr0_0 = VecRRRLongOp::Smull8;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2581,7 +2563,7 @@ pub fn constructor_umull8<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1735.
+    // Rule at src/isa/aarch64/inst.isle line 1725.
     let expr0_0 = VecRRRLongOp::Umull8;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2597,7 +2579,7 @@ pub fn constructor_smull16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1739.
+    // Rule at src/isa/aarch64/inst.isle line 1729.
     let expr0_0 = VecRRRLongOp::Smull16;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2613,7 +2595,7 @@ pub fn constructor_umull16<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1743.
+    // Rule at src/isa/aarch64/inst.isle line 1733.
     let expr0_0 = VecRRRLongOp::Umull16;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2629,7 +2611,7 @@ pub fn constructor_smull32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1747.
+    // Rule at src/isa/aarch64/inst.isle line 1737.
     let expr0_0 = VecRRRLongOp::Smull32;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2645,7 +2627,7 @@ pub fn constructor_umull32<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1751.
+    // Rule at src/isa/aarch64/inst.isle line 1741.
     let expr0_0 = VecRRRLongOp::Umull32;
     let expr1_0 = constructor_vec_rrr_long(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2656,7 +2638,7 @@ pub fn constructor_asr<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1755.
+    // Rule at src/isa/aarch64/inst.isle line 1745.
     let expr0_0 = ALUOp::Asr;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2672,7 +2654,7 @@ pub fn constructor_asr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1758.
+    // Rule at src/isa/aarch64/inst.isle line 1748.
     let expr0_0 = ALUOp::Asr;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2683,7 +2665,7 @@ pub fn constructor_lsr<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1762.
+    // Rule at src/isa/aarch64/inst.isle line 1752.
     let expr0_0 = ALUOp::Lsr;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2699,7 +2681,7 @@ pub fn constructor_lsr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1765.
+    // Rule at src/isa/aarch64/inst.isle line 1755.
     let expr0_0 = ALUOp::Lsr;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2710,7 +2692,7 @@ pub fn constructor_lsl<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1769.
+    // Rule at src/isa/aarch64/inst.isle line 1759.
     let expr0_0 = ALUOp::Lsl;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2726,7 +2708,7 @@ pub fn constructor_lsl_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1772.
+    // Rule at src/isa/aarch64/inst.isle line 1762.
     let expr0_0 = ALUOp::Lsl;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2742,7 +2724,7 @@ pub fn constructor_a64_udiv<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1776.
+    // Rule at src/isa/aarch64/inst.isle line 1766.
     let expr0_0 = ALUOp::UDiv;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2758,7 +2740,7 @@ pub fn constructor_a64_sdiv<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1780.
+    // Rule at src/isa/aarch64/inst.isle line 1770.
     let expr0_0 = ALUOp::SDiv;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2768,7 +2750,7 @@ pub fn constructor_a64_sdiv<C: Context>(
 pub fn constructor_not<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1784.
+    // Rule at src/isa/aarch64/inst.isle line 1774.
     let expr0_0 = VecMisc2::Not;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2784,7 +2766,7 @@ pub fn constructor_orr_not<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1789.
+    // Rule at src/isa/aarch64/inst.isle line 1779.
     let expr0_0 = ALUOp::OrrNot;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2802,7 +2784,7 @@ pub fn constructor_orr_not_shift<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 1792.
+    // Rule at src/isa/aarch64/inst.isle line 1782.
     let expr0_0 = ALUOp::OrrNot;
     let expr1_0 = constructor_alu_rrr_shift(
         ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0, pattern3_0,
@@ -2815,7 +2797,7 @@ pub fn constructor_orr<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1797.
+    // Rule at src/isa/aarch64/inst.isle line 1787.
     let expr0_0 = ALUOp::Orr;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2831,7 +2813,7 @@ pub fn constructor_orr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1800.
+    // Rule at src/isa/aarch64/inst.isle line 1790.
     let expr0_0 = ALUOp::Orr;
     let expr1_0 = constructor_alu_rr_imm_logic(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2847,7 +2829,7 @@ pub fn constructor_orr_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1803.
+    // Rule at src/isa/aarch64/inst.isle line 1793.
     let expr0_0 = VecALUOp::Orr;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2863,7 +2845,7 @@ pub fn constructor_and_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1808.
+    // Rule at src/isa/aarch64/inst.isle line 1798.
     let expr0_0 = ALUOp::And;
     let expr1_0 = constructor_alu_rr_imm_logic(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2879,7 +2861,7 @@ pub fn constructor_and_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1811.
+    // Rule at src/isa/aarch64/inst.isle line 1801.
     let expr0_0 = VecALUOp::And;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2895,7 +2877,7 @@ pub fn constructor_eor_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1815.
+    // Rule at src/isa/aarch64/inst.isle line 1805.
     let expr0_0 = VecALUOp::Eor;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2911,7 +2893,7 @@ pub fn constructor_bic_vec<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1819.
+    // Rule at src/isa/aarch64/inst.isle line 1809.
     let expr0_0 = VecALUOp::Bic;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2927,7 +2909,7 @@ pub fn constructor_sshl<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1823.
+    // Rule at src/isa/aarch64/inst.isle line 1813.
     let expr0_0 = VecALUOp::Sshl;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2943,7 +2925,7 @@ pub fn constructor_ushl<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1827.
+    // Rule at src/isa/aarch64/inst.isle line 1817.
     let expr0_0 = VecALUOp::Ushl;
     let expr1_0 = constructor_vec_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2959,7 +2941,7 @@ pub fn constructor_a64_rotr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1832.
+    // Rule at src/isa/aarch64/inst.isle line 1822.
     let expr0_0 = ALUOp::RotR;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2975,7 +2957,7 @@ pub fn constructor_a64_rotr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1835.
+    // Rule at src/isa/aarch64/inst.isle line 1825.
     let expr0_0 = ALUOp::RotR;
     let expr1_0 = constructor_alu_rr_imm_shift(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -2985,7 +2967,7 @@ pub fn constructor_a64_rotr_imm<C: Context>(
 pub fn constructor_rbit<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1840.
+    // Rule at src/isa/aarch64/inst.isle line 1830.
     let expr0_0 = BitOp::RBit;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -2995,7 +2977,7 @@ pub fn constructor_rbit<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Optio
 pub fn constructor_a64_clz<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1845.
+    // Rule at src/isa/aarch64/inst.isle line 1835.
     let expr0_0 = BitOp::Clz;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3005,7 +2987,7 @@ pub fn constructor_a64_clz<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Op
 pub fn constructor_a64_cls<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1850.
+    // Rule at src/isa/aarch64/inst.isle line 1840.
     let expr0_0 = BitOp::Cls;
     let expr1_0 = constructor_bit_rr(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3016,7 +2998,7 @@ pub fn constructor_eon<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1855.
+    // Rule at src/isa/aarch64/inst.isle line 1845.
     let expr0_0 = ALUOp::EorNot;
     let expr1_0 = constructor_alu_rrr(ctx, &expr0_0, pattern0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -3026,7 +3008,7 @@ pub fn constructor_eon<C: Context>(ctx: &mut C, arg0: Type, arg1: Reg, arg2: Reg
 pub fn constructor_vec_cnt<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 1860.
+    // Rule at src/isa/aarch64/inst.isle line 1850.
     let expr0_0 = VecMisc2::Cnt;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3043,7 +3025,7 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
         };
         if let Some(pattern3_0) = closure3() {
             if let Some(pattern4_0) = C::imm_logic_from_u64(ctx, pattern2_0, pattern3_0) {
-                // Rule at src/isa/aarch64/inst.isle line 1875.
+                // Rule at src/isa/aarch64/inst.isle line 1865.
                 let expr0_0: Type = I64;
                 let expr1_0 = C::zero_reg(ctx);
                 let expr2_0 = constructor_orr_imm(ctx, expr0_0, expr1_0, pattern4_0)?;
@@ -3051,18 +3033,18 @@ pub fn constructor_imm<C: Context>(ctx: &mut C, arg0: Type, arg1: u64) -> Option
             }
         }
         if let Some(pattern3_0) = C::move_wide_const_from_u64(ctx, pattern2_0) {
-            // Rule at src/isa/aarch64/inst.isle line 1867.
+            // Rule at src/isa/aarch64/inst.isle line 1857.
             let expr0_0 = OperandSize::Size64;
             let expr1_0 = constructor_movz(ctx, pattern3_0, &expr0_0)?;
             return Some(expr1_0);
         }
         if let Some(pattern3_0) = C::move_wide_const_from_negated_u64(ctx, pattern2_0) {
-            // Rule at src/isa/aarch64/inst.isle line 1871.
+            // Rule at src/isa/aarch64/inst.isle line 1861.
             let expr0_0 = OperandSize::Size64;
             let expr1_0 = constructor_movn(ctx, pattern3_0, &expr0_0)?;
             return Some(expr1_0);
         }
-        // Rule at src/isa/aarch64/inst.isle line 1882.
+        // Rule at src/isa/aarch64/inst.isle line 1872.
         let expr0_0 = C::load_constant64_full(ctx, pattern2_0);
         return Some(expr0_0);
     }
@@ -3074,17 +3056,17 @@ pub fn constructor_put_in_reg_sext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I32 {
-        // Rule at src/isa/aarch64/inst.isle line 1893.
+        // Rule at src/isa/aarch64/inst.isle line 1883.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1894.
+        // Rule at src/isa/aarch64/inst.isle line 1884.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1889.
+        // Rule at src/isa/aarch64/inst.isle line 1879.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = true;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -3100,17 +3082,17 @@ pub fn constructor_put_in_reg_zext32<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I32 {
-        // Rule at src/isa/aarch64/inst.isle line 1902.
+        // Rule at src/isa/aarch64/inst.isle line 1892.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1903.
+        // Rule at src/isa/aarch64/inst.isle line 1893.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1898.
+        // Rule at src/isa/aarch64/inst.isle line 1888.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = false;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -3126,12 +3108,12 @@ pub fn constructor_put_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1911.
+        // Rule at src/isa/aarch64/inst.isle line 1901.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1907.
+        // Rule at src/isa/aarch64/inst.isle line 1897.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = true;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -3147,12 +3129,12 @@ pub fn constructor_put_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
     let pattern0_0 = arg0;
     let pattern1_0 = C::value_type(ctx, pattern0_0);
     if pattern1_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1919.
+        // Rule at src/isa/aarch64/inst.isle line 1909.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         return Some(expr0_0);
     }
     if let Some(pattern2_0) = C::fits_in_32(ctx, pattern1_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1915.
+        // Rule at src/isa/aarch64/inst.isle line 1905.
         let expr0_0 = C::put_in_reg(ctx, pattern0_0);
         let expr1_0: bool = false;
         let expr2_0 = C::ty_bits(ctx, pattern2_0);
@@ -3166,7 +3148,7 @@ pub fn constructor_put_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Value) -> Op
 // Generated as internal constructor for term trap_if_zero_divisor.
 pub fn constructor_trap_if_zero_divisor<C: Context>(ctx: &mut C, arg0: Reg) -> Option<Reg> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/inst.isle line 1924.
+    // Rule at src/isa/aarch64/inst.isle line 1914.
     let expr0_0 = C::cond_br_zero(ctx, pattern0_0);
     let expr1_0 = C::trap_code_division_by_zero(ctx);
     let expr2_0 = MInst::TrapIf {
@@ -3181,12 +3163,12 @@ pub fn constructor_trap_if_zero_divisor<C: Context>(ctx: &mut C, arg0: Reg) -> O
 pub fn constructor_size_from_ty<C: Context>(ctx: &mut C, arg0: Type) -> Option<OperandSize> {
     let pattern0_0 = arg0;
     if pattern0_0 == I64 {
-        // Rule at src/isa/aarch64/inst.isle line 1930.
+        // Rule at src/isa/aarch64/inst.isle line 1920.
         let expr0_0 = OperandSize::Size64;
         return Some(expr0_0);
     }
     if let Some(pattern1_0) = C::fits_in_32(ctx, pattern0_0) {
-        // Rule at src/isa/aarch64/inst.isle line 1929.
+        // Rule at src/isa/aarch64/inst.isle line 1919.
         let expr0_0 = OperandSize::Size32;
         return Some(expr0_0);
     }
@@ -3203,7 +3185,7 @@ pub fn constructor_trap_if_div_overflow<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 1936.
+    // Rule at src/isa/aarch64/inst.isle line 1926.
     let expr0_0 = ALUOp::AddS;
     let expr1_0 = constructor_operand_size(ctx, pattern0_0)?;
     let expr2_0 = C::writable_zero_reg(ctx);
@@ -3272,7 +3254,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                             C::imm_logic_from_imm64(ctx, pattern5_1, pattern7_0)
                         {
                             let pattern9_0 = arg3;
-                            // Rule at src/isa/aarch64/inst.isle line 1981.
+                            // Rule at src/isa/aarch64/inst.isle line 1971.
                             let expr0_0 = C::put_in_reg(ctx, pattern9_0);
                             let expr1_0 = constructor_alu_rr_imm_logic(
                                 ctx, pattern0_0, pattern1_0, expr0_0, pattern8_0,
@@ -3304,7 +3286,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                                         C::lshl_from_imm64(ctx, pattern10_1, pattern12_0)
                                     {
                                         let pattern14_0 = arg3;
-                                        // Rule at src/isa/aarch64/inst.isle line 1987.
+                                        // Rule at src/isa/aarch64/inst.isle line 1977.
                                         let expr0_0 = C::put_in_reg(ctx, pattern14_0);
                                         let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                         let expr2_0 = constructor_alu_rrr_shift(
@@ -3342,7 +3324,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                         if let Some(pattern9_0) =
                             C::imm_logic_from_imm64(ctx, pattern6_1, pattern8_0)
                         {
-                            // Rule at src/isa/aarch64/inst.isle line 1979.
+                            // Rule at src/isa/aarch64/inst.isle line 1969.
                             let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                             let expr1_0 = constructor_alu_rr_imm_logic(
                                 ctx, pattern0_0, pattern1_0, expr0_0, pattern9_0,
@@ -3373,7 +3355,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
                                     if let Some(pattern14_0) =
                                         C::lshl_from_imm64(ctx, pattern11_1, pattern13_0)
                                     {
-                                        // Rule at src/isa/aarch64/inst.isle line 1985.
+                                        // Rule at src/isa/aarch64/inst.isle line 1975.
                                         let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                                         let expr1_0 = C::put_in_reg(ctx, pattern8_0);
                                         let expr2_0 = constructor_alu_rrr_shift(
@@ -3395,7 +3377,7 @@ pub fn constructor_alu_rs_imm_logic_commutative<C: Context>(
             _ => {}
         }
     }
-    // Rule at src/isa/aarch64/inst.isle line 1975.
+    // Rule at src/isa/aarch64/inst.isle line 1965.
     let expr0_0 = C::put_in_reg(ctx, pattern2_0);
     let expr1_0 = C::put_in_reg(ctx, pattern3_0);
     let expr2_0 = constructor_alu_rrr(ctx, pattern0_0, pattern1_0, expr0_0, expr1_0)?;
@@ -3429,7 +3411,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
                         if let Some(pattern9_0) =
                             C::imm_logic_from_imm64(ctx, pattern6_1, pattern8_0)
                         {
-                            // Rule at src/isa/aarch64/inst.isle line 1995.
+                            // Rule at src/isa/aarch64/inst.isle line 1985.
                             let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                             let expr1_0 = constructor_alu_rr_imm_logic(
                                 ctx, pattern0_0, pattern1_0, expr0_0, pattern9_0,
@@ -3460,7 +3442,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
                                     if let Some(pattern14_0) =
                                         C::lshl_from_imm64(ctx, pattern11_1, pattern13_0)
                                     {
-                                        // Rule at src/isa/aarch64/inst.isle line 1997.
+                                        // Rule at src/isa/aarch64/inst.isle line 1987.
                                         let expr0_0 = C::put_in_reg(ctx, pattern2_0);
                                         let expr1_0 = C::put_in_reg(ctx, pattern8_0);
                                         let expr2_0 = constructor_alu_rrr_shift(
@@ -3482,7 +3464,7 @@ pub fn constructor_alu_rs_imm_logic<C: Context>(
             _ => {}
         }
     }
-    // Rule at src/isa/aarch64/inst.isle line 1993.
+    // Rule at src/isa/aarch64/inst.isle line 1983.
     let expr0_0 = C::put_in_reg(ctx, pattern2_0);
     let expr1_0 = C::put_in_reg(ctx, pattern3_0);
     let expr2_0 = constructor_alu_rrr(ctx, pattern0_0, pattern1_0, expr0_0, expr1_0)?;
@@ -3501,7 +3483,7 @@ pub fn constructor_i128_alu_bitop<C: Context>(
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
     let pattern3_0 = arg3;
-    // Rule at src/isa/aarch64/inst.isle line 2005.
+    // Rule at src/isa/aarch64/inst.isle line 1995.
     let expr0_0 = C::put_in_regs(ctx, pattern2_0);
     let expr1_0: usize = 0;
     let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -3528,7 +3510,7 @@ pub fn constructor_float_cmp_zero<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 2045.
+    // Rule at src/isa/aarch64/inst.isle line 2035.
     let expr0_0 = C::float_cc_cmp_zero_to_vec_misc_op(ctx, pattern0_0);
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -3544,7 +3526,7 @@ pub fn constructor_float_cmp_zero_swap<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 2050.
+    // Rule at src/isa/aarch64/inst.isle line 2040.
     let expr0_0 = C::float_cc_cmp_zero_to_vec_misc_op_swap(ctx, pattern0_0);
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -3554,7 +3536,7 @@ pub fn constructor_float_cmp_zero_swap<C: Context>(
 pub fn constructor_fcmeq0<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 2055.
+    // Rule at src/isa/aarch64/inst.isle line 2045.
     let expr0_0 = VecMisc2::Fcmeq0;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3570,7 +3552,7 @@ pub fn constructor_int_cmp_zero<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 2081.
+    // Rule at src/isa/aarch64/inst.isle line 2071.
     let expr0_0 = C::int_cc_cmp_zero_to_vec_misc_op(ctx, pattern0_0);
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -3586,7 +3568,7 @@ pub fn constructor_int_cmp_zero_swap<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/inst.isle line 2086.
+    // Rule at src/isa/aarch64/inst.isle line 2076.
     let expr0_0 = C::int_cc_cmp_zero_to_vec_misc_op_swap(ctx, pattern0_0);
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern1_0, pattern2_0)?;
     return Some(expr1_0);
@@ -3596,7 +3578,7 @@ pub fn constructor_int_cmp_zero_swap<C: Context>(
 pub fn constructor_cmeq0<C: Context>(ctx: &mut C, arg0: Reg, arg1: &VectorSize) -> Option<Reg> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/inst.isle line 2091.
+    // Rule at src/isa/aarch64/inst.isle line 2081.
     let expr0_0 = VecMisc2::Cmeq0;
     let expr1_0 = constructor_vec_misc(ctx, &expr0_0, pattern0_0, pattern1_0)?;
     return Some(expr1_0);
@@ -3616,7 +3598,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
             {
                 match pattern5_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 974.
+                        // Rule at src/isa/aarch64/lower.isle line 980.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = C::put_in_reg(ctx, pattern5_1);
@@ -3628,7 +3610,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr7_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 995.
+                        // Rule at src/isa/aarch64/lower.isle line 1001.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3640,7 +3622,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr7_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1042.
+                        // Rule at src/isa/aarch64/lower.isle line 1048.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3652,7 +3634,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr7_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1025.
+                        // Rule at src/isa/aarch64/lower.isle line 1031.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0: Type = I32;
@@ -3667,7 +3649,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr10_0);
                     }
                     &Opcode::Popcnt => {
-                        // Rule at src/isa/aarch64/lower.isle line 1093.
+                        // Rule at src/isa/aarch64/lower.isle line 1099.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3692,7 +3674,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
             {
                 match pattern5_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 980.
+                        // Rule at src/isa/aarch64/lower.isle line 986.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = C::put_in_reg(ctx, pattern5_1);
@@ -3704,7 +3686,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr7_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 998.
+                        // Rule at src/isa/aarch64/lower.isle line 1004.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3716,7 +3698,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr7_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1045.
+                        // Rule at src/isa/aarch64/lower.isle line 1051.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_put_in_reg_zext32(ctx, pattern5_1)?;
@@ -3728,7 +3710,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr7_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1028.
+                        // Rule at src/isa/aarch64/lower.isle line 1034.
                         let expr0_0: Type = I32;
                         let expr1_0: Type = I32;
                         let expr2_0: Type = I32;
@@ -3743,7 +3725,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         return Some(expr10_0);
                     }
                     &Opcode::Popcnt => {
-                        // Rule at src/isa/aarch64/lower.isle line 1099.
+                        // Rule at src/isa/aarch64/lower.isle line 1105.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3789,7 +3771,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 865.
+                                                // Rule at src/isa/aarch64/lower.isle line 871.
                                                 let expr0_0: Type = I32;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0: Type = I32;
@@ -3805,7 +3787,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 855.
+                            // Rule at src/isa/aarch64/lower.isle line 861.
                             let expr0_0: Type = I32;
                             let expr1_0 = C::zero_reg(ctx);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3836,7 +3818,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 907.
+                                                // Rule at src/isa/aarch64/lower.isle line 913.
                                                 let expr0_0: Type = I32;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0 = constructor_a64_rotr_imm(
@@ -3852,7 +3834,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 895.
+                            // Rule at src/isa/aarch64/lower.isle line 901.
                             let expr0_0: Type = I32;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3868,7 +3850,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Popcnt = pattern5_0 {
-                        // Rule at src/isa/aarch64/lower.isle line 1105.
+                        // Rule at src/isa/aarch64/lower.isle line 1111.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size32;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -3896,7 +3878,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     match pattern5_0 {
                         &Opcode::Umulhi => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 367.
+                            // Rule at src/isa/aarch64/lower.isle line 371.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3906,7 +3888,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Smulhi => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 355.
+                            // Rule at src/isa/aarch64/lower.isle line 359.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -3916,7 +3898,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 586.
+                            // Rule at src/isa/aarch64/lower.isle line 592.
                             let expr0_0 = ALUOp::And;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
@@ -3927,7 +3909,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 599.
+                            // Rule at src/isa/aarch64/lower.isle line 605.
                             let expr0_0 = ALUOp::Orr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
@@ -3938,7 +3920,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 612.
+                            // Rule at src/isa/aarch64/lower.isle line 618.
                             let expr0_0 = ALUOp::Eor;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic_commutative(
@@ -3949,7 +3931,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::BandNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 625.
+                            // Rule at src/isa/aarch64/lower.isle line 631.
                             let expr0_0 = ALUOp::AndNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic(
@@ -3960,7 +3942,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::BorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 638.
+                            // Rule at src/isa/aarch64/lower.isle line 644.
                             let expr0_0 = ALUOp::OrrNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic(
@@ -3971,7 +3953,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::BxorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 648.
+                            // Rule at src/isa/aarch64/lower.isle line 654.
                             let expr0_0 = ALUOp::EorNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_alu_rs_imm_logic(
@@ -4000,7 +3982,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 869.
+                                                // Rule at src/isa/aarch64/lower.isle line 875.
                                                 let expr0_0: Type = I64;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0: Type = I64;
@@ -4016,7 +3998,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 860.
+                            // Rule at src/isa/aarch64/lower.isle line 866.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::zero_reg(ctx);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -4047,7 +4029,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                 pattern10_1,
                                                 pattern12_0,
                                             ) {
-                                                // Rule at src/isa/aarch64/lower.isle line 911.
+                                                // Rule at src/isa/aarch64/lower.isle line 917.
                                                 let expr0_0: Type = I64;
                                                 let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr2_0 = constructor_a64_rotr_imm(
@@ -4063,7 +4045,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 899.
+                            // Rule at src/isa/aarch64/lower.isle line 905.
                             let expr0_0: Type = I64;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -4073,7 +4055,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 660.
+                            // Rule at src/isa/aarch64/lower.isle line 666.
                             let expr0_0 = ALUOp::Lsl;
                             let expr1_0: Type = I64;
                             let expr2_0 = C::put_in_reg(ctx, pattern7_0);
@@ -4084,7 +4066,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 744.
+                            // Rule at src/isa/aarch64/lower.isle line 750.
                             let expr0_0 = ALUOp::Lsr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
@@ -4095,7 +4077,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 791.
+                            // Rule at src/isa/aarch64/lower.isle line 797.
                             let expr0_0 = ALUOp::Asr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
@@ -4112,7 +4094,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     arg: pattern5_1,
                 } => {
                     if let &Opcode::Popcnt = pattern5_0 {
-                        // Rule at src/isa/aarch64/lower.isle line 1111.
+                        // Rule at src/isa/aarch64/lower.isle line 1117.
                         let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                         let expr1_0 = ScalarSize::Size64;
                         let expr2_0 = constructor_mov_to_fpu(ctx, expr0_0, &expr1_0)?;
@@ -4140,7 +4122,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     match pattern5_0 {
                         &Opcode::Iadd => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 79.
+                            // Rule at src/isa/aarch64/lower.isle line 83.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4162,7 +4144,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 129.
+                            // Rule at src/isa/aarch64/lower.isle line 133.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4184,7 +4166,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 183.
+                            // Rule at src/isa/aarch64/lower.isle line 187.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4197,17 +4179,23 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr9_0 = C::value_regs_get(ctx, expr5_0, expr8_0);
                             let expr10_0: Type = I64;
                             let expr11_0 = constructor_umulh(ctx, expr10_0, expr2_0, expr7_0)?;
-                            let expr12_0 = constructor_madd64(ctx, expr2_0, expr9_0, expr11_0)?;
-                            let expr13_0 = constructor_madd64(ctx, expr4_0, expr7_0, expr12_0)?;
-                            let expr14_0 = C::zero_reg(ctx);
-                            let expr15_0 = constructor_madd64(ctx, expr2_0, expr7_0, expr14_0)?;
-                            let expr16_0 = C::value_regs(ctx, expr15_0, expr13_0);
-                            let expr17_0 = C::output(ctx, expr16_0);
-                            return Some(expr17_0);
+                            let expr12_0: Type = I64;
+                            let expr13_0 =
+                                constructor_madd(ctx, expr12_0, expr2_0, expr9_0, expr11_0)?;
+                            let expr14_0: Type = I64;
+                            let expr15_0 =
+                                constructor_madd(ctx, expr14_0, expr4_0, expr7_0, expr13_0)?;
+                            let expr16_0: Type = I64;
+                            let expr17_0 = C::zero_reg(ctx);
+                            let expr18_0 =
+                                constructor_madd(ctx, expr16_0, expr2_0, expr7_0, expr17_0)?;
+                            let expr19_0 = C::value_regs(ctx, expr18_0, expr15_0);
+                            let expr20_0 = C::output(ctx, expr19_0);
+                            return Some(expr20_0);
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 589.
+                            // Rule at src/isa/aarch64/lower.isle line 595.
                             let expr0_0 = ALUOp::And;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4218,7 +4206,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 602.
+                            // Rule at src/isa/aarch64/lower.isle line 608.
                             let expr0_0 = ALUOp::Orr;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4229,7 +4217,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 615.
+                            // Rule at src/isa/aarch64/lower.isle line 621.
                             let expr0_0 = ALUOp::Eor;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4240,7 +4228,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::BandNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 628.
+                            // Rule at src/isa/aarch64/lower.isle line 634.
                             let expr0_0 = ALUOp::AndNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4251,7 +4239,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::BorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 641.
+                            // Rule at src/isa/aarch64/lower.isle line 647.
                             let expr0_0 = ALUOp::OrrNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4262,7 +4250,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::BxorNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 651.
+                            // Rule at src/isa/aarch64/lower.isle line 657.
                             let expr0_0 = ALUOp::EorNot;
                             let expr1_0: Type = I64;
                             let expr2_0 = constructor_i128_alu_bitop(
@@ -4273,7 +4261,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Rotl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 878.
+                            // Rule at src/isa/aarch64/lower.isle line 884.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4303,7 +4291,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Rotr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 959.
+                            // Rule at src/isa/aarch64/lower.isle line 965.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4333,7 +4321,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 664.
+                            // Rule at src/isa/aarch64/lower.isle line 670.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4344,7 +4332,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 748.
+                            // Rule at src/isa/aarch64/lower.isle line 754.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4355,7 +4343,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 795.
+                            // Rule at src/isa/aarch64/lower.isle line 801.
                             let expr0_0 = C::put_in_regs(ctx, pattern7_0);
                             let expr1_0 = C::put_in_regs(ctx, pattern7_1);
                             let expr2_0: usize = 0;
@@ -4373,7 +4361,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                 } => {
                     match pattern5_0 {
                         &Opcode::Bnot => {
-                            // Rule at src/isa/aarch64/lower.isle line 569.
+                            // Rule at src/isa/aarch64/lower.isle line 575.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4390,7 +4378,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             return Some(expr12_0);
                         }
                         &Opcode::Bitrev => {
-                            // Rule at src/isa/aarch64/lower.isle line 983.
+                            // Rule at src/isa/aarch64/lower.isle line 989.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: Type = I64;
                             let expr2_0: usize = 0;
@@ -4405,14 +4393,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             return Some(expr10_0);
                         }
                         &Opcode::Clz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1001.
+                            // Rule at src/isa/aarch64/lower.isle line 1007.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0 = constructor_lower_clz128(ctx, expr0_0)?;
                             let expr2_0 = C::output(ctx, expr1_0);
                             return Some(expr2_0);
                         }
                         &Opcode::Cls => {
-                            // Rule at src/isa/aarch64/lower.isle line 1057.
+                            // Rule at src/isa/aarch64/lower.isle line 1063.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4428,25 +4416,27 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             let expr12_0: u8 = 63;
                             let expr13_0 = C::imm_shift_from_u8(ctx, expr12_0);
                             let expr14_0 = constructor_lsr_imm(ctx, expr11_0, expr10_0, expr13_0)?;
-                            let expr15_0 = constructor_madd64(ctx, expr6_0, expr14_0, expr14_0)?;
-                            let expr16_0: u8 = 63;
-                            let expr17_0 = C::u8_into_imm12(ctx, expr16_0);
-                            let expr18_0 = constructor_cmp64_imm(ctx, expr8_0, expr17_0)?;
-                            let expr19_0 = Cond::Eq;
-                            let expr20_0 = C::zero_reg(ctx);
-                            let expr21_0 = constructor_csel(ctx, &expr19_0, expr15_0, expr20_0)?;
-                            let expr22_0 = constructor_with_flags_reg(ctx, &expr18_0, &expr21_0)?;
-                            let expr23_0: Type = I64;
-                            let expr24_0 = constructor_add(ctx, expr23_0, expr22_0, expr8_0)?;
-                            let expr25_0: Type = I64;
-                            let expr26_0: u64 = 0;
-                            let expr27_0 = constructor_imm(ctx, expr25_0, expr26_0)?;
-                            let expr28_0 = C::value_regs(ctx, expr24_0, expr27_0);
-                            let expr29_0 = C::output(ctx, expr28_0);
-                            return Some(expr29_0);
+                            let expr15_0: Type = I64;
+                            let expr16_0 =
+                                constructor_madd(ctx, expr15_0, expr6_0, expr14_0, expr14_0)?;
+                            let expr17_0: u8 = 63;
+                            let expr18_0 = C::u8_into_imm12(ctx, expr17_0);
+                            let expr19_0 = constructor_cmp64_imm(ctx, expr8_0, expr18_0)?;
+                            let expr20_0 = Cond::Eq;
+                            let expr21_0 = C::zero_reg(ctx);
+                            let expr22_0 = constructor_csel(ctx, &expr20_0, expr16_0, expr21_0)?;
+                            let expr23_0 = constructor_with_flags_reg(ctx, &expr19_0, &expr22_0)?;
+                            let expr24_0: Type = I64;
+                            let expr25_0 = constructor_add(ctx, expr24_0, expr23_0, expr8_0)?;
+                            let expr26_0: Type = I64;
+                            let expr27_0: u64 = 0;
+                            let expr28_0 = constructor_imm(ctx, expr26_0, expr27_0)?;
+                            let expr29_0 = C::value_regs(ctx, expr25_0, expr28_0);
+                            let expr30_0 = C::output(ctx, expr29_0);
+                            return Some(expr30_0);
                         }
                         &Opcode::Ctz => {
-                            // Rule at src/isa/aarch64/lower.isle line 1031.
+                            // Rule at src/isa/aarch64/lower.isle line 1037.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: Type = I64;
                             let expr2_0: usize = 0;
@@ -4462,7 +4452,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             return Some(expr11_0);
                         }
                         &Opcode::Popcnt => {
-                            // Rule at src/isa/aarch64/lower.isle line 1117.
+                            // Rule at src/isa/aarch64/lower.isle line 1123.
                             let expr0_0 = C::put_in_regs(ctx, pattern5_1);
                             let expr1_0: usize = 0;
                             let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -4501,7 +4491,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                        // Rule at src/isa/aarch64/lower.isle line 499.
+                                        // Rule at src/isa/aarch64/lower.isle line 505.
                                         let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                         let expr1_0 = constructor_vector_size(ctx, pattern11_0)?;
                                         let expr2_0 = constructor_mov_from_vec(
@@ -4519,7 +4509,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 494.
+                            // Rule at src/isa/aarch64/lower.isle line 500.
                             let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern5_1)?;
                             let expr1_0: Type = I64;
                             let expr2_0: u64 = 0;
@@ -4541,7 +4531,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         if pattern11_0 == I64X2 {
                                             let pattern13_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                            // Rule at src/isa/aarch64/lower.isle line 543.
+                                            // Rule at src/isa/aarch64/lower.isle line 549.
                                             let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                             let expr1_0 = VectorSize::Size64x2;
                                             let expr2_0 = constructor_mov_from_vec(
@@ -4562,7 +4552,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                         }
                                         if let Some(()) = C::not_i64x2(ctx, pattern11_0) {
                                             let pattern13_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                            // Rule at src/isa/aarch64/lower.isle line 532.
+                                            // Rule at src/isa/aarch64/lower.isle line 538.
                                             let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                             let expr1_0 =
                                                 constructor_vector_size(ctx, pattern11_0)?;
@@ -4588,7 +4578,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 522.
+                            // Rule at src/isa/aarch64/lower.isle line 528.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern5_1)?;
                             let expr1_0: Type = I64;
                             let expr2_0: u8 = 63;
@@ -4612,7 +4602,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
             } = &pattern4_0
             {
                 if let &Opcode::Popcnt = pattern5_0 {
-                    // Rule at src/isa/aarch64/lower.isle line 1125.
+                    // Rule at src/isa/aarch64/lower.isle line 1131.
                     let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                     let expr1_0 = VectorSize::Size8x16;
                     let expr2_0 = constructor_vec_cnt(ctx, expr0_0, &expr1_0)?;
@@ -4652,7 +4642,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 282.
+                                                        // Rule at src/isa/aarch64/lower.isle line 286.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4684,7 +4674,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 288.
+                                                        // Rule at src/isa/aarch64/lower.isle line 292.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4716,7 +4706,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 294.
+                                                        // Rule at src/isa/aarch64/lower.isle line 298.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4748,7 +4738,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I8X16 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 300.
+                                                        // Rule at src/isa/aarch64/lower.isle line 304.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4804,7 +4794,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 306.
+                                                        // Rule at src/isa/aarch64/lower.isle line 310.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4836,7 +4826,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 312.
+                                                        // Rule at src/isa/aarch64/lower.isle line 316.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4868,7 +4858,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 318.
+                                                        // Rule at src/isa/aarch64/lower.isle line 322.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4900,7 +4890,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I16X8 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 324.
+                                                        // Rule at src/isa/aarch64/lower.isle line 328.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4956,7 +4946,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 330.
+                                                        // Rule at src/isa/aarch64/lower.isle line 334.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -4988,7 +4978,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 336.
+                                                        // Rule at src/isa/aarch64/lower.isle line 340.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -5020,7 +5010,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 342.
+                                                        // Rule at src/isa/aarch64/lower.isle line 346.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -5052,7 +5042,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     let pattern18_0 =
                                                         C::value_type(ctx, pattern16_1);
                                                     if pattern18_0 == I32X4 {
-                                                        // Rule at src/isa/aarch64/lower.isle line 348.
+                                                        // Rule at src/isa/aarch64/lower.isle line 352.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern10_1);
                                                         let expr1_0 =
@@ -5074,7 +5064,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             }
                         }
                     }
-                    // Rule at src/isa/aarch64/lower.isle line 243.
+                    // Rule at src/isa/aarch64/lower.isle line 247.
                     let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                     let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                     let expr2_0 = VectorSize::Size32x4;
@@ -5148,28 +5138,28 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
             } => {
                 match pattern4_0 {
                     &Opcode::Bitrev => {
-                        // Rule at src/isa/aarch64/lower.isle line 989.
+                        // Rule at src/isa/aarch64/lower.isle line 995.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_rbit(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Clz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1004.
+                        // Rule at src/isa/aarch64/lower.isle line 1010.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_a64_clz(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Cls => {
-                        // Rule at src/isa/aarch64/lower.isle line 1071.
+                        // Rule at src/isa/aarch64/lower.isle line 1077.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_a64_cls(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                         return Some(expr2_0);
                     }
                     &Opcode::Ctz => {
-                        // Rule at src/isa/aarch64/lower.isle line 1037.
+                        // Rule at src/isa/aarch64/lower.isle line 1043.
                         let expr0_0 = C::put_in_reg(ctx, pattern4_1);
                         let expr1_0 = constructor_rbit(ctx, pattern2_0, expr0_0)?;
                         let expr2_0 = constructor_a64_clz(ctx, pattern2_0, expr1_0)?;
@@ -5191,7 +5181,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     match pattern5_0 {
                         &Opcode::Iadd => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 75.
+                            // Rule at src/isa/aarch64/lower.isle line 79.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern2_0)?;
@@ -5201,7 +5191,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Isub => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 125.
+                            // Rule at src/isa/aarch64/lower.isle line 129.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern2_0)?;
@@ -5241,7 +5231,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                         if let Some(pattern17_0) =
                                                             C::fcmp_zero_cond(ctx, pattern5_2)
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1145.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1151.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_1);
                                                             let expr1_0 = constructor_vector_size(
@@ -5264,7 +5254,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                 ctx, pattern5_2,
                                                             )
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1140.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1146.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_1);
                                                             let expr1_0 = constructor_vector_size(
@@ -5295,7 +5285,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                         if let Some(pattern17_0) =
                                                             C::fcmp_zero_cond(ctx, pattern5_2)
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1167.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1173.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_1);
                                                             let expr1_0 = constructor_vector_size(
@@ -5318,7 +5308,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                 ctx, pattern5_2,
                                                             )
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1162.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1168.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_1);
                                                             let expr1_0 = constructor_vector_size(
@@ -5366,7 +5356,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                         if let Some(pattern17_0) =
                                                             C::fcmp_zero_cond(ctx, pattern5_2)
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1135.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1141.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_0);
                                                             let expr1_0 = constructor_vector_size(
@@ -5389,7 +5379,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                 ctx, pattern5_2,
                                                             )
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1130.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1136.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_0);
                                                             let expr1_0 = constructor_vector_size(
@@ -5420,7 +5410,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                         if let Some(pattern17_0) =
                                                             C::fcmp_zero_cond(ctx, pattern5_2)
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1157.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1163.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_0);
                                                             let expr1_0 = constructor_vector_size(
@@ -5443,7 +5433,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                 ctx, pattern5_2,
                                                             )
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 1152.
+                                                            // Rule at src/isa/aarch64/lower.isle line 1158.
                                                             let expr0_0 =
                                                                 C::put_in_reg(ctx, pattern7_0);
                                                             let expr1_0 = constructor_vector_size(
@@ -5500,7 +5490,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     if let Some(pattern17_0) =
                                                         C::icmp_zero_cond(ctx, pattern5_2)
                                                     {
-                                                        // Rule at src/isa/aarch64/lower.isle line 1189.
+                                                        // Rule at src/isa/aarch64/lower.isle line 1195.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern7_1);
                                                         let expr1_0 = constructor_vector_size(
@@ -5520,7 +5510,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     if let Some(pattern17_0) =
                                                         C::icmp_zero_cond_not_eq(ctx, pattern5_2)
                                                     {
-                                                        // Rule at src/isa/aarch64/lower.isle line 1184.
+                                                        // Rule at src/isa/aarch64/lower.isle line 1190.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern7_1);
                                                         let expr1_0 = constructor_vector_size(
@@ -5565,7 +5555,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     if let Some(pattern17_0) =
                                                         C::icmp_zero_cond(ctx, pattern5_2)
                                                     {
-                                                        // Rule at src/isa/aarch64/lower.isle line 1179.
+                                                        // Rule at src/isa/aarch64/lower.isle line 1185.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern7_0);
                                                         let expr1_0 = constructor_vector_size(
@@ -5584,7 +5574,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                     if let Some(pattern17_0) =
                                                         C::icmp_zero_cond_not_eq(ctx, pattern5_2)
                                                     {
-                                                        // Rule at src/isa/aarch64/lower.isle line 1174.
+                                                        // Rule at src/isa/aarch64/lower.isle line 1180.
                                                         let expr0_0 =
                                                             C::put_in_reg(ctx, pattern7_0);
                                                         let expr1_0 = constructor_vector_size(
@@ -5637,7 +5627,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                         if let Some(pattern13_0) =
                                             C::imm_shift_from_imm64(ctx, pattern10_1, pattern12_0)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 843.
+                                            // Rule at src/isa/aarch64/lower.isle line 849.
                                             let expr0_0 =
                                                 constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                                             let expr1_0 =
@@ -5652,7 +5642,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 }
                             }
                         }
-                        // Rule at src/isa/aarch64/lower.isle line 838.
+                        // Rule at src/isa/aarch64/lower.isle line 844.
                         let expr0_0: Type = I32;
                         let expr1_0 = C::zero_reg(ctx);
                         let expr2_0 = C::put_in_reg(ctx, pattern7_1);
@@ -5679,7 +5669,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                         if let Some(pattern13_0) =
                                             C::imm_shift_from_imm64(ctx, pattern10_1, pattern12_0)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 903.
+                                            // Rule at src/isa/aarch64/lower.isle line 909.
                                             let expr0_0 =
                                                 constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                                             let expr1_0 = constructor_small_rotr_imm(
@@ -5695,7 +5685,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 }
                             }
                         }
-                        // Rule at src/isa/aarch64/lower.isle line 891.
+                        // Rule at src/isa/aarch64/lower.isle line 897.
                         let expr0_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                         let expr2_0 = constructor_small_rotr(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -5716,35 +5706,38 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                 match pattern5_0 {
                     &Opcode::Umulhi => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 370.
+                        // Rule at src/isa/aarch64/lower.isle line 374.
                         let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_1)?;
-                        let expr2_0 = C::zero_reg(ctx);
-                        let expr3_0 = constructor_madd64(ctx, expr0_0, expr1_0, expr2_0)?;
-                        let expr4_0: Type = I64;
-                        let expr5_0 = C::ty_bits(ctx, pattern3_0);
-                        let expr6_0 = C::imm_shift_from_u8(ctx, expr5_0);
-                        let expr7_0 = constructor_lsr_imm(ctx, expr4_0, expr3_0, expr6_0)?;
-                        let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
-                        return Some(expr8_0);
+                        let expr2_0: Type = I64;
+                        let expr3_0 = C::zero_reg(ctx);
+                        let expr4_0 = constructor_madd(ctx, expr2_0, expr0_0, expr1_0, expr3_0)?;
+                        let expr5_0: Type = I64;
+                        let expr6_0 = C::ty_bits(ctx, pattern3_0);
+                        let expr7_0 = C::imm_shift_from_u8(ctx, expr6_0);
+                        let expr8_0 = constructor_lsr_imm(ctx, expr5_0, expr4_0, expr7_0)?;
+                        let expr9_0 = C::value_reg(ctx, expr8_0);
+                        let expr10_0 = C::output(ctx, expr9_0);
+                        return Some(expr10_0);
                     }
                     &Opcode::Smulhi => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 358.
+                        // Rule at src/isa/aarch64/lower.isle line 362.
                         let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                         let expr1_0 = constructor_put_in_reg_sext64(ctx, pattern7_1)?;
-                        let expr2_0 = C::zero_reg(ctx);
-                        let expr3_0 = constructor_madd64(ctx, expr0_0, expr1_0, expr2_0)?;
-                        let expr4_0: Type = I64;
-                        let expr5_0 = C::ty_bits(ctx, pattern3_0);
-                        let expr6_0 = C::imm_shift_from_u8(ctx, expr5_0);
-                        let expr7_0 = constructor_asr_imm(ctx, expr4_0, expr3_0, expr6_0)?;
-                        let expr8_0 = constructor_output_reg(ctx, expr7_0)?;
-                        return Some(expr8_0);
+                        let expr2_0: Type = I64;
+                        let expr3_0 = C::zero_reg(ctx);
+                        let expr4_0 = constructor_madd(ctx, expr2_0, expr0_0, expr1_0, expr3_0)?;
+                        let expr5_0: Type = I64;
+                        let expr6_0 = C::ty_bits(ctx, pattern3_0);
+                        let expr7_0 = C::imm_shift_from_u8(ctx, expr6_0);
+                        let expr8_0 = constructor_asr_imm(ctx, expr5_0, expr4_0, expr7_0)?;
+                        let expr9_0 = constructor_output_reg(ctx, expr8_0)?;
+                        return Some(expr9_0);
                     }
                     &Opcode::Band => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 583.
+                        // Rule at src/isa/aarch64/lower.isle line 589.
                         let expr0_0 = ALUOp::And;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5754,7 +5747,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::Bor => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 596.
+                        // Rule at src/isa/aarch64/lower.isle line 602.
                         let expr0_0 = ALUOp::Orr;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5764,7 +5757,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::Bxor => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 609.
+                        // Rule at src/isa/aarch64/lower.isle line 615.
                         let expr0_0 = ALUOp::Eor;
                         let expr1_0 = constructor_alu_rs_imm_logic_commutative(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5774,7 +5767,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::BandNot => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 622.
+                        // Rule at src/isa/aarch64/lower.isle line 628.
                         let expr0_0 = ALUOp::AndNot;
                         let expr1_0 = constructor_alu_rs_imm_logic(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5784,7 +5777,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::BorNot => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 635.
+                        // Rule at src/isa/aarch64/lower.isle line 641.
                         let expr0_0 = ALUOp::OrrNot;
                         let expr1_0 = constructor_alu_rs_imm_logic(
                             ctx, &expr0_0, pattern3_0, pattern7_0, pattern7_1,
@@ -5794,7 +5787,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::BxorNot => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 645.
+                        // Rule at src/isa/aarch64/lower.isle line 651.
                         let expr0_0 = ALUOp::EorNot;
                         let expr1_0: Type = I32;
                         let expr2_0 = constructor_alu_rs_imm_logic(
@@ -5805,7 +5798,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::Ishl => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 656.
+                        // Rule at src/isa/aarch64/lower.isle line 662.
                         let expr0_0 = ALUOp::Lsl;
                         let expr1_0 = C::put_in_reg(ctx, pattern7_0);
                         let expr2_0 =
@@ -5815,7 +5808,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::Ushr => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 740.
+                        // Rule at src/isa/aarch64/lower.isle line 746.
                         let expr0_0 = ALUOp::Lsr;
                         let expr1_0 = constructor_put_in_reg_zext32(ctx, pattern7_0)?;
                         let expr2_0 =
@@ -5825,7 +5818,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     }
                     &Opcode::Sshr => {
                         let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                        // Rule at src/isa/aarch64/lower.isle line 787.
+                        // Rule at src/isa/aarch64/lower.isle line 793.
                         let expr0_0 = ALUOp::Asr;
                         let expr1_0 = constructor_put_in_reg_sext32(ctx, pattern7_0)?;
                         let expr2_0 =
@@ -6116,7 +6109,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                             if let Some(pattern13_0) =
                                                 C::imm12_from_u64(ctx, pattern12_0)
                                             {
-                                                // Rule at src/isa/aarch64/lower.isle line 105.
+                                                // Rule at src/isa/aarch64/lower.isle line 109.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr1_0 = constructor_sub_imm(
                                                     ctx,
@@ -6130,7 +6123,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                             if let Some(pattern13_0) =
                                                 C::imm12_from_negated_u64(ctx, pattern12_0)
                                             {
-                                                // Rule at src/isa/aarch64/lower.isle line 110.
+                                                // Rule at src/isa/aarch64/lower.isle line 114.
                                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                                 let expr1_0 = constructor_add_imm(
                                                     ctx,
@@ -6147,52 +6140,73 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                         opcode: ref pattern10_0,
                                         args: ref pattern10_1,
                                     } => {
-                                        if let &Opcode::Ishl = pattern10_0 {
-                                            let (pattern12_0, pattern12_1) =
-                                                C::unpack_value_array_2(ctx, pattern10_1);
-                                            if let Some(pattern13_0) = C::def_inst(ctx, pattern12_1)
-                                            {
-                                                let pattern14_0 = C::inst_data(ctx, pattern13_0);
-                                                if let &InstructionData::UnaryImm {
-                                                    opcode: ref pattern15_0,
-                                                    imm: pattern15_1,
-                                                } = &pattern14_0
+                                        match pattern10_0 {
+                                            &Opcode::Imul => {
+                                                let (pattern12_0, pattern12_1) =
+                                                    C::unpack_value_array_2(ctx, pattern10_1);
+                                                // Rule at src/isa/aarch64/lower.isle line 74.
+                                                let expr0_0 = C::put_in_reg(ctx, pattern12_0);
+                                                let expr1_0 = C::put_in_reg(ctx, pattern12_1);
+                                                let expr2_0 = C::put_in_reg(ctx, pattern7_0);
+                                                let expr3_0 = constructor_msub(
+                                                    ctx, pattern3_0, expr0_0, expr1_0, expr2_0,
+                                                )?;
+                                                let expr4_0 = constructor_output_reg(ctx, expr3_0)?;
+                                                return Some(expr4_0);
+                                            }
+                                            &Opcode::Ishl => {
+                                                let (pattern12_0, pattern12_1) =
+                                                    C::unpack_value_array_2(ctx, pattern10_1);
+                                                if let Some(pattern13_0) =
+                                                    C::def_inst(ctx, pattern12_1)
                                                 {
-                                                    if let &Opcode::Iconst = pattern15_0 {
-                                                        let closure17 = || {
-                                                            return Some(pattern3_0);
-                                                        };
-                                                        if let Some(pattern17_0) = closure17() {
-                                                            if let Some(pattern18_0) =
-                                                                C::lshl_from_imm64(
-                                                                    ctx,
-                                                                    pattern15_1,
-                                                                    pattern17_0,
-                                                                )
-                                                            {
-                                                                // Rule at src/isa/aarch64/lower.isle line 120.
-                                                                let expr0_0 =
-                                                                    C::put_in_reg(ctx, pattern7_0);
-                                                                let expr1_0 =
-                                                                    C::put_in_reg(ctx, pattern12_0);
-                                                                let expr2_0 =
-                                                                    constructor_sub_shift(
+                                                    let pattern14_0 =
+                                                        C::inst_data(ctx, pattern13_0);
+                                                    if let &InstructionData::UnaryImm {
+                                                        opcode: ref pattern15_0,
+                                                        imm: pattern15_1,
+                                                    } = &pattern14_0
+                                                    {
+                                                        if let &Opcode::Iconst = pattern15_0 {
+                                                            let closure17 = || {
+                                                                return Some(pattern3_0);
+                                                            };
+                                                            if let Some(pattern17_0) = closure17() {
+                                                                if let Some(pattern18_0) =
+                                                                    C::lshl_from_imm64(
                                                                         ctx,
-                                                                        pattern3_0,
-                                                                        expr0_0,
-                                                                        expr1_0,
-                                                                        pattern18_0,
-                                                                    )?;
-                                                                let expr3_0 =
-                                                                    constructor_output_reg(
-                                                                        ctx, expr2_0,
-                                                                    )?;
-                                                                return Some(expr3_0);
+                                                                        pattern15_1,
+                                                                        pattern17_0,
+                                                                    )
+                                                                {
+                                                                    // Rule at src/isa/aarch64/lower.isle line 124.
+                                                                    let expr0_0 = C::put_in_reg(
+                                                                        ctx, pattern7_0,
+                                                                    );
+                                                                    let expr1_0 = C::put_in_reg(
+                                                                        ctx,
+                                                                        pattern12_0,
+                                                                    );
+                                                                    let expr2_0 =
+                                                                        constructor_sub_shift(
+                                                                            ctx,
+                                                                            pattern3_0,
+                                                                            expr0_0,
+                                                                            expr1_0,
+                                                                            pattern18_0,
+                                                                        )?;
+                                                                    let expr3_0 =
+                                                                        constructor_output_reg(
+                                                                            ctx, expr2_0,
+                                                                        )?;
+                                                                    return Some(expr3_0);
+                                                                }
                                                             }
                                                         }
                                                     }
                                                 }
                                             }
+                                            _ => {}
                                         }
                                     }
                                     _ => {}
@@ -6200,14 +6214,14 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             }
                             if let Some(pattern8_0) = C::extended_value_from_value(ctx, pattern7_1)
                             {
-                                // Rule at src/isa/aarch64/lower.isle line 115.
+                                // Rule at src/isa/aarch64/lower.isle line 119.
                                 let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                                 let expr1_0 =
                                     constructor_sub_extend(ctx, pattern3_0, expr0_0, &pattern8_0)?;
                                 let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 101.
+                            // Rule at src/isa/aarch64/lower.isle line 105.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -6216,7 +6230,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Imul => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 179.
+                            // Rule at src/isa/aarch64/lower.isle line 183.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = C::zero_reg(ctx);
@@ -6227,7 +6241,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Udiv => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 384.
+                            // Rule at src/isa/aarch64/lower.isle line 390.
                             let expr0_0: Type = I64;
                             let expr1_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr2_0 = constructor_put_nonzero_in_reg_zext64(ctx, pattern7_1)?;
@@ -6248,7 +6262,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                         if let Some(pattern12_0) =
                                             C::safe_divisor_from_imm64(ctx, pattern10_1)
                                         {
-                                            // Rule at src/isa/aarch64/lower.isle line 430.
+                                            // Rule at src/isa/aarch64/lower.isle line 436.
                                             let expr0_0: Type = I64;
                                             let expr1_0 =
                                                 constructor_put_in_reg_sext64(ctx, pattern7_0)?;
@@ -6263,7 +6277,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 417.
+                            // Rule at src/isa/aarch64/lower.isle line 423.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_sext64(ctx, pattern7_1)?;
                             let expr2_0 = constructor_trap_if_div_overflow(
@@ -6276,25 +6290,29 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Urem => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 458.
+                            // Rule at src/isa/aarch64/lower.isle line 464.
                             let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_zext64(ctx, pattern7_1)?;
                             let expr2_0: Type = I64;
                             let expr3_0 = constructor_a64_udiv(ctx, expr2_0, expr0_0, expr1_0)?;
-                            let expr4_0 = constructor_msub64(ctx, expr3_0, expr1_0, expr0_0)?;
-                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
-                            return Some(expr5_0);
+                            let expr4_0: Type = I64;
+                            let expr5_0 =
+                                constructor_msub(ctx, expr4_0, expr3_0, expr1_0, expr0_0)?;
+                            let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
+                            return Some(expr6_0);
                         }
                         &Opcode::Srem => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 465.
+                            // Rule at src/isa/aarch64/lower.isle line 471.
                             let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern7_0)?;
                             let expr1_0 = constructor_put_nonzero_in_reg_sext64(ctx, pattern7_1)?;
                             let expr2_0: Type = I64;
                             let expr3_0 = constructor_a64_sdiv(ctx, expr2_0, expr0_0, expr1_0)?;
-                            let expr4_0 = constructor_msub64(ctx, expr3_0, expr1_0, expr0_0)?;
-                            let expr5_0 = constructor_output_reg(ctx, expr4_0)?;
-                            return Some(expr5_0);
+                            let expr4_0: Type = I64;
+                            let expr5_0 =
+                                constructor_msub(ctx, expr4_0, expr3_0, expr1_0, expr0_0)?;
+                            let expr6_0 = constructor_output_reg(ctx, expr5_0)?;
+                            return Some(expr6_0);
                         }
                         _ => {}
                     }
@@ -6305,7 +6323,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/aarch64/lower.isle line 169.
+                            // Rule at src/isa/aarch64/lower.isle line 173.
                             let expr0_0 = C::zero_reg(ctx);
                             let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr2_0 = constructor_sub(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -6342,7 +6360,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                                                 pattern16_0,
                                                             )
                                                         {
-                                                            // Rule at src/isa/aarch64/lower.isle line 564.
+                                                            // Rule at src/isa/aarch64/lower.isle line 570.
                                                             let expr0_0 = C::zero_reg(ctx);
                                                             let expr1_0 =
                                                                 C::put_in_reg(ctx, pattern11_0);
@@ -6366,7 +6384,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     }
                                 }
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 559.
+                            // Rule at src/isa/aarch64/lower.isle line 565.
                             let expr0_0 = C::zero_reg(ctx);
                             let expr1_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr2_0 = constructor_orr_not(ctx, pattern3_0, expr0_0, expr1_0)?;
@@ -6385,7 +6403,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                        // Rule at src/isa/aarch64/lower.isle line 481.
+                                        // Rule at src/isa/aarch64/lower.isle line 487.
                                         let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                         let expr1_0 = constructor_vector_size(ctx, pattern11_0)?;
                                         let expr2_0 = constructor_mov_from_vec(
@@ -6401,13 +6419,13 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             }
                             let pattern7_0 = C::value_type(ctx, pattern5_1);
                             if let Some(pattern8_0) = C::sinkable_atomic_load(ctx, pattern5_1) {
-                                // Rule at src/isa/aarch64/lower.isle line 488.
+                                // Rule at src/isa/aarch64/lower.isle line 494.
                                 let expr0_0 = C::sink_atomic_load(ctx, &pattern8_0);
                                 let expr1_0 = constructor_load_acquire(ctx, pattern7_0, expr0_0)?;
                                 let expr2_0 = constructor_output_reg(ctx, expr1_0)?;
                                 return Some(expr2_0);
                             }
-                            // Rule at src/isa/aarch64/lower.isle line 476.
+                            // Rule at src/isa/aarch64/lower.isle line 482.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0: bool = false;
                             let expr2_0 = C::ty_bits(ctx, pattern7_0);
@@ -6429,7 +6447,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                     if let &Opcode::Extractlane = pattern9_0 {
                                         let pattern11_0 = C::value_type(ctx, pattern9_1);
                                         let pattern12_0 = C::u8_from_uimm8(ctx, pattern9_2);
-                                        // Rule at src/isa/aarch64/lower.isle line 513.
+                                        // Rule at src/isa/aarch64/lower.isle line 519.
                                         let expr0_0 = C::put_in_reg(ctx, pattern9_1);
                                         let expr1_0 = constructor_vector_size(ctx, pattern11_0)?;
                                         let expr2_0 = constructor_size_from_ty(ctx, pattern3_0)?;
@@ -6446,7 +6464,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                                 }
                             }
                             let pattern7_0 = C::value_type(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 508.
+                            // Rule at src/isa/aarch64/lower.isle line 514.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0: bool = true;
                             let expr2_0 = C::ty_bits(ctx, pattern7_0);
@@ -6472,7 +6490,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                     match pattern5_0 {
                         &Opcode::UaddSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 148.
+                            // Rule at src/isa/aarch64/lower.isle line 152.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6482,7 +6500,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::SaddSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 153.
+                            // Rule at src/isa/aarch64/lower.isle line 157.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6492,7 +6510,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::UsubSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 158.
+                            // Rule at src/isa/aarch64/lower.isle line 162.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6502,7 +6520,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::SsubSat => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 163.
+                            // Rule at src/isa/aarch64/lower.isle line 167.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6512,7 +6530,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Band => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 591.
+                            // Rule at src/isa/aarch64/lower.isle line 597.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6522,7 +6540,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Bor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 604.
+                            // Rule at src/isa/aarch64/lower.isle line 610.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6532,7 +6550,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Bxor => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 617.
+                            // Rule at src/isa/aarch64/lower.isle line 623.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6542,7 +6560,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::BandNot => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 630.
+                            // Rule at src/isa/aarch64/lower.isle line 636.
                             let expr0_0 = C::put_in_reg(ctx, pattern7_0);
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6552,7 +6570,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Ishl => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 694.
+                            // Rule at src/isa/aarch64/lower.isle line 700.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0 = C::put_in_reg(ctx, pattern7_1);
                             let expr2_0 = constructor_vec_dup(ctx, expr1_0, &expr0_0)?;
@@ -6563,7 +6581,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Ushr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 752.
+                            // Rule at src/isa/aarch64/lower.isle line 758.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0: Type = I32;
                             let expr2_0 = C::zero_reg(ctx);
@@ -6577,7 +6595,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                         }
                         &Opcode::Sshr => {
                             let (pattern7_0, pattern7_1) = C::unpack_value_array_2(ctx, pattern5_1);
-                            // Rule at src/isa/aarch64/lower.isle line 801.
+                            // Rule at src/isa/aarch64/lower.isle line 807.
                             let expr0_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr1_0: Type = I32;
                             let expr2_0 = C::zero_reg(ctx);
@@ -6598,7 +6616,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                 } => {
                     match pattern5_0 {
                         &Opcode::Ineg => {
-                            // Rule at src/isa/aarch64/lower.isle line 173.
+                            // Rule at src/isa/aarch64/lower.isle line 177.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr2_0 = constructor_neg(ctx, expr0_0, &expr1_0)?;
@@ -6606,7 +6624,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                             return Some(expr3_0);
                         }
                         &Opcode::Bnot => {
-                            // Rule at src/isa/aarch64/lower.isle line 578.
+                            // Rule at src/isa/aarch64/lower.isle line 584.
                             let expr0_0 = C::put_in_reg(ctx, pattern5_1);
                             let expr1_0 = constructor_vector_size(ctx, pattern3_0)?;
                             let expr2_0 = constructor_not(ctx, expr0_0, &expr1_0)?;
@@ -6627,7 +6645,7 @@ pub fn constructor_lower<C: Context>(ctx: &mut C, arg0: Inst) -> Option<InstOutp
                 {
                     if let &Opcode::Imul = pattern6_0 {
                         let (pattern8_0, pattern8_1) = C::unpack_value_array_2(ctx, pattern6_1);
-                        // Rule at src/isa/aarch64/lower.isle line 211.
+                        // Rule at src/isa/aarch64/lower.isle line 215.
                         let expr0_0 = C::put_in_reg(ctx, pattern8_0);
                         let expr1_0 = C::put_in_reg(ctx, pattern8_1);
                         let expr2_0 = constructor_vector_size(ctx, pattern3_0)?;
@@ -6655,14 +6673,14 @@ pub fn constructor_put_nonzero_in_reg_zext64<C: Context>(ctx: &mut C, arg0: Valu
         {
             if let &Opcode::Iconst = pattern4_0 {
                 if let Some(pattern6_0) = C::nonzero_u64_from_imm64(ctx, pattern4_1) {
-                    // Rule at src/isa/aarch64/lower.isle line 394.
+                    // Rule at src/isa/aarch64/lower.isle line 400.
                     let expr0_0 = constructor_imm(ctx, pattern1_0, pattern6_0)?;
                     return Some(expr0_0);
                 }
             }
         }
     }
-    // Rule at src/isa/aarch64/lower.isle line 389.
+    // Rule at src/isa/aarch64/lower.isle line 395.
     let expr0_0 = constructor_put_in_reg_zext64(ctx, pattern0_0)?;
     let expr1_0 = constructor_trap_if_zero_divisor(ctx, expr0_0)?;
     return Some(expr1_0);
@@ -6681,14 +6699,14 @@ pub fn constructor_put_nonzero_in_reg_sext64<C: Context>(ctx: &mut C, arg0: Valu
         {
             if let &Opcode::Iconst = pattern4_0 {
                 if let Some(pattern6_0) = C::nonzero_u64_from_imm64(ctx, pattern4_1) {
-                    // Rule at src/isa/aarch64/lower.isle line 440.
+                    // Rule at src/isa/aarch64/lower.isle line 446.
                     let expr0_0 = constructor_imm(ctx, pattern1_0, pattern6_0)?;
                     return Some(expr0_0);
                 }
             }
         }
     }
-    // Rule at src/isa/aarch64/lower.isle line 435.
+    // Rule at src/isa/aarch64/lower.isle line 441.
     let expr0_0 = constructor_put_in_reg_sext64(ctx, pattern0_0)?;
     let expr1_0 = constructor_trap_if_zero_divisor(ctx, expr0_0)?;
     return Some(expr1_0);
@@ -6702,7 +6720,7 @@ pub fn constructor_lower_shl128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 677.
+    // Rule at src/isa/aarch64/lower.isle line 683.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6762,7 +6780,7 @@ pub fn constructor_do_shift<C: Context>(
                 };
                 if let Some(pattern8_0) = closure8() {
                     if let Some(pattern9_0) = C::imm_shift_from_imm64(ctx, pattern6_1, pattern8_0) {
-                        // Rule at src/isa/aarch64/lower.isle line 734.
+                        // Rule at src/isa/aarch64/lower.isle line 740.
                         let expr0_0 = constructor_alu_rr_imm_shift(
                             ctx, pattern0_0, pattern1_0, pattern2_0, pattern9_0,
                         )?;
@@ -6777,7 +6795,7 @@ pub fn constructor_do_shift<C: Context>(
     if pattern1_0 == I32 {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 725.
+        // Rule at src/isa/aarch64/lower.isle line 731.
         let expr0_0: Type = I32;
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0: usize = 0;
@@ -6788,7 +6806,7 @@ pub fn constructor_do_shift<C: Context>(
     if pattern1_0 == I64 {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 726.
+        // Rule at src/isa/aarch64/lower.isle line 732.
         let expr0_0: Type = I64;
         let expr1_0 = C::put_in_regs(ctx, pattern4_0);
         let expr2_0: usize = 0;
@@ -6799,7 +6817,7 @@ pub fn constructor_do_shift<C: Context>(
     if let Some(pattern2_0) = C::fits_in_16(ctx, pattern1_0) {
         let pattern3_0 = arg2;
         let pattern4_0 = arg3;
-        // Rule at src/isa/aarch64/lower.isle line 716.
+        // Rule at src/isa/aarch64/lower.isle line 722.
         let expr0_0 = C::put_in_regs(ctx, pattern4_0);
         let expr1_0: usize = 0;
         let expr2_0 = C::value_regs_get(ctx, expr0_0, expr1_0);
@@ -6821,7 +6839,7 @@ pub fn constructor_lower_ushr128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 767.
+    // Rule at src/isa/aarch64/lower.isle line 773.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6864,7 +6882,7 @@ pub fn constructor_lower_sshr128<C: Context>(
 ) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
-    // Rule at src/isa/aarch64/lower.isle line 817.
+    // Rule at src/isa/aarch64/lower.isle line 823.
     let expr0_0: usize = 0;
     let expr1_0 = C::value_regs_get(ctx, pattern0_0, expr0_0);
     let expr2_0: usize = 1;
@@ -6912,7 +6930,7 @@ pub fn constructor_small_rotr<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/lower.isle line 927.
+    // Rule at src/isa/aarch64/lower.isle line 933.
     let expr0_0: Type = I32;
     let expr1_0 = C::rotr_mask(ctx, pattern0_0);
     let expr2_0 = constructor_and_imm(ctx, expr0_0, pattern2_0, expr1_0)?;
@@ -6942,7 +6960,7 @@ pub fn constructor_small_rotr_imm<C: Context>(
     let pattern0_0 = arg0;
     let pattern1_0 = arg1;
     let pattern2_0 = arg2;
-    // Rule at src/isa/aarch64/lower.isle line 948.
+    // Rule at src/isa/aarch64/lower.isle line 954.
     let expr0_0: Type = I32;
     let expr1_0 = constructor_lsr_imm(ctx, expr0_0, pattern1_0, pattern2_0)?;
     let expr2_0: Type = I32;
@@ -6956,7 +6974,7 @@ pub fn constructor_small_rotr_imm<C: Context>(
 // Generated as internal constructor for term lower_clz128.
 pub fn constructor_lower_clz128<C: Context>(ctx: &mut C, arg0: ValueRegs) -> Option<ValueRegs> {
     let pattern0_0 = arg0;
-    // Rule at src/isa/aarch64/lower.isle line 1013.
+    // Rule at src/isa/aarch64/lower.isle line 1019.
     let expr0_0: Type = I64;
     let expr1_0: usize = 1;
     let expr2_0 = C::value_regs_get(ctx, pattern0_0, expr1_0);
@@ -6969,10 +6987,11 @@ pub fn constructor_lower_clz128<C: Context>(ctx: &mut C, arg0: ValueRegs) -> Opt
     let expr9_0: u8 = 6;
     let expr10_0 = C::imm_shift_from_u8(ctx, expr9_0);
     let expr11_0 = constructor_lsr_imm(ctx, expr8_0, expr3_0, expr10_0)?;
-    let expr12_0 = constructor_madd64(ctx, expr7_0, expr11_0, expr3_0)?;
-    let expr13_0: Type = I64;
-    let expr14_0: u64 = 0;
-    let expr15_0 = constructor_imm(ctx, expr13_0, expr14_0)?;
-    let expr16_0 = C::value_regs(ctx, expr12_0, expr15_0);
-    return Some(expr16_0);
+    let expr12_0: Type = I64;
+    let expr13_0 = constructor_madd(ctx, expr12_0, expr7_0, expr11_0, expr3_0)?;
+    let expr14_0: Type = I64;
+    let expr15_0: u64 = 0;
+    let expr16_0 = constructor_imm(ctx, expr14_0, expr15_0)?;
+    let expr17_0 = C::value_regs(ctx, expr13_0, expr16_0);
+    return Some(expr17_0);
 }

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -406,6 +406,52 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   madd w0, w1, w2, w0
 ;   ret
 
+function %msub_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = imul v1, v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; block0:
+;   msub w0, w1, w2, w0
+;   ret
+
+function %msub_i64(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = imul v1, v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; block0:
+;   msub x0, x1, x2, x0
+;   ret
+
+function %imul_sub_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = imul v1, v2
+    v4 = isub v3, v0
+    return v4
+}
+
+; block0:
+;   madd w8, w1, w2, wzr
+;   sub w0, w8, w0
+;   ret
+
+function %imul_sub_i64(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = imul v1, v2
+    v4 = isub v3, v0
+    return v4
+}
+
+; block0:
+;   madd x8, x1, x2, xzr
+;   sub x0, x8, x0
+;   ret
+
 function %srem_const (i64) -> i64 {
 block0(v0: i64):
   v1 = iconst.i64 2

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -183,6 +183,154 @@ block0(v0: i8,v1: i8):
 ; run: %mul_i8(0xC0, 0xDE) == 0x80
 
 
+function %madd_i8(i8, i8, i8) -> i8 {
+block0(v0: i8, v1: i8, v2: i8):
+    v3 = imul v1, v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %madd_i8(0, 1, 0) == 0
+; run: %madd_i8(1, 0, 0) == 1
+; run: %madd_i8(0, -1, 1) == -1
+; run: %madd_i8(2, 2, 2) == 6
+; run: %madd_i8(0, 0x7F, 0x7F) == 1
+; run: %madd_i8(0x7F, 0x7F, -1) == 0
+; run: %madd_i8(0x80, 0x7F, 0) == 0x80
+; run: %madd_i8(0x80, 0x7F, 0x80) == 0
+; run: %madd_i8(0x01, 0xFE, 0) == 1
+; run: %madd_i8(0x01, 0xFE, 2) == -3
+; run: %madd_i8(0, 0xC0, 0xDE) == 0x80
+; run: %madd_i8(0xC0, 0xC0, 0xDE) == 0x40
+
+function %madd_i16(i16, i16, i16) -> i16 {
+block0(v0: i16, v1: i16, v2: i16):
+    v3 = imul v1, v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %madd_i16(0, 1, 0) == 0
+; run: %madd_i16(1, 0, 0) == 1
+; run: %madd_i16(0, -1, 1) == -1
+; run: %madd_i16(2, 2, 2) == 6
+; run: %madd_i16(0, 0x7FFF, 0x7FFF) == 1
+; run: %madd_i16(0x7FFF, 1, 0x7FFF) == -2
+; run: %madd_i16(0x8000, 1, 0x7FFF) == -1
+; run: %madd_i16(0x0123, 0x0456, 0xFEDC) == 0xF0B
+; run: %madd_i16(0xC0FF, 0x0123, 0xDECA) == 0x9D
+
+function %madd_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = imul v1, v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %madd_i32(0, 1, 0) == 0
+; run: %madd_i32(1, 0, 0) == 1
+; run: %madd_i32(0, -1, 1) == -1
+; run: %madd_i32(2, 2, 2) == 6
+; run: %madd_i32(0, 0x7FFFFFFF, 0x7FFFFFFF) == 1
+; run: %madd_i32(-1, 0x7FFFFFFF, 0x7FFFFFFF) == 0
+; run: %madd_i32(0x80000000, 1, 0x7FFFFFFF) == -1
+; run: %madd_i32(0x80000000, 0x01234567, 0x7FFFFFFF) == 0xFEDCBA99
+; run: %madd_i32(0x01234567, 0x80000000, 0xFEDCBA98) == 0x1234567
+; run: %madd_i32(0xC0FFEEEE, 0xDECAFFFF, 0x0DEBAC1E) == 0x32DE42D0
+
+function %madd_i64(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = imul v1, v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %madd_i64(0, 1, 0) == 0
+; run: %madd_i64(1, 0, 0) == 1
+; run: %madd_i64(0, -1, 1) == -1
+; run: %madd_i64(2, 2, 2) == 6
+; run: %madd_i64(0, 0x7FFFFFFF_FFFFFFFF, 0x7FFFFFFF_FFFFFFFF) == 1
+; run: %madd_i64(-1, 0x7FFFFFFF_FFFFFFFF, 0x7FFFFFFF_FFFFFFFF) == 0
+; run: %madd_i64(0, 0x80000000_00000000, 0x7FFFFFFF_FFFFFFFF) == 0x80000000_00000000
+; run: %madd_i64(1, 0x80000000_00000000, 0x7FFFFFFF_FFFFFFFF) == 0x80000000_00000001
+; run: %madd_i64(0x01234567_89ABCDEF, 0x01234567_FEDCBA98, 0xFEDCBA98_76543210) == 0x89C0845D_DDC9276F
+; run: %madd_i64(0xC0FFEEEE_C0FFEEEE, 0xBAADF00D_BAADF00D, 0xDECAFFFF_DECAFFFF) == 0x2EB8ECEC_A6A0FEE1
+
+function %msub_i8(i8, i8, i8) -> i8 {
+block0(v0: i8, v1: i8, v2: i8):
+    v3 = imul v1, v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %msub_i8(0, 0, 0) == 0
+; run: %msub_i8(1, 1, 1) == 0
+; run: %msub_i8(1, 1, 0) == 1
+; run: %msub_i8(0, 1, 1) == -1
+; run: %msub_i8(1, 1, -1) == 2
+; run: %msub_i8(-2, 1, -1) == -1
+; run: %msub_i8(2, 2, 2) == -2
+; run: %msub_i8(0, 0x7F, 0x7F) == -1
+; run: %msub_i8(0x7F, 0x80, 0x7F) == -1
+; run: %msub_i8(0x80, 1, 0x7F) == 1
+; run: %msub_i8(0x01, 0x80, 0xFE) == 1
+; run: %msub_i8(0xFF, 1, 0xDE) == 0x21
+
+function %msub_i16(i16, i16, i16) -> i16 {
+block0(v0: i16, v1: i16, v2: i16):
+    v3 = imul v1, v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %msub_i16(0, 0, 0) == 0
+; run: %msub_i16(1, 1, 1) == 0
+; run: %msub_i16(1, 1, 0) == 1
+; run: %msub_i16(0, 1, 1) == -1
+; run: %msub_i16(1, 1, -1) == 2
+; run: %msub_i16(-2, 1, -1) == -1
+; run: %msub_i16(2, 2, 2) == -2
+; run: %msub_i16(0, 0x7FFF, 0x7FFF) == -1
+; run: %msub_i16(0x0FFF, 1, 0x7FFF) == 0x9000
+; run: %msub_i16(0x7000, 1, 0x7FFF) == 0xF001
+; run: %msub_i16(0x0123, 0x0456, 0xFEDC) == 0xF33B
+; run: %msub_i16(0xC0FF, 0x0123, 0xDECA) == 0x8161
+
+function %msub_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = imul v1, v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %msub_i32(0, 0, 0) == 0
+; run: %msub_i32(1, 1, 1) == 0
+; run: %msub_i32(1, 1, 0) == 1
+; run: %msub_i32(0, 1, 1) == -1
+; run: %msub_i32(1, 1, -1) == 2
+; run: %msub_i32(-2, 1, -1) == -1
+; run: %msub_i32(2, 2, 2) == -2
+; run: %msub_i32(0, 0x7FFFFFFF, 0x7FFFFFFF) == -1
+; run: %msub_i32(0x0FFFFF, 1, 0x7FFFFFFF) == 0x80100000
+; run: %msub_i32(0x7FFFFFFF, 1, 0x80000000) == -1
+; run: %msub_i32(0x80000000, 0x01234567, 0x7FFFFFFF) == 0x01234567
+; run: %msub_i32(0xFEDCBA98, 0x80000000, 0x01234567) == 0x7EDCBA98
+; run: %msub_i32(0xC0FFEEEE, 0xDECAFFFF, 0x0DEBAC1E) == 0x4F219B0C
+
+function %msub_i64(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = imul v1, v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %msub_i64(0, 0, 0) == 0
+; run: %msub_i64(1, 1, 1) == 0
+; run: %msub_i64(1, 1, 0) == 1
+; run: %msub_i64(0, 1, 1) == -1
+; run: %msub_i64(1, 1, -1) == 2
+; run: %msub_i64(-2, 1, -1) == -1
+; run: %msub_i64(2, 2, 2) == -2
+; run: %msub_i64(0, 0x7FFFFFFF_FFFFFFFF, 0x7FFFFFFF_FFFFFFFF) == -1
+; run: %msub_i64(0x0FFFFF_FFFFFFFF, 1, 0x7FFFFFFF_FFFFFFFF) == 0x80100000_00000000
+; run: %msub_i64(0, 0x80000000_00000000, 0x7FFFFFFF_FFFFFFFF) == 0x80000000_00000000
+; run: %msub_i64(1, 0x80000000_00000000, 0x7FFFFFFF_FFFFFFFF) == 0x80000000_00000001
+; run: %msub_i64(0x01234567_89ABCDEF, 0x01234567_FEDCBA98, 0xFEDCBA98_76543210) == 0x78860671_358E746F
+; run: %msub_i64(0xC0FFEEEE_C0FFEEEE, 0xBAADF00D_BAADF00D, 0xDECAFFFF_DECAFFFF) == 0x5346F0F0_DB5EDEFB
+
+
 function %sdiv_i64(i64, i64) -> i64 {
 block0(v0: i64,v1: i64):
     v2 = sdiv v0, v1


### PR DESCRIPTION
As well as adding generic pattern for msub along with runtests
for madd and msub.

Copyright (c) 2022, Arm Limited.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
