### PR TITLE
Cranelift: fix regalloc2 integration bug wrt blockparam branch args.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -98,7 +98,6 @@ pub struct CallIndInfo {
 pub struct JTSequenceInfo {
     pub targets: Vec<BranchTarget>,
     pub default_target: BranchTarget,
-    pub targets_for_term: Vec<MachLabel>, // needed for MachTerminator.
 }
 
 fn count_zero_half_words(mut value: u64, num_half_words: u8) -> usize {
@@ -1091,17 +1090,13 @@ impl MachInst for Inst {
         }
     }
 
-    fn is_term<'a>(&'a self) -> MachTerminator<'a> {
+    fn is_term(&self) -> MachTerminator {
         match self {
             &Inst::Ret { .. } | &Inst::EpiloguePlaceholder => MachTerminator::Ret,
-            &Inst::Jump { dest } => MachTerminator::Uncond(dest.as_label().unwrap()),
-            &Inst::CondBr {
-                taken, not_taken, ..
-            } => MachTerminator::Cond(taken.as_label().unwrap(), not_taken.as_label().unwrap()),
-            &Inst::IndirectBr { ref targets, .. } => MachTerminator::Indirect(&targets[..]),
-            &Inst::JTSequence { ref info, .. } => {
-                MachTerminator::Indirect(&info.targets_for_term[..])
-            }
+            &Inst::Jump { .. } => MachTerminator::Uncond,
+            &Inst::CondBr { .. } => MachTerminator::Cond,
+            &Inst::IndirectBr { .. } => MachTerminator::Indirect,
+            &Inst::JTSequence { .. } => MachTerminator::Indirect,
             _ => MachTerminator::None,
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -2739,7 +2739,6 @@ pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
                     .map(|bix| BranchTarget::Label(*bix))
                     .collect();
                 let default_target = BranchTarget::Label(targets[0]);
-                let targets_for_term: Vec<MachLabel> = targets.to_vec();
                 ctx.emit(Inst::JTSequence {
                     ridx,
                     rtmp1,
@@ -2747,7 +2746,6 @@ pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
                     info: Box::new(JTSequenceInfo {
                         targets: jt_targets,
                         default_target,
-                        targets_for_term,
                     }),
                 });
             }

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -733,19 +733,17 @@ impl MachInst for Inst {
         }
     }
 
-    fn is_term<'a>(&'a self) -> MachTerminator<'a> {
+    fn is_term(&self) -> MachTerminator {
         match self {
             &Inst::Ret { .. } | &Inst::EpiloguePlaceholder => MachTerminator::Ret,
-            &Inst::Jump { dest } => MachTerminator::Uncond(dest),
-            &Inst::CondBr {
-                taken, not_taken, ..
-            } => MachTerminator::Cond(taken, not_taken),
+            &Inst::Jump { .. } => MachTerminator::Uncond,
+            &Inst::CondBr { .. } => MachTerminator::Cond,
             &Inst::OneWayCondBr { .. } => {
                 // Explicitly invisible to CFG processing.
                 MachTerminator::None
             }
-            &Inst::IndirectBr { ref targets, .. } => MachTerminator::Indirect(&targets[..]),
-            &Inst::JTSequence { ref targets, .. } => MachTerminator::Indirect(&targets[..]),
+            &Inst::IndirectBr { .. } => MachTerminator::Indirect,
+            &Inst::JTSequence { .. } => MachTerminator::Indirect,
             _ => MachTerminator::None,
         }
     }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2119,18 +2119,13 @@ impl MachInst for Inst {
         }
     }
 
-    fn is_term<'a>(&'a self) -> MachTerminator<'a> {
+    fn is_term(&self) -> MachTerminator {
         match self {
             // Interesting cases.
             &Self::Ret { .. } | &Self::EpiloguePlaceholder => MachTerminator::Ret,
-            &Self::JmpKnown { dst } => MachTerminator::Uncond(dst),
-            &Self::JmpCond {
-                taken, not_taken, ..
-            } => MachTerminator::Cond(taken, not_taken),
-            &Self::JmpTableSeq {
-                ref targets_for_term,
-                ..
-            } => MachTerminator::Indirect(&targets_for_term[..]),
+            &Self::JmpKnown { .. } => MachTerminator::Uncond,
+            &Self::JmpCond { .. } => MachTerminator::Cond,
+            &Self::JmpTableSeq { .. } => MachTerminator::Indirect,
             // All other cases are boring.
             _ => MachTerminator::None,
         }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -94,7 +94,7 @@ pub trait MachInst: Clone + Debug {
 
     /// Is this a terminator (branch or ret)? If so, return its type
     /// (ret/uncond/cond) and target if applicable.
-    fn is_term<'a>(&'a self) -> MachTerminator<'a>;
+    fn is_term(&self) -> MachTerminator;
 
     /// Returns true if the instruction is an epilogue placeholder.
     fn is_epilogue_placeholder(&self) -> bool;
@@ -221,18 +221,22 @@ pub trait MachInstLabelUse: Clone + Copy + Debug + Eq {
 
 /// Describes a block terminator (not call) in the vcode, when its branches
 /// have not yet been finalized (so a branch may have two targets).
+///
+/// Actual targets are not included: the single-source-of-truth for
+/// those is the VCode itself, which holds, for each block, successors
+/// and outgoing branch args per successor.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum MachTerminator<'a> {
+pub enum MachTerminator {
     /// Not a terminator.
     None,
     /// A return instruction.
     Ret,
     /// An unconditional branch to another block.
-    Uncond(MachLabel),
+    Uncond,
     /// A conditional branch to one of two other blocks.
-    Cond(MachLabel, MachLabel),
+    Cond,
     /// An indirect branch with known possible targets.
-    Indirect(&'a [MachLabel]),
+    Indirect,
 }
 
 /// A trait describing the ability to encode a MachInst into binary machine code.


### PR DESCRIPTION
Previously, the block successor accumulation and the blockparam branch
arg setup were decoupled. The lowering backend implicitly specified
the order of successor edges via its `MachTerminator` enum on the last
instruction in the block, while the `Lower` toplevel
machine-independent driver set up blockparam branch args in the edge
order seen in CLIF.

In some cases, these orders did not match -- for example, when the
conditional branch depended on an FP condition that was implemented by
swapping taken/not-taken edges and inverting the condition code.

This PR refactors the successor handling to be centralized in `Lower`
rather than flow through the terminator `MachInst`, and adds a
successor block and its blockparam args at the same time, ensuring the
orders match.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
