### PR TITLE
Split wasmtime-runtime's single getter into typed getters

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -10,7 +10,7 @@ use std::panic::{self, AssertUnwindSafe};
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::Arc;
-use wasmtime_environ::{EntityIndex, FuncIndex};
+use wasmtime_environ::FuncIndex;
 use wasmtime_runtime::{
     raise_user_trap, ExportFunction, InstanceAllocator, InstanceHandle, OnDemandInstanceAllocator,
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMSharedSignatureIndex,
@@ -2047,11 +2047,7 @@ impl HostFunc {
     /// Requires that this function's signature is already registered within
     /// `Engine`. This happens automatically during the above two constructors.
     fn _new(engine: &Engine, mut instance: InstanceHandle, trampoline: VMTrampoline) -> Self {
-        let idx = EntityIndex::Function(FuncIndex::from_u32(0));
-        let export = match instance.lookup_by_declaration(&idx) {
-            wasmtime_runtime::Export::Function(f) => f,
-            _ => unreachable!(),
-        };
+        let export = instance.get_exported_func(FuncIndex::from_u32(0));
 
         HostFunc {
             instance,

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -17,7 +17,7 @@ use crate::{GlobalType, MemoryType, TableType, Val};
 use anyhow::Result;
 use std::any::Any;
 use std::sync::Arc;
-use wasmtime_environ::{EntityIndex, GlobalIndex, MemoryIndex, Module, SignatureIndex, TableIndex};
+use wasmtime_environ::{GlobalIndex, MemoryIndex, Module, SignatureIndex, TableIndex};
 use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstanceAllocator, OnDemandInstanceAllocator, StorePtr,
     VMFunctionImport, VMSharedSignatureIndex,
@@ -60,11 +60,9 @@ pub fn generate_global_export(
     val: Val,
 ) -> Result<wasmtime_runtime::ExportGlobal> {
     let instance = create_global(store, gt, val)?;
-    let idx = EntityIndex::Global(GlobalIndex::from_u32(0));
-    match store.instance_mut(instance).lookup_by_declaration(&idx) {
-        wasmtime_runtime::Export::Global(g) => Ok(g),
-        _ => unreachable!(),
-    }
+    Ok(store
+        .instance_mut(instance)
+        .get_exported_global(GlobalIndex::from_u32(0)))
 }
 
 pub fn generate_memory_export(
@@ -72,11 +70,9 @@ pub fn generate_memory_export(
     m: &MemoryType,
 ) -> Result<wasmtime_runtime::ExportMemory> {
     let instance = create_memory(store, m)?;
-    let idx = EntityIndex::Memory(MemoryIndex::from_u32(0));
-    match store.instance_mut(instance).lookup_by_declaration(&idx) {
-        wasmtime_runtime::Export::Memory(m) => Ok(m),
-        _ => unreachable!(),
-    }
+    Ok(store
+        .instance_mut(instance)
+        .get_exported_memory(MemoryIndex::from_u32(0)))
 }
 
 pub fn generate_table_export(
@@ -84,9 +80,7 @@ pub fn generate_table_export(
     t: &TableType,
 ) -> Result<wasmtime_runtime::ExportTable> {
     let instance = create_table(store, t)?;
-    let idx = EntityIndex::Table(TableIndex::from_u32(0));
-    match store.instance_mut(instance).lookup_by_declaration(&idx) {
-        wasmtime_runtime::Export::Table(t) => Ok(t),
-        _ => unreachable!(),
-    }
+    Ok(store
+        .instance_mut(instance)
+        .get_exported_table(TableIndex::from_u32(0)))
 }

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -71,11 +71,9 @@ pub fn create_global(store: &mut StoreOpaque, gt: &GlobalType, val: Val) -> Resu
 
     if let Some(x) = externref_init {
         let instance = store.instance_mut(id);
-        match instance.lookup_by_declaration(&EntityIndex::Global(global_id)) {
-            wasmtime_runtime::Export::Global(g) => unsafe {
-                *(*g.definition).as_externref_mut() = Some(x.inner);
-            },
-            _ => unreachable!(),
+        let g = instance.get_exported_global(global_id);
+        unsafe {
+            *(*g.definition).as_externref_mut() = Some(x.inner);
         }
     }
 


### PR DESCRIPTION
This splits the existing `lookup_by_declaration` function into a
lookup-per-type-of-item. This refactor ends up cleaning up a fair bit of
code in the `wasmtime` crate by removing a number of `unreachable!()`
blocks which are now no longer necessary.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
