### PR TITLE
Update to clap 3.*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.28.3",
+ "object",
  "rustc-demangle",
 ]
 
@@ -424,7 +424,7 @@ version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -654,7 +654,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-module",
  "log",
- "object 0.27.1",
+ "object",
  "target-lexicon",
 ]
 
@@ -1074,19 +1074,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime 2.1.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
@@ -1317,15 +1304,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -1481,7 +1459,7 @@ version = "0.1.0"
 dependencies = [
  "clap 3.1.12",
  "cranelift-isle",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "miette",
 ]
 
@@ -1858,15 +1836,6 @@ dependencies = [
  "crc32fast",
  "hashbrown",
  "indexmap",
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
-dependencies = [
  "memchr",
 ]
 
@@ -3014,12 +2983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3356,7 +3319,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object 0.27.1",
+ "object",
  "once_cell",
  "paste",
  "psm",
@@ -3399,7 +3362,7 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "cap-std",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "once_cell",
  "wasi-cap-std-sync",
  "wasmtime",
@@ -3447,7 +3410,7 @@ dependencies = [
  "async-trait",
  "clap 3.1.12",
  "criterion",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "file-per-thread-logger",
  "filecheck",
  "humantime 2.1.0",
@@ -3476,7 +3439,7 @@ dependencies = [
  "wasmtime-wasi-crypto",
  "wasmtime-wasi-nn",
  "wasmtime-wast",
- "wast 39.0.0",
+ "wast 40.0.0",
  "wat",
  "winapi",
 ]
@@ -3494,7 +3457,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object 0.27.1",
+ "object",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -3511,7 +3474,7 @@ dependencies = [
  "indexmap",
  "log",
  "more-asserts",
- "object 0.27.1",
+ "object",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -3551,7 +3514,7 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -3582,7 +3545,7 @@ dependencies = [
  "gimli",
  "ittapi-rs",
  "log",
- "object 0.27.1",
+ "object",
  "region",
  "rustc-demangle",
  "rustix",
@@ -3600,7 +3563,7 @@ name = "wasmtime-jit-debug"
 version = "0.37.0"
 dependencies = [
  "lazy_static",
- "object 0.27.1",
+ "object",
  "rustix",
 ]
 
@@ -3692,17 +3655,6 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bbbd53432b267421186feee3e52436531fa69a7cfee9403f5204352df3dd05"
-dependencies = [
- "leb128",
- "memchr",
- "unicode-width",
-]
-
-[[package]]
-name = "wast"
 version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb4f48a8b083dbc50e291e430afb8f524092bb00428957bcc63f49f856c64ac"
@@ -3764,7 +3716,7 @@ name = "wiggle-generate"
 version = "0.37.0"
 dependencies = [
  "anyhow",
- "heck 0.3.3",
+ "heck",
  "proc-macro2",
  "quote",
  "shellexpand",
@@ -3787,7 +3739,7 @@ dependencies = [
 name = "wiggle-test"
 version = "0.21.0"
 dependencies = [
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "proptest",
  "thiserror",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.28.3",
  "rustc-demangle",
 ]
 
@@ -396,13 +396,48 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -619,7 +654,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-module",
  "log",
- "object",
+ "object 0.27.1",
  "target-lexicon",
 ]
 
@@ -643,7 +678,7 @@ dependencies = [
 name = "cranelift-serde"
 version = "0.84.0"
 dependencies = [
- "clap",
+ "clap 3.1.12",
  "cranelift-codegen",
  "cranelift-reader",
  "serde_json",
@@ -656,6 +691,7 @@ dependencies = [
  "anyhow",
  "capstone",
  "cfg-if",
+ "clap 3.1.12",
  "cranelift",
  "cranelift-codegen",
  "cranelift-entity",
@@ -675,7 +711,6 @@ dependencies = [
  "log",
  "pretty_env_logger",
  "rayon",
- "structopt",
  "target-lexicon",
  "termcolor",
  "thiserror",
@@ -718,7 +753,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -1290,6 +1325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,10 +1479,10 @@ dependencies = [
 name = "islec"
 version = "0.1.0"
 dependencies = [
+ "clap 3.1.12",
  "cranelift-isle",
  "env_logger 0.8.4",
  "miette",
- "structopt",
 ]
 
 [[package]]
@@ -1821,6 +1862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ocaml-boxroot-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +1958,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "owo-colors"
@@ -2639,33 +2695,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2823,6 +2855,12 @@ dependencies = [
  "unicode-linebreak",
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -3030,12 +3068,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -3324,7 +3356,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object",
+ "object 0.27.1",
  "once_cell",
  "paste",
  "psm",
@@ -3413,6 +3445,7 @@ version = "0.37.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap 3.1.12",
  "criterion",
  "env_logger 0.8.4",
  "file-per-thread-logger",
@@ -3428,7 +3461,6 @@ dependencies = [
  "pretty_env_logger",
  "rayon",
  "rustix",
- "structopt",
  "target-lexicon",
  "tempfile",
  "test-programs",
@@ -3462,7 +3494,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object",
+ "object 0.27.1",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -3479,7 +3511,7 @@ dependencies = [
  "indexmap",
  "log",
  "more-asserts",
- "object",
+ "object 0.27.1",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -3550,7 +3582,7 @@ dependencies = [
  "gimli",
  "ittapi-rs",
  "log",
- "object",
+ "object 0.27.1",
  "region",
  "rustc-demangle",
  "rustix",
@@ -3568,7 +3600,7 @@ name = "wasmtime-jit-debug"
 version = "0.37.0"
 dependencies = [
  "lazy_static",
- "object",
+ "object 0.27.1",
  "rustix",
 ]
 
@@ -3732,7 +3764,7 @@ name = "wiggle-generate"
 version = "0.37.0"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasmtime-wast = { path = "crates/wast", version = "=0.37.0" }
 wasmtime-wasi = { path = "crates/wasi", version = "0.37.0" }
 wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "0.37.0", optional = true }
 wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.37.0", optional = true }
-structopt = { version = "0.3.5", features = ["color", "suggestions"] }
+clap = { version = "3.1.12", features = ["color", "suggestions", "derive"] }
 anyhow = "1.0.19"
 target-lexicon = { version = "0.12.0", default-features = false }
 pretty_env_logger = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rustix = "0.33.7"
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests
 wasmtime = { path = "crates/wasmtime", version = "0.37.0" }
-env_logger = "0.8.1"
+env_logger = "0.9.0"
 filecheck = "0.5.0"
 more-asserts = "0.2.1"
 tempfile = "3.1.0"
@@ -55,7 +55,7 @@ test-programs = { path = "crates/test-programs" }
 wasmtime-runtime = { path = "crates/runtime" }
 tokio = { version = "1.8.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.1"
-wast = "39.0.0"
+wast = "40.0.0"
 criterion = "0.3.4"
 num_cpus = "1.13.0"
 winapi = { version = "0.3.9", features = ['memoryapi'] }

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -41,7 +41,7 @@ indicatif = "0.13.0"
 thiserror = "1.0.15"
 walkdir = "2.2"
 anyhow = "1.0.32"
-structopt = "0.3.17"
+clap = { version = "3.1.12", features = ["derive"] }
 
 [features]
 default = ["disas", "wasm", "cranelift-codegen/all-arch", "souper-harvest"]

--- a/cranelift/isle/islec/Cargo.toml
+++ b/cranelift/isle/islec/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 cranelift-isle = { version = "*", path = "../isle/" }
 env_logger = { version = "0.8", default-features = false }
 miette = { version = "3.0.0", features = ["fancy"] }
-structopt = "0.3.23"
+clap = { version = "3.1.12", features = ["derive"] }

--- a/cranelift/isle/islec/Cargo.toml
+++ b/cranelift/isle/islec/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 cranelift-isle = { version = "*", path = "../isle/" }
-env_logger = { version = "0.8", default-features = false }
+env_logger = { version = "0.9", default-features = false }
 miette = { version = "3.0.0", features = ["fancy"] }
 clap = { version = "3.1.12", features = ["derive"] }

--- a/cranelift/isle/islec/src/main.rs
+++ b/cranelift/isle/islec/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use cranelift_isle::{compile, lexer, parser};
 use miette::{Context, IntoDiagnostic, Result};
 use std::{
@@ -5,17 +6,16 @@ use std::{
     io::{self, Write},
     path::PathBuf,
 };
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Opts {
     /// The output file to write the generated Rust code to. `stdout` is used if
     /// this is not given.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long)]
     output: Option<PathBuf>,
 
     /// The input ISLE DSL source files.
-    #[structopt(parse(from_os_str), required(true))]
+    #[clap(required = true)]
     inputs: Vec<PathBuf>,
 }
 
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
         )
     }));
 
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
 
     let lexer = lexer::Lexer::from_files(opts.inputs)?;
     let defs = parser::parse(lexer)?;

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -14,7 +14,7 @@ name = "clif-json"
 path = "src/clif-json.rs"
 
 [dependencies]
-clap = "2.32.0"
+clap = { version = "3.1.12", features = ["derive"] }
 serde_json = "1.0.26"
 cranelift-codegen = { path = "../codegen", version = "0.84.0", features = ["enable-serde"] }
 cranelift-reader = { path = "../reader", version = "0.84.0" }

--- a/cranelift/serde/src/clif-json.rs
+++ b/cranelift/serde/src/clif-json.rs
@@ -21,7 +21,7 @@
     )
 )]
 
-use clap::{App, Arg, SubCommand};
+use clap::Parser;
 use cranelift_codegen::ir::Function;
 use cranelift_reader::parse_functions;
 use std::fs::File;
@@ -54,50 +54,40 @@ fn call_de(file: &File) -> Result<(), String> {
     Ok(())
 }
 
-fn main() {
-    let matches = App::new("Cranelift JSON serializer/deserializer utility")
-        .subcommand(
-            SubCommand::with_name("serialize")
-                .display_order(1)
-                .about("Serializes Cranelift IR into JSON.")
-                .arg(Arg::with_name("pretty").short("p").help("pretty json"))
-                .arg(
-                    Arg::with_name("FILE")
-                        .required(true)
-                        .value_name("FILE")
-                        .help("Input file for serialization"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("deserialize")
-                .about("Deserializes Cranelift IR into JSON.")
-                .arg(
-                    Arg::with_name("FILE")
-                        .required(true)
-                        .value_name("FILE")
-                        .help("Input file for deserialization"),
-                ),
-        )
-        .get_matches();
+/// Cranelift JSON serializer/deserializer utility
+#[derive(Parser, Debug)]
+#[clap(about)]
+enum Args {
+    /// Serializes Cranelift IR into JSON
+    Serialize {
+        /// Generate pretty json
+        #[clap(long, short)]
+        pretty: bool,
 
-    let res_serde = match matches.subcommand() {
-        ("serialize", Some(m)) => {
-            let mut file =
-                File::open(m.value_of("FILE").unwrap()).expect("Unable to open the file");
+        /// Input file for serialization
+        file: String,
+    },
+    /// Deserializes Cranelift IR into JSON
+    Deserialize {
+        /// Input file for deserialization
+        file: String,
+    },
+}
+
+fn main() {
+    let res_serde = match Args::parse() {
+        Args::Serialize { pretty, file } => {
             let mut contents = String::new();
+            let mut file = File::open(file).expect("Unable to open the file");
             file.read_to_string(&mut contents)
                 .expect("Unable to read the file");
 
-            match m.occurrences_of("pretty") {
-                0 => call_ser(&contents, false),
-                _ => call_ser(&contents, true),
-            }
+            call_ser(&contents, pretty)
         }
-        ("deserialize", Some(m)) => {
-            let file = File::open(m.value_of("FILE").unwrap()).expect("Unable to open the file");
+        Args::Deserialize { file } => {
+            let file = File::open(file).expect("Unable to open the file");
             call_de(&file)
         }
-        _ => Err("Invalid subcommand.".to_string()),
     };
 
     if let Err(mut msg) = res_serde {

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -2,6 +2,7 @@
 
 use crate::utils::{parse_sets_and_triple, read_to_string};
 use anyhow::{Context as _, Result};
+use clap::Parser;
 use cranelift_codegen::cursor::{Cursor, FuncCursor};
 use cranelift_codegen::flowgraph::ControlFlowGraph;
 use cranelift_codegen::ir::types::{F32, F64};
@@ -16,24 +17,22 @@ use cranelift_reader::{parse_test, ParseOptions};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 /// Reduce size of clif file causing panic during compilation.
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(parse(from_os_str))]
     file: PathBuf,
 
     /// Configure Cranelift settings
-    #[structopt(long("set"))]
+    #[clap(long = "set")]
     settings: Vec<String>,
 
     /// Specify the target architecture.
     target: String,
 
     /// Be more verbose
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short, long)]
     verbose: bool,
 }
 

--- a/cranelift/src/cat.rs
+++ b/cranelift/src/cat.rs
@@ -5,19 +5,19 @@
 
 use crate::utils::read_to_string;
 use anyhow::{Context, Result};
+use clap::Parser;
 use cranelift_reader::parse_functions;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
 /// Outputs .clif file
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Specify input file(s) to be used. Use '-' for stdin.
-    #[structopt(required(true), parse(from_os_str))]
+    #[clap(required = true)]
     files: Vec<PathBuf>,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short)]
     debug: bool,
 }
 

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -12,9 +12,9 @@
     )
 )]
 
+use clap::Parser;
 use cranelift_codegen::dbg::LOG_FILENAME_PREFIX;
-use std::{option::Option, path::PathBuf};
-use structopt::StructOpt;
+use std::path::PathBuf;
 
 mod bugpoint;
 mod cat;
@@ -40,7 +40,7 @@ fn handle_debug_flag(debug: bool) {
 }
 
 /// Cranelift code generator utility.
-#[derive(StructOpt)]
+#[derive(Parser)]
 enum Commands {
     Test(TestOptions),
     Run(run::Options),
@@ -63,58 +63,57 @@ enum Commands {
 }
 
 /// Run Cranelift tests
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct TestOptions {
     /// Be more verbose
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short, long)]
     verbose: bool,
 
     /// Print pass timing report for test
-    #[structopt(short = "T")]
+    #[clap(short = 'T')]
     time_passes: bool,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short = 'd')]
     debug: bool,
 
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(required(true), parse(from_os_str))]
+    #[clap(required = true)]
     files: Vec<PathBuf>,
 }
 
 /// Run specified pass(es) on an input file.
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct PassOptions {
     /// Be more verbose
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short, long)]
     verbose: bool,
 
     /// Print pass timing report for test
-    #[structopt(short = "T")]
+    #[clap(short = 'T')]
     time_passes: bool,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short)]
     debug: bool,
 
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(parse(from_os_str))]
     file: PathBuf,
 
     /// Specify the target architecture.
     target: String,
 
     /// Specify pass(es) to be run on the input file
-    #[structopt(required(true))]
+    #[clap(required = true)]
     passes: Vec<String>,
 }
 
 /// (Compiled without support for this subcommand)
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct CompiledWithoutSupportOptions {}
 
 fn main() -> anyhow::Result<()> {
-    match Commands::from_args() {
+    match Commands::parse() {
         Commands::Cat(c) => cat::run(&c)?,
         Commands::Run(r) => run::run(&r)?,
         Commands::Interpret(i) => interpret::run(&i)?,

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -3,6 +3,7 @@
 use crate::disasm::print_all;
 use crate::utils::{parse_sets_and_triple, read_to_string};
 use anyhow::{Context as _, Result};
+use clap::Parser;
 use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::settings::FlagsOrIsa;
 use cranelift_codegen::timing;
@@ -10,37 +11,35 @@ use cranelift_codegen::Context;
 use cranelift_reader::{parse_test, ParseOptions};
 use std::path::Path;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 /// Compiles Cranelift IR into target language
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Print the resulting Cranelift IR
-    #[structopt(short("p"))]
+    #[clap(short)]
     print: bool,
 
     /// Print pass timing report
-    #[structopt(short("T"))]
+    #[clap(short = 'T')]
     report_times: bool,
 
     /// Print machine code disassembly
-    #[structopt(short("D"), long("disasm"))]
+    #[clap(short = 'D', long)]
     disasm: bool,
 
     /// Configure Cranelift settings
-    #[structopt(long("set"))]
+    #[clap(long = "set")]
     settings: Vec<String>,
 
     /// Specify the Cranelift target
-    #[structopt(long("target"))]
+    #[clap(long = "target")]
     target: String,
 
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(parse(from_os_str))]
     files: Vec<PathBuf>,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short)]
     debug: bool,
 }
 

--- a/cranelift/src/interpret.rs
+++ b/cranelift/src/interpret.rs
@@ -1,28 +1,28 @@
 //! CLI tool to interpret Cranelift IR files.
 
 use crate::utils::iterate_files;
+use clap::Parser;
 use cranelift_interpreter::environment::FunctionStore;
 use cranelift_interpreter::interpreter::{Interpreter, InterpreterState};
 use cranelift_interpreter::step::ControlFlow;
 use cranelift_reader::{parse_run_command, parse_test, ParseError, ParseOptions};
 use std::path::PathBuf;
 use std::{fs, io};
-use structopt::StructOpt;
 use thiserror::Error;
 
 /// Interpret clif code
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(required(true), parse(from_os_str))]
+    #[clap(required = true)]
     files: Vec<PathBuf>,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short)]
     debug: bool,
 
     /// Be more verbose
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short, long)]
     verbose: bool,
 }
 

--- a/cranelift/src/print_cfg.rs
+++ b/cranelift/src/print_cfg.rs
@@ -5,20 +5,20 @@
 
 use crate::utils::read_to_string;
 use anyhow::Result;
+use clap::Parser;
 use cranelift_codegen::cfg_printer::CFGPrinter;
 use cranelift_reader::parse_functions;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
 /// Prints out cfg in GraphViz Dot format
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(required(true), parse(from_os_str))]
+    #[clap(required = true)]
     files: Vec<PathBuf>,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short)]
     debug: bool,
 }
 

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -2,27 +2,27 @@
 
 use crate::utils::{iterate_files, read_to_string};
 use anyhow::Result;
+use clap::Parser;
 use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_filetests::SingleFunctionCompiler;
 use cranelift_native::builder as host_isa_builder;
 use cranelift_reader::{parse_run_command, parse_test, Details, IsaSpec, ParseOptions};
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use target_lexicon::Triple;
 
 /// Execute clif code and verify with test expressions
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(required(true), parse(from_os_str))]
+    #[clap(required = true)]
     files: Vec<PathBuf>,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short)]
     debug: bool,
 
     /// Be more verbose
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short, long)]
     verbose: bool,
 }
 

--- a/cranelift/src/souper_harvest.rs
+++ b/cranelift/src/souper_harvest.rs
@@ -1,11 +1,11 @@
 use crate::utils::parse_sets_and_triple;
 use anyhow::{Context as _, Result};
+use clap::Parser;
 use cranelift_codegen::Context;
 use cranelift_wasm::{DummyEnvironment, ReturnMode};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
-use structopt::StructOpt;
 
 static WASM_MAGIC: &[u8] = &[0x00, 0x61, 0x73, 0x6D];
 
@@ -13,22 +13,21 @@ static WASM_MAGIC: &[u8] = &[0x00, 0x61, 0x73, 0x6D];
 ///
 /// Candidates are emitted in Souper's text format:
 /// <https://github.com/google/souper>
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(parse(from_os_str))]
     input: PathBuf,
 
     /// Specify the output file to be used. Use '-' for stdout.
-    #[structopt(short("o"), long("output"), default_value("-"), parse(from_os_str))]
+    #[clap(short, long, default_value("-"))]
     output: PathBuf,
 
     /// Configure Cranelift settings
-    #[structopt(long("set"))]
+    #[clap(long = "set")]
     settings: Vec<String>,
 
     /// Specify the Cranelift target
-    #[structopt(long("target"))]
+    #[clap(long = "target")]
     target: String,
 }
 

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -10,6 +10,7 @@
 use crate::disasm::print_all;
 use crate::utils::parse_sets_and_triple;
 use anyhow::{Context as _, Result};
+use clap::Parser;
 use cranelift_codegen::ir::DisplayFunctionAnnotations;
 use cranelift_codegen::print_errors::{pretty_error, pretty_verifier_error};
 use cranelift_codegen::settings::FlagsOrIsa;
@@ -20,7 +21,6 @@ use cranelift_wasm::{translate_module, DummyEnvironment, FuncIndex, ReturnMode};
 use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 /// For verbose printing: only print if the `$x` expression is true.
@@ -61,58 +61,57 @@ macro_rules! vcprint {
 }
 
 /// Compiles Wasm binary/text into Cranelift IR and then into target language
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Options {
     /// Be more verbose
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short, long)]
     verbose: bool,
 
     /// Print the resulting Cranelift IR
-    #[structopt(short("p"))]
+    #[clap(short)]
     print: bool,
 
     /// Print pass timing report
-    #[structopt(short("T"))]
+    #[clap(short = 'T')]
     report_times: bool,
 
     /// Print machine code disassembly
-    #[structopt(short("D"), long("disasm"))]
+    #[clap(short = 'D', long)]
     disasm: bool,
 
     /// Configure Cranelift settings
-    #[structopt(long("set"))]
+    #[clap(long = "set")]
     settings: Vec<String>,
 
     /// Specify the Cranelift target
-    #[structopt(long("target"))]
+    #[clap(long = "target")]
     target: String,
 
     /// Specify an input file to be used. Use '-' for stdin.
-    #[structopt(parse(from_os_str))]
     files: Vec<PathBuf>,
 
     /// Enable debug output on stderr/stdout
-    #[structopt(short = "d")]
+    #[clap(short)]
     debug: bool,
 
     /// Print bytecode size
-    #[structopt(short("X"))]
+    #[clap(short = 'X')]
     print_size: bool,
 
     /// Just decode Wasm into Cranelift IR, don't compile it to native code
-    #[structopt(short("t"))]
+    #[clap(short = 't')]
     just_decode: bool,
 
     /// Just checks the correctness of Cranelift IR translated from Wasm
-    #[structopt(short("c"))]
+    #[clap(short = 'c')]
     check_translation: bool,
 
     /// Display values' ranges and their locations
-    #[structopt(long("value-ranges"))]
+    #[clap(long = "value-ranges")]
     value_ranges: bool,
 
     /// Use colors in output? [options: auto/never/always; default: auto]
-    #[structopt(long("color"), default_value("auto"))]
+    #[clap(long = "color", default_value("auto"))]
     color: ColorOpt,
 }
 

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -17,7 +17,7 @@ test = false
 doctest = false
 
 [dependencies]
-env_logger = "0.8"
+env_logger = "0.9"
 anyhow = "1.0"
 once_cell = "1.3"
 wasmtime = { path = "../wasmtime", default-features = false, features = ['cranelift', 'wasm-backtrace'] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 [dependencies]
 anyhow = "1.0.22"
 arbitrary = { version = "1.1.0", features = ["derive"] }
-env_logger = "0.8.1"
+env_logger = "0.9.0"
 log = "0.4.8"
 rayon = "1.2.1"
 target-lexicon = "0.12.3"

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src/**/*", "README.md", "LICENSE"]
 witx = { version = "0.9.1", path = "../../wasi-common/WASI/tools/witx" }
 quote = "1.0"
 proc-macro2 = "1.0"
-heck = "0.3"
+heck = "0.4"
 anyhow = "1"
 syn = { version = "1.0", features = ["full"] }
 shellexpand = "2.0"

--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -7,7 +7,7 @@ mod names;
 mod types;
 pub mod wasmtime;
 
-use heck::ShoutySnakeCase;
+use heck::ToShoutySnakeCase;
 use lifetimes::anon_lifetime;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;

--- a/crates/wiggle/generate/src/names.rs
+++ b/crates/wiggle/generate/src/names.rs
@@ -1,5 +1,5 @@
 use escaping::{escape_id, handle_2big_enum_variant, NamingConvention};
-use heck::{ShoutySnakeCase, SnakeCase};
+use heck::{ToShoutySnakeCase, ToSnakeCase};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use witx::{BuiltinType, Id, Type, TypeRef, WasmType};
@@ -216,7 +216,7 @@ impl Names {
 /// variable. `dyn` was promoted to a strict keyword beginning in the 2018 edition.
 mod escaping {
     use {
-        heck::{CamelCase, SnakeCase},
+        heck::{ToSnakeCase, ToUpperCamelCase},
         proc_macro2::Ident,
         quote::format_ident,
         witx::Id,
@@ -245,7 +245,7 @@ mod escaping {
         match (conv, id.as_str()) {
             // For camel-cased identifiers, `Self` is the only potential keyword conflict.
             (CamelCase, "self") => format_ident!("Self_"),
-            (CamelCase, s) => format_ident!("{}", s.to_camel_case()),
+            (CamelCase, s) => format_ident!("{}", s.to_upper_camel_case()),
             // Snake-cased identifiers are where the bulk of conflicts can occur.
             (SnakeCase, s) => {
                 let s = s.to_snake_case();

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -19,7 +19,7 @@ wiggle = { path = "..", features = ["tracing_log"] }
 thiserror = "1.0"
 tracing = "0.1.26"
 tracing-subscriber = "0.3.1"
-env_logger = "0.8"
+env_logger = "0.9"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/deny.toml
+++ b/deny.toml
@@ -27,13 +27,17 @@ multiple-versions = "deny"
 wildcards = "allow"
 deny = []
 
-# Skip some multiple-versions checks, until they can be fixed.
-skip = [
-    { name = "ansi_term" }, # transitive dependencies only
-    { name = "env_logger" }, # pretty_env_logger and file-per-thread-logger depend on 0.7
-    { name = "humantime" }, # caused by env_logger
-    { name = "wast" }, # old one pulled in by witx
-    { name = "quick-error" }, # transitive dependencies
-    { name = "textwrap" }, # `miette` and `clap` depend on different versions
-    { name = "itoa" }, # `rustix` and `criterion` depend on different versions
+skip-tree = [
+    # Criterion 0.3 is pretty old at this point and has had an upcoming 0.4 for
+    # a long time. This is a dev-dependency so we don't really mind its
+    # dependency tree, so skip it entirely.
+    { name = "criterion", depth = 20 },
+
+    # This is maintained externally and we allow it to have duplicate
+    # dependencies relative to Wasmtime's main dependency tree.
+    { name = "witx", depth = 20 },
+
+    # This is somewhat unmaintained at this point and seems to pull in an old
+    # version of `env_logger`, so ignore it.
+    { name = "pretty_env_logger", depth = 20 },
 ]

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -2,9 +2,9 @@
 
 use crate::CommonOptions;
 use anyhow::{bail, Context, Result};
+use clap::Parser;
 use std::fs;
 use std::path::PathBuf;
-use structopt::{clap::AppSettings, StructOpt};
 use target_lexicon::Triple;
 use wasmtime::Engine;
 
@@ -34,27 +34,26 @@ lazy_static::lazy_static! {
 }
 
 /// Compiles a WebAssembly module.
-#[derive(StructOpt)]
+#[derive(Parser)]
 #[structopt(
     name = "compile",
-    version = env!("CARGO_PKG_VERSION"),
-    setting = AppSettings::ColoredHelp,
+    version,
     after_help = AFTER_HELP.as_str()
 )]
 pub struct CompileCommand {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     common: CommonOptions,
 
     /// The target triple; default is the host triple
-    #[structopt(long, value_name = "TARGET")]
+    #[clap(long, value_name = "TARGET")]
     target: Option<String>,
 
     /// The path of the output compiled module; defaults to <MODULE>.cwasm
-    #[structopt(short = "o", long, value_name = "OUTPUT", parse(from_os_str))]
+    #[clap(short = 'o', long, value_name = "OUTPUT", parse(from_os_str))]
     output: Option<PathBuf>,
 
     /// The path of the WebAssembly to compile
-    #[structopt(index = 1, value_name = "MODULE", parse(from_os_str))]
+    #[clap(index = 1, value_name = "MODULE", parse(from_os_str))]
     module: PathBuf,
 }
 
@@ -110,7 +109,7 @@ mod test {
 
         let output_path = NamedTempFile::new()?.into_temp_path();
 
-        let command = CompileCommand::from_iter_safe(vec![
+        let command = CompileCommand::try_parse_from(vec![
             "compile",
             "--disable-logging",
             "-o",
@@ -141,7 +140,7 @@ mod test {
         let output_path = NamedTempFile::new()?.into_temp_path();
 
         // Set all the x64 flags to make sure they work
-        let command = CompileCommand::from_iter_safe(vec![
+        let command = CompileCommand::try_parse_from(vec![
             "compile",
             "--disable-logging",
             "--cranelift-enable",
@@ -190,7 +189,7 @@ mod test {
         let output_path = NamedTempFile::new()?.into_temp_path();
 
         // Set all the aarch64 flags to make sure they work
-        let command = CompileCommand::from_iter_safe(vec![
+        let command = CompileCommand::try_parse_from(vec![
             "compile",
             "--disable-logging",
             "--cranelift-enable",
@@ -215,7 +214,7 @@ mod test {
         let output_path = NamedTempFile::new()?.into_temp_path();
 
         // aarch64 flags should not be supported
-        let command = CompileCommand::from_iter_safe(vec![
+        let command = CompileCommand::try_parse_from(vec![
             "compile",
             "--disable-logging",
             "--cranelift-enable",
@@ -251,7 +250,7 @@ mod test {
             "icelake",
             "znver1",
         ] {
-            let command = CompileCommand::from_iter_safe(vec![
+            let command = CompileCommand::try_parse_from(vec![
                 "compile",
                 "--disable-logging",
                 "--cranelift-enable",

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,35 +1,41 @@
 //! The module that implements the `wasmtime config` command.
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Parser;
 
 const CONFIG_NEW_AFTER_HELP: &str =
     "If no file path is specified, the system configuration file path will be used.";
 
 /// Controls Wasmtime configuration settings
-#[derive(StructOpt)]
-#[structopt(name = "run")]
-pub enum ConfigCommand {
+#[derive(Parser)]
+#[clap(name = "config")]
+pub struct ConfigCommand {
+    #[clap(subcommand)]
+    subcommand: ConfigSubcommand,
+}
+
+#[derive(clap::Subcommand)]
+enum ConfigSubcommand {
     /// Creates a new Wasmtime configuration file
-    #[structopt(after_help = CONFIG_NEW_AFTER_HELP)]
+    #[clap(after_help = CONFIG_NEW_AFTER_HELP)]
     New(ConfigNewCommand),
 }
 
 impl ConfigCommand {
     /// Executes the command.
     pub fn execute(self) -> Result<()> {
-        match self {
-            Self::New(c) => c.execute(),
+        match self.subcommand {
+            ConfigSubcommand::New(c) => c.execute(),
         }
     }
 }
 
 /// Creates a new Wasmtime configuration file
-#[derive(StructOpt)]
-#[structopt(name = "new", after_help = CONFIG_NEW_AFTER_HELP)]
+#[derive(Parser)]
+#[clap(name = "new", after_help = CONFIG_NEW_AFTER_HELP)]
 pub struct ConfigNewCommand {
     /// The path of the new configuration file
-    #[structopt(index = 1, value_name = "FILE_PATH")]
+    #[clap(index = 1, value_name = "FILE_PATH")]
     path: Option<String>,
 }
 

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -1,17 +1,17 @@
 //! The module that implements the `wasmtime settings` command.
 
 use anyhow::{anyhow, Result};
+use clap::Parser;
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use structopt::StructOpt;
 use wasmtime_environ::{FlagValue, Setting, SettingKind};
 
 /// Displays available Cranelift settings for a target.
-#[derive(StructOpt)]
-#[structopt(name = "run")]
+#[derive(Parser)]
+#[clap(name = "run")]
 pub struct SettingsCommand {
     /// The target triple to get the settings for; defaults to the host triple.
-    #[structopt(long, value_name = "TARGET")]
+    #[clap(long, value_name = "TARGET")]
     target: Option<String>,
 }
 

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -2,8 +2,8 @@
 
 use crate::CommonOptions;
 use anyhow::{Context as _, Result};
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::{clap::AppSettings, StructOpt};
 use wasmtime::{Engine, Store};
 use wasmtime_wast::WastContext;
 
@@ -14,19 +14,18 @@ lazy_static::lazy_static! {
 }
 
 /// Runs a WebAssembly test script file
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     name = "wast",
-    version = env!("CARGO_PKG_VERSION"),
-    setting = AppSettings::ColoredHelp,
+    version,
     after_help = AFTER_HELP.as_str(),
 )]
 pub struct WastCommand {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     common: CommonOptions,
 
     /// The path of the WebAssembly test script to run
-    #[structopt(required = true, value_name = "SCRIPT_FILE", parse(from_os_str))]
+    #[clap(required = true, value_name = "SCRIPT_FILE", parse(from_os_str))]
     scripts: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
This commit migrates all CLI commands internally used in this project
from structopt/clap2 to clap 3. The intent here is to ensure that we're
using maintained versions of the dependencies as structopt and clap 2
are less maintained nowadays. Most transitions were pretty
straightforward and mostly dealing with structopt/clap3 differences.

Along the way this also improves `cargo deny` a bit to ignore old crates we're using with outdated dependencies.