### PR TITLE
bump spec interpreter commit to address performance issues

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/build.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/build.rs
@@ -12,7 +12,7 @@ const OCAML_DIR: &'static str = "ocaml";
 const SPEC_DIR: &'static str = "ocaml/spec";
 const SPEC_REPOSITORY: &'static str = "https://github.com/conrad-watt/spec";
 const SPEC_REPOSITORY_BRANCH: &'static str = "wasmtime_fuzzing";
-const SPEC_REPOSITORY_REV: &'static str = "52851c8394ee4099fb8bdeaec6d60d92e787052f";
+const SPEC_REPOSITORY_REV: &'static str = "5395f07394eac9383b99ae04bb1fb34a77394555";
 
 fn main() {
     if cfg!(feature = "build-libinterpret") {


### PR DESCRIPTION
This [commit of the interpreter](https://github.com/conrad-watt/spec/compare/conrad-new-interpreter...conrad-watt:wasmtime_fuzzing) introduces a new strategy for handling bitwise ops, which fixes the performance of `popcnt`, `reinterpret`, and signed integer comparison, and should result in fewer fuzzing timeouts (see https://github.com/bytecodealliance/wasmtime/issues/4059).

For reference, similar performance issues still exist for the integer operations `clz`, `ctz`, `rem_s`, `rotl`, `rotr`, `wrap`, `extend_u`, and `extend_s` - my current plan is to address these in a follow-up, so long as this current fix causes no issues.

EDIT: currently fuzzing locally with no issues found so far