### PR TITLE
ISLE: add support for implicit `=x` variable matchers.

### DIFF
--- a/cranelift/isle/isle/isle_examples/fail/bound_var_type_mismatch.isle
+++ b/cranelift/isle/isle/isle_examples/fail/bound_var_type_mismatch.isle
@@ -1,0 +1,7 @@
+(type u32 (primitive u32))
+(type u64 (primitive u64))
+
+(decl A (u32 u64) u32)
+
+(rule 1 (A x x) x)
+(rule 0 (A x _) 0)

--- a/cranelift/isle/isle/isle_examples/pass/bound_var.isle
+++ b/cranelift/isle/isle/isle_examples/pass/bound_var.isle
@@ -1,0 +1,6 @@
+(type u32 (primitive u32))
+
+(decl A (u32 u32) u32)
+
+(rule 1 (A x x) x)
+(rule 0 (A x _) 0)

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -412,6 +412,10 @@ impl<'a> Parser<'a> {
         } else if self.is_sym() {
             let s = self.symbol()?;
             if s.starts_with("=") {
+                // Deprecated `=x` syntax. This will go away once we
+                // change all uses to just `x`, which we can do
+                // because we disambiguate whether a mention of `x` is
+                // a binding or a matching of the already-bound value.
                 let s = &s[1..];
                 let var = self.str_to_ident(pos, s)?;
                 Ok(Pattern::Var { var, pos })
@@ -422,11 +426,7 @@ impl<'a> Parser<'a> {
                     let subpat = Box::new(self.parse_pattern()?);
                     Ok(Pattern::BindPattern { var, subpat, pos })
                 } else {
-                    Ok(Pattern::BindPattern {
-                        var,
-                        subpat: Box::new(Pattern::Wildcard { pos }),
-                        pos,
-                    })
+                    Ok(Pattern::Var { var, pos })
                 }
             }
         } else if self.is_lparen() {


### PR DESCRIPTION
Currently, a variable can be named in two different ways in an ISLE
pattern. One can write a pattern like `(T x y)` that binds the two
args of `T` with the subpatterns `x` and `y`, each of which match
anything and capture the value as a bound variable. Or, one can write
a pattern like `(T x =x)`, where the first arg pattern `x` captures
the value in `x` and the second arg pattern `=x` matches only the same
value that was already captured.

It turns out (thanks to @fitzgen for this insight here [1]) that this
distinction can actually be inferred easily: if `x` isn't bound, then
mentioning it binds it; otherwise, it matches only the already-bound
variable. There's no concern about ordering (one mention binding
vs. the other) because (i) the value is equal either way, and (ii) the
types at both sites must be the same.

This language tweak seems like it should simplify things nicely! We
can remove the `=x` syntax later if we want, but this PR doesn't do
so.

[1] https://github.com/bytecodealliance/wasmtime/pull/4071#discussion_r859111513

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
