### PR TITLE
runtime: refactor `Memory` to always use `Box<dyn RuntimeLinearMemory>`

### DIFF
--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -447,7 +447,7 @@ impl InstancePool {
     ) {
         // Decommit any linear memories that were used.
         let memories = mem::take(memories);
-        for ((def_mem_idx, memory), base) in
+        for ((def_mem_idx, mut memory), base) in
             memories.into_iter().zip(self.memories.get(instance_index))
         {
             assert!(memory.is_static());

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -446,10 +446,10 @@ impl InstancePool {
         memories: &mut PrimaryMap<DefinedMemoryIndex, Memory>,
     ) {
         // Decommit any linear memories that were used.
+        let memories = mem::take(memories);
         for ((def_mem_idx, memory), base) in
-            memories.iter_mut().zip(self.memories.get(instance_index))
+            memories.into_iter().zip(self.memories.get(instance_index))
         {
-            let memory = mem::take(memory);
             assert!(memory.is_external());
             let size = memory.byte_size();
             if let Some(mut image) = memory.unwrap_image_slot() {

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -450,9 +450,9 @@ impl InstancePool {
         for ((def_mem_idx, memory), base) in
             memories.into_iter().zip(self.memories.get(instance_index))
         {
-            assert!(memory.is_external());
+            assert!(memory.is_static());
             let size = memory.byte_size();
-            if let Some(mut image) = memory.unwrap_image_slot() {
+            if let Some(mut image) = memory.unwrap_static_image() {
                 // Reset the image slot. If there is any error clearing the
                 // image, just drop it here, and let the drop handler for the
                 // slot unmap in a way that retains the address space

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -68,12 +68,18 @@ pub trait RuntimeLinearMemory: Send + Sync {
 
     /// Return a `VMMemoryDefinition` for exposing the memory to compiled wasm
     /// code.
-    fn vmmemory(&self) -> VMMemoryDefinition;
+    fn vmmemory(&mut self) -> VMMemoryDefinition;
 
     /// Does this memory need initialization? It may not if it already
     /// has initial contents courtesy of the `MemoryImage` passed to
     /// `RuntimeMemoryCreator::new_memory()`.
     fn needs_init(&self) -> bool;
+
+    /// For the pooling allocator, we must be able to downcast this trait to its
+    /// underlying structure; this trampoline function allows us to use
+    /// `Box::downcast` which only takes a `Box<dyn Any>`.
+    #[cfg(feature = "pooling-allocator")]
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any>;
 }
 
 /// A linear memory instance.
@@ -242,7 +248,7 @@ impl RuntimeLinearMemory for MmapMemory {
         Ok(())
     }
 
-    fn vmmemory(&self) -> VMMemoryDefinition {
+    fn vmmemory(&mut self) -> VMMemoryDefinition {
         VMMemoryDefinition {
             base: unsafe { self.mmap.as_mut_ptr().add(self.pre_guard_size) },
             current_length: self.accessible,
@@ -254,34 +260,135 @@ impl RuntimeLinearMemory for MmapMemory {
         // is needed.
         self.memory_image.is_none()
     }
+
+    #[cfg(feature = "pooling-allocator")]
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}
+
+/// A "static" memory where the lifetime of the backing memory is managed
+/// elsewhere. Currently used with the pooling allocator.
+pub(crate) struct ExternalMemory {
+    /// The memory in the host for this wasm memory. The length of this
+    /// slice is the maximum size of the memory that can be grown to.
+    base: &'static mut [u8],
+
+    /// The current size, in bytes, of this memory.
+    size: usize,
+
+    /// A callback which makes portions of `base` accessible for when memory
+    /// is grown. Otherwise it's expected that accesses to `base` will
+    /// fault.
+    make_accessible: Option<fn(*mut u8, usize) -> Result<()>>,
+
+    /// The image management, if any, for this memory. Owned here and
+    /// returned to the pooling allocator when termination occurs.
+    pub(crate) memory_image: Option<MemoryImageSlot>,
+}
+
+impl ExternalMemory {
+    fn new(
+        base: &'static mut [u8],
+        size: usize,
+        make_accessible: Option<fn(*mut u8, usize) -> Result<()>>,
+        memory_image: Option<MemoryImageSlot>,
+    ) -> Result<Self> {
+        if base.len() < size {
+            bail!(
+                "initial memory size of {} exceeds the pooling allocator's \
+                 configured maximum memory size of {} bytes",
+                size,
+                base.len(),
+            );
+        }
+
+        if let Some(make_accessible) = make_accessible {
+            if size > 0 {
+                make_accessible(base.as_mut_ptr(), size)?;
+            }
+        }
+
+        Ok(Self {
+            base,
+            size,
+            make_accessible,
+            memory_image,
+        })
+    }
+}
+
+impl Default for ExternalMemory {
+    fn default() -> Self {
+        Self {
+            base: &mut [],
+            size: 0,
+            make_accessible: Some(|_, _| unreachable!()),
+            memory_image: None,
+        }
+    }
+}
+
+impl RuntimeLinearMemory for ExternalMemory {
+    fn byte_size(&self) -> usize {
+        self.size
+    }
+
+    fn maximum_byte_size(&self) -> Option<usize> {
+        Some(self.base.len())
+    }
+
+    fn grow_to(&mut self, new_byte_size: usize) -> Result<()> {
+        // Never exceed the static memory size.
+        if new_byte_size > self.base.len() {
+            bail!("static memory size exceeded")
+        }
+
+        // Actually grow the memory.
+        if let Some(image) = &mut self.memory_image {
+            image.set_heap_limit(new_byte_size)?;
+            self.size = new_byte_size;
+        } else {
+            let make_accessible = self
+                .make_accessible
+                .expect("make_accessible must be Some if this is not a CoW memory");
+
+            // Operating system can fail to make memory accessible.
+            let old_byte_size = self.byte_size();
+            make_accessible(
+                unsafe { self.base.as_mut_ptr().add(old_byte_size) },
+                new_byte_size - old_byte_size,
+            )?;
+        }
+
+        // Update our accounting of the available size.
+        self.size = new_byte_size;
+        Ok(())
+    }
+
+    fn vmmemory(&mut self) -> VMMemoryDefinition {
+        VMMemoryDefinition {
+            base: self.base.as_mut_ptr().cast(),
+            current_length: self.size,
+        }
+    }
+
+    fn needs_init(&self) -> bool {
+        if let Some(slot) = &self.memory_image {
+            !slot.has_image()
+        } else {
+            true
+        }
+    }
+
+    #[cfg(feature = "pooling-allocator")]
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
 }
 
 /// Representation of a runtime wasm linear memory.
-pub enum Memory {
-    /// A "static" memory where the lifetime of the backing memory is managed
-    /// elsewhere. Currently used with the pooling allocator.
-    Static {
-        /// The memory in the host for this wasm memory. The length of this
-        /// slice is the maximum size of the memory that can be grown to.
-        base: &'static mut [u8],
-
-        /// The current size, in bytes, of this memory.
-        size: usize,
-
-        /// A callback which makes portions of `base` accessible for when memory
-        /// is grown. Otherwise it's expected that accesses to `base` will
-        /// fault.
-        make_accessible: Option<fn(*mut u8, usize) -> Result<()>>,
-
-        /// The image management, if any, for this memory. Owned here and
-        /// returned to the pooling allocator when termination occurs.
-        memory_image: Option<MemoryImageSlot>,
-    },
-
-    /// A "dynamic" memory whose data is managed at runtime and lifetime is tied
-    /// to this instance.
-    Dynamic(Box<dyn RuntimeLinearMemory>),
-}
+pub struct Memory(pub(crate) Box<dyn RuntimeLinearMemory>);
 
 impl Memory {
     /// Create a new dynamic (movable) memory instance for the specified plan.
@@ -292,7 +399,7 @@ impl Memory {
         memory_image: Option<&Arc<MemoryImage>>,
     ) -> Result<Self> {
         let (minimum, maximum) = Self::limit_new(plan, store)?;
-        Ok(Memory::Dynamic(creator.new_memory(
+        Ok(Memory(creator.new_memory(
             plan,
             minimum,
             maximum,
@@ -310,32 +417,14 @@ impl Memory {
     ) -> Result<Self> {
         let (minimum, maximum) = Self::limit_new(plan, store)?;
 
-        if base.len() < minimum {
-            bail!(
-                "initial memory size of {} exceeds the pooling allocator's \
-                 configured maximum memory size of {} bytes",
-                minimum,
-                base.len(),
-            );
-        }
-
+        // Only use the part of the slice that is necessary.
         let base = match maximum {
             Some(max) if max < base.len() => &mut base[..max],
             _ => base,
         };
 
-        if let Some(make_accessible) = make_accessible {
-            if minimum > 0 {
-                make_accessible(base.as_mut_ptr(), minimum)?;
-            }
-        }
-
-        Ok(Memory::Static {
-            base,
-            size: minimum,
-            make_accessible,
-            memory_image,
-        })
+        let pooled_memory = ExternalMemory::new(base, minimum, make_accessible, memory_image)?;
+        Ok(Memory(Box::new(pooled_memory)))
     }
 
     /// Calls the `store`'s limiter to optionally prevent a memory from being allocated.
@@ -423,10 +512,7 @@ impl Memory {
 
     /// Returns the number of allocated wasm pages.
     pub fn byte_size(&self) -> usize {
-        match self {
-            Memory::Static { size, .. } => *size,
-            Memory::Dynamic(mem) => mem.byte_size(),
-        }
+        self.0.byte_size()
     }
 
     /// Returns the maximum number of pages the memory can grow to at runtime.
@@ -436,34 +522,14 @@ impl Memory {
     /// The runtime maximum may not be equal to the maximum from the linear memory's
     /// Wasm type when it is being constrained by an instance allocator.
     pub fn maximum_byte_size(&self) -> Option<usize> {
-        match self {
-            Memory::Static { base, .. } => Some(base.len()),
-            Memory::Dynamic(mem) => mem.maximum_byte_size(),
-        }
-    }
-
-    /// Returns whether or not the underlying storage of the memory is "static".
-    #[cfg(feature = "pooling-allocator")]
-    pub(crate) fn is_static(&self) -> bool {
-        if let Memory::Static { .. } = self {
-            true
-        } else {
-            false
-        }
+        self.0.maximum_byte_size()
     }
 
     /// Returns whether or not this memory needs initialization. It
     /// may not if it already has initial content thanks to a CoW
     /// mechanism.
     pub(crate) fn needs_init(&self) -> bool {
-        match self {
-            Memory::Static {
-                memory_image: Some(slot),
-                ..
-            } => !slot.has_image(),
-            Memory::Dynamic(mem) => mem.needs_init(),
-            _ => true,
-        }
+        self.0.needs_init()
     }
 
     /// Grow memory by the specified amount of wasm pages.
@@ -524,80 +590,23 @@ impl Memory {
             }
         }
 
-        match self {
-            Memory::Static {
-                base,
-                size,
-                memory_image: Some(image),
-                ..
-            } => {
-                // Never exceed static memory size
-                if new_byte_size > base.len() {
-                    store.memory_grow_failed(&format_err!("static memory size exceeded"));
-                    return Ok(None);
-                }
-
-                if let Err(e) = image.set_heap_limit(new_byte_size) {
-                    store.memory_grow_failed(&e);
-                    return Ok(None);
-                }
-                *size = new_byte_size;
-            }
-            Memory::Static {
-                base,
-                size,
-                make_accessible,
-                ..
-            } => {
-                let make_accessible = make_accessible
-                    .expect("make_accessible must be Some if this is not a CoW memory");
-
-                // Never exceed static memory size
-                if new_byte_size > base.len() {
-                    store.memory_grow_failed(&format_err!("static memory size exceeded"));
-                    return Ok(None);
-                }
-
-                // Operating system can fail to make memory accessible
-                if let Err(e) = make_accessible(
-                    base.as_mut_ptr().add(old_byte_size),
-                    new_byte_size - old_byte_size,
-                ) {
-                    store.memory_grow_failed(&e);
-                    return Ok(None);
-                }
-                *size = new_byte_size;
-            }
-            Memory::Dynamic(mem) => {
-                if let Err(e) = mem.grow_to(new_byte_size) {
-                    store.memory_grow_failed(&e);
-                    return Ok(None);
-                }
-            }
+        if let Err(e) = self.0.grow_to(new_byte_size) {
+            store.memory_grow_failed(&e);
+            return Ok(None);
         }
+
         Ok(Some(old_byte_size))
     }
 
     /// Return a `VMMemoryDefinition` for exposing the memory to compiled wasm code.
     pub fn vmmemory(&mut self) -> VMMemoryDefinition {
-        match self {
-            Memory::Static { base, size, .. } => VMMemoryDefinition {
-                base: base.as_mut_ptr().cast(),
-                current_length: *size,
-            },
-            Memory::Dynamic(mem) => mem.vmmemory(),
-        }
+        self.0.vmmemory()
     }
 }
 
 // The default memory representation is an empty memory that cannot grow.
 impl Default for Memory {
     fn default() -> Self {
-        Memory::Static {
-            base: &mut [],
-            size: 0,
-            make_accessible: Some(|_, _| unreachable!()),
-            memory_image: None,
-        }
+        Memory(Box::new(ExternalMemory::default()))
     }
 }

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -607,18 +607,19 @@ impl Memory {
         self.0.vmmemory()
     }
 
-    /// Check if the inner implementation of [`Memory`] is indeed an
-    /// `ExternalMemory`.
+    /// Check if the inner implementation of [`Memory`] is a memory created with
+    /// [`Memory::new_static()`].
     #[cfg(feature = "pooling-allocator")]
-    pub fn is_external(&self) -> bool {
+    pub fn is_static(&self) -> bool {
         let as_any = self.0.as_any();
         as_any.downcast_ref::<ExternalMemory>().is_some()
     }
 
     /// Consume the memory, returning its [`MemoryImageSlot`] if any is present.
-    /// This implicitly checks that the memory is an external memory.
+    /// The image should only be present for a subset of memories created with
+    /// [`Memory::new_static()`].
     #[cfg(feature = "pooling-allocator")]
-    pub fn unwrap_image_slot(self) -> Option<MemoryImageSlot> {
+    pub fn unwrap_static_image(self) -> Option<MemoryImageSlot> {
         let as_any = self.0.into_any();
         if let Ok(m) = as_any.downcast::<ExternalMemory>() {
             m.memory_image

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -80,6 +80,10 @@ pub trait RuntimeLinearMemory: Send + Sync {
     /// `Box::downcast` which only takes a `Box<dyn Any>`.
     #[cfg(feature = "pooling-allocator")]
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any>;
+
+    /// TODO
+    #[cfg(feature = "pooling-allocator")]
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 /// A linear memory instance.
@@ -265,6 +269,11 @@ impl RuntimeLinearMemory for MmapMemory {
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
         self
     }
+
+    #[cfg(feature = "pooling-allocator")]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// A "static" memory where the lifetime of the backing memory is managed
@@ -388,6 +397,11 @@ impl RuntimeLinearMemory for ExternalMemory {
 
     #[cfg(feature = "pooling-allocator")]
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+
+    #[cfg(feature = "pooling-allocator")]
+    fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 }
@@ -608,7 +622,7 @@ impl Memory {
     /// `ExternalMemory`.
     #[cfg(feature = "pooling-allocator")]
     pub fn is_external(&self) -> bool {
-        let as_any = &self.0 as &dyn std::any::Any;
+        let as_any = self.0.as_any();
         as_any.downcast_ref::<ExternalMemory>().is_some()
     }
 

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -81,7 +81,8 @@ pub trait RuntimeLinearMemory: Send + Sync {
     #[cfg(feature = "pooling-allocator")]
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any>;
 
-    /// TODO
+    /// Similar to [`RuntimeLinearMemory::into_any()`], this function allows us
+    /// to downcast this trait to its underlying structure by reference.
     #[cfg(feature = "pooling-allocator")]
     fn as_any(&self) -> &dyn std::any::Any;
 }

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -346,10 +346,9 @@ impl RuntimeLinearMemory for ExternalMemory {
     }
 
     fn grow_to(&mut self, new_byte_size: usize) -> Result<()> {
-        // Never exceed the static memory size.
-        if new_byte_size > self.base.len() {
-            bail!("static memory size exceeded")
-        }
+        // Never exceed the static memory size; this check should have been made
+        // prior to arriving here.
+        assert!(new_byte_size > self.base.len());
 
         // Actually grow the memory.
         if let Some(image) = &mut self.memory_image {

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -357,7 +357,7 @@ impl RuntimeLinearMemory for ExternalMemory {
     fn grow_to(&mut self, new_byte_size: usize) -> Result<()> {
         // Never exceed the static memory size; this check should have been made
         // prior to arriving here.
-        assert!(new_byte_size > self.base.len());
+        assert!(new_byte_size <= self.base.len());
 
         // Actually grow the memory.
         if let Some(image) = &mut self.memory_image {

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -334,17 +334,6 @@ impl ExternalMemory {
     }
 }
 
-impl Default for ExternalMemory {
-    fn default() -> Self {
-        Self {
-            base: &mut [],
-            size: 0,
-            make_accessible: Some(|_, _| unreachable!()),
-            memory_image: None,
-        }
-    }
-}
-
 impl RuntimeLinearMemory for ExternalMemory {
     fn byte_size(&self) -> usize {
         self.size
@@ -636,12 +625,5 @@ impl Memory {
         } else {
             None
         }
-    }
-}
-
-// The default memory representation is an empty memory that cannot grow.
-impl Default for Memory {
-    fn default() -> Self {
-        Memory(Box::new(ExternalMemory::default()))
     }
 }

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -54,12 +54,7 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
     }
 
     #[cfg(feature = "pooling-allocator")]
-    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
-        self
-    }
-
-    #[cfg(feature = "pooling-allocator")]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
     }
 }

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -57,6 +57,11 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
         self
     }
+
+    #[cfg(feature = "pooling-allocator")]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[derive(Clone)]

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -42,7 +42,7 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
         self.mem.grow_to(new_size)
     }
 
-    fn vmmemory(&self) -> VMMemoryDefinition {
+    fn vmmemory(&mut self) -> VMMemoryDefinition {
         VMMemoryDefinition {
             base: self.mem.as_ptr(),
             current_length: self.mem.byte_size(),
@@ -51,6 +51,11 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
 
     fn needs_init(&self) -> bool {
         true
+    }
+
+    #[cfg(feature = "pooling-allocator")]
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
     }
 }
 


### PR DESCRIPTION
While working with the runtime `Memory` object, it became clear that
some refactoring was needed. In order to implement shared memory from
the threads proposal, we must be able to atomically change the memory
size. Previously, the split into variants, `Memory::Static` and
`Memory::Dynamic`, made any attempt to lock duplicate logic
in various places.

This change moves `enum Memory { Static..., Dynamic... }` to simply
`struct Memory(Box<dyn RuntimeLinearMemory>)`. A new type,
`ExternalMemory`, takes the place of `Memory::Static` and also
implements the `RuntimeLinearMemory` trait, allowing `Memory` to contain
the same two options as before: `MmapMemory` for `Memory::Dynamic` and
`ExternalMemory` for `Memory::Static`. To interface with the
`PoolingAllocator`, this change also required the ability to downcast to
the internal representation.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
