### PR TITLE
c-api: add missing bcrypt.lib dependency in docs.

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -41,7 +41,7 @@
  *
  * * Linux - `-lpthread -ldl -lm`
  * * macOS - no extra flags needed
- * * Windows - `ws2_32.lib advapi32.lib userenv.lib ntdll.lib shell32.lib ole32.lib`
+ * * Windows - `ws2_32.lib advapi32.lib userenv.lib ntdll.lib shell32.lib ole32.lib bcrypt.lib`
  *
  * ## Building from Source
  *


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>