### PR TITLE
Remove some dead code

### DIFF
--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 /// Information about a function, such as trap information, address map,
 /// and stack maps.
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Default)]
 #[allow(missing_docs)]
 pub struct FunctionInfo {
     pub start_srcloc: FilePos,
@@ -31,7 +31,7 @@ pub struct FunctionInfo {
 
 /// Information about a compiled trampoline which the host can call to enter
 /// wasm.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct Trampoline {
     /// The signature this trampoline is for
@@ -45,7 +45,7 @@ pub struct Trampoline {
 
 /// The offset within a function of a GC safepoint, and its associated stack
 /// map.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct StackMapInformation {
     /// The offset of the GC safepoint within the function's native code. It is
     /// relative to the beginning of the function.

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -128,7 +128,7 @@ pub struct StaticMemoryInitializer {
 }
 
 /// The type of WebAssembly linear memory initialization to use for a module.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum MemoryInitialization {
     /// Memory initialization is segmented.
     ///
@@ -779,7 +779,7 @@ pub struct TableInitializer {
 }
 
 /// Table initialization data for all tables in the module.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum TableInitialization {
     /// "Segment" mode: table initializer segments, possibly with
     /// dynamic bases, possibly applying to an imported memory.
@@ -850,7 +850,7 @@ impl ModuleType {
 
 /// A translated WebAssembly module, excluding the function bodies and
 /// memory initializers.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Module {
     /// The name of this wasm module, often found in the wasm file.
     pub name: Option<String>,
@@ -916,7 +916,7 @@ pub struct Module {
 
 /// Initialization routines for creating an instance, encompassing imports,
 /// modules, instances, aliases, etc.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Initializer {
     /// An imported item is required to be provided.
     Import {
@@ -934,12 +934,6 @@ impl Module {
     /// Allocates the module data structures.
     pub fn new() -> Self {
         Module::default()
-    }
-
-    /// Get the given passive element, if it exists.
-    pub fn get_passive_element(&self, index: ElemIndex) -> Option<&[FuncIndex]> {
-        let index = *self.passive_elements_map.get(&index)?;
-        Some(self.passive_elements[index].as_ref())
     }
 
     /// Convert a `DefinedFuncIndex` into a `FuncIndex`.
@@ -1086,14 +1080,14 @@ impl Module {
 ///
 /// Note that this is shared amongst all modules coming out of a translation
 /// in the case of nested modules and the module linking proposal.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct TypeTables {
     pub wasm_signatures: PrimaryMap<SignatureIndex, WasmFuncType>,
 }
 
 /// Type information about functions in a wasm module.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FunctionType {
     /// The type of this function, indexed into the module-wide type tables for
     /// a module compilation.

--- a/crates/environ/src/stack_map.rs
+++ b/crates/environ/src/stack_map.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Note that this is currently primarily documented as cranelift's
 /// `binemit::StackMap`, so for detailed documentation about this please read
 /// the docs over there.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StackMap {
     bits: Box<[u32]>,
     mapped_words: u32,

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -776,22 +776,6 @@ impl<P: PtrSize> VMOffsets<P> {
     }
 }
 
-/// Target specific type for shared signature index.
-#[derive(Debug, Copy, Clone)]
-pub struct TargetSharedSignatureIndex(u32);
-
-impl TargetSharedSignatureIndex {
-    /// Constructs `TargetSharedSignatureIndex`.
-    pub fn new(value: u32) -> Self {
-        Self(value)
-    }
-
-    /// Returns index value.
-    pub fn index(self) -> u32 {
-        self.0
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::vmoffsets::align;

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -526,11 +526,6 @@ impl CompiledModule {
         &self.module
     }
 
-    /// Returns the `FunctionInfo` map for all defined functions.
-    pub fn functions(&self) -> &PrimaryMap<DefinedFuncIndex, FunctionInfo> {
-        &self.funcs
-    }
-
     /// Looks up the `name` section name for the function index `idx`, if one
     /// was specified in the original wasm module.
     pub fn func_name(&self, idx: FuncIndex) -> Option<&str> {

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -502,7 +502,7 @@ pub struct VMSharedSignatureIndex(u32);
 mod test_vmshared_signature_index {
     use super::VMSharedSignatureIndex;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, TargetSharedSignatureIndex, VMOffsets};
+    use wasmtime_environ::{Module, VMOffsets};
 
     #[test]
     fn check_vmshared_signature_index() {
@@ -511,14 +511,6 @@ mod test_vmshared_signature_index {
         assert_eq!(
             size_of::<VMSharedSignatureIndex>(),
             usize::from(offsets.size_of_vmshared_signature_index())
-        );
-    }
-
-    #[test]
-    fn check_target_shared_signature_index() {
-        assert_eq!(
-            size_of::<VMSharedSignatureIndex>(),
-            size_of::<TargetSharedSignatureIndex>()
         );
     }
 }


### PR DESCRIPTION
This commit removes methods that are never used between crates or trait
impls like `Clone` which may have been used one day but are no longer used.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
