### PR TITLE
fix(sockets): preopened directories first

### DIFF
--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -135,6 +135,18 @@ impl WasiCtxBuilder {
         self.0.insert_file(fd, file, caps);
         Ok(self)
     }
+    pub fn push_preopened_socket(mut self, socket: impl Into<Socket>) -> Result<Self, Error> {
+        let socket: Socket = socket.into();
+        let file: Box<dyn WasiFile> = socket.into();
+
+        let caps = FileCaps::FDSTAT_SET_FLAGS
+            | FileCaps::FILESTAT_GET
+            | FileCaps::READ
+            | FileCaps::POLL_READWRITE;
+
+        self.0.push_file(file, caps)?;
+        Ok(self)
+    }
     pub fn build(self) -> WasiCtx {
         self.0
     }

--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -43,6 +43,10 @@ impl WasiCtx {
             .insert_at(fd, Box::new(FileEntry::new(caps, file)));
     }
 
+    pub fn push_file(&mut self, file: Box<dyn WasiFile>, caps: FileCaps) -> Result<u32, Error> {
+        self.table().push(Box::new(FileEntry::new(caps, file)))
+    }
+
     pub fn insert_dir(
         &mut self,
         fd: u32,


### PR DESCRIPTION
Existing libraries and applications use `fd_prestat_get()` to find out
about preopened directories. To not break the old logic of those,
if preopened sockets are added, push the directories first.

See https://github.com/bytecodealliance/wasmtime/issues/3936

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
