### PR TITLE
Update wasm-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,18 +3316,18 @@ checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9d9bf45fc46f71c407837c9b30b1e874197f2dc357588430b21e5017d290ab"
+checksum = "a35138d119147af92d7e44ae0f052f6496ee5f38e7c0cad3e0338befdb8f3753"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f7ccba3995e0533a62e5fa5786236e7a61e7b421a460ca68bc4c5382c7ed82"
+checksum = "f9e5f369abe36f3dca16811234da3550d72075c6b1365173811118307478f51d"
 dependencies = [
  "egg",
  "log",
@@ -3339,15 +3339,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1f1ae7d995f2d82326fda2c92deb2444fd3e59bf885fe9a4bbe9bde3b6c93"
+checksum = "50b4138c138f975e29dbd3ceea3a8d3ea2bb43f71abd4b236640d0cb14cb8ef7"
 dependencies = [
  "arbitrary",
  "flagset",
  "indexmap",
  "leb128",
  "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3385,15 +3386,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f973822fb3ca7e03ab421910274514b405df19a3d53acb131ae4df3a2fc4eb58"
+checksum = "9b72b3c96567183a4eca151040b5f61735b2d53e7cadd4242dbb61cd9011d865"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3734,7 +3738,7 @@ version = "0.37.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 39.0.0",
+ "wast 40.0.0",
 ]
 
 [[package]]
@@ -3758,12 +3762,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.0.41"
+name = "wast"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab98ed25494f97c69f28758617f27c3e92e5336040b5c3a14634f2dd3fe61830"
+checksum = "9bb4f48a8b083dbc50e291e430afb8f524092bb00428957bcc63f49f856c64ac"
 dependencies = [
- "wast 39.0.0",
+ "leb128",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0401b6395ce0db91629a75b29597ccb66ea29950af9fc859f1bb3a736609c76e"
+dependencies = [
+ "wast 40.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ file-per-thread-logger = "0.1.1"
 libc = "0.2.60"
 rayon = "1.5.0"
 humantime = "2.0.0"
-wasmparser = "0.83.0"
+wasmparser = "0.84.0"
 lazy_static = "1.4.0"
 listenfd = "0.3.5"
 
@@ -61,7 +61,7 @@ num_cpus = "1.13.0"
 winapi = { version = "0.3.9", features = ['memoryapi'] }
 memchr = "2.4"
 async-trait = "0.1"
-wat = "1.0.41"
+wat = "1.0.42"
 once_cell = "1.9.0"
 
 [build-dependencies]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2021"
 
 [dependencies]
-wasmparser = { version = "0.83.0", default-features = false }
+wasmparser = { version = "0.84.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.84.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.84.0" }
 cranelift-frontend = { path = "../frontend", version = "0.84.0", default-features = false }

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -596,7 +596,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             state.popn(num_args);
             state.pushn(inst_results);
         }
-        Operator::CallIndirect { index, table_index } => {
+        Operator::CallIndirect {
+            index,
+            table_index,
+            table_byte: _,
+        } => {
             // `index` is the index of the function's signature and `table_index` is the index of
             // the table to search the function in.
             let (sigref, num_args) = state.get_indirect_sig(builder.func, *index, environ)?;

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -289,7 +289,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
                 WasmType::F32 => ir::types::F32,
                 WasmType::F64 => ir::types::F64,
                 WasmType::V128 => ir::types::I8X16,
-                WasmType::ExnRef | WasmType::FuncRef | WasmType::ExternRef => ir::types::R64,
+                WasmType::FuncRef | WasmType::ExternRef => ir::types::R64,
             },
         })
     }
@@ -685,7 +685,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
                 WasmType::F32 => ir::types::F32,
                 WasmType::F64 => ir::types::F64,
                 WasmType::V128 => ir::types::I8X16,
-                WasmType::FuncRef | WasmType::ExternRef | WasmType::ExnRef => reference_type,
+                WasmType::FuncRef | WasmType::ExternRef => reference_type,
             })
         };
         sig.params.extend(wasm.params().iter().map(&mut cvt));
@@ -698,7 +698,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         &mut self,
         index: TypeIndex,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()> {
         assert_eq!(
             self.info.functions.len(),
@@ -708,7 +708,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         self.info.functions.push(Exportable::new(index));
         self.info
             .imported_funcs
-            .push((String::from(module), String::from(field.unwrap())));
+            .push((String::from(module), String::from(field)));
         Ok(())
     }
 
@@ -726,12 +726,12 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         &mut self,
         global: Global,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()> {
         self.info.globals.push(Exportable::new(global));
         self.info
             .imported_globals
-            .push((String::from(module), String::from(field.unwrap())));
+            .push((String::from(module), String::from(field)));
         Ok(())
     }
 
@@ -744,12 +744,12 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         &mut self,
         table: Table,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()> {
         self.info.tables.push(Exportable::new(table));
         self.info
             .imported_tables
-            .push((String::from(module), String::from(field.unwrap())));
+            .push((String::from(module), String::from(field)));
         Ok(())
     }
 
@@ -789,12 +789,12 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         &mut self,
         memory: Memory,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()> {
         self.info.memories.push(Exportable::new(memory));
         self.info
             .imported_memories
-            .push((String::from(module), String::from(field.unwrap())));
+            .push((String::from(module), String::from(field)));
         Ok(())
     }
 

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -8,9 +8,8 @@
 
 use crate::state::FuncTranslationState;
 use crate::{
-    DataIndex, ElemIndex, EntityType, FuncIndex, Global, GlobalIndex, Memory, MemoryIndex,
-    SignatureIndex, Table, TableIndex, Tag, TagIndex, TypeIndex, WasmError, WasmFuncType,
-    WasmResult, WasmType,
+    DataIndex, ElemIndex, FuncIndex, Global, GlobalIndex, Memory, MemoryIndex, SignatureIndex,
+    Table, TableIndex, Tag, TagIndex, TypeIndex, WasmError, WasmFuncType, WasmResult, WasmType,
 };
 use core::convert::From;
 use cranelift_codegen::cursor::FuncCursor;
@@ -531,22 +530,6 @@ pub trait ModuleEnvironment<'data> {
     /// Declares a function signature to the environment.
     fn declare_type_func(&mut self, wasm_func_type: WasmFuncType) -> WasmResult<()>;
 
-    /// Declares a module type signature to the environment.
-    fn declare_type_module(
-        &mut self,
-        imports: &[(&'data str, Option<&'data str>, EntityType)],
-        exports: &[(&'data str, EntityType)],
-    ) -> WasmResult<()> {
-        drop((imports, exports));
-        Err(WasmError::Unsupported("module linking".to_string()))
-    }
-
-    /// Declares an instance type signature to the environment.
-    fn declare_type_instance(&mut self, exports: &[(&'data str, EntityType)]) -> WasmResult<()> {
-        drop(exports);
-        Err(WasmError::Unsupported("module linking".to_string()))
-    }
-
     /// Translates a type index to its signature index, only called for type
     /// indices which point to functions.
     fn type_to_signature(&self, index: TypeIndex) -> WasmResult<SignatureIndex> {
@@ -565,7 +548,7 @@ pub trait ModuleEnvironment<'data> {
         &mut self,
         index: TypeIndex,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()>;
 
     /// Declares a table import to the environment.
@@ -573,7 +556,7 @@ pub trait ModuleEnvironment<'data> {
         &mut self,
         table: Table,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()>;
 
     /// Declares a memory import to the environment.
@@ -581,7 +564,7 @@ pub trait ModuleEnvironment<'data> {
         &mut self,
         memory: Memory,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()>;
 
     /// Declares an tag import to the environment.
@@ -589,7 +572,7 @@ pub trait ModuleEnvironment<'data> {
         &mut self,
         tag: Tag,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()> {
         drop((tag, module, field));
         Err(WasmError::Unsupported("wasm tags".to_string()))
@@ -600,19 +583,8 @@ pub trait ModuleEnvironment<'data> {
         &mut self,
         global: Global,
         module: &'data str,
-        field: Option<&'data str>,
+        field: &'data str,
     ) -> WasmResult<()>;
-
-    /// Declares a module import to the environment.
-    fn declare_module_import(
-        &mut self,
-        ty_index: TypeIndex,
-        module: &'data str,
-        field: Option<&'data str>,
-    ) -> WasmResult<()> {
-        drop((ty_index, module, field));
-        Err(WasmError::Unsupported("module linking".to_string()))
-    }
 
     /// Notifies the implementation that all imports have been declared.
     fn finish_imports(&mut self) -> WasmResult<()> {

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -8,7 +8,6 @@ use crate::code_translator::{bitcast_arguments, translate_operator, wasm_param_t
 use crate::environ::{FuncEnvironment, ReturnMode};
 use crate::state::FuncTranslationState;
 use crate::translation_utils::get_vmctx_value_label;
-use crate::wasm_unsupported;
 use crate::WasmResult;
 use core::convert::TryInto;
 use cranelift_codegen::entity::EntityRef;
@@ -206,7 +205,6 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
         ExternRef | FuncRef => {
             environ.translate_ref_null(builder.cursor(), wasm_type.try_into()?)?
         }
-        ty => return Err(wasm_unsupported!("unsupported local type {:?}", ty)),
     };
 
     let ty = builder.func.dfg.value_type(zeroval);

--- a/cranelift/wasm/src/state/func_state.rs
+++ b/cranelift/wasm/src/state/func_state.rs
@@ -58,7 +58,7 @@ pub enum ControlStackFrame {
         num_return_values: usize,
         original_stack_size: usize,
         exit_is_branched_to: bool,
-        blocktype: wasmparser::TypeOrFuncType,
+        blocktype: wasmparser::BlockType,
         /// Was the head of the `if` reachable?
         head_is_reachable: bool,
         /// What was the reachability at the end of the consequent?
@@ -411,7 +411,7 @@ impl FuncTranslationState {
         else_data: ElseData,
         num_param_types: usize,
         num_result_types: usize,
-        blocktype: wasmparser::TypeOrFuncType,
+        blocktype: wasmparser::BlockType,
     ) {
         debug_assert!(num_param_types <= self.stack.len());
 

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime = { path = "../wasmtime", default-features = false, features = ['cranel
 wasmtime-c-api-macros = { path = "macros" }
 
 # Optional dependency for the `wat2wasm` API
-wat = { version = "1.0.36", optional = true }
+wat = { version = "1.0.42", optional = true }
 
 # Optional dependencies for the `wasi` feature
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -19,7 +19,7 @@ cranelift-codegen = { path = "../../cranelift/codegen", version = "0.84.0" }
 cranelift-frontend = { path = "../../cranelift/frontend", version = "0.84.0" }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.84.0" }
 cranelift-native = { path = "../../cranelift/native", version = "0.84.0" }
-wasmparser = "0.83.0"
+wasmparser = "0.84.0"
 target-lexicon = "0.12"
 gimli = { version = "0.26.0", default-features = false, features = ['read', 'std'] }
 object = { version = "0.27.0", default-features = false, features = ['write'] }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -184,7 +184,6 @@ fn value_type(isa: &dyn TargetIsa, ty: WasmType) -> ir::types::Type {
         WasmType::F64 => ir::types::F64,
         WasmType::V128 => ir::types::I8X16,
         WasmType::FuncRef | WasmType::ExternRef => reference_type(ty, isa.pointer_type()),
-        WasmType::ExnRef => unimplemented!(),
     }
 }
 

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 anyhow = "1.0"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.84.0" }
 wasmtime-types = { path = "../types", version = "0.37.0" }
-wasmparser = "0.83.0"
+wasmparser = "0.84.0"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -15,13 +15,13 @@ log = "0.4.8"
 rayon = "1.2.1"
 target-lexicon = "0.12.3"
 tempfile = "3.3.0"
-wasmparser = "0.83.0"
-wasmprinter = "0.2.32"
+wasmparser = "0.84.0"
+wasmprinter = "0.2.34"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
-wasm-encoder = "0.10.0"
-wasm-smith = "0.9.0"
-wasm-mutate = "0.2"
+wasm-encoder = "0.11.0"
+wasm-smith = "0.10.0"
+wasm-mutate = "0.2.2"
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
 wasmi = "0.7.0"
 

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -422,10 +422,12 @@ mod tests {
       global.get 0
       call 1
       br 0 (;@1;)
-    end)
+    end
+  )
   (table (;0;) 20 externref)
   (global (;0;) (mut externref) ref.null extern)
-  (export "run" (func 3)))
+  (export "run" (func 3))
+)
 "#;
         eprintln!("expected WAT = {}", expected);
 

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -95,9 +95,9 @@ impl TableOps {
 
         // Import the GC function.
         let mut imports = ImportSection::new();
-        imports.import("", Some("gc"), EntityType::Function(0));
-        imports.import("", Some("take_refs"), EntityType::Function(2));
-        imports.import("", Some("make_refs"), EntityType::Function(3));
+        imports.import("", "gc", EntityType::Function(0));
+        imports.import("", "take_refs", EntityType::Function(2));
+        imports.import("", "make_refs", EntityType::Function(3));
 
         // Define our table.
         let mut tables = TableSection::new();

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -20,7 +20,7 @@ pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
-wat = "1.0.37"
+wat = "1.0.42"
 cap-std = "0.24.1"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2021"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.84.0", features = ['enable-serde'] }
 serde = { version = "1.0.94", features = ["derive"] }
 thiserror = "1.0.4"
-wasmparser = { version = "0.83.0", default-features = false }
+wasmparser = { version = "0.84.0", default-features = false }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -29,8 +29,6 @@ pub enum WasmType {
     FuncRef,
     /// ExternRef type
     ExternRef,
-    /// ExnRef type
-    ExnRef,
 }
 
 impl TryFrom<wasmparser::Type> for WasmType {
@@ -45,11 +43,6 @@ impl TryFrom<wasmparser::Type> for WasmType {
             V128 => Ok(WasmType::V128),
             FuncRef => Ok(WasmType::FuncRef),
             ExternRef => Ok(WasmType::ExternRef),
-            ExnRef => Ok(WasmType::ExnRef),
-            EmptyBlockType | Func => Err(WasmError::InvalidWebAssembly {
-                message: "unexpected value type".to_string(),
-                offset: 0,
-            }),
         }
     }
 }
@@ -64,7 +57,6 @@ impl From<WasmType> for wasmparser::Type {
             WasmType::V128 => wasmparser::Type::V128,
             WasmType::FuncRef => wasmparser::Type::FuncRef,
             WasmType::ExternRef => wasmparser::Type::ExternRef,
-            WasmType::ExnRef => wasmparser::Type::ExnRef,
         }
     }
 }
@@ -79,7 +71,6 @@ impl fmt::Display for WasmType {
             WasmType::V128 => write!(f, "v128"),
             WasmType::ExternRef => write!(f, "externref"),
             WasmType::FuncRef => write!(f, "funcref"),
-            WasmType::ExnRef => write!(f, "exnref"),
         }
     }
 }
@@ -356,8 +347,10 @@ pub struct Tag {
 
 impl From<wasmparser::TagType> for Tag {
     fn from(ty: wasmparser::TagType) -> Tag {
-        Tag {
-            ty: TypeIndex::from_u32(ty.type_index),
+        match ty.kind {
+            wasmparser::TagKind::Exception => Tag {
+                ty: TypeIndex::from_u32(ty.func_type_idx),
+            },
         }
     }
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -20,14 +20,14 @@ wasmtime-cache = { path = "../cache", version = "=0.37.0", optional = true }
 wasmtime-fiber = { path = "../fiber", version = "=0.37.0", optional = true }
 wasmtime-cranelift = { path = "../cranelift", version = "=0.37.0", optional = true }
 target-lexicon = { version = "0.12.0", default-features = false }
-wasmparser = "0.83.0"
+wasmparser = "0.84.0"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"
 cfg-if = "1.0"
 backtrace = { version = "0.3.61", optional = true }
 log = "0.4.8"
-wat = { version = "1.0.36", optional = true }
+wat = { version = "1.0.42", optional = true }
 serde = { version = "1.0.94", features = ["derive"] }
 bincode = "1.2.1"
 indexmap = "1.6"

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -542,8 +542,7 @@ impl Module {
     ///
     /// [binary]: https://webassembly.github.io/spec/core/binary/index.html
     pub fn validate(engine: &Engine, binary: &[u8]) -> Result<()> {
-        let mut validator = Validator::new();
-        validator.wasm_features(engine.config().features);
+        let mut validator = Validator::new_with_features(engine.config().features);
 
         let mut functions = Vec::new();
         for payload in Parser::new(0).parse_all(binary) {

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -60,7 +60,7 @@ struct WasmFeatures {
     pub reference_types: bool,
     pub multi_value: bool,
     pub bulk_memory: bool,
-    pub module_linking: bool,
+    pub component_model: bool,
     pub simd: bool,
     pub threads: bool,
     pub tail_call: bool,
@@ -78,7 +78,7 @@ impl From<&wasmparser::WasmFeatures> for WasmFeatures {
             reference_types,
             multi_value,
             bulk_memory,
-            module_linking,
+            component_model,
             simd,
             threads,
             tail_call,
@@ -99,7 +99,7 @@ impl From<&wasmparser::WasmFeatures> for WasmFeatures {
             reference_types,
             multi_value,
             bulk_memory,
-            module_linking,
+            component_model,
             simd,
             threads,
             tail_call,
@@ -479,7 +479,7 @@ impl<'a> SerializedModule<'a> {
             reference_types,
             multi_value,
             bulk_memory,
-            module_linking,
+            component_model,
             simd,
             threads,
             tail_call,
@@ -507,9 +507,9 @@ impl<'a> SerializedModule<'a> {
             "WebAssembly bulk memory support",
         )?;
         Self::check_bool(
-            module_linking,
-            other.module_linking,
-            "WebAssembly module linking support",
+            component_model,
+            other.component_model,
+            "WebAssembly component model support",
         )?;
         Self::check_bool(simd, other.simd, "WebAssembly SIMD support")?;
         Self::check_bool(threads, other.threads, "WebAssembly threads support")?;

--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -92,7 +92,6 @@ impl ValType {
             WasmType::V128 => Self::V128,
             WasmType::FuncRef => Self::FuncRef,
             WasmType::ExternRef => Self::ExternRef,
-            WasmType::ExnRef => unimplemented!(),
         }
     }
 }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.37.0", default-features = false, features = ['cranelift'] }
-wast = "39.0.0"
+wast = "40.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This commit updates the wasm-tools family of crates as used in Wasmtime.
Notably this brings in the update which removes module linking support
as well as a number of internal refactorings around names and such
within wasmparser itself. This updates all of the wasm translation
support which binds to wasmparser as appropriate.

Other crates all had API-compatible changes for at least what Wasmtime
used so no further changes were necessary beyond updating version
requirements.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
