### PR TITLE
ISLE: add support for extended left-hand sides with `if-let` clauses.

### DIFF
--- a/cranelift/isle/isle/isle_examples/fail/impure_expression.isle
+++ b/cranelift/isle/isle/isle_examples/fail/impure_expression.isle
@@ -1,0 +1,10 @@
+(type u32 (primitive u32))
+
+(decl ctor (u32) u32)
+(rule (ctor x) x)
+
+(decl entry (u32) u32)
+
+(rule (entry x)
+      (if-let y (ctor x))
+      y)

--- a/cranelift/isle/isle/isle_examples/fail/impure_rhs.isle
+++ b/cranelift/isle/isle/isle_examples/fail/impure_rhs.isle
@@ -1,0 +1,15 @@
+(type u32 (primitive u32))
+
+(decl pure ctor (u32) u32)
+(decl impure (u32) u32)
+
+(decl entry (u32) u32)
+
+(rule (entry x)
+      (if-let y (ctor x))
+      y)
+
+(rule (ctor x)
+      (impure x))
+
+(rule (impure x) x)

--- a/cranelift/isle/isle/isle_examples/link/borrows.isle
+++ b/cranelift/isle/isle/isle_examples/link/borrows.isle
@@ -1,0 +1,15 @@
+(type u32 (primitive u32))
+(type A extern (enum (B (x u32) (y u32))))
+
+(decl get_a (A) u32)
+(extern extractor get_a get_a)
+
+(decl pure u32_pure (u32) u32)
+(extern constructor u32_pure u32_pure)
+
+(decl entry (u32) u32)
+(rule (entry x @ (get_a a1))
+      (if-let (get_a a2) x)
+      (if-let (A.B p q) a1)
+      (if-let r (u32_pure p))
+      r)

--- a/cranelift/isle/isle/isle_examples/link/borrows_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/borrows_main.rs
@@ -1,0 +1,21 @@
+mod borrows;
+
+#[derive(Clone)]
+pub enum A {
+    B { x: u32, y: u32 },
+}
+
+struct Context(A);
+impl borrows::Context for Context {
+    fn get_a(&mut self, _: u32) -> Option<A> {
+        Some(self.0.clone())
+    }
+
+    fn u32_pure(&mut self, value: u32) -> Option<u32> {
+        Some(value + 1)
+    }
+}
+
+fn main() {
+    borrows::constructor_entry(&mut Context(A::B { x: 1, y: 2 }), 42);
+}

--- a/cranelift/isle/isle/isle_examples/link/iflets.isle
+++ b/cranelift/isle/isle/isle_examples/link/iflets.isle
@@ -1,0 +1,29 @@
+(type u32 (primitive u32))
+
+(decl pure A (u32 u32) u32)
+(extern constructor A A)
+
+(decl B (u32 u32) u32)
+(extern extractor B B)
+
+(decl C (u32 u32 u32 u32) u32)
+
+(decl pure predicate () u32)
+(rule (predicate) 1)
+
+(rule (C a b c (B d e))
+      (if-let (B f g) d)
+      (if-let h (A a b))
+      (A h a))
+
+(rule (C a b c d)
+      (if (predicate))
+      42)
+
+(rule (C a b a b)
+      (if-let x (D a b))
+      x)
+
+(decl pure D (u32 u32) u32)
+(rule (D x 0) x)
+(rule (D 0 x) x)

--- a/cranelift/isle/isle/isle_examples/link/iflets_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/iflets_main.rs
@@ -1,0 +1,16 @@
+mod iflets;
+
+struct Context;
+impl iflets::Context for Context {
+    fn A(&mut self, a: u32, b: u32) -> Option<u32> {
+        Some(a + b)
+    }
+
+    fn B(&mut self, value: u32) -> Option<(u32, u32)> {
+        Some((value, value + 1))
+    }
+}
+
+fn main() {
+    iflets::constructor_C(&mut Context, 1, 2, 3, 4);
+}

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -69,15 +69,25 @@ pub struct Decl {
     pub term: Ident,
     pub arg_tys: Vec<Ident>,
     pub ret_ty: Ident,
+    /// Whether this term's constructor is pure.
+    pub pure: bool,
     pub pos: Pos,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Rule {
     pub pattern: Pattern,
+    pub iflets: Vec<IfLet>,
     pub expr: Expr,
     pub pos: Pos,
     pub prio: Option<i64>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct IfLet {
+    pub pattern: Pattern,
+    pub expr: Expr,
+    pub pos: Pos,
 }
 
 /// An extractor macro: (A x y) becomes (B x _ y ...). Expanded during

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -68,7 +68,7 @@ impl<'a> Codegen<'a> {
         .unwrap();
         writeln!(
             code,
-            "#![allow(unused_imports, unused_variables, non_snake_case)]"
+            "#![allow(unused_imports, unused_variables, non_snake_case, unused_mut)]"
         )
         .unwrap();
         writeln!(code, "#![allow(irrefutable_let_patterns)]").unwrap();
@@ -626,7 +626,7 @@ impl<'a> Codegen<'a> {
                 ref seq, output_ty, ..
             } => {
                 let closure_name = format!("closure{}", id.index());
-                writeln!(code, "{}let {} = || {{", indent, closure_name).unwrap();
+                writeln!(code, "{}let mut {} = || {{", indent, closure_name).unwrap();
                 let subindent = format!("{}    ", indent);
                 let mut subctx = ctx.clone();
                 let mut returns = vec![];

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -232,6 +232,8 @@ pub enum TermKind {
     },
     /// A term declared via a `(decl ...)` form.
     Decl {
+        /// Whether the term is marked as `pure`.
+        pure: bool,
         /// The kind of this term's constructor, if any.
         constructor_kind: Option<ConstructorKind>,
         /// The kind of this term's extractor, if any.
@@ -392,13 +394,14 @@ impl Term {
         match &self.kind {
             TermKind::Decl {
                 constructor_kind: Some(ConstructorKind::ExternalConstructor { name }),
+                pure,
                 ..
             } => Some(ExternalSig {
                 func_name: tyenv.syms[name.index()].clone(),
                 full_name: format!("C::{}", tyenv.syms[name.index()]),
                 param_tys: self.arg_tys.clone(),
                 ret_tys: vec![self.ret_ty],
-                infallible: true,
+                infallible: !pure,
             }),
             TermKind::Decl {
                 constructor_kind: Some(ConstructorKind::InternalConstructor { .. }),
@@ -410,6 +413,10 @@ impl Term {
                     full_name: name,
                     param_tys: self.arg_tys.clone(),
                     ret_tys: vec![self.ret_ty],
+                    // Internal constructors are always fallible, even
+                    // if not pure, because ISLE allows partial
+                    // matching at the toplevel (an entry point can
+                    // fail to rewrite).
                     infallible: false,
                 })
             }
@@ -425,6 +432,8 @@ pub struct Rule {
     pub id: RuleId,
     /// The left-hand side pattern that this rule matches.
     pub lhs: Pattern,
+    /// Any subpattern "if-let" clauses.
+    pub iflets: Vec<IfLet>,
     /// The right-hand side expression that this rule evaluates upon successful
     /// match.
     pub rhs: Expr,
@@ -432,6 +441,18 @@ pub struct Rule {
     pub prio: Option<i64>,
     /// The source position where this rule is defined.
     pub pos: Pos,
+}
+
+/// An `if-let` clause with a subpattern match on an expr after the
+/// main LHS matches.
+#[derive(Clone, Debug)]
+pub struct IfLet {
+    /// The left-hand side pattern that this `if-let` clause matches
+    /// against the expression below.
+    pub lhs: Pattern,
+    /// The right-hand side expression that this pattern
+    /// evaluates. Must be pure.
+    pub rhs: Expr,
 }
 
 /// A left-hand side pattern of some rule.
@@ -861,6 +882,7 @@ impl TermEnv {
                         kind: TermKind::Decl {
                             constructor_kind: None,
                             extractor_kind: None,
+                            pure: decl.pure,
                         },
                     });
                 }
@@ -1337,6 +1359,18 @@ impl TermEnv {
                         }
                     };
 
+                    let pure = match &self.terms[rule_term.index()].kind {
+                        &TermKind::Decl { pure, .. } => pure,
+                        _ => {
+                            tyenv.report_error(
+                                pos,
+                                "Cannot define a rule on a left-hand-side that is an enum variant"
+                                    .to_string(),
+                            );
+                            continue;
+                        }
+                    };
+
                     let (lhs, ty) = unwrap_or_continue!(self.translate_pattern(
                         tyenv,
                         rule_term,
@@ -1345,17 +1379,25 @@ impl TermEnv {
                         &mut bindings,
                         /* is_root = */ true,
                     ));
+                    let iflets = unwrap_or_continue!(self.translate_iflets(
+                        tyenv,
+                        rule_term,
+                        &rule.iflets[..],
+                        &mut bindings,
+                    ));
                     let rhs = unwrap_or_continue!(self.translate_expr(
                         tyenv,
                         &rule.expr,
-                        ty,
-                        &mut bindings
+                        Some(ty),
+                        &mut bindings,
+                        pure,
                     ));
 
                     let rid = RuleId(self.rules.len());
                     self.rules.push(Rule {
                         id: rid,
                         lhs,
+                        iflets,
                         rhs,
                         prio: rule.prio,
                         pos,
@@ -1829,7 +1871,13 @@ impl TermEnv {
                     return None;
                 }
                 let ty = expected_ty.unwrap();
-                let expr = self.translate_expr(tyenv, expr, expected_ty.unwrap(), bindings)?;
+                let expr = self.translate_expr(
+                    tyenv,
+                    expr,
+                    expected_ty,
+                    bindings,
+                    /* pure = */ true,
+                )?;
                 Some((TermArgPattern::Expr(expr), ty))
             }
         }
@@ -1863,8 +1911,9 @@ impl TermEnv {
         &self,
         tyenv: &mut TypeEnv,
         expr: &ast::Expr,
-        ty: TypeId,
+        ty: Option<TypeId>,
         bindings: &mut Bindings,
+        pure: bool,
     ) -> Option<Expr> {
         log::trace!("translate_expr: {:?}", expr);
         match expr {
@@ -1890,25 +1939,43 @@ impl TermEnv {
                 // are doing an implicit conversion. Report an error
                 // if types don't match and no conversion is possible.
                 let ret_ty = self.terms[tid.index()].ret_ty;
-                let ty = if ret_ty != ty {
+                let ty = if ty.is_some() && ret_ty != ty.unwrap() {
                     // Is there a converter for this type mismatch?
                     if let Some(expanded_expr) =
-                        self.maybe_implicit_convert_expr(tyenv, expr, ret_ty, ty)
+                        self.maybe_implicit_convert_expr(tyenv, expr, ret_ty, ty.unwrap())
                     {
-                        return self.translate_expr(tyenv, &expanded_expr, ty, bindings);
+                        return self.translate_expr(tyenv, &expanded_expr, ty, bindings, pure);
                     }
 
                     tyenv.report_error(
                         pos,
                         format!("Mismatched types: expression expects type '{}' but term has return type '{}'",
-                                tyenv.types[ty.index()].name(tyenv),
+                                tyenv.types[ty.unwrap().index()].name(tyenv),
                                 tyenv.types[ret_ty.index()].name(tyenv)));
 
                     // Keep going, to discover more errors.
                     ret_ty
                 } else {
-                    ty
+                    ret_ty
                 };
+
+                // Check that the term's constructor is pure.
+                match &self.terms[tid.index()].kind {
+                    TermKind::Decl {
+                        pure: ctor_is_pure, ..
+                    } => {
+                        if pure && !ctor_is_pure {
+                            tyenv.report_error(
+                                pos,
+                                format!(
+                                    "Used non-pure constructor '{}' in pure expression context",
+                                    tyenv.syms[name.index()]
+                                ),
+                            );
+                        }
+                    }
+                    _ => {}
+                }
 
                 // Check that we have the correct argument count.
                 if self.terms[tid.index()].arg_tys.len() != args.len() {
@@ -1928,8 +1995,13 @@ impl TermEnv {
                 for (i, arg) in args.iter().enumerate() {
                     let term = unwrap_or_continue!(self.terms.get(tid.index()));
                     let arg_ty = unwrap_or_continue!(term.arg_tys.get(i).copied());
-                    let subexpr =
-                        unwrap_or_continue!(self.translate_expr(tyenv, arg, arg_ty, bindings));
+                    let subexpr = unwrap_or_continue!(self.translate_expr(
+                        tyenv,
+                        arg,
+                        Some(arg_ty),
+                        bindings,
+                        pure
+                    ));
                     subexprs.push(subexpr);
                 }
 
@@ -1947,12 +2019,12 @@ impl TermEnv {
                 };
 
                 // Verify type. Maybe do an implicit conversion.
-                if bv.ty != ty {
+                if ty.is_some() && bv.ty != ty.unwrap() {
                     // Is there a converter for this type mismatch?
                     if let Some(expanded_expr) =
-                        self.maybe_implicit_convert_expr(tyenv, expr, bv.ty, ty)
+                        self.maybe_implicit_convert_expr(tyenv, expr, bv.ty, ty.unwrap())
                     {
-                        return self.translate_expr(tyenv, &expanded_expr, ty, bindings);
+                        return self.translate_expr(tyenv, &expanded_expr, ty, bindings, pure);
                     }
 
                     tyenv.report_error(
@@ -1961,7 +2033,7 @@ impl TermEnv {
                             "Variable '{}' has type {} but we need {} in context",
                             name.0,
                             tyenv.types[bv.ty.index()].name(tyenv),
-                            tyenv.types[ty.index()].name(tyenv)
+                            tyenv.types[ty.unwrap().index()].name(tyenv)
                         ),
                     );
                 }
@@ -1969,6 +2041,15 @@ impl TermEnv {
                 Some(Expr::Var(bv.ty, bv.id))
             }
             &ast::Expr::ConstInt { val, pos } => {
+                if ty.is_none() {
+                    tyenv.report_error(
+                        pos,
+                        "integer literal in a context that needs an explicit type".to_string(),
+                    );
+                    return None;
+                }
+                let ty = ty.unwrap();
+
                 if !tyenv.types[ty.index()].is_prim() {
                     tyenv.report_error(
                         pos,
@@ -1990,19 +2071,19 @@ impl TermEnv {
                         return None;
                     }
                 };
-                if const_ty != ty {
+                if ty.is_some() && const_ty != ty.unwrap() {
                     tyenv.report_error(
                         pos,
                         format!(
                             "Constant '{}' has wrong type: expected {}, but is actually {}",
                             tyenv.syms[val.index()],
-                            tyenv.types[ty.index()].name(tyenv),
+                            tyenv.types[ty.unwrap().index()].name(tyenv),
                             tyenv.types[const_ty.index()].name(tyenv)
                         ),
                     );
                     return None;
                 }
-                Some(Expr::ConstPrim(ty, val))
+                Some(Expr::ConstPrim(const_ty, val))
             }
             &ast::Expr::Let {
                 ref defs,
@@ -2043,20 +2124,24 @@ impl TermEnv {
                     };
 
                     // Evaluate the variable's value.
-                    let val = Box::new(unwrap_or_continue!(
-                        self.translate_expr(tyenv, &def.val, tid, bindings)
-                    ));
+                    let val = Box::new(unwrap_or_continue!(self.translate_expr(
+                        tyenv,
+                        &def.val,
+                        Some(tid),
+                        bindings,
+                        pure
+                    )));
 
                     // Bind the var with the given type.
                     let id = VarId(bindings.next_var);
                     bindings.next_var += 1;
                     bindings.vars.push(BoundVar { name, id, ty: tid });
 
-                    let_defs.push((id, ty, val));
+                    let_defs.push((id, tid, val));
                 }
 
                 // Evaluate the body, expecting the type of the overall let-expr.
-                let body = Box::new(self.translate_expr(tyenv, body, ty, bindings)?);
+                let body = Box::new(self.translate_expr(tyenv, body, ty, bindings, pure)?);
                 let body_ty = body.ty();
 
                 // Pop the bindings.
@@ -2069,6 +2154,45 @@ impl TermEnv {
                 })
             }
         }
+    }
+
+    fn translate_iflets(
+        &self,
+        tyenv: &mut TypeEnv,
+        rule_term: TermId,
+        iflets: &[ast::IfLet],
+        bindings: &mut Bindings,
+    ) -> Option<Vec<IfLet>> {
+        let mut translated = vec![];
+        for iflet in iflets {
+            translated.push(unwrap_or_continue!(
+                self.translate_iflet(tyenv, rule_term, iflet, bindings)
+            ));
+        }
+        Some(translated)
+    }
+
+    fn translate_iflet(
+        &self,
+        tyenv: &mut TypeEnv,
+        rule_term: TermId,
+        iflet: &ast::IfLet,
+        bindings: &mut Bindings,
+    ) -> Option<IfLet> {
+        // Translate the expr first. Ensure it's pure.
+        let rhs =
+            self.translate_expr(tyenv, &iflet.expr, None, bindings, /* pure = */ true)?;
+        let ty = rhs.ty();
+        let (lhs, _lhs_ty) = self.translate_pattern(
+            tyenv,
+            rule_term,
+            &iflet.pattern,
+            Some(ty),
+            bindings,
+            /* is_root = */ true,
+        )?;
+
+        Some(IfLet { lhs, rhs })
     }
 }
 


### PR DESCRIPTION
This PR adds support for `if-let` clauses, as proposed in
bytecodealliance/rfcs#21. These clauses augment the left-hand side (pattern-matching
phase) of rules in the ISLE instruction-selection DSL with
sub-patterns matching on sub-expressions. The ability to list
additional match operations to perform, out-of-line from the original
toplevel pattern, greatly simplifies some idioms. See the RFC for more
details and examples of use.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
