### PR TITLE
Reduce contention on the global module rwlock

### DIFF
--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -398,7 +398,7 @@ impl CompiledModule {
         info: Option<CompiledModuleInfo>,
         profiler: &dyn ProfilingAgent,
         id_allocator: &CompiledModuleIdAllocator,
-    ) -> Result<Arc<Self>> {
+    ) -> Result<Self> {
         // Transfer ownership of `obj` to a `CodeMemory` object which will
         // manage permissions, such as the executable bit. Once it's located
         // there we also publish it for being able to execute. Note that this
@@ -454,7 +454,7 @@ impl CompiledModule {
         };
         ret.register_debug_and_profiling(profiler)?;
 
-        Ok(Arc::new(ret))
+        Ok(ret)
     }
 
     fn register_debug_and_profiling(&mut self, profiler: &dyn ProfilingAgent) -> Result<()> {

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -99,6 +99,7 @@
 //! Examination of Deferred Reference Counting and Cycle Detection* by Quinane:
 //! <https://openresearch-repository.anu.edu.au/bitstream/1885/42030/2/hon-thesis.pdf>
 
+use std::alloc::Layout;
 use std::any::Any;
 use std::cell::UnsafeCell;
 use std::cmp;
@@ -108,7 +109,6 @@ use std::mem;
 use std::ops::Deref;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{self, AtomicUsize, Ordering};
-use std::{alloc::Layout, sync::Arc};
 use wasmtime_environ::StackMap;
 
 /// An external reference to some opaque data.
@@ -814,7 +814,7 @@ impl VMExternRefActivationsTable {
 /// program counter value.
 pub trait ModuleInfoLookup {
     /// Lookup the module information from a program counter value.
-    fn lookup(&self, pc: usize) -> Option<Arc<dyn ModuleInfo>>;
+    fn lookup(&self, pc: usize) -> Option<&dyn ModuleInfo>;
 }
 
 /// Used by the runtime to query module information.

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -105,9 +105,9 @@ struct ModuleInner {
     /// executed.
     module: Arc<CompiledModule>,
     /// Type information of this module.
-    types: Arc<TypeTables>,
+    types: TypeTables,
     /// Registered shared signature for the module.
-    signatures: Arc<SignatureCollection>,
+    signatures: SignatureCollection,
     /// A set of initialization images for memories, if any.
     ///
     /// Note that this is behind a `OnceCell` to lazily create this image. On
@@ -191,22 +191,6 @@ impl Module {
         #[cfg(feature = "wat")]
         let bytes = wat::parse_bytes(bytes)?;
         Self::from_binary(engine, &bytes)
-    }
-
-    /// Creates a new WebAssembly `Module` from the given in-memory `binary`
-    /// data. The provided `name` will be used in traps/backtrace details.
-    ///
-    /// See [`Module::new`] for other details.
-    #[cfg(compiler)]
-    #[cfg_attr(nightlydoc, doc(cfg(feature = "cranelift")))] // see build.rs
-    pub fn new_with_name(engine: &Engine, bytes: impl AsRef<[u8]>, name: &str) -> Result<Module> {
-        let mut module = Self::new(engine, bytes.as_ref())?;
-        Arc::get_mut(&mut Arc::get_mut(&mut module.inner).unwrap().module)
-            .unwrap()
-            .module_mut()
-            .expect("mutable module")
-            .name = Some(name.to_string());
-        Ok(module)
     }
 
     /// Creates a new WebAssembly `Module` from the contents of the given
@@ -332,7 +316,7 @@ impl Module {
             }
         };
 
-        Self::from_parts(engine, mmap, info, Arc::new(types))
+        Self::from_parts(engine, mmap, info, types)
     }
 
     /// Converts an input binary-encoded WebAssembly module to compilation
@@ -487,23 +471,29 @@ impl Module {
         engine: &Engine,
         mmap: MmapVec,
         info: Option<CompiledModuleInfo>,
-        types: Arc<TypeTables>,
+        types: TypeTables,
     ) -> Result<Self> {
-        let module = CompiledModule::from_artifacts(
+        let module = Arc::new(CompiledModule::from_artifacts(
             mmap,
             info,
             &*engine.config().profiler,
             engine.unique_id_allocator(),
-        )?;
+        )?);
 
         // Validate the module can be used with the current allocator
         engine.allocator().validate(module.module())?;
 
-        let signatures = Arc::new(SignatureCollection::new_for_module(
+        let signatures = SignatureCollection::new_for_module(
             engine.signatures(),
             &types,
             module.trampolines().map(|(idx, f, _)| (idx, f)),
-        ));
+        );
+
+        // We're about to create a `Module` for real now so enter this module
+        // into the global registry of modules so we can resolve traps
+        // appropriately. Note that the corresponding `unregister` happens below
+        // in `Drop for ModuleInner`.
+        registry::register(engine, &module);
 
         Ok(Self {
             inner: Arc::new(ModuleInner {
@@ -564,7 +554,7 @@ impl Module {
         SerializedModule::new(self).to_bytes(&self.inner.engine.config().module_version)
     }
 
-    pub(crate) fn compiled_module(&self) -> &Arc<CompiledModule> {
+    pub(crate) fn compiled_module(&self) -> &CompiledModule {
         &self.inner.module
     }
 
@@ -572,11 +562,11 @@ impl Module {
         self.compiled_module().module()
     }
 
-    pub(crate) fn types(&self) -> &Arc<TypeTables> {
+    pub(crate) fn types(&self) -> &TypeTables {
         &self.inner.types
     }
 
-    pub(crate) fn signatures(&self) -> &Arc<SignatureCollection> {
+    pub(crate) fn signatures(&self) -> &SignatureCollection {
         &self.inner.signatures
     }
 
@@ -599,8 +589,6 @@ impl Module {
     /// let module = Module::new(&engine, "(module)")?;
     /// assert_eq!(module.name(), None);
     ///
-    /// let module = Module::new_with_name(&engine, "(module)", "bar")?;
-    /// assert_eq!(module.name(), Some("bar"));
     /// # Ok(())
     /// # }
     /// ```
@@ -798,6 +786,10 @@ impl Module {
         self.inner.clone()
     }
 
+    pub(crate) fn module_info(&self) -> &dyn wasmtime_runtime::ModuleInfo {
+        &*self.inner
+    }
+
     /// Returns the range of bytes in memory where this module's compilation
     /// image resides.
     ///
@@ -914,6 +906,38 @@ impl wasmtime_runtime::ModuleRuntimeInfo for ModuleInner {
 
     fn signature_ids(&self) -> &[VMSharedSignatureIndex] {
         self.signatures.as_module_map().values().as_slice()
+    }
+}
+
+impl wasmtime_runtime::ModuleInfo for ModuleInner {
+    fn lookup_stack_map(&self, pc: usize) -> Option<&wasmtime_environ::StackMap> {
+        let text_offset = pc - self.module.code().as_ptr() as usize;
+        let (index, func_offset) = self.module.func_by_text_offset(text_offset)?;
+        let info = self.module.func_info(index);
+
+        // Do a binary search to find the stack map for the given offset.
+        let index = match info
+            .stack_maps
+            .binary_search_by_key(&func_offset, |i| i.code_offset)
+        {
+            // Found it.
+            Ok(i) => i,
+
+            // No stack map associated with this PC.
+            //
+            // Because we know we are in Wasm code, and we must be at some kind
+            // of call/safepoint, then the Cranelift backend must have avoided
+            // emitting a stack map for this location because no refs were live.
+            Err(_) => return None,
+        };
+
+        Some(&info.stack_maps[index].stack_map)
+    }
+}
+
+impl Drop for ModuleInner {
+    fn drop(&mut self) {
+        registry::unregister(&self.module);
     }
 }
 

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -47,7 +47,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::Arc;
 use wasmtime_environ::{FlagValue, Tunables, TypeTables};
 use wasmtime_jit::{subslice_range, CompiledModuleInfo};
 use wasmtime_runtime::MmapVec;
@@ -206,7 +205,7 @@ impl<'a> SerializedModule<'a> {
 
     pub fn into_module(self, engine: &Engine) -> Result<Module> {
         let (mmap, info, types) = self.into_parts(engine)?;
-        Module::from_parts(engine, mmap, info, Arc::new(types))
+        Module::from_parts(engine, mmap, info, types)
     }
 
     pub fn into_parts(

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1929,7 +1929,7 @@ impl Drop for StoreOpaque {
 }
 
 impl wasmtime_runtime::ModuleInfoLookup for ModuleRegistry {
-    fn lookup(&self, pc: usize) -> Option<Arc<dyn ModuleInfo>> {
+    fn lookup(&self, pc: usize) -> Option<&dyn ModuleInfo> {
         self.lookup_module(pc)
     }
 }

--- a/tests/all/name.rs
+++ b/tests/all/name.rs
@@ -27,8 +27,5 @@ fn test_module_name() -> anyhow::Result<()> {
     let module = Module::new(&engine, wat)?;
     assert_eq!(module.name(), Some("from_name_section"));
 
-    let module = Module::new_with_name(&engine, wat, "override")?;
-    assert_eq!(module.name(), Some("override"));
-
     Ok(())
 }


### PR DESCRIPTION
This commit intendes to close #4025 by reducing contention on the global
rwlock Wasmtime has for module information during instantiation and
dropping a store. Currently registration of a module into this global
map happens during instantiation, but this can be a hot path as
embeddings may want to, in parallel, instantiate modules.

Instead this switches to a strategy of inserting into the global module
map when a `Module` is created and then removing it from the map when
the `Module` is dropped. Registration in a `Store` now preserves the
entire `Module` within the store as opposed to trying to only save it
piecemeal. In reality the only piece that wasn't saved within a store
was the `TypeTables` which was pretty inconsequential for core wasm
modules anyway.

This means that instantiation should now clone a singluar `Arc` into a
`Store` per `Module` (previously it cloned two) with zero managemnt on
the global rwlock as that happened at `Module` creation time.
Additionally dropping a `Store` again involves zero rwlock management
and only a single `Arc` drop per-instantiated module (previously it was
two).

In the process of doing this I also went ahead and removed the
`Module::new_with_name` API. This has been difficult to support
historically with various variations on the internals of `ModuleInner`
because it involves mutating a `Module` after it's been created. My hope
is that this API is pretty rarely used and/or isn't super important, so
it's ok to remove.

Finally this change removes some internal `Arc` layerings that are no
longer necessary, attempting to use either `T` or `&T` where possible
without dealing with the overhead of an `Arc`.

Closes #4025

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
