### PR TITLE
Fix the release process's latest step

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -107,14 +107,15 @@ jobs:
         run: |
           set -ex
           git fetch origin
-          cur=$(git for-each-ref refs/remotes/origin --format '%(refname)' | grep release | sed 's/.*release-//' | sort -n -r | head -n 1)
 
-          # Update the release date for $cur on the `main` branch. Note that the
-          # sed here is a little complicated because we will have two entries in
-          # `RELEASES.md`, one for $cur+1 which `main` is at plus one for $cur
-          # which we're about to release. We only want to update the release
-          # date of the second one.
-          sed -i "/^##.*$cur/,+3 s/^Unreleased/Released $(date +'%Y-%m-%d')/" RELEASES.md
+          # Determine the latest release branch
+          rustc ci/find-latest-release.rs -o /tmp/find-latest-release
+          cur=`/tmp/find-latest-release`
+
+          # Update the release date of $cur in RELEASES.md
+          rustc ci/update-release-date.rs -o /tmp/update-release-date
+          /tmp/update-release-date $(date +'%Y-%m-%d')
+
           git commit -a -F-<<EOF
           Update release date of Wasmtime $cur
 

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Bump major version number
         run: |
+          set -ex
           # Push the current contents of `main` to a new release branch
           cur=$(./ci/print-current-version.sh)
           git push origin HEAD:release-$cur
@@ -104,8 +105,9 @@ jobs:
 
       - name: Perform latest release
         run: |
+          set -ex
           git fetch origin
-          cur=$(git for-each-ref --sort=-committerdate refs/remotes/origin --format '%(refname)' | grep release | head -n 1 | sed 's/.*release-//')
+          cur=$(git for-each-ref refs/remotes/origin --format '%(refname)' | grep release | sed 's/.*release-//' | sort -n -r | head -n 1)
 
           # Update the release date for $cur on the `main` branch. Note that the
           # sed here is a little complicated because we will have two entries in
@@ -183,6 +185,7 @@ jobs:
 
       - name: Bump and release patch version number
         run: |
+          set -ex
           # Update version numbers on a patch basis and update RELEASES.md if a
           # patch release marker is already in there. Note that this commit
           # message indicates that on-merge a release will be made.
@@ -222,6 +225,7 @@ jobs:
         # become a json-encoded string literal to send to GitHub. This
         # represents my best attempt.
         run: |
+          set -ex
           body=$(jq -sR < ./pr-body)
 
           curl --include --request POST \

--- a/ci/find-latest-release.rs
+++ b/ci/find-latest-release.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+fn main() {
+    let output = Command::new("git")
+        .arg("for-each-ref")
+        .arg("refs/remotes/origin")
+        .arg("--format")
+        .arg("%(refname)")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let mut releases = std::str::from_utf8(&output.stdout)
+        .unwrap()
+        .lines()
+        .filter_map(|l| l.strip_prefix("refs/remotes/origin/release-"))
+        .filter_map(|l| {
+            let mut parts = l.split('.');
+            let major = parts.next()?.parse::<u32>().ok()?;
+            let minor = parts.next()?.parse::<u32>().ok()?;
+            let patch = parts.next()?.parse::<u32>().ok()?;
+            Some((major, minor, patch))
+        })
+        .collect::<Vec<_>>();
+    releases.sort();
+    let (major, minor, patch) = releases.last().unwrap();
+    println!("{}.{}.{}", major, minor, patch);
+}

--- a/ci/update-release-date.rs
+++ b/ci/update-release-date.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let date = std::env::args().nth(1).unwrap();
+    let relnotes = std::fs::read_to_string("RELEASES.md").unwrap();
+    let mut new_relnotes = String::new();
+    let mut counter = 0;
+    for line in relnotes.lines() {
+        if line.starts_with("Unreleased") {
+            counter += 1;
+            if counter == 2 {
+                new_relnotes.push_str(&format!("Released {}\n", date));
+                continue;
+            }
+        }
+        new_relnotes.push_str(line);
+        new_relnotes.push_str("\n");
+    }
+    std::fs::write("RELEASES.md", new_relnotes).unwrap();
+}


### PR DESCRIPTION
The automated release of 0.36.0 was attempted last night but it failed
due to a [failure on CI][bad]. This failure comes about because it was
trying to change the release date of 0.35.0 which ended up not modifying
any fails so `git` failed to commit as no files were changed.

The original bug though was that 0.35.0 was being changed instead of
0.36.0. The reason for this is that the script used
`--sort=-committerdate` to determine the latest branch. I forgot,
though, that with backports it's possible for 0.35.0 to have a more
recent commit date than 0.36.0 (as is currently the case). This commit
updates the script to perform a numerical sort outside of git to get the
latest release branch.

Additionally this adds in some `set -ex` commands for the shell which
should help print out commands as they're run and assist in future
debugging.

[bad]: https://github.com/bytecodealliance/wasmtime/runs/6087188708

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
