### PR TITLE
Deduplicate creation of `CompiledModule`

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -332,14 +332,7 @@ impl Module {
             }
         };
 
-        let module = CompiledModule::from_artifacts(
-            mmap,
-            info,
-            &*engine.config().profiler,
-            engine.unique_id_allocator(),
-        )?;
-
-        Self::from_parts(engine, module, Arc::new(types))
+        Self::from_parts(engine, mmap, info, Arc::new(types))
     }
 
     /// Converts an input binary-encoded WebAssembly module to compilation
@@ -498,9 +491,17 @@ impl Module {
 
     fn from_parts(
         engine: &Engine,
-        module: Arc<CompiledModule>,
+        mmap: MmapVec,
+        info: Option<CompiledModuleInfo>,
         types: Arc<TypeTables>,
     ) -> Result<Self> {
+        let module = CompiledModule::from_artifacts(
+            mmap,
+            info,
+            &*engine.config().profiler,
+            engine.unique_id_allocator(),
+        )?;
+
         // Validate the module can be used with the current allocator
         engine.allocator().validate(module.module())?;
 

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -49,7 +49,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use wasmtime_environ::{FlagValue, Tunables, TypeTables};
-use wasmtime_jit::{subslice_range, CompiledModule, CompiledModuleInfo};
+use wasmtime_jit::{subslice_range, CompiledModuleInfo};
 use wasmtime_runtime::MmapVec;
 
 const HEADER: &[u8] = b"\0wasmtime-aot";
@@ -206,14 +206,7 @@ impl<'a> SerializedModule<'a> {
 
     pub fn into_module(self, engine: &Engine) -> Result<Module> {
         let (mmap, info, types) = self.into_parts(engine)?;
-        let module = CompiledModule::from_artifacts(
-            mmap,
-            info,
-            &*engine.config().profiler,
-            engine.unique_id_allocator(),
-        )?;
-
-        Module::from_parts(engine, module, Arc::new(types))
+        Module::from_parts(engine, mmap, info, Arc::new(types))
     }
 
     pub fn into_parts(


### PR DESCRIPTION
Push the creation of a module's `CompiledModule` into one location of
`Module::from_parts` instead of duplicating it across two callers.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
