### PR TITLE
Upgrade to the high-level `ittapi` v0.3.0 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,10 +1485,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "ittapi-rs"
-version = "0.2.0"
+name = "ittapi"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f712648a1ad72fbfb7adc2772c331e8d90f022f8cf30cbabefba2878dd3172b0"
+checksum = "663fe0550070071ff59e981864a9cd3ee1c869ed0a088140d9ac4dc05ea6b1a1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21911b7183f38c71d75ab478a527f314e28db51027037ece2e5511ed9410703"
 dependencies = [
  "cc",
 ]
@@ -3571,7 +3582,7 @@ dependencies = [
  "cfg-if",
  "cpp_demangle",
  "gimli",
- "ittapi-rs",
+ "ittapi",
  "log",
  "object",
  "rustc-demangle",

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -22,7 +22,7 @@ gimli = { version = "0.26.0", default-features = false, features = ["std", "read
 object = { version = "0.29.0", default-features = false, features = ["std", "read_core", "elf"] }
 serde = { version = "1.0.94", features = ["derive"] }
 addr2line = { version = "0.17.0", default-features = false }
-ittapi-rs = { version = "0.2.0", optional = true  }
+ittapi = { version = "0.3.0", optional = true  }
 bincode = "1.2.1"
 rustc-demangle = "0.1.16"
 cpp_demangle = "0.3.2"
@@ -39,7 +39,7 @@ rustix = { version = "0.35.6", features = ["process"] }
 
 [features]
 jitdump = ['wasmtime-jit-debug']
-vtune = ['ittapi-rs']
+vtune = ['ittapi']
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/jit/src/profiling.rs
+++ b/crates/jit/src/profiling.rs
@@ -12,7 +12,9 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "vtune", target_arch = "x86_64"))] {
+    // Note: VTune support is disabled on windows mingw because the ittapi crate doesn't compile
+    // there; see also https://github.com/bytecodealliance/wasmtime/pull/4003 for rationale.
+    if #[cfg(all(feature = "vtune", target_arch = "x86_64", not(all(target_os = "windows", target_env = "gnu"))))] {
         #[path = "profiling/vtune.rs"]
         mod vtune;
     } else {


### PR DESCRIPTION
This is using the new fancy `ittapi` high-level crate that we've worked on, @abrown @jlb6740 and myself, and it upgrades to the latest version.

Could someone please test it locally and confirm it works for them? On my machine I get a weird failure that I also hit on main, not sure what's going on:

```
Assertion failed: tool:1328: g_instr_global.is_libpthread_so_loaded == 0 : g_instr_global.is_libpthread_so_loaded == 1
. Please contact the technical support. vtune: Error: Assertion failed: tool:1328: g_instr_global.is_libpthread_so_loaded == 0 : g_instr_global.is_libpthread_so_loaded == 1
. Please contact the technical support. 
```