### PR TITLE
Turn on the regalloc2 checker in the `compile` fuzz target.

### DIFF
--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -1,10 +1,21 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use wasmtime::{Engine, Module};
+use wasmtime::{Config, Engine, Module};
+
+fn create_engine() -> Engine {
+    let mut config = Config::default();
+    // Safety: the Cranelift option `regalloc_checker` does not alter
+    // the generated code at all; it only does extra checking after
+    // compilation.
+    unsafe {
+        config.cranelift_flag_enable("regalloc_checker").unwrap();
+    }
+    Engine::new(&config).expect("Could not construct Engine")
+}
 
 fuzz_target!(|data: &[u8]| {
-    let engine = Engine::default();
+    let engine = create_engine();
     wasmtime_fuzzing::oracles::log_wasm(data);
     drop(Module::new(&engine, data));
 });


### PR DESCRIPTION
This tells Cranelift to run regalloc2's symbolic verifier on the results
of register allocation after compiling each function.

We already fuzz regalloc2 independently, but that provides coverage
using regalloc2's purpose-built (synthetic) `Function` implementation.
This fuzz target with this change, in contrast, exercises regalloc2 with
whatever particular details of generated code Cranelift generates.
Testing the whole pipeline together and ensuring that the register
allocation is still valid is at least as important as fuzzing regalloc2
independently, IMHO.

Fuzzed locally for a brief time (~10M inputs) to smoke-test; let's see
what oss-fuzz can find (hopefully it's boring)!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
