### PR TITLE
x64: fix pretty-printing argument order for XmmRmR instructions.

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1108,8 +1108,8 @@ impl PrettyPrint for Inst {
                 ..
             } => {
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let src2 = src2.pretty_print(8, allocs);
                 format!("{} {}, {}, {}", ljustify(op.to_string()), src1, src2, dst)
             }
 

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -267,30 +267,30 @@ block0(v0: i64):
 ;   movsd   136(%rcx), %xmm3
 ;   movsd   144(%rcx), %xmm4
 ;   movdqu  rsp(80 + virtual offset), %xmm6
-;   addsd   %xmm0, %xmm0, %xmm6
+;   addsd   %xmm0, %xmm6, %xmm0
 ;   movdqu  rsp(0 + virtual offset), %xmm6
 ;   movdqu  rsp(64 + virtual offset), %xmm7
-;   addsd   %xmm6, %xmm6, %xmm7
+;   addsd   %xmm6, %xmm7, %xmm6
 ;   movdqu  rsp(48 + virtual offset), %xmm7
-;   addsd   %xmm14, %xmm14, %xmm7
+;   addsd   %xmm14, %xmm7, %xmm14
 ;   movdqu  rsp(32 + virtual offset), %xmm7
-;   addsd   %xmm9, %xmm9, %xmm7
+;   addsd   %xmm9, %xmm7, %xmm9
 ;   movdqu  rsp(16 + virtual offset), %xmm7
-;   addsd   %xmm13, %xmm13, %xmm7
-;   addsd   %xmm11, %xmm11, %xmm10
-;   addsd   %xmm5, %xmm5, %xmm12
-;   addsd   %xmm1, %xmm1, %xmm2
-;   addsd   %xmm8, %xmm8, %xmm3
-;   addsd   %xmm4, 152(%xmm4), %rcx
-;   addsd   %xmm0, %xmm0, %xmm6
-;   addsd   %xmm14, %xmm14, %xmm9
-;   addsd   %xmm13, %xmm13, %xmm11
-;   addsd   %xmm5, %xmm5, %xmm1
-;   addsd   %xmm8, %xmm8, %xmm4
-;   addsd   %xmm0, %xmm0, %xmm14
-;   addsd   %xmm13, %xmm13, %xmm5
-;   addsd   %xmm0, %xmm0, %xmm13
-;   addsd   %xmm0, %xmm0, %xmm8
+;   addsd   %xmm13, %xmm7, %xmm13
+;   addsd   %xmm11, %xmm10, %xmm11
+;   addsd   %xmm5, %xmm12, %xmm5
+;   addsd   %xmm1, %xmm2, %xmm1
+;   addsd   %xmm8, %xmm3, %xmm8
+;   addsd   %xmm4, 152(%rcx), %xmm4
+;   addsd   %xmm0, %xmm6, %xmm0
+;   addsd   %xmm14, %xmm9, %xmm14
+;   addsd   %xmm13, %xmm11, %xmm13
+;   addsd   %xmm5, %xmm1, %xmm5
+;   addsd   %xmm8, %xmm4, %xmm8
+;   addsd   %xmm0, %xmm14, %xmm0
+;   addsd   %xmm13, %xmm5, %xmm13
+;   addsd   %xmm0, %xmm13, %xmm0
+;   addsd   %xmm0, %xmm8, %xmm0
 ;   movdqu  96(%rsp), %xmm6
 ;   movdqu  112(%rsp), %xmm7
 ;   movdqu  128(%rsp), %xmm8

--- a/cranelift/filetests/filetests/isa/x64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/x64/floating-point.clif
@@ -14,7 +14,7 @@ block0(v0: f64):
 ;   movabsq $9223372036854775807, %rdx
 ;   movq    %rdx, %xmm0
 ;   movdqa  %xmm5, %xmm7
-;   andpd   %xmm0, %xmm0, %xmm7
+;   andpd   %xmm0, %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -32,7 +32,7 @@ block0(v0: i64):
 ;   movsd   0(%rdi), %xmm5
 ;   movabsq $9223372036854775807, %r8
 ;   movq    %r8, %xmm0
-;   andpd   %xmm0, %xmm0, %xmm5
+;   andpd   %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -11,7 +11,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   andps   %xmm0, %xmm0, %xmm1
+;   andps   %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -25,7 +25,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   andpd   %xmm0, %xmm0, %xmm1
+;   andpd   %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -39,7 +39,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pand    %xmm0, %xmm0, %xmm1
+;   pand    %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -53,7 +53,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orps    %xmm0, %xmm0, %xmm1
+;   orps    %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -67,7 +67,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orpd    %xmm0, %xmm0, %xmm1
+;   orpd    %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -81,7 +81,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   por     %xmm0, %xmm0, %xmm1
+;   por     %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -95,7 +95,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorps   %xmm0, %xmm0, %xmm1
+;   xorps   %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -109,7 +109,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorpd   %xmm0, %xmm0, %xmm1
+;   xorpd   %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -123,7 +123,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pxor    %xmm0, %xmm0, %xmm1
+;   pxor    %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -143,9 +143,9 @@ block0:
 ;   load_const VCodeConstant(0), %xmm0
 ;   load_const VCodeConstant(0), %xmm5
 ;   load_const VCodeConstant(0), %xmm4
-;   pand    %xmm5, %xmm5, %xmm0
-;   pandn   %xmm0, %xmm0, %xmm4
-;   por     %xmm0, %xmm0, %xmm5
+;   pand    %xmm5, %xmm0, %xmm5
+;   pandn   %xmm0, %xmm4, %xmm0
+;   por     %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -159,7 +159,7 @@ block0(v0: b16x8, v1: i16x8, v2: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pblendvb %xmm2, %xmm2, %xmm1
+;   pblendvb %xmm2, %xmm1, %xmm2
 ;   movdqa  %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -174,7 +174,7 @@ block0(v0: b32x4, v1: f32x4, v2: f32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blendvps %xmm2, %xmm2, %xmm1
+;   blendvps %xmm2, %xmm1, %xmm2
 ;   movdqa  %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -189,7 +189,7 @@ block0(v0: b64x2, v1: f64x2, v2: f64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blendvpd %xmm2, %xmm2, %xmm1
+;   blendvpd %xmm2, %xmm1, %xmm2
 ;   movdqa  %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -211,7 +211,7 @@ block0(v0: i32):
 ;   lea     const(VCodeConstant(0)), %rax
 ;   shlq    $4, %rdi, %rdi
 ;   movdqu  0(%rax,%rdi,1), %xmm13
-;   pand    %xmm0, %xmm0, %xmm13
+;   pand    %xmm0, %xmm13, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -230,7 +230,7 @@ block0:
 ;   load_const VCodeConstant(1), %xmm0
 ;   psrlw   %xmm0, $1, %xmm0
 ;   movdqu  const(VCodeConstant(0)), %xmm5
-;   pand    %xmm0, %xmm0, %xmm5
+;   pand    %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -247,13 +247,13 @@ block0(v0: i32):
 ; block0:
 ;   load_const VCodeConstant(0), %xmm9
 ;   movdqa  %xmm9, %xmm0
-;   punpcklbw %xmm0, %xmm0, %xmm9
+;   punpcklbw %xmm0, %xmm9, %xmm0
 ;   punpckhbw %xmm9, %xmm9, %xmm9
 ;   addl    %edi, $8, %edi
 ;   movd    %edi, %xmm11
 ;   psraw   %xmm0, %xmm11, %xmm0
 ;   psraw   %xmm9, %xmm11, %xmm9
-;   packsswb %xmm0, %xmm0, %xmm9
+;   packsswb %xmm0, %xmm9, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -268,14 +268,14 @@ block0(v0: i8x16, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm9
-;   punpcklbw %xmm9, %xmm9, %xmm0
+;   punpcklbw %xmm9, %xmm0, %xmm9
 ;   punpckhbw %xmm0, %xmm0, %xmm0
 ;   movdqa  %xmm9, %xmm12
 ;   psraw   %xmm12, $11, %xmm12
 ;   movdqa  %xmm12, %xmm9
 ;   psraw   %xmm0, $11, %xmm0
 ;   movdqa  %xmm9, %xmm1
-;   packsswb %xmm1, %xmm1, %xmm0
+;   packsswb %xmm1, %xmm0, %xmm1
 ;   movdqa  %xmm1, %xmm9
 ;   movdqa  %xmm9, %xmm0
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -11,9 +11,9 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pcmpeqd %xmm0, %xmm0, %xmm1
+;   pcmpeqd %xmm0, %xmm1, %xmm0
 ;   pcmpeqd %xmm7, %xmm7, %xmm7
-;   pxor    %xmm0, %xmm0, %xmm7
+;   pxor    %xmm0, %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -27,10 +27,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pmaxud  %xmm0, %xmm0, %xmm1
-;   pcmpeqd %xmm0, %xmm0, %xmm1
+;   pmaxud  %xmm0, %xmm1, %xmm0
+;   pcmpeqd %xmm0, %xmm1, %xmm0
 ;   pcmpeqd %xmm9, %xmm9, %xmm9
-;   pxor    %xmm0, %xmm0, %xmm9
+;   pxor    %xmm0, %xmm9, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -45,8 +45,8 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
-;   pmaxsw  %xmm5, %xmm5, %xmm1
-;   pcmpeqw %xmm0, %xmm0, %xmm5
+;   pmaxsw  %xmm5, %xmm1, %xmm5
+;   pcmpeqw %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -61,8 +61,8 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
-;   pmaxub  %xmm5, %xmm5, %xmm1
-;   pcmpeqb %xmm0, %xmm0, %xmm5
+;   pmaxub  %xmm5, %xmm1, %xmm5
+;   pcmpeqb %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -18,10 +18,10 @@ block0:
 ;   load_const VCodeConstant(3), %xmm1
 ;   load_const VCodeConstant(2), %xmm0
 ;   load_const VCodeConstant(0), %xmm9
-;   pshufb  %xmm1, %xmm1, %xmm9
+;   pshufb  %xmm1, %xmm9, %xmm1
 ;   load_const VCodeConstant(1), %xmm12
-;   pshufb  %xmm0, %xmm0, %xmm12
-;   orps    %xmm0, %xmm0, %xmm1
+;   pshufb  %xmm0, %xmm12, %xmm0
+;   orps    %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -38,7 +38,7 @@ block0:
 ; block0:
 ;   load_const VCodeConstant(1), %xmm0
 ;   load_const VCodeConstant(0), %xmm5
-;   pshufb  %xmm0, %xmm0, %xmm5
+;   pshufb  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -57,8 +57,8 @@ block0:
 ;   load_const VCodeConstant(1), %xmm0
 ;   load_const VCodeConstant(1), %xmm2
 ;   load_const VCodeConstant(0), %xmm7
-;   paddusb %xmm2, %xmm2, %xmm7
-;   pshufb  %xmm0, %xmm0, %xmm2
+;   paddusb %xmm2, %xmm7, %xmm2
+;   pshufb  %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -75,7 +75,7 @@ block0(v0: i8):
 ;   uninit  %xmm0
 ;   pinsrb  $0, %xmm0, %rdi, %xmm0
 ;   pxor    %xmm6, %xmm6, %xmm6
-;   pshufb  %xmm0, %xmm0, %xmm6
+;   pshufb  %xmm0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -127,8 +127,8 @@ block0(v0: f64):
 ;   movdqa  %xmm0, %xmm4
 ;   uninit  %xmm0
 ;   movdqa  %xmm4, %xmm5
-;   movsd   %xmm0, %xmm0, %xmm5
-;   movlhps %xmm0, %xmm0, %xmm5
+;   movsd   %xmm0, %xmm5, %xmm0
+;   movlhps %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -12,7 +12,7 @@ block0(v0: b32x4):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm3, %xmm3, %xmm3
-;   pxor    %xmm0, %xmm0, %xmm3
+;   pxor    %xmm0, %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -42,7 +42,7 @@ block0(v0: i64x2):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   pxor    %xmm4, %xmm4, %xmm4
-;   pcmpeqq %xmm4, %xmm4, %xmm0
+;   pcmpeqq %xmm4, %xmm0, %xmm4
 ;   ptest   %xmm4, %xmm4
 ;   setz    %al
 ;   movq    %rbp, %rsp


### PR DESCRIPTION
The pretty-printing had swapped dst and src2; this was introduced when
we moved to RA2 (sorry about that! IMHO we should do something to
automate the mapping between regalloc arg collection and pretty
printing/emission).

`src2` comes at the end because it has a variable number of register
mentions; this is in line with how many of the other inst formats work.

Actual emitted code was never incorrect, just the pretty-printing.

Updated test golden outputs look correct to me now, including the one
that we saw was incorrect in #3945.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
