### PR TITLE
Enable AArch64 processor feature detection unconditionally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2021-12-15
+        toolchain: nightly-2022-04-27
 
     # Build C API documentation
     - run: sudo apt-get update -y && sudo apt-get install -y libclang1-9 libclang-cpp9
@@ -178,7 +178,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2021-12-15
+        toolchain: nightly-2022-04-27
     - run: cargo install cargo-fuzz --vers "^0.11"
     # Install OCaml packages necessary for 'differential_spec' fuzz target.
     - run: sudo apt install -y ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -105,8 +105,7 @@ pub fn builder_with_options(infer_native_flags: bool) -> Result<isa::Builder, &'
         }
     }
 
-    // `stdsimd` is necessary for std::is_aarch64_feature_detected!().
-    #[cfg(all(target_arch = "aarch64", feature = "stdsimd"))]
+    #[cfg(target_arch = "aarch64")]
     {
         use cranelift_codegen::settings::Configurable;
 
@@ -114,7 +113,7 @@ pub fn builder_with_options(infer_native_flags: bool) -> Result<isa::Builder, &'
             return Ok(isa_builder);
         }
 
-        if std::is_aarch64_feature_detected!("lse") {
+        if std::arch::is_aarch64_feature_detected!("lse") {
             isa_builder.enable("has_lse").unwrap();
         }
     }

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -702,7 +702,7 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                         // print a warning and return an error because this fuzz
                         // input must be discarded.
                         #[cfg(target_arch = $arch)]
-                        if enable && !std::$test!($std) {
+                        if enable && !std::arch::$test!($std) {
                             log::warn!("want to enable clif `{}` but host doesn't support it",
                                 $clif);
                             return Err(arbitrary::Error::EmptyChoose)
@@ -751,6 +751,11 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                     std:"avx512f" => clif:"has_avx512f" ratio: 1 in 1000,
                     std:"avx512vl" => clif:"has_avx512vl" ratio: 1 in 1000,
                     std:"avx512vbmi" => clif:"has_avx512vbmi" ratio: 1 in 1000,
+                },
+                "aarch64" => {
+                    test: is_aarch64_feature_detected,
+
+                    std: "lse" => clif: "has_lse",
                 },
             };
             return Ok(CodegenSettings::Target {


### PR DESCRIPTION
`std::arch::is_aarch64_feature_detected!()` is now part of stable Rust, so we can always use it.

Actually this PR depends on a fix in #4021 (hence the test failure), but I am opening it to gather early feedback.