### PR TITLE
Update to rustix 0.33.6.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.33.5"
+version = "0.33.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03627528abcc4a365554d32a9f3bbf67f7694c102cfeda792dc86a2d6057cc85"
+checksum = "7ac32d9fc97153ca55305284cb6c2dcbb84e1fc6d7ac13392cea02222f2d8741"
 dependencies = [
  "bitflags",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ lazy_static = "1.4.0"
 listenfd = "0.3.5"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -24,7 +24,7 @@ zstd = { version = "0.11.1", default-features = false }
 winapi = "0.3.7"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [dev-dependencies]
 filetime = "0.2.7"

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 links = "wasmtime-fiber-shims"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = {version = "1.3.0", optional = true }
 object = { version = "0.27.0", default-features = false, features = ["std", "read_core"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "0.33.5", optional = true }
+rustix = { version = "0.33.6", optional = true }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -33,7 +33,7 @@ log = "0.4.8"
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [features]
 jitdump = ['wasmtime-jit-debug']

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -31,7 +31,7 @@ memfd = { version = "0.4.1", optional = true }
 mach = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi", "handleapi"] }

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -27,7 +27,7 @@ cap-rand = "0.24.1"
 bitflags = "1.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [target.'cfg(windows)'.dependencies]
 io-extras = "0.13.2"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -26,7 +26,7 @@ io-lifetimes = { version = "0.5.0", default-features = false }
 is-terminal = "0.1.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1"
 io-lifetimes = { version = "0.5.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.33.5"
+rustix = "0.33.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"


### PR DESCRIPTION
Relevant to Wasmtime, this fixes undefined references to `utimensat` and
`futimens` on macOS 10.12 and earlier. See bytecodealliance/rustix#157
for details.

It also contains a fix for s390x which isn't currently needed by Wasmtime
itself, but which is needed to make rustix's own testsuite pass on s390x,
which helps people packaging rustix for use in Wasmtime. See
bytecodealliance/rustix#277 for details.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
