### PR TITLE
Remove shell prompt from README installation CLI code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Wasmtime CLI can be installed on Linux and macOS with a small install
 script:
 
 ```sh
-$ curl https://wasmtime.dev/install.sh -sSf | bash
+curl https://wasmtime.dev/install.sh -sSf | bash
 ```
 
 Windows or otherwise interested users can download installers and


### PR DESCRIPTION
GitHub's readme markdown rendering adds a button which allows
a user to copy the CLI into their copy cache to then paste into
a terminal and run.

Currently as the curl command contains a dollar sign, that gets
included (which means the user needs to manually remove it).

Really not a big deal and if this is closed I won't be upset,
but noted it's been a bit of a nit to me a few times.

Signed-off-by: Luke Hinds <lhinds@redhat.com>

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
