### PR TITLE
Adding set_paths to WasiNnCtx

### DIFF
--- a/crates/wasi-nn/src/api.rs
+++ b/crates/wasi-nn/src/api.rs
@@ -13,6 +13,7 @@ pub(crate) trait Backend {
         &mut self,
         builders: &GraphBuilderArray<'_>,
         target: ExecutionTarget,
+        map_dir: &Option<Vec<(String, String)>>,
     ) -> Result<Box<dyn BackendGraph>, BackendError>;
 }
 
@@ -42,4 +43,8 @@ pub enum BackendError {
     InvalidNumberOfBuilders(u32, u32),
     #[error("Not enough memory to copy tensor data of size: {0}")]
     NotEnoughMemory(usize),
+    #[error(
+        "A mapped directory is required for this backend, but none was provided or it wasn't found"
+    )]
+    MissingMapDir(),
 }

--- a/crates/wasi-nn/src/ctx.rs
+++ b/crates/wasi-nn/src/ctx.rs
@@ -21,6 +21,8 @@ impl Ctx {
     /// Make a new context from the default state.
     pub fn new() -> WasiNnResult<Self> {
         let mut backends = HashMap::new();
+
+        // Insert OpenVino backend
         backends.insert(
             // This is necessary because Wiggle's variant types do not derive
             // `Hash` and `Eq`.
@@ -38,6 +40,7 @@ impl Ctx {
 /// This struct solely wraps [Ctx] in a `RefCell`.
 pub struct WasiNnCtx {
     pub(crate) ctx: RefCell<Ctx>,
+    pub map_dir: Option<Vec<(String, String)>>,
 }
 
 impl WasiNnCtx {
@@ -45,7 +48,20 @@ impl WasiNnCtx {
     pub fn new() -> WasiNnResult<Self> {
         Ok(Self {
             ctx: RefCell::new(Ctx::new()?),
+            map_dir: None,
         })
+    }
+
+    // Save mapped paths so they can be used by backends later.
+    pub fn set_paths(&mut self, paths: &Vec<(String, String)>) {
+        if paths.len() > 0 {
+            self.map_dir = Some(Vec::<(String, String)>::new());
+            let md = self.map_dir.as_mut().unwrap();
+
+            for (guest, host) in paths.iter() {
+                md.push((guest.clone(), host.clone()));
+            }
+        }
     }
 }
 

--- a/crates/wasi-nn/src/openvino.rs
+++ b/crates/wasi-nn/src/openvino.rs
@@ -16,6 +16,7 @@ impl Backend for OpenvinoBackend {
         &mut self,
         builders: &GraphBuilderArray<'_>,
         target: ExecutionTarget,
+        _map_dir: &Option<Vec<(String, String)>>,
     ) -> Result<Box<dyn BackendGraph>, BackendError> {
         if builders.len() != 2 {
             return Err(BackendError::InvalidNumberOfBuilders(2, builders.len()).into());

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -190,6 +190,12 @@ impl RunCommand {
             preopen_sockets,
         )?;
 
+        // Save the mapped directories so they can be read later from wasi-nn
+        if store.data_mut().wasi_nn.is_some() {
+            let wasinn = store.data_mut().wasi_nn.as_mut().unwrap();
+            wasinn.set_paths(&self.map_dirs);
+        }
+
         // Load the preload wasm modules.
         for (name, path) in self.preloads.iter() {
             // Read the wasm module binary either as `*.wat` or a raw binary


### PR DESCRIPTION
This function will allow storage of the real paths
of the --mapdir values given to wasmtime. This is
needed because TensorFlow and possibly other
backends require a path to the model and other
files.
