### PR TITLE
Store the `ValRaw` type in little-endian format

### DIFF
--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -119,24 +119,38 @@ typedef uint8_t wasmtime_v128[16];
  */
 typedef union wasmtime_valunion {
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_I32
+  ///
+  /// Note that this field is always stored in a little-endian format.
   int32_t i32;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_I64
+  ///
+  /// Note that this field is always stored in a little-endian format.
   int64_t i64;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_F32
+  ///
+  /// Note that this field is always stored in a little-endian format.
   float32_t f32;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_F64
+  ///
+  /// Note that this field is always stored in a little-endian format.
   float64_t f64;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
   ///
   /// If this value represents a `ref.null func` value then the `store_id` field
   /// is set to zero.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   wasmtime_func_t funcref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_EXTERNREF
   ///
   /// If this value represents a `ref.null extern` value then this pointer will
   /// be `NULL`.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   wasmtime_externref_t *externref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
+  ///
+  /// Note that this field is always stored in a little-endian format.
   wasmtime_v128 v128;
 } wasmtime_valunion_t;
 

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -427,7 +427,8 @@ impl Compiler {
         };
 
         // Load the argument values out of `values_vec`.
-        let mflags = ir::MemFlags::trusted();
+        let mut mflags = ir::MemFlags::trusted();
+        mflags.set_endianness(ir::Endianness::Little);
         let callee_args = wasm_signature
             .params
             .iter()
@@ -458,7 +459,6 @@ impl Compiler {
         let results = builder.func.dfg.inst_results(call).to_vec();
 
         // Store the return values into `values_vec`.
-        let mflags = ir::MemFlags::trusted();
         for (i, r) in results.iter().enumerate() {
             builder
                 .ins()
@@ -507,7 +507,8 @@ impl Compiler {
         builder.seal_block(block0);
 
         let values_vec_ptr_val = builder.ins().stack_addr(pointer_type, ss, 0);
-        let mflags = MemFlags::trusted();
+        let mut mflags = MemFlags::trusted();
+        mflags.set_endianness(ir::Endianness::Little);
         for i in 0..ty.params().len() {
             let val = builder.func.dfg.block_params(block0)[i + 2];
             builder
@@ -528,7 +529,6 @@ impl Compiler {
             .ins()
             .call_indirect(new_sig, callee_value, &callee_args);
 
-        let mflags = MemFlags::trusted();
         let mut results = Vec::new();
         for (i, r) in ty.returns().iter().enumerate() {
             let load = builder.ins().load(

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1395,7 +1395,7 @@ where
     }
 
     unsafe fn wrap_trampoline(ptr: *mut ValRaw, f: impl FnOnce(Self::Retptr) -> Self::Abi) {
-        *ptr.cast::<Self::Abi>() = f(());
+        T::abi_into_raw(f(()), ptr);
     }
 
     fn into_fallible(self) -> Result<T, Trap> {
@@ -1483,7 +1483,7 @@ macro_rules! impl_wasm_host_results {
             unsafe fn wrap_trampoline(mut _ptr: *mut ValRaw, f: impl FnOnce(Self::Retptr) -> Self::Abi) {
                 let ($($t,)*) = <($($t::Abi,)*) as HostAbi>::call(f);
                 $(
-                    *_ptr.cast() = $t;
+                    $t::abi_into_raw($t, _ptr);
                     _ptr = _ptr.add(1);
                 )*
             }
@@ -1936,7 +1936,7 @@ macro_rules! impl_into_func {
 
                     let mut _n = 0;
                     $(
-                        let $args = *args.add(_n).cast::<$args::Abi>();
+                        let $args = $args::abi_from_raw(args.add(_n));
                         _n += 1;
                     )*
                     R::wrap_trampoline(args, |retptr| {

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -103,24 +103,28 @@ impl Val {
     /// [`Func::to_raw`] are unsafe.
     pub unsafe fn to_raw(&self, store: impl AsContextMut) -> ValRaw {
         match self {
-            Val::I32(i) => ValRaw { i32: *i },
-            Val::I64(i) => ValRaw { i64: *i },
-            Val::F32(u) => ValRaw { f32: *u },
-            Val::F64(u) => ValRaw { f64: *u },
-            Val::V128(b) => ValRaw { v128: *b },
+            Val::I32(i) => ValRaw { i32: i.to_le() },
+            Val::I64(i) => ValRaw { i64: i.to_le() },
+            Val::F32(u) => ValRaw { f32: u.to_le() },
+            Val::F64(u) => ValRaw { f64: u.to_le() },
+            Val::V128(b) => ValRaw { v128: b.to_le() },
             Val::ExternRef(e) => {
                 let externref = match e {
                     Some(e) => e.to_raw(store),
                     None => 0,
                 };
-                ValRaw { externref }
+                ValRaw {
+                    externref: externref.to_le(),
+                }
             }
             Val::FuncRef(f) => {
                 let funcref = match f {
                     Some(f) => f.to_raw(store),
                     None => 0,
                 };
-                ValRaw { funcref }
+                ValRaw {
+                    funcref: funcref.to_le(),
+                }
             }
         }
     }
@@ -134,13 +138,15 @@ impl Val {
     /// otherwise that `raw` should have the type `ty` specified.
     pub unsafe fn from_raw(store: impl AsContextMut, raw: ValRaw, ty: ValType) -> Val {
         match ty {
-            ValType::I32 => Val::I32(raw.i32),
-            ValType::I64 => Val::I64(raw.i64),
-            ValType::F32 => Val::F32(raw.f32),
-            ValType::F64 => Val::F64(raw.f64),
-            ValType::V128 => Val::V128(raw.v128),
-            ValType::ExternRef => Val::ExternRef(ExternRef::from_raw(raw.externref)),
-            ValType::FuncRef => Val::FuncRef(Func::from_raw(store, raw.funcref)),
+            ValType::I32 => Val::I32(i32::from_le(raw.i32)),
+            ValType::I64 => Val::I64(i64::from_le(raw.i64)),
+            ValType::F32 => Val::F32(u32::from_le(raw.f32)),
+            ValType::F64 => Val::F64(u64::from_le(raw.f64)),
+            ValType::V128 => Val::V128(u128::from_le(raw.v128)),
+            ValType::ExternRef => {
+                Val::ExternRef(ExternRef::from_raw(usize::from_le(raw.externref)))
+            }
+            ValType::FuncRef => Val::FuncRef(Func::from_raw(store, usize::from_le(raw.funcref))),
         }
     }
 

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -52,10 +52,10 @@ fn call_wrapped_func() -> Result<(), Error> {
             |caller: Caller<State>, space| {
                 verify(caller.data());
 
-                assert_eq!((*space.add(0)).i32, 1);
-                assert_eq!((*space.add(1)).i64, 2);
-                assert_eq!((*space.add(2)).f32, 3.0f32.to_bits());
-                assert_eq!((*space.add(3)).f64, 4.0f64.to_bits());
+                assert_eq!((*space.add(0)).i32, 1i32.to_le());
+                assert_eq!((*space.add(1)).i64, 2i64.to_le());
+                assert_eq!((*space.add(2)).f32, 3.0f32.to_bits().to_le());
+                assert_eq!((*space.add(3)).f64, 4.0f64.to_bits().to_le());
                 Ok(())
             },
         )


### PR DESCRIPTION
This commit changes the internal representation of the `ValRaw` type to
an unconditionally little-endian format instead of its current
native-endian format. The documentation and various accessors here have
been updated as well as the associated trampolines that read `ValRaw`
to always work with little-endian values, converting to the host
endianness as necessary.

The motivation for this change originally comes from the implementation
of the component model that I'm working on. One aspect of the component
model's canonical ABI is how variants are passed to functions as
immediate arguments. For example for a component model function:

```
foo: function(x: expected<i32, f64>)
```

This translates to a core wasm function:

```wasm
(module
  (func (export "foo") (param i32 i64)
    ;; ...
  )
)
```

The first `i32` parameter to the core wasm function is the discriminant
of whether the result is an "ok" or an "err". The second `i64`, however,
is the "join" operation on the `i32` and `f64` payloads. Essentially
these two types are unioned into one type to get passed into the function.

Currently in the implementation of the component model my plan is to
construct a `*mut [ValRaw]` to pass through to WebAssembly, always
invoking component exports through host trampolines. This means that the
implementation for `Result<T, E>` needs to do the correct "join"
operation here when encoding a particular case into the corresponding
`ValRaw`.

I personally found this particularly tricky to do structurally. The
solution that I settled on with fitzgen was that if `ValRaw` was always
stored in a little endian format then we could employ a trick where when
encoding a variant we first set all the `ValRaw` slots to zero, then the
associated case we have is encoding. Afterwards the `ValRaw` values are
already encoded into the correct format as if they'd been "join"ed.

For example if we were to encode `Ok(1i32)` then this would produce
`ValRaw { i32: 1 }`, which memory-wise is equivalent to `ValRaw { i64: 1 }`
if the other bytes in the `ValRaw` are guaranteed to be zero. Similarly
storing `ValRaw { f64 }` is equivalent to the storage required for
`ValRaw { i64 }` here in the join operation.

Note, though, that this equivalence relies on everything being
little-endian. Otherwise the in-memory representations of `ValRaw { i32: 1 }`
and `ValRaw { i64: 1 }` are different.

That motivation is what leads to this change. It's expected that this is
a low-to-zero cost change in the sense that little-endian platforms will
see no change and big-endian platforms are already required to
efficiently byte-swap loads/stores as WebAssembly requires that.
Additionally the `ValRaw` type is an esoteric niche use case primarily
used for accelerating the C API right now, so it's expected that not
many users will have to update for this change.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
