### PR TITLE
ISLE language reference: move subsection to proper section.

### DIFF
--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -941,14 +941,6 @@ A term can have:
    
 4. A single external constructor binding (see next section).
 
-## ISLE to Rust
-
-Now that we have described the core ISLE language, we will document
-how it interacts with Rust code. We consider these interactions to be
-semantically as important as the core language: they are not
-implementation details, but rather, a well-defined interface by which
-ISLE can interface with the outside world (an "FFI" of sorts).
-
 ### If-Let Clauses
 
 As an extension to the basic left-hand-side / right-hand-side rule
@@ -1060,6 +1052,14 @@ following shorthand notation using `if` instead:
       (if (isa_extension_enabled))
       (isa_special_inst ...))
 ```
+
+## ISLE to Rust
+
+Now that we have described the core ISLE language, we will document
+how it interacts with Rust code. We consider these interactions to be
+semantically as important as the core language: they are not
+implementation details, but rather, a well-defined interface by which
+ISLE can interface with the outside world (an "FFI" of sorts).
 
 ### Mapping to Rust: Constructors, Functions, and Control Flow
 


### PR DESCRIPTION
In #4072 I mistakenly put the subsection about if-let clauses in the
language doc just below the next section header, so it's in the wrong
section ("mapping to Rust"). This moves it back upward to where it
should be. Sorry about that!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
