### PR TITLE
c-api: Add a way to get type of `wasmtime_module_t`

### DIFF
--- a/crates/c-api/include/wasmtime/module.h
+++ b/crates/c-api/include/wasmtime/module.h
@@ -60,6 +60,22 @@ WASM_API_EXTERN void wasmtime_module_delete(wasmtime_module_t *m);
 WASM_API_EXTERN wasmtime_module_t *wasmtime_module_clone(wasmtime_module_t *m);
 
 /**
+ * \brief Same as #wasm_module_imports, but for #wasmtime_module_t.
+ */
+WASM_API_EXTERN void wasmtime_module_imports(
+    const wasmtime_module_t *module,
+    wasm_importtype_vec_t *out
+);
+
+/**
+ * \brief Same as #wasm_module_exports, but for #wasmtime_module_t.
+ */
+WASM_API_EXTERN void wasmtime_module_exports(
+    const wasmtime_module_t *module,
+    wasm_exporttype_vec_t *out
+);
+
+/**
  * \brief Validate a WebAssembly binary.
  *
  * This function will validate the provided byte sequence to determine if it is

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -47,10 +47,8 @@ pub unsafe extern "C" fn wasm_module_validate(
     Module::validate(store.store.context().engine(), binary.as_slice()).is_ok()
 }
 
-#[no_mangle]
-pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exporttype_vec_t) {
+fn fill_exports(module: &Module, out: &mut wasm_exporttype_vec_t) {
     let exports = module
-        .module
         .exports()
         .map(|e| {
             Some(Box::new(wasm_exporttype_t::new(
@@ -62,10 +60,8 @@ pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exp
     out.set_buffer(exports);
 }
 
-#[no_mangle]
-pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_importtype_vec_t) {
+fn fill_imports(module: &Module, out: &mut wasm_importtype_vec_t) {
     let imports = module
-        .module
         .imports()
         .map(|i| {
             Some(Box::new(wasm_importtype_t::new(
@@ -76,6 +72,16 @@ pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_imp
         })
         .collect::<Vec<_>>();
     out.set_buffer(imports);
+}
+
+#[no_mangle]
+pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exporttype_vec_t) {
+    fill_exports(&module.module, out);
+}
+
+#[no_mangle]
+pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_importtype_vec_t) {
+    fill_imports(&module.module, out);
 }
 
 #[no_mangle]
@@ -142,6 +148,22 @@ pub extern "C" fn wasmtime_module_delete(_module: Box<wasmtime_module_t>) {}
 #[no_mangle]
 pub extern "C" fn wasmtime_module_clone(module: &wasmtime_module_t) -> Box<wasmtime_module_t> {
     Box::new(module.clone())
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_module_exports(
+    module: &wasmtime_module_t,
+    out: &mut wasm_exporttype_vec_t,
+) {
+    fill_exports(&module.module, out);
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_module_imports(
+    module: &wasmtime_module_t,
+    out: &mut wasm_importtype_vec_t,
+) {
+    fill_imports(&module.module, out);
 }
 
 #[no_mangle]


### PR DESCRIPTION
My previous PR at #3958 accidentally removed the only way to get type
information from a `wasmtime_module_t`, so this commit re-adds methods
back in to continue to be able to get import/export information from a
compiled module.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
