### PR TITLE
Fix an issue where massive memory images are created

### DIFF
--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -252,10 +252,12 @@ impl ModuleTranslation<'_> {
                 };
                 let info = &mut info[memory];
                 let data_len = u64::from(init.data.end - init.data.start);
-                info.data_size += data_len;
-                info.min_addr = info.min_addr.min(init.offset);
-                info.max_addr = info.max_addr.max(init.offset + data_len);
-                info.segments.push((idx, init.clone()));
+                if data_len > 0 {
+                    info.data_size += data_len;
+                    info.min_addr = info.min_addr.min(init.offset);
+                    info.max_addr = info.max_addr.max(init.offset + data_len);
+                    info.segments.push((idx, init.clone()));
+                }
                 idx += 1;
                 true
             },


### PR DESCRIPTION
This commit fixes an issue introduced in #4046 where the checks for
ensuring that the memory initialization image for a module was
constrained in its size failed to trigger and a very small module could
produce an arbitrarily large memory image.

The bug in question was that if a module only had empty data segments at
arbitrarily small and large addresses then the loop which checks whether
or not the image is allowed was skipped entirely since it was seen that
the memory had no data size. The fix here is to skip segments that are
empty to ensure that if the validation loop is skipped then no data
segments will be processed to create the image (and the module won't end
up having an image in the end).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
