### PR TITLE
fuzz: improve wasm-spec-interpreter documentation, add library path

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/README.md
+++ b/crates/fuzzing/wasm-spec-interpreter/README.md
@@ -15,25 +15,23 @@ This crate only builds in an environment with:
 - `ocamlopt`, `ocamlbuild` (available with, e.g., `dnf install ocaml`)
 - Linux tools (e.g. `ar`); currently it is easiest to build the static
   libraries in a single environment but this could be fixed in the future (TODO)
-
-Remember to retrieve the Wasm spec submodule:
-
-```
-git clone ... --recursive
-```
+- `libgmp`, for the OCaml `zarith` package
+- `git` is used by `build.rs` to retrieve the repository containing the Wasm
+  spec interpreter; it is safe to completely remove `ocaml/spec` to get a new
+  copy
 
 ### Build
 
 ```
-RUSTFLAGS=--cfg=fuzzing cargo build
+cargo build --features build-libinterpret
 ```
 
 Use `FFI_LIB_DIR=path/to/lib/...` to specify a different location for the static
-library (this is mainly for debugging). If the `--cfg=fuzzing` configuration is
+library (this is mainly for debugging). If the `build-libinterpret` feature is
 not provided, this crate will build successfully but fail at runtime.
 
 ### Test
 
 ```
-RUSTFLAGS=--cfg=fuzzing cargo test
+cargo test --features build-libinterpret
 ```

--- a/crates/fuzzing/wasm-spec-interpreter/ocaml/Makefile
+++ b/crates/fuzzing/wasm-spec-interpreter/ocaml/Makefile
@@ -13,7 +13,7 @@ SPEC_LIB := $(SPEC_BUILD_DIR)/wasm.cmxa
 
 # A space-separated list of paths that the linker will use to search for libgmp.
 # Override with `make LIBGMP_PATHS=...`.
-LIBGMP_PATHS ?= /usr/lib /usr/lib/x86_64-linux-gnu
+LIBGMP_PATHS ?= /usr/lib /usr/lib/x86_64-linux-gnu /lib64
 
 PKGS = zarith
 

--- a/crates/fuzzing/wasm-spec-interpreter/ocaml/README.md
+++ b/crates/fuzzing/wasm-spec-interpreter/ocaml/README.md
@@ -6,5 +6,5 @@ access to the Wasm spec interpreter. Its major parts:
    for FFI access
  - `Makefile`: the steps for gluing these pieces together into a static library
 
-Note: the makefile must be configured with the path to libgmp. See LIBGMP_PATHS
-in the makefile.
+Note: the `Makefile` must be configured with the path to `libgmp.a`; see
+`LIBGMP_PATHS` in the `Makefile` (Ubuntu: `libgmp-dev`, Fedora: `gmp-static`).


### PR DESCRIPTION
The documentation for the `wasm-spec-interpreter` was not up-to-date,
causing some confusion on non-Ubuntu machines. This change adds the
correct dependencies to install and includes the `libgmp` path for
Fedora by default (i.e., `/lib64`).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
