### PR TITLE
Cranelift: fix broken `selinux-fix` refactor

### DIFF
--- a/cranelift/jit/src/memory.rs
+++ b/cranelift/jit/src/memory.rs
@@ -37,11 +37,11 @@ impl PtrLen {
         MmapMut::map_anon(alloc_size).map(|mut mmap| {
             // The order here is important; we assign the pointer first to get
             // around compile time borrow errors.
-            Ok(Self {
+            Self {
                 ptr: mmap.as_mut_ptr(),
                 map: Some(mmap),
                 len: alloc_size,
-            })
+            }
         })
     }
 


### PR DESCRIPTION
Cranelift-JIT's `selinux-fix` broke in 05b9037bbba80f43ef43f771d85576b775c193cd.
(Tangentially related to #4000)