### PR TITLE
Prevent triage workflow from executing on forks.

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   triage:
+    if: github.repository == 'bytecodealliance/wasmtime'
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
This PR limits the triage workflow to only `bytecodealliance/wasmtime`.

Hopefully this will prevent the labeler from adding the "do you even fuzz?"
comment to PRs to wasmtime's forks.