### PR TITLE
Disable module linking in instantiate fuzzer

### DIFF
--- a/fuzz/fuzz_targets/instantiate.rs
+++ b/fuzz/fuzz_targets/instantiate.rs
@@ -24,9 +24,6 @@ fn run(data: &[u8]) -> Result<()> {
         Timeout::None
     };
 
-    // Enable module linking for this fuzz target specifically
-    config.module_config.config.module_linking_enabled = u.arbitrary()?;
-
     let module = config.generate(
         &mut u,
         if let Timeout::None = timeout {


### PR DESCRIPTION
Support was removed from Wasmtime so there's no need to fuzz it any
more.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
