### PR TITLE
Expose `TrapCode::Interrupt` on epoch based interruption

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -593,7 +593,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         // The reason is that one can construct a "zip-bomb-like"
         // program with exponential-in-program-size runtime, with no
         // backedges (loops), by building a tree of function calls: f0
-        // calls f1 ten tims, f1 calls f2 ten times, etc. E.g., nine
+        // calls f1 ten times, f1 calls f2 ten times, etc. E.g., nine
         // levels of this yields a billion function calls with no
         // backedges. So we can't do checks only at backedges.
         //

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
     let trap = run.call(&mut store, ()).unwrap_err();
 
     println!("trap received...");
-    assert!(trap.to_string().contains("epoch deadline reached"));
+    assert!(trap.trap_code().unwrap() == TrapCode::Interrupt);
 
     Ok(())
 }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -175,7 +175,7 @@ fn timeout_in_start() -> Result<()> {
     assert_eq!(output.stdout, b"");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("epoch deadline reached during execution"),
+        stderr.contains("wasm trap: interrupt"),
         "bad stderr: {}",
         stderr
     );
@@ -196,7 +196,7 @@ fn timeout_in_invoke() -> Result<()> {
     assert_eq!(output.stdout, b"");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("epoch deadline reached during execution"),
+        stderr.contains("wasm trap: interrupt"),
         "bad stderr: {}",
         stderr
     );

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -33,7 +33,7 @@ fn loops_interruptable() -> anyhow::Result<()> {
     store.engine().increment_epoch();
     let trap = iloop.call(&mut store, ()).unwrap_err();
     assert!(
-        trap.to_string().contains("epoch deadline reached"),
+        trap.trap_code().unwrap() == TrapCode::Interrupt,
         "bad message: {}",
         trap
     );
@@ -50,7 +50,7 @@ fn functions_interruptable() -> anyhow::Result<()> {
     store.engine().increment_epoch();
     let trap = iloop.call(&mut store, ()).unwrap_err();
     assert!(
-        trap.to_string().contains("epoch deadline reached"),
+        trap.trap_code().unwrap() == TrapCode::Interrupt,
         "{}",
         trap.to_string()
     );
@@ -103,7 +103,7 @@ fn loop_interrupt_from_afar() -> anyhow::Result<()> {
     thread.join().unwrap();
     assert!(HITS.load(SeqCst) > NUM_HITS);
     assert!(
-        trap.to_string().contains("epoch deadline reached"),
+        trap.trap_code().unwrap() == TrapCode::Interrupt,
         "bad message: {}",
         trap.to_string()
     );
@@ -143,7 +143,7 @@ fn function_interrupt_from_afar() -> anyhow::Result<()> {
     thread.join().unwrap();
     assert!(HITS.load(SeqCst) > NUM_HITS);
     assert!(
-        trap.to_string().contains("epoch deadline reached"),
+        trap.trap_code().unwrap() == TrapCode::Interrupt,
         "bad message: {}",
         trap.to_string()
     );


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

I had a discussion via Zulip with @alexcrichton about this change. I decided to expose the `TrapCode` instead of the private error (`EpochDeadlineError`) mainly to keep the same behaviour as the deprecated [InterruptHandle approach](https://docs.rs/wasmtime/0.33.0/wasmtime/struct.InterruptHandle.html).
