### PR TITLE
x64: add test for #3744

### DIFF
--- a/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
@@ -1,0 +1,16 @@
+test compile
+target x86_64
+
+; Check that no intervening moves are inserted when lowering `select` (see
+; https://github.com/bytecodealliance/wasmtime/issues/3744).
+function %select_eq_f32(f32, f32) -> i32 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp eq v0, v1
+    v3 = iconst.i32 1
+    v4 = iconst.i32 0
+    v5 = select v2, v3, v4
+    ; check: ucomiss %xmm0, %xmm1
+    ; nextln: cmovnzl %r8d, %eax, %eax
+    ; nextln: cmovpl  %r8d, %eax, %eax
+    return v5
+}


### PR DESCRIPTION
In #3744, we identified that extra `mov` instructions were inserted in
between the `cmov` instructions that CLIF's `select` lowers to. The
switch to regalloc2 resolved this and this test checks that no
intervening `mov`s are inserted. Closes #3744.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
