### PR TITLE
ISLE: handle out-of-order extern converter decls.

### DIFF
--- a/cranelift/isle/isle/isle_examples/pass/conversions_extern.isle
+++ b/cranelift/isle/isle/isle_examples/pass/conversions_extern.isle
@@ -1,0 +1,22 @@
+(type T (primitive T))
+(type U (primitive U))
+(type V (primitive V))
+
+(convert T U t_to_u)
+
+(type Result (enum (T (u U) (v V))))
+
+;; Use the implicit converter before the underlying constructor is
+;; declared (below). Also use one of the conversions before it is
+;; declared (below).
+(decl entry (T) Result)
+(rule (entry t)
+      (Result.T t t))
+
+(convert T V t_to_v)
+
+(decl t_to_u (T) U)
+(extern constructor t_to_u t_to_u)
+
+(decl t_to_v (T) V)
+(rule (t_to_v _) 0)


### PR DESCRIPTION
This fixes a bug where the ISLE compiler would refuse to accept
out-of-order declarations in the order of: (i) use of an implicit
conversion backed by an extern constructor; (ii) extern declaration
for that constructor.

The issue was one of phase separation: we were capturing and noting
"extern constructor" status on terms in the same pass in which we were
typechecking and resolving implicit conversions. Given this knowledge,
the fix is straightforward: externs are picked up in a prior pass.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
