### PR TITLE
Update release notes for 0.36.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,9 +4,11 @@
 
 Unreleased.
 
-### Added
+### Fixed
 
-### Changed
+* Using `InstancePre::instantiate` or `Linker::instantiate` will now panic as
+  intended when used with an async-configured `Store`.
+  [#TODO](https://github.com/bytecodealliance/wasmtime/pull/TODO)
 
 --------------------------------------------------------------------------------
 
@@ -19,11 +21,21 @@ Unreleased.
 * Support for epoch-based interruption has been added to the C API.
   [#3925](https://github.com/bytecodealliance/wasmtime/pull/3925)
 
+* Support for disabling libunwind-based backtraces of WebAssembly code at
+  compile time has been added.
+  [#3932](https://github.com/bytecodealliance/wasmtime/pull/3932)
+
+* Async support for call hooks has been added to optionally execute "blocking"
+  work whenever a wasm module is entered or exited relative to the host.
+  [#3876](https://github.com/bytecodealliance/wasmtime/pull/3876)
+
 ### Fixed
 
-* Using `InstancePre::instantiate` or `Linker::instantiate` will now panic as
-  intended when used with an async-configured `Store`.
-  [#TODO](https://github.com/bytecodealliance/wasmtime/pull/TODO)
+* Loading a `Module` will now check, at runtime, that the compilation settings
+  enabled in a `Config` are compatible with the native host. For example this
+  ensures that if avx2 is enabled that the host actually has avx2 support.
+  [#3899](https://github.com/bytecodealliance/wasmtime/pull/3899)
+>>>>>>> Update release notes for 0.36.0
 
 ### Removed
 
@@ -32,7 +44,20 @@ Unreleased.
   interruption instead.
   [#3925](https://github.com/bytecodealliance/wasmtime/pull/3925)
 
+* The module linking implementation of Wasmtime has been removed to make room
+  for the upcoming support for the component model.
+  [#3958](https://github.com/bytecodealliance/wasmtime/pull/3958)
+
 --------------------------------------------------------------------------------
+
+## 0.35.2
+
+Released 2022-03-31.
+
+### Security Fixes
+
+* [CVE-2022-24791](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gwc9-348x-qwv2):
+  Fixed a use after free with `externref`s and epoch interruption.
 
 ## 0.35.1
 
@@ -111,6 +136,15 @@ Released 2022-03-07.
   [#3799](https://github.com/bytecodealliance/wasmtime/pull/3799)
 
 --------------------------------------------------------------------------------
+
+## 0.34.2
+
+Released 2022-03-31.
+
+### Security Fixes
+
+* [CVE-2022-24791](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gwc9-348x-qwv2):
+  Fixed a use after free with `externref`s and epoch interruption.
 
 ## 0.34.1
 


### PR DESCRIPTION
Fill in some more items that were added and additionally fill in entries
for the recent patch releases for
[CVE-2022-24791](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gwc9-348x-qwv2)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
