### PR TITLE
Don't make a value label range smaller than it was

### DIFF
--- a/cranelift/codegen/src/machinst/debug.rs
+++ b/cranelift/codegen/src/machinst/debug.rs
@@ -513,7 +513,8 @@ pub(crate) fn compute<I: VCodeInst>(
                             end: end + 1,
                         });
                     } else {
-                        list.last_mut().unwrap().end = end + 1;
+                        let last = list.last_mut().unwrap();
+                        last.end = last.end.max(end + 1);
                     }
                 }
             }


### PR DESCRIPTION
I see this code has disappeared from `main` with the port to regalloc2,
but it seems there was a bug affecting 0.36.0 (and previous versions)
where the end of a range could end up being placed before the start of
that range, triggering an assertion in `ValueLabelRangeBuilders::process_label` (`assert_lt!(range_start, range_end);`). I think the only way this could happen was that, during construction of these value label ranges, we'd
"extend" a range with the new end of an instruction, but the end of that
instruction is located before the end of the range we're overwriting, so we'd end up incorrectly "compressing" a value range to the left! The fix is quite simple and consists in taking the maximum value of the new end offset and the previous end offset, I think.

Upstreaming in case it's of interest to get a tiny dot release (or have this patch ride along other security fixes) for this in
0.36.0, otherwise I can put it on an internal fork if preferred, as this
is a real-world issue affecting our users who are trying to use debugging.