### PR TITLE
[0.37.0] Fix an issue where massive memory images are created

### DIFF
--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -252,10 +252,12 @@ impl ModuleTranslation<'_> {
                 };
                 let info = &mut info[memory];
                 let data_len = u64::from(init.data.end - init.data.start);
-                info.data_size += data_len;
-                info.min_addr = info.min_addr.min(init.offset);
-                info.max_addr = info.max_addr.max(init.offset + data_len);
-                info.segments.push((idx, init.clone()));
+                if data_len > 0 {
+                    info.data_size += data_len;
+                    info.min_addr = info.min_addr.min(init.offset);
+                    info.max_addr = info.max_addr.max(init.offset + data_len);
+                    info.segments.push((idx, init.clone()));
+                }
                 idx += 1;
                 true
             },


### PR DESCRIPTION
This is a backport of https://github.com/bytecodealliance/wasmtime/pull/4112 to the 0.37.0 branch to fix an issue in https://github.com/bytecodealliance/wasmtime/pull/4046 which was merged just before the branch was created.