### PR TITLE
Add m1 to build matrix and release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,8 +217,6 @@ jobs:
           - os: ubuntu-latest
           # defaults to x86_64-apple-darwin
           - os: macos-latest
-          - os: macos-latest
-            target: aarch64-apple-darwin
           - os: windows-2019
           - os: windows-2019
             target: x86_64-pc-windows-gnu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,7 +215,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+          # defaults to x86_64-apple-darwin
           - os: macos-latest
+          - os: macos-latest
+            target: aarch64-apple-darwin
           - os: windows-2019
           - os: windows-2019
             target: x86_64-pc-windows-gnu
@@ -390,6 +393,9 @@ jobs:
           os: ubuntu-latest
         - build: x86_64-macos
           os: macos-latest
+        - build: aarch64-macos
+          os: macos-latest
+          target: aarch64-apple-darwin
         - build: x86_64-windows
           os: windows-latest
         - build: x86_64-mingw

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -79,6 +79,9 @@ jobs:
           PRs to the \`main\` branch to update [RELEASES.md] and then backport
           these PRs to the [release branch][branch].
 
+          Maintainers should also review that aarch64-apple-darwin builds
+          are passing via [embark's CI](https://buildkite.com/embark-studios/wasmtime-aarch64-apple-darwin).
+
           Another automated PR will be made in roughly 2 weeks time when for
           the actual release itself.
 

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -59,6 +59,10 @@ elif [ "$platform" = "x86_64-macos" ]; then
   install_name_tool -id "@rpath/libwasmtime.dylib" target/release/libwasmtime.dylib
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
+elif [ "$platform" = "aarch64-macos" ]; then
+  install_name_tool -id "@rpath/libwasmtime.dylib" target/aarch64-apple-darwin/release/libwasmtime.dylib
+  cp target/aarch64-apple-darwin/release/wasmtime tmp/$bin_pkgname
+  cp target/aarch64-apple-darwin/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
 elif [ "$target" = "" ]; then
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib


### PR DESCRIPTION
Adds m1 target as discussed in #3982. 

NOTE: This doesn't adjust the install.sh script.

Locally, I ran the wasmtime tests on a 2020 macOS Monterey M1: 

```
test result: ok. 641 passed; 0 failed; 20 ignored; 0 measured; 0 filtered out; finished in 13.92s
```