### PR TITLE
Reduce clones of `Arc<HostFunc>` during instantiation

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -224,6 +224,21 @@ enum FuncKind {
     /// situations is `SharedHost` and `StoreOwned`, so this ideally isn't
     /// larger than those two.
     Host(Box<HostFunc>),
+
+    /// A reference to a `HostFunc`, but one that's "rooted" in the `Store`
+    /// itself.
+    ///
+    /// This variant is created when an `InstancePre<T>` is instantiated in to a
+    /// `Store<T>`. In that situation the `InstancePre<T>` already has a list of
+    /// host functions that are packaged up in an `Arc`, so the `Arc<[T]>` is
+    /// cloned once into the `Store` to avoid each individual function requiring
+    /// an `Arc::clone`.
+    ///
+    /// The lifetime management of this type is `unsafe` because
+    /// `RootedHostFunc` is a small wrapper around `NonNull<HostFunc>`. To be
+    /// safe this is required that the memory of the host function is pinned
+    /// elsewhere (e.g. the `Arc` in the `Store`).
+    RootedHost(RootedHostFunc),
 }
 
 macro_rules! for_each_function_signature {
@@ -2070,6 +2085,29 @@ impl HostFunc {
         Func::from_func_kind(FuncKind::SharedHost(me), store)
     }
 
+    /// Inserts this `HostFunc` into a `Store`, returning the `Func` pointing to
+    /// it.
+    ///
+    /// This function is similar to, but not equivalent, to `HostFunc::to_func`.
+    /// Notably this function requires that the `Arc<Self>` pointer is otherwise
+    /// rooted within the `StoreOpaque` via another means. When in doubt use
+    /// `to_func` above as it's safer.
+    ///
+    /// # Unsafety
+    ///
+    /// Can only be inserted into stores with a matching `T` relative to when
+    /// this `HostFunc` was first created.
+    ///
+    /// Additionally the `&Arc<Self>` is not cloned in this function. Instead a
+    /// raw pointer to `Self` is stored within the `Store` for this function.
+    /// The caller must arrange for the `Arc<Self>` to be "rooted" in the store
+    /// provided via another means, probably by pushing to
+    /// `StoreOpaque::rooted_host_funcs`.
+    pub unsafe fn to_func_store_rooted(self: &Arc<Self>, store: &mut StoreOpaque) -> Func {
+        self.validate_store(store);
+        Func::from_func_kind(FuncKind::RootedHost(RootedHostFunc::new(self)), store)
+    }
+
     /// Same as [`HostFunc::to_func`], different ownership.
     unsafe fn into_func(self, store: &mut StoreOpaque) -> Func {
         self.validate_store(store);
@@ -2112,6 +2150,7 @@ impl FuncData {
         match &self.kind {
             FuncKind::StoreOwned { trampoline, .. } => *trampoline,
             FuncKind::SharedHost(host) => host.trampoline,
+            FuncKind::RootedHost(host) => host.trampoline,
             FuncKind::Host(host) => host.trampoline,
         }
     }
@@ -2132,7 +2171,50 @@ impl FuncKind {
         match self {
             FuncKind::StoreOwned { export, .. } => export,
             FuncKind::SharedHost(host) => &host.export,
+            FuncKind::RootedHost(host) => &host.export,
             FuncKind::Host(host) => &host.export,
+        }
+    }
+}
+
+use self::rooted::*;
+
+/// An inner module is used here to force unsafe construction of
+/// `RootedHostFunc` instead of accidentally safely allowing access to its
+/// constructor.
+mod rooted {
+    use super::HostFunc;
+    use std::ops::Deref;
+    use std::ptr::NonNull;
+    use std::sync::Arc;
+
+    /// A variant of a pointer-to-a-host-function used in `FuncKind::RootedHost`
+    /// above.
+    ///
+    /// For more documentation see `FuncKind::RootedHost`, `InstancePre`, and
+    /// `HostFunc::to_func_store_rooted`.
+    pub(crate) struct RootedHostFunc(NonNull<HostFunc>);
+
+    // These are required due to the usage of `NonNull` but should be safe
+    // because `HostFunc` is itself send/sync.
+    unsafe impl Send for RootedHostFunc where HostFunc: Send {}
+    unsafe impl Sync for RootedHostFunc where HostFunc: Sync {}
+
+    impl RootedHostFunc {
+        /// Note that this is `unsafe` because this wrapper type allows safe
+        /// access to the pointer given at any time, including outside the
+        /// window of validity of `func`, so callers must not use the return
+        /// value past the lifetime of the provided `func`.
+        pub(crate) unsafe fn new(func: &Arc<HostFunc>) -> RootedHostFunc {
+            RootedHostFunc(NonNull::from(&**func))
+        }
+    }
+
+    impl Deref for RootedHostFunc {
+        type Target = HostFunc;
+
+        fn deref(&self) -> &HostFunc {
+            unsafe { self.0.as_ref() }
         }
     }
 }

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -1194,6 +1194,15 @@ impl Definition {
         }
     }
 
+    /// Note the unsafety here is due to calling
+    /// `HostFunc::to_func_store_rooted`.
+    pub(crate) unsafe fn to_extern_store_rooted(&self, store: &mut StoreOpaque) -> Extern {
+        match self {
+            Definition::Extern(e) => e.clone(),
+            Definition::HostFunc(func) => func.to_func_store_rooted(store).into(),
+        }
+    }
+
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
         match self {
             Definition::Extern(e) => e.comes_from_same_store(store),


### PR DESCRIPTION
This commit implements an optimization to help improve concurrently
creating instances of a module on many threads simultaneously. One
bottleneck to this measured has been the reference count modification on
`Arc<HostFunc>`. Each host function stored within a `Linker<T>` is
wrapped in an `Arc<HostFunc>` structure, and when any of those host
functions are inserted into a store the reference count is incremented.
When the store is dropped the reference count is then decremented.

This ends up meaning that when a module imports N functions it ends up
doing 2N atomic modifications over the lifetime of the instance. For
embeddings where the `Linker<T>` is rarely modified but instances are
frequently created this can be a surprising bottleneck to creating many
instances.

A change implemented here is to optimize the instantiation process when
using an `InstancePre<T>`. An `InstancePre` serves as an opportunity to
take the list of items used to instantiate a module and wrap them all up
in an `Arc<[T]>`. Everything is going to get cloned into a `Store<T>`
anyway so to optimize this the `Arc<[T]>` is cloned at the top-level and
then nothing else is cloned internally. This continues to, however,
preserve a strong reference count for all contained items to prevent
them from being deallocated.

A new variant of `FuncKind` was added for host functions which is
effectively stored via `*mut HostFunc`. This variant is unsafe to create
and manage and has been documented internally.

Performance-wise the overall impact of this change is somewhat minor.
It's already a bit esoteric if this atomic increment and decrement are a
bottleneck due to the number of concurrent instances being created. In
my measurements I've seen that this can reduce instantiation time by up
to 10% for a module that imports two dozen functions. For larger modules
with more imports this is expected to have a larger win.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
